### PR TITLE
Basic CI

### DIFF
--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -1,0 +1,33 @@
+name: repo
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn verify

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atp",
   "version": "0.0.1",
-  "repository": "git@github.com:bluesky-social/atp.git",
+  "repository": "git@github.com:bluesky-social/atproto.git",
   "author": "Bluesky PBLLC <hello@blueskyweb.xyz>",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Hello again & congrats on the atproto release!  

I noticed that CI, which I originally added in https://github.com/bluesky-social/atproto/pull/120, went away in a11c1754a2aa5126e2662cb1e92813913a52bc51 -- so this commit adds it again, but more simply now: just calling the top level monorepo scripts: `build`, `test`, `verify`.

As of this writing, `verify` and `test` are failing on my branch: https://github.com/harlantwood/adx/actions/runs/3306753316 

My suggestion is to merge this PR first, as it just gives visibility into the current state, and then merge fixes for those issues; but happy to rebase if you prefer to do fixes first.