### PR TITLE
Add public url config to pds for setting did service endpoint

### DIFF
--- a/packages/pds/src/api/com/atproto/account.ts
+++ b/packages/pds/src/api/com/atproto/account.ts
@@ -129,7 +129,7 @@ export default function (server: Server) {
           keypair,
           recoveryKey || config.recoveryKey,
           username,
-          config.origin,
+          config.publicUrl,
         )
       } catch (err) {
         logger.error(

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -1,6 +1,7 @@
 export interface ServerConfigValues {
   debugMode?: boolean
 
+  publicUrl?: string
   scheme: string
   port: number
   hostname: string
@@ -33,6 +34,7 @@ export class ServerConfig {
   static readEnv(overrides?: Partial<ServerConfig>) {
     const debugMode = process.env.DEBUG_MODE === '1'
 
+    const publicUrl = process.env.PUBLIC_URL || undefined
     const hostname = process.env.HOSTNAME || 'localhost'
     let scheme
     if ('TLS' in process.env) {
@@ -74,6 +76,7 @@ export class ServerConfig {
 
     return new ServerConfig({
       debugMode,
+      publicUrl,
       scheme,
       hostname,
       port,
@@ -115,7 +118,10 @@ export class ServerConfig {
     return u.origin
   }
 
-  // @TODO should protect this better
+  get publicUrl() {
+    return this.cfg.publicUrl || this.origin
+  }
+
   get dbPostgresUrl() {
     return this.cfg.dbPostgresUrl
   }
@@ -124,7 +130,6 @@ export class ServerConfig {
     return this.cfg.dbPostgresSchema
   }
 
-  // @TODO should protect this better
   get jwtSecret() {
     return this.cfg.jwtSecret
   }

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -46,6 +46,7 @@ export const runTestServer = async (
     testNameRegistry: {},
     appUrlPasswordReset: 'app://forgot-password',
     emailNoReplyAddress: 'noreply@blueskyweb.xyz',
+    publicUrl: 'https://pds.public.url',
     dbPostgresUrl: process.env.DB_POSTGRES_URL,
     ...params,
   })

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -144,7 +144,7 @@ describe('account', () => {
     expect(didData.username).toBe(username)
     expect(didData.signingKey).toBe(serverKey)
     expect(didData.recoveryKey).toBe(cfg.recoveryKey)
-    expect(didData.atpPds).toBe(serverUrl)
+    expect(didData.atpPds).toBe('https://pds.public.url') // Mapped from publicUrl
   })
 
   it('allows a custom set recovery key', async () => {


### PR DESCRIPTION
The PDS's `origin` is enough to locate the service relative to the machine/network it's running on, but for the purposes of setting service endpoints in a did doc, the PDS also needs to know its public URL if it has one.  This ensures the public URL makes its way into the did doc when present.