### PR TITLE
Add subject to password reset email

### DIFF
--- a/packages/pds/src/mailer/index.ts
+++ b/packages/pds/src/mailer/index.ts
@@ -33,7 +33,10 @@ export class ServerMailer {
   }
 
   async sendResetPassword(params: { token: string }, mailOpts: Mail.Options) {
-    return this.sendTemplate('resetPassword', params, mailOpts)
+    return this.sendTemplate('resetPassword', params, {
+      subject: 'Password Reset Requested',
+      ...mailOpts,
+    })
   }
 
   private async sendTemplate(templateName, params, mailOpts: Mail.Options) {


### PR DESCRIPTION
The password reset email was missing a subject line— this adds one in!