### PR TITLE
Fix a couple build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,7 @@
     ],
     "nohoist": [
       "**/ipld-hashmap",
-      "**/ipld-hashmap/**",
-      "**/better-sqlite3",
-      "**/better-sqlite3/**"
+      "**/ipld-hashmap/**"
     ]
   }
 }

--- a/packages/dev-env/build.js
+++ b/packages/dev-env/build.js
@@ -8,9 +8,8 @@ require('esbuild')
     outdir: 'dist',
     platform: 'node',
     external: [
-      '../plc/node_modules/better-sqlite3/*',
-      '../pds/node_modules/better-sqlite3/*',
-      '../../node_modules/classic-level/*',
+      'better-sqlite3',
+      'classic-level',
       // Referenced in pg driver, but optional and we don't use it
       'pg-native',
     ],

--- a/packages/dev-env/build.js
+++ b/packages/dev-env/build.js
@@ -8,8 +8,9 @@ require('esbuild')
     outdir: 'dist',
     platform: 'node',
     external: [
-      'better-sqlite3',
-      'classic-level',
+      '../plc/node_modules/better-sqlite3/*',
+      '../pds/node_modules/better-sqlite3/*',
+      '../../node_modules/classic-level/*',
       // Referenced in pg driver, but optional and we don't use it
       'pg-native',
     ],

--- a/packages/pds/src/bin.ts
+++ b/packages/pds/src/bin.ts
@@ -20,6 +20,9 @@ const run = async () => {
   let blockstore: IpldStore
   let db: Database
 
+  const keypair = await crypto.EcdsaKeypair.create()
+  process.env.RECOVERY_KEY = keypair.did()
+
   const cfg = ServerConfig.readEnv()
 
   if (cfg.blockstoreLocation) {
@@ -40,8 +43,6 @@ const run = async () => {
   }
 
   await db.migrateToLatestOrThrow()
-
-  const keypair = await crypto.EcdsaKeypair.create()
 
   const { listener } = server(blockstore, db, keypair, cfg)
   listener.on('listening', () => {

--- a/packages/pds/src/bin.ts
+++ b/packages/pds/src/bin.ts
@@ -21,9 +21,7 @@ const run = async () => {
   let db: Database
 
   const keypair = await crypto.EcdsaKeypair.create()
-  process.env.RECOVERY_KEY = keypair.did()
-
-  const cfg = ServerConfig.readEnv()
+  const cfg = ServerConfig.readEnv({ recoveryKey: keypair.did() })
 
   if (cfg.blockstoreLocation) {
     blockstore = new PersistentBlockstore(cfg.blockstoreLocation)


### PR DESCRIPTION
Two things:
- external dependency issue in: https://github.com/bluesky-social/atproto/issues/274
  - the problem here being that `dev-env` doesn't install `better-sqlite3` itself & so needs to reference the location where it is _actually_ installed
- we weren't supply the required env variables in server/bin. For this simple setup it just sets the recovery did to the signing key