### PR TITLE
Parse TIDs & ints in zod schemas

### DIFF
--- a/common/src/blockstore/ipld-store.ts
+++ b/common/src/blockstore/ipld-store.ts
@@ -9,6 +9,12 @@ import * as check from '../common/check.js'
 import { BlockstoreI } from './types.js'
 import { PersistentBlockstore } from './persistent-blockstore.js'
 
+type AllowedIpldRecordVal = string | number | CID | CID[] | Uint8Array | null
+
+export type AllowedIpldVal =
+  | AllowedIpldRecordVal
+  | Record<string, AllowedIpldRecordVal>
+
 export class IpldStore {
   rawBlockstore: BlockstoreI
 
@@ -24,7 +30,9 @@ export class IpldStore {
     return new IpldStore(new PersistentBlockstore(location))
   }
 
-  async put(value: Record<string, unknown> | string): Promise<CID> {
+  async put(
+    value: Record<string, AllowedIpldVal> | AllowedIpldVal,
+  ): Promise<CID> {
     const block = await Block.encode({
       value,
       codec: blockCodec,

--- a/common/src/common/check.ts
+++ b/common/src/common/check.ts
@@ -7,7 +7,7 @@ export const is = <T>(obj: unknown, schema: Schema<T>): obj is T => {
   return schema.safeParse(obj).success
 }
 
-export const assure = <T>(schema: Schema<T>, obj: unknown) => {
+export const assure = <T>(schema: Schema<T>, obj: unknown): T => {
   return schema.parse(obj)
 }
 

--- a/common/src/common/types.ts
+++ b/common/src/common/types.ts
@@ -14,9 +14,17 @@ export type Bytes = z.infer<typeof bytes>
 
 export type Keypair = ucan.Keypair & ucan.Didable
 
+const strToInt = z
+  .string()
+  .refine((str) => !isNaN(parseInt(str)), {
+    message: 'Cannot parse string to integer',
+  })
+  .transform(parseInt)
+
 export const schema = {
   string: z.string(),
   cid,
   did,
   bytes,
+  strToInt,
 }

--- a/common/src/microblog/types.ts
+++ b/common/src/microblog/types.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
+import { schema as repo } from '../repo/types.js'
 
 const post = z.object({
-  tid: z.string(),
+  tid: repo.strToTid,
   author: z.string(),
   namespace: z.string(),
   text: z.string(),
@@ -9,19 +10,42 @@ const post = z.object({
 })
 export type Post = z.infer<typeof post>
 
+// @TODO move flatten methods to ipld store?
+export const flattenPost = (like: Post): Record<string, string | number> => {
+  return {
+    tid: like.tid.toString(),
+    author: like.author,
+    namespace: like.namespace,
+    text: like.text,
+    time: like.time,
+  }
+}
+
 const like = z.object({
-  tid: z.string(),
+  tid: repo.strToTid,
   author: z.string(),
   namespace: z.string(),
   time: z.string(),
-  post_tid: z.string(),
+  post_tid: repo.strToTid,
   post_author: z.string(),
   post_namespace: z.string(),
 })
 export type Like = z.infer<typeof like>
 
+export const flattenLike = (like: Like): Record<string, string | number> => {
+  return {
+    tid: like.tid.toString(),
+    author: like.author,
+    namespace: like.namespace,
+    time: like.time,
+    post_tid: like.post_tid.toString(),
+    post_author: like.post_author,
+    post_namespace: like.post_namespace,
+  }
+}
+
 const timelinePost = z.object({
-  tid: z.string(),
+  tid: repo.strToTid,
   author_did: z.string(),
   author_name: z.string(),
   text: z.string(),

--- a/common/src/repo/index.ts
+++ b/common/src/repo/index.ts
@@ -14,7 +14,7 @@ import {
 } from './types.js'
 import { DID, Keypair } from '../common/types.js'
 import * as check from '../common/check.js'
-import IpldStore from '../blockstore/ipld-store.js'
+import IpldStore, { AllowedIpldVal } from '../blockstore/ipld-store.js'
 import { streamToArray } from '../common/util.js'
 import Namespace from './namespace.js'
 import Relationships from './relationships.js'
@@ -241,7 +241,7 @@ export class Repo implements CarStreamable {
   // IPLD store methods
   // -----------
 
-  async put(value: Record<string, unknown> | string): Promise<CID> {
+  async put(value: AllowedIpldVal): Promise<CID> {
     return this.blockstore.put(value)
   }
 

--- a/common/src/repo/namespace-impl.ts
+++ b/common/src/repo/namespace-impl.ts
@@ -3,11 +3,11 @@ import Repo from './index.js'
 import Namespace from './namespace'
 
 export class NamespaceImpl {
-  name: string
+  namespace: string
   repo: Repo
 
-  constructor(name: string, repo: Repo) {
-    this.name = name
+  constructor(namespace: string, repo: Repo) {
+    this.namespace = namespace
     this.repo = repo
   }
 
@@ -18,7 +18,7 @@ export class NamespaceImpl {
   async runOnNamespace<T>(
     fn: (namespace: Namespace) => Promise<T>,
   ): Promise<T> {
-    return this.repo.runOnNamespace(this.name, fn)
+    return this.repo.runOnNamespace(this.namespace, fn)
   }
 }
 

--- a/common/src/repo/tid.ts
+++ b/common/src/repo/tid.ts
@@ -50,6 +50,15 @@ export class TID {
     return a.compareTo(b)
   }
 
+  static is(str: string): boolean {
+    try {
+      TID.fromStr(str)
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
   timestamp(): number {
     const substr = this.str.slice(0, 11)
     return s32decode(substr)

--- a/common/src/repo/types.ts
+++ b/common/src/repo/types.ts
@@ -6,6 +6,11 @@ import CidSet from './cid-set.js'
 
 const tid = z.instanceof(TID)
 
+const strToTid = z
+  .string()
+  .refine(TID.is, { message: 'Not a valid TID' })
+  .transform(TID.fromStr)
+
 const repoRoot = z.object({
   did: common.did,
   prev: common.cid.nullable(),
@@ -58,6 +63,7 @@ export type UpdateData = {
 export const schema = {
   ...common,
   tid,
+  strToTid,
   repoRoot,
   namespaceRoot,
   commit,

--- a/common/test/microblog.ts
+++ b/common/test/microblog.ts
@@ -7,8 +7,6 @@ import Microblog from '../src/microblog/index.js'
 import Repo from '../src/repo/index.js'
 import IpldStore from '../src/blockstore/ipld-store.js'
 
-import TID from '../src/repo/tid.js'
-
 type Context = {
   ipld: IpldStore
   keypair: ucan.EdKeypair
@@ -30,7 +28,7 @@ test.beforeEach(async (t) => {
 test('basic post operations', async (t) => {
   const { microblog } = t.context as Context
   const created = await microblog.addPost('hello world')
-  const tid = TID.fromStr(created.tid)
+  const tid = created.tid
   const post = await microblog.getPost(tid)
   t.is(post?.text, 'hello world', 'retrieves correct post')
 
@@ -46,11 +44,15 @@ test('basic post operations', async (t) => {
 test('basic like operations', async (t) => {
   const { microblog } = t.context as Context
   const post = await microblog.addPost('hello world')
-  const likeTid = await microblog.likePost(post.author, TID.fromStr(post.tid))
+  const likeTid = await microblog.likePost(post.author, post.tid)
   let likes = await microblog.listLikes(1)
   t.is(likes.length, 1, 'correct number of likes')
-  t.is(likes[0]?.tid, likeTid.toString(), 'correct id on like')
-  t.is(likes[0]?.post_tid, post.tid, 'correct post_id on like')
+  t.is(likes[0]?.tid?.toString(), likeTid?.toString(), 'correct id on like')
+  t.is(
+    likes[0]?.post_tid?.toString(),
+    post.tid?.toString(),
+    'correct post_id on like',
+  )
 
   await microblog.deleteLike(likeTid)
   likes = await microblog.listLikes(1)

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsc -w --project tsconfig.json & nodemon -q -w dist dist/index.js",
     "build": "(cd ../common && yarn build) && tsc --project tsconfig.json",
-    "test": "ava -v test/*.ts",
+    "test": "ava -v */data.ts",
     "temp": "IN_MEMORY=true yarn dev",
     "wipe-db": "rimraf dev.sqlite && rimraf blockstore"
   },

--- a/server/src/routes/data/post.ts
+++ b/server/src/routes/data/post.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import * as auth from '../../auth.js'
 import * as util from '../../util.js'
 import { ServerError } from '../../error.js'
-import { schema, check, TID, ucanCheck } from '@bluesky-demo/common'
+import { flattenPost, schema, TID, ucanCheck } from '@bluesky-demo/common'
 import { SERVER_DID } from '../../server-identity.js'
 
 const router = express.Router()
@@ -14,24 +14,21 @@ const router = express.Router()
 export const getPostReq = z.object({
   did: z.string(),
   namespace: z.string(),
-  tid: z.string(),
+  tid: schema.repo.strToTid,
 })
 export type GetPostReq = z.infer<typeof getPostReq>
 
 router.get('/', async (req, res) => {
-  if (!check.is(req.query, getPostReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { did, namespace, tid } = req.query
+  const { did, namespace, tid } = util.checkReqBody(req.query, getPostReq)
   const repo = await util.loadRepo(res, did)
   const postCid = await repo.runOnNamespace(namespace, async (store) => {
-    return store.posts.getEntry(TID.fromStr(tid))
+    return store.posts.getEntry(tid)
   })
   if (postCid === null) {
     throw new ServerError(404, 'Could not find post')
   }
   const post = await repo.get(postCid, schema.microblog.post)
-  res.status(200).send(post)
+  res.status(200).send(flattenPost(post))
 })
 
 // LIST POSTS
@@ -40,32 +37,26 @@ router.get('/', async (req, res) => {
 export const listPostsReq = z.object({
   did: z.string(),
   namespace: z.string(),
-  count: z.string(),
+  count: schema.common.strToInt,
   from: z.string().optional(),
 })
 export type ListPostsReq = z.infer<typeof listPostsReq>
 
 router.get('/list', async (req, res) => {
-  if (!check.is(req.query, listPostsReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { did, namespace, count, from } = req.query
-  const countParsed = parseInt(count)
-  if (isNaN(countParsed)) {
-    throw new ServerError(
-      400,
-      'Poorly formatted request: `count` is not a number',
-    )
-  }
+  const { did, namespace, count, from } = util.checkReqBody(
+    req.query,
+    listPostsReq,
+  )
   const fromTid = from ? TID.fromStr(from) : undefined
   const repo = await util.loadRepo(res, did)
   const entries = await repo.runOnNamespace(namespace, async (store) => {
-    return store.posts.getEntries(countParsed, fromTid)
+    return store.posts.getEntries(count, fromTid)
   })
   const posts = await Promise.all(
     entries.map((entry) => repo.get(entry.cid, schema.microblog.post)),
   )
-  res.status(200).send(posts)
+  const flattened = posts.map(flattenPost)
+  res.status(200).send(flattened)
 })
 
 // CREATE POST
@@ -75,10 +66,7 @@ export const createPostReq = schema.microblog.post
 export type CreatePostReq = z.infer<typeof createPostReq>
 
 router.post('/', async (req, res) => {
-  if (!check.is(req.body, createPostReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const post = req.body
+  const post = util.checkReqBody(req.body, createPostReq)
   const ucanStore = await auth.checkReq(
     req,
     ucanCheck.hasAudience(SERVER_DID),
@@ -86,13 +74,13 @@ router.post('/', async (req, res) => {
       post.author,
       post.namespace,
       'posts',
-      TID.fromStr(post.tid),
+      post.tid,
     ),
   )
   const repo = await util.loadRepo(res, post.author, ucanStore)
-  const postCid = await repo.put(post)
+  const postCid = await repo.put(flattenPost(post))
   await repo.runOnNamespace(post.namespace, async (store) => {
-    return store.posts.addEntry(TID.fromStr(post.tid), postCid)
+    return store.posts.addEntry(post.tid, postCid)
   })
   const db = util.getDB(res)
   await db.createPost(post, postCid)
@@ -107,20 +95,21 @@ export const editPostReq = schema.microblog.post
 export type EditPostReq = z.infer<typeof editPostReq>
 
 router.put('/', async (req, res) => {
-  if (!check.is(req.body, editPostReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const post = req.body
-  const tid = TID.fromStr(post.tid)
+  const post = util.checkReqBody(req.body, editPostReq)
   const ucanStore = await auth.checkReq(
     req,
     ucanCheck.hasAudience(SERVER_DID),
-    ucanCheck.hasPostingPermission(post.author, post.namespace, 'posts', tid),
+    ucanCheck.hasPostingPermission(
+      post.author,
+      post.namespace,
+      'posts',
+      post.tid,
+    ),
   )
   const repo = await util.loadRepo(res, post.author, ucanStore)
-  const postCid = await repo.put(post)
+  const postCid = await repo.put(flattenPost(post))
   await repo.runOnNamespace(post.namespace, async (store) => {
-    return store.posts.editEntry(tid, postCid)
+    return store.posts.editEntry(post.tid, postCid)
   })
   const db = util.getDB(res)
   await db.updatePost(post, postCid)
@@ -134,27 +123,23 @@ router.put('/', async (req, res) => {
 export const deletePostReq = z.object({
   did: z.string(),
   namespace: z.string(),
-  tid: z.string(),
+  tid: schema.repo.strToTid,
 })
 export type DeletePostReq = z.infer<typeof deletePostReq>
 
 router.delete('/', async (req, res) => {
-  if (!check.is(req.body, deletePostReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { did, namespace, tid } = req.body
-  const tidObj = TID.fromStr(tid)
+  const { did, namespace, tid } = util.checkReqBody(req.body, deletePostReq)
   const ucanStore = await auth.checkReq(
     req,
     ucanCheck.hasAudience(SERVER_DID),
-    ucanCheck.hasPostingPermission(did, namespace, 'posts', tidObj),
+    ucanCheck.hasPostingPermission(did, namespace, 'posts', tid),
   )
   const repo = await util.loadRepo(res, did, ucanStore)
   await repo.runOnNamespace(namespace, async (store) => {
-    return store.posts.deleteEntry(tidObj)
+    return store.posts.deleteEntry(tid)
   })
   const db = util.getDB(res)
-  await db.deletePost(tidObj.toString(), did, namespace)
+  await db.deletePost(tid.toString(), did, namespace)
   await db.updateRepoRoot(did, repo.cid)
   res.status(200).send()
 })

--- a/server/src/routes/data/relationship.ts
+++ b/server/src/routes/data/relationship.ts
@@ -18,10 +18,7 @@ export const createRelReq = z.object({
 export type CreateRelReq = z.infer<typeof createRelReq>
 
 router.post('/', async (req, res) => {
-  if (!check.is(req.body, createRelReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { creator, target } = req.body
+  const { creator, target } = util.checkReqBody(req.body, createRelReq)
   const ucanStore = await auth.checkReq(
     req,
     ucanCheck.hasAudience(SERVER_DID),
@@ -49,10 +46,7 @@ export const deleteRelReq = z.object({
 export type DeleteRelReq = z.infer<typeof deleteRelReq>
 
 router.delete('/', async (req, res) => {
-  if (!check.is(req.body, deleteRelReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { creator, target } = req.body
+  const { creator, target } = util.checkReqBody(req.body, deleteRelReq)
   const ucanStore = await auth.checkReq(
     req,
     ucanCheck.hasAudience(SERVER_DID),
@@ -74,10 +68,7 @@ export const listRelReq = z.object({
 export type ListRelReq = z.infer<typeof listRelReq>
 
 router.get('/list', async (req, res) => {
-  if (!check.is(req.query, listRelReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { user } = req.query
+  const { user } = util.checkReqBody(req.query, listRelReq)
   const db = util.getDB(res)
   const follows = await db.listFollows(user)
   res.status(200).send(follows)

--- a/server/src/routes/data/root.ts
+++ b/server/src/routes/data/root.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { z } from 'zod'
-import { check } from '@bluesky-demo/common'
 import * as util from '../../util.js'
 
 const router = express.Router()
@@ -11,11 +10,9 @@ export const getRootReq = z.object({
 export type GetRootReq = z.infer<typeof getRootReq>
 
 router.get('/', async (req, res) => {
-  if (!check.is(req.query, getRootReq)) {
-    return res.status(400).send('Poorly formatted request')
-  }
+  const { did } = util.checkReqBody(req.query, getRootReq)
   const db = util.getDB(res)
-  const root = await db.getRepoRoot(req.query.did)
+  const root = await db.getRepoRoot(did)
   res.status(200).send({ root })
 })
 

--- a/server/src/routes/id.ts
+++ b/server/src/routes/id.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import { z } from 'zod'
 
-import { Repo, ucanCheck, check } from '@bluesky-demo/common'
+import { Repo, ucanCheck } from '@bluesky-demo/common'
 
 import * as auth from '../auth.js'
 import { SERVER_DID, SERVER_KEYPAIR } from '../server-identity.js'
@@ -17,10 +17,7 @@ export const registerReq = z.object({
 export type registerReq = z.infer<typeof registerReq>
 
 router.post('/register', async (req, res) => {
-  if (!check.is(req.body, registerReq)) {
-    throw new ServerError(400, 'Poorly formatted request')
-  }
-  const { username, did } = req.body
+  const { username, did } = util.checkReqBody(req.body, registerReq)
   if (username.startsWith('did:')) {
     throw new ServerError(
       400,

--- a/server/src/routes/indexer/account-info.ts
+++ b/server/src/routes/indexer/account-info.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { z } from 'zod'
-import { check } from '@bluesky-demo/common'
 import * as util from '../../util.js'
 
 const router = express.Router()
@@ -11,11 +10,7 @@ export const accountInfoReq = z.object({
 export type AccountInfoReq = z.infer<typeof accountInfoReq>
 
 router.get('/', async (req, res) => {
-  console.log('HERE')
-  if (!check.is(req.query, accountInfoReq)) {
-    return res.status(400).send('Poorly formatted request')
-  }
-  const { did } = req.query
+  const { did } = util.checkReqBody(req.query, accountInfoReq)
   const db = util.getDB(res)
   const accountInfo = await db.getAccountInfo(did)
   res.status(200).send(accountInfo)

--- a/server/src/routes/indexer/count.ts
+++ b/server/src/routes/indexer/count.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { z } from 'zod'
-import { check } from '@bluesky-demo/common'
+import { schema } from '@bluesky-demo/common'
 import * as util from '../../util.js'
 
 const router = express.Router()
@@ -8,17 +8,14 @@ const router = express.Router()
 export const likeCountReq = z.object({
   author: z.string(),
   namespace: z.string(),
-  tid: z.string(),
+  tid: schema.repo.strToTid,
 })
 export type LikeCountReq = z.infer<typeof likeCountReq>
 
 router.get('/likes', async (req, res) => {
-  if (!check.is(req.query, likeCountReq)) {
-    return res.status(400).send('Poorly formatted request')
-  }
-  const { author, namespace, tid } = req.query
+  const { author, namespace, tid } = util.checkReqBody(req.query, likeCountReq)
   const db = util.getDB(res)
-  const count = await db.likeCount(author, namespace, tid)
+  const count = await db.likeCount(author, namespace, tid.toString())
   res.status(200).send({ count })
 })
 

--- a/server/src/routes/indexer/followers.ts
+++ b/server/src/routes/indexer/followers.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { z } from 'zod'
-import { check } from '@bluesky-demo/common'
 import * as util from '../../util.js'
 
 const router = express.Router()
@@ -11,10 +10,7 @@ export const followersReq = z.object({
 export type FollowersReq = z.infer<typeof followersReq>
 
 router.get('/', async (req, res) => {
-  if (!check.is(req.query, followersReq)) {
-    return res.status(400).send('Poorly formatted request')
-  }
-  const { user } = req.query
+  const { user } = util.checkReqBody(req.query, followersReq)
   const db = util.getDB(res)
   const followers = await db.listFollowers(user)
   res.status(200).send(followers)

--- a/server/src/routes/indexer/timeline.ts
+++ b/server/src/routes/indexer/timeline.ts
@@ -1,33 +1,21 @@
 import express from 'express'
 import { z } from 'zod'
-import { check } from '@bluesky-demo/common'
+import { schema } from '@bluesky-demo/common'
 import * as util from '../../util.js'
-import { ServerError } from '../../error.js'
 
 const router = express.Router()
 
 export const getTimelineReq = z.object({
   user: z.string(),
-  count: z.string(),
-  from: z.string().optional(),
+  count: schema.common.strToInt,
+  from: schema.repo.strToTid.optional(),
 })
 export type GetTimelineReq = z.infer<typeof getTimelineReq>
 
 router.get('/', async (req, res) => {
-  if (!check.is(req.query, getTimelineReq)) {
-    return res.status(400).send('Poorly formatted request')
-  }
-  const { user, count, from } = req.query
-  // @TODO: do this with zod. also in list posts & list likes
-  const countParsed = parseInt(count)
-  if (isNaN(countParsed)) {
-    throw new ServerError(
-      400,
-      'Poorly formatted request: `count` is not a number',
-    )
-  }
+  const { user, count, from } = util.checkReqBody(req.query, getTimelineReq)
   const db = util.getDB(res)
-  const timeline = await db.retrieveTimeline(user, countParsed, from)
+  const timeline = await db.retrieveTimeline(user, count, from?.toString())
   res.status(200).send(timeline)
 })
 

--- a/server/src/routes/well-known.ts
+++ b/server/src/routes/well-known.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import { z } from 'zod'
 import { SERVER_DID } from '../server-identity.js'
 import * as util from '../util.js'
 
@@ -9,12 +10,14 @@ router.get('/did.json', (_req, res) => {
   return res.send({ id: SERVER_DID })
 })
 
+const webfingerReq = z.object({
+  resource: z.string(),
+})
+export type WebfingerReq = z.infer<typeof webfingerReq>
+
 // Retrieve a user's DID by their username
 router.get('/webfinger', async (req, res) => {
-  const { resource } = req.query
-  if (typeof resource !== 'string') {
-    return res.status(400).send('Bad param: expected `resource` to be a string')
-  }
+  const { resource } = util.checkReqBody(req.query, webfingerReq)
   const db = util.getDB(res)
   const did = await db.getDidForUser(resource)
   if (!did) {

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -4,6 +4,7 @@ import { Database } from './db/index.js'
 import { SERVER_KEYPAIR } from './server-identity.js'
 import { ServerError } from './error.js'
 import * as ucan from 'ucans'
+import { check } from '@bluesky-demo/common'
 
 export const readReqBytes = async (req: Request): Promise<Uint8Array> => {
   return new Promise((resolve) => {
@@ -17,6 +18,14 @@ export const readReqBytes = async (req: Request): Promise<Uint8Array> => {
       resolve(new Uint8Array(Buffer.concat(chunks)))
     })
   })
+}
+
+export const checkReqBody = <T>(body: unknown, schema: check.Schema<T>): T => {
+  try {
+    return check.assure(schema, body)
+  } catch (err) {
+    throw new ServerError(400, `Poorly formatted request: ${err}`)
+  }
 }
 
 export const getBlockstore = (res: Response): IpldStore => {

--- a/server/test/data.ts
+++ b/server/test/data.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { TID, MicroblogDelegator, Post, Like } from '@bluesky-demo/common'
+import { MicroblogDelegator, Post, Like } from '@bluesky-demo/common'
 
 import { newClient, runTestServer } from './_util.js'
 
@@ -32,55 +32,51 @@ test.serial('id retrieval', async (t) => {
 })
 
 let post: Post
-let postTid: TID
 const postText = 'hello world!'
 
 test.serial('create post', async (t) => {
   post = await alice.addPost(postText)
-  postTid = TID.fromStr(post.tid)
   t.pass('create post successful')
 })
 
 test.serial('get post', async (t) => {
-  const got = await alice.getPost(postTid)
+  const got = await alice.getPost(post.tid)
   t.is(got?.text, postText, 'post matches')
 })
 
 test.serial('edit post', async (t) => {
   const newText = 'howdy universe!'
-  await alice.editPost(postTid, newText)
+  await alice.editPost(post.tid, newText)
   t.pass('edit post successful')
-  const post = await alice.getPost(postTid)
-  t.is(post?.text, newText, 'edited post matches')
+  const got = await alice.getPost(post.tid)
+  t.is(got?.text, newText, 'edited post matches')
 })
 
 let like: Like
-let likeTid: TID
 
 test.serial('create like', async (t) => {
-  like = await bob.likePost(alice.did, postTid)
-  likeTid = TID.fromStr(like.tid)
+  like = await bob.likePost(alice.did, post.tid)
   t.pass('create like successful')
 })
 
 test.serial('list likes', async (t) => {
   const likes = await bob.listLikes(10)
   t.is(likes.length, 1, 'registered like')
-  t.is(likes[0].tid, likeTid.toString(), 'matching tid')
-  t.is(likes[0].post_tid, postTid.toString(), 'matching post tid')
+  t.is(likes[0].tid.toString(), like.tid.toString(), 'matching tid')
+  t.is(likes[0].post_tid.toString(), post.tid.toString(), 'matching post tid')
 })
 
 test.serial('delete like', async (t) => {
-  await bob.deleteLike(likeTid)
+  await bob.deleteLike(like.tid)
   t.pass('delete request successful')
   const likes = await bob.listLikes(10)
   t.is(likes.length, 0, 'properly deleted like')
 })
 
 test.serial('delete post', async (t) => {
-  await alice.deletePost(postTid)
-  const post = await alice.getPost(postTid)
-  t.is(post, null, 'post successfully deleted')
+  await alice.deletePost(post.tid)
+  const got = await alice.getPost(post.tid)
+  t.is(got, null, 'post successfully deleted')
 })
 
 test.serial('follow user', async (t) => {

--- a/server/test/indexer.ts
+++ b/server/test/indexer.ts
@@ -74,7 +74,7 @@ test.serial('get timeline', async (t) => {
 
 test.serial('get old timeline', async (t) => {
   const timeline = await alice.retrieveTimeline(2)
-  const lastSeen = TID.fromStr(timeline[1].tid)
+  const lastSeen = timeline[1].tid
   const oldTimeline = await alice.retrieveTimeline(10, lastSeen)
   const timelineText = oldTimeline.map((p: TimelinePost) => p.text)
   const expected = [
@@ -94,7 +94,7 @@ let post: Post
 
 test.serial('get some likes on your post', async (t) => {
   post = await alice.addPost('hello world!')
-  const tid = TID.fromStr(post.tid)
+  const tid = post.tid
   await bob.likePost(alice.did, tid)
   await carol.likePost(alice.did, tid)
   await dan.likePost(alice.did, tid)
@@ -102,6 +102,6 @@ test.serial('get some likes on your post', async (t) => {
 })
 
 test.serial('count likes on post', async (t) => {
-  const count = await alice.likeCount(alice.did, TID.fromStr(post.tid))
+  const count = await alice.likeCount(alice.did, post.tid)
   t.is(count, 3, 'counted likes')
 })


### PR DESCRIPTION
I introduced the TID type so that we have strong type guarantees around passing TIDs into functions (would like to do this with DIDs, namespaces, etc as well). But after being pulled from ipld store or an http request, they were strings & we then had to check them & transform them in the application logic. 

Added validation & transform to the zod parsing step. Same with integers that are passed in as query params to routes.

Now TIDs are TIDs! Also need to flatten TIDs before sending in a req or adding to blockstore so they are added as strings. There may be a better way to do this that isn't as heavy handed but I just left that as a TODO for now.