### PR TITLE
Fix PDS readme link

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -2,7 +2,7 @@
 
 ## Applications
 
-- [Server](./server): The Personal Data Server (PDS). This is ATP's main server-side implementation.
+- [PDS](./pds): The Personal Data Server (PDS). This is ATP's main server-side implementation.
 - [Dev Env](./dev-env): A command-line application for developers to construct and manage development environments.
 - [Lexicon CLI](./lex-cli/): A command-line application for generating code and documentation from Lexicon schemas.
 - [CLI](./cli): A command-line application for interacting with ATP. (Currently not maintained, and in need of updates.)


### PR DESCRIPTION
Fixes a link in the packages readme, directing server/ instead to pds/.  Resolves #284 