### PR TITLE
Use public hostname in invite codes

### DIFF
--- a/packages/pds/src/api/com/atproto/invites.ts
+++ b/packages/pds/src/api/com/atproto/invites.ts
@@ -16,7 +16,7 @@ export default function (server: Server) {
       // generate a 5 char b32 invite code - preceeded by the hostname
       // ex: bsky.app-abc12
       const code =
-        config.hostname +
+        config.publicHostname +
         '-' +
         uint8arrays.toString(await crypto.randomBytes(5), 'base32').slice(0, 5)
 

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -136,13 +136,22 @@ export class ServerConfig {
     return this.cfg.hostname
   }
 
+  get internalUrl() {
+    return `${this.scheme}://${this.hostname}:${this.port}`
+  }
+
   get origin() {
-    const u = new URL(`${this.scheme}://${this.hostname}:${this.port}`)
+    const u = new URL(this.internalUrl)
     return u.origin
   }
 
   get publicUrl() {
-    return this.cfg.publicUrl || this.origin
+    return this.cfg.publicUrl || this.internalUrl
+  }
+
+  get publicHostname() {
+    const u = new URL(this.publicUrl)
+    return u.hostname
   }
 
   get dbPostgresUrl() {

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -77,7 +77,7 @@ describe('account', () => {
   it('creates an invite code', async () => {
     inviteCode = await createInviteCode(client, 1)
     const [host, code] = inviteCode.split('-')
-    expect(host).toBe(new URL(serverUrl).hostname)
+    expect(host).toBe('pds.public.url') // Hostname of public url
     expect(code.length).toBe(5)
   })
 


### PR DESCRIPTION
A fix to make invite codes a little more secure and a little prettier.