### PR TITLE
Add app.bsky.graph.getAssertions()

### DIFF
--- a/lexicons/app/bsky/graph/getAssertions.json
+++ b/lexicons/app/bsky/graph/getAssertions.json
@@ -5,9 +5,9 @@
   "description": "General-purpose query for assertions.",
   "parameters": {
     "type": "object",
-    "required": ["actor"],
     "properties": {
-      "actor": {"type": "string"},
+      "author": {"type": "string"},
+      "subject": {"type": "string"},
       "assertion": {"type": "string"},
       "confirmed": {"type": "boolean"},
       "limit": {"type": "number", "maximum": 100},
@@ -18,32 +18,20 @@
     "encoding": "application/json",
     "schema": {
       "type": "object",
-      "required": ["subject", "assertions"],
+      "required": ["assertions"],
       "properties": {
-        "subject": {
-          "type": "object",
-          "required": ["did", "declaration", "handle"],
-          "properties": {
-            "did": {"type": "string"},
-            "declaration": {"$ref": "#/defs/declaration"},
-            "handle": {"type": "string"},
-            "displayName": {
-              "type": "string",
-              "maxLength": 64
-            }
-          }
-        },
         "cursor": {"type": "string"},
         "assertions": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["uri", "cid", "assertion", "subject", "indexedAt", "createdAt"],
+            "required": ["uri", "cid", "assertion", "author", "subject", "indexedAt", "createdAt"],
             "properties": {
               "uri": {"type": "string"},
               "cid": {"type": "string"},
               "assertion": {"type": "string"},
               "confirmation": {"$ref": "#/defs/confirmation"},
+              "author": {"$ref": "#/defs/actor"},
               "subject": {"$ref": "#/defs/actor"},
               "indexedAt": {"type": "string", "format": "date-time"},
               "createdAt": {"type": "string", "format": "date-time"}

--- a/lexicons/app/bsky/graph/getAssertions.json
+++ b/lexicons/app/bsky/graph/getAssertions.json
@@ -1,0 +1,102 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getAssertions",
+  "type": "query",
+  "description": "General-purpose query for assertions.",
+  "parameters": {
+    "type": "object",
+    "required": ["actor"],
+    "properties": {
+      "actor": {"type": "string"},
+      "assertion": {"type": "string"},
+      "confirmed": {"type": "boolean"},
+      "limit": {"type": "number", "maximum": 100},
+      "before": {"type": "string"}
+    }
+  },
+  "output": {
+    "encoding": "application/json",
+    "schema": {
+      "type": "object",
+      "required": ["subject", "assertions"],
+      "properties": {
+        "subject": {
+          "type": "object",
+          "required": ["did", "declaration", "handle"],
+          "properties": {
+            "did": {"type": "string"},
+            "declaration": {"$ref": "#/defs/declaration"},
+            "handle": {"type": "string"},
+            "displayName": {
+              "type": "string",
+              "maxLength": 64
+            }
+          }
+        },
+        "cursor": {"type": "string"},
+        "assertions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["uri", "cid", "assertion", "subject", "indexedAt", "createdAt"],
+            "properties": {
+              "uri": {"type": "string"},
+              "cid": {"type": "string"},
+              "assertion": {"type": "string"},
+              "confirmation": {"$ref": "#/defs/confirmation"},
+              "subject": {"$ref": "#/defs/actor"},
+              "indexedAt": {"type": "string", "format": "date-time"},
+              "createdAt": {"type": "string", "format": "date-time"}
+            }
+          }
+        }
+      }
+    }
+  },
+  "defs": {
+    "confirmation": {
+      "type": "object",
+      "required": ["uri", "cid", "indexedAt", "createdAt"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"},
+        "indexedAt": {"type": "string", "format": "date-time"},
+        "createdAt": {"type": "string", "format": "date-time"}
+      }
+    },
+    "actor": {
+      "type": "object",
+      "required": ["did", "declaration", "handle"],
+      "properties": {
+        "did": {"type": "string"},
+        "declaration": {"$ref": "#/defs/declaration"},
+        "handle": {"type": "string"},
+        "displayName": {
+          "type": "string",
+          "maxLength": 64
+        }
+      }
+    },
+    "declaration": {
+      "type": "object",
+      "required": ["cid", "actorType"],
+      "properties": {
+        "cid": {"type": "string"},
+        "actorType": {
+          "oneOf": [
+            {"$ref": "#/defs/actorKnown"},
+            {"$ref": "#/defs/actorUnknown"}
+          ]
+        }
+      }
+    },
+    "actorKnown": {
+      "type": "string",
+      "enum": ["app.bsky.system.actorUser", "app.bsky.system.actorScene"]
+    },
+    "actorUnknown": {
+      "type": "string",
+      "not": {"enum": ["app.bsky.system.actorUser", "app.bsky.system.actorScene"]}
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -49,6 +49,7 @@ import * as AppBskyFeedVote from './types/app/bsky/feed/vote'
 import * as AppBskyGraphAssertion from './types/app/bsky/graph/assertion'
 import * as AppBskyGraphConfirmation from './types/app/bsky/graph/confirmation'
 import * as AppBskyGraphFollow from './types/app/bsky/graph/follow'
+import * as AppBskyGraphGetAssertions from './types/app/bsky/graph/getAssertions'
 import * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 import * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
 import * as AppBskyGraphGetMembers from './types/app/bsky/graph/getMembers'
@@ -101,6 +102,7 @@ export * as AppBskyFeedVote from './types/app/bsky/feed/vote'
 export * as AppBskyGraphAssertion from './types/app/bsky/graph/assertion'
 export * as AppBskyGraphConfirmation from './types/app/bsky/graph/confirmation'
 export * as AppBskyGraphFollow from './types/app/bsky/graph/follow'
+export * as AppBskyGraphGetAssertions from './types/app/bsky/graph/getAssertions'
 export * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 export * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
 export * as AppBskyGraphGetMembers from './types/app/bsky/graph/getMembers'
@@ -1041,6 +1043,17 @@ export class GraphNS {
     this.assertion = new AssertionRecord(service)
     this.confirmation = new ConfirmationRecord(service)
     this.follow = new FollowRecord(service)
+  }
+
+  getAssertions(
+    params?: AppBskyGraphGetAssertions.QueryParams,
+    opts?: AppBskyGraphGetAssertions.CallOptions
+  ): Promise<AppBskyGraphGetAssertions.Response> {
+    return this._service.xrpc
+      .call('app.bsky.graph.getAssertions', params, undefined, opts)
+      .catch((e) => {
+        throw AppBskyGraphGetAssertions.toKnownErr(e)
+      })
   }
 
   getFollowers(

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -3005,6 +3005,222 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       },
     },
   },
+  'app.bsky.graph.getAssertions': {
+    lexicon: 1,
+    id: 'app.bsky.graph.getAssertions',
+    type: 'query',
+    description: 'General-purpose query for assertions.',
+    parameters: {
+      type: 'object',
+      required: ['actor'],
+      properties: {
+        actor: {
+          type: 'string',
+        },
+        assertion: {
+          type: 'string',
+        },
+        confirmed: {
+          type: 'boolean',
+        },
+        limit: {
+          type: 'number',
+          maximum: 100,
+        },
+        before: {
+          type: 'string',
+        },
+      },
+    },
+    output: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['subject', 'assertions'],
+        properties: {
+          subject: {
+            type: 'object',
+            required: ['did', 'declaration', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              declaration: {
+                $ref: '#/$defs/declaration',
+              },
+              handle: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          cursor: {
+            type: 'string',
+          },
+          assertions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: [
+                'uri',
+                'cid',
+                'assertion',
+                'subject',
+                'indexedAt',
+                'createdAt',
+              ],
+              properties: {
+                uri: {
+                  type: 'string',
+                },
+                cid: {
+                  type: 'string',
+                },
+                assertion: {
+                  type: 'string',
+                },
+                confirmation: {
+                  $ref: '#/$defs/confirmation',
+                },
+                subject: {
+                  $ref: '#/$defs/actor',
+                },
+                indexedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+              },
+            },
+          },
+        },
+        $defs: {
+          declaration: {
+            type: 'object',
+            required: ['cid', 'actorType'],
+            properties: {
+              cid: {
+                type: 'string',
+              },
+              actorType: {
+                oneOf: [
+                  {
+                    $ref: '#/$defs/actorKnown',
+                  },
+                  {
+                    $ref: '#/$defs/actorUnknown',
+                  },
+                ],
+              },
+            },
+          },
+          actorKnown: {
+            type: 'string',
+            enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+          },
+          actorUnknown: {
+            type: 'string',
+            not: {
+              enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+            },
+          },
+          confirmation: {
+            type: 'object',
+            required: ['uri'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+            },
+          },
+          actor: {
+            type: 'object',
+            required: ['did', 'declaration', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              declaration: {
+                $ref: '#/$defs/declaration',
+              },
+              handle: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      confirmation: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+        },
+      },
+      actor: {
+        type: 'object',
+        required: ['did', 'declaration', 'handle'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          declaration: {
+            $ref: '#/$defs/declaration',
+          },
+          handle: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      declaration: {
+        type: 'object',
+        required: ['cid', 'actorType'],
+        properties: {
+          cid: {
+            type: 'string',
+          },
+          actorType: {
+            oneOf: [
+              {
+                $ref: '#/$defs/actorKnown',
+              },
+              {
+                $ref: '#/$defs/actorUnknown',
+              },
+            ],
+          },
+        },
+      },
+      actorKnown: {
+        type: 'string',
+        enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+      },
+      actorUnknown: {
+        type: 'string',
+        not: {
+          enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+        },
+      },
+    },
+  },
   'app.bsky.graph.getFollowers': {
     lexicon: 1,
     id: 'app.bsky.graph.getFollowers',

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -3012,9 +3012,11 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     description: 'General-purpose query for assertions.',
     parameters: {
       type: 'object',
-      required: ['actor'],
       properties: {
-        actor: {
+        author: {
+          type: 'string',
+        },
+        subject: {
           type: 'string',
         },
         assertion: {
@@ -3036,9 +3038,77 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['subject', 'assertions'],
+        required: ['assertions'],
         properties: {
-          subject: {
+          cursor: {
+            type: 'string',
+          },
+          assertions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: [
+                'uri',
+                'cid',
+                'assertion',
+                'author',
+                'subject',
+                'indexedAt',
+                'createdAt',
+              ],
+              properties: {
+                uri: {
+                  type: 'string',
+                },
+                cid: {
+                  type: 'string',
+                },
+                assertion: {
+                  type: 'string',
+                },
+                confirmation: {
+                  $ref: '#/$defs/confirmation',
+                },
+                author: {
+                  $ref: '#/$defs/actor',
+                },
+                subject: {
+                  $ref: '#/$defs/actor',
+                },
+                indexedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+              },
+            },
+          },
+        },
+        $defs: {
+          confirmation: {
+            type: 'object',
+            required: ['uri', 'cid', 'indexedAt', 'createdAt'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+              cid: {
+                type: 'string',
+              },
+              indexedAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+            },
+          },
+          actor: {
             type: 'object',
             required: ['did', 'declaration', 'handle'],
             properties: {
@@ -3057,50 +3127,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               },
             },
           },
-          cursor: {
-            type: 'string',
-          },
-          assertions: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: [
-                'uri',
-                'cid',
-                'assertion',
-                'subject',
-                'indexedAt',
-                'createdAt',
-              ],
-              properties: {
-                uri: {
-                  type: 'string',
-                },
-                cid: {
-                  type: 'string',
-                },
-                assertion: {
-                  type: 'string',
-                },
-                confirmation: {
-                  $ref: '#/$defs/confirmation',
-                },
-                subject: {
-                  $ref: '#/$defs/actor',
-                },
-                indexedAt: {
-                  type: 'string',
-                  format: 'date-time',
-                },
-                createdAt: {
-                  type: 'string',
-                  format: 'date-time',
-                },
-              },
-            },
-          },
-        },
-        $defs: {
           declaration: {
             type: 'object',
             required: ['cid', 'actorType'],
@@ -3130,44 +3156,27 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
             },
           },
-          confirmation: {
-            type: 'object',
-            required: ['uri'],
-            properties: {
-              uri: {
-                type: 'string',
-              },
-            },
-          },
-          actor: {
-            type: 'object',
-            required: ['did', 'declaration', 'handle'],
-            properties: {
-              did: {
-                type: 'string',
-              },
-              declaration: {
-                $ref: '#/$defs/declaration',
-              },
-              handle: {
-                type: 'string',
-              },
-              displayName: {
-                type: 'string',
-                maxLength: 64,
-              },
-            },
-          },
         },
       },
     },
     defs: {
       confirmation: {
         type: 'object',
-        required: ['uri'],
+        required: ['uri', 'cid', 'indexedAt', 'createdAt'],
         properties: {
           uri: {
             type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
@@ -1,0 +1,67 @@
+/**
+* GENERATED CODE - DO NOT MODIFY
+*/
+import { Headers, XRPCError } from '@atproto/xrpc'
+
+export interface QueryParams {
+  actor: string;
+  assertion?: string;
+  confirmed?: boolean;
+  limit?: number;
+  before?: string;
+}
+
+export interface CallOptions {
+  headers?: Headers;
+}
+
+export type InputSchema = undefined
+
+export type ActorKnown =
+  | 'app.bsky.system.actorUser'
+  | 'app.bsky.system.actorScene'
+export type ActorUnknown = string
+
+export interface OutputSchema {
+  subject: {
+    did: string,
+    declaration: Declaration,
+    handle: string,
+    displayName?: string,
+  };
+  cursor?: string;
+  assertions: {
+    uri: string,
+    cid: string,
+    assertion: string,
+    confirmation?: Confirmation,
+    subject: Actor,
+    indexedAt: string,
+    createdAt: string,
+  }[];
+}
+export interface Declaration {
+  cid: string;
+  actorType: ActorKnown | ActorUnknown;
+}
+export interface Confirmation {
+  uri: string;
+}
+export interface Actor {
+  did: string;
+  declaration: Declaration;
+  handle: string;
+  displayName?: string;
+}
+
+export interface Response {
+  success: boolean;
+  headers: Headers;
+  data: OutputSchema;
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
@@ -4,7 +4,8 @@
 import { Headers, XRPCError } from '@atproto/xrpc'
 
 export interface QueryParams {
-  actor: string;
+  author?: string;
+  subject?: string;
   assertion?: string;
   confirmed?: boolean;
   limit?: number;
@@ -23,35 +24,33 @@ export type ActorKnown =
 export type ActorUnknown = string
 
 export interface OutputSchema {
-  subject: {
-    did: string,
-    declaration: Declaration,
-    handle: string,
-    displayName?: string,
-  };
   cursor?: string;
   assertions: {
     uri: string,
     cid: string,
     assertion: string,
     confirmation?: Confirmation,
+    author: Actor,
     subject: Actor,
     indexedAt: string,
     createdAt: string,
   }[];
 }
-export interface Declaration {
-  cid: string;
-  actorType: ActorKnown | ActorUnknown;
-}
 export interface Confirmation {
   uri: string;
+  cid: string;
+  indexedAt: string;
+  createdAt: string;
 }
 export interface Actor {
   did: string;
   declaration: Declaration;
   handle: string;
   displayName?: string;
+}
+export interface Declaration {
+  cid: string;
+  actorType: ActorKnown | ActorUnknown;
 }
 
 export interface Response {

--- a/packages/pds/src/api/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/api/app/bsky/graph/getAssertions.ts
@@ -1,0 +1,96 @@
+import { Server } from '../../../../lexicon'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import * as GetAssertions from '../../../../lexicon/types/app/bsky/graph/getAssertions'
+import { getActorInfo } from '../util'
+import * as locals from '../../../../locals'
+import { paginate } from '../../../../db/util'
+
+export default function (server: Server) {
+  server.app.bsky.graph.getAssertions(
+    async (params: GetAssertions.QueryParams, _input, _req, res) => {
+      const { actor, assertion, confirmed, limit, before } = params
+      const { db } = locals.get(res)
+      const { ref } = db.db.dynamic
+
+      const subject = await getActorInfo(db.db, actor).catch((_e) => {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      })
+
+      let assertionsReq = db.db
+        .selectFrom('assertion')
+        .where('assertion.creator', '=', subject.did)
+        .if(typeof assertion === 'string', (q) =>
+          q.where('assertion.assertion', '=', assertion as string),
+        )
+        .if(confirmed === true, (q) =>
+          q.where('assertion.confirmUri', 'is not', null),
+        )
+        .if(confirmed === false, (q) =>
+          q.where('assertion.confirmUri', 'is', null),
+        )
+        .innerJoin(
+          'did_handle as subject',
+          'subject.did',
+          'assertion.subjectDid',
+        )
+        .leftJoin('profile', 'profile.creator', 'subject.did')
+        .select([
+          'assertion.uri as uri',
+          'assertion.cid as cid',
+          'assertion.assertion as assertionType',
+          'assertion.confirmUri',
+          'assertion.confirmCid',
+          'assertion.confirmCreated',
+          'assertion.confirmIndexed',
+          'subject.did as subjectDid',
+          'subject.handle as subjectHandle',
+          'subject.declarationCid as subjectDeclarationCid',
+          'subject.actorType as subjectActorType',
+          'profile.displayName as subjectDisplayName',
+          'assertion.createdAt as createdAt',
+          'assertion.indexedAt as indexedAt',
+        ])
+
+      assertionsReq = paginate(assertionsReq, {
+        limit,
+        before,
+        by: ref('assertion.createdAt'),
+      })
+
+      const assertionsRes = await assertionsReq.execute()
+      const assertions = assertionsRes.map((row) => ({
+        uri: row.uri,
+        cid: row.cid,
+        assertion: row.assertionType,
+        confirmation: row.confirmUri
+          ? {
+              uri: row.confirmUri,
+              cid: row.confirmCid,
+              indexedAt: row.confirmIndexed,
+              createdAt: row.confirmCreated,
+            }
+          : undefined,
+        subject: {
+          did: row.subjectDid,
+          handle: row.subjectHandle,
+          declaration: {
+            cid: row.subjectDeclarationCid,
+            actorType: row.subjectActorType,
+          },
+          displayName: row.subjectDisplayName || undefined,
+        },
+        createdAt: row.createdAt,
+        indexedAt: row.indexedAt,
+      }))
+
+      return {
+        encoding: 'application/json',
+        body: {
+          subject,
+          assertions,
+          cursor: assertions.at(-1)?.createdAt,
+        },
+      }
+    },
+  )
+}

--- a/packages/pds/src/api/app/bsky/index.ts
+++ b/packages/pds/src/api/app/bsky/index.ts
@@ -12,6 +12,7 @@ import getFollowers from './graph/getFollowers'
 import getFollows from './graph/getFollows'
 import getMembers from './graph/getMembers'
 import getMemberships from './graph/getMemberships'
+import getAssertions from './graph/getAssertions'
 import getUsersSearch from './actor/search'
 import getUsersTypeahead from './actor/searchTypeahead'
 import getNotifications from './notification/list'
@@ -33,6 +34,7 @@ export default function (server: Server) {
   getFollows(server)
   getMembers(server)
   getMemberships(server)
+  getAssertions(server)
   getUsersSearch(server)
   getUsersTypeahead(server)
   getNotifications(server)

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -40,6 +40,7 @@ import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy'
 import * as AppBskyFeedGetTimeline from './types/app/bsky/feed/getTimeline'
 import * as AppBskyFeedGetVotes from './types/app/bsky/feed/getVotes'
 import * as AppBskyFeedSetVote from './types/app/bsky/feed/setVote'
+import * as AppBskyGraphGetAssertions from './types/app/bsky/graph/getAssertions'
 import * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 import * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
 import * as AppBskyGraphGetMembers from './types/app/bsky/graph/getMembers'
@@ -369,6 +370,11 @@ export class GraphNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  getAssertions(handler: AppBskyGraphGetAssertions.Handler) {
+    const schema = 'app.bsky.graph.getAssertions' // @ts-ignore
+    return this._server.xrpc.method(schema, handler)
   }
 
   getFollowers(handler: AppBskyGraphGetFollowers.Handler) {

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -3005,6 +3005,222 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       },
     },
   },
+  'app.bsky.graph.getAssertions': {
+    lexicon: 1,
+    id: 'app.bsky.graph.getAssertions',
+    type: 'query',
+    description: 'General-purpose query for assertions.',
+    parameters: {
+      type: 'object',
+      required: ['actor'],
+      properties: {
+        actor: {
+          type: 'string',
+        },
+        assertion: {
+          type: 'string',
+        },
+        confirmed: {
+          type: 'boolean',
+        },
+        limit: {
+          type: 'number',
+          maximum: 100,
+        },
+        before: {
+          type: 'string',
+        },
+      },
+    },
+    output: {
+      encoding: 'application/json',
+      schema: {
+        type: 'object',
+        required: ['subject', 'assertions'],
+        properties: {
+          subject: {
+            type: 'object',
+            required: ['did', 'declaration', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              declaration: {
+                $ref: '#/$defs/declaration',
+              },
+              handle: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          cursor: {
+            type: 'string',
+          },
+          assertions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: [
+                'uri',
+                'cid',
+                'assertion',
+                'subject',
+                'indexedAt',
+                'createdAt',
+              ],
+              properties: {
+                uri: {
+                  type: 'string',
+                },
+                cid: {
+                  type: 'string',
+                },
+                assertion: {
+                  type: 'string',
+                },
+                confirmation: {
+                  $ref: '#/$defs/confirmation',
+                },
+                subject: {
+                  $ref: '#/$defs/actor',
+                },
+                indexedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+              },
+            },
+          },
+        },
+        $defs: {
+          declaration: {
+            type: 'object',
+            required: ['cid', 'actorType'],
+            properties: {
+              cid: {
+                type: 'string',
+              },
+              actorType: {
+                oneOf: [
+                  {
+                    $ref: '#/$defs/actorKnown',
+                  },
+                  {
+                    $ref: '#/$defs/actorUnknown',
+                  },
+                ],
+              },
+            },
+          },
+          actorKnown: {
+            type: 'string',
+            enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+          },
+          actorUnknown: {
+            type: 'string',
+            not: {
+              enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+            },
+          },
+          confirmation: {
+            type: 'object',
+            required: ['uri'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+            },
+          },
+          actor: {
+            type: 'object',
+            required: ['did', 'declaration', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              declaration: {
+                $ref: '#/$defs/declaration',
+              },
+              handle: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      confirmation: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+        },
+      },
+      actor: {
+        type: 'object',
+        required: ['did', 'declaration', 'handle'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          declaration: {
+            $ref: '#/$defs/declaration',
+          },
+          handle: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      declaration: {
+        type: 'object',
+        required: ['cid', 'actorType'],
+        properties: {
+          cid: {
+            type: 'string',
+          },
+          actorType: {
+            oneOf: [
+              {
+                $ref: '#/$defs/actorKnown',
+              },
+              {
+                $ref: '#/$defs/actorUnknown',
+              },
+            ],
+          },
+        },
+      },
+      actorKnown: {
+        type: 'string',
+        enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+      },
+      actorUnknown: {
+        type: 'string',
+        not: {
+          enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
+        },
+      },
+    },
+  },
   'app.bsky.graph.getFollowers': {
     lexicon: 1,
     id: 'app.bsky.graph.getFollowers',

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -3012,9 +3012,11 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
     description: 'General-purpose query for assertions.',
     parameters: {
       type: 'object',
-      required: ['actor'],
       properties: {
-        actor: {
+        author: {
+          type: 'string',
+        },
+        subject: {
           type: 'string',
         },
         assertion: {
@@ -3036,9 +3038,77 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       encoding: 'application/json',
       schema: {
         type: 'object',
-        required: ['subject', 'assertions'],
+        required: ['assertions'],
         properties: {
-          subject: {
+          cursor: {
+            type: 'string',
+          },
+          assertions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: [
+                'uri',
+                'cid',
+                'assertion',
+                'author',
+                'subject',
+                'indexedAt',
+                'createdAt',
+              ],
+              properties: {
+                uri: {
+                  type: 'string',
+                },
+                cid: {
+                  type: 'string',
+                },
+                assertion: {
+                  type: 'string',
+                },
+                confirmation: {
+                  $ref: '#/$defs/confirmation',
+                },
+                author: {
+                  $ref: '#/$defs/actor',
+                },
+                subject: {
+                  $ref: '#/$defs/actor',
+                },
+                indexedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+              },
+            },
+          },
+        },
+        $defs: {
+          confirmation: {
+            type: 'object',
+            required: ['uri', 'cid', 'indexedAt', 'createdAt'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+              cid: {
+                type: 'string',
+              },
+              indexedAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+            },
+          },
+          actor: {
             type: 'object',
             required: ['did', 'declaration', 'handle'],
             properties: {
@@ -3057,50 +3127,6 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               },
             },
           },
-          cursor: {
-            type: 'string',
-          },
-          assertions: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: [
-                'uri',
-                'cid',
-                'assertion',
-                'subject',
-                'indexedAt',
-                'createdAt',
-              ],
-              properties: {
-                uri: {
-                  type: 'string',
-                },
-                cid: {
-                  type: 'string',
-                },
-                assertion: {
-                  type: 'string',
-                },
-                confirmation: {
-                  $ref: '#/$defs/confirmation',
-                },
-                subject: {
-                  $ref: '#/$defs/actor',
-                },
-                indexedAt: {
-                  type: 'string',
-                  format: 'date-time',
-                },
-                createdAt: {
-                  type: 'string',
-                  format: 'date-time',
-                },
-              },
-            },
-          },
-        },
-        $defs: {
           declaration: {
             type: 'object',
             required: ['cid', 'actorType'],
@@ -3130,44 +3156,27 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               enum: ['app.bsky.system.actorUser', 'app.bsky.system.actorScene'],
             },
           },
-          confirmation: {
-            type: 'object',
-            required: ['uri'],
-            properties: {
-              uri: {
-                type: 'string',
-              },
-            },
-          },
-          actor: {
-            type: 'object',
-            required: ['did', 'declaration', 'handle'],
-            properties: {
-              did: {
-                type: 'string',
-              },
-              declaration: {
-                $ref: '#/$defs/declaration',
-              },
-              handle: {
-                type: 'string',
-              },
-              displayName: {
-                type: 'string',
-                maxLength: 64,
-              },
-            },
-          },
         },
       },
     },
     defs: {
       confirmation: {
         type: 'object',
-        required: ['uri'],
+        required: ['uri', 'cid', 'indexedAt', 'createdAt'],
         properties: {
           uri: {
             type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
@@ -4,7 +4,8 @@
 import express from 'express'
 
 export interface QueryParams {
-  actor: string;
+  author?: string;
+  subject?: string;
   assertion?: string;
   confirmed?: boolean;
   limit?: number;
@@ -31,35 +32,33 @@ export type ActorKnown =
 export type ActorUnknown = string
 
 export interface OutputSchema {
-  subject: {
-    did: string,
-    declaration: Declaration,
-    handle: string,
-    displayName?: string,
-  };
   cursor?: string;
   assertions: {
     uri: string,
     cid: string,
     assertion: string,
     confirmation?: Confirmation,
+    author: Actor,
     subject: Actor,
     indexedAt: string,
     createdAt: string,
   }[];
 }
-export interface Declaration {
-  cid: string;
-  actorType: ActorKnown | ActorUnknown;
-}
 export interface Confirmation {
   uri: string;
+  cid: string;
+  indexedAt: string;
+  createdAt: string;
 }
 export interface Actor {
   did: string;
   declaration: Declaration;
   handle: string;
   displayName?: string;
+}
+export interface Declaration {
+  cid: string;
+  actorType: ActorKnown | ActorUnknown;
 }
 
 export type Handler = (

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
@@ -1,0 +1,70 @@
+/**
+* GENERATED CODE - DO NOT MODIFY
+*/
+import express from 'express'
+
+export interface QueryParams {
+  actor: string;
+  assertion?: string;
+  confirmed?: boolean;
+  limit?: number;
+  before?: string;
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json';
+  body: OutputSchema;
+}
+
+export interface HandlerError {
+  status: number;
+  message?: string;
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export type ActorKnown =
+  | 'app.bsky.system.actorUser'
+  | 'app.bsky.system.actorScene'
+export type ActorUnknown = string
+
+export interface OutputSchema {
+  subject: {
+    did: string,
+    declaration: Declaration,
+    handle: string,
+    displayName?: string,
+  };
+  cursor?: string;
+  assertions: {
+    uri: string,
+    cid: string,
+    assertion: string,
+    confirmation?: Confirmation,
+    subject: Actor,
+    indexedAt: string,
+    createdAt: string,
+  }[];
+}
+export interface Declaration {
+  cid: string;
+  actorType: ActorKnown | ActorUnknown;
+}
+export interface Confirmation {
+  uri: string;
+}
+export interface Actor {
+  did: string;
+  declaration: Declaration;
+  handle: string;
+  displayName?: string;
+}
+
+export type Handler = (
+  params: QueryParams,
+  input: HandlerInput,
+  req: express.Request,
+  res: express.Response
+) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
@@ -1,13 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pds assertion views fetches assertions 1`] = `
+exports[`pds assertion views fetches assertions by author & subject 1`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(0)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+}
+`;
+
+exports[`pds assertion views fetches assertions by author 1`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(0)",
+      "confirmation": Object {
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -26,6 +72,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -47,6 +101,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -68,7 +130,15 @@ Object {
       "uri": "record(4)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(8)",
       "confirmation": Object {
         "cid": "cids(9)",
@@ -90,7 +160,15 @@ Object {
       "uri": "record(6)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(10)",
       "confirmation": Object {
         "cid": "cids(11)",
@@ -113,23 +191,23 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions 2`] = `
+exports[`pds assertion views fetches assertions by author 2`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
+      "cid": "cids(0)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "subject": Object {
@@ -144,6 +222,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
       "cid": "cids(3)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -160,6 +246,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -182,6 +276,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -204,25 +306,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "other-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions 3`] = `
+exports[`pds assertion views fetches assertions by author 3`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -241,6 +343,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(4)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -257,6 +367,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(5)",
       "confirmation": Object {
         "cid": "cids(6)",
@@ -279,6 +397,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(7)",
       "confirmation": Object {
         "cid": "cids(8)",
@@ -300,6 +426,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(9)",
       "confirmation": Object {
         "cid": "cids(10)",
@@ -321,25 +455,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "carol-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 1`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 1`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -358,6 +492,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -379,6 +521,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -400,7 +550,15 @@ Object {
       "uri": "record(4)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(8)",
       "confirmation": Object {
         "cid": "cids(9)",
@@ -422,7 +580,15 @@ Object {
       "uri": "record(6)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(10)",
       "confirmation": Object {
         "cid": "cids(11)",
@@ -445,39 +611,31 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 2`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 2`] = `
 Object {
   "assertions": Array [],
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 3`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 3`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertCreator",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -497,6 +655,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -519,23 +685,23 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "other-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 4`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 4`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
+      "cid": "cids(0)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "subject": Object {
@@ -550,6 +716,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(1)",
+        },
+        "did": "user(0)",
+        "handle": "other-scene.test",
+      },
       "cid": "cids(3)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -566,25 +740,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "other-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 5`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 5`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -603,6 +777,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -625,6 +807,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -646,6 +836,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(8)",
       "confirmation": Object {
         "cid": "cids(9)",
@@ -667,25 +865,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "carol-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by confirmation status 6`] = `
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 6`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -704,6 +902,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -726,6 +932,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -747,6 +961,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(8)",
       "confirmation": Object {
         "cid": "cids(9)",
@@ -768,25 +990,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "carol-scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by type 1`] = `
+exports[`pds assertion views fetches assertions by author filtered by type 1`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertMember",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -805,6 +1027,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(4)",
       "confirmation": Object {
         "cid": "cids(5)",
@@ -826,6 +1056,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(6)",
       "confirmation": Object {
         "cid": "cids(7)",
@@ -848,6 +1086,14 @@ Object {
     },
     Object {
       "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
       "cid": "cids(8)",
       "confirmation": Object {
         "cid": "cids(9)",
@@ -870,25 +1116,25 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
-      "cid": "cids(0)",
-    },
-    "did": "user(0)",
-    "handle": "scene.test",
-  },
 }
 `;
 
-exports[`pds assertion views fetches assertions filtered by type 2`] = `
+exports[`pds assertion views fetches assertions by author filtered by type 2`] = `
 Object {
   "assertions": Array [
     Object {
       "assertion": "app.bsky.graph.assertCreator",
-      "cid": "cids(1)",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(0)",
       "confirmation": Object {
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "uri": "record(1)",
@@ -908,13 +1154,157 @@ Object {
     },
   ],
   "cursor": "1970-01-01T00:00:00.000Z",
-  "subject": Object {
-    "declaration": Object {
-      "actorType": "app.bsky.system.actorScene",
+}
+`;
+
+exports[`pds assertion views fetches assertions by subject 1`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(0)",
+        "handle": "carol-scene.test",
+      },
       "cid": "cids(0)",
+      "confirmation": Object {
+        "cid": "cids(1)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(0)",
     },
-    "did": "user(0)",
-    "handle": "scene.test",
-  },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(2)",
+        "handle": "other-scene.test",
+      },
+      "cid": "cids(4)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(3)",
+        "handle": "alice-scene.test",
+      },
+      "cid": "cids(5)",
+      "confirmation": Object {
+        "cid": "cids(6)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(4)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(3)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(3)",
+        "handle": "alice-scene.test",
+      },
+      "cid": "cids(7)",
+      "confirmation": Object {
+        "cid": "cids(8)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(6)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(5)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorScene",
+          "cid": "cids(2)",
+        },
+        "did": "user(4)",
+        "handle": "scene.test",
+      },
+      "cid": "cids(9)",
+      "confirmation": Object {
+        "cid": "cids(10)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(8)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(7)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
 }
 `;

--- a/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
@@ -1,0 +1,920 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds assertion views fetches assertions 1`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "handle": "carol.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(4)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(8)",
+      "confirmation": Object {
+        "cid": "cids(9)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(7)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(6)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(10)",
+      "confirmation": Object {
+        "cid": "cids(11)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(9)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(8)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions 2`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(1)",
+        "handle": "carol.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(3)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(2)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(1)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(3)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(3)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(4)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "other-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions 3`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(5)",
+      "confirmation": Object {
+        "cid": "cids(6)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(4)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(3)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(7)",
+      "confirmation": Object {
+        "cid": "cids(8)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(6)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "handle": "carol.test",
+      },
+      "uri": "record(5)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(9)",
+      "confirmation": Object {
+        "cid": "cids(10)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(8)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "handle": "carol.test",
+      },
+      "uri": "record(7)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "carol-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 1`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "handle": "carol.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(4)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(8)",
+      "confirmation": Object {
+        "cid": "cids(9)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(7)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(6)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(10)",
+      "confirmation": Object {
+        "cid": "cids(11)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(9)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(8)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 2`] = `
+Object {
+  "assertions": Array [],
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 3`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(2)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "other-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 4`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(1)",
+        "handle": "carol.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(3)",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(2)",
+        },
+        "did": "user(2)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(1)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "other-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 5`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "handle": "carol.test",
+      },
+      "uri": "record(4)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(8)",
+      "confirmation": Object {
+        "cid": "cids(9)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(7)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "handle": "carol.test",
+      },
+      "uri": "record(6)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "carol-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by confirmation status 6`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "handle": "carol.test",
+      },
+      "uri": "record(4)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(8)",
+      "confirmation": Object {
+        "cid": "cids(9)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(7)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "handle": "carol.test",
+      },
+      "uri": "record(6)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "carol-scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by type 1`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "handle": "dan.test",
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(4)",
+      "confirmation": Object {
+        "cid": "cids(5)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(3)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(2)",
+        "handle": "carol.test",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(6)",
+      "confirmation": Object {
+        "cid": "cids(7)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(5)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(3)",
+        "displayName": "ali",
+        "handle": "alice.test",
+      },
+      "uri": "record(4)",
+    },
+    Object {
+      "assertion": "app.bsky.graph.assertMember",
+      "cid": "cids(8)",
+      "confirmation": Object {
+        "cid": "cids(9)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(7)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(4)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(6)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "scene.test",
+  },
+}
+`;
+
+exports[`pds assertion views fetches assertions filtered by type 2`] = `
+Object {
+  "assertions": Array [
+    Object {
+      "assertion": "app.bsky.graph.assertCreator",
+      "cid": "cids(1)",
+      "confirmation": Object {
+        "cid": "cids(2)",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(1)",
+      },
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "subject": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(3)",
+        },
+        "did": "user(1)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "uri": "record(0)",
+    },
+  ],
+  "cursor": "1970-01-01T00:00:00.000Z",
+  "subject": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorScene",
+      "cid": "cids(0)",
+    },
+    "did": "user(0)",
+    "handle": "scene.test",
+  },
+}
+`;

--- a/packages/pds/tests/views/assertions.test.ts
+++ b/packages/pds/tests/views/assertions.test.ts
@@ -1,0 +1,187 @@
+import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import {
+  runTestServer,
+  forSnapshot,
+  CloseFn,
+  constantDate,
+  paginateAll,
+} from '../_util'
+import { SeedClient } from '../seeds/client'
+import basicSeed from '../seeds/basic'
+
+describe('pds assertion views', () => {
+  let client: AtpServiceClient
+  let close: CloseFn
+  let sc: SeedClient
+
+  // account dids, for convenience
+  let alice: string
+  const scene = 'scene.test'
+  const otherScene = 'other-scene.test'
+  const carolScene = 'carol-scene.test'
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'views_assertions',
+    })
+    close = server.close
+    client = AtpApi.service(server.url)
+    sc = new SeedClient(client)
+    await basicSeed(sc)
+    alice = sc.dids.alice
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  const getCursors = (items: { createdAt?: string }[]) =>
+    items.map((item) => item.createdAt ?? constantDate)
+
+  const getSortedCursors = (items: { createdAt?: string }[]) =>
+    getCursors(items).sort((a, b) => tstamp(b) - tstamp(a))
+
+  const tstamp = (x: string) => new Date(x).getTime()
+
+  it('fetches assertions', async () => {
+    const sceneAssertions = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[scene].did,
+    })
+
+    expect(forSnapshot(sceneAssertions.data)).toMatchSnapshot()
+    expect(getCursors(sceneAssertions.data.assertions)).toEqual(
+      getSortedCursors(sceneAssertions.data.assertions),
+    )
+
+    const otherSceneAssertions = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[otherScene].did,
+    })
+
+    expect(forSnapshot(otherSceneAssertions.data)).toMatchSnapshot()
+    expect(getCursors(otherSceneAssertions.data.assertions)).toEqual(
+      getSortedCursors(otherSceneAssertions.data.assertions),
+    )
+
+    const carolSceneAssertions = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[carolScene].did,
+    })
+
+    expect(forSnapshot(carolSceneAssertions.data)).toMatchSnapshot()
+    expect(getCursors(carolSceneAssertions.data.assertions)).toEqual(
+      getSortedCursors(carolSceneAssertions.data.assertions),
+    )
+  })
+
+  it('fetches assertions filtered by confirmation status', async () => {
+    const sceneAssertionsConfirmed = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[scene].did,
+      confirmed: true,
+    })
+
+    expect(forSnapshot(sceneAssertionsConfirmed.data)).toMatchSnapshot()
+    expect(getCursors(sceneAssertionsConfirmed.data.assertions)).toEqual(
+      getSortedCursors(sceneAssertionsConfirmed.data.assertions),
+    )
+
+    const sceneAssertionsUnconfirmed =
+      await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[scene].did,
+        confirmed: false,
+      })
+
+    expect(forSnapshot(sceneAssertionsUnconfirmed.data)).toMatchSnapshot()
+    expect(getCursors(sceneAssertionsUnconfirmed.data.assertions)).toEqual(
+      getSortedCursors(sceneAssertionsUnconfirmed.data.assertions),
+    )
+
+    const otherSceneAssertionsConfirmed =
+      await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[otherScene].did,
+        confirmed: true,
+      })
+
+    expect(forSnapshot(otherSceneAssertionsConfirmed.data)).toMatchSnapshot()
+    expect(getCursors(otherSceneAssertionsConfirmed.data.assertions)).toEqual(
+      getSortedCursors(otherSceneAssertionsConfirmed.data.assertions),
+    )
+
+    const otherSceneAssertionsUnconfirmed =
+      await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[otherScene].did,
+        confirmed: false,
+      })
+
+    expect(forSnapshot(otherSceneAssertionsUnconfirmed.data)).toMatchSnapshot()
+    expect(getCursors(otherSceneAssertionsUnconfirmed.data.assertions)).toEqual(
+      getSortedCursors(otherSceneAssertionsUnconfirmed.data.assertions),
+    )
+
+    const carolSceneAssertionsConfirmed =
+      await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[carolScene].did,
+        confirmed: true,
+      })
+
+    expect(forSnapshot(carolSceneAssertionsConfirmed.data)).toMatchSnapshot()
+    expect(getCursors(carolSceneAssertionsConfirmed.data.assertions)).toEqual(
+      getSortedCursors(carolSceneAssertionsConfirmed.data.assertions),
+    )
+
+    const carolSceneAssertionsUnconfirmed =
+      await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[carolScene].did,
+        confirmed: true,
+      })
+
+    expect(forSnapshot(carolSceneAssertionsUnconfirmed.data)).toMatchSnapshot()
+    expect(getCursors(carolSceneAssertionsUnconfirmed.data.assertions)).toEqual(
+      getSortedCursors(carolSceneAssertionsUnconfirmed.data.assertions),
+    )
+  })
+
+  it('fetches assertions filtered by type', async () => {
+    const sceneAssertionsMember = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[scene].did,
+      assertion: 'app.bsky.graph.assertMember',
+    })
+
+    expect(forSnapshot(sceneAssertionsMember.data)).toMatchSnapshot()
+    expect(getCursors(sceneAssertionsMember.data.assertions)).toEqual(
+      getSortedCursors(sceneAssertionsMember.data.assertions),
+    )
+
+    const sceneAssertionsCreator = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[scene].did,
+      assertion: 'app.bsky.graph.assertCreator',
+    })
+
+    expect(forSnapshot(sceneAssertionsCreator.data)).toMatchSnapshot()
+    expect(getCursors(sceneAssertionsCreator.data.assertions)).toEqual(
+      getSortedCursors(sceneAssertionsCreator.data.assertions),
+    )
+  })
+
+  it('paginates assertions', async () => {
+    const results = (results) => results.flatMap((res) => res.assertions)
+    const paginator = async (cursor?: string) => {
+      const res = await client.app.bsky.graph.getAssertions({
+        actor: sc.scenes[scene].did,
+        before: cursor,
+        limit: 2,
+      })
+      return res.data
+    }
+
+    const paginatedAll = await paginateAll(paginator)
+    paginatedAll.forEach((res) =>
+      expect(res.assertions.length).toBeLessThanOrEqual(2),
+    )
+
+    const full = await client.app.bsky.graph.getAssertions({
+      actor: sc.scenes[scene].did,
+    })
+
+    expect(full.data.assertions.length).toEqual(4)
+    expect(results(paginatedAll)).toEqual(results([full.data]))
+  })
+})

