### PR TITLE
Bug fix: Accept numbers as posts

### DIFF
--- a/cli/src/commands/posts/post.ts
+++ b/cli/src/commands/posts/post.ts
@@ -8,7 +8,7 @@ export default cmd({
   help: 'Create a new post.',
   args: [{ name: 'text' }],
   async command(args) {
-    const text = args._[0]
+    const text = String(args._[0])
     const client = await loadClient(REPO_PATH)
     const post = await client.addPost(text)
     const tid = post.tid


### PR DESCRIPTION
CLI was parsing numbers in post text as numbers.

Cast input to a string before posting to server.

Closes https://github.com/bluesky-social/bluesky-experiment/issues/76