### PR TITLE
Bug fix: mismatched roots

### DIFF
--- a/cli/src/commands/setup/destroy.ts
+++ b/cli/src/commands/setup/destroy.ts
@@ -20,7 +20,7 @@ export default cmd({
       required: true,
       default: false,
     })
-    if (!isSure) {
+    if (!isSure.question) {
       console.log('Exiting without deleting')
       return
     }


### PR DESCRIPTION
There was a bug where the server was updating the root on a post, but erroring out on post-processing (indexing & notifying subscribers). So the cli reported an error & did not update its root. Then each actor had two diverging histories & we don't have a merge/rebase api, so posts were forever broken afterwards.

I changed the POST repo route such that _the last thing_ that the server does is update the root in the DB. This should prevent the client from getting out of sync with the server.

A long term feature that we need is rebasing/merging on diverging histories.

Closes https://github.com/bluesky-social/bluesky-experiment/issues/78