### PR TITLE
Add NotFoundError to getPostThread

### DIFF
--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -120,5 +120,8 @@
       "type": "string",
       "not": {"enum": ["app.bsky.system.actorUser", "app.bsky.system.actorScene"]}
     }
-  }
+  },
+  "errors": [
+    {"name": "NotFound"}
+  ]
 }

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -2243,6 +2243,11 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
       },
     },
+    errors: [
+      {
+        name: 'NotFound',
+      },
+    ],
   },
   'app.bsky.feed.getRepostedBy': {
     lexicon: 1,

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -73,8 +73,15 @@ export interface Response {
   data: OutputSchema;
 }
 
+export class NotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'NotFound') return new NotFoundError(e)
   }
   return e
 }

--- a/packages/pds/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPostThread.ts
@@ -24,7 +24,7 @@ export default function (server: Server) {
         .executeTakeFirst()
 
       if (!queryRes) {
-        throw new InvalidRequestError(`Post not found: ${uri}`)
+        throw new InvalidRequestError(`Post not found: ${uri}`, 'NotFound')
       }
 
       const thread = rowToPost(queryRes)

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -2243,6 +2243,11 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
       },
     },
+    errors: [
+      {
+        name: 'NotFound',
+      },
+    ],
   },
   'app.bsky.feed.getRepostedBy': {
     lexicon: 1,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -18,6 +18,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number;
   message?: string;
+  error?: 'NotFound';
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -1,4 +1,7 @@
-import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import AtpApi, {
+  ServiceClient as AtpServiceClient,
+  AppBskyFeedGetPostThread,
+} from '@atproto/api'
 import { runTestServer, forSnapshot, CloseFn } from '../_util'
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
@@ -66,6 +69,8 @@ describe('pds thread views', () => {
       { headers: sc.getHeaders(bob) },
     )
 
-    await expect(promise).rejects.toThrow('Post not found: does.not.exist')
+    await expect(promise).rejects.toThrow(
+      AppBskyFeedGetPostThread.NotFoundError,
+    )
   })
 })


### PR DESCRIPTION
Adds an explicit NotFound error so I can handle it better in the client.