### PR TITLE
Misc HTTP error fixes

### DIFF
--- a/packages/pds/src/error.ts
+++ b/packages/pds/src/error.ts
@@ -1,7 +1,12 @@
-import { Request, Response } from 'express'
+import { InternalServerError } from '@atproto/xrpc-server'
+import { ErrorRequestHandler } from 'express'
 import { httpLogger as log } from './logger'
 
-export const handler = (err: Error, _req: Request, res: Response) => {
-  log.error({ err }, 'unexpected internal server error')
-  res.status(500).send(err.message)
+export const handler: ErrorRequestHandler = (err, _req, res, next) => {
+  log.error(err, 'unexpected internal server error')
+  if (res.headersSent) {
+    return next(err)
+  }
+  const internalErr = new InternalServerError()
+  res.status(internalErr.type).json(internalErr.payload)
 }

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -1,7 +1,6 @@
 import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
 import * as Post from '@atproto/api/src/types/app/bsky/post'
 import { AtUri } from '@atproto/uri'
-import { response } from 'express'
 import { CloseFn, paginateAll, runTestServer } from './_util'
 
 const alice = {

--- a/packages/pds/tests/server.test.ts
+++ b/packages/pds/tests/server.test.ts
@@ -1,0 +1,44 @@
+import { CloseFn, runTestServer, TestServerInfo } from './_util'
+import axios, { AxiosError } from 'axios'
+
+describe('server', () => {
+  let server: TestServerInfo
+  let close: CloseFn
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'server',
+    })
+    close = server.close
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('preserves 404s.', async () => {
+    const promise = axios.get(`${server.url}/unknown`)
+    await expect(promise).rejects.toThrow('failed with status code 404')
+  })
+
+  it('turns unknown errors into 500s.', async () => {
+    // Sneak a new, failing route in before the server's error handler
+    const errorHandler = server.app._router.stack.pop()
+    server.app.get('/oops', () => {
+      throw new Error('Oops!')
+    })
+    server.app._router.stack.push(errorHandler)
+
+    const promise = axios.get(`${server.url}/oops`)
+    await expect(promise).rejects.toThrow('failed with status code 500')
+    try {
+      await promise
+    } catch (err: unknown) {
+      const axiosError = err as AxiosError
+      expect(axiosError.response?.status).toEqual(500)
+      expect(axiosError.response?.data).toEqual({
+        message: 'Internal Server Error',
+      })
+    }
+  })
+})

--- a/packages/plc/src/server/error.ts
+++ b/packages/plc/src/server/error.ts
@@ -1,13 +1,20 @@
 import { ErrorRequestHandler } from 'express'
 import * as locals from './locals'
 
-export const handler: ErrorRequestHandler = (err, _req, res, _next) => {
+export const handler: ErrorRequestHandler = (err, _req, res, next) => {
   const { logger } = locals.get(res)
+  logger.info(
+    err,
+    ServerError.is(err)
+      ? 'handled server error'
+      : 'unexpected internal server error',
+  )
+  if (res.headersSent) {
+    return next(err)
+  }
   if (ServerError.is(err)) {
-    logger.info(err, 'handled server error')
     return res.status(err.status).json({ message: err.message })
   } else {
-    logger.error(err, 'unexpected internal server error')
     return res.status(500).json({ message: 'Internal Server Error' })
   }
 }

--- a/packages/plc/src/server/error.ts
+++ b/packages/plc/src/server/error.ts
@@ -1,22 +1,15 @@
-import { Request, Response, NextFunction } from 'express'
+import { ErrorRequestHandler } from 'express'
 import * as locals from './locals'
 
-export const handler = (
-  err: Error,
-  _req: Request,
-  res: Response,
-  _next: NextFunction,
-) => {
+export const handler: ErrorRequestHandler = (err, _req, res, _next) => {
   const { logger } = locals.get(res)
-  let status
   if (ServerError.is(err)) {
-    status = err.status
     logger.info(err, 'handled server error')
+    return res.status(err.status).json({ message: err.message })
   } else {
-    status = 500
     logger.error(err, 'unexpected internal server error')
+    return res.status(500).json({ message: 'Internal Server Error' })
   }
-  res.status(status).send(err.message)
 }
 
 export class ServerError extends Error {

--- a/packages/plc/src/server/routes.ts
+++ b/packages/plc/src/server/routes.ts
@@ -9,7 +9,7 @@ const router = express.Router()
 
 // Get data for a DID document
 router.get(`/:did`, async function (req, res) {
-  const did = decodeURIComponent(req.params.did)
+  const { did } = req.params
   const { db } = locals.get(res)
   const log = await db.opsForDid(did)
   if (log.length === 0) {
@@ -23,7 +23,7 @@ router.get(`/:did`, async function (req, res) {
 
 // Get data for a DID document
 router.get(`/data/:did`, async function (req, res) {
-  const did = decodeURIComponent(req.params.did)
+  const { did } = req.params
   const { db } = locals.get(res)
   const log = await db.opsForDid(did)
   if (log.length === 0) {
@@ -35,7 +35,7 @@ router.get(`/data/:did`, async function (req, res) {
 
 // Get operation log for a DID
 router.get(`/log/:did`, async function (req, res) {
-  const did = decodeURIComponent(req.params.did)
+  const { did } = req.params
   const { db } = locals.get(res)
   const log = await db.opsForDid(did)
   if (log.length === 0) {
@@ -46,7 +46,7 @@ router.get(`/log/:did`, async function (req, res) {
 
 // Update or create a DID doc
 router.post(`/:did`, async function (req, res) {
-  const did = decodeURIComponent(req.params.did)
+  const { did } = req.params
   const op = req.body
   if (!check.is(op, t.def.operation)) {
     throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -159,13 +159,10 @@ export class Server {
           message: outputUnvalidated.message,
         })
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       if (e instanceof XRPCError) {
         log.info(e, `error in xrpc method ${req.params.methodId}`)
-        res.status(e.type).json({
-          error: e.customErrorName,
-          message: e.errorMessage || e.typeStr,
-        })
+        res.status(e.type).json(e.payload)
       } else {
         log.error(
           e,

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -41,7 +41,14 @@ export class XRPCError extends Error {
     super(errorMessage)
   }
 
-  get typeStr() {
+  get payload() {
+    return {
+      error: this.customErrorName,
+      message: this.errorMessage || this.typeStr,
+    }
+  }
+
+  get typeStr(): string | undefined {
     return ResponseTypeStrings[this.type]
   }
 }


### PR DESCRIPTION
A few little http fixes in here:
 - Avoid double-decoding route params in PLC.
 - Avoid including error details from unexpected errors.
 - Do not reflect user input into HTML output on PLC, move to JSON error responses on PLC.
 - Check if headers are already sent in http error handlers.
 - Fix an issue where 404s were turning into 500s on the PDS, resolves #273.