### PR TITLE
Update getPostThread to handle missing parents

### DIFF
--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -16,7 +16,9 @@
       "type": "object",
       "required": ["thread"],
       "properties": {
-        "thread": {"$ref": "#/defs/post"}
+        "thread": {
+          "oneOf": [{"$ref": "#/defs/post"}, {"$ref": "#/defs/notFoundPost"}]
+        }
       }
     }
   },
@@ -36,11 +38,11 @@
             {"$ref": "#/defs/unknownEmbed"}
           ]
         },
-        "parent": {"$ref": "#/defs/post"},
+        "parent": {"oneOf": [{"$ref": "#/defs/post"}, {"$ref": "#/defs/notFoundPost"}]},
         "replyCount": {"type": "integer"},
         "replies": {
           "type": "array",
-          "items": {"$ref": "#/defs/post"}
+          "items": {"oneOf": [{"$ref": "#/defs/post"}, {"$ref": "#/defs/notFoundPost"}]}
         },
         "repostCount": {"type": "integer"},
         "upvoteCount": {"type": "integer"},
@@ -54,6 +56,14 @@
             "downvote": {"type": "string"}
           }
         }
+      }
+    },
+    "notFoundPost": {
+      "type": "object",
+      "required": ["uri", "notFound"],
+      "properties": {
+        "uri": {"type": "string"},
+        "notFound": {"type": "boolean"}
       }
     },
     "user": {

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -1882,7 +1882,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['thread'],
         properties: {
           thread: {
-            $ref: '#/$defs/post',
+            oneOf: [
+              {
+                $ref: '#/$defs/post',
+              },
+              {
+                $ref: '#/$defs/notFoundPost',
+              },
+            ],
           },
         },
         $defs: {
@@ -1926,7 +1933,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               parent: {
-                $ref: '#/$defs/post',
+                oneOf: [
+                  {
+                    $ref: '#/$defs/post',
+                  },
+                  {
+                    $ref: '#/$defs/notFoundPost',
+                  },
+                ],
               },
               replyCount: {
                 type: 'integer',
@@ -1934,7 +1948,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               replies: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/post',
+                  oneOf: [
+                    {
+                      $ref: '#/$defs/post',
+                    },
+                    {
+                      $ref: '#/$defs/notFoundPost',
+                    },
+                  ],
                 },
               },
               repostCount: {
@@ -2062,6 +2083,18 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               },
             },
           },
+          notFoundPost: {
+            type: 'object',
+            required: ['uri', 'notFound'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+              notFound: {
+                type: 'boolean',
+              },
+            },
+          },
         },
       },
     },
@@ -2106,7 +2139,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           parent: {
-            $ref: '#/$defs/post',
+            oneOf: [
+              {
+                $ref: '#/$defs/post',
+              },
+              {
+                $ref: '#/$defs/notFoundPost',
+              },
+            ],
           },
           replyCount: {
             type: 'integer',
@@ -2114,7 +2154,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           replies: {
             type: 'array',
             items: {
-              $ref: '#/$defs/post',
+              oneOf: [
+                {
+                  $ref: '#/$defs/post',
+                },
+                {
+                  $ref: '#/$defs/notFoundPost',
+                },
+              ],
             },
           },
           repostCount: {
@@ -2143,6 +2190,18 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 type: 'string',
               },
             },
