### PR TITLE
Fix typo in PLC docs to point to correct key for recovery

### DIFF
--- a/packages/plc/README.md
+++ b/packages/plc/README.md
@@ -69,7 +69,7 @@ This is to be used in adversarial situations in which a user's `signingKey` leak
 
 In a situation such as this, the `recoveryKey` may be used to rotate both the `signingKey` and `recoveryKey`.
 
-If a user wishes to recovery from this situation, they sign a new operation rotating the `signingKey` to a key that they hold and set the `prev` of that operation to point to the most recent pre-attack operation.
+If a user wishes to recover from this situation, they sign a new operation rotating the `signingKey` to a key that they hold and set the `prev` of that operation to point to the most recent pre-attack operation.
 
 ## Example
 

--- a/packages/plc/README.md
+++ b/packages/plc/README.md
@@ -67,7 +67,7 @@ The PLC server provides a 72hr window during which the `recoveryKey` can "rewrit
 
 This is to be used in adversarial situations in which a user's `signingKey` leaks or is being held by some custodian who turns out to be a bad actor.
 
-In a situation such as this, the `signingKey` may be used to rotate both the `signingKey` and `recoveryKey`.
+In a situation such as this, the `recoveryKey` may be used to rotate both the `signingKey` and `recoveryKey`.
 
 If a user wishes to recovery from this situation, they sign a new operation rotating the `signingKey` to a key that they hold and set the `prev` of that operation to point to the most recent pre-attack operation.
 


### PR DESCRIPTION
Reading through this doc today and I think this a typo, or at least does not seem to follow from the preceding paragraphs.