### PR TITLE
Update XRPC procedures to use request body by default

### DIFF
--- a/lexicons/atproto.com/createAccount.json
+++ b/lexicons/atproto.com/createAccount.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.createAccount",
   "type": "procedure",
   "description": "Create an account.",
-  "parameters": {},
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/atproto.com/createInviteCode.json
+++ b/lexicons/atproto.com/createInviteCode.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.createInviteCode",
   "type": "procedure",
   "description": "Create an invite code.",
-  "parameters": {},
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/atproto.com/createSession.json
+++ b/lexicons/atproto.com/createSession.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.createSession",
   "type": "procedure",
   "description": "Create an authentication session.",
-  "parameters": {},
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/atproto.com/deleteAccount.json
+++ b/lexicons/atproto.com/deleteAccount.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.deleteAccount",
   "type": "procedure",
   "description": "Delete an account.",
-  "parameters": {},
   "input": {
     "encoding": "",
     "schema": {}

--- a/lexicons/atproto.com/getAccount.json
+++ b/lexicons/atproto.com/getAccount.json
@@ -4,10 +4,6 @@
   "type": "query",
   "description": "Get information about an account.",
   "parameters": {},
-  "input": {
-    "encoding": "",
-    "schema": {}
-  },
   "output": {
     "encoding": "",
     "schema": {}

--- a/lexicons/atproto.com/repoBatchWrite.json
+++ b/lexicons/atproto.com/repoBatchWrite.json
@@ -3,16 +3,21 @@
   "id": "com.atproto.repoBatchWrite",
   "type": "procedure",
   "description": "Apply a batch transaction of creates, puts, and deletes.",
-  "parameters": {
-    "did": {"type": "string", "required": true, "description": "The DID of the repo."},
-    "validate": {"type": "boolean", "default": true, "description": "Validate the records?"}
-  },
   "input": {
     "encoding": "application/json",
     "schema": {
       "type": "object",
-      "required": ["writes"],
+      "required": ["did", "writes"],
       "properties": {
+        "did": {
+          "type": "string",
+          "description": "The DID of the repo."
+        },
+        "validate": {
+          "type": "boolean",
+          "default": true,
+          "description": "Validate the records?"
+        },
         "writes": {
           "type": "array",
           "items": {

--- a/lexicons/atproto.com/repoCreateRecord.json
+++ b/lexicons/atproto.com/repoCreateRecord.json
@@ -3,15 +3,31 @@
   "id": "com.atproto.repoCreateRecord",
   "type": "procedure",
   "description": "Create a new record.",
-  "parameters": {
-    "did": {"type": "string", "required": true, "description": "The DID of the repo."},
-    "collection": {"type": "string", "required": true, "description": "The NSID of the record collection."},
-    "validate": {"type": "boolean", "default": true, "description": "Validate the record?"}
-  },
   "input": {
     "encoding": "application/json",
-    "description": "The record to create",
-    "schema": {}
+    "schema": {
+      "type": "object",
+      "required": ["did", "collection", "record"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "description": "The DID of the repo."
+        },
+        "collection": {
+          "type": "string",
+          "description": "The NSID of the record collection."
+        },
+        "validate": {
+          "type": "boolean",
+          "default": true,
+          "description": "Validate the record?"
+        },
+        "record": {
+          "type": "object",
+          "description": "The record to create"
+        }
+      }
+    }
   },
   "output": {
     "encoding": "application/json",

--- a/lexicons/atproto.com/repoDeleteRecord.json
+++ b/lexicons/atproto.com/repoDeleteRecord.json
@@ -3,9 +3,25 @@
   "id": "com.atproto.repoDeleteRecord",
   "type": "procedure",
   "description": "Delete a record.",
-  "parameters": {
-    "did": {"type": "string", "required": true, "description": "The DID of the repo."},
-    "collection": {"type": "string", "required": true, "description": "The NSID of the record collection."},
-    "rkey": {"type": "string", "required": true, "description": "The key of the record."}
+  "input": {
+    "encoding": "application/json",
+    "schema": {
+      "type": "object",
+      "required": ["did", "collection", "rkey"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "description": "The DID of the repo."
+        },
+        "collection": {
+          "type": "string",
+          "description": "The NSID of the record collection."
+        },
+        "rkey": {
+          "type": "string",
+          "description": "The key of the record."
+        }
+      }
+    }
   }
 }

--- a/lexicons/atproto.com/repoPutRecord.json
+++ b/lexicons/atproto.com/repoPutRecord.json
@@ -3,15 +3,35 @@
   "id": "com.atproto.repoPutRecord",
   "type": "procedure",
   "description": "Write a record.",
-  "parameters": {
-    "did": {"type": "string", "required": true, "description": "The DID of the repo."},
-    "collection": {"type": "string", "required": true, "description": "The NSID of the record type."},
-    "rkey": {"type": "string", "required": true, "description": "The TID of the record."},
-    "validate": {"type": "boolean", "default": true, "description": "Validate the record?"}
-  },
   "input": {
     "encoding": "application/json",
-    "schema": {}
+    "schema": {
+      "type": "object",
+      "required": ["did", "collection", "rkey", "record"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "description": "The DID of the repo."
+        },
+        "collection": {
+          "type": "string",
+          "description": "The NSID of the record type."
+        },
+        "rkey": {
+          "type": "string",
+          "description": "The TID of the record."
+        },
+        "validate": {
+          "type": "boolean",
+          "default": true,
+          "description": "Validate the record?"
+        },
+        "record": {
+          "type": "object",
+          "description": "The record to create"
+        }
+      }
+    }
   },
   "output": {
     "encoding": "application/json",

--- a/lexicons/atproto.com/requestAccountPasswordReset.json
+++ b/lexicons/atproto.com/requestAccountPasswordReset.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.requestAccountPasswordReset",
   "type": "procedure",
   "description": "Initiate a user account password reset via email",
-  "parameters": {},
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/atproto.com/resetAccountPassword.json
+++ b/lexicons/atproto.com/resetAccountPassword.json
@@ -3,7 +3,6 @@
   "id": "com.atproto.resetAccountPassword",
   "type": "procedure",
   "description": "Reset a user account password using a token",
-  "parameters": {},
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/bsky.app/postNotificationsSeen.json
+++ b/lexicons/bsky.app/postNotificationsSeen.json
@@ -3,7 +3,6 @@
   "id": "app.bsky.postNotificationsSeen",
   "type": "procedure",
   "description": "Notify server that the user has seen notifications",
-  "parameters": { },
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/lexicons/bsky.app/updateProfile.json
+++ b/lexicons/bsky.app/updateProfile.json
@@ -3,7 +3,6 @@
   "id": "app.bsky.updateProfile",
   "type": "procedure",
   "description": "Notify server that the user has seen notifications",
-  "parameters": { },
   "input": {
     "encoding": "application/json",
     "schema": {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -9,19 +9,25 @@ const client = API.service('http://example.com')
 
 // xrpc methods
 const res1 = await client.com.atproto.repoCreateRecord(
-  {did: alice.did, type: 'app.bsky.post'},
   {
-    $type: 'app.bsky.post',
-    text: 'Hello, world!',
-    createdAt: (new Date()).toISOString()
+    did: alice.did,
+    collection: 'app.bsky.post',
+    record: {
+      $type: 'app.bsky.post',
+      text: 'Hello, world!',
+      createdAt: (new Date()).toISOString()
+    }
   }
 )
 const res2 = await client.com.atproto.repoListRecords({did: alice.did, type: 'app.bsky.post'})
 
 // repo record methods
-const res3 = await client.app.bsky.post.create({did: alice.did}, {
-  text: 'Hello, world!',
-  createdAt: (new Date()).toISOString()
+const res3 = await client.app.bsky.post.create({
+  did: alice.did,
+  record: {
+    text: 'Hello, world!',
+    createdAt: (new Date()).toISOString()
+  }
 })
 const res4 = await client.app.bsky.post.list({did: alice.did})
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -22,12 +22,9 @@ const res1 = await client.com.atproto.repoCreateRecord(
 const res2 = await client.com.atproto.repoListRecords({did: alice.did, type: 'app.bsky.post'})
 
 // repo record methods
-const res3 = await client.app.bsky.post.create({
-  did: alice.did,
-  record: {
-    text: 'Hello, world!',
-    createdAt: (new Date()).toISOString()
-  }
+const res3 = await client.app.bsky.post.create({did: alice.did}, {
+  text: 'Hello, world!',
+  createdAt: (new Date()).toISOString()
 })
 const res4 = await client.app.bsky.post.list({did: alice.did})
 ```

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -98,6 +98,11 @@ export * as AppBskyProfile from './types/app/bsky/profile'
 export * as AppBskyRepost from './types/app/bsky/repost'
 export * as AppBskyUpdateProfile from './types/app/bsky/updateProfile'
 
+export const APP_BSKY = {
+  ActorScene: 'app.bsky.actorScene',
+  ActorUser: 'app.bsky.actorUser',
+}
+
 export class Client {
   xrpc: XrpcClient = new XrpcClient()
 
@@ -149,264 +154,242 @@ export class AtprotoNS {
   }
 
   createAccount(
-    params: ComAtprotoCreateAccount.QueryParams,
     data?: ComAtprotoCreateAccount.InputSchema,
     opts?: ComAtprotoCreateAccount.CallOptions
   ): Promise<ComAtprotoCreateAccount.Response> {
     return this._service.xrpc
-      .call('com.atproto.createAccount', params, data, opts)
+      .call('com.atproto.createAccount', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoCreateAccount.toKnownErr(e)
       })
   }
 
   createInviteCode(
-    params: ComAtprotoCreateInviteCode.QueryParams,
     data?: ComAtprotoCreateInviteCode.InputSchema,
     opts?: ComAtprotoCreateInviteCode.CallOptions
   ): Promise<ComAtprotoCreateInviteCode.Response> {
     return this._service.xrpc
-      .call('com.atproto.createInviteCode', params, data, opts)
+      .call('com.atproto.createInviteCode', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoCreateInviteCode.toKnownErr(e)
       })
   }
 
   createSession(
-    params: ComAtprotoCreateSession.QueryParams,
     data?: ComAtprotoCreateSession.InputSchema,
     opts?: ComAtprotoCreateSession.CallOptions
   ): Promise<ComAtprotoCreateSession.Response> {
     return this._service.xrpc
-      .call('com.atproto.createSession', params, data, opts)
+      .call('com.atproto.createSession', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoCreateSession.toKnownErr(e)
       })
   }
 
   deleteAccount(
-    params: ComAtprotoDeleteAccount.QueryParams,
     data?: ComAtprotoDeleteAccount.InputSchema,
     opts?: ComAtprotoDeleteAccount.CallOptions
   ): Promise<ComAtprotoDeleteAccount.Response> {
     return this._service.xrpc
-      .call('com.atproto.deleteAccount', params, data, opts)
+      .call('com.atproto.deleteAccount', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoDeleteAccount.toKnownErr(e)
       })
   }
 
   deleteSession(
-    params: ComAtprotoDeleteSession.QueryParams,
     data?: ComAtprotoDeleteSession.InputSchema,
     opts?: ComAtprotoDeleteSession.CallOptions
   ): Promise<ComAtprotoDeleteSession.Response> {
     return this._service.xrpc
-      .call('com.atproto.deleteSession', params, data, opts)
+      .call('com.atproto.deleteSession', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoDeleteSession.toKnownErr(e)
       })
   }
 
   getAccount(
-    params: ComAtprotoGetAccount.QueryParams,
-    data?: ComAtprotoGetAccount.InputSchema,
+    params?: ComAtprotoGetAccount.QueryParams,
     opts?: ComAtprotoGetAccount.CallOptions
   ): Promise<ComAtprotoGetAccount.Response> {
     return this._service.xrpc
-      .call('com.atproto.getAccount', params, data, opts)
+      .call('com.atproto.getAccount', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoGetAccount.toKnownErr(e)
       })
   }
 
   getAccountsConfig(
-    params: ComAtprotoGetAccountsConfig.QueryParams,
-    data?: ComAtprotoGetAccountsConfig.InputSchema,
+    params?: ComAtprotoGetAccountsConfig.QueryParams,
     opts?: ComAtprotoGetAccountsConfig.CallOptions
   ): Promise<ComAtprotoGetAccountsConfig.Response> {
     return this._service.xrpc
-      .call('com.atproto.getAccountsConfig', params, data, opts)
+      .call('com.atproto.getAccountsConfig', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoGetAccountsConfig.toKnownErr(e)
       })
   }
 
   getSession(
-    params: ComAtprotoGetSession.QueryParams,
-    data?: ComAtprotoGetSession.InputSchema,
+    params?: ComAtprotoGetSession.QueryParams,
     opts?: ComAtprotoGetSession.CallOptions
   ): Promise<ComAtprotoGetSession.Response> {
     return this._service.xrpc
-      .call('com.atproto.getSession', params, data, opts)
+      .call('com.atproto.getSession', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoGetSession.toKnownErr(e)
       })
   }
 
   refreshSession(
-    params: ComAtprotoRefreshSession.QueryParams,
     data?: ComAtprotoRefreshSession.InputSchema,
     opts?: ComAtprotoRefreshSession.CallOptions
   ): Promise<ComAtprotoRefreshSession.Response> {
     return this._service.xrpc
-      .call('com.atproto.refreshSession', params, data, opts)
+      .call('com.atproto.refreshSession', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRefreshSession.toKnownErr(e)
       })
   }
 
   repoBatchWrite(
-    params: ComAtprotoRepoBatchWrite.QueryParams,
     data?: ComAtprotoRepoBatchWrite.InputSchema,
     opts?: ComAtprotoRepoBatchWrite.CallOptions
   ): Promise<ComAtprotoRepoBatchWrite.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoBatchWrite', params, data, opts)
+      .call('com.atproto.repoBatchWrite', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRepoBatchWrite.toKnownErr(e)
       })
   }
 
   repoCreateRecord(
-    params: ComAtprotoRepoCreateRecord.QueryParams,
     data?: ComAtprotoRepoCreateRecord.InputSchema,
     opts?: ComAtprotoRepoCreateRecord.CallOptions
   ): Promise<ComAtprotoRepoCreateRecord.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoCreateRecord', params, data, opts)
+      .call('com.atproto.repoCreateRecord', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRepoCreateRecord.toKnownErr(e)
       })
   }
 
   repoDeleteRecord(
-    params: ComAtprotoRepoDeleteRecord.QueryParams,
     data?: ComAtprotoRepoDeleteRecord.InputSchema,
     opts?: ComAtprotoRepoDeleteRecord.CallOptions
   ): Promise<ComAtprotoRepoDeleteRecord.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoDeleteRecord', params, data, opts)
+      .call('com.atproto.repoDeleteRecord', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRepoDeleteRecord.toKnownErr(e)
       })
   }
 
   repoDescribe(
-    params: ComAtprotoRepoDescribe.QueryParams,
-    data?: ComAtprotoRepoDescribe.InputSchema,
+    params?: ComAtprotoRepoDescribe.QueryParams,
     opts?: ComAtprotoRepoDescribe.CallOptions
   ): Promise<ComAtprotoRepoDescribe.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoDescribe', params, data, opts)
+      .call('com.atproto.repoDescribe', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoRepoDescribe.toKnownErr(e)
       })
   }
 
   repoGetRecord(
-    params: ComAtprotoRepoGetRecord.QueryParams,
-    data?: ComAtprotoRepoGetRecord.InputSchema,
+    params?: ComAtprotoRepoGetRecord.QueryParams,
     opts?: ComAtprotoRepoGetRecord.CallOptions
   ): Promise<ComAtprotoRepoGetRecord.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoGetRecord', params, data, opts)
+      .call('com.atproto.repoGetRecord', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoRepoGetRecord.toKnownErr(e)
       })
   }
 
   repoListRecords(
-    params: ComAtprotoRepoListRecords.QueryParams,
-    data?: ComAtprotoRepoListRecords.InputSchema,
+    params?: ComAtprotoRepoListRecords.QueryParams,
     opts?: ComAtprotoRepoListRecords.CallOptions
   ): Promise<ComAtprotoRepoListRecords.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoListRecords', params, data, opts)
+      .call('com.atproto.repoListRecords', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoRepoListRecords.toKnownErr(e)
       })
   }
 
   repoPutRecord(
-    params: ComAtprotoRepoPutRecord.QueryParams,
     data?: ComAtprotoRepoPutRecord.InputSchema,
     opts?: ComAtprotoRepoPutRecord.CallOptions
   ): Promise<ComAtprotoRepoPutRecord.Response> {
     return this._service.xrpc
-      .call('com.atproto.repoPutRecord', params, data, opts)
+      .call('com.atproto.repoPutRecord', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRepoPutRecord.toKnownErr(e)
       })
   }
 
   requestAccountPasswordReset(
-    params: ComAtprotoRequestAccountPasswordReset.QueryParams,
     data?: ComAtprotoRequestAccountPasswordReset.InputSchema,
     opts?: ComAtprotoRequestAccountPasswordReset.CallOptions
   ): Promise<ComAtprotoRequestAccountPasswordReset.Response> {
     return this._service.xrpc
-      .call('com.atproto.requestAccountPasswordReset', params, data, opts)
+      .call('com.atproto.requestAccountPasswordReset', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoRequestAccountPasswordReset.toKnownErr(e)
       })
   }
 
   resetAccountPassword(
-    params: ComAtprotoResetAccountPassword.QueryParams,
     data?: ComAtprotoResetAccountPassword.InputSchema,
     opts?: ComAtprotoResetAccountPassword.CallOptions
   ): Promise<ComAtprotoResetAccountPassword.Response> {
     return this._service.xrpc
-      .call('com.atproto.resetAccountPassword', params, data, opts)
+      .call('com.atproto.resetAccountPassword', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoResetAccountPassword.toKnownErr(e)
       })
   }
 
   resolveName(
-    params: ComAtprotoResolveName.QueryParams,
-    data?: ComAtprotoResolveName.InputSchema,
+    params?: ComAtprotoResolveName.QueryParams,
     opts?: ComAtprotoResolveName.CallOptions
   ): Promise<ComAtprotoResolveName.Response> {
     return this._service.xrpc
-      .call('com.atproto.resolveName', params, data, opts)
+      .call('com.atproto.resolveName', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoResolveName.toKnownErr(e)
       })
   }
 
   syncGetRepo(
-    params: ComAtprotoSyncGetRepo.QueryParams,
-    data?: ComAtprotoSyncGetRepo.InputSchema,
+    params?: ComAtprotoSyncGetRepo.QueryParams,
     opts?: ComAtprotoSyncGetRepo.CallOptions
   ): Promise<ComAtprotoSyncGetRepo.Response> {
     return this._service.xrpc
-      .call('com.atproto.syncGetRepo', params, data, opts)
+      .call('com.atproto.syncGetRepo', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoSyncGetRepo.toKnownErr(e)
       })
   }
 
   syncGetRoot(
-    params: ComAtprotoSyncGetRoot.QueryParams,
-    data?: ComAtprotoSyncGetRoot.InputSchema,
+    params?: ComAtprotoSyncGetRoot.QueryParams,
     opts?: ComAtprotoSyncGetRoot.CallOptions
   ): Promise<ComAtprotoSyncGetRoot.Response> {
     return this._service.xrpc
-      .call('com.atproto.syncGetRoot', params, data, opts)
+      .call('com.atproto.syncGetRoot', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoSyncGetRoot.toKnownErr(e)
       })
   }
 
   syncUpdateRepo(
-    params: ComAtprotoSyncUpdateRepo.QueryParams,
     data?: ComAtprotoSyncUpdateRepo.InputSchema,
     opts?: ComAtprotoSyncUpdateRepo.CallOptions
   ): Promise<ComAtprotoSyncUpdateRepo.Response> {
     return this._service.xrpc
-      .call('com.atproto.syncUpdateRepo', params, data, opts)
+      .call('com.atproto.syncUpdateRepo', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoSyncUpdateRepo.toKnownErr(e)
       })
@@ -449,168 +432,154 @@ export class BskyNS {
   }
 
   getAuthorFeed(
-    params: AppBskyGetAuthorFeed.QueryParams,
-    data?: AppBskyGetAuthorFeed.InputSchema,
+    params?: AppBskyGetAuthorFeed.QueryParams,
     opts?: AppBskyGetAuthorFeed.CallOptions
   ): Promise<AppBskyGetAuthorFeed.Response> {
     return this._service.xrpc
-      .call('app.bsky.getAuthorFeed', params, data, opts)
+      .call('app.bsky.getAuthorFeed', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetAuthorFeed.toKnownErr(e)
       })
   }
 
   getHomeFeed(
-    params: AppBskyGetHomeFeed.QueryParams,
-    data?: AppBskyGetHomeFeed.InputSchema,
+    params?: AppBskyGetHomeFeed.QueryParams,
     opts?: AppBskyGetHomeFeed.CallOptions
   ): Promise<AppBskyGetHomeFeed.Response> {
     return this._service.xrpc
-      .call('app.bsky.getHomeFeed', params, data, opts)
+      .call('app.bsky.getHomeFeed', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetHomeFeed.toKnownErr(e)
       })
   }
 
   getLikedBy(
-    params: AppBskyGetLikedBy.QueryParams,
-    data?: AppBskyGetLikedBy.InputSchema,
+    params?: AppBskyGetLikedBy.QueryParams,
     opts?: AppBskyGetLikedBy.CallOptions
   ): Promise<AppBskyGetLikedBy.Response> {
     return this._service.xrpc
-      .call('app.bsky.getLikedBy', params, data, opts)
+      .call('app.bsky.getLikedBy', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetLikedBy.toKnownErr(e)
       })
   }
 
   getNotificationCount(
-    params: AppBskyGetNotificationCount.QueryParams,
-    data?: AppBskyGetNotificationCount.InputSchema,
+    params?: AppBskyGetNotificationCount.QueryParams,
     opts?: AppBskyGetNotificationCount.CallOptions
   ): Promise<AppBskyGetNotificationCount.Response> {
     return this._service.xrpc
-      .call('app.bsky.getNotificationCount', params, data, opts)
+      .call('app.bsky.getNotificationCount', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetNotificationCount.toKnownErr(e)
       })
   }
 
   getNotifications(
-    params: AppBskyGetNotifications.QueryParams,
-    data?: AppBskyGetNotifications.InputSchema,
+    params?: AppBskyGetNotifications.QueryParams,
     opts?: AppBskyGetNotifications.CallOptions
   ): Promise<AppBskyGetNotifications.Response> {
     return this._service.xrpc
-      .call('app.bsky.getNotifications', params, data, opts)
+      .call('app.bsky.getNotifications', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetNotifications.toKnownErr(e)
       })
   }
 
   getPostThread(
-    params: AppBskyGetPostThread.QueryParams,
-    data?: AppBskyGetPostThread.InputSchema,
+    params?: AppBskyGetPostThread.QueryParams,
     opts?: AppBskyGetPostThread.CallOptions
   ): Promise<AppBskyGetPostThread.Response> {
     return this._service.xrpc
-      .call('app.bsky.getPostThread', params, data, opts)
+      .call('app.bsky.getPostThread', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetPostThread.toKnownErr(e)
       })
   }
 
   getProfile(
-    params: AppBskyGetProfile.QueryParams,
-    data?: AppBskyGetProfile.InputSchema,
+    params?: AppBskyGetProfile.QueryParams,
     opts?: AppBskyGetProfile.CallOptions
   ): Promise<AppBskyGetProfile.Response> {
     return this._service.xrpc
-      .call('app.bsky.getProfile', params, data, opts)
+      .call('app.bsky.getProfile', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetProfile.toKnownErr(e)
       })
   }
 
   getRepostedBy(
-    params: AppBskyGetRepostedBy.QueryParams,
-    data?: AppBskyGetRepostedBy.InputSchema,
+    params?: AppBskyGetRepostedBy.QueryParams,
     opts?: AppBskyGetRepostedBy.CallOptions
   ): Promise<AppBskyGetRepostedBy.Response> {
     return this._service.xrpc
-      .call('app.bsky.getRepostedBy', params, data, opts)
+      .call('app.bsky.getRepostedBy', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetRepostedBy.toKnownErr(e)
       })
   }
 
   getUserFollowers(
-    params: AppBskyGetUserFollowers.QueryParams,
-    data?: AppBskyGetUserFollowers.InputSchema,
+    params?: AppBskyGetUserFollowers.QueryParams,
     opts?: AppBskyGetUserFollowers.CallOptions
   ): Promise<AppBskyGetUserFollowers.Response> {
     return this._service.xrpc
-      .call('app.bsky.getUserFollowers', params, data, opts)
+      .call('app.bsky.getUserFollowers', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetUserFollowers.toKnownErr(e)
       })
   }
 
   getUserFollows(
-    params: AppBskyGetUserFollows.QueryParams,
-    data?: AppBskyGetUserFollows.InputSchema,
+    params?: AppBskyGetUserFollows.QueryParams,
     opts?: AppBskyGetUserFollows.CallOptions
   ): Promise<AppBskyGetUserFollows.Response> {
     return this._service.xrpc
-      .call('app.bsky.getUserFollows', params, data, opts)
+      .call('app.bsky.getUserFollows', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetUserFollows.toKnownErr(e)
       })
   }
 
   getUsersSearch(
-    params: AppBskyGetUsersSearch.QueryParams,
-    data?: AppBskyGetUsersSearch.InputSchema,
+    params?: AppBskyGetUsersSearch.QueryParams,
     opts?: AppBskyGetUsersSearch.CallOptions
   ): Promise<AppBskyGetUsersSearch.Response> {
     return this._service.xrpc
-      .call('app.bsky.getUsersSearch', params, data, opts)
+      .call('app.bsky.getUsersSearch', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetUsersSearch.toKnownErr(e)
       })
   }
 
   getUsersTypeahead(
-    params: AppBskyGetUsersTypeahead.QueryParams,
-    data?: AppBskyGetUsersTypeahead.InputSchema,
+    params?: AppBskyGetUsersTypeahead.QueryParams,
     opts?: AppBskyGetUsersTypeahead.CallOptions
   ): Promise<AppBskyGetUsersTypeahead.Response> {
     return this._service.xrpc
-      .call('app.bsky.getUsersTypeahead', params, data, opts)
+      .call('app.bsky.getUsersTypeahead', params, undefined, opts)
       .catch((e) => {
         throw AppBskyGetUsersTypeahead.toKnownErr(e)
       })
   }
 
   postNotificationsSeen(
-    params: AppBskyPostNotificationsSeen.QueryParams,
     data?: AppBskyPostNotificationsSeen.InputSchema,
     opts?: AppBskyPostNotificationsSeen.CallOptions
   ): Promise<AppBskyPostNotificationsSeen.Response> {
     return this._service.xrpc
-      .call('app.bsky.postNotificationsSeen', params, data, opts)
+      .call('app.bsky.postNotificationsSeen', opts?.qp, data, opts)
       .catch((e) => {
         throw AppBskyPostNotificationsSeen.toKnownErr(e)
       })
   }
 
   updateProfile(
-    params: AppBskyUpdateProfile.QueryParams,
     data?: AppBskyUpdateProfile.InputSchema,
     opts?: AppBskyUpdateProfile.CallOptions
   ): Promise<AppBskyUpdateProfile.Response> {
     return this._service.xrpc
-      .call('app.bsky.updateProfile', params, data, opts)
+      .call('app.bsky.updateProfile', opts?.qp, data, opts)
       .catch((e) => {
         throw AppBskyUpdateProfile.toKnownErr(e)
       })
@@ -648,15 +617,18 @@ export class DeclarationRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyDeclaration.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.declaration'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.declaration', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.declaration', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -668,8 +640,8 @@ export class DeclarationRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.declaration', ...params },
       undefined,
+      { collection: 'app.bsky.declaration', ...params },
       { headers }
     )
   }
@@ -706,15 +678,18 @@ export class FollowRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyFollow.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.follow'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.follow', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.follow', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -726,8 +701,8 @@ export class FollowRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.follow', ...params },
       undefined,
+      { collection: 'app.bsky.follow', ...params },
       { headers }
     )
   }
@@ -764,15 +739,18 @@ export class InviteRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyInvite.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.invite'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.invite', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.invite', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -784,8 +762,8 @@ export class InviteRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.invite', ...params },
       undefined,
+      { collection: 'app.bsky.invite', ...params },
       { headers }
     )
   }
@@ -822,15 +800,18 @@ export class InviteAcceptRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyInviteAccept.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.inviteAccept'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.inviteAccept', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.inviteAccept', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -842,8 +823,8 @@ export class InviteAcceptRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.inviteAccept', ...params },
       undefined,
+      { collection: 'app.bsky.inviteAccept', ...params },
       { headers }
     )
   }
@@ -880,15 +861,18 @@ export class LikeRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyLike.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.like'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.like', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.like', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -900,8 +884,8 @@ export class LikeRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.like', ...params },
       undefined,
+      { collection: 'app.bsky.like', ...params },
       { headers }
     )
   }
@@ -938,15 +922,18 @@ export class MediaEmbedRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyMediaEmbed.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.mediaEmbed'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.mediaEmbed', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.mediaEmbed', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -958,8 +945,8 @@ export class MediaEmbedRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.mediaEmbed', ...params },
       undefined,
+      { collection: 'app.bsky.mediaEmbed', ...params },
       { headers }
     )
   }
@@ -996,15 +983,18 @@ export class PostRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyPost.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.post'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.post', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.post', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -1016,8 +1006,8 @@ export class PostRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.post', ...params },
       undefined,
+      { collection: 'app.bsky.post', ...params },
       { headers }
     )
   }
@@ -1054,15 +1044,18 @@ export class ProfileRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyProfile.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.profile'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.profile', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.profile', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -1074,8 +1067,8 @@ export class ProfileRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.profile', ...params },
       undefined,
+      { collection: 'app.bsky.profile', ...params },
       { headers }
     )
   }
@@ -1112,15 +1105,18 @@ export class RepostRecord {
   }
 
   async create(
-    params: Omit<ComAtprotoRepoCreateRecord.QueryParams, 'collection'>,
+    params: Omit<
+      ComAtprotoRepoCreateRecord.InputSchema,
+      'collection' | 'record'
+    >,
     record: AppBskyRepost.Record,
     headers?: Record<string, string>
   ): Promise<{ uri: string, cid: string }> {
     record.$type = 'app.bsky.repost'
     const res = await this._service.xrpc.call(
       'com.atproto.repoCreateRecord',
-      { collection: 'app.bsky.repost', ...params },
-      record,
+      undefined,
+      { collection: 'app.bsky.repost', ...params, record },
       { encoding: 'application/json', headers }
     )
     return res.data
@@ -1132,8 +1128,8 @@ export class RepostRecord {
   ): Promise<void> {
     await this._service.xrpc.call(
       'com.atproto.repoDeleteRecord',
-      { collection: 'app.bsky.repost', ...params },
       undefined,
+      { collection: 'app.bsky.repost', ...params },
       { headers }
     )
   }

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -9,7 +9,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createAccount',
     type: 'procedure',
     description: 'Create an account.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -86,7 +85,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createInviteCode',
     type: 'procedure',
     description: 'Create an invite code.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -119,7 +117,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createSession',
     type: 'procedure',
     description: 'Create an authentication session.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -164,7 +161,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.deleteAccount',
     type: 'procedure',
     description: 'Delete an account.',
-    parameters: {},
     input: {
       encoding: '',
       schema: {
@@ -196,12 +192,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     type: 'query',
     description: 'Get information about an account.',
     parameters: {},
-    input: {
-      encoding: '',
-      schema: {
-        $defs: {},
-      },
-    },
     output: {
       encoding: '',
       schema: {
@@ -292,24 +282,21 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoBatchWrite',
     type: 'procedure',
     description: 'Apply a batch transaction of creates, puts, and deletes.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the records?',
-      },
-    },
     input: {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['writes'],
+        required: ['did', 'writes'],
         properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the records?',
+          },
           writes: {
             type: 'array',
             items: {
@@ -383,27 +370,30 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoCreateRecord',
     type: 'procedure',
     description: 'Create a new record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record collection.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the record?',
-      },
-    },
     input: {
       encoding: 'application/json',
-      description: 'The record to create',
       schema: {
+        type: 'object',
+        required: ['did', 'collection', 'record'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record collection.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the record?',
+          },
+          record: {
+            type: 'object',
+            description: 'The record to create',
+          },
+        },
         $defs: {},
       },
     },
@@ -429,21 +419,26 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoDeleteRecord',
     type: 'procedure',
     description: 'Delete a record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record collection.',
-      },
-      rkey: {
-        type: 'string',
-        required: true,
-        description: 'The key of the record.',
+    input: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['did', 'collection', 'rkey'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record collection.',
+          },
+          rkey: {
+            type: 'string',
+            description: 'The key of the record.',
+          },
+        },
+        $defs: {},
       },
     },
   },
@@ -610,31 +605,34 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoPutRecord',
     type: 'procedure',
     description: 'Write a record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record type.',
-      },
-      rkey: {
-        type: 'string',
-        required: true,
-        description: 'The TID of the record.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the record?',
-      },
-    },
     input: {
       encoding: 'application/json',
       schema: {
+        type: 'object',
+        required: ['did', 'collection', 'rkey', 'record'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record type.',
+          },
+          rkey: {
+            type: 'string',
+            description: 'The TID of the record.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the record?',
+          },
+          record: {
+            type: 'object',
+            description: 'The record to create',
+          },
+        },
         $defs: {},
       },
     },
@@ -660,7 +658,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.requestAccountPasswordReset',
     type: 'procedure',
     description: 'Initiate a user account password reset via email',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -688,7 +685,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.resetAccountPassword',
     type: 'procedure',
     description: 'Reset a user account password using a token',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -2363,7 +2359,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'app.bsky.updateProfile',
     type: 'procedure',
     description: 'Notify server that the user has seen notifications',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -2332,7 +2332,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'app.bsky.postNotificationsSeen',
     type: 'procedure',
     description: 'Notify server that the user has seen notifications',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {

--- a/packages/api/src/client/types/app/bsky/postNotificationsSeen.ts
+++ b/packages/api/src/client/types/app/bsky/postNotificationsSeen.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/app/bsky/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/updateProfile.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/createAccount.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/createInviteCode.ts
+++ b/packages/api/src/client/types/com/atproto/createInviteCode.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/createSession.ts
+++ b/packages/api/src/client/types/com/atproto/createSession.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/deleteAccount.ts
+++ b/packages/api/src/client/types/com/atproto/deleteAccount.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: '';
 }
 

--- a/packages/api/src/client/types/com/atproto/deleteSession.ts
+++ b/packages/api/src/client/types/com/atproto/deleteSession.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/com/atproto/getAccount.ts
+++ b/packages/api/src/client/types/com/atproto/getAccount.ts
@@ -7,12 +7,9 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
-  encoding: '';
 }
 
-export interface InputSchema {
-  [k: string]: unknown;
-}
+export type InputSchema = undefined
 
 export interface OutputSchema {
   [k: string]: unknown;

--- a/packages/api/src/client/types/com/atproto/refreshSession.ts
+++ b/packages/api/src/client/types/com/atproto/refreshSession.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/com/atproto/repoBatchWrite.ts
+++ b/packages/api/src/client/types/com/atproto/repoBatchWrite.ts
@@ -3,17 +3,23 @@
 */
 import { Headers, XRPCError } from '@atproto/xrpc'
 
-export interface QueryParams {
-  did: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 
 export interface InputSchema {
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * Validate the records?
+   */
+  validate?: boolean;
   writes: (
     | {
         action: 'create',

--- a/packages/api/src/client/types/com/atproto/repoCreateRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repoCreateRecord.ts
@@ -3,19 +3,31 @@
 */
 import { Headers, XRPCError } from '@atproto/xrpc'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 
 export interface InputSchema {
-  [k: string]: unknown;
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record collection.
+   */
+  collection: string;
+  /**
+   * Validate the record?
+   */
+  validate?: boolean;
+  /**
+   * The record to create
+   */
+  record: {};
 }
 
 export interface OutputSchema {

--- a/packages/api/src/client/types/com/atproto/repoDeleteRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repoDeleteRecord.ts
@@ -3,17 +3,28 @@
 */
 import { Headers, XRPCError } from '@atproto/xrpc'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  rkey: string;
-}
+export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
+  encoding: 'application/json';
 }
 
-export type InputSchema = undefined
+export interface InputSchema {
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record collection.
+   */
+  collection: string;
+  /**
+   * The key of the record.
+   */
+  rkey: string;
+}
 
 export interface Response {
   success: boolean;

--- a/packages/api/src/client/types/com/atproto/repoPutRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repoPutRecord.ts
@@ -3,20 +3,35 @@
 */
 import { Headers, XRPCError } from '@atproto/xrpc'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  rkey: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 
 export interface InputSchema {
-  [k: string]: unknown;
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record type.
+   */
+  collection: string;
+  /**
+   * The TID of the record.
+   */
+  rkey: string;
+  /**
+   * Validate the record?
+   */
+  validate?: boolean;
+  /**
+   * The record to create
+   */
+  record: {};
 }
 
 export interface OutputSchema {

--- a/packages/api/src/client/types/com/atproto/requestAccountPasswordReset.ts
+++ b/packages/api/src/client/types/com/atproto/requestAccountPasswordReset.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/resetAccountPassword.ts
+++ b/packages/api/src/client/types/com/atproto/resetAccountPassword.ts
@@ -7,6 +7,7 @@ export interface QueryParams {}
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/json';
 }
 

--- a/packages/api/src/client/types/com/atproto/syncUpdateRepo.ts
+++ b/packages/api/src/client/types/com/atproto/syncUpdateRepo.ts
@@ -9,6 +9,7 @@ export interface QueryParams {
 
 export interface CallOptions {
   headers?: Headers;
+  qp?: QueryParams;
   encoding: 'application/cbor';
 }
 

--- a/packages/api/tests/session.test.ts
+++ b/packages/api/tests/session.test.ts
@@ -27,10 +27,11 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    const { data: account } = await client.com.atproto.createAccount(
-      {},
-      { username: 'alice.test', email: 'alice@test.com', password: 'password' },
-    )
+    const { data: account } = await client.com.atproto.createAccount({
+      username: 'alice.test',
+      email: 'alice@test.com',
+      password: 'password',
+    })
 
     expect(client.sessionManager.active()).toEqual(true)
     expect(sessions).toEqual([
@@ -48,7 +49,7 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    await client.com.atproto.deleteSession({})
+    await client.com.atproto.deleteSession()
 
     expect(sessions).toEqual([undefined])
     expect(client.sessionManager.active()).toEqual(false)
@@ -63,10 +64,10 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    const { data: session } = await client.com.atproto.createSession(
-      {},
-      { username: 'alice.test', password: 'password' },
-    )
+    const { data: session } = await client.com.atproto.createSession({
+      username: 'alice.test',
+      password: 'password',
+    })
 
     expect(sessions).toEqual([
       { accessJwt: session.accessJwt, refreshJwt: session.refreshJwt },
@@ -84,12 +85,12 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    const { data: session } = await client.com.atproto.createSession(
-      {},
-      { username: 'alice.test', password: 'password' },
-    )
+    const { data: session } = await client.com.atproto.createSession({
+      username: 'alice.test',
+      password: 'password',
+    })
 
-    const { data: sessionRefresh } = await client.com.atproto.refreshSession({})
+    const { data: sessionRefresh } = await client.com.atproto.refreshSession()
 
     expect(sessions).toEqual([
       { accessJwt: session.accessJwt, refreshJwt: session.refreshJwt },
@@ -107,13 +108,9 @@ describe('session', () => {
     })
 
     // Uses escape hatch: authorization set, so sessions are not managed by this call
-    const refreshStaleSession = client.com.atproto.refreshSession(
-      {},
-      undefined,
-      {
-        headers: { authorization: `Bearer ${session.refreshJwt}` },
-      },
-    )
+    const refreshStaleSession = client.com.atproto.refreshSession(undefined, {
+      headers: { authorization: `Bearer ${session.refreshJwt}` },
+    })
     await expect(refreshStaleSession).rejects.toThrow('Token has been revoked')
 
     expect(sessions.length).toEqual(2)
@@ -124,13 +121,13 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    const { data: session } = await client.com.atproto.createSession(
-      {},
-      { username: 'alice.test', password: 'password' },
-    )
+    const { data: session } = await client.com.atproto.createSession({
+      username: 'alice.test',
+      password: 'password',
+    })
 
     const [{ data: sessionRefresh }] = await Promise.all(
-      [...Array(10)].map(() => client.com.atproto.refreshSession({})),
+      [...Array(10)].map(() => client.com.atproto.refreshSession()),
     )
 
     expect(sessions).toEqual([
@@ -153,10 +150,10 @@ describe('session', () => {
     const sessions: (Session | undefined)[] = []
     client.sessionManager.on('session', (session) => sessions.push(session))
 
-    const { data: session } = await client.com.atproto.createSession(
-      {},
-      { username: 'alice.test', password: 'password' },
-    )
+    const { data: session } = await client.com.atproto.createSession({
+      username: 'alice.test',
+      password: 'password',
+    })
     const sessionCreds = {
       accessJwt: session.accessJwt,
       refreshJwt: session.refreshJwt,

--- a/packages/dev-env/src/cli.ts
+++ b/packages/dev-env/src/cli.ts
@@ -88,14 +88,11 @@ const envApi = {
 
     // create the PDS account
     const client = pds.getClient()
-    const pdsRes = await client.com.atproto.createAccount(
-      {},
-      {
-        email: usernameNoTld + '@test.com',
-        username,
-        password: usernameNoTld + '-pass',
-      },
-    )
+    const pdsRes = await client.com.atproto.createAccount({
+      email: usernameNoTld + '@test.com',
+      username,
+      password: usernameNoTld + '-pass',
+    })
     users.set(username, pds)
   },
 

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -84,10 +84,11 @@ export async function generateMockSetup(env: DevEnv) {
 
   let _i = 1
   for (const user of users) {
-    const res = await clients.loggedout.com.atproto.createAccount(
-      {},
-      { email: user.email, username: user.username, password: user.password },
-    )
+    const res = await clients.loggedout.com.atproto.createAccount({
+      email: user.email,
+      username: user.username,
+      password: user.password,
+    })
     user.did = res.data.did
     user.declarationCid = res.data.declarationCid
     user.api.setHeader('Authorization', `Bearer ${res.data.accessJwt}`)

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -43,6 +43,11 @@ import * as AppBskyGetUsersTypeahead from './types/app/bsky/getUsersTypeahead'
 import * as AppBskyPostNotificationsSeen from './types/app/bsky/postNotificationsSeen'
 import * as AppBskyUpdateProfile from './types/app/bsky/updateProfile'
 
+export const APP_BSKY = {
+  ActorScene: 'app.bsky.actorScene',
+  ActorUser: 'app.bsky.actorUser',
+}
+
 export function createServer(): Server {
   return new Server()
 }

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -9,7 +9,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createAccount',
     type: 'procedure',
     description: 'Create an account.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -86,7 +85,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createInviteCode',
     type: 'procedure',
     description: 'Create an invite code.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -119,7 +117,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.createSession',
     type: 'procedure',
     description: 'Create an authentication session.',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -164,7 +161,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.deleteAccount',
     type: 'procedure',
     description: 'Delete an account.',
-    parameters: {},
     input: {
       encoding: '',
       schema: {
@@ -196,12 +192,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     type: 'query',
     description: 'Get information about an account.',
     parameters: {},
-    input: {
-      encoding: '',
-      schema: {
-        $defs: {},
-      },
-    },
     output: {
       encoding: '',
       schema: {
@@ -292,24 +282,21 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoBatchWrite',
     type: 'procedure',
     description: 'Apply a batch transaction of creates, puts, and deletes.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the records?',
-      },
-    },
     input: {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['writes'],
+        required: ['did', 'writes'],
         properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the records?',
+          },
           writes: {
             type: 'array',
             items: {
@@ -383,27 +370,30 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoCreateRecord',
     type: 'procedure',
     description: 'Create a new record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record collection.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the record?',
-      },
-    },
     input: {
       encoding: 'application/json',
-      description: 'The record to create',
       schema: {
+        type: 'object',
+        required: ['did', 'collection', 'record'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record collection.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the record?',
+          },
+          record: {
+            type: 'object',
+            description: 'The record to create',
+          },
+        },
         $defs: {},
       },
     },
@@ -429,21 +419,26 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoDeleteRecord',
     type: 'procedure',
     description: 'Delete a record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record collection.',
-      },
-      rkey: {
-        type: 'string',
-        required: true,
-        description: 'The key of the record.',
+    input: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['did', 'collection', 'rkey'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record collection.',
+          },
+          rkey: {
+            type: 'string',
+            description: 'The key of the record.',
+          },
+        },
+        $defs: {},
       },
     },
   },
@@ -610,31 +605,34 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.repoPutRecord',
     type: 'procedure',
     description: 'Write a record.',
-    parameters: {
-      did: {
-        type: 'string',
-        required: true,
-        description: 'The DID of the repo.',
-      },
-      collection: {
-        type: 'string',
-        required: true,
-        description: 'The NSID of the record type.',
-      },
-      rkey: {
-        type: 'string',
-        required: true,
-        description: 'The TID of the record.',
-      },
-      validate: {
-        type: 'boolean',
-        default: true,
-        description: 'Validate the record?',
-      },
-    },
     input: {
       encoding: 'application/json',
       schema: {
+        type: 'object',
+        required: ['did', 'collection', 'rkey', 'record'],
+        properties: {
+          did: {
+            type: 'string',
+            description: 'The DID of the repo.',
+          },
+          collection: {
+            type: 'string',
+            description: 'The NSID of the record type.',
+          },
+          rkey: {
+            type: 'string',
+            description: 'The TID of the record.',
+          },
+          validate: {
+            type: 'boolean',
+            default: true,
+            description: 'Validate the record?',
+          },
+          record: {
+            type: 'object',
+            description: 'The record to create',
+          },
+        },
         $defs: {},
       },
     },
@@ -660,7 +658,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.requestAccountPasswordReset',
     type: 'procedure',
     description: 'Initiate a user account password reset via email',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -688,7 +685,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'com.atproto.resetAccountPassword',
     type: 'procedure',
     description: 'Reset a user account password using a token',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {
@@ -2363,7 +2359,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'app.bsky.updateProfile',
     type: 'procedure',
     description: 'Notify server that the user has seen notifications',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -2332,7 +2332,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     id: 'app.bsky.postNotificationsSeen',
     type: 'procedure',
     description: 'Notify server that the user has seen notifications',
-    parameters: {},
     input: {
       encoding: 'application/json',
       schema: {

--- a/packages/pds/src/lexicon/types/com/atproto/getAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/getAccount.ts
@@ -7,10 +7,6 @@ export interface QueryParams {}
 
 export type HandlerInput = undefined
 
-export interface InputSchema {
-  [k: string]: unknown;
-}
-
 export interface HandlerSuccess {
   encoding: '';
   body: OutputSchema;

--- a/packages/pds/src/lexicon/types/com/atproto/repoBatchWrite.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repoBatchWrite.ts
@@ -3,10 +3,7 @@
 */
 import express from 'express'
 
-export interface QueryParams {
-  did: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface HandlerInput {
   encoding: 'application/json';
@@ -14,6 +11,14 @@ export interface HandlerInput {
 }
 
 export interface InputSchema {
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * Validate the records?
+   */
+  validate?: boolean;
   writes: (
     | {
         action: 'create',

--- a/packages/pds/src/lexicon/types/com/atproto/repoCreateRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repoCreateRecord.ts
@@ -3,11 +3,7 @@
 */
 import express from 'express'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface HandlerInput {
   encoding: 'application/json';
@@ -15,7 +11,22 @@ export interface HandlerInput {
 }
 
 export interface InputSchema {
-  [k: string]: unknown;
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record collection.
+   */
+  collection: string;
+  /**
+   * Validate the record?
+   */
+  validate?: boolean;
+  /**
+   * The record to create
+   */
+  record: {};
 }
 
 export interface HandlerSuccess {

--- a/packages/pds/src/lexicon/types/com/atproto/repoDeleteRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repoDeleteRecord.ts
@@ -3,13 +3,27 @@
 */
 import express from 'express'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  rkey: string;
+export interface QueryParams {}
+
+export interface HandlerInput {
+  encoding: 'application/json';
+  body: InputSchema;
 }
 
-export type HandlerInput = undefined
+export interface InputSchema {
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record collection.
+   */
+  collection: string;
+  /**
+   * The key of the record.
+   */
+  rkey: string;
+}
 
 export interface HandlerError {
   status: number;

--- a/packages/pds/src/lexicon/types/com/atproto/repoPutRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repoPutRecord.ts
@@ -3,12 +3,7 @@
 */
 import express from 'express'
 
-export interface QueryParams {
-  did: string;
-  collection: string;
-  rkey: string;
-  validate?: boolean;
-}
+export interface QueryParams {}
 
 export interface HandlerInput {
   encoding: 'application/json';
@@ -16,7 +11,26 @@ export interface HandlerInput {
 }
 
 export interface InputSchema {
-  [k: string]: unknown;
+  /**
+   * The DID of the repo.
+   */
+  did: string;
+  /**
+   * The NSID of the record type.
+   */
+  collection: string;
+  /**
+   * The TID of the record.
+   */
+  rkey: string;
+  /**
+   * Validate the record?
+   */
+  validate?: boolean;
+  /**
+   * The record to create
+   */
+  record: {};
 }
 
 export interface HandlerSuccess {

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -21,27 +21,30 @@ describe('auth', () => {
   })
 
   const createAccount = async (info) => {
-    const { data } = await client.com.atproto.createAccount({}, info)
+    const { data } = await client.com.atproto.createAccount(info)
     return data
   }
   const getSession = async (jwt) => {
-    const { data } = await client.com.atproto.getSession({}, undefined, {
-      headers: SeedClient.getHeaders(jwt),
-    })
+    const { data } = await client.com.atproto.getSession(
+      {},
+      {
+        headers: SeedClient.getHeaders(jwt),
+      },
+    )
     return data
   }
   const createSession = async (info) => {
-    const { data } = await client.com.atproto.createSession({}, info)
+    const { data } = await client.com.atproto.createSession(info)
     return data
   }
   const deleteSession = async (jwt) => {
-    const { data } = await client.com.atproto.deleteSession({}, undefined, {
+    const { data } = await client.com.atproto.deleteSession(undefined, {
       headers: SeedClient.getHeaders(jwt),
     })
     return data
   }
   const refreshSession = async (jwt) => {
-    const { data } = await client.com.atproto.refreshSession({}, undefined, {
+    const { data } = await client.com.atproto.refreshSession(undefined, {
       headers: SeedClient.getHeaders(jwt),
     })
     return data

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -35,24 +35,18 @@ describe('crud operations', () => {
   })
 
   it('registers users', async () => {
-    const res = await client.com.atproto.createAccount(
-      {},
-      {
-        email: alice.email,
-        username: alice.username,
-        password: alice.password,
-      },
-    )
+    const res = await client.com.atproto.createAccount({
+      email: alice.email,
+      username: alice.username,
+      password: alice.password,
+    })
     aliceClient.setHeader('authorization', `Bearer ${res.data.accessJwt}`)
     alice.did = res.data.did
-    const res2 = await client.com.atproto.createAccount(
-      {},
-      {
-        email: bob.email,
-        username: bob.username,
-        password: bob.password,
-      },
-    )
+    const res2 = await client.com.atproto.createAccount({
+      email: bob.email,
+      username: bob.username,
+      password: bob.password,
+    })
     bob.did = res2.data.did
   })
 
@@ -71,14 +65,15 @@ describe('crud operations', () => {
 
   let uri: AtUri
   it('creates records', async () => {
-    const res = await aliceClient.com.atproto.repoCreateRecord(
-      { did: alice.did, collection: 'app.bsky.post' },
-      {
+    const res = await aliceClient.com.atproto.repoCreateRecord({
+      did: alice.did,
+      collection: 'app.bsky.post',
+      record: {
         $type: 'app.bsky.post',
         text: 'Hello, world!',
         createdAt: new Date().toISOString(),
       },
-    )
+    })
     uri = new AtUri(res.data.uri)
     expect(res.data.uri).toBe(`at://${alice.did}/app.bsky.post/${uri.rkey}`)
   })
@@ -342,10 +337,11 @@ describe('crud operations', () => {
   // --------------
 
   it('requires a $type on records', async () => {
-    const prom1 = aliceClient.com.atproto.repoCreateRecord(
-      { did: alice.did, collection: 'app.bsky.post' },
-      {},
-    )
+    const prom1 = aliceClient.com.atproto.repoCreateRecord({
+      did: alice.did,
+      collection: 'app.bsky.post',
+      record: {},
+    })
     await expect(prom1).rejects.toThrow(
       'The passed value does not declare a $type',
     )
@@ -357,28 +353,31 @@ describe('crud operations', () => {
     //   type: 'com.example.foobar',
     // })
     // await expect(prom1).rejects.toThrow('Schema not found: com.example.foobar')
-    const prom2 = aliceClient.com.atproto.repoCreateRecord(
-      { did: alice.did, collection: 'com.example.foobar' },
-      { $type: 'com.example.foobar' },
-    )
+    const prom2 = aliceClient.com.atproto.repoCreateRecord({
+      did: alice.did,
+      collection: 'com.example.foobar',
+      record: { $type: 'com.example.foobar' },
+    })
     await expect(prom2).rejects.toThrow('Schema not found')
   })
 
   it('requires the $type to match the schema', async () => {
     await expect(
-      aliceClient.com.atproto.repoCreateRecord(
-        { did: alice.did, collection: 'app.bsky.post' },
-        { $type: 'app.bsky.like' },
-      ),
+      aliceClient.com.atproto.repoCreateRecord({
+        did: alice.did,
+        collection: 'app.bsky.post',
+        record: { $type: 'app.bsky.like' },
+      }),
     ).rejects.toThrow('Record type app.bsky.like is not supported')
   })
 
   it('validates the record on write', async () => {
     await expect(
-      aliceClient.com.atproto.repoCreateRecord(
-        { did: alice.did, collection: 'app.bsky.post' },
-        { $type: 'app.bsky.post' },
-      ),
+      aliceClient.com.atproto.repoCreateRecord({
+        did: alice.did,
+        collection: 'app.bsky.post',
+        record: { $type: 'app.bsky.post' },
+      }),
     ).rejects.toThrow(
       "Failed app.bsky.post validation for #/required: must have required property 'text'",
     )
@@ -388,7 +387,7 @@ describe('crud operations', () => {
   // it('validates the record on read', async () => {
   //   const res1 = await client.com.atproto.repoCreateRecord(
   //     url,
-  //     { did: alice.did, type: 'app.bsky.post', validate: false },
+  //     {did: alice.did, type: 'app.bsky.post', validate: false },
   //     {
   //       encoding: 'application/json',
   //       data: { $type: 'app.bsky.post', record: 'is bad' },

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -98,7 +98,7 @@ export class SeedClient {
       password: string
     },
   ) {
-    const { data } = await this.client.com.atproto.createAccount({}, params)
+    const { data } = await this.client.com.atproto.createAccount(params)
     this.dids[shortName] = data.did
     this.accounts[data.did] = {
       ...data,

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -35,7 +35,6 @@ describe('pds author feed views', () => {
   it('fetches full author feeds for self (sorted, minimal myState).', async () => {
     const aliceForAlice = await client.app.bsky.getAuthorFeed(
       { author: sc.accounts[alice].username },
-      undefined,
       {
         headers: sc.getHeaders(alice),
       },
@@ -45,7 +44,6 @@ describe('pds author feed views', () => {
 
     const bobForBob = await client.app.bsky.getAuthorFeed(
       { author: sc.accounts[bob].username },
-      undefined,
       {
         headers: sc.getHeaders(bob),
       },
@@ -55,7 +53,6 @@ describe('pds author feed views', () => {
 
     const carolForCarol = await client.app.bsky.getAuthorFeed(
       { author: sc.accounts[carol].username },
-      undefined,
       {
         headers: sc.getHeaders(carol),
       },
@@ -65,7 +62,6 @@ describe('pds author feed views', () => {
 
     const danForDan = await client.app.bsky.getAuthorFeed(
       { author: sc.accounts[dan].username },
-      undefined,
       {
         headers: sc.getHeaders(dan),
       },
@@ -77,7 +73,6 @@ describe('pds author feed views', () => {
   it("reflects fetching user's state in the feed.", async () => {
     const aliceForCarol = await client.app.bsky.getAuthorFeed(
       { author: sc.accounts[alice].username },
-      undefined,
       {
         headers: sc.getHeaders(carol),
       },
@@ -100,7 +95,6 @@ describe('pds author feed views', () => {
           before: cursor,
           limit: 2,
         },
-        undefined,
         { headers: sc.getHeaders(dan) },
       )
       return res.data
@@ -115,7 +109,6 @@ describe('pds author feed views', () => {
       {
         author: sc.accounts[alice].username,
       },
-      undefined,
       { headers: sc.getHeaders(dan) },
     )
 

--- a/packages/pds/tests/views/home-feed.test.ts
+++ b/packages/pds/tests/views/home-feed.test.ts
@@ -53,7 +53,6 @@ describe('pds home feed views', () => {
 
     const aliceFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
-      undefined,
       {
         headers: sc.getHeaders(alice),
       },
@@ -64,7 +63,6 @@ describe('pds home feed views', () => {
 
     const bobFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
-      undefined,
       {
         headers: sc.getHeaders(bob),
       },
@@ -75,7 +73,6 @@ describe('pds home feed views', () => {
 
     const carolFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
-      undefined,
       {
         headers: sc.getHeaders(carol),
       },
@@ -86,7 +83,6 @@ describe('pds home feed views', () => {
 
     const danFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
-      undefined,
       {
         headers: sc.getHeaders(dan),
       },
@@ -107,7 +103,6 @@ describe('pds home feed views', () => {
 
     const aliceFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.Firehose },
-      undefined,
       {
         headers: sc.getHeaders(alice),
       },
@@ -118,7 +113,6 @@ describe('pds home feed views', () => {
 
     const carolFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.Firehose },
-      undefined,
       {
         headers: sc.getHeaders(carol),
       },
@@ -129,12 +123,14 @@ describe('pds home feed views', () => {
   })
 
   it("fetches authenticated user's home feed w/ default algorithm", async () => {
-    const defaultFeed = await client.app.bsky.getHomeFeed({}, undefined, {
-      headers: sc.getHeaders(alice),
-    })
+    const defaultFeed = await client.app.bsky.getHomeFeed(
+      {},
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
     const reverseChronologicalFeed = await client.app.bsky.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
-      undefined,
       {
         headers: sc.getHeaders(alice),
       },
@@ -151,7 +147,6 @@ describe('pds home feed views', () => {
           before: cursor,
           limit: 4,
         },
-        undefined,
         { headers: sc.getHeaders(carol) },
       )
       return res.data
@@ -166,7 +161,6 @@ describe('pds home feed views', () => {
       {
         algorithm: FeedAlgorithm.ReverseChronological,
       },
-      undefined,
       { headers: sc.getHeaders(carol) },
     )
 
@@ -183,7 +177,6 @@ describe('pds home feed views', () => {
           before: cursor,
           limit: 5,
         },
-        undefined,
         { headers: sc.getHeaders(alice) },
       )
       return res.data
@@ -198,7 +191,6 @@ describe('pds home feed views', () => {
       {
         algorithm: FeedAlgorithm.Firehose,
       },
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -33,7 +33,6 @@ describe('pds notification views', () => {
   it('fetches notification count without a last-seen', async () => {
     const notifCount = await client.app.bsky.getNotificationCount(
       {},
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -41,9 +40,12 @@ describe('pds notification views', () => {
   })
 
   it('fetches notifications without a last-seen', async () => {
-    const notifRes = await client.app.bsky.getNotifications({}, undefined, {
-      headers: sc.getHeaders(alice),
-    })
+    const notifRes = await client.app.bsky.getNotifications(
+      {},
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
 
     const notifs = notifRes.data.notifications
     expect(notifs.length).toBe(11)
@@ -65,7 +67,6 @@ describe('pds notification views', () => {
           before: cursor,
           limit: 4,
         },
-        undefined,
         { headers: sc.getHeaders(alice) },
       )
       return res.data
@@ -76,9 +77,12 @@ describe('pds notification views', () => {
       expect(res.notifications.length).toBeLessThanOrEqual(4),
     )
 
-    const full = await client.app.bsky.getNotifications({}, undefined, {
-      headers: sc.getHeaders(alice),
-    })
+    const full = await client.app.bsky.getNotifications(
+      {},
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
 
     expect(full.data.notifications.length).toEqual(11)
     expect(results(paginatedAll)).toEqual(results([full.data]))
@@ -87,9 +91,12 @@ describe('pds notification views', () => {
   it('updates notifications last seen', async () => {
     const { db } = locals.get(app)
 
-    const full = await client.app.bsky.getNotifications({}, undefined, {
-      headers: sc.getHeaders(alice),
-    })
+    const full = await client.app.bsky.getNotifications(
+      {},
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
 
     // Need to look-up createdAt time as a cursor since it's not in the method's output
     const beforeNotif = await db.db
@@ -99,7 +106,6 @@ describe('pds notification views', () => {
       .executeTakeFirstOrThrow()
 
     await client.app.bsky.postNotificationsSeen(
-      {},
       { seenAt: beforeNotif.indexedAt },
       { encoding: 'application/json', headers: sc.getHeaders(alice) },
     )
@@ -108,7 +114,6 @@ describe('pds notification views', () => {
   it('fetches notification count with a last-seen', async () => {
     const notifCount = await client.app.bsky.getNotificationCount(
       {},
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -116,9 +121,12 @@ describe('pds notification views', () => {
   })
 
   it('fetches notifications with a last-seen', async () => {
-    const notifRes = await client.app.bsky.getNotifications({}, undefined, {
-      headers: sc.getHeaders(alice),
-    })
+    const notifRes = await client.app.bsky.getNotifications(
+      {},
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
 
     const notifs = notifRes.data.notifications
     expect(notifs.length).toBe(11)

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -35,7 +35,6 @@ describe('pds profile views', () => {
   it('fetches own profile', async () => {
     const aliceForAlice = await client.app.bsky.getProfile(
       { user: alice },
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -45,7 +44,6 @@ describe('pds profile views', () => {
   it("fetches other's profile, with a follow", async () => {
     const aliceForBob = await client.app.bsky.getProfile(
       { user: alice },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 
@@ -55,7 +53,6 @@ describe('pds profile views', () => {
   it("fetches other's profile, without a follow", async () => {
     const danForBob = await client.app.bsky.getProfile(
       { user: dan },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 
@@ -64,14 +61,12 @@ describe('pds profile views', () => {
 
   it('updates profile', async () => {
     await client.app.bsky.updateProfile(
-      {},
       { displayName: 'ali', description: 'new descript' },
       { headers: sc.getHeaders(alice), encoding: 'application/json' },
     )
 
     const aliceForAlice = await client.app.bsky.getProfile(
       { user: alice },
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -80,14 +75,12 @@ describe('pds profile views', () => {
 
   it('handles partial updates', async () => {
     await client.app.bsky.updateProfile(
-      {},
       { description: 'blah blah' },
       { headers: sc.getHeaders(alice), encoding: 'application/json' },
     )
 
     const aliceForAlice = await client.app.bsky.getProfile(
       { user: alice },
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -103,7 +96,6 @@ describe('pds profile views', () => {
     await Promise.all(
       descriptions.map(async (description) => {
         await client.app.bsky.updateProfile(
-          {},
           { description },
           { headers: sc.getHeaders(alice), encoding: 'application/json' },
         )
@@ -112,7 +104,6 @@ describe('pds profile views', () => {
 
     const profile = await client.app.bsky.getProfile(
       { user: alice },
-      undefined,
       { headers: sc.getHeaders(alice) },
     )
 
@@ -124,13 +115,15 @@ describe('pds profile views', () => {
   })
 
   it('fetches profile by username', async () => {
-    const byDid = await client.app.bsky.getProfile({ user: alice }, undefined, {
-      headers: sc.getHeaders(bob),
-    })
+    const byDid = await client.app.bsky.getProfile(
+      { user: alice },
+      {
+        headers: sc.getHeaders(bob),
+      },
+    )
 
     const byUsername = await client.app.bsky.getProfile(
       { user: sc.accounts[alice].username },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -36,7 +36,6 @@ describe('pds thread views', () => {
   it('fetches deep post thread', async () => {
     const thread = await client.app.bsky.getPostThread(
       { uri: sc.posts[alice][1].ref.uriStr },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 
@@ -46,7 +45,6 @@ describe('pds thread views', () => {
   it('fetches shallow post thread', async () => {
     const thread = await client.app.bsky.getPostThread(
       { depth: 1, uri: sc.posts[alice][1].ref.uriStr },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 
@@ -56,7 +54,6 @@ describe('pds thread views', () => {
   it('fails for an unknown post', async () => {
     const promise = client.app.bsky.getPostThread(
       { uri: 'does.not.exist' },
-      undefined,
       { headers: sc.getHeaders(bob) },
     )
 

--- a/packages/pds/tests/views/user-search.test.ts
+++ b/packages/pds/tests/views/user-search.test.ts
@@ -31,7 +31,6 @@ describe('pds user search views', () => {
   it('typeahead gives relevant results', async () => {
     const result = await client.app.bsky.getUsersTypeahead(
       { term: 'car' },
-      undefined,
       { headers },
     )
 
@@ -76,7 +75,6 @@ describe('pds user search views', () => {
   it('typeahead gives empty result set when provided empty term', async () => {
     const result = await client.app.bsky.getUsersTypeahead(
       { term: '' },
-      undefined,
       { headers },
     )
 
@@ -86,7 +84,6 @@ describe('pds user search views', () => {
   it('typeahead applies limit', async () => {
     const full = await client.app.bsky.getUsersTypeahead(
       { term: 'p' },
-      undefined,
       { headers },
     )
 
@@ -94,7 +91,6 @@ describe('pds user search views', () => {
 
     const limited = await client.app.bsky.getUsersTypeahead(
       { term: 'p', limit: 5 },
-      undefined,
       { headers },
     )
 
@@ -104,7 +100,6 @@ describe('pds user search views', () => {
   it('search gives relevant results', async () => {
     const result = await client.app.bsky.getUsersSearch(
       { term: 'car' },
-      undefined,
       { headers },
     )
 
@@ -149,7 +144,6 @@ describe('pds user search views', () => {
   it('search gives empty result set when provided empty term', async () => {
     const result = await client.app.bsky.getUsersSearch(
       { term: '' },
-      undefined,
       { headers },
     )
 
@@ -161,7 +155,6 @@ describe('pds user search views', () => {
     const paginator = async (cursor?: string) => {
       const res = await client.app.bsky.getUsersSearch(
         { term: 'p', before: cursor, limit: 3 },
-        undefined,
         { headers },
       )
       return res.data
@@ -174,7 +167,6 @@ describe('pds user search views', () => {
 
     const full = await client.app.bsky.getUsersSearch(
       { term: 'p' },
-      undefined,
       { headers },
     )
 
@@ -187,7 +179,6 @@ describe('pds user search views', () => {
     // get stripped. This input triggers a special case where there are no "safe" words for sqlite to search on.
     const result = await client.app.bsky.getUsersSearch(
       { term: ' % _ ' },
-      undefined,
       { headers },
     )
 


### PR DESCRIPTION
- Updates code generated by lex-cli to expect the first param to be the input body, and moves query params to the `qp` field in the `opts`.
- Updates procedure lexicons to favor input bodies.
- Updates all code to use new lexicons and API signatures.