### PR TITLE
Fix a few MST bugs

### DIFF
--- a/packages/repo/src/mst/mst.ts
+++ b/packages/repo/src/mst/mst.ts
@@ -165,12 +165,12 @@ export class MST implements DataStore {
     return this.pointer
   }
 
-  // We should be able to find the layer of a node by either a hint on creation or by looking at the first leaf
-  // If we have neither a hint nor a leaf, we throw an error
-  // We could recurse to find the layer, but it isn't necessary for any of our current operations
+  // In most cases, we get the layer of a node from a hint on creation
+  // In the case of the topmost node in the tree, we look for a key in the node & determine the layer
+  // In the case where we don't find one, we recurse down until we do.
+  // If we still can't find one, then we have an empty tree and the node is layer 0
   async getLayer(): Promise<number> {
     this.layer = await this.attemptGetLayer()
-    // we walked the whole tree & couldn't find a single key, so must be an empty tree, ie layer 0
     if (this.layer === null) this.layer = 0
     return this.layer
   }

--- a/packages/repo/src/mst/mst.ts
+++ b/packages/repo/src/mst/mst.ts
@@ -612,10 +612,12 @@ export class MST implements DataStore {
 
   async createParent(): Promise<MST> {
     const layer = await this.getLayer()
-    return MST.create(this.blockstore, [this], {
+    const parent = await MST.create(this.blockstore, [this], {
       layer: layer + 1,
       fanout: this.fanout,
     })
+    parent.outdatedPointer = true
+    return parent
   }
 
   // Finding insertion points

--- a/packages/repo/tests/mst.test.ts
+++ b/packages/repo/tests/mst.test.ts
@@ -224,6 +224,9 @@ describe('Merkle Search Tree', () => {
     const layer = await mst.getLayer()
     expect(layer).toBe(2)
 
+    const root = await mst.stage()
+    mst = MST.load(blockstore, root, { fanout: 32 })
+
     const allTids = [...layer0, ...layer1, layer2]
     for (const tid of allTids) {
       const got = await mst.get(tid)
@@ -245,7 +248,6 @@ describe('Merkle Search Tree', () => {
    */
   it('handles new layers that are two higher than existing', async () => {
     const layer0 = ['3j6hnk65jis2t', '3j6hnk65kvz2t']
-    const layer1 = ['3j6hnk65jju2t', '3j6hnk65l222t']
     const layer2 = '3j6hnk65jng2t'
     mst = await MST.create(blockstore, [], { fanout: 32 })
     const cid = await util.randomCid()
@@ -253,13 +255,13 @@ describe('Merkle Search Tree', () => {
       mst = await mst.add(tid, cid)
     }
     mst = await mst.add(layer2, cid)
-    for (const tid of layer1) {
-      mst = await mst.add(tid, cid)
-    }
+
+    const root = await mst.stage()
+    mst = MST.load(blockstore, root, { fanout: 32 })
 
     const layer = await mst.getLayer()
     expect(layer).toBe(2)
-    const allTids = [...layer0, ...layer1, layer2]
+    const allTids = [...layer0, layer2]
     for (const tid of allTids) {
       const got = await mst.get(tid)
       expect(cid.equals(got)).toBeTruthy()

--- a/packages/repo/tests/mst.test.ts
+++ b/packages/repo/tests/mst.test.ts
@@ -157,6 +157,30 @@ describe('Merkle Search Tree', () => {
   // Special Cases (these are made for fanout 32)
   // ------------
 
+  it('trims the top of an MST on stage', async () => {
+    const layer0 = [
+      '3j6hnk65jis2t',
+      '3j6hnk65jit2t',
+      '3j6hnk65jiu2t',
+      '3j6hnk65jne2t',
+      '3j6hnk65jnm2t',
+    ]
+    const layer1 = '3j6hnk65jju2t'
+    mst = await MST.create(blockstore, [], { fanout: 32 })
+    const cid = await util.randomCid()
+    const tids = [...layer0, layer1]
+    for (const tid of tids) {
+      mst = await mst.add(tid, cid)
+    }
+    const layer = await mst.getLayer()
+    expect(layer).toBe(1)
+    mst = await mst.delete(layer1)
+    const root = await mst.stage()
+    const loaded = MST.load(blockstore, root)
+    const loadedLayer = await loaded.getLayer()
+    expect(loadedLayer).toBe(0)
+  })
+
   // These are some tricky things that can come up that may not be included in a randomized tree
 
   /**


### PR DESCRIPTION
Failing deletes were actually caused by 2 issues:

### Trimming top
One stemmed from the case where a delete leaves the root of the MST pointing to only one node which is a tree. This makes it impossible to tell the layer of the root without further recursing down the tree which breaks some of our logic.

This PR includes 2 fixes:
- on stage, trim the top of the MST if it is a tree pointing to only a tree
- on load, if you need the layer of a tree, recurse until you find it. This shouldn't ever need to be done after taking into account the first fix, but it's good to have around for completeness

### Outdated pointers
The second issue was the case where a key is added that is 2 layers higher than the current highest key. We have to add some empty nodes to preserve the structure. These nodes weren't getting marked as having outdated pointers so when the tree was persisted to the blockstore, they weren't calling for their children to update & were getting persisted with bad pointers

Closes https://github.com/bluesky-social/atproto/issues/271