### PR TITLE
Allow duplicate block by the same did w/ sql blockstore

### DIFF
--- a/packages/pds/src/sql-blockstore.ts
+++ b/packages/pds/src/sql-blockstore.ts
@@ -45,6 +45,7 @@ export class SqlBlockstore extends IpldStore {
     const insertBlockOwner = this.db.db
       .insertInto('ipld_block_creator')
       .values({ cid: cid.toString(), did: this.did })
+      .onConflict((oc) => oc.doNothing())
       .execute()
     await Promise.all([insertBlock, insertBlockOwner])
   }

--- a/packages/pds/tests/sql-blockstore.test.ts
+++ b/packages/pds/tests/sql-blockstore.test.ts
@@ -1,0 +1,51 @@
+import SqlBlockstore from '../src/sql-blockstore'
+import { CloseFn, runTestServer, TestServerInfo } from './_util'
+import * as locals from '../src/locals'
+
+describe('server', () => {
+  let server: TestServerInfo
+  let close: CloseFn
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'sql_blockstore',
+    })
+    close = server.close
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('puts and gets blocks.', async () => {
+    const { db } = locals.get(server.app)
+    const did = 'did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme'
+
+    const cid = await db.transaction((dbTxn) => {
+      const blockstore = new SqlBlockstore(dbTxn, did)
+      return blockstore.put({ my: 'block' })
+    })
+
+    const blockstore = new SqlBlockstore(db, did)
+    const value = await blockstore.getUnchecked(cid)
+
+    expect(value).toEqual({ my: 'block' })
+  })
+
+  it('allows same content to be put multiple times by the same did.', async () => {
+    const { db } = locals.get(server.app)
+    const did = 'did:key:zQ3shtxV1FrJfhqE1dvxYRcCknWNjHc3c5X1y3ZSoPDi2aur2'
+
+    const cidA = await db.transaction((dbTxn) => {
+      const blockstore = new SqlBlockstore(dbTxn, did)
+      return blockstore.put({ my: 'block' })
+    })
+
+    const cidB = await db.transaction((dbTxn) => {
+      const blockstore = new SqlBlockstore(dbTxn, did)
+      return blockstore.put({ my: 'block' })
+    })
+
+    expect(cidA.equals(cidB)).toBe(true)
+  })
+})

--- a/packages/pds/tests/sql-blockstore.test.ts
+++ b/packages/pds/tests/sql-blockstore.test.ts
@@ -2,7 +2,7 @@ import SqlBlockstore from '../src/sql-blockstore'
 import { CloseFn, runTestServer, TestServerInfo } from './_util'
 import * as locals from '../src/locals'
 
-describe('server', () => {
+describe('sql blockstore', () => {
   let server: TestServerInfo
   let close: CloseFn
 


### PR DESCRIPTION
Fixes a bug where the `SqlBlockstore` would hit a uniqueness error inserting the same block multiple times for the same did.  Also added a test for prevent regression.