+          },
+        },
+      },
+      notFoundPost: {
+        type: 'object',
+        required: ['uri', 'notFound'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          notFound: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -20,7 +20,7 @@ export type ActorKnown =
 export type ActorUnknown = string
 
 export interface OutputSchema {
-  thread: Post;
+  thread: Post | NotFoundPost;
 }
 export interface Post {
   uri: string;
@@ -28,9 +28,9 @@ export interface Post {
   author: User;
   record: {};
   embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
-  parent?: Post;
+  parent?: Post | NotFoundPost;
   replyCount: number;
-  replies?: Post[];
+  replies?: (Post | NotFoundPost)[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;
@@ -65,6 +65,10 @@ export interface ExternalEmbed {
 }
 export interface UnknownEmbed {
   type: string;
+}
+export interface NotFoundPost {
+  uri: string;
+  notFound: boolean;
 }
 
 export interface Response {

--- a/packages/pds/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPostThread.ts
@@ -47,10 +47,16 @@ const getAncestors = async (
   db: Kysely<DatabaseSchema>,
   parentUri: string,
   requester: string,
-): Promise<GetPostThread.Post> => {
+): Promise<GetPostThread.Post | GetPostThread.NotFoundPost> => {
   const parentRes = await postInfoBuilder(db, requester)
     .where('post.uri', '=', parentUri)
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+  if (!parentRes) {
+    return {
+      uri: parentUri,
+      notFound: true,
+    }
+  }
   const parentObj = rowToPost(parentRes)
   if (parentRes.parent !== null) {
     parentObj.parent = await getAncestors(db, parentRes.parent, requester)

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -1882,7 +1882,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         required: ['thread'],
         properties: {
           thread: {
-            $ref: '#/$defs/post',
+            oneOf: [
+              {
+                $ref: '#/$defs/post',
+              },
+              {
+                $ref: '#/$defs/notFoundPost',
+              },
+            ],
           },
         },
         $defs: {
@@ -1926,7 +1933,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 ],
               },
               parent: {
-                $ref: '#/$defs/post',
+                oneOf: [
+                  {
+                    $ref: '#/$defs/post',
+                  },
+                  {
+                    $ref: '#/$defs/notFoundPost',
+                  },
+                ],
               },
               replyCount: {
                 type: 'integer',
@@ -1934,7 +1948,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               replies: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/post',
+                  oneOf: [
+                    {
+                      $ref: '#/$defs/post',
+                    },
+                    {
+                      $ref: '#/$defs/notFoundPost',
+                    },
+                  ],
                 },
               },
               repostCount: {
@@ -2062,6 +2083,18 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
               },
             },
           },
+          notFoundPost: {
+            type: 'object',
+            required: ['uri', 'notFound'],
+            properties: {
+              uri: {
+                type: 'string',
+              },
+              notFound: {
+                type: 'boolean',
+              },
+            },
+          },
         },
       },
     },
@@ -2106,7 +2139,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
             ],
           },
           parent: {
-            $ref: '#/$defs/post',
+            oneOf: [
+              {
+                $ref: '#/$defs/post',
+              },
+              {
+                $ref: '#/$defs/notFoundPost',
+              },
+            ],
           },
           replyCount: {
             type: 'integer',
@@ -2114,7 +2154,14 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
           replies: {
             type: 'array',
             items: {
-              $ref: '#/$defs/post',
+              oneOf: [
+                {
+                  $ref: '#/$defs/post',
+                },
+                {
+                  $ref: '#/$defs/notFoundPost',
+                },
+              ],
             },
           },
           repostCount: {
@@ -2143,6 +2190,18 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
                 type: 'string',
               },
             },
