### PR TITLE
Setup PLC server with postgres and migrations

### DIFF
--- a/packages/dev-env/src/index.ts
+++ b/packages/dev-env/src/index.ts
@@ -89,7 +89,8 @@ export class DevEnvServer {
         break
       }
       case ServerType.DidPlaceholder: {
-        const db = await plc.Database.memory().createTables()
+        const db = plc.Database.memory()
+        await db.migrateToLatestOrThrow()
         this.inst = await onServerReady(plc.server(db, this.port))
         break
       }

--- a/packages/did-resolver/tests/resolver.test.ts
+++ b/packages/did-resolver/tests/resolver.test.ts
@@ -25,7 +25,7 @@ describe('resolver', () => {
     })
 
     const plcDB = DidPlcDb.memory()
-    await plcDB.createTables()
+    await plcDB.migrateToLatestOrThrow()
     const plcPort = await getPort()
     const plcServer = await runPlcServer(plcDB, plcPort)
 

--- a/packages/plc/bin/migration-create.ts
+++ b/packages/plc/bin/migration-create.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env ts-node
+
+import * as fs from 'fs/promises'
+import * as path from 'path'
+
+export async function main() {
+  const now = new Date()
+  const prefix = now.toISOString().replace(/[^a-z0-9]/gi, '') // Order of migrations matches alphabetical order of their names
+  const name = process.argv[2]
+  if (!name || !name.match(/^[a-z0-9-]+$/)) {
+    process.exitCode = 1
+    return console.error(
+      'Must pass a migration name consisting of lowercase digits, numbers, and dashes.',
+    )
+  }
+  const filename = `${prefix}-${name}`
+  const dir = path.join(__dirname, '..', 'src', 'server', 'migrations')
+
+  await fs.writeFile(path.join(dir, `${filename}.ts`), template, { flag: 'wx' })
+  await fs.writeFile(
+    path.join(dir, 'index.ts'),
+    `export * as _${prefix} from './${filename}'\n`,
+    { flag: 'a' },
+  )
+}
+
+const template = `import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Migration code
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Migration code
+}
+`
+
+main()

--- a/packages/plc/build.js
+++ b/packages/plc/build.js
@@ -13,10 +13,11 @@ require('esbuild')
     platform: 'node',
     assetNames: 'src/static',
     external: [
-      './node_modules/better-sqlite3/*',
-      '../../node_modules/better-sqlite3/*',
+      'better-sqlite3',
       '../../node_modules/level/*',
       '../../node_modules/classic-level/*',
+      // Referenced in pg driver, but optional and we don't use it
+      'pg-native',
     ],
   })
   .catch(() => process.exit(1))

--- a/packages/plc/package.json
+++ b/packages/plc/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node dist/bin.js",
     "test": "jest",
+    "test:pg": "../pg/with-test-db.sh jest",
     "test:log": "cat test.log | pino-pretty",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
@@ -29,12 +30,14 @@
     "express": "^4.17.2",
     "express-async-errors": "^3.1.1",
     "kysely": "^0.22.0",
+    "pg": "^8.8.0",
     "pino": "^8.6.1",
     "pino-http": "^8.2.1",
     "uint8arrays": "3.0.0",
     "zod": "^3.14.2"
   },
   "devDependencies": {
+    "@types/pg": "^8.6.5",
     "eslint-plugin-prettier": "^4.2.1",
     "get-port": "^6.1.2"
   }

