### PR TITLE
Dont reexport CID type

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -8,9 +8,6 @@ const cid = z
   })
   .transform((obj: unknown) => mf.CID.asCID(obj) as mf.CID)
 
-// const cid = z.instanceof(mf.CID)
-export type CID = z.infer<typeof cid>
-
 export const isCid = (str: string): boolean => {
   try {
     mf.CID.parse(str)

--- a/packages/pds/src/db/records/repost.ts
+++ b/packages/pds/src/db/records/repost.ts
@@ -3,7 +3,7 @@ import { AtUri } from '@atproto/uri'
 import * as Repost from '../../lexicon/types/app/bsky/repost'
 import { DbRecordPlugin, Notification } from '../types'
 import * as schemas from '../schemas'
-import { CID } from '@atproto/common'
+import { CID } from 'multiformats/cid'
 
 const type = schemas.ids.AppBskyRepost
 const tableName = 'app_bsky_repost'


### PR DESCRIPTION
This is the correct type, but it's not the `multiformats` class & doesn't give static methods.

Tired of code completion assuming I wanted this type when I want the multiformats one