### PR TITLE
Enforce max payload size for PLC and PDS

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -51,6 +51,7 @@ const runServer = (
   const mailer = new ServerMailer(mailTransport, config)
 
   const app = express()
+  app.use(express.json({ limit: '100kb' }))
   app.use(cors())
   app.use(loggerMiddleware)
 

--- a/packages/plc/src/server/index.ts
+++ b/packages/plc/src/server/index.ts
@@ -18,7 +18,7 @@ export type App = express.Application
 export const server = (db: Database, port?: number, _version?: string) => {
   const version = _version || '0.0.0'
   const app = express()
-  app.use(express.json())
+  app.use(express.json({ limit: '100kb' }))
   app.use(cors())
 
   app.use(loggerMiddleware)

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -21,6 +21,7 @@ import {
   validateReqParams,
   validateInput,
   validateOutput,
+  hasBody,
 } from './util'
 import log from './logger'
 import { ResponseType } from '@atproto/xrpc'
@@ -170,12 +171,12 @@ export class Server {
       }
     } catch (e: unknown) {
       if (e instanceof XRPCError) {
-        log.info(e, `error in xrpc method ${req.params.methodId}`)
+        log.error(e, `error in xrpc method ${req.params.methodId}`)
         res.status(e.type).json(e.payload)
       } else {
         log.error(
           e,
-          `Unhandled exception in ${req.params.methodId} xrpc handler:`,
+          `unhandled exception in xrpc method ${req.params.methodId}`,
         )
         res.status(500).json({
           message: 'Unexpected internal server error',
@@ -194,10 +195,10 @@ function isHandlerError(v: HandlerOutput): v is HandlerError {
 }
 
 function assertWellConfigured(req: express.Request) {
-  if (!('body' in req)) {
+  if (hasBody(req) && !req.complete) {
     throw new XRPCError(
       ResponseType.InternalServerError,
-      `XRPC server didn't see req.body. Ensure that your server is using json() and raw() middleware for parsing request bodies.`,
+      `XRPC server didn't see req.body. Ensure that your server is using json(), raw(), and/or text() middleware for parsing request bodies.`,
     )
   }
 }

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -44,7 +44,10 @@ export class XRPCError extends Error {
   get payload() {
     return {
       error: this.customErrorName,
-      message: this.errorMessage || this.typeStr,
+      message:
+        this.type === ResponseType.InternalServerError
+          ? this.typeStr // Do not respond with error details for 500s
+          : this.errorMessage || this.typeStr,
     }
   }
 

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -39,16 +39,16 @@ export function validateReqParams(
 export function validateInput(
   schema: MethodSchema,
   req: express.Request,
-  inputBodyBuf: Uint8Array,
   jsonValidator?: ValidateFunction,
 ): HandlerInput | undefined {
   // request expectation
-  if (inputBodyBuf?.byteLength && !schema.input) {
+  const reqHasBody = hasBody(req)
+  if (reqHasBody && !schema.input) {
     throw new InvalidRequestError(
       `A request body was provided when none was expected`,
     )
   }
-  if (!inputBodyBuf?.byteLength && schema.input) {
+  if (!reqHasBody && schema.input) {
     throw new InvalidRequestError(
       `A request body is expected but none was provided`,
     )
@@ -68,12 +68,9 @@ export function validateInput(
     return undefined
   }
 
-  // parse
-  const inputBody = parseInputBodyBuf(inputBodyBuf, inputEncoding)
-
   // json schema
   if (jsonValidator) {
-    if (!jsonValidator(inputBody)) {
+    if (!jsonValidator(req.body)) {
       throw new InvalidRequestError(
         ajv.errorsText(jsonValidator.errors, {
           dataVar: 'input',
@@ -84,7 +81,7 @@ export function validateInput(
 
   return {
     encoding: inputEncoding,
-    body: inputBody,
+    body: req.body,
   }
 }
 
@@ -143,14 +140,6 @@ export function normalizeMime(v: string) {
   return shortType
 }
 
-export async function readReqBody(req: express.Request): Promise<Uint8Array> {
-  return new Promise((resolve) => {
-    const chunks: Buffer[] = []
-    req.on('data', (chunk) => chunks.push(chunk))
-    req.on('end', () => resolve(new Uint8Array(Buffer.concat(chunks))))
-  })
-}
-
 function isValidEncoding(possible: string | string[], value: string) {
   const normalized = normalizeMime(value)
   if (!normalized) return false
@@ -160,13 +149,11 @@ function isValidEncoding(possible: string | string[], value: string) {
   return possible === normalized
 }
 
-function parseInputBodyBuf(inputBodyBuf: Uint8Array, encoding: string) {
-  if (encoding.startsWith('text/') || encoding === 'application/json') {
-    const str = new TextDecoder().decode(inputBodyBuf)
-    if (encoding === 'application/json') {
-      return JSON.parse(str)
-    }
-    return str
-  }
-  return inputBodyBuf
+function hasBody(req: express.Request) {
+  const contentLength = req.headers['content-length']
+  const transferEncoding = req.headers['transfer-encoding']
+  return (
+    (contentLength !== undefined && !isNaN(parseInt(contentLength, 10))) ||
+    transferEncoding !== undefined
+  )
 }

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -149,11 +149,8 @@ function isValidEncoding(possible: string | string[], value: string) {
   return possible === normalized
 }
 
-function hasBody(req: express.Request) {
+export function hasBody(req: express.Request) {
   const contentLength = req.headers['content-length']
   const transferEncoding = req.headers['transfer-encoding']
-  return (
-    (contentLength !== undefined && !isNaN(parseInt(contentLength, 10))) ||
-    transferEncoding !== undefined
-  )
+  return (contentLength && parseInt(contentLength, 10) > 0) || transferEncoding
 }

--- a/packages/xrpc-server/tests/_util.ts
+++ b/packages/xrpc-server/tests/_util.ts
@@ -5,8 +5,12 @@ import * as xrpc from '../src/index'
 export async function createServer(
   port: number,
   server: xrpc.Server,
+  parse?: { json?: boolean; raw?: boolean; text?: boolean },
 ): Promise<http.Server> {
   const app = express()
+  if (parse?.json !== false) app.use(express.json())
+  if (parse?.raw !== false) app.use(express.raw())
+  if (parse?.text !== false) app.use(express.text())
   app.use(server.router)
   const httpServer = app.listen(port)
   await new Promise((r) => httpServer.on('listening', r))

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -2,6 +2,7 @@ import * as http from 'http'
 import { createServer, closeServer } from './_util'
 import * as xrpcServer from '../src'
 import xrpc from '@atproto/xrpc'
+import logger from '../src/logger'
 
 const SCHEMAS = [
   {
@@ -95,8 +96,63 @@ describe('Parameters', () => {
       client.call('io.example.validationTest', {}, { foo: 123 }),
     ).rejects.toThrow(`input/foo must be string`)
 
+    // 500 responses don't include details, so we nab details from the logger.
+    let error: string | undefined
+    const origError = logger.error
+    logger.error = (obj, ...args) => {
+      error = obj.message
+      logger.error = origError
+      return logger.error(obj, ...args)
+    }
+
     await expect(client.call('io.example.validationTest2')).rejects.toThrow(
-      `output must have required property 'foo'`,
+      'Internal Server Error',
+    )
+    expect(error).toEqual(`output must have required property 'foo'`)
+  })
+})
+
+describe('Parsing', () => {
+  let s: http.Server
+  const server = xrpcServer.createServer(SCHEMAS)
+  server.method(
+    'io.example.validationTest',
+    (params: xrpcServer.Params, input?: xrpcServer.HandlerInput) => ({
+      encoding: 'json',
+      body: input?.body,
+    }),
+  )
+  const client = xrpc.service(`http://localhost:8892`)
+  xrpc.addSchemas(SCHEMAS)
+  beforeAll(async () => {
+    s = await createServer(8892, server, { json: false })
+  })
+  afterAll(async () => {
+    await closeServer(s)
+  })
+
+  it('fails when missing parser for body type', async () => {
+    // 500 responses don't include details, so we nab details from the logger.
+    let error: string | undefined
+    const origError = logger.error
+    logger.error = (obj, ...args) => {
+      error = obj.message
+      logger.error = origError
+      return logger.error(obj, ...args)
+    }
+
+    const promise = client.call(
+      'io.example.validationTest',
+      {},
+      {
+        foo: 'hello',
+        bar: 123,
+      },
+    )
+
+    await expect(promise).rejects.toThrow('Internal Server Error')
+    expect(error).toEqual(
+      `XRPC server didn't see req.body. Ensure that your server is using json(), raw(), and/or text() middleware for parsing request bodies.`,
     )
   })
 })


### PR DESCRIPTION
This enforces a max payload size of 100kb for JSON requests to PLC and the PDS.  This involved a little rejiggering of xrpc-server so that it could rely on the consumer providing payload parsing rather than implementing it itself.