### PR TITLE
Move to federated (email-like) usernames (close #23)

### DIFF
--- a/common/src/ipld-store.ts
+++ b/common/src/ipld-store.ts
@@ -43,6 +43,13 @@ export class IpldStore {
     await this.db.put(block.cid, block.bytes)
     return block.cid
   }
+
+  putUser (value: Object): Promise<CID> {
+    if (!check.isUser(value)) {
+      throw new Error(`Not a valid user object`)
+    }
+    return this.put(value)
+  }
 }
 
 export default IpldStore 

--- a/common/src/type-check.ts
+++ b/common/src/type-check.ts
@@ -5,9 +5,17 @@ export const isObject = (obj: any): obj is Object => {
   return obj && typeof obj === 'object'
 }
 
+export const isString = (str: any): str is string => {
+  return typeof str === 'string'
+}
+
+export const isUsername = (str: any): str is string => {
+  return isString(str) && /(.+)@(.+)/.test(str)
+}
+
 export const isUser = (obj: any): obj is User => {
   return isObject(obj)
-    && typeof obj.name === 'string'
+    && isUsername(obj.name)
     && typeof obj.did === 'string'
     && typeof obj.nextPost === 'number'
     && !!CID.asCID(obj.postsRoot)

--- a/common/src/user-store.ts
+++ b/common/src/user-store.ts
@@ -44,7 +44,7 @@ export class UserStore {
       follows: []
     }
   
-    const userCid = await ipldStore.put(user)
+    const userCid = await ipldStore.putUser(user)
     const signedRoot = {
       user: userCid,
       sig: await keypair.sign(userCid.bytes)
@@ -104,7 +104,7 @@ export class UserStore {
     user.nextPost++
     user.postsRoot = this.postMap.cid
 
-    const userCid = await this.ipldStore.put(user)
+    const userCid = await this.ipldStore.putUser(user)
     const signedRoot = {
       user: userCid,
       sig: await this.keypair.sign(userCid.bytes)

--- a/frontend/components/App.module.scss
+++ b/frontend/components/App.module.scss
@@ -73,3 +73,7 @@
   border-left: 1px solid #B1D4E0;
   padding: 10px;
 }
+
+.error {
+  color: red;
+}

--- a/frontend/components/Register.tsx
+++ b/frontend/components/Register.tsx
@@ -2,7 +2,7 @@ import styles from "@components/App.module.scss";
 
 import React, { ChangeEvent, FormEvent } from 'react'
 
-import { service, LocalUser, UserStore } from '@bluesky-demo/common'
+import { service, LocalUser, UserStore, check } from '@bluesky-demo/common'
 import * as ucan from 'ucans'
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 function Register(props: Props) {
 
   const [username, setUsername] = React.useState<string>('')
+  const [usernameIssue, setUsernameIssue] = React.useState<string>('')
 
   const updateUsername = (e: ChangeEvent<HTMLInputElement>) => {
     setUsername(e.target.value)
@@ -20,6 +21,14 @@ function Register(props: Props) {
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    setUsernameIssue('')
+
+    if (!check.isUsername(username)) {
+      // TODO: the domain comes from somewhere else, obviously
+      setUsernameIssue('Must be an email-like username, e.g. bob@home.com')
+      return
+    }
+
     const keypair = await ucan.EdKeypair.create({ exportable: true })
     const blueskyDid = await service.getServerDid()
     const token = await ucan.build({
@@ -40,6 +49,7 @@ function Register(props: Props) {
       <p className={styles.paragraph}>Register account</p>
       <form onSubmit={onSubmit}>
         <input onChange={updateUsername} value={username} />
+        {usernameIssue !== '' ? <div className={styles.error}>{usernameIssue}</div> : null}
         <br/>
         <button type='submit'>Register</button>
       </form>


### PR DESCRIPTION
Note that I made the username syntax a part of the user-object validation, and added a `putUser()` to the ipld store which runs validation for that object-type before put. (LMK if this is how we want to do it)