### PR TITLE
Well-defined pagination in PDS

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -30,7 +30,6 @@
     "@atproto/repo": "*",
     "@atproto/uri": "*",
     "@atproto/xrpc-server": "*",
-    "@hapi/bourne": "^3.0.0",
     "better-sqlite3": "^7.6.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",

--- a/packages/pds/src/api/app/bsky/actor/search.ts
+++ b/packages/pds/src/api/app/bsky/actor/search.ts
@@ -8,7 +8,7 @@ import {
   cleanTerm,
   getUserSearchQueryPg,
   getUserSearchQuerySqlite,
-  packCursor,
+  SearchKeyset,
 } from '../util/search'
 
 export default function (server: Server) {
@@ -44,13 +44,13 @@ export default function (server: Server) {
       indexedAt: result.indexedAt ?? undefined,
     }))
 
-    const lastResult = results.at(-1)
+    const keyset = new SearchKeyset(sql``, sql``)
 
     return {
       encoding: 'application/json',
       body: {
         users,
-        cursor: lastResult && packCursor(lastResult),
+        cursor: keyset.packFromResult(results),
       },
     }
   })

--- a/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -4,7 +4,8 @@ import { Server } from '../../../../lexicon'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
 import * as locals from '../../../../locals'
 import { FeedItemType, rowToFeedItem, FeedKeyset } from '../util/feed'
-import { countAll, paginate } from '../../../../db/util'
+import { countAll } from '../../../../db/util'
+import { paginate } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.feed.getAuthorFeed(
@@ -148,7 +149,7 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
-      const keyset = new FeedKeyset(ref('cursor'), ref('postUri'))
+      const keyset = new FeedKeyset(ref('cursor'), ref('postCid'))
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -148,7 +148,7 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
-      const keyset = new FeedKeyset()
+      const keyset = new FeedKeyset(ref('cursor'), ref('postUri'))
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -3,7 +3,7 @@ import { AuthRequiredError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
 import * as locals from '../../../../locals'
-import { FeedItemType, rowToFeedItem } from '../util/feed'
+import { FeedItemType, rowToFeedItem, FeedKeyset } from '../util/feed'
 import { countAll, paginate } from '../../../../db/util'
 
 export default function (server: Server) {
@@ -148,10 +148,11 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
+      const keyset = new FeedKeyset()
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,
-        by: ref('cursor'),
+        keyset,
       })
 
       const queryRes = await feedItemsQb.execute()
@@ -161,7 +162,7 @@ export default function (server: Server) {
         encoding: 'application/json',
         body: {
           feed,
-          cursor: queryRes.at(-1)?.cursor,
+          cursor: keyset.packFromResult(queryRes),
         },
       }
     },

--- a/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
@@ -1,7 +1,7 @@
 import { Server } from '../../../../lexicon'
 import * as GetRepostedBy from '../../../../lexicon/types/app/bsky/feed/getRepostedBy'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import { getDeclarationSimple } from '../util'
 
 export default function (server: Server) {
@@ -22,7 +22,7 @@ export default function (server: Server) {
           'did_handle.actorType as actorType',
           'did_handle.handle as handle',
           'profile.displayName as displayName',
-          'repost.uri as uri',
+          'repost.cid as cid',
           'repost.createdAt as createdAt',
           'repost.indexedAt as indexedAt',
         ])
@@ -31,7 +31,10 @@ export default function (server: Server) {
         builder = builder.where('repost.subjectCid', '=', cid)
       }
 