+          },
+        },
+      },
+      notFoundPost: {
+        type: 'object',
+        required: ['uri', 'notFound'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          notFound: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -28,7 +28,7 @@ export type ActorKnown =
 export type ActorUnknown = string
 
 export interface OutputSchema {
-  thread: Post;
+  thread: Post | NotFoundPost;
 }
 export interface Post {
   uri: string;
@@ -36,9 +36,9 @@ export interface Post {
   author: User;
   record: {};
   embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
-  parent?: Post;
+  parent?: Post | NotFoundPost;
   replyCount: number;
-  replies?: Post[];
+  replies?: (Post | NotFoundPost)[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;
@@ -73,6 +73,10 @@ export interface ExternalEmbed {
 }
 export interface UnknownEmbed {
   type: string;
+}
+export interface NotFoundPost {
+  uri: string;
+  notFound: boolean;
 }
 
 export type Handler = (

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -179,6 +179,16 @@ export class SeedClient {
     return post
   }
 
+  async deletePost(by: string, uri: AtUri) {
+    await this.client.app.bsky.feed.post.delete(
+      {
+        did: by,
+        rkey: uri.rkey,
+      },
+      this.getHeaders(by),
+    )
+  }
+
   async vote(direction: 'up' | 'down', by: string, subject: RecordRef) {
     const res = await this.client.app.bsky.feed.vote.create(
       { did: by },

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -499,3 +499,255 @@ Object {
   "uri": "record(0)",
 }
 `;
+
+exports[`pds thread views handles deleted posts correctly 1`] = `
+Object {
+  "author": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorUser",
+      "cid": "cids(1)",
+    },
+    "did": "user(0)",
+    "displayName": "ali",
+    "handle": "alice.test",
+  },
+  "cid": "cids(0)",
+  "downvoteCount": 0,
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "myState": Object {},
+  "record": Object {
+    "$type": "app.bsky.feed.post",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "text": "Deletion thread",
+  },
+  "replies": Array [
+    Object {
+      "author": Object {
+        "declaration": Object {
+          "actorType": "app.bsky.system.actorUser",
+          "cid": "cids(1)",
+        },
+        "did": "user(1)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+      },
+      "cid": "cids(2)",
+      "downvoteCount": 0,
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "myState": Object {},
+      "parent": Object {
+        "author": Object {
+          "declaration": Object {
+            "actorType": "app.bsky.system.actorUser",
+            "cid": "cids(1)",
+          },
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+        },
+        "cid": "cids(0)",
+        "downvoteCount": 0,
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "myState": Object {},
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "text": "Deletion thread",
+        },
+        "replyCount": 1,
+        "repostCount": 0,
+        "upvoteCount": 0,
+        "uri": "record(0)",
+      },
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "reply": Object {
+          "parent": Object {
+            "cid": "cids(0)",
+            "uri": "record(0)",
+          },
+          "root": Object {
+            "cid": "cids(0)",
+            "uri": "record(0)",
+          },
+        },
+        "text": "Reply",
+      },
+      "replies": Array [
+        Object {
+          "author": Object {
+            "declaration": Object {
+              "actorType": "app.bsky.system.actorUser",
+              "cid": "cids(1)",
+            },
+            "did": "user(0)",
+            "displayName": "ali",
+            "handle": "alice.test",
+          },
+          "cid": "cids(3)",
+          "downvoteCount": 0,
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "myState": Object {},
+          "parent": Object {
+            "author": Object {
+              "declaration": Object {
+                "actorType": "app.bsky.system.actorUser",
+                "cid": "cids(1)",
+              },
+              "did": "user(1)",
+              "displayName": "bobby",
+              "handle": "bob.test",
+            },
+            "cid": "cids(2)",
+            "downvoteCount": 0,
+            "indexedAt": "1970-01-01T00:00:00.000Z",
+            "myState": Object {},
+            "parent": Object {
+              "author": Object {
+                "declaration": Object {
+                  "actorType": "app.bsky.system.actorUser",
+                  "cid": "cids(1)",
+                },
+                "did": "user(0)",
+                "displayName": "ali",
+                "handle": "alice.test",
+              },
+              "cid": "cids(0)",
+              "downvoteCount": 0,
+              "indexedAt": "1970-01-01T00:00:00.000Z",
+              "myState": Object {},
+              "record": Object {
+                "$type": "app.bsky.feed.post",
+                "createdAt": "1970-01-01T00:00:00.000Z",
+                "text": "Deletion thread",
+              },
+              "replyCount": 1,
+              "repostCount": 0,
+              "upvoteCount": 0,
+              "uri": "record(0)",
+            },
+            "record": Object {
+              "$type": "app.bsky.feed.post",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "reply": Object {
+                "parent": Object {
+                  "cid": "cids(0)",
+                  "uri": "record(0)",
+                },
+                "root": Object {
+                  "cid": "cids(0)",
+                  "uri": "record(0)",
+                },
+              },
+              "text": "Reply",
+            },
+            "replyCount": 1,
+            "repostCount": 0,
+            "upvoteCount": 0,
+            "uri": "record(1)",
+          },
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "reply": Object {
+              "parent": Object {
+                "cid": "cids(2)",
+                "uri": "record(1)",
+              },
+              "root": Object {
+                "cid": "cids(0)",
+                "uri": "record(0)",
+              },
+            },
+            "text": "Reply reply",
+          },
+          "replies": Array [],
+          "replyCount": 0,
+          "repostCount": 0,
+          "upvoteCount": 0,
+          "uri": "record(2)",
+        },
+      ],
+      "replyCount": 1,
+      "repostCount": 0,
+      "upvoteCount": 0,
+      "uri": "record(1)",
+    },
+  ],
+  "replyCount": 1,
+  "repostCount": 0,
+  "upvoteCount": 0,
+  "uri": "record(0)",
+}
+`;
+
+exports[`pds thread views handles deleted posts correctly 2`] = `
+Object {
+  "author": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorUser",
+      "cid": "cids(1)",
+    },
+    "did": "user(0)",
+    "displayName": "ali",
+    "handle": "alice.test",
+  },
+  "cid": "cids(0)",
+  "downvoteCount": 0,
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "myState": Object {},
+  "record": Object {
+    "$type": "app.bsky.feed.post",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "text": "Deletion thread",
+  },
+  "replies": Array [],
+  "replyCount": 0,
+  "repostCount": 0,
+  "upvoteCount": 0,
+  "uri": "record(0)",
+}
+`;
+
+exports[`pds thread views handles deleted posts correctly 3`] = `
+Object {
+  "author": Object {
+    "declaration": Object {
+      "actorType": "app.bsky.system.actorUser",
+      "cid": "cids(1)",
+    },
+    "did": "user(0)",
+    "displayName": "ali",
+    "handle": "alice.test",
+  },
+  "cid": "cids(0)",
+  "downvoteCount": 0,
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "myState": Object {},
+  "parent": Object {
+    "notFound": true,
+    "uri": "record(2)",
+  },
+  "record": Object {
+    "$type": "app.bsky.feed.post",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "reply": Object {
+      "parent": Object {
+        "cid": "cids(3)",
+        "uri": "record(2)",
+      },
+      "root": Object {
+        "cid": "cids(2)",
+        "uri": "record(1)",
+      },
+    },
+    "text": "Reply reply",
+  },
+  "replies": Array [],
+  "replyCount": 0,
+  "repostCount": 0,
+  "upvoteCount": 0,
+  "uri": "record(0)",
+}
+`;

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -68,4 +68,53 @@ describe('pds thread views', () => {
 
     await expect(promise).rejects.toThrow('Post not found: does.not.exist')
   })
+
+  it('handles deleted posts correctly', async () => {
+    const alice = sc.dids.alice
+    const bob = sc.dids.bob
+
+    const indexes = {
+      aliceRoot: -1,
+      bobReply: -1,
+      aliceReplyReply: -1,
+    }
+
+    await sc.post(alice, 'Deletion thread')
+    indexes.aliceRoot = sc.posts[alice].length - 1
+
+    await sc.reply(
+      bob,
+      sc.posts[alice][indexes.aliceRoot].ref,
+      sc.posts[alice][indexes.aliceRoot].ref,
+      'Reply',
+    )
+    indexes.bobReply = sc.replies[bob].length - 1
+    await sc.reply(
+      alice,
+      sc.posts[alice][indexes.aliceRoot].ref,
+      sc.replies[bob][indexes.bobReply].ref,
+      'Reply reply',
+    )
+    indexes.aliceReplyReply = sc.replies[alice].length - 1
+
+    const thread1 = await client.app.bsky.feed.getPostThread(
+      { uri: sc.posts[alice][indexes.aliceRoot].ref.uriStr },
+      { headers: sc.getHeaders(bob) },
+    )
+    expect(forSnapshot(thread1.data.thread)).toMatchSnapshot()
+
+    await sc.deletePost(bob, sc.replies[bob][indexes.bobReply].ref.uri)
+
+    const thread2 = await client.app.bsky.feed.getPostThread(
+      { uri: sc.posts[alice][indexes.aliceRoot].ref.uriStr },
+      { headers: sc.getHeaders(bob) },
+    )
+    expect(forSnapshot(thread2.data.thread)).toMatchSnapshot()
+
+    const thread3 = await client.app.bsky.feed.getPostThread(
+      { uri: sc.replies[alice][indexes.aliceReplyReply].ref.uriStr },
+      { headers: sc.getHeaders(bob) },
+    )
+    expect(forSnapshot(thread3.data.thread)).toMatchSnapshot()
+  })
 })

--- a/packages/pds/tests/views/votes.test.ts
+++ b/packages/pds/tests/views/votes.test.ts
@@ -146,8 +146,10 @@ describe('pds vote views', () => {
       }
 
       post = await getPost()
-      expect(post.thread.downvoteCount).toEqual(0)
-      expect(post.thread.myState).toEqual({})
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).downvoteCount,
+      ).toEqual(0)
+      expect((post.thread as AppBskyFeedGetPostThread.Post).myState).toEqual({})
 
       // Upvote
       const { data: upvoted } = await client.app.bsky.feed.setVote(
@@ -163,9 +165,15 @@ describe('pds vote views', () => {
       post = await getPost()
       expect(upvoted.upvote).not.toBeUndefined()
       expect(upvoted.downvote).toBeUndefined()
-      expect(post.thread.upvoteCount).toEqual(1)
-      expect(post.thread.downvoteCount).toEqual(0)
-      expect(post.thread.myState).toEqual(upvoted)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).upvoteCount,
+      ).toEqual(1)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).downvoteCount,
+      ).toEqual(0)
+      expect((post.thread as AppBskyFeedGetPostThread.Post).myState).toEqual(
+        upvoted,
+      )
 
       // Downvote
       const { data: downvoted } = await client.app.bsky.feed.setVote(
@@ -181,9 +189,15 @@ describe('pds vote views', () => {
       post = await getPost()
       expect(downvoted.upvote).toBeUndefined()
       expect(downvoted.downvote).not.toBeUndefined()
-      expect(post.thread.upvoteCount).toEqual(0)
-      expect(post.thread.downvoteCount).toEqual(1)
-      expect(post.thread.myState).toEqual(downvoted)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).upvoteCount,
+      ).toEqual(0)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).downvoteCount,
+      ).toEqual(1)
+      expect((post.thread as AppBskyFeedGetPostThread.Post).myState).toEqual(
+        downvoted,
+      )
 
       // No vote
       const { data: novoted } = await client.app.bsky.feed.setVote(
@@ -199,9 +213,15 @@ describe('pds vote views', () => {
       post = await getPost()
       expect(novoted.upvote).toBeUndefined()
       expect(novoted.downvote).toBeUndefined()
-      expect(post.thread.upvoteCount).toEqual(0)
-      expect(post.thread.downvoteCount).toEqual(0)
-      expect(post.thread.myState).toEqual(novoted)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).upvoteCount,
+      ).toEqual(0)
+      expect(
+        (post.thread as AppBskyFeedGetPostThread.Post).downvoteCount,
+      ).toEqual(0)
+      expect((post.thread as AppBskyFeedGetPostThread.Post).myState).toEqual(
+        novoted,
+      )
     })
 
     it('no-ops when already in correct state', async () => {


### PR DESCRIPTION
- Add a variant to the `getPostThread` output for identifying when a post is not found
- Update `getPostThread` to emit the not-found variant for ancestors on 404