### PR TITLE
Userstore interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ type Follow = {
 }
 ```
 
-The CID of the IPLD-encoded "User" block is then signed by the user and added to to an "SignedRoot" IPLD object:
+The CID of the IPLD-encoded "User" block is then signed by the user and added to to an "Commit" IPLD object:
 ```ts
-type SignedRoot = {
+type Commit = {
   user: CID
   sig: Uint8Array
 }
 ```
 
-The CID of the SignedRoot serves as the root of the datastructure.
+The CID of the Commit serves as the root of the datastructure.
 
 ## Persistence
 User data is persisted in [Level](https://github.com/Level/level) which is a simple key-value store. This **Blockstore** is a mapping of `CID -> Bytes` and represents the consituent blocks that make up the UserStore.

--- a/common/src/ipld-store.ts
+++ b/common/src/ipld-store.ts
@@ -3,7 +3,7 @@ import { CID } from 'multiformats/cid'
 import { sha256 as blockHasher } from 'multiformats/hashes/sha2'
 import * as blockCodec from '@ipld/dag-cbor'
 
-import { BlockstoreI, SignedRoot, User } from "./types.js"
+import { BlockstoreI, Commit, User } from "./types.js"
 import * as check from './type-check.js'
 
 export class IpldStore {
@@ -28,9 +28,9 @@ export class IpldStore {
     return obj
   }
 
-  async getSignedRoot (cid: CID): Promise<SignedRoot> {
+  async getCommit (cid: CID): Promise<Commit> {
     const obj = await this.get(cid)
-    if (!check.isSignedRoot(obj)) {
+    if (!check.isCommit(obj)) {
       throw new Error(`Could not find a signed root at ${cid.toString()}`)
     }
     return obj

--- a/common/src/type-check.ts
+++ b/common/src/type-check.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import { SignedRoot, User } from './types.js'
+import { Commit, User } from './types.js'
 
 export const isObject = (obj: any): obj is Object => {
   return obj && typeof obj === 'object'
@@ -14,7 +14,7 @@ export const isUser = (obj: any): obj is User => {
     && Array.isArray(obj.follows)
 }
 
-export const isSignedRoot = (obj: any): obj is SignedRoot => {
+export const isCommit = (obj: any): obj is Commit => {
   return isObject(obj)
     && !!CID.asCID(obj.user)
     && ArrayBuffer.isView(obj.sig)

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -26,7 +26,7 @@ export type Post = {
   time: string // ISO 8601
 }
 
-export type SignedRoot = {
+export type Commit = {
   user: CID
   sig: Uint8Array
 }


### PR DESCRIPTION
Flesh out user store interface.

The following have a naive implementation:
- Add/edit/delete post
- list posts
- follow/unfollow
- list followers

The rest are just stubbed out:
- reply to post
- like/unlike
- list likes

Also made the `keypair` optional for read-only user stores. It throws an error if trying to make a change without a keypair. Arguably these should be two separate classes so that it can be handled at the type level instead of with errors :thinking: 

Closes https://github.com/bluesky-social/bluesky-hack/issues/37