### PR TITLE
Use integers in lexicons

### DIFF
--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -27,10 +27,10 @@
           "type": "string",
           "maxLength": 256
         },
-        "followersCount": {"type": "number"},
-        "followsCount": {"type": "number"},
-        "membersCount": {"type": "number"},
-        "postsCount": {"type": "number"},
+        "followersCount": {"type": "integer"},
+        "followsCount": {"type": "integer"},
+        "membersCount": {"type": "integer"},
+        "postsCount": {"type": "integer"},
         "myState": {
           "type": "object",
           "properties": {

--- a/lexicons/app/bsky/actor/getSuggestions.json
+++ b/lexicons/app/bsky/actor/getSuggestions.json
@@ -6,7 +6,7 @@
   "parameters": {
     "type": "object",
     "properties": {
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "cursor": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/actor/search.json
+++ b/lexicons/app/bsky/actor/search.json
@@ -8,7 +8,7 @@
     "required": ["term"],
     "properties": {
       "term": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/actor/searchTypeahead.json
+++ b/lexicons/app/bsky/actor/searchTypeahead.json
@@ -8,7 +8,7 @@
     "required": ["term"],
     "properties": {
       "term": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100}
+      "limit": {"type": "integer", "maximum": 100}
     }
   },
   "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -8,7 +8,7 @@
     "required": ["author"],
     "properties": {
       "author": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },
@@ -44,10 +44,10 @@
             {"$ref": "#/defs/unknownEmbed"}
           ]
         },
-        "replyCount": {"type": "number"},
-        "repostCount": {"type": "number"},
-        "upvoteCount": {"type": "number"},
-        "downvoteCount": {"type": "number"},
+        "replyCount": {"type": "integer"},
+        "repostCount": {"type": "integer"},
+        "upvoteCount": {"type": "integer"},
+        "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "string", "format": "date-time"},
         "myState": {
           "type": "object",

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -7,7 +7,7 @@
     "required": ["uri"],
     "properties": {
       "uri": {"type": "string"},
-      "depth": {"type": "number"}
+      "depth": {"type": "integer"}
     }
   },
   "output": {
@@ -37,14 +37,14 @@
           ]
         },
         "parent": {"$ref": "#/defs/post"},
-        "replyCount": {"type": "number"},
+        "replyCount": {"type": "integer"},
         "replies": {
           "type": "array",
           "items": {"$ref": "#/defs/post"}
         },
-        "repostCount": {"type": "number"},
-        "upvoteCount": {"type": "number"},
-        "downvoteCount": {"type": "number"},
+        "repostCount": {"type": "integer"},
+        "upvoteCount": {"type": "integer"},
+        "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "string", "format": "date-time"},
         "myState": {
           "type": "object",

--- a/lexicons/app/bsky/feed/getRepostedBy.json
+++ b/lexicons/app/bsky/feed/getRepostedBy.json
@@ -8,7 +8,7 @@
     "properties": {
       "uri": {"type": "string"},
       "cid": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -7,7 +7,7 @@
     "type": "object",
     "properties": {
       "algorithm": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },
@@ -43,10 +43,10 @@
             {"$ref": "#/defs/unknownEmbed"}
           ]
         },
-        "replyCount": {"type": "number"},
-        "repostCount": {"type": "number"},
-        "upvoteCount": {"type": "number"},
-        "downvoteCount": {"type": "number"},
+        "replyCount": {"type": "integer"},
+        "repostCount": {"type": "integer"},
+        "upvoteCount": {"type": "integer"},
+        "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "string", "format": "date-time"},
         "myState": {
           "type": "object",

--- a/lexicons/app/bsky/feed/getVotes.json
+++ b/lexicons/app/bsky/feed/getVotes.json
@@ -9,7 +9,7 @@
       "uri": {"type": "string"},
       "cid": {"type": "string"},
       "direction": {"type": "string", "enum": ["up", "down"]},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/feed/post.json
+++ b/lexicons/app/bsky/feed/post.json
@@ -48,8 +48,8 @@
       "type": "object",
       "required": ["start", "end"],
       "properties": {
-        "start": {"type": "number", "minimum": 0},
-        "end": {"type": "number", "minimum": 0}
+        "start": {"type": "integer", "minimum": 0},
+        "end": {"type": "integer", "minimum": 0}
       }
     }
   }

