### PR TITLE
MessageQueue fix

### DIFF
--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -126,6 +126,7 @@ export class Database {
   }
 
   async close(): Promise<void> {
+    this.messageQueue?.destroy()
     await this.db.destroy()
   }
 

--- a/packages/pds/src/db/message-queue/index.ts
+++ b/packages/pds/src/db/message-queue/index.ts
@@ -62,7 +62,7 @@ export class SqlMessageQueue implements MessageQueue {
     } catch (err) {
       log.error({ err }, 'error ensuring queue is up to date')
     }
-    setTimeout(this.ensureCaughtUp, 180000) // 3 min
+    setTimeout(this.ensureCaughtUp, 60000) // 1 min
   }
 
   async processAll(): Promise<void> {

--- a/packages/pds/src/db/message-queue/index.ts
+++ b/packages/pds/src/db/message-queue/index.ts
@@ -20,6 +20,7 @@ type GetAuthStoreFn = (did: string) => AuthStore
 
 export class SqlMessageQueue implements MessageQueue {
   private cursorExists = false
+  private ensureCaughtUpTimeout: ReturnType<typeof setTimeout> | undefined
 
   constructor(
     private name: string,
@@ -62,7 +63,13 @@ export class SqlMessageQueue implements MessageQueue {
     } catch (err) {
       log.error({ err }, 'error ensuring queue is up to date')
     }
-    setTimeout(this.ensureCaughtUp, 60000) // 1 min
+    this.ensureCaughtUpTimeout = setTimeout(() => this.ensureCaughtUp(), 60000) // 1 min
+  }
+
+  destroy() {
+    if (this.ensureCaughtUpTimeout) {
+      clearTimeout(this.ensureCaughtUpTimeout)
+    }
   }
 
   async processAll(): Promise<void> {

--- a/packages/pds/src/db/message-queue/index.ts
+++ b/packages/pds/src/db/message-queue/index.ts
@@ -26,9 +26,7 @@ export class SqlMessageQueue implements MessageQueue {
     private db: Database,
     private getAuthStore: GetAuthStoreFn,
   ) {
-    this.ensureCaughtUp().catch((err) =>
-      log.error({ err }, 'error catching queue up on startup'),
-    )
+    this.ensureCaughtUp()
   }
 
   async send(tx: Database, messages: Message | Message[]): Promise<void> {
@@ -59,12 +57,12 @@ export class SqlMessageQueue implements MessageQueue {
   }
 
   async ensureCaughtUp(): Promise<void> {
-    await this.processAll()
-    setTimeout(async () => {
-      this.ensureCaughtUp().catch((err) =>
-        log.error({ err }, 'error ensuring queue is up to date'),
-      )
-    }, 180000) // 3 min
+    try {
+      await this.processAll()
+    } catch (err) {
+      log.error({ err }, 'error ensuring queue is up to date')
+    }
+    setTimeout(this.ensureCaughtUp, 180000) // 3 min
   }
 
   async processAll(): Promise<void> {

--- a/packages/pds/src/db/types.ts
+++ b/packages/pds/src/db/types.ts
@@ -24,4 +24,5 @@ export interface MessageQueue {
   send(tx: Database, message: Message | Message[]): Promise<void>
   processNext(): Promise<void>
   processAll(): Promise<void>
+  destroy(): void
 }


### PR DESCRIPTION
Message queue was getting behind because for each batch of messages added (could be 1 or multiple) we were only prompting the receiver to process 1.

This fixes that & prompts `processNext` for the number of messages sent.

We also add in a sanity check interval where we process any unprocessed messages every 3 min.

Closes https://github.com/bluesky-social/atproto/issues/350