--- a/packages/plc/package.json
+++ b/packages/plc/package.json
@@ -16,7 +16,8 @@
     "verify:fix": "yarn prettier:fix && yarn lint:fix",
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
-    "low": "node dist/scripts/low_pid.js"
+    "low": "node dist/scripts/low_pid.js",
+    "migration:create": "ts-node ./bin/migration-create.ts"
   },
   "dependencies": {
     "@atproto/common": "*",

--- a/packages/plc/src/bin.ts
+++ b/packages/plc/src/bin.ts
@@ -22,6 +22,8 @@ const run = async () => {
     db = Database.memory()
   }
 
+  await db.migrateToLatestOrThrow()
+
   const envPort = parseInt(process.env.PORT || '')
   const port = isNaN(envPort) ? 2582 : envPort
 

--- a/packages/plc/src/bin.ts
+++ b/packages/plc/src/bin.ts
@@ -10,12 +10,16 @@ const run = async () => {
     dotenv.config()
   }
 
-  let db: Database
   const dbLoc = process.env.DATABASE_LOC
-  if (dbLoc) {
-    db = await Database.sqlite(dbLoc)
+  const dbPostgresUrl = process.env.DB_POSTGRES_URL
+
+  let db: Database
+  if (dbPostgresUrl) {
+    db = Database.postgres({ url: dbPostgresUrl })
+  } else if (dbLoc) {
+    db = Database.sqlite(dbLoc)
   } else {
-    db = await Database.memory()
+    db = Database.memory()
   }
 
   const envPort = parseInt(process.env.PORT || '')

--- a/packages/plc/src/server/migrations/20221020T204908820Z-operations-init.ts
+++ b/packages/plc/src/server/migrations/20221020T204908820Z-operations-init.ts
@@ -1,0 +1,17 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('operations')
+    .addColumn('did', 'varchar', (col) => col.notNull())
+    .addColumn('operation', 'text', (col) => col.notNull())
+    .addColumn('cid', 'varchar', (col) => col.notNull())
+    .addColumn('nullified', 'int2', (col) => col.defaultTo(0))
+    .addColumn('createdAt', 'varchar', (col) => col.notNull())
+    .addPrimaryKeyConstraint('primary_key', ['did', 'cid'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('operations').execute()
+}

--- a/packages/plc/src/server/migrations/index.ts
+++ b/packages/plc/src/server/migrations/index.ts
@@ -1,1 +1,5 @@
+// NOTE this file can be edited by hand, but it is also appended to by the migrations:create command.
+// It's important that every migration is exported from here with the proper name. We'd simplify
+// this with kysely's FileMigrationProvider, but it doesn't play nicely with the build process.
+
 export * as _20221020T204908820Z from './20221020T204908820Z-operations-init'

--- a/packages/plc/src/server/migrations/index.ts
+++ b/packages/plc/src/server/migrations/index.ts
@@ -1,0 +1,1 @@
+export * as _20221020T204908820Z from './20221020T204908820Z-operations-init'

--- a/packages/plc/tests/server.test.ts
+++ b/packages/plc/tests/server.test.ts
@@ -24,7 +24,10 @@ describe('PLC server', () => {
     let port: number
     if (USE_TEST_SERVER) {
       port = await getPort()
-      closeFn = await util.runTestServer(port)
+      closeFn = await util.runTestServer({
+        port,
+        dbPostgresSchema: 'server',
+      })
     } else {
       port = 2582
     }

--- a/packages/plc/tests/util.ts
+++ b/packages/plc/tests/util.ts
@@ -12,13 +12,13 @@ export const runTestServer = async (opts: {
 
   const db =
     dbPostgresUrl !== undefined
-      ? await Database.postgres({
+      ? Database.postgres({
           url: dbPostgresUrl,
           schema: dbPostgresSchema,
         })
-      : await Database.memory()
+      : Database.memory()
 
-  await db.createTables()
+  await db.migrateToLatestOrThrow()
   const s = server(db, port)
   return async () => {
     await db.close()

--- a/packages/plc/tests/util.ts
+++ b/packages/plc/tests/util.ts
@@ -3,8 +3,21 @@ import Database from '../src/server/db'
 
 export type CloseFn = () => Promise<void>
 
-export const runTestServer = async (port: number): Promise<CloseFn> => {
-  const db = Database.memory()
+export const runTestServer = async (opts: {
+  port: number
+  dbPostgresSchema: string
+}): Promise<CloseFn> => {
+  const { port, dbPostgresSchema } = opts
+  const dbPostgresUrl = process.env.DB_POSTGRES_URL || undefined
+
+  const db =
+    dbPostgresUrl !== undefined
+      ? await Database.postgres({
+          url: dbPostgresUrl,
+          schema: dbPostgresSchema,
+        })
+      : await Database.memory()
+
   await db.createTables()
   const s = server(db, port)
   return async () => {

--- a/packages/server/tests/_util.ts
+++ b/packages/server/tests/_util.ts
@@ -27,7 +27,8 @@ export const runTestServer = async (
   // run plc server
   const plcPort = await getPort()
   const plcUrl = `http://localhost:${plcPort}`
-  const plcDb = await plc.Database.memory().createTables()
+  const plcDb = plc.Database.memory()
+  await plcDb.migrateToLatestOrThrow()
   const plcServer = plc.server(plcDb, plcPort)
 
   // setup server did


### PR DESCRIPTION
The PLC server now supports the postgres dialect.  Also sets-up a system for managing incremental db migrations.  Some of this will be a little easier to review while ignoring whitespace.