### PR TITLE
Session refresh token for PDS

### DIFF
--- a/lexicons/atproto.com/createAccount.json
+++ b/lexicons/atproto.com/createAccount.json
@@ -22,9 +22,10 @@
     "encoding": "application/json",
     "schema": {
       "type": "object",
-      "required": ["jwt", "username", "did"],
+      "required": ["accessJwt", "refreshJwt", "username", "did"],
       "properties": {
-        "jwt": { "type": "string" },
+        "accessJwt": { "type": "string" },
+        "refreshJwt": { "type": "string" },
         "username": { "type": "string" },
         "did": { "type": "string" }
       }

--- a/lexicons/atproto.com/deleteSession.json
+++ b/lexicons/atproto.com/deleteSession.json
@@ -3,13 +3,8 @@
   "id": "com.atproto.deleteSession",
   "type": "procedure",
   "description": "Delete the current session.",
-  "parameters": {},
-  "input": {
-    "encoding": "",
-    "schema": {}
-  },
   "output": {
-    "encoding": "",
+    "encoding": "application/json",
     "schema": {}
   }
 }

--- a/lexicons/atproto.com/refreshSession.json
+++ b/lexicons/atproto.com/refreshSession.json
@@ -1,20 +1,8 @@
 {
   "lexicon": 1,
-  "id": "com.atproto.createSession",
+  "id": "com.atproto.refreshSession",
   "type": "procedure",
-  "description": "Create an authentication session.",
-  "parameters": {},
-  "input": {
-    "encoding": "application/json",
-    "schema": {
-      "type": "object",
-      "required": ["username", "password"],
-      "properties": {
-        "username": {"type": "string"},
-        "password": {"type": "string"}
-      }
-    }
-  },
+  "description": "Refresh an authentication session.",
   "output": {
     "encoding": "application/json",
     "schema": {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,6 +14,7 @@ import * as ComAtprotoDeleteSession from './types/com/atproto/deleteSession'
 import * as ComAtprotoGetAccount from './types/com/atproto/getAccount'
 import * as ComAtprotoGetAccountsConfig from './types/com/atproto/getAccountsConfig'
 import * as ComAtprotoGetSession from './types/com/atproto/getSession'
+import * as ComAtprotoRefreshSession from './types/com/atproto/refreshSession'
 import * as ComAtprotoRepoBatchWrite from './types/com/atproto/repoBatchWrite'
 import * as ComAtprotoRepoCreateRecord from './types/com/atproto/repoCreateRecord'
 import * as ComAtprotoRepoDeleteRecord from './types/com/atproto/repoDeleteRecord'
@@ -60,6 +61,7 @@ export * as ComAtprotoDeleteSession from './types/com/atproto/deleteSession'
 export * as ComAtprotoGetAccount from './types/com/atproto/getAccount'
 export * as ComAtprotoGetAccountsConfig from './types/com/atproto/getAccountsConfig'
 export * as ComAtprotoGetSession from './types/com/atproto/getSession'
+export * as ComAtprotoRefreshSession from './types/com/atproto/refreshSession'
 export * as ComAtprotoRepoBatchWrite from './types/com/atproto/repoBatchWrite'
 export * as ComAtprotoRepoCreateRecord from './types/com/atproto/repoCreateRecord'
 export * as ComAtprotoRepoDeleteRecord from './types/com/atproto/repoDeleteRecord'
@@ -241,6 +243,18 @@ export class AtprotoNS {
       .call('com.atproto.getSession', params, data, opts)
       .catch((e) => {
         throw ComAtprotoGetSession.toKnownErr(e)
+      })
+  }
+
+  refreshSession(
+    params: ComAtprotoRefreshSession.QueryParams,
+    data?: ComAtprotoRefreshSession.InputSchema,
+    opts?: ComAtprotoRefreshSession.CallOptions
+  ): Promise<ComAtprotoRefreshSession.Response> {
+    return this._service.xrpc
+      .call('com.atproto.refreshSession', params, data, opts)
+      .catch((e) => {
+        throw ComAtprotoRefreshSession.toKnownErr(e)
       })
   }
 

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -39,9 +39,12 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['jwt', 'username', 'did'],
+        required: ['accessJwt', 'refreshJwt', 'username', 'did'],
         properties: {
-          jwt: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
             type: 'string',
           },
           username: {
@@ -128,9 +131,12 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['jwt', 'name', 'did'],
+        required: ['accessJwt', 'refreshJwt', 'name', 'did'],
         properties: {
-          jwt: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
             type: 'string',
           },
           name: {
@@ -168,15 +174,8 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.deleteSession',
     type: 'procedure',
     description: 'Delete the current session.',
-    parameters: {},
-    input: {
-      encoding: '',
-      schema: {
-        $defs: {},
-      },
-    },
     output: {
-      encoding: '',
+      encoding: 'application/json',
       schema: {
         $defs: {},
       },
@@ -240,6 +239,34 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         type: 'object',
         required: ['name', 'did'],
         properties: {
+          name: {
+            type: 'string',
+          },
+          did: {
+            type: 'string',
+          },
+        },
+        $defs: {},
+      },
+    },
+  },
+  'com.atproto.refreshSession': {
+    lexicon: 1,
+    id: 'com.atproto.refreshSession',
+    type: 'procedure',
+    description: 'Refresh an authentication session.',
+    output: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['accessJwt', 'refreshJwt', 'name', 'did'],
+        properties: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
+            type: 'string',
+          },
           name: {
             type: 'string',
           },
@@ -2397,7 +2424,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              required: ['did', 'name', 'createdAt', 'indexedAt'],
+              required: ['did', 'name'],
               properties: {
                 did: {
                   type: 'string',
@@ -2411,10 +2438,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 },
                 description: {
                   type: 'string',
-                },
-                createdAt: {
-                  type: 'string',
-                  format: 'date-time',
                 },
                 indexedAt: {
                   type: 'string',

--- a/packages/api/src/types/app/bsky/getUsersSearch.ts
+++ b/packages/api/src/types/app/bsky/getUsersSearch.ts
@@ -22,8 +22,7 @@ export interface OutputSchema {
     name: string,
     displayName?: string,
     description?: string,
-    createdAt: string,
-    indexedAt: string,
+    indexedAt?: string,
   }[];
 }
 

--- a/packages/api/src/types/com/atproto/createAccount.ts
+++ b/packages/api/src/types/com/atproto/createAccount.ts
@@ -19,7 +19,8 @@ export interface InputSchema {
 }
 
 export interface OutputSchema {
-  jwt: string;
+  accessJwt: string;
+  refreshJwt: string;
   username: string;
   did: string;
 }

--- a/packages/api/src/types/com/atproto/deleteSession.ts
+++ b/packages/api/src/types/com/atproto/deleteSession.ts
@@ -7,12 +7,9 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
-  encoding: '';
 }
 
-export interface InputSchema {
-  [k: string]: unknown;
-}
+export type InputSchema = undefined
 
 export interface OutputSchema {
   [k: string]: unknown;

--- a/packages/api/src/types/com/atproto/refreshSession.ts
+++ b/packages/api/src/types/com/atproto/refreshSession.ts
@@ -7,13 +7,9 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
-  encoding: 'application/json';
 }
 
-export interface InputSchema {
-  username: string;
-  password: string;
-}
+export type InputSchema = undefined
 
 export interface OutputSchema {
   accessJwt: string;

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -85,7 +85,7 @@ export async function generateMockSetup(env: DevEnv) {
       { email: user.email, username: user.username, password: user.password },
     )
     user.did = res.data.did
-    user.api.setHeader('Authorization', `Bearer ${res.data.jwt}`)
+    user.api.setHeader('Authorization', `Bearer ${res.data.accessJwt}`)
     await user.api.app.bsky.profile.create(
       { did: user.did },
       {

--- a/packages/pds/src/api/com/atproto/account.ts
+++ b/packages/pds/src/api/com/atproto/account.ts
@@ -6,6 +6,7 @@ import * as locals from '../../../locals'
 import { countAll } from '../../../db/util'
 import { UserAlreadyExistsError } from '../../../db'
 import SqlBlockstore from '../../../sql-blockstore'
+import { grantRefreshToken } from './util/auth'
 
 export default function (server: Server) {
   server.com.atproto.getAccountsConfig((_params, _input, _req, res) => {
@@ -152,14 +153,7 @@ export default function (server: Server) {
 
       const access = auth.createAccessToken(did)
       const refresh = auth.createRefreshToken(did)
-      await dbTxn.db
-        .insertInto('refresh_token')
-        .values({
-          id: refresh.payload.jti,
-          did: refresh.payload.sub,
-          expiresAt: new Date(refresh.payload.exp * 1000).toISOString(),
-        })
-        .execute()
+      await grantRefreshToken(dbTxn, refresh.payload)
 
       return { did, accessJwt: access.jwt, refreshJwt: refresh.jwt }
     })

--- a/packages/pds/src/api/com/atproto/password-reset.ts
+++ b/packages/pds/src/api/com/atproto/password-reset.ts
@@ -1,10 +1,9 @@
 import jwt from 'jsonwebtoken'
+import { AuthScopes } from '../../../auth'
 import { ServerConfig } from '../../../config'
 import { User } from '../../../db/tables/user'
 import { Server } from '../../../lexicon'
 import * as locals from '../../../locals'
-
-const PASSWORD_RESET_SCOPE = 'com.atproto.resetAccountPassword'
 
 export default function (server: Server) {
   server.com.atproto.requestAccountPasswordReset(
@@ -20,7 +19,7 @@ export default function (server: Server) {
         const token = jwt.sign(
           {
             sub: user.did,
-            scope: PASSWORD_RESET_SCOPE,
+            scope: AuthScopes.ResetPassword,
           },
           getSigningKey(user, config),
           { expiresIn: '15mins' },
@@ -46,7 +45,7 @@ export default function (server: Server) {
     }
 
     const { sub: did, scope } = tokenBody
-    if (typeof did !== 'string' || scope !== PASSWORD_RESET_SCOPE) {
+    if (typeof did !== 'string' || scope !== AuthScopes.ResetPassword) {
       return createInvalidTokenError('Malformed token')
     }
 

--- a/packages/pds/src/api/com/atproto/session.ts
+++ b/packages/pds/src/api/com/atproto/session.ts
@@ -93,15 +93,14 @@ export default function (server: Server) {
     if (!token) {
       throw new AuthRequiredError()
     }
-    const lastRefreshId = auth.verifyToken(token, AuthScopes.Refresh).jti
-    if (!lastRefreshId) {
+    const refreshToken = auth.verifyToken(token, AuthScopes.Refresh, {
+      ignoreExpiration: true,
+    })
+    if (!refreshToken.jti) {
       throw new Error('Unexpected missing refresh token id')
     }
 
-    const revoked = await revokeRefreshToken(db, lastRefreshId)
-    if (!revoked) {
-      throw new InvalidRequestError('Token has been revoked', 'ExpiredToken')
-    }
+    await revokeRefreshToken(db, refreshToken.jti)
 
     return {
       encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/session.ts
+++ b/packages/pds/src/api/com/atproto/session.ts
@@ -1,15 +1,12 @@
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
+import { AuthScopes } from '../../../auth'
 import { Server } from '../../../lexicon'
 import * as locals from '../../../locals'
 
 export default function (server: Server) {
   server.com.atproto.getSession(async (_params, _input, req, res) => {
     const { db, auth } = locals.get(res)
-    const did = auth.getUserDid(req)
-    if (!did) {
-      throw new AuthRequiredError()
-    }
-
+    const did = auth.getUserDidOrThrow(req)
     const user = await db.getUser(did)
     if (!user) {
       throw new InvalidRequestError(
@@ -37,14 +34,90 @@ export default function (server: Server) {
       )
     }
 
-    const jwt = auth.createToken(user.did)
+    const access = auth.createAccessToken(user.did)
+    const refresh = auth.createRefreshToken(user.did)
+    await db.db
+      .insertInto('refresh_token')
+      .values({
+        id: refresh.payload.jti,
+        did: refresh.payload.sub,
+        expiresAt: new Date(refresh.payload.exp * 1000).toISOString(),
+      })
+      .execute()
+
     return {
       encoding: 'application/json',
-      body: { jwt, name: user.username, did: user.did },
+      body: {
+        did: user.did,
+        name: user.username,
+        accessJwt: access.jwt,
+        refreshJwt: refresh.jwt,
+      },
     }
   })
 
-  server.com.atproto.deleteSession(() => {
-    throw new InvalidRequestError('Not implemented')
+  server.com.atproto.refreshSession(async (_params, _input, req, res) => {
+    const { db, auth } = locals.get(res)
+    const did = auth.getUserDidOrThrow(req, AuthScopes.Refresh)
+    const user = await db.getUser(did)
+    if (!user) {
+      throw new InvalidRequestError(
+        `Could not find user info for account: ${did}`,
+      )
+    }
+
+    const lastRefreshId = auth.verifyToken(auth.getToken(req) ?? '').jti
+    if (!lastRefreshId) {
+      throw new Error('Unexpected missing refresh token id')
+    }
+
+    const access = auth.createAccessToken(user.did)
+    const refresh = auth.createRefreshToken(user.did)
+    await db.transaction(async (dbTxn) => {
+      await dbTxn.db
+        .insertInto('refresh_token')
+        .values({
+          id: refresh.payload.jti,
+          did: refresh.payload.sub,
+          expiresAt: new Date(refresh.payload.exp * 1000).toISOString(),
+        })
+        .execute()
+      await dbTxn.db
+        .deleteFrom('refresh_token')
+        .where('id', '=', lastRefreshId)
+        .execute()
+    })
+
+    return {
+      encoding: 'application/json',
+      body: {
+        did: user.did,
+        name: user.username,
+        accessJwt: access.jwt,
+        refreshJwt: refresh.jwt,
+      },
+    }
+  })
+
+  server.com.atproto.deleteSession(async (_params, _input, req, res) => {
+    const { db, auth } = locals.get(res)
+    const token = auth.getToken(req)
+    if (!token) {
+      throw new AuthRequiredError()
+    }
+    const lastRefreshId = auth.verifyToken(token, AuthScopes.Refresh).jti
+    if (!lastRefreshId) {
+      throw new Error('Unexpected missing refresh token id')
+    }
+
+    await db.db
+      .deleteFrom('refresh_token')
+      .where('id', '=', lastRefreshId)
+      .execute()
+
+    return {
+      encoding: 'application/json',
+      body: {},
+    }
   })
 }

--- a/packages/pds/src/api/com/atproto/util/auth.ts
+++ b/packages/pds/src/api/com/atproto/util/auth.ts
@@ -1,0 +1,24 @@
+import { RefreshToken } from '../../../../auth'
+import Database from '../../../../db'
+
+export const grantRefreshToken = async (
+  db: Database,
+  payload: RefreshToken,
+) => {
+  return db.db
+    .insertInto('refresh_token')
+    .values({
+      id: payload.jti,
+      did: payload.sub,
+      expiresAt: new Date(payload.exp * 1000).toISOString(),
+    })
+    .executeTakeFirst()
+}
+
+export const revokeRefreshToken = async (db: Database, id: string) => {
+  const { numDeletedRows } = await db.db
+    .deleteFrom('refresh_token')
+    .where('id', '=', id)
+    .executeTakeFirst()
+  return numDeletedRows > 0
+}

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -110,10 +110,10 @@ export class ServerAuth {
     return header.slice(BEARER.length)
   }
 
-  verifyToken(token: string, scope?: AuthScopes) {
+  verifyToken(token: string, scope?: AuthScopes, options?: jwt.VerifyOptions) {
     try {
-      const payload = jwt.verify(token, this._secret)
-      if (typeof payload === 'string') {
+      const payload = jwt.verify(token, this._secret, options)
+      if (typeof payload === 'string' || 'signature' in payload) {
         throw new InvalidRequestError('Malformed token', 'InvalidToken')
       }
       if (scope && payload.scope !== scope) {

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -40,7 +40,7 @@ export class ServerAuth {
     this.verifier = new auth.Verifier({ didResolver: opts.didResolver })
   }
 
-  createAccessToken(did: string) {
+  createAccessToken(did: string, expiresIn?: string | number) {
     const payload = {
       scope: AuthScopes.Access,
       sub: did,
@@ -48,13 +48,13 @@ export class ServerAuth {
     return {
       payload: payload as AuthToken, // exp set by sign()
       jwt: jwt.sign(payload, this._secret, {
-        expiresIn: '15mins',
+        expiresIn: expiresIn ?? '15mins',
         mutatePayload: true,
       }),
     }
   }
 
-  createRefreshToken(did: string) {
+  createRefreshToken(did: string, expiresIn?: string | number) {
     const payload = {
       scope: AuthScopes.Refresh,
       sub: did,
@@ -63,7 +63,7 @@ export class ServerAuth {
     return {
       payload: payload as AuthToken & { jti: string }, // exp set by sign()
       jwt: jwt.sign(payload, this._secret, {
-        expiresIn: '7days',
+        expiresIn: expiresIn ?? '7days',
         mutatePayload: true,
       }),
     }

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -21,11 +21,13 @@ export enum AuthScopes {
   ResetPassword = 'com.atproto.resetAccountPassword',
 }
 
-type AuthToken = {
+export type AuthToken = {
   scope: AuthScopes
   sub: string
   exp: number
 }
+
+export type RefreshToken = AuthToken & { jti: string }
 
 export class ServerAuth {
   private _secret: string
@@ -61,7 +63,7 @@ export class ServerAuth {
       jti: uint8arrays.toString(crypto.randomBytes(32), 'base64'),
     }
     return {
-      payload: payload as AuthToken & { jti: string }, // exp set by sign()
+      payload: payload as RefreshToken, // exp set by sign()
       jwt: jwt.sign(payload, this._secret, {
         expiresIn: expiresIn ?? '7days',
         mutatePayload: true,

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -1,5 +1,6 @@
 import * as auth from '@atproto/auth'
-import { AuthRequiredError } from '@atproto/xrpc-server'
+import * as crypto from '@atproto/crypto'
+import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import * as uint8arrays from 'uint8arrays'
 import { DidResolver } from '@atproto/did-resolver'
 import express from 'express'
@@ -13,6 +14,19 @@ export type ServerAuthOpts = {
   didResolver: DidResolver
   adminPass: string
 }
+
+export enum AuthScopes {
+  Access = 'com.atproto.access',
+  Refresh = 'com.atproto.refresh',
+  ResetPassword = 'com.atproto.resetAccountPassword',
+}
+
+type AuthToken = {
+  scope: AuthScopes
+  sub: string
+  exp: number
+}
+
 export class ServerAuth {
   private _secret: string
   private _adminPass: string
@@ -26,36 +40,56 @@ export class ServerAuth {
     this.verifier = new auth.Verifier({ didResolver: opts.didResolver })
   }
 
-  createToken(did: string): string {
-    return jwt.sign(
-      {
-        sub: did,
-      },
-      this._secret,
-    )
+  createAccessToken(did: string) {
+    const payload = {
+      scope: AuthScopes.Access,
+      sub: did,
+    }
+    return {
+      payload: payload as AuthToken, // exp set by sign()
+      jwt: jwt.sign(payload, this._secret, {
+        expiresIn: '15mins',
+        mutatePayload: true,
+      }),
+    }
   }
 
-  getUserDid(req: express.Request): string | null {
-    const header = req.headers.authorization || ''
-    if (!header.startsWith(BEARER)) return null
-    const token = header.slice(BEARER.length)
-    const payload = jwt.verify(token, this._secret)
+  createRefreshToken(did: string) {
+    const payload = {
+      scope: AuthScopes.Refresh,
+      sub: did,
+      jti: uint8arrays.toString(crypto.randomBytes(32), 'base64'),
+    }
+    return {
+      payload: payload as AuthToken & { jti: string }, // exp set by sign()
+      jwt: jwt.sign(payload, this._secret, {
+        expiresIn: '7days',
+        mutatePayload: true,
+      }),
+    }
+  }
+
+  getUserDid(req: express.Request, scope = AuthScopes.Access): string | null {
+    const token = this.getToken(req)
+    if (!token) return null
+    const payload = this.verifyToken(token, scope)
     const sub = payload.sub
-    if (typeof sub !== 'string') return null
-    if (!sub.startsWith('did:')) return null
+    if (typeof sub !== 'string' || !sub.startsWith('did:')) {
+      throw new InvalidRequestError('Malformed token', 'InvalidToken')
+    }
     return sub
   }
 
-  getUserDidOrThrow(req: express.Request): string {
-    const did = this.getUserDid(req)
+  getUserDidOrThrow(req: express.Request, scope?: AuthScopes): string {
+    const did = this.getUserDid(req, scope)
     if (did === null) {
       throw new AuthRequiredError()
     }
     return did
   }
 
-  verifyUser(req: express.Request, did: string): boolean {
-    const authorized = this.getUserDid(req)
+  verifyUser(req: express.Request, did: string, scope?: AuthScopes): boolean {
+    const authorized = this.getUserDid(req, scope)
     return authorized === did
   }
 
@@ -66,6 +100,33 @@ export class ServerAuth {
     if (username !== 'admin') return false
     if (password !== this._adminPass) return false
     return true
+  }
+
+  getToken(req: express.Request) {
+    const header = req.headers.authorization || ''
+    if (!header.startsWith(BEARER)) return null
+    return header.slice(BEARER.length)
+  }
+
+  verifyToken(token: string, scope?: AuthScopes) {
+    try {
+      const payload = jwt.verify(token, this._secret)
+      if (typeof payload === 'string') {
+        throw new InvalidRequestError('Malformed token', 'InvalidToken')
+      }
+      if (scope && payload.scope !== scope) {
+        throw new InvalidRequestError('Bad token scope', 'InvalidToken')
+      }
+      return payload
+    } catch (err) {
+      if (err instanceof jwt.TokenExpiredError) {
+        throw new InvalidRequestError('Token has expired', 'ExpiredToken')
+      }
+      throw new InvalidRequestError(
+        'Token could not be verified',
+        'InvalidToken',
+      )
+    }
   }
 
   toString(): string {

--- a/packages/pds/src/db/database-schema.ts
+++ b/packages/pds/src/db/database-schema.ts
@@ -1,6 +1,7 @@
 import * as user from './tables/user'
 import * as userDid from './tables/user-did'
 import * as repoRoot from './tables/repo-root'
+import * as refreshToken from './tables/refresh-token'
 import * as record from './tables/record'
 import * as ipldBlock from './tables/ipld-block'
 import * as ipldBlockCreator from './tables/ipld-block-creator'
@@ -17,6 +18,7 @@ import * as badgeOffer from './records/badgeOffer'
 
 export type DatabaseSchema = user.PartialDB &
   userDid.PartialDB &
+  refreshToken.PartialDB &
   repoRoot.PartialDB &
   record.PartialDB &
   ipldBlock.PartialDB &

--- a/packages/pds/src/db/migrations/20221021T162202001Z-init.ts
+++ b/packages/pds/src/db/migrations/20221021T162202001Z-init.ts
@@ -3,6 +3,7 @@ import { Dialect } from '..'
 
 const userTable = 'user'
 const userDidTable = 'user_did'
+const refreshTokenTable = 'refresh_token'
 const repoRootTable = 'repo_root'
 const recordTable = 'record'
 const ipldBlockTable = 'ipld_block'
@@ -74,6 +75,13 @@ export async function up(db: Kysely<unknown>, dialect: Dialect): Promise<void> {
       .expression(sql`"username" gist_trgm_ops`)
       .execute()
   }
+  // Refresh Tokens
+  await db.schema
+    .createTable(refreshTokenTable)
+    .addColumn('id', 'varchar', (col) => col.primaryKey())
+    .addColumn('did', 'varchar', (col) => col.notNull())
+    .addColumn('expiresAt', 'varchar', (col) => col.notNull())
+    .execute()
   // Repo roots
   await db.schema
     .createTable(repoRootTable)

--- a/packages/pds/src/db/migrations/provider.ts
+++ b/packages/pds/src/db/migrations/provider.ts
@@ -11,8 +11,8 @@ export class CtxMigrationProvider<T> implements MigrationProvider {
     const ctxMigrations: Record<string, Migration> = {}
     Object.entries(this.migrations).forEach(([name, migration]) => {
       ctxMigrations[name] = {
-        up: (db) => migration.up(db, this.ctx),
-        down: (db) => Promise.resolve(migration.down?.(db, this.ctx)),
+        up: async (db) => await migration.up(db, this.ctx),
+        down: async (db) => await migration.down?.(db, this.ctx),
       }
     })
     return ctxMigrations

--- a/packages/pds/src/db/tables/refresh-token.ts
+++ b/packages/pds/src/db/tables/refresh-token.ts
@@ -1,0 +1,9 @@
+export interface RefreshToken {
+  id: string
+  did: string
+  expiresAt: string
+}
+
+export const tableName = 'refresh_token'
+
+export type PartialDB = { [tableName]: RefreshToken }

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -14,6 +14,7 @@ import * as ComAtprotoDeleteSession from './types/com/atproto/deleteSession'
 import * as ComAtprotoGetAccount from './types/com/atproto/getAccount'
 import * as ComAtprotoGetAccountsConfig from './types/com/atproto/getAccountsConfig'
 import * as ComAtprotoGetSession from './types/com/atproto/getSession'
+import * as ComAtprotoRefreshSession from './types/com/atproto/refreshSession'
 import * as ComAtprotoRepoBatchWrite from './types/com/atproto/repoBatchWrite'
 import * as ComAtprotoRepoCreateRecord from './types/com/atproto/repoCreateRecord'
 import * as ComAtprotoRepoDeleteRecord from './types/com/atproto/repoDeleteRecord'
@@ -112,6 +113,11 @@ export class AtprotoNS {
 
   getSession(handler: ComAtprotoGetSession.Handler) {
     const schema = 'com.atproto.getSession' // @ts-ignore
+    return this.server.xrpc.method(schema, handler)
+  }
+
+  refreshSession(handler: ComAtprotoRefreshSession.Handler) {
+    const schema = 'com.atproto.refreshSession' // @ts-ignore
     return this.server.xrpc.method(schema, handler)
   }
 

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -39,9 +39,12 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['jwt', 'username', 'did'],
+        required: ['accessJwt', 'refreshJwt', 'username', 'did'],
         properties: {
-          jwt: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
             type: 'string',
           },
           username: {
@@ -128,9 +131,12 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['jwt', 'name', 'did'],
+        required: ['accessJwt', 'refreshJwt', 'name', 'did'],
         properties: {
-          jwt: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
             type: 'string',
           },
           name: {
@@ -168,15 +174,8 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.deleteSession',
     type: 'procedure',
     description: 'Delete the current session.',
-    parameters: {},
-    input: {
-      encoding: '',
-      schema: {
-        $defs: {},
-      },
-    },
     output: {
-      encoding: '',
+      encoding: 'application/json',
       schema: {
         $defs: {},
       },
@@ -240,6 +239,34 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         type: 'object',
         required: ['name', 'did'],
         properties: {
+          name: {
+            type: 'string',
+          },
+          did: {
+            type: 'string',
+          },
+        },
+        $defs: {},
+      },
+    },
+  },
+  'com.atproto.refreshSession': {
+    lexicon: 1,
+    id: 'com.atproto.refreshSession',
+    type: 'procedure',
+    description: 'Refresh an authentication session.',
+    output: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['accessJwt', 'refreshJwt', 'name', 'did'],
+        properties: {
+          accessJwt: {
+            type: 'string',
+          },
+          refreshJwt: {
+            type: 'string',
+          },
           name: {
             type: 'string',
           },

--- a/packages/pds/src/lexicon/types/com/atproto/createSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/createSession.ts
@@ -28,7 +28,8 @@ export interface HandlerError {
 export type HandlerOutput = HandlerError | HandlerSuccess
 
 export interface OutputSchema {
-  jwt: string;
+  accessJwt: string;
+  refreshJwt: string;
   name: string;
   did: string;
 }

--- a/packages/pds/src/lexicon/types/com/atproto/deleteSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/deleteSession.ts
@@ -7,12 +7,8 @@ export interface QueryParams {}
 
 export type HandlerInput = undefined
 
-export interface InputSchema {
-  [k: string]: unknown;
-}
-
 export interface HandlerSuccess {
-  encoding: '';
+  encoding: 'application/json';
   body: OutputSchema;
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/refreshSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/refreshSession.ts
@@ -5,18 +5,7 @@ import express from 'express'
 
 export interface QueryParams {}
 
-export interface HandlerInput {
-  encoding: 'application/json';
-  body: InputSchema;
-}
-
-export interface InputSchema {
-  email: string;
-  username: string;
-  inviteCode?: string;
-  password: string;
-  recoveryKey?: string;
-}
+export type HandlerInput = undefined
 
 export interface HandlerSuccess {
   encoding: 'application/json';
@@ -26,11 +15,6 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number;
   message?: string;
-  error?:
-    | 'InvalidUsername'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'UsernameNotAvailable';
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess
@@ -38,7 +22,7 @@ export type HandlerOutput = HandlerError | HandlerSuccess
 export interface OutputSchema {
   accessJwt: string;
   refreshJwt: string;
-  username: string;
+  name: string;
   did: string;
 }
 

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -130,7 +130,7 @@ describe('account', () => {
       { email, username, password, inviteCode },
     )
     did = res.data.did
-    jwt = res.data.jwt
+    jwt = res.data.accessJwt
 
     expect(typeof jwt).toBe('string')
     expect(did.startsWith('did:plc:')).toBeTruthy()
@@ -293,7 +293,7 @@ describe('account', () => {
       {},
       { username, password },
     )
-    jwt = res.data.jwt
+    jwt = res.data.accessJwt
     expect(typeof jwt).toBe('string')
     expect(res.data.name).toBe('alice.test')
     expect(res.data.did).toBe(did)

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -14,6 +14,7 @@ import Mail from 'nodemailer/lib/mailer'
 import { App, ServerConfig } from '../src'
 import * as locals from '../src/locals'
 import * as util from './_util'
+import { AuthScopes } from '../src/auth'
 
 const email = 'alice@test.com'
 const username = 'alice.test'
@@ -387,7 +388,7 @@ describe('account', () => {
 
     const signingKey = `${config.jwtSecret}::${user.password}`
     const expiredToken = await sign(
-      { sub: did, scope: 'com.atproto.resetAccountPassword' },
+      { sub: did, scope: AuthScopes.ResetPassword },
       signingKey,
       { expiresIn: -1 },
     )

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -135,8 +135,7 @@ describe('auth', () => {
     await deleteSession(account.refreshJwt)
     const refreshDeleted = refreshSession(account.refreshJwt)
     await expect(refreshDeleted).rejects.toThrow('Token has been revoked')
-    const deleteDeleted = deleteSession(account.refreshJwt)
-    await expect(deleteDeleted).rejects.toThrow('Token has been revoked')
+    await deleteSession(account.refreshJwt) // No problem double-revoking a token
   })
 
   it('access token cannot be used to refresh a session.', async () => {
@@ -161,5 +160,6 @@ describe('auth', () => {
     const refresh = auth.createRefreshToken(account.did, -1)
     const refreshExpired = refreshSession(refresh.jwt)
     await expect(refreshExpired).rejects.toThrow('Token has expired')
+    await deleteSession(refresh.jwt) // No problem revoking an expired token
   })
 })

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -1,0 +1,165 @@
+import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import { SeedClient } from './seeds/client'
+import { CloseFn, runTestServer, TestServerInfo } from './_util'
+import * as locals from '../src/locals'
+
+describe('auth', () => {
+  let server: TestServerInfo
+  let client: AtpServiceClient
+  let close: CloseFn
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'auth',
+    })
+    client = AtpApi.service(server.url)
+    close = server.close
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  const createAccount = async (info) => {
+    const { data } = await client.com.atproto.createAccount({}, info)
+    return data
+  }
+  const getSession = async (jwt) => {
+    const { data } = await client.com.atproto.getSession({}, undefined, {
+      headers: SeedClient.getHeaders(jwt),
+    })
+    return data
+  }
+  const createSession = async (info) => {
+    const { data } = await client.com.atproto.createSession({}, info)
+    return data
+  }
+  const deleteSession = async (jwt) => {
+    const { data } = await client.com.atproto.deleteSession({}, undefined, {
+      headers: SeedClient.getHeaders(jwt),
+    })
+    return data
+  }
+  const refreshSession = async (jwt) => {
+    const { data } = await client.com.atproto.refreshSession({}, undefined, {
+      headers: SeedClient.getHeaders(jwt),
+    })
+    return data
+  }
+
+  it('provides valid access and refresh token on account creation.', async () => {
+    const account = await createAccount({
+      username: 'alice.test',
+      email: 'alice@test.com',
+      password: 'password',
+    })
+    // Valid access token
+    const sessionInfo = await getSession(account.accessJwt)
+    expect(sessionInfo).toEqual({ did: account.did, name: account.username }) // @TODO standardize on name or username?
+    // Valid refresh token
+    const nextSession = await refreshSession(account.refreshJwt)
+    expect(nextSession).toEqual(
+      expect.objectContaining({
+        did: account.did,
+        name: account.username,
+      }),
+    )
+  })
+
+  it('provides valid access and refresh token on session creation.', async () => {
+    await createAccount({
+      username: 'bob.test',
+      email: 'bob@test.com',
+      password: 'password',
+    })
+    const session = await createSession({
+      username: 'bob.test',
+      password: 'password',
+    })
+    // Valid access token
+    const sessionInfo = await getSession(session.accessJwt)
+    expect(sessionInfo).toEqual({
+      did: session.did,
+      name: session.name,
+    })
+    // Valid refresh token
+    const nextSession = await refreshSession(session.refreshJwt)
+    expect(nextSession).toEqual(
+      expect.objectContaining({
+        did: session.did,
+        name: session.name,
+      }),
+    )
+  })
+
+  it('provides valid access and refresh token on session refresh.', async () => {
+    const account = await createAccount({
+      username: 'carol.test',
+      email: 'carol@test.com',
+      password: 'password',
+    })
+    const session = await refreshSession(account.refreshJwt)
+    // Valid access token
+    const sessionInfo = await getSession(session.accessJwt)
+    expect(sessionInfo).toEqual({
+      did: session.did,
+      name: session.name,
+    })
+    // Valid refresh token
+    const nextSession = await refreshSession(session.refreshJwt)
+    expect(nextSession).toEqual(
+      expect.objectContaining({
+        did: session.did,
+        name: session.name,
+      }),
+    )
+  })
+
+  it('refresh token is revoked after use.', async () => {
+    const account = await createAccount({
+      username: 'eve.test',
+      email: 'eve@test.com',
+      password: 'password',
+    })
+    await refreshSession(account.refreshJwt)
+    const refreshAgain = refreshSession(account.refreshJwt)
+    await expect(refreshAgain).rejects.toThrow('Token has been revoked')
+  })
+
+  it('refresh token is revoked when session is deleted.', async () => {
+    const account = await createAccount({
+      username: 'finn.test',
+      email: 'finn@test.com',
+      password: 'password',
+    })
+    await deleteSession(account.refreshJwt)
+    const refreshDeleted = refreshSession(account.refreshJwt)
+    await expect(refreshDeleted).rejects.toThrow('Token has been revoked')
+    const deleteDeleted = deleteSession(account.refreshJwt)
+    await expect(deleteDeleted).rejects.toThrow('Token has been revoked')
+  })
+
+  it('access token cannot be used to refresh a session.', async () => {
+    const account = await createAccount({
+      username: 'gordon.test',
+      email: 'gordon@test.com',
+      password: 'password',
+    })
+    const refreshWithAccess = refreshSession(account.accessJwt)
+    await expect(refreshWithAccess).rejects.toThrow(
+      'Token could not be verified',
+    )
+  })
+
+  it('expired refresh token cannot be used to refresh a session.', async () => {
+    const account = await createAccount({
+      username: 'holga.test',
+      email: 'holga@test.com',
+      password: 'password',
+    })
+    const { auth } = locals.get(server.app)
+    const refresh = auth.createRefreshToken(account.did, -1)
+    const refreshExpired = refreshSession(refresh.jwt)
+    await expect(refreshExpired).rejects.toThrow('Token has expired')
+  })
+})

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -43,7 +43,7 @@ describe('crud operations', () => {
         password: alice.password,
       },
     )
-    aliceClient.setHeader('authorization', `Bearer ${res.data.jwt}`)
+    aliceClient.setHeader('authorization', `Bearer ${res.data.accessJwt}`)
     alice.did = res.data.did
     const res2 = await client.com.atproto.createAccount(
       {},

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -223,6 +223,10 @@ export class SeedClient {
   }
 
   getHeaders(did: string) {
-    return { authorization: `Bearer ${this.accounts[did].accessJwt}` }
+    return SeedClient.getHeaders(this.accounts[did].accessJwt)
+  }
+
+  static getHeaders(jwt: string) {
+    return { authorization: `Bearer ${jwt}` }
   }
 }

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -35,7 +35,8 @@ export class SeedClient {
     string,
     {
       did: string
-      jwt: string
+      accessJwt: string
+      refreshJwt: string
       username: string
       email: string
       password: string
@@ -222,6 +223,6 @@ export class SeedClient {
   }
 
   getHeaders(did: string) {
-    return { authorization: `Bearer ${this.accounts[did].jwt}` }
+    return { authorization: `Bearer ${this.accounts[did].accessJwt}` }
   }
 }


### PR DESCRIPTION
Here we implement refresh tokens for the PDS.  When the users obtains a session, they receive to tokens: a short-lived access token and a longer-lived refresh token.

The access token is not revocable but the refresh token is revocable, and the user may revoke their session using `com.atproto.deleteSession()` e.g. during logout.

When the access token expires, `com.atproto.refreshSession()` may be used to obtain a new session containing a fresh access token and refresh token.  The refresh token used to perform the session refresh is revoked.

The overall effect is that users can stay logged-in indefinitely without providing their username and password so long as they have some activity within the window of the long-lived duration of a refresh token.