### PR TITLE
Ignore conflicts when inserting user_did maps

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -43,7 +43,11 @@ export class Database {
     did: string,
     host: string,
   ): Promise<void> {
-    await this.db.insert({ username, did, host }).into('user_dids')
+    await this.db
+      .insert({ username, did, host })
+      .into('user_dids')
+      .onConflict()
+      .ignore()
   }
 
   async getDidForUser(username: string, host: string): Promise<string | null> {


### PR DESCRIPTION
Fix a conflict error that occurs with repeated follows of a user. Note, this ignores instead of updates the record!