### PR TITLE
Transactional invite code use, username/email creation

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
     "start": "node dist/bin.js",
-    "test": "jest tests/crud.test.ts",
+    "test": "jest",
     "test:pg": "../pg/with-test-db.sh yarn test",
     "test:log": "cat test.log | pino-pretty",
     "test:updateSnapshot": "jest --updateSnapshot",

--- a/packages/server/src/db/tables/user.ts
+++ b/packages/server/src/db/tables/user.ts
@@ -27,6 +27,18 @@ export const createTable = async (
     .addColumn('lastSeenNotifs', 'varchar', (col) => col.notNull())
     .addColumn('createdAt', 'varchar', (col) => col.notNull())
     .execute()
+  await db.schema
+    .createIndex(`${tableName}_username_lower_idx`)
+    .unique()
+    .on(tableName)
+    .expression(sql`lower("username")`)
+    .execute()
+  await db.schema
+    .createIndex(`${tableName}_email_lower_idx`)
+    .unique()
+    .on(tableName)
+    .expression(sql`lower("email")`)
+    .execute()
   if (dialect === 'pg') {
     await db.schema // Supports user search
       .createIndex(`${tableName}_username_tgrm_idx`)

--- a/packages/server/src/db/util.ts
+++ b/packages/server/src/db/util.ts
@@ -34,22 +34,6 @@ export const paginate = <QB extends SelectQueryBuilder<any, any, any>>(
     .if(opts.before !== undefined, (q) => q.where(opts.by, '<', opts.before))
 }
 
-// Useful to select values in a conditional insert
-export const selectValues = <EB extends ExpressionBuilder<any, any>>(
-  eb: EB,
-  vals: unknown[],
-) => {
-  return eb.selectFrom(sql`(values (${sql.join(vals)}))`.as('vals')).selectAll()
-}
-
-export const keys = <O extends { [s: string]: unknown }>(obj: O) => {
-  return Object.keys(obj) as (keyof O)[]
-}
-
-export const vals = <O extends { [s: string]: unknown }>(obj: O) => {
-  return Object.values(obj)
-}
-
 export const dummyDialect = {
   createAdapter() {
     return new SqliteAdapter()


### PR DESCRIPTION
Picking-up from https://github.com/bluesky-social/atproto/pull/245#discussion_r1001288568, I wanted to throw out a couple options for avoiding a. double-spends of invite codes w/o a table lock and b. multiple users claiming the same username or email.

For the first one, I think we can replace the table lock for invite_code_use with a row lock on the invite_code itself.  That should be a bit more granular, allowing different invite codes to be used in parallel without blocking each other.  I did this using a `SELECT FOR UPDATE` on postgres.  On sqlite this isn't needed since the transactions are already serialized.

The test for races for username was relying on the invite_code_use table lock.  I changed the test to show what happens when the users trying to claim the same username aren't using the same invite code, and as expected it exposed a race.  I think enforcing uniqueness of username/email is best enforced at the database level using a uniqueness constraint.  So I added that constraint into the db, and when creating the user added an `ON CONFLICT DO NOTHING`.  We can detect whether the insert was successful by checking if there was any result of the insert (this was just a bit more convenient to code around versus surfacing the a uniqueness constraint error).

Thanks for surfacing these issues @dholms 🙏 🙏  All good to take these changes as-is, not take them at all, or adapt them— mostly just wanted to get these options out there and expose the username race!