### PR TITLE
Multibase tag for the did:plc hash

### DIFF
--- a/packages/plc/src/lib/document.ts
+++ b/packages/plc/src/lib/document.ts
@@ -129,7 +129,10 @@ export const hashAndFindDid = async (op: t.CreateOp, truncate = 24) => {
   const hashOfGenesis = await crypto.sha256(cbor.encode(op))
   const hashB32 = uint8arrays.toString(hashOfGenesis, 'base32')
   const truncated = hashB32.slice(0, truncate)
-  return `did:plc:${truncated}`
+  // https://github.com/multiformats/multibase/blob/master/multibase.csv
+  // | encoding | code | description                           |
+  // | base32   | b    | rfc4648 case-insensitive - no padding |
+  return `did:plc:b${truncated}`
 }
 
 export const assureValidCreationOp = async (did: string, op: t.CreateOp) => {


### PR DESCRIPTION
https://github.com/multiformats/multibase/blob/master/multibase.csv

| encoding | code | description                           |
|-|-|-|
| base32    | b    | rfc4648 case-insensitive - no padding |

To be able to change the base in the future we may wish to tag with the multibase prefix.

also consider multihash prefix 0x1218 to be able to update the hash algorithm and prefix length 
```TS
// https://github.com/multiformats/multihash
// 0x12 SHA-256, 24 byte prefix length
prefix = new Uint8Array([0x12, 24])
const hashB32 = uint8arrays.toString( prefix + hashOfGenesis, 'base32')
```
0x12 SHA-256
0x18 prefix length 24 bytes
https://github.com/multiformats/multihash