### PR TITLE
Wait for servers to close at end of test suite

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/bin.js",
     "test": "jest",
     "test:pg": "../pg/with-test-db.sh yarn test",
-    "test:log": "cat test.log | pino-pretty",
+    "test:log": "tail -50 test.log | pino-pretty",
     "test:updateSnapshot": "jest --updateSnapshot",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -1,4 +1,5 @@
 import { AddressInfo } from 'net'
+import http from 'http'
 import * as crypto from '@atproto/crypto'
 import * as plc from '@atproto/plc'
 import { AtUri } from '@atproto/uri'
@@ -83,12 +84,21 @@ export const runTestServer = async (
     close: async () => {
       await Promise.all([
         db.close(),
-        listener.close(),
-        plcServer.listener.close(),
+        closeServer(listener),
+        closeServer(plcServer.listener),
         plcDb.close(),
       ])
     },
   }
+}
+
+const closeServer = (s: http.Server): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    s.close((err) => {
+      if (err) reject(err)
+      resolve()
+    })
+  })
 }
 
 export const adminAuth = () => {


### PR DESCRIPTION
The open handles warning we were getting was actually from the callback from shutting down the server. We wrap that in a promise to get everything shutdown nicely & throw an error if encountered.

Also snuck in a chance to just tail the logs (defaults to 50 logs) instead of piping it all through pino-prettier