### PR TITLE
Rework post text slices to be objects

### DIFF
--- a/lexicons/app/bsky/feed/post.json
+++ b/lexicons/app/bsky/feed/post.json
@@ -45,10 +45,12 @@
       }
     },
     "textSlice": {
-      "type": "array",
-      "items": [{"type": "number"}, {"type": "number"}],
-      "minItems": 2,
-      "maxItems": 2
+      "type": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": {"type": "number", "minimum": 0},
+        "end": {"type": "number", "minimum": 0}
+      }
     }
   }
 }

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -2609,17 +2609,18 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
           },
         },
         textSlice: {
-          type: 'array',
-          items: [
-            {
+          type: 'object',
+          required: ['start', 'end'],
+          properties: {
+            start: {
               type: 'number',
+              minimum: 0,
             },
-            {
+            end: {
               type: 'number',
+              minimum: 0,
             },
-          ],
-          minItems: 2,
-          maxItems: 2,
+          },
         },
         postRef: {
           type: 'object',
@@ -2665,17 +2666,18 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
         },
       },
       textSlice: {
-        type: 'array',
-        items: [
-          {
+        type: 'object',
+        required: ['start', 'end'],
+        properties: {
+          start: {
             type: 'number',
+            minimum: 0,
           },
-          {
+          end: {
             type: 'number',
+            minimum: 0,
           },
-        ],
-        minItems: 2,
-        maxItems: 2,
+        },
       },
     },
   },

--- a/packages/api/src/client/types/app/bsky/feed/post.ts
+++ b/packages/api/src/client/types/app/bsky/feed/post.ts
@@ -1,12 +1,6 @@
 /**
 * GENERATED CODE - DO NOT MODIFY
 */
-/**
- * @minItems 2
- * @maxItems 2
- */
-export type TextSlice = [number, number]
-
 export interface Record {
   text: string;
   entities?: Entity[];
@@ -22,6 +16,11 @@ export interface Entity {
   index: TextSlice;
   type: string;
   value: string;
+  [k: string]: unknown;
+}
+export interface TextSlice {
+  start: number;
+  end: number;
   [k: string]: unknown;
 }
 export interface PostRef {

--- a/packages/pds/src/db/records/post.ts
+++ b/packages/pds/src/db/records/post.ts
@@ -79,7 +79,7 @@ const getFn =
     if (!post) return null
     const record = translateDbObj(post)
     record.entities = entities.map((row) => ({
-      index: [row.startIndex, row.endIndex],
+      index: { start: row.startIndex, end: row.endIndex },
       type: row.type,
       value: row.value,
     }))
@@ -99,8 +99,8 @@ const insertFn =
     }
     const entities = (obj.entities || []).map((entity) => ({
       postUri: uri.toString(),
-      startIndex: entity.index[0],
-      endIndex: entity.index[1],
+      startIndex: entity.index.start,
+      endIndex: entity.index.end,
       type: entity.type,
       value: entity.value,
     }))

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -2609,17 +2609,18 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
           },
         },
         textSlice: {
-          type: 'array',
-          items: [
-            {
+          type: 'object',
+          required: ['start', 'end'],
+          properties: {
+            start: {
               type: 'number',
+              minimum: 0,
             },
-            {
+            end: {
               type: 'number',
+              minimum: 0,
             },
-          ],
-          minItems: 2,
-          maxItems: 2,
+          },
         },
         postRef: {
           type: 'object',
@@ -2665,17 +2666,18 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
         },
       },
       textSlice: {
-        type: 'array',
-        items: [
-          {
+        type: 'object',
+        required: ['start', 'end'],
+        properties: {
+          start: {
             type: 'number',
+            minimum: 0,
           },
-          {
+          end: {
             type: 'number',
+            minimum: 0,
           },
-        ],
-        minItems: 2,
-        maxItems: 2,
+        },
       },
     },
   },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
@@ -1,12 +1,6 @@
 /**
 * GENERATED CODE - DO NOT MODIFY
 */
-/**
- * @minItems 2
- * @maxItems 2
- */
-export type TextSlice = [number, number]
-
 export interface Record {
   text: string;
   entities?: Entity[];
@@ -22,6 +16,11 @@ export interface Entity {
   index: TextSlice;
   type: string;
   value: string;
+  [k: string]: unknown;
+}
+export interface TextSlice {
+  start: number;
+  end: number;
   [k: string]: unknown;
 }
 export interface PostRef {

--- a/packages/pds/tests/seeds/basic.ts
+++ b/packages/pds/tests/seeds/basic.ts
@@ -29,7 +29,7 @@ export default async (sc: SeedClient) => {
   await sc.post(dan, posts.dan[0])
   await sc.post(dan, posts.dan[1], [
     {
-      index: [0, 18],
+      index: { start: 0, end: 18 },
       type: 'mention',
       value: alice,
     },

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -181,10 +181,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(2)",
         },
@@ -290,10 +290,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -193,10 +193,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(3)",
         },
@@ -440,10 +440,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(3)",
         },

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -39,10 +39,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },
@@ -214,10 +214,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },
@@ -495,10 +495,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },
@@ -625,10 +625,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },
@@ -800,10 +800,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(0)",
         },
@@ -907,10 +907,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(2)",
         },
@@ -1336,10 +1336,10 @@ Array [
       "createdAt": "1970-01-01T00:00:00.000Z",
       "entities": Array [
         Object {
-          "index": Array [
-            0,
-            18,
-          ],
+          "index": Object {
+            "end": 18,
+            "start": 0,
+          },
           "type": "mention",
           "value": "user(2)",
         },


### PR DESCRIPTION
Changes the text slices in posts to be objects instead of tuple-like arrays. This is to be more friendly to typed languages, and to generally improve clarity.