### PR TITLE
CidSet

### DIFF
--- a/common/src/user-store/cid-set.ts
+++ b/common/src/user-store/cid-set.ts
@@ -1,0 +1,45 @@
+import { CID } from 'multiformats'
+
+export class CidSet {
+  private set: Set<string>
+
+  constructor(arr: CID[] = []) {
+    const strArr = arr.map((c) => c.toString())
+    this.set = new Set(strArr)
+  }
+
+  add(cid: CID): CidSet {
+    this.set.add(cid.toString())
+    return this
+  }
+
+  addSet(toMerge: CidSet): CidSet {
+    toMerge.toList().map((c) => this.add(c))
+    return this
+  }
+
+  delete(cid: CID) {
+    this.set.delete(cid.toString())
+    return this
+  }
+
+  has(cid: CID): boolean {
+    return this.set.has(cid.toString())
+  }
+
+  size(): number {
+    return this.set.size
+  }
+
+  clear(): CidSet {
+    this.set.clear()
+    return this
+  }
+
+  toList(): CID[] {
+    const arr = [...this.set]
+    return arr.map((c) => CID.parse(c))
+  }
+}
+
+export default CidSet

--- a/common/src/user-store/did-collection.ts
+++ b/common/src/user-store/did-collection.ts
@@ -5,14 +5,15 @@ import * as HAMT from 'ipld-hashmap'
 import { BlockWriter } from '@ipld/car/lib/writer-browser'
 
 import IpldStore from '../blockstore/ipld-store.js'
-import { CarStreamable, Collection, NewCids } from './types.js'
+import { CarStreamable, Collection } from './types.js'
 import { DID } from '../common/types.js'
+import CidSet from './cid-set.js'
 
 export class DidCollection implements Collection<DID>, CarStreamable {
   store: IpldStore
   cid: CID
   hamt: HAMT.HashMap<CID>
-  onUpdate: ((newCids: NewCids) => Promise<void>) | null
+  onUpdate: ((newCids: CidSet) => Promise<void>) | null
 
   constructor(store: IpldStore, cid: CID, hamt: HAMT.HashMap<CID>) {
     this.store = store
@@ -45,7 +46,7 @@ export class DidCollection implements Collection<DID>, CarStreamable {
       // we're likely removing the relationships branch from user repo
       // so we punted on implementing the proper logic here.
       // send empty NewCids array for now
-      await this.onUpdate(new Set())
+      await this.onUpdate(new CidSet())
     }
   }
 

--- a/common/src/user-store/index.ts
+++ b/common/src/user-store/index.ts
@@ -4,19 +4,13 @@ import { BlockWriter } from '@ipld/car/lib/writer-browser'
 
 import { Didable, Keypair } from 'ucans'
 
-import {
-  UserRoot,
-  CarStreamable,
-  IdMapping,
-  Commit,
-  NewCids,
-  schema,
-} from './types.js'
+import { UserRoot, CarStreamable, IdMapping, Commit, schema } from './types.js'
 import { DID } from '../common/types.js'
 import * as check from '../common/check.js'
 import IpldStore from '../blockstore/ipld-store.js'
 import { streamToArray } from '../common/util.js'
 import ProgramStore from './program-store.js'
+import CidSet from './cid-set.js'
 
 export class UserStore implements CarStreamable {
   store: IpldStore
@@ -103,7 +97,7 @@ export class UserStore implements CarStreamable {
   // arrow fn to preserve scope
   updateRoot =
     (programName: string) =>
-    async (newCids: NewCids): Promise<void> => {
+    async (newCids: CidSet): Promise<void> => {
       if (this.keypair === null) {
         throw new Error('No keypair provided. UserStore is read-only.')
       }
@@ -125,7 +119,7 @@ export class UserStore implements CarStreamable {
       const userRoot: UserRoot = {
         did: this.did,
         prev: this.cid,
-        new_cids: [...newCids],
+        new_cids: newCids.toList(),
         programs: this.programCids,
       }
       const userCid = await this.store.put(userRoot)

--- a/common/src/user-store/program-store.ts
+++ b/common/src/user-store/program-store.ts
@@ -1,11 +1,11 @@
 import { CID } from 'multiformats/cid'
 import { BlockWriter } from '@ipld/car/lib/writer-browser'
 
-import * as check from '../common/check.js'
 import IpldStore from '../blockstore/ipld-store.js'
 import TidCollection from './tid-collection.js'
 import DidCollection from './did-collection.js'
-import { NewCids, ProgramRoot, schema } from './types.js'
+import { ProgramRoot, schema } from './types.js'
+import CidSet from './cid-set.js'
 
 export class ProgramStore {
   store: IpldStore
@@ -14,7 +14,7 @@ export class ProgramStore {
   relationships: DidCollection
   profile: CID | null
   cid: CID
-  onUpdate: ((newCids: NewCids) => Promise<void>) | null
+  onUpdate: ((newCids: CidSet) => Promise<void>) | null
 
   constructor(params: {
     store: IpldStore
@@ -77,7 +77,7 @@ export class ProgramStore {
   }
 
   // arrow fn to preserve scope
-  updateRoot = async (newCids: NewCids): Promise<void> => {
+  updateRoot = async (newCids: CidSet): Promise<void> => {
     this.cid = await this.store.put({
       posts: this.posts.cid,
       relationships: this.relationships.cid,
@@ -91,7 +91,7 @@ export class ProgramStore {
 
   async setProfile(cid: CID | null): Promise<void> {
     this.profile = cid
-    const newCids = new Set(cid === null ? [] : [cid])
+    const newCids = new CidSet(cid === null ? [] : [cid])
     await this.updateRoot(newCids)
   }
 

--- a/common/src/user-store/types.ts
+++ b/common/src/user-store/types.ts
@@ -37,9 +37,6 @@ const entry = z.object({
 })
 export type Entry = z.infer<typeof entry>
 
-const newCids = z.set(common.cid)
-export type NewCids = z.infer<typeof newCids>
-
 export const schema = {
   ...common,
   tid,
@@ -48,7 +45,6 @@ export const schema = {
   commit,
   idMapping,
   entry,
-  newCids,
 }
 
 export interface CarStreamable {


### PR DESCRIPTION
We use sets to prevent duplicate listings of CIDs.  However, when confronted with a js object (like a CID), sets don't check for deep equality, they just check pointer. So we were getting duplicate CIDs in our sets. 

This PR introduces a new `CidSet` class that converts to/from strings under the hood for better uniqueness checks.

Taken from: https://github.com/bluesky-social/bluesky-hack/pull/57