### PR TITLE
Miscellaneous dep and build fixes

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@atproto/crypto": "*",
+    "@atproto/did-resolver": "*",
     "@ucans/core": "0.11.0",
     "uint8arrays": "3.0.0"
   }

--- a/packages/dev-env/build.js
+++ b/packages/dev-env/build.js
@@ -8,9 +8,8 @@ require('esbuild')
     outdir: 'dist',
     platform: 'node',
     external: [
-      '../plc/node_modules/better-sqlite3/*',
-      '../pds/node_modules/better-sqlite3/*',
-      '../../node_modules/classic-level/*',
+      'better-sqlite3',
+      'classic-level',
       // Referenced in pg driver, but optional and we don't use it
       'pg-native',
     ],

--- a/packages/pds/build.js
+++ b/packages/pds/build.js
@@ -9,8 +9,8 @@ require('esbuild')
     platform: 'node',
     external: [
       'better-sqlite3',
-      '../../node_modules/level/*',
-      '../../node_modules/classic-level/*',
+      'level',
+      'classic-level',
       // Referenced in pg driver, but optional and we don't use it
       'pg-native',
     ],

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -29,6 +29,7 @@
     "@atproto/plc": "*",
     "@atproto/repo": "*",
     "@atproto/uri": "*",
+    "@atproto/xrpc-server": "*",
     "@hapi/bourne": "^3.0.0",
     "better-sqlite3": "^7.6.2",
     "cors": "^2.8.5",

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -30,7 +30,7 @@ export interface ServerConfigValues {
 export class ServerConfig {
   constructor(private cfg: ServerConfigValues) {}
 
-  static readEnv() {
+  static readEnv(overrides?: Partial<ServerConfig>) {
     const debugMode = process.env.DEBUG_MODE === '1'
 
     const hostname = process.env.HOSTNAME || 'localhost'
@@ -47,10 +47,10 @@ export class ServerConfig {
 
     const didPlcUrl = process.env.DID_PLC_URL || 'http://localhost:2582'
 
-    if (typeof process.env.RECOVERY_KEY !== 'string') {
+    const recoveryKey = overrides?.recoveryKey || process.env.RECOVERY_KEY
+    if (typeof recoveryKey !== 'string') {
       throw new Error('No value provided for process.env.RECOVERY_KEY')
     }
-    const recoveryKey = process.env.RECOVERY_KEY
 
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin'
 
@@ -90,6 +90,7 @@ export class ServerConfig {
       appUrlPasswordReset,
       emailSmtpUrl,
       emailNoReplyAddress,
+      ...overrides,
     })
   }
 

--- a/packages/plc/build.js
+++ b/packages/plc/build.js
@@ -14,8 +14,8 @@ require('esbuild')
     assetNames: 'src/static',
     external: [
       'better-sqlite3',
-      '../../node_modules/level/*',
-      '../../node_modules/classic-level/*',
+      'level',
+      'classic-level',
       // Referenced in pg driver, but optional and we don't use it
       'pg-native',
     ],

--- a/packages/repo/build.js
+++ b/packages/repo/build.js
@@ -1,7 +1,7 @@
 require('esbuild')
   .build({
     logLevel: 'info',
-    entryPoints: ['src/bin.ts'],
+    entryPoints: ['src/index.ts'],
     bundle: true,
     outdir: 'dist',
     platform: 'node',

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "yarn lint --fix",
     "verify": "run-p prettier lint",
     "verify:fix": "yarn prettier:fix && yarn lint:fix",
-    "build": "esbuild src/index.ts --define:process.env.NODE_ENV=\\\"production\\\" --bundle --platform=node --sourcemap --outfile=dist/index.js",
+    "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json"
   },
   "dependencies": {


### PR DESCRIPTION
Just a little of this and that:
 - Changing the leveldb externals for builds to use the same convention we started using for sqlite in #249, which is a little simpler to configure and works equally well or better.
 - Add a build script to the repo package in order to list leveldb externals.
 - Add some missing dependencies to packages, e.g. auth depends on did-resolver, so did-resolver has been added to auth's package.json.
 - Support config overrides when using pds's `ServerConfig.readEnv()`.