--- a/lexicons/app/bsky/graph/getAssertions.json
+++ b/lexicons/app/bsky/graph/getAssertions.json
@@ -10,7 +10,7 @@
       "subject": {"type": "string"},
       "assertion": {"type": "string"},
       "confirmed": {"type": "boolean"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -8,7 +8,7 @@
     "required": ["user"],
     "properties": {
       "user": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -8,7 +8,7 @@
     "required": ["user"],
     "properties": {
       "user": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getMembers.json
+++ b/lexicons/app/bsky/graph/getMembers.json
@@ -8,7 +8,7 @@
     "required": ["actor"],
     "properties": {
       "actor": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getMemberships.json
+++ b/lexicons/app/bsky/graph/getMemberships.json
@@ -8,7 +8,7 @@
     "required": ["actor"],
     "properties": {
       "actor": {"type": "string"},
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/notification/getCount.json
+++ b/lexicons/app/bsky/notification/getCount.json
@@ -8,7 +8,7 @@
       "type": "object",
       "required": ["count"],
       "properties": {
-        "count": { "type": "number"}
+        "count": { "type": "integer"}
       }
     }
   }

--- a/lexicons/app/bsky/notification/list.json
+++ b/lexicons/app/bsky/notification/list.json
@@ -5,7 +5,7 @@
   "parameters": {
     "type": "object",
     "properties": {
-      "limit": {"type": "number", "maximum": 100},
+      "limit": {"type": "integer", "maximum": 100},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/com/atproto/account/createInviteCode.json
+++ b/lexicons/com/atproto/account/createInviteCode.json
@@ -9,7 +9,7 @@
       "type": "object",
       "required": ["useCount"],
       "properties": {
-        "useCount": {"type": "number"}
+        "useCount": {"type": "integer"}
       }
     }
   },

--- a/lexicons/com/atproto/repo/listRecords.json
+++ b/lexicons/com/atproto/repo/listRecords.json
@@ -9,7 +9,7 @@
     "properties": {
       "user": {"type": "string", "description": "The handle or DID of the repo."},
       "collection": {"type": "string", "description": "The NSID of the record type."},
-      "limit": {"type": "number", "minimum": 1, "default": 50, "description": "The number of records to return. TODO-max number?"},
+      "limit": {"type": "integer", "minimum": 1, "default": 50, "description": "The number of records to return. TODO-max number?"},
       "before": {"type": "string", "description": "A TID to filter the range of records returned."},
       "after": {"type": "string", "description": "A TID to filter the range of records returned."},
       "reverse": {"type": "boolean", "description": "Reverse the order of the returned records?"}

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -83,7 +83,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['useCount'],
         properties: {
           useCount: {
-            type: 'number',
+            type: 'integer',
           },
         },
         $defs: {},
@@ -503,7 +503,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           description: 'The NSID of the record type.',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           minimum: 1,
           default: 50,
           description: 'The number of records to return. TODO-max number?',
@@ -969,16 +969,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             maxLength: 256,
           },
           followersCount: {
-            type: 'number',
+            type: 'integer',
           },
           followsCount: {
-            type: 'number',
+            type: 'integer',
           },
           membersCount: {
-            type: 'number',
+            type: 'integer',
           },
           postsCount: {
-            type: 'number',
+            type: 'integer',
           },
           myState: {
             type: 'object',
@@ -1067,7 +1067,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       type: 'object',
       properties: {
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         cursor: {
@@ -1200,7 +1200,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -1325,7 +1325,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
       },
@@ -1482,7 +1482,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -1553,16 +1553,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -1730,16 +1730,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -1871,7 +1871,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         depth: {
-          type: 'number',
+          type: 'integer',
         },
       },
     },
@@ -1929,7 +1929,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 $ref: '#/$defs/post',
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               replies: {
                 type: 'array',
@@ -1938,13 +1938,13 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 },
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -2109,7 +2109,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             $ref: '#/$defs/post',
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           replies: {
             type: 'array',
@@ -2118,13 +2118,13 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             },
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2259,7 +2259,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -2390,7 +2390,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -2461,16 +2461,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -2641,16 +2641,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2792,7 +2792,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           enum: ['up', 'down'],
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3029,7 +3029,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'boolean',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3246,7 +3246,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3391,7 +3391,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3536,7 +3536,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3681,7 +3681,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3824,7 +3824,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['count'],
         properties: {
           count: {
-            type: 'number',
+            type: 'integer',
           },
         },
         $defs: {},
@@ -3839,7 +3839,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       type: 'object',
       properties: {
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -4241,11 +4241,11 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
           required: ['start', 'end'],
           properties: {
             start: {
-              type: 'number',
+              type: 'integer',
               minimum: 0,
             },
             end: {
-              type: 'number',
+              type: 'integer',
               minimum: 0,
             },
           },
@@ -4298,11 +4298,11 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
         required: ['start', 'end'],
         properties: {
           start: {
-            type: 'number',
+            type: 'integer',
             minimum: 0,
           },
           end: {
-            type: 'number',
+            type: 'integer',
             minimum: 0,
           },
         },

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -83,7 +83,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['useCount'],
         properties: {
           useCount: {
-            type: 'number',
+            type: 'integer',
           },
         },
         $defs: {},
@@ -503,7 +503,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           description: 'The NSID of the record type.',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           minimum: 1,
           default: 50,
           description: 'The number of records to return. TODO-max number?',
@@ -969,16 +969,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             maxLength: 256,
           },
           followersCount: {
-            type: 'number',
+            type: 'integer',
           },
           followsCount: {
-            type: 'number',
+            type: 'integer',
           },
           membersCount: {
-            type: 'number',
+            type: 'integer',
           },
           postsCount: {
-            type: 'number',
+            type: 'integer',
           },
           myState: {
             type: 'object',
@@ -1067,7 +1067,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       type: 'object',
       properties: {
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         cursor: {
@@ -1200,7 +1200,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -1325,7 +1325,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
       },
@@ -1482,7 +1482,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -1553,16 +1553,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -1730,16 +1730,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -1871,7 +1871,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         depth: {
-          type: 'number',
+          type: 'integer',
         },
       },
     },
@@ -1929,7 +1929,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 $ref: '#/$defs/post',
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               replies: {
                 type: 'array',
@@ -1938,13 +1938,13 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 },
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -2109,7 +2109,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             $ref: '#/$defs/post',
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           replies: {
             type: 'array',
@@ -2118,13 +2118,13 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             },
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2259,7 +2259,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -2390,7 +2390,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -2461,16 +2461,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               replyCount: {
-                type: 'number',
+                type: 'integer',
               },
               repostCount: {
-                type: 'number',
+                type: 'integer',
               },
               upvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               downvoteCount: {
-                type: 'number',
+                type: 'integer',
               },
               indexedAt: {
                 type: 'string',
@@ -2641,16 +2641,16 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           replyCount: {
-            type: 'number',
+            type: 'integer',
           },
           repostCount: {
-            type: 'number',
+            type: 'integer',
           },
           upvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           downvoteCount: {
-            type: 'number',
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2792,7 +2792,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           enum: ['up', 'down'],
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3029,7 +3029,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'boolean',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3246,7 +3246,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3391,7 +3391,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3536,7 +3536,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3681,7 +3681,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           type: 'string',
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -3824,7 +3824,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['count'],
         properties: {
           count: {
-            type: 'number',
+            type: 'integer',
           },
         },
         $defs: {},
@@ -3839,7 +3839,7 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       type: 'object',
       properties: {
         limit: {
-          type: 'number',
+          type: 'integer',
           maximum: 100,
         },
         before: {
@@ -4241,11 +4241,11 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
           required: ['start', 'end'],
           properties: {
             start: {
-              type: 'number',
+              type: 'integer',
               minimum: 0,
             },
             end: {
-              type: 'number',
+              type: 'integer',
               minimum: 0,
             },
           },
@@ -4298,11 +4298,11 @@ export const recordSchemaDict: Record<string, RecordSchema> = {
         required: ['start', 'end'],
         properties: {
           start: {
-            type: 'number',
+            type: 'integer',
             minimum: 0,
           },
           end: {
-            type: 'number',
+            type: 'integer',
             minimum: 0,
           },
         },


### PR DESCRIPTION
Includes a fix for lexicons that were using json schema `number` where `integer` would be more appropriate.