--- a/packages/pds/tests/views/members.test.ts
+++ b/packages/pds/tests/views/members.test.ts
@@ -44,7 +44,7 @@ describe('pds member views', () => {
   const tstamp = (x: string) => new Date(x).getTime()
 
   it('fetches members', async () => {
-    const sceneMembers = await client.app.bsky.graph.getMembers({
+    const sceneMembers = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[scene].did,
     })
 
@@ -53,7 +53,7 @@ describe('pds member views', () => {
       getSortedCursors(sceneMembers.data.members),
     )
 
-    const otherSceneMembers = await client.app.bsky.graph.getMembers({
+    const otherSceneMembers = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[otherScene].did,
     })
 
@@ -62,7 +62,7 @@ describe('pds member views', () => {
       getSortedCursors(otherSceneMembers.data.members),
     )
 
-    const carolSceneMembers = await client.app.bsky.graph.getMembers({
+    const carolSceneMembers = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[carolScene].did,
     })
 
@@ -73,10 +73,10 @@ describe('pds member views', () => {
   })
 
   it('fetches members by handle', async () => {
-    const byDid = await client.app.bsky.graph.getMembers({
+    const byDid = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[scene].did,
     })
-    const byHandle = await client.app.bsky.graph.getMembers({
+    const byHandle = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[scene].handle,
     })
     expect(byHandle.data).toEqual(byDid.data)
@@ -85,7 +85,7 @@ describe('pds member views', () => {
   it('paginates members', async () => {
     const results = (results) => results.flatMap((res) => res.members)
     const paginator = async (cursor?: string) => {
-      const res = await client.app.bsky.graph.getMembers({
+      const res = await client.app.bsky.graph.getAssertions({
         actor: sc.scenes[scene].did,
         before: cursor,
         limit: 2,
@@ -98,7 +98,7 @@ describe('pds member views', () => {
       expect(res.members.length).toBeLessThanOrEqual(2),
     )
 
-    const full = await client.app.bsky.graph.getMembers({
+    const full = await client.app.bsky.graph.getAssertions({
       actor: sc.scenes[scene].did,
     })
 

--- a/packages/pds/tests/views/members.test.ts
+++ b/packages/pds/tests/views/members.test.ts
@@ -44,7 +44,7 @@ describe('pds member views', () => {
   const tstamp = (x: string) => new Date(x).getTime()
 
   it('fetches members', async () => {
-    const sceneMembers = await client.app.bsky.graph.getAssertions({
+    const sceneMembers = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[scene].did,
     })
 
@@ -53,7 +53,7 @@ describe('pds member views', () => {
       getSortedCursors(sceneMembers.data.members),
     )
 
-    const otherSceneMembers = await client.app.bsky.graph.getAssertions({
+    const otherSceneMembers = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[otherScene].did,
     })
 
@@ -62,7 +62,7 @@ describe('pds member views', () => {
       getSortedCursors(otherSceneMembers.data.members),
     )
 
-    const carolSceneMembers = await client.app.bsky.graph.getAssertions({
+    const carolSceneMembers = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[carolScene].did,
     })
 
@@ -73,10 +73,10 @@ describe('pds member views', () => {
   })
 
   it('fetches members by handle', async () => {
-    const byDid = await client.app.bsky.graph.getAssertions({
+    const byDid = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[scene].did,
     })
-    const byHandle = await client.app.bsky.graph.getAssertions({
+    const byHandle = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[scene].handle,
     })
     expect(byHandle.data).toEqual(byDid.data)
@@ -85,7 +85,7 @@ describe('pds member views', () => {
   it('paginates members', async () => {
     const results = (results) => results.flatMap((res) => res.members)
     const paginator = async (cursor?: string) => {
-      const res = await client.app.bsky.graph.getAssertions({
+      const res = await client.app.bsky.graph.getMembers({
         actor: sc.scenes[scene].did,
         before: cursor,
         limit: 2,
@@ -98,7 +98,7 @@ describe('pds member views', () => {
       expect(res.members.length).toBeLessThanOrEqual(2),
     )
 
-    const full = await client.app.bsky.graph.getAssertions({
+    const full = await client.app.bsky.graph.getMembers({
       actor: sc.scenes[scene].did,
     })
 


### PR DESCRIPTION
- Adds `app.bsky.graph.getAssertions()`
  - Can select by author and/or subject
  - Can filter by confirmation status and assertion type

I need this to check on pending invites. Built it to be fairly generic.