### PR TITLE
Add 'member' to getProfile state output, and add some dev-env mock data

### DIFF
--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -35,7 +35,8 @@
         "myState": {
           "type": "object",
           "properties": {
-            "follow": {"type": "string"}
+            "follow": {"type": "string"},
+            "member": {"type": "string"}
           }
         }
       }

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -926,6 +926,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               follow: {
                 type: 'string',
               },
+              member: {
+                type: 'string',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/app/bsky/actor/getProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfile.ts
@@ -31,6 +31,7 @@ export interface OutputSchema {
   postsCount: number;
   myState?: {
     follow?: string,
+    member?: string,
   };
 }
 

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -2,7 +2,7 @@ import { DevEnv } from '../index'
 import { ServerType } from '../types'
 import { genServerCfg } from '../util'
 import { AtUri } from '@atproto/uri'
-import { ServiceClient } from '@atproto/api'
+import { ServiceClient, APP_BSKY_GRAPH } from '@atproto/api'
 import { postTexts, replyTexts } from './data'
 
 // NOTE
@@ -120,6 +120,65 @@ export async function generateMockSetup(env: DevEnv) {
   await follow(bob, carla)
   await follow(carla, alice)
   await follow(carla, bob)
+
+  // everybody's in the "besties" scene
+  const bestiesScene = await alice.api.app.bsky.actor.createScene({
+    handle: 'besties.test',
+  })
+  {
+    const invite = await alice.api.app.bsky.graph.assertion.create(
+      { did: bestiesScene.data.did },
+      {
+        assertion: APP_BSKY_GRAPH.AssertMember,
+        subject: {
+          did: bob.did,
+          declarationCid: bob.declarationCid,
+        },
+        createdAt: new Date().toISOString(),
+      },
+    )
+    bob.api.app.bsky.graph.confirmation.create(
+      { did: bob.did },
+      {
+        originator: {
+          did: bestiesScene.data.did,
+          declarationCid: bestiesScene.data.declarationCid,
+        },
+        assertion: {
+          uri: invite.uri,
+          cid: invite.cid,
+        },
+        createdAt: new Date().toISOString(),
+      },
+    )
+  }
+  {
+    const invite = await alice.api.app.bsky.graph.assertion.create(
+      { did: bestiesScene.data.did },
+      {
+        assertion: APP_BSKY_GRAPH.AssertMember,
+        subject: {
+          did: carla.did,
+          declarationCid: carla.declarationCid,
+        },
+        createdAt: new Date().toISOString(),
+      },
+    )
+    carla.api.app.bsky.graph.confirmation.create(
+      { did: carla.did },
+      {
+        originator: {
+          did: bestiesScene.data.did,
+          declarationCid: bestiesScene.data.declarationCid,
+        },
+        assertion: {
+          uri: invite.uri,
+          cid: invite.cid,
+        },
+        createdAt: new Date().toISOString(),
+      },
+    )
+  }
 
   // a set of posts and reposts
   const posts: { uri: string; cid: string }[] = []

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -137,7 +137,7 @@ export async function generateMockSetup(env: DevEnv) {
         createdAt: new Date().toISOString(),
       },
     )
-    bob.api.app.bsky.graph.confirmation.create(
+    await bob.api.app.bsky.graph.confirmation.create(
       { did: bob.did },
       {
         originator: {
@@ -164,7 +164,7 @@ export async function generateMockSetup(env: DevEnv) {
         createdAt: new Date().toISOString(),
       },
     )
-    carla.api.app.bsky.graph.confirmation.create(
+    await carla.api.app.bsky.graph.confirmation.create(
       { did: carla.did },
       {
         originator: {

--- a/packages/pds/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/api/app/bsky/actor/getProfile.ts
@@ -58,6 +58,14 @@ export default function (server: Server) {
             .whereRef('subjectDid', '=', ref('did_handle.did'))
             .select('uri')
             .as('requesterFollow'),
+          db.db
+            .selectFrom('assertion')
+            .whereRef('creator', '=', ref('did_handle.did'))
+            .where('assertion', '=', APP_BSKY_GRAPH.AssertMember)
+            .where('confirmUri', 'is not', null)
+            .where('subjectDid', '=', requester)
+            .select('confirmUri')
+            .as('requesterMember'),
         ])
         .executeTakeFirst()
 
@@ -80,6 +88,7 @@ export default function (server: Server) {
           postsCount: queryRes.postsCount,
           myState: {
             follow: queryRes.requesterFollow || undefined,
+            member: queryRes.requesterMember || undefined,
           },
         },
       }

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -926,6 +926,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               follow: {
                 type: 'string',
               },
+              member: {
+                type: 'string',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -39,6 +39,7 @@ export interface OutputSchema {
   postsCount: number;
   myState?: {
     follow?: string,
+    member?: string,
   };
 }
 

--- a/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
@@ -57,7 +57,9 @@ Object {
   "followsCount": 0,
   "handle": "scene.test",
   "membersCount": 4,
-  "myState": Object {},
+  "myState": Object {
+    "member": "record(0)",
+  },
   "postsCount": 0,
 }
 `;

--- a/packages/pds/tests/views/members.test.ts
+++ b/packages/pds/tests/views/members.test.ts
@@ -177,4 +177,25 @@ describe('pds member views', () => {
     expect(full.data.memberships.length).toEqual(3)
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
+
+  it('includes membership state in getProfile', async () => {
+    const profile1 = await client.app.bsky.actor.getProfile(
+      {
+        actor: scene,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(profile1.data.myState?.member).toBeTruthy()
+    const profile2 = await client.app.bsky.actor.getProfile(
+      {
+        actor: otherScene,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(profile2.data.myState?.member).toBeFalsy()
+  })
 })


### PR DESCRIPTION
- Adds `member` to the `myState` output of `getProfile`. The value is the URI of the confirmation record.
- Adds some scene mock data to the dev environment