-      const keyset = new Keyset(ref('repost.createdAt'), ref('repost.uri'))
+      const keyset = new TimeCidKeyset(
+        ref('repost.createdAt'),
+        ref('repost.cid'),
+      )
       builder = paginate(builder, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { Server } from '../../../../lexicon'
 import * as GetRepostedBy from '../../../../lexicon/types/app/bsky/feed/getRepostedBy'
 import * as locals from '../../../../locals'
@@ -10,6 +9,7 @@ export default function (server: Server) {
     async (params: GetRepostedBy.QueryParams, _input, _req, res) => {
       const { uri, limit, before, cid } = params
       const { db } = locals.get(res)
+      const { ref } = db.db.dynamic
 
       let builder = db.db
         .selectFrom('repost')
@@ -31,7 +31,7 @@ export default function (server: Server) {
         builder = builder.where('repost.subjectCid', '=', cid)
       }
 
-      const keyset = new RepostsKeyset()
+      const keyset = new Keyset(ref('repost.createdAt'), ref('repost.uri'))
       builder = paginate(builder, {
         limit,
         before,
@@ -59,9 +59,4 @@ export default function (server: Server) {
       }
     },
   )
-}
-
-class RepostsKeyset extends Keyset {
-  primary = sql`repost."createdAt"`
-  secondary = sql`repost.uri`
 }

--- a/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
@@ -63,7 +63,7 @@ export default function (server: Server) {
 
 type RepostRow = { createdAt: string; uri: string }
 class RepostsKeyset extends Keyset<RepostRow> {
-  primary = sql`repost.createdAt`
+  primary = sql`repost."createdAt"`
   secondary = sql`repost.uri`
   cursorFromResult(result: RepostRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
@@ -61,11 +61,7 @@ export default function (server: Server) {
   )
 }
 
-type RepostRow = { createdAt: string; uri: string }
-class RepostsKeyset extends Keyset<RepostRow> {
+class RepostsKeyset extends Keyset {
   primary = sql`repost."createdAt"`
   secondary = sql`repost.uri`
-  cursorFromResult(result: RepostRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/api/app/bsky/feed/getTimeline.ts
@@ -4,7 +4,12 @@ import { Server } from '../../../../lexicon'
 import * as GetTimeline from '../../../../lexicon/types/app/bsky/feed/getTimeline'
 import * as locals from '../../../../locals'
 import { isEnum } from '../util'
-import { FeedAlgorithm, FeedItemType, rowToFeedItem } from '../util/feed'
+import {
+  FeedAlgorithm,
+  FeedItemType,
+  rowToFeedItem,
+  FeedKeyset,
+} from '../util/feed'
 import { countAll, paginate } from '../../../../db/util'
 
 export default function (server: Server) {
@@ -163,10 +168,11 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
+      const keyset = new FeedKeyset()
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,
-        by: ref('cursor'),
+        keyset,
       })
 
       const queryRes = await feedItemsQb.execute()
@@ -176,7 +182,7 @@ export default function (server: Server) {
         encoding: 'application/json',
         body: {
           feed,
-          cursor: queryRes.at(-1)?.cursor,
+          cursor: keyset.packFromResult(queryRes),
         },
       }
     },

--- a/packages/pds/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/api/app/bsky/feed/getTimeline.ts
@@ -10,7 +10,8 @@ import {
   rowToFeedItem,
   FeedKeyset,
 } from '../util/feed'
-import { countAll, paginate } from '../../../../db/util'
+import { countAll } from '../../../../db/util'
+import { paginate } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.feed.getTimeline(
@@ -168,7 +169,7 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
-      const keyset = new FeedKeyset(ref('cursor'), ref('postUri'))
+      const keyset = new FeedKeyset(ref('cursor'), ref('postCid'))
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/api/app/bsky/feed/getTimeline.ts
@@ -168,7 +168,7 @@ export default function (server: Server) {
             .as('requesterDownvote'),
         ])
 
-      const keyset = new FeedKeyset()
+      const keyset = new FeedKeyset(ref('cursor'), ref('postUri'))
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getVotes.ts
@@ -1,7 +1,7 @@
 import { Server } from '../../../../lexicon'
 import * as GetVotes from '../../../../lexicon/types/app/bsky/feed/getVotes'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import { getDeclarationSimple } from '../util'
 
 export default function (server: Server) {
@@ -17,7 +17,7 @@ export default function (server: Server) {
         .innerJoin('did_handle', 'vote.creator', 'did_handle.did')
         .leftJoin('profile', 'profile.creator', 'did_handle.did')
         .select([
-          'vote.uri as uri',
+          'vote.cid as cid',
           'vote.direction as direction',
           'vote.createdAt as createdAt',
           'vote.indexedAt as indexedAt',
@@ -36,7 +36,7 @@ export default function (server: Server) {
         builder = builder.where('vote.subjectCid', '=', cid)
       }
 
-      const keyset = new Keyset(ref('vote.createdAt'), ref('vote.uri'))
+      const keyset = new TimeCidKeyset(ref('vote.createdAt'), ref('vote.cid'))
       builder = paginate(builder, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getVotes.ts
@@ -1,7 +1,8 @@
+import { sql } from 'kysely'
 import { Server } from '../../../../lexicon'
 import * as GetVotes from '../../../../lexicon/types/app/bsky/feed/getVotes'
 import * as locals from '../../../../locals'
-import { paginate } from '../../../../db/util'
+import { Keyset, paginate } from '../../../../db/util'
 import { getDeclarationSimple } from '../util'
 
 export default function (server: Server) {
@@ -9,7 +10,6 @@ export default function (server: Server) {
     async (params: GetVotes.QueryParams, _input, _req, res) => {
       const { uri, limit, before, cid, direction } = params
       const { db } = locals.get(res)
-      const { ref } = db.db.dynamic
 
       let builder = db.db
         .selectFrom('vote')
@@ -17,6 +17,7 @@ export default function (server: Server) {
         .innerJoin('did_handle', 'vote.creator', 'did_handle.did')
         .leftJoin('profile', 'profile.creator', 'did_handle.did')
         .select([
+          'vote.uri as uri',
           'vote.direction as direction',
           'vote.createdAt as createdAt',
           'vote.indexedAt as indexedAt',
@@ -35,14 +36,14 @@ export default function (server: Server) {
         builder = builder.where('vote.subjectCid', '=', cid)
       }
 
+      const keyset = new VotesKeyset()
       builder = paginate(builder, {
         limit,
         before,
-        by: ref('vote.createdAt'),
+        keyset,
       })
 
       const votesRes = await builder.execute()
-
       const votes = votesRes.map((row) => ({
         direction: row.direction,
         createdAt: row.createdAt,
@@ -60,10 +61,19 @@ export default function (server: Server) {
         body: {
           uri,
           cid,
-          cursor: votes.at(-1)?.createdAt,
+          cursor: keyset.packFromResult(votesRes),
           votes,
         },
       }
     },
   )
+}
+
+type VoteRow = { createdAt: string; uri: string }
+class VotesKeyset extends Keyset<VoteRow> {
+  primary = sql`vote.createdAt`
+  secondary = sql`vote.uri`
+  cursorFromResult(result: VoteRow) {
+    return { primary: result.createdAt, secondary: result.uri }
+  }
 }

--- a/packages/pds/src/api/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getVotes.ts
@@ -71,7 +71,7 @@ export default function (server: Server) {
 
 type VoteRow = { createdAt: string; uri: string }
 class VotesKeyset extends Keyset<VoteRow> {
-  primary = sql`vote.createdAt`
+  primary = sql`vote."createdAt"`
   secondary = sql`vote.uri`
   cursorFromResult(result: VoteRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getVotes.ts
@@ -69,11 +69,7 @@ export default function (server: Server) {
   )
 }
 
-type VoteRow = { createdAt: string; uri: string }
-class VotesKeyset extends Keyset<VoteRow> {
+class VotesKeyset extends Keyset {
   primary = sql`vote."createdAt"`
   secondary = sql`vote.uri`
-  cursorFromResult(result: VoteRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getVotes.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { Server } from '../../../../lexicon'
 import * as GetVotes from '../../../../lexicon/types/app/bsky/feed/getVotes'
 import * as locals from '../../../../locals'
@@ -10,6 +9,7 @@ export default function (server: Server) {
     async (params: GetVotes.QueryParams, _input, _req, res) => {
       const { uri, limit, before, cid, direction } = params
       const { db } = locals.get(res)
+      const { ref } = db.db.dynamic
 
       let builder = db.db
         .selectFrom('vote')
@@ -36,7 +36,7 @@ export default function (server: Server) {
         builder = builder.where('vote.subjectCid', '=', cid)
       }
 
-      const keyset = new VotesKeyset()
+      const keyset = new Keyset(ref('vote.createdAt'), ref('vote.uri'))
       builder = paginate(builder, {
         limit,
         before,
@@ -67,9 +67,4 @@ export default function (server: Server) {
       }
     },
   )
-}
-
-class VotesKeyset extends Keyset {
-  primary = sql`vote."createdAt"`
-  secondary = sql`vote.uri`
 }

--- a/packages/pds/src/api/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/api/app/bsky/graph/getAssertions.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { Server } from '../../../../lexicon'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetAssertions from '../../../../lexicon/types/app/bsky/graph/getAssertions'
@@ -11,6 +10,7 @@ export default function (server: Server) {
     async (params: GetAssertions.QueryParams, _input, _req, res) => {
       const { author, subject, assertion, confirmed, limit, before } = params
       const { db } = locals.get(res)
+      const { ref } = db.db.dynamic
 
       if (!author && !subject) {
         throw new InvalidRequestError(`Must provide an author or subject`)
@@ -92,7 +92,10 @@ export default function (server: Server) {
         )
       }
 
-      const keyset = new AssertionsKeyset()
+      const keyset = new Keyset(
+        ref('assertion.createdAt'),
+        ref('assertion.uri'),
+      )
       assertionsReq = paginate(assertionsReq, {
         limit,
         before,
@@ -147,9 +150,4 @@ export default function (server: Server) {
       }
     },
   )
-}
-
-class AssertionsKeyset extends Keyset {
-  primary = sql`assertion."createdAt"`
-  secondary = sql`assertion.uri`
 }

--- a/packages/pds/src/api/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/api/app/bsky/graph/getAssertions.ts
@@ -3,7 +3,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetAssertions from '../../../../lexicon/types/app/bsky/graph/getAssertions'
 import { getActorInfo } from '../util'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.graph.getAssertions(
@@ -92,9 +92,9 @@ export default function (server: Server) {
         )
       }
 
-      const keyset = new Keyset(
+      const keyset = new TimeCidKeyset(
         ref('assertion.createdAt'),
-        ref('assertion.uri'),
+        ref('assertion.cid'),
       )
       assertionsReq = paginate(assertionsReq, {
         limit,

--- a/packages/pds/src/api/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/api/app/bsky/graph/getAssertions.ts
@@ -149,11 +149,7 @@ export default function (server: Server) {
   )
 }
 
-type AssertionRow = { createdAt: string; uri: string }
-class AssertionsKeyset extends Keyset<AssertionRow> {
+class AssertionsKeyset extends Keyset {
   primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
-  cursorFromResult(result: AssertionRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/api/app/bsky/graph/getAssertions.ts
@@ -151,7 +151,7 @@ export default function (server: Server) {
 
 type AssertionRow = { createdAt: string; uri: string }
 class AssertionsKeyset extends Keyset<AssertionRow> {
-  primary = sql`assertion.createdAt`
+  primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
   cursorFromResult(result: AssertionRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollowers.ts
@@ -61,11 +61,7 @@ export default function (server: Server) {
   )
 }
 
-type FollowerRow = { createdAt: string; uri: string }
-class FollowersKeyset extends Keyset<FollowerRow> {
+class FollowersKeyset extends Keyset {
   primary = sql`follow."createdAt"`
   secondary = sql`follow.uri`
-  cursorFromResult(result: FollowerRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollowers.ts
@@ -63,7 +63,7 @@ export default function (server: Server) {
 
 type FollowerRow = { createdAt: string; uri: string }
 class FollowersKeyset extends Keyset<FollowerRow> {
-  primary = sql`follow.createdAt`
+  primary = sql`follow."createdAt"`
   secondary = sql`follow.uri`
   cursorFromResult(result: FollowerRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollowers.ts
@@ -3,7 +3,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetFollowers from '../../../../lexicon/types/app/bsky/graph/getFollowers'
 import { getActorInfo, getDeclarationSimple } from '../util'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.graph.getFollowers(
@@ -27,12 +27,15 @@ export default function (server: Server) {
           'creator.actorType as actorType',
           'creator.handle as handle',
           'profile.displayName as displayName',
-          'follow.uri as uri',
+          'follow.cid as cid',
           'follow.createdAt as createdAt',
           'follow.indexedAt as indexedAt',
         ])
 
-      const keyset = new Keyset(ref('follow.createdAt'), ref('follow.uri'))
+      const keyset = new TimeCidKeyset(
+        ref('follow.createdAt'),
+        ref('follow.cid'),
+      )
       followersReq = paginate(followersReq, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollows.ts
@@ -61,11 +61,7 @@ export default function (server: Server) {
   )
 }
 
-type FollowRow = { createdAt: string; uri: string }
-class FollowsKeyset extends Keyset<FollowRow> {
+class FollowsKeyset extends Keyset {
   primary = sql`follow."createdAt"`
   secondary = sql`follow.uri`
-  cursorFromResult(result: FollowRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollows.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { Server } from '../../../../lexicon'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetFollows from '../../../../lexicon/types/app/bsky/graph/getFollows'
@@ -11,6 +10,7 @@ export default function (server: Server) {
     async (params: GetFollows.QueryParams, _input, _req, res) => {
       const { user, limit, before } = params
       const { db } = locals.get(res)
+      const { ref } = db.db.dynamic
 
       const creator = await getActorInfo(db.db, user).catch((_e) => {
         throw new InvalidRequestError(`User not found: ${user}`)
@@ -32,7 +32,7 @@ export default function (server: Server) {
           'follow.indexedAt as indexedAt',
         ])
 
-      const keyset = new FollowsKeyset()
+      const keyset = new Keyset(ref('follow.createdAt'), ref('follow.uri'))
       followsReq = paginate(followsReq, {
         limit,
         before,
@@ -59,9 +59,4 @@ export default function (server: Server) {
       }
     },
   )
-}
-
-class FollowsKeyset extends Keyset {
-  primary = sql`follow."createdAt"`
-  secondary = sql`follow.uri`
 }

--- a/packages/pds/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollows.ts
@@ -3,7 +3,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetFollows from '../../../../lexicon/types/app/bsky/graph/getFollows'
 import { getActorInfo, getDeclarationSimple } from '../util'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.graph.getFollows(
@@ -27,12 +27,15 @@ export default function (server: Server) {
           'subject.actorType as actorType',
           'subject.handle as handle',
           'profile.displayName as displayName',
-          'follow.uri as uri',
+          'follow.cid as cid',
           'follow.createdAt as createdAt',
           'follow.indexedAt as indexedAt',
         ])
 
-      const keyset = new Keyset(ref('follow.createdAt'), ref('follow.uri'))
+      const keyset = new TimeCidKeyset(
+        ref('follow.createdAt'),
+        ref('follow.cid'),
+      )
       followsReq = paginate(followsReq, {
         limit,
         before,

--- a/packages/pds/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollows.ts
@@ -63,7 +63,7 @@ export default function (server: Server) {
 
 type FollowRow = { createdAt: string; uri: string }
 class FollowsKeyset extends Keyset<FollowRow> {
-  primary = sql`follow.createdAt`
+  primary = sql`follow."createdAt"`
   secondary = sql`follow.uri`
   cursorFromResult(result: FollowRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/graph/getMembers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMembers.ts
@@ -3,7 +3,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetMembers from '../../../../lexicon/types/app/bsky/graph/getMembers'
 import { getActorInfo, getDeclarationSimple } from '../util'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.graph.getMembers(
@@ -33,14 +33,14 @@ export default function (server: Server) {
           'subject.declarationCid as declarationCid',
           'subject.actorType as actorType',
           'profile.displayName as displayName',
-          'assertion.uri as uri',
+          'assertion.cid as cid',
           'assertion.createdAt as createdAt',
           'assertion.indexedAt as indexedAt',
         ])
 
-      const keyset = new Keyset(
+      const keyset = new TimeCidKeyset(
         ref('assertion.createdAt'),
-        ref('assertion.uri'),
+        ref('assertion.cid'),
       )
       membersReq = paginate(membersReq, {
         limit,

--- a/packages/pds/src/api/app/bsky/graph/getMembers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMembers.ts
@@ -69,7 +69,7 @@ export default function (server: Server) {
 
 type MemberRow = { createdAt: string; uri: string }
 class MembersKeyset extends Keyset<MemberRow> {
-  primary = sql`assertion.createdAt`
+  primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
   cursorFromResult(result: MemberRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/graph/getMembers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMembers.ts
@@ -67,11 +67,7 @@ export default function (server: Server) {
   )
 }
 
-type MemberRow = { createdAt: string; uri: string }
-class MembersKeyset extends Keyset<MemberRow> {
+class MembersKeyset extends Keyset {
   primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
-  cursorFromResult(result: MemberRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/graph/getMemberships.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMemberships.ts
@@ -65,7 +65,7 @@ export default function (server: Server) {
 
 type MembershipRow = { createdAt: string; uri: string }
 class MembershipsKeyset extends Keyset<MembershipRow> {
-  primary = sql`assertion.createdAt`
+  primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
   cursorFromResult(result: MembershipRow) {
     return { primary: result.createdAt, secondary: result.uri }

--- a/packages/pds/src/api/app/bsky/graph/getMemberships.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMemberships.ts
@@ -63,11 +63,7 @@ export default function (server: Server) {
   )
 }
 
-type MembershipRow = { createdAt: string; uri: string }
-class MembershipsKeyset extends Keyset<MembershipRow> {
+class MembershipsKeyset extends Keyset {
   primary = sql`assertion."createdAt"`
   secondary = sql`assertion.uri`
-  cursorFromResult(result: MembershipRow) {
-    return { primary: result.createdAt, secondary: result.uri }
-  }
 }

--- a/packages/pds/src/api/app/bsky/graph/getMemberships.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMemberships.ts
@@ -3,7 +3,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import * as GetMemberships from '../../../../lexicon/types/app/bsky/graph/getMemberships'
 import { getActorInfo, getDeclarationSimple } from '../util'
 import * as locals from '../../../../locals'
-import { Keyset, paginate } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 
 export default function (server: Server) {
   server.app.bsky.graph.getMemberships(
@@ -29,14 +29,14 @@ export default function (server: Server) {
           'creator.declarationCid as declarationCid',
           'creator.actorType as actorType',
           'profile.displayName as displayName',
-          'assertion.uri as uri',
+          'assertion.cid as cid',
           'assertion.createdAt as createdAt',
           'assertion.indexedAt as indexedAt',
         ])
 
-      const keyset = new Keyset(
+      const keyset = new TimeCidKeyset(
         ref('assertion.createdAt'),
-        ref('assertion.uri'),
+        ref('assertion.cid'),
       )
       membershipsReq = paginate(membershipsReq, {
         limit,

--- a/packages/pds/src/api/app/bsky/notification/list.ts
+++ b/packages/pds/src/api/app/bsky/notification/list.ts
@@ -3,7 +3,7 @@ import * as common from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import * as List from '../../../../lexicon/types/app/bsky/notification/list'
 import * as locals from '../../../../locals'
-import { paginate, Keyset } from '../../../../db/util'
+import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import { getDeclaration } from '../util'
 
 export default function (server: Server) {
@@ -44,7 +44,7 @@ export default function (server: Server) {
 
       const keyset = new NotifsKeyset(
         ref('notif.indexedAt'),
-        ref('notif.recordUri'),
+        ref('notif.recordCid'),
       )
       notifBuilder = paginate(notifBuilder, {
         before,
@@ -93,9 +93,9 @@ export default function (server: Server) {
   )
 }
 
-type NotifRow = { indexedAt: string; uri: string }
-class NotifsKeyset extends Keyset<NotifRow> {
-  cursorFromResult(result: NotifRow) {
-    return { primary: result.indexedAt, secondary: result.uri }
+type NotifRow = { indexedAt: string; cid: string }
+class NotifsKeyset extends TimeCidKeyset<NotifRow> {
+  labelResult(result: NotifRow) {
+    return { primary: result.indexedAt, secondary: result.cid }
   }
 }

--- a/packages/pds/src/api/app/bsky/notification/list.ts
+++ b/packages/pds/src/api/app/bsky/notification/list.ts
@@ -92,8 +92,8 @@ export default function (server: Server) {
 
 type NotifRow = { indexedAt: string; uri: string }
 class NotifsKeyset extends Keyset<NotifRow> {
-  primary = sql`notif.indexedAt`
-  secondary = sql`notif.recordUri`
+  primary = sql`notif."indexedAt"`
+  secondary = sql`notif."recordUri"`
   cursorFromResult(result: NotifRow) {
     return { primary: result.indexedAt, secondary: result.uri }
   }

--- a/packages/pds/src/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/api/app/bsky/util/feed.ts
@@ -1,5 +1,7 @@
 import * as common from '@atproto/common'
+import { sql } from 'kysely'
 import { getDeclaration } from '.'
+import { DbRef, Keyset } from '../../../../db/util'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
 import * as GetTimeline from '../../../../lexicon/types/app/bsky/feed/getTimeline'
 
@@ -71,4 +73,12 @@ type FeedRow = {
   requesterRepost: string | null
   requesterUpvote: string | null
   requesterDownvote: string | null
+}
+
+export class FeedKeyset extends Keyset<FeedRow> {
+  primary = sql`cursor`
+  secondary = sql`postUri`
+  cursorFromResult(result: FeedRow) {
+    return { primary: result.cursor, secondary: result.postUri }
+  }
 }

--- a/packages/pds/src/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/api/app/bsky/util/feed.ts
@@ -1,6 +1,6 @@
 import * as common from '@atproto/common'
 import { getDeclaration } from '.'
-import { Keyset } from '../../../../db/util'
+import { TimeCidKeyset } from '../../../../db/pagination'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
 import * as GetTimeline from '../../../../lexicon/types/app/bsky/feed/getTimeline'
 
@@ -74,8 +74,8 @@ type FeedRow = {
   requesterDownvote: string | null
 }
 
-export class FeedKeyset extends Keyset<FeedRow> {
-  cursorFromResult(result: FeedRow) {
-    return { primary: result.cursor, secondary: result.postUri }
+export class FeedKeyset extends TimeCidKeyset<FeedRow> {
+  labelResult(result: FeedRow) {
+    return { primary: result.cursor, secondary: result.postCid }
   }
 }

--- a/packages/pds/src/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/api/app/bsky/util/feed.ts
@@ -1,7 +1,7 @@
 import * as common from '@atproto/common'
 import { sql } from 'kysely'
 import { getDeclaration } from '.'
-import { DbRef, Keyset } from '../../../../db/util'
+import { Keyset } from '../../../../db/util'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
 import * as GetTimeline from '../../../../lexicon/types/app/bsky/feed/getTimeline'
 
@@ -77,7 +77,7 @@ type FeedRow = {
 
 export class FeedKeyset extends Keyset<FeedRow> {
   primary = sql`cursor`
-  secondary = sql`postUri`
+  secondary = sql`"postUri"`
   cursorFromResult(result: FeedRow) {
     return { primary: result.cursor, secondary: result.postUri }
   }

--- a/packages/pds/src/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/api/app/bsky/util/feed.ts
@@ -1,5 +1,4 @@
 import * as common from '@atproto/common'
-import { sql } from 'kysely'
 import { getDeclaration } from '.'
 import { Keyset } from '../../../../db/util'
 import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/feed/getAuthorFeed'
@@ -76,8 +75,6 @@ type FeedRow = {
 }
 
 export class FeedKeyset extends Keyset<FeedRow> {
-  primary = sql`cursor`
-  secondary = sql`"postUri"`
   cursorFromResult(result: FeedRow) {
     return { primary: result.cursor, secondary: result.postUri }
   }

--- a/packages/pds/src/api/app/bsky/util/search.ts
+++ b/packages/pds/src/api/app/bsky/util/search.ts
@@ -161,5 +161,5 @@ const distance = (term: string, ref: DbRef) =>
 // Keyset condition for a cursor
 const keyset = (cursor, refs: { handle: DbRef; distance: DbRef }) => {
   if (cursor === undefined) return undefined
-  return sql`(${refs.distance} > ${cursor.distance}) or (${refs.distance} = ${cursor.distance} and ${refs.handle} > ${cursor.handle})`
+  return sql`((${refs.distance} > ${cursor.distance}) or (${refs.distance} = ${cursor.distance} and ${refs.handle} > ${cursor.handle}))`
 }

--- a/packages/pds/src/api/app/bsky/util/search.ts
+++ b/packages/pds/src/api/app/bsky/util/search.ts
@@ -1,8 +1,8 @@
 import { sql } from 'kysely'
-import { safeParse } from '@hapi/bourne'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import Database from '../../../../db'
 import { DbRef } from '../../../../db/util'
+import { GenericKeyset, paginate } from '../../../../db/pagination'
 
 export const getUserSearchQueryPg = (
   db: Database,
@@ -15,38 +15,33 @@ export const getUserSearchQueryPg = (
   // The more characters the user gives us, the more we can ratchet down
   // the distance threshold for matching.
   const threshold = term.length < 3 ? 0.9 : 0.8
-  const cursor = before !== undefined ? unpackCursor(before) : undefined
 
   // Matching user accounts based on handle
   const distanceAccount = distance(term, ref('handle'))
-  const keysetAccount = keyset(cursor, {
-    handle: ref('handle'),
-    distance: distanceAccount,
-  })
-  const accountsQb = db.db
+  let accountsQb = db.db
     .selectFrom('did_handle')
     .where(distanceAccount, '<', threshold)
-    .if(!!keysetAccount, (qb) => (keysetAccount ? qb.where(keysetAccount) : qb))
     .select(['did_handle.did as did', distanceAccount.as('distance')])
-    .orderBy(distanceAccount)
-    .orderBy('handle')
-    .limit(limit)
+  accountsQb = paginate(accountsQb, {
+    limit,
+    before,
+    direction: 'asc',
+    keyset: new SearchKeyset(distanceAccount, ref('handle')),
+  })
 
   // Matching profiles based on display name
   const distanceProfile = distance(term, ref('displayName'))
-  const keysetProfile = keyset(cursor, {
-    handle: ref('handle'),
-    distance: distanceProfile,
-  })
-  const profilesQb = db.db
+  let profilesQb = db.db
     .selectFrom('profile')
     .innerJoin('did_handle', 'did_handle.did', 'profile.creator')
     .where(distanceProfile, '<', threshold)
-    .if(!!keysetProfile, (qb) => (keysetProfile ? qb.where(keysetProfile) : qb))
     .select(['did_handle.did as did', distanceProfile.as('distance')])
-    .orderBy(distanceProfile)
-    .orderBy('handle')
-    .limit(limit)
+  profilesQb = paginate(profilesQb, {
+    limit,
+    before,
+    direction: 'asc',
+    keyset: new SearchKeyset(distanceProfile, ref('handle')),
+  })
 
   // Combine user account and profile results, taking best matches from each
   const emptyQb = db.db
@@ -66,17 +61,15 @@ export const getUserSearchQueryPg = (
     .orderBy('distance')
 
   // Sort and paginate all user results
-  const keysetAll = keyset(cursor, {
-    handle: ref('handle'),
-    distance: ref('distance'),
-  })
-  return db.db
+  const allQb = db.db
     .selectFrom(resultsQb.as('results'))
     .innerJoin('did_handle', 'did_handle.did', 'results.did')
-    .if(!!keysetAll, (qb) => (keysetAll ? qb.where(keysetAll) : qb))
-    .orderBy('distance')
-    .orderBy('handle') // Keep order stable: break ties in distance arbitrarily using handle
-    .limit(limit)
+  return paginate(allQb, {
+    limit,
+    before,
+    direction: 'asc',
+    keyset: new SearchKeyset(ref('distance'), ref('handle')),
+  })
 }
 
 export const getUserSearchQuerySqlite = (
@@ -107,7 +100,8 @@ export const getUserSearchQuerySqlite = (
     'did_handle.handle',
   )} || ' ' || coalesce(${ref('profile.displayName')}, ''))`
 
-  const cursor = before !== undefined ? unpackCursor(before) : undefined
+  const keyset = new SearchKeyset(sql``, sql``)
+  const cursor = keyset.unpackCursor(before)
 
   return db.db
     .selectFrom('did_handle')
@@ -119,36 +113,10 @@ export const getUserSearchQuerySqlite = (
       return q
     })
     .if(!!cursor, (qb) =>
-      cursor ? qb.where('handle', '>', cursor.handle) : qb,
+      cursor ? qb.where('handle', '>', cursor.secondary) : qb,
     )
     .orderBy('handle')
     .limit(limit)
-}
-
-// E.g. { distance: .94827, handle: 'pfrazee' } -> '[0.94827,"pfrazee"]'
-export const packCursor = (row: {
-  distance: number
-  handle: string
-}): string => {
-  const { distance, handle } = row
-  return JSON.stringify([distance, handle])
-}
-
-export const unpackCursor = (
-  before: string,
-): { distance: number; handle: string } => {
-  const result = safeParse(before)
-  if (!Array.isArray(result)) {
-    throw new InvalidRequestError('Malformed cursor')
-  }
-  const [distance, handle, ...others] = result
-  if (typeof distance !== 'number' || !handle || others.length > 0) {
-    throw new InvalidRequestError('Malformed cursor')
-  }
-  return {
-    handle,
-    distance,
-  }
 }
 
 // Remove leading @ in case a handle is input that way
@@ -158,8 +126,29 @@ export const cleanTerm = (term: string) => term.trim().replace(/^@/g, '')
 const distance = (term: string, ref: DbRef) =>
   sql<number>`(${term} <<<-> ${ref})`
 
-// Keyset condition for a cursor
-const keyset = (cursor, refs: { handle: DbRef; distance: DbRef }) => {
-  if (cursor === undefined) return undefined
-  return sql`((${refs.distance} > ${cursor.distance}) or (${refs.distance} = ${cursor.distance} and ${refs.handle} > ${cursor.handle}))`
+type Result = { distance: number; handle: string }
+type LabeledResult = { primary: number; secondary: string }
+export class SearchKeyset extends GenericKeyset<Result, LabeledResult> {
+  labelResult(result: Result) {
+    return {
+      primary: result.distance,
+      secondary: result.handle,
+    }
+  }
+  labeledResultToCursor(labeled: LabeledResult) {
+    return {
+      primary: labeled.primary.toString().replace('0.', '.'),
+      secondary: labeled.secondary,
+    }
+  }
+  cursorToLabeledResult(cursor: { primary: string; secondary: string }) {
+    const distance = parseFloat(cursor.primary)
+    if (isNaN(distance)) {
+      throw new InvalidRequestError('Malformed cursor')
+    }
+    return {
+      primary: distance,
+      secondary: cursor.secondary,
+    }
+  }
 }

--- a/packages/pds/src/db/pagination.ts
+++ b/packages/pds/src/db/pagination.ts
@@ -1,0 +1,110 @@
+import { SelectQueryBuilder, sql } from 'kysely'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { DbRef } from './util'
+
+type Cursor = { primary: string; secondary: string }
+type LabeledResult = { primary: string | number; secondary: string | number }
+
+/**
+ * The GenericKeyset is an abstract class that sets-up the interface and partial implementation
+ * of a keyset-paginated cursor with two parts. There are three types involved:
+ *  - Result: a raw result (i.e. a row from the db) containing data that will make-up a cursor.
+ *    - E.g. { createdAt: '2022-01-01T12:00:00Z', cid: 'bafyx' }
+ *  - LabeledResult: a Result processed such that the "primary" and "secondary" parts of the cursor are labeled.
+ *    - E.g. { primary: '2022-01-01T12:00:00Z', secondary: 'bafyx' }
+ *  - Cursor: the two string parts that make-up the packed/string cursor.
+ *    - E.g. packed cursor '1641038400000::bafyx' in parts { primary: '1641038400000', secondary: 'bafyx' }
+ *
+ * These types relate as such. Implementers define the relations marked with a *:
+ *   Result -*-> LabeledResult <-*-> Cursor <--> packed/string cursor
+ *                     ↳ SQL Condition
+ */
+export abstract class GenericKeyset<R, LR extends LabeledResult> {
+  constructor(public primary: DbRef, public secondary: DbRef) {}
+  abstract labelResult(result: R): LR
+  abstract labeledResultToCursor(labeled: LR): Cursor
+  abstract cursorToLabeledResult(cursor: Cursor): LR
+  packFromResult(results: R | R[]): string | undefined {
+    const result = Array.isArray(results) ? results.at(-1) : results
+    if (!result) return
+    return this.pack(this.labelResult(result))
+  }
+  pack(labeled?: LR): string | undefined {
+    if (!labeled) return
+    const cursor = this.labeledResultToCursor(labeled)
+    return this.packCursor(cursor)
+  }
+  unpack(cursorStr?: string): LR | undefined {
+    const cursor = this.unpackCursor(cursorStr)
+    if (!cursor) return
+    return this.cursorToLabeledResult(cursor)
+  }
+  packCursor(cursor?: Cursor): string | undefined {
+    if (!cursor) return
+    return `${cursor.primary}::${cursor.secondary}`
+  }
+  unpackCursor(cursorStr?: string): Cursor | undefined {
+    if (!cursorStr) return
+    const result = cursorStr.split('::')
+    const [primary, secondary, ...others] = result
+    if (!primary || !secondary || others.length > 0) {
+      throw new InvalidRequestError('Malformed cursor')
+    }
+    return {
+      primary,
+      secondary,
+    }
+  }
+  getSql(labeled?: LR) {
+    if (labeled === undefined) return
+    return sql`((${this.primary} < ${labeled.primary}) or (${this.primary} = ${labeled.primary} and ${this.secondary} < ${labeled.secondary}))`
+  }
+}
+
+type CreatedAtCidResult = { createdAt: string; cid: string }
+type TimeCidLabeledResult = Cursor
+
+export class TimeCidKeyset<
+  TimeCidResult = CreatedAtCidResult,
+> extends GenericKeyset<TimeCidResult, TimeCidLabeledResult> {
+  labelResult(result: TimeCidResult): TimeCidLabeledResult
+  labelResult<TimeCidResult extends CreatedAtCidResult>(result: TimeCidResult) {
+    return { primary: result.createdAt, secondary: result.cid }
+  }
+  labeledResultToCursor(labeled: TimeCidLabeledResult) {
+    return {
+      primary: new Date(labeled.primary).getTime().toString(),
+      secondary: labeled.secondary,
+    }
+  }
+  cursorToLabeledResult(cursor: Cursor) {
+    const primaryDate = new Date(parseInt(cursor.primary, 10))
+    if (isNaN(primaryDate.getTime())) {
+      throw new InvalidRequestError('Malformed cursor')
+    }
+    return {
+      primary: primaryDate.toISOString(),
+      secondary: cursor.secondary,
+    }
+  }
+}
+
+export const paginate = <
+  QB extends SelectQueryBuilder<any, any, any>,
+  K extends GenericKeyset<unknown, any>,
+>(
+  qb: QB,
+  opts: {
+    limit?: number
+    before?: string
+    keyset: K
+  },
+) => {
+  const { limit, before, keyset } = opts
+  const keysetSql = keyset.getSql(keyset.unpack(before))
+  return qb
+    .if(!!limit, (q) => q.limit(limit as number))
+    .orderBy(keyset.primary, 'desc')
+    .orderBy(keyset.secondary, 'desc')
+    .if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb))
+}

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -52,10 +52,17 @@ export const paginate = <QB extends SelectQueryBuilder<any, any, any>, T>(
     )
 }
 
-export abstract class Keyset<T> {
+type DefaultRow = { createdAt: string; uri: string }
+export abstract class Keyset<T = DefaultRow> {
   abstract primary: DbRef
   abstract secondary: DbRef
-  abstract cursorFromResult(result: T): Cursor
+  cursorFromResult(result: T): Cursor
+  cursorFromResult<T extends DefaultRow>(result: T): Cursor {
+    return {
+      primary: result.createdAt,
+      secondary: result.uri,
+    }
+  }
   packFromResult(results: T | T[]): string | undefined {
     const result = Array.isArray(results) ? results.at(-1) : results
     if (result === undefined) return

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -23,24 +23,12 @@ export const countAll = sql<number>`count(*)`
 
 export const paginate = <QB extends SelectQueryBuilder<any, any, any>, T>(
   qb: QB,
-  opts:
-    | {
-        limit?: number
-        before?: string
-        by: DbRef
-      }
-    | {
-        limit?: number
-        before?: string
-        keyset: Keyset<T>
-      },
+  opts: {
+    limit?: number
+    before?: string
+    keyset: Keyset<T>
+  },
 ) => {
-  if ('by' in opts) {
-    return qb
-      .if(opts.limit !== undefined, (q) => q.limit(opts.limit as number))
-      .orderBy(opts.by, 'desc')
-      .if(opts.before !== undefined, (q) => q.where(opts.by, '<', opts.before))
-  }
   const cursor = opts.keyset.unpack(opts.before)
   const keysetCondition = getKeysetCondition(cursor, opts.keyset)
   return qb

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -8,6 +8,8 @@ import {
   SqliteIntrospector,
   SqliteQueryCompiler,
 } from 'kysely'
+import { safeParse } from '@hapi/bourne'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export const actorWhereClause = (actor: string) => {
   if (actor.startsWith('did:')) {
@@ -19,22 +21,80 @@ export const actorWhereClause = (actor: string) => {
 
 export const countAll = sql<number>`count(*)`
 
-export const paginate = <QB extends SelectQueryBuilder<any, any, any>>(
+export const paginate = <QB extends SelectQueryBuilder<any, any, any>, T>(
   qb: QB,
-  opts: {
-    limit?: number
-    before?: string
-    by: DbRef
-    secondaryOrder?: DbRef
-  },
+  opts:
+    | {
+        limit?: number
+        before?: string
+        by: DbRef
+      }
+    | {
+        limit?: number
+        before?: string
+        keyset: Keyset<T>
+      },
 ) => {
+  if ('by' in opts) {
+    return qb
+      .if(opts.limit !== undefined, (q) => q.limit(opts.limit as number))
+      .orderBy(opts.by, 'desc')
+      .if(opts.before !== undefined, (q) => q.where(opts.by, '<', opts.before))
+  }
+  const cursor = opts.keyset.unpack(opts.before)
+  const keysetCondition = getKeysetCondition(cursor, opts.keyset)
   return qb
-    .orderBy(opts.by, 'desc')
-    .if(opts.secondaryOrder !== undefined, (q) =>
-      q.orderBy(opts.secondaryOrder as DbRef, 'desc'),
-    )
     .if(opts.limit !== undefined, (q) => q.limit(opts.limit as number))
-    .if(opts.before !== undefined, (q) => q.where(opts.by, '<', opts.before))
+    .orderBy(opts.keyset.primary, 'desc')
+    .orderBy(opts.keyset.secondary, 'desc')
+    .if(keysetCondition !== undefined, (qb) =>
+      keysetCondition ? qb.where(keysetCondition) : qb,
+    )
+}
+
+export abstract class Keyset<T> {
+  abstract primary: DbRef
+  abstract secondary: DbRef
+  abstract cursorFromResult(result: T): Cursor
+  packFromResult(results: T | T[]): string | undefined {
+    const result = Array.isArray(results) ? results.at(-1) : results
+    if (result === undefined) return
+    return this.pack(this.cursorFromResult(result))
+  }
+  pack(cursor?: Cursor): string | undefined {
+    if (cursor === undefined) return
+    return JSON.stringify([cursor.primary, cursor.secondary])
+  }
+  unpack(cursorStr?: string): Cursor | undefined {
+    if (cursorStr === undefined) return
+    const result = safeParse(cursorStr)
+    if (!Array.isArray(result)) {
+      throw new InvalidRequestError('Malformed cursor')
+    }
+    const [primary, secondary, ...others] = result
+    if (
+      typeof primary !== 'string' ||
+      typeof secondary !== 'string' ||
+      others.length > 0
+    ) {
+      throw new InvalidRequestError('Malformed cursor')
+    }
+    return {
+      primary,
+      secondary,
+    }
+  }
+}
+
+type Cursor = { primary: string; secondary: string }
+
+// Keyset condition for a cursor
+const getKeysetCondition = <T>(
+  cursor: Cursor | undefined,
+  keyset: Keyset<T>,
+) => {
+  if (cursor === undefined) return undefined
+  return sql`(${keyset.primary} < ${cursor.primary}) or (${keyset.primary} = ${cursor.primary} and ${keyset.secondary} < ${cursor.secondary})`
 }
 
 export const dummyDialect = {

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -53,9 +53,8 @@ export const paginate = <QB extends SelectQueryBuilder<any, any, any>, T>(
 }
 
 type DefaultRow = { createdAt: string; uri: string }
-export abstract class Keyset<T = DefaultRow> {
-  abstract primary: DbRef
-  abstract secondary: DbRef
+export class Keyset<T = DefaultRow> {
+  constructor(public primary: DbRef, public secondary: DbRef) {}
   cursorFromResult(result: T): Cursor
   cursorFromResult<T extends DefaultRow>(result: T): Cursor {
     return {

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -94,7 +94,7 @@ const getKeysetCondition = <T>(
   keyset: Keyset<T>,
 ) => {
   if (cursor === undefined) return undefined
-  return sql`(${keyset.primary} < ${cursor.primary}) or (${keyset.primary} = ${cursor.primary} and ${keyset.secondary} < ${cursor.secondary})`
+  return sql`((${keyset.primary} < ${cursor.primary}) or (${keyset.primary} = ${cursor.primary} and ${keyset.secondary} < ${cursor.secondary}))`
 }
 
 export const dummyDialect = {

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -2,14 +2,11 @@ import {
   DummyDriver,
   DynamicModule,
   RawBuilder,
-  SelectQueryBuilder,
   sql,
   SqliteAdapter,
   SqliteIntrospector,
   SqliteQueryCompiler,
 } from 'kysely'
-import { safeParse } from '@hapi/bourne'
-import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export const actorWhereClause = (actor: string) => {
   if (actor.startsWith('did:')) {
@@ -20,76 +17,6 @@ export const actorWhereClause = (actor: string) => {
 }
 
 export const countAll = sql<number>`count(*)`
-
-export const paginate = <QB extends SelectQueryBuilder<any, any, any>, T>(
-  qb: QB,
-  opts: {
-    limit?: number
-    before?: string
-    keyset: Keyset<T>
-  },
-) => {
-  const cursor = opts.keyset.unpack(opts.before)
-  const keysetCondition = getKeysetCondition(cursor, opts.keyset)
-  return qb
-    .if(opts.limit !== undefined, (q) => q.limit(opts.limit as number))
-    .orderBy(opts.keyset.primary, 'desc')
-    .orderBy(opts.keyset.secondary, 'desc')
-    .if(keysetCondition !== undefined, (qb) =>
-      keysetCondition ? qb.where(keysetCondition) : qb,
-    )
-}
-
-type DefaultRow = { createdAt: string; uri: string }
-export class Keyset<T = DefaultRow> {
-  constructor(public primary: DbRef, public secondary: DbRef) {}
-  cursorFromResult(result: T): Cursor
-  cursorFromResult<T extends DefaultRow>(result: T): Cursor {
-    return {
-      primary: result.createdAt,
-      secondary: result.uri,
-    }
-  }
-  packFromResult(results: T | T[]): string | undefined {
-    const result = Array.isArray(results) ? results.at(-1) : results
-    if (result === undefined) return
-    return this.pack(this.cursorFromResult(result))
-  }
-  pack(cursor?: Cursor): string | undefined {
-    if (cursor === undefined) return
-    return JSON.stringify([cursor.primary, cursor.secondary])
-  }
-  unpack(cursorStr?: string): Cursor | undefined {
-    if (cursorStr === undefined) return
-    const result = safeParse(cursorStr)
-    if (!Array.isArray(result)) {
-      throw new InvalidRequestError('Malformed cursor')
-    }
-    const [primary, secondary, ...others] = result
-    if (
-      typeof primary !== 'string' ||
-      typeof secondary !== 'string' ||
-      others.length > 0
-    ) {
-      throw new InvalidRequestError('Malformed cursor')
-    }
-    return {
-      primary,
-      secondary,
-    }
-  }
-}
-
-type Cursor = { primary: string; secondary: string }
-
-// Keyset condition for a cursor
-const getKeysetCondition = <T>(
-  cursor: Cursor | undefined,
-  keyset: Keyset<T>,
-) => {
-  if (cursor === undefined) return undefined
-  return sql`((${keyset.primary} < ${cursor.primary}) or (${keyset.primary} = ${cursor.primary} and ${keyset.secondary} < ${cursor.secondary}))`
-}
 
 export const dummyDialect = {
   createAdapter() {

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -140,7 +140,7 @@ export const forSnapshot = (obj: unknown) => {
     if (str.match(/^\d{4}-\d{2}-\d{2}T/)) {
       return constantDate
     }
-    if (str.match(/^\["\d{4}-\d{2}-\d{2}T/) && str.includes('at://')) {
+    if (str.match(/^\d+::bafy/)) {
       return constantKeysetCursor
     }
     let isCid: boolean
@@ -189,10 +189,7 @@ export function take(
 }
 
 export const constantDate = new Date(0).toISOString()
-export const constantKeysetCursor = JSON.stringify([
-  constantDate,
-  'at://did:plc:w/app.bsky.x.y/z',
-])
+export const constantKeysetCursor = '0000000000000::bafycid'
 
 const mapLeafValues = (obj: unknown, fn: (val: unknown) => unknown) => {
   if (Array.isArray(obj)) {

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -140,6 +140,9 @@ export const forSnapshot = (obj: unknown) => {
     if (str.match(/^\d{4}-\d{2}-\d{2}T/)) {
       return constantDate
     }
+    if (str.match(/^\["\d{4}-\d{2}-\d{2}T/) && str.includes('at://')) {
+      return constantKeysetCursor
+    }
     let isCid: boolean
     try {
       CID.parse(str)
@@ -186,6 +189,10 @@ export function take(
 }
 
 export const constantDate = new Date(0).toISOString()
+export const constantKeysetCursor = JSON.stringify([
+  constantDate,
+  'at://did:plc:w/app.bsky.x.y/z',
+])
 
 const mapLeafValues = (obj: unknown, fn: (val: unknown) => unknown) => {
   if (Array.isArray(obj)) {

--- a/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
@@ -35,7 +35,7 @@ Object {
       "uri": "record(0)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -196,7 +196,7 @@ Object {
       "uri": "record(8)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -311,7 +311,7 @@ Object {
       "uri": "record(4)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -460,7 +460,7 @@ Object {
       "uri": "record(7)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -621,7 +621,7 @@ Object {
       "uri": "record(8)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -695,7 +695,7 @@ Object {
       "uri": "record(2)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -750,7 +750,7 @@ Object {
       "uri": "record(1)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -875,7 +875,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -1000,7 +1000,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -1130,7 +1130,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -1169,7 +1169,7 @@ Object {
       "uri": "record(0)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;
 
@@ -1322,6 +1322,6 @@ Object {
       "uri": "record(7)",
     },
   ],
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
 }
 `;

--- a/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
@@ -35,7 +35,7 @@ Object {
       "uri": "record(0)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -134,7 +134,7 @@ Object {
       "uri": "record(4)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -165,7 +165,7 @@ Object {
       "uri": "record(6)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -196,7 +196,7 @@ Object {
       "uri": "record(8)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -251,7 +251,7 @@ Object {
       "uri": "record(1)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -281,7 +281,7 @@ Object {
       "uri": "record(2)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -311,7 +311,7 @@ Object {
       "uri": "record(4)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -460,7 +460,7 @@ Object {
       "uri": "record(7)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -559,7 +559,7 @@ Object {
       "uri": "record(4)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -590,7 +590,7 @@ Object {
       "uri": "record(6)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -621,7 +621,7 @@ Object {
       "uri": "record(8)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -635,7 +635,7 @@ exports[`pds assertion views fetches assertions by author filtered by confirmati
 Object {
   "assertions": Array [
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -665,7 +665,7 @@ Object {
       "uri": "record(0)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -695,7 +695,7 @@ Object {
       "uri": "record(2)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -750,7 +750,7 @@ Object {
       "uri": "record(1)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -875,7 +875,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -1000,7 +1000,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -1130,7 +1130,7 @@ Object {
       "uri": "record(6)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -1169,7 +1169,7 @@ Object {
       "uri": "record(0)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -1231,7 +1231,7 @@ Object {
       "uri": "record(2)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertMember",
+      "assertion": "app.bsky.graph.assertCreator",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -1261,7 +1261,7 @@ Object {
       "uri": "record(3)",
     },
     Object {
-      "assertion": "app.bsky.graph.assertCreator",
+      "assertion": "app.bsky.graph.assertMember",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorScene",
@@ -1322,6 +1322,6 @@ Object {
       "uri": "record(7)",
     },
   ],
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
 }
 `;

--- a/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/assertions.test.ts.snap
@@ -1,1327 +1,1287 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`pds assertion views fetches assertions by author & subject 1`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(0)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author 1`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "handle": "carol.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
+      "did": "user(2)",
+      "handle": "carol.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(4)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(8)",
-      "confirmation": Object {
-        "cid": "cids(9)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(7)",
+      "did": "user(3)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(4)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(8)",
+    "confirmation": Object {
+      "cid": "cids(9)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(6)",
+      "uri": "record(7)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(10)",
-      "confirmation": Object {
-        "cid": "cids(11)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(9)",
+      "did": "user(4)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(6)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(10)",
+    "confirmation": Object {
+      "cid": "cids(11)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(8)",
+      "uri": "record(9)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(4)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(8)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author 2`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
       },
-      "cid": "cids(0)",
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(0)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
+      },
+      "did": "user(1)",
+      "handle": "carol.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
+      },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(3)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
+      },
+      "did": "user(2)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(1)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
+      },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(1)",
-        "handle": "carol.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
       },
-      "cid": "cids(3)",
+      "did": "user(3)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
+      },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(2)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(1)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
-      },
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(3)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(2)",
+      "did": "user(3)",
+      "displayName": "bobby",
+      "handle": "bob.test",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
-      },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
-      },
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(3)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(4)",
-    },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "uri": "record(4)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author 3`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
+      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(4)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(2)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
+      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(5)",
+    "confirmation": Object {
+      "cid": "cids(6)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(4)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(5)",
-      "confirmation": Object {
-        "cid": "cids(6)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(4)",
+      "did": "user(3)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(3)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(7)",
+    "confirmation": Object {
+      "cid": "cids(8)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(3)",
+      "uri": "record(6)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(7)",
-      "confirmation": Object {
-        "cid": "cids(8)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(6)",
+      "did": "user(4)",
+      "handle": "carol.test",
+    },
+    "uri": "record(5)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(9)",
+    "confirmation": Object {
+      "cid": "cids(10)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "handle": "carol.test",
-      },
-      "uri": "record(5)",
+      "uri": "record(8)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(9)",
-      "confirmation": Object {
-        "cid": "cids(10)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(8)",
-      },
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "handle": "carol.test",
-      },
-      "uri": "record(7)",
+      "did": "user(4)",
+      "handle": "carol.test",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "uri": "record(7)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by confirmation status 1`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "handle": "carol.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
+      "did": "user(2)",
+      "handle": "carol.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(4)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(8)",
-      "confirmation": Object {
-        "cid": "cids(9)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(7)",
+      "did": "user(3)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(4)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(8)",
+    "confirmation": Object {
+      "cid": "cids(9)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(6)",
+      "uri": "record(7)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(10)",
-      "confirmation": Object {
-        "cid": "cids(11)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(9)",
+      "did": "user(4)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(6)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(10)",
+    "confirmation": Object {
+      "cid": "cids(11)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(8)",
+      "uri": "record(9)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(4)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(8)",
+  },
+]
 `;
 
-exports[`pds assertion views fetches assertions by author filtered by confirmation status 2`] = `
-Object {
-  "assertions": Array [],
-}
-`;
+exports[`pds assertion views fetches assertions by author filtered by confirmation status 2`] = `Array []`;
 
 exports[`pds assertion views fetches assertions by author filtered by confirmation status 3`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(1)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(2)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by confirmation status 4`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
       },
-      "cid": "cids(0)",
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(1)",
-        "handle": "carol.test",
-      },
-      "uri": "record(0)",
+      "did": "user(0)",
+      "handle": "other-scene.test",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(1)",
-        },
-        "did": "user(0)",
-        "handle": "other-scene.test",
+    "cid": "cids(0)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
       },
-      "cid": "cids(3)",
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(2)",
-        },
-        "did": "user(2)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(1)",
+      "did": "user(1)",
+      "handle": "carol.test",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(1)",
+      },
+      "did": "user(0)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(3)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(2)",
+      },
+      "did": "user(2)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(1)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by confirmation status 5`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
+      "did": "user(2)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "handle": "carol.test",
-      },
-      "uri": "record(4)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(8)",
-      "confirmation": Object {
-        "cid": "cids(9)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(7)",
+      "did": "user(3)",
+      "handle": "carol.test",
+    },
+    "uri": "record(4)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(8)",
+    "confirmation": Object {
+      "cid": "cids(9)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "handle": "carol.test",
-      },
-      "uri": "record(6)",
+      "uri": "record(7)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(3)",
+      "handle": "carol.test",
+    },
+    "uri": "record(6)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by confirmation status 6`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
+      "did": "user(2)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "handle": "carol.test",
-      },
-      "uri": "record(4)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(8)",
-      "confirmation": Object {
-        "cid": "cids(9)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(7)",
+      "did": "user(3)",
+      "handle": "carol.test",
+    },
+    "uri": "record(4)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(8)",
+    "confirmation": Object {
+      "cid": "cids(9)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "handle": "carol.test",
-      },
-      "uri": "record(6)",
+      "uri": "record(7)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(3)",
+      "handle": "carol.test",
+    },
+    "uri": "record(6)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by type 1`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "handle": "dan.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
-      "confirmation": Object {
-        "cid": "cids(5)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(3)",
+      "did": "user(1)",
+      "handle": "dan.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(4)",
+    "confirmation": Object {
+      "cid": "cids(5)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(2)",
-        "handle": "carol.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(3)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(6)",
-      "confirmation": Object {
-        "cid": "cids(7)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(5)",
+      "did": "user(2)",
+      "handle": "carol.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(6)",
+    "confirmation": Object {
+      "cid": "cids(7)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(3)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(4)",
+      "uri": "record(5)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(8)",
-      "confirmation": Object {
-        "cid": "cids(9)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(7)",
+      "did": "user(3)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(4)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(8)",
+    "confirmation": Object {
+      "cid": "cids(9)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(4)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(6)",
+      "uri": "record(7)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(4)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(6)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by author filtered by type 2`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "displayName": "besties",
-        "handle": "scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(1)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+    },
+    "uri": "record(0)",
+  },
+]
 `;
 
 exports[`pds assertion views fetches assertions by subject 1`] = `
-Object {
-  "assertions": Array [
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(0)",
-        "handle": "carol-scene.test",
+Array [
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
-      "cid": "cids(0)",
-      "confirmation": Object {
-        "cid": "cids(1)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(1)",
-      },
+      "did": "user(0)",
+      "handle": "carol-scene.test",
+    },
+    "cid": "cids(0)",
+    "confirmation": Object {
+      "cid": "cids(1)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(0)",
+      "uri": "record(1)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(2)",
-        "handle": "other-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(4)",
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(0)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
+      },
+      "did": "user(2)",
+      "handle": "other-scene.test",
+    },
+    "cid": "cids(4)",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
+      },
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(2)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
+      },
+      "did": "user(3)",
+      "handle": "alice-scene.test",
+    },
+    "cid": "cids(5)",
+    "confirmation": Object {
+      "cid": "cids(6)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(2)",
+      "uri": "record(4)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertCreator",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(3)",
-        "handle": "alice-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(5)",
-      "confirmation": Object {
-        "cid": "cids(6)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(4)",
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(3)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertCreator",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(3)",
+      "handle": "alice-scene.test",
+    },
+    "cid": "cids(7)",
+    "confirmation": Object {
+      "cid": "cids(8)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(3)",
+      "uri": "record(6)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(3)",
-        "handle": "alice-scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(7)",
-      "confirmation": Object {
-        "cid": "cids(8)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(6)",
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+    },
+    "uri": "record(5)",
+  },
+  Object {
+    "assertion": "app.bsky.graph.assertMember",
+    "author": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorScene",
+        "cid": "cids(2)",
       },
+      "did": "user(4)",
+      "displayName": "besties",
+      "handle": "scene.test",
+    },
+    "cid": "cids(9)",
+    "confirmation": Object {
+      "cid": "cids(10)",
       "createdAt": "1970-01-01T00:00:00.000Z",
       "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(5)",
+      "uri": "record(8)",
     },
-    Object {
-      "assertion": "app.bsky.graph.assertMember",
-      "author": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorScene",
-          "cid": "cids(2)",
-        },
-        "did": "user(4)",
-        "displayName": "besties",
-        "handle": "scene.test",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "subject": Object {
+      "declaration": Object {
+        "actorType": "app.bsky.system.actorUser",
+        "cid": "cids(3)",
       },
-      "cid": "cids(9)",
-      "confirmation": Object {
-        "cid": "cids(10)",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "indexedAt": "1970-01-01T00:00:00.000Z",
-        "uri": "record(8)",
-      },
-      "createdAt": "1970-01-01T00:00:00.000Z",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "subject": Object {
-        "declaration": Object {
-          "actorType": "app.bsky.system.actorUser",
-          "cid": "cids(3)",
-        },
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-      },
-      "uri": "record(7)",
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
     },
-  ],
-  "cursor": "0000000000000::bafycid",
-}
+    "uri": "record(7)",
+  },
+]
 `;

--- a/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds follow views fetches followers 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -58,7 +58,7 @@ Object {
 
 exports[`pds follow views fetches followers 2`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -94,7 +94,7 @@ Object {
 
 exports[`pds follow views fetches followers 3`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -140,7 +140,7 @@ Object {
 
 exports[`pds follow views fetches followers 4`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -166,7 +166,7 @@ Object {
 
 exports[`pds follow views fetches followers 5`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -202,7 +202,7 @@ Object {
 
 exports[`pds follow views fetches follows 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -258,7 +258,7 @@ Object {
 
 exports[`pds follow views fetches follows 2`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -294,7 +294,7 @@ Object {
 
 exports[`pds follow views fetches follows 3`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -320,7 +320,7 @@ Object {
 
 exports[`pds follow views fetches follows 4`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -366,7 +366,7 @@ Object {
 
 exports[`pds follow views fetches follows 5`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds follow views fetches followers 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -58,7 +58,7 @@ Object {
 
 exports[`pds follow views fetches followers 2`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -94,7 +94,7 @@ Object {
 
 exports[`pds follow views fetches followers 3`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -140,7 +140,7 @@ Object {
 
 exports[`pds follow views fetches followers 4`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -166,7 +166,7 @@ Object {
 
 exports[`pds follow views fetches followers 5`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -202,7 +202,7 @@ Object {
 
 exports[`pds follow views fetches follows 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -258,7 +258,7 @@ Object {
 
 exports[`pds follow views fetches follows 2`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -294,7 +294,7 @@ Object {
 
 exports[`pds follow views fetches follows 3`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -320,7 +320,7 @@ Object {
 
 exports[`pds follow views fetches follows 4`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -366,7 +366,7 @@ Object {
 
 exports[`pds follow views fetches follows 5`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/__snapshots__/members.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/members.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds member views fetches members 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -61,7 +61,7 @@ Object {
 
 exports[`pds member views fetches members 2`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -88,7 +88,7 @@ Object {
 
 exports[`pds member views fetches members 3`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -135,7 +135,7 @@ Object {
 
 exports[`pds member views fetches memberships 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -183,7 +183,7 @@ Object {
 
 exports[`pds member views fetches memberships 2`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -221,7 +221,7 @@ Object {
 
 exports[`pds member views fetches memberships 3`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -258,7 +258,7 @@ Object {
 
 exports[`pds member views fetches memberships 4`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/__snapshots__/members.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/members.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds member views fetches members 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -61,7 +61,7 @@ Object {
 
 exports[`pds member views fetches members 2`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -88,7 +88,7 @@ Object {
 
 exports[`pds member views fetches members 3`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "members": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -135,7 +135,7 @@ Object {
 
 exports[`pds member views fetches memberships 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -183,7 +183,7 @@ Object {
 
 exports[`pds member views fetches memberships 2`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -221,7 +221,7 @@ Object {
 
 exports[`pds member views fetches memberships 3`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",
@@ -258,7 +258,7 @@ Object {
 
 exports[`pds member views fetches memberships 4`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "memberships": Array [
     Object {
       "createdAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/__snapshots__/votes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/votes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds vote views fetches post votes 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "uri": "record(0)",
   "votes": Array [
     Object {
@@ -64,7 +64,7 @@ Object {
 
 exports[`pds vote views fetches reply votes 1`] = `
 Object {
-  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
+  "cursor": "0000000000000::bafycid",
   "uri": "record(0)",
   "votes": Array [
     Object {

--- a/packages/pds/tests/views/__snapshots__/votes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/votes.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pds vote views fetches post votes 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "uri": "record(0)",
   "votes": Array [
     Object {
@@ -64,7 +64,7 @@ Object {
 
 exports[`pds vote views fetches reply votes 1`] = `
 Object {
-  "cursor": "1970-01-01T00:00:00.000Z",
+  "cursor": "[\\"1970-01-01T00:00:00.000Z\\",\\"at://did:plc:w/app.bsky.x.y/z\\"]",
   "uri": "record(0)",
   "votes": Array [
     Object {

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -70,9 +70,6 @@ describe('pds notification views', () => {
   })
 
   it('paginates', async () => {
-    // @TODO there is a small bug where notifications generated with the same
-    // indexedAt time paginate together, even if the page lands between them.
-    // Can see this with assertMember and assertCreator notifications.
     const results = (results) =>
       sort(results.flatMap((res) => res.notifications))
     const paginator = async (cursor?: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,11 +1630,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@hapi/bourne@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-3.0.0.tgz#f11fdf7dda62fe8e336fa7c6642d9041f30356d7"
-  integrity sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==
-
 "@hapi/hoek@^10.0.0":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-10.0.1.tgz#ee9da297fabc557e1c040a0f44ee89c266ccc306"


### PR DESCRIPTION
Make keyset cursors a tuple in the PDS in order to avoid ambiguous pagination, e.g. when paginating by datetime when datetimes need not be unique.  In these cases, we now first order by a datetime, and then in the case of a tie order by some unique field such as a URI.