### PR TITLE
Standardize limit schema across lexicons

### DIFF
--- a/lexicons/app/bsky/actor/getSuggestions.json
+++ b/lexicons/app/bsky/actor/getSuggestions.json
@@ -6,7 +6,7 @@
   "parameters": {
     "type": "object",
     "properties": {
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "cursor": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/actor/search.json
+++ b/lexicons/app/bsky/actor/search.json
@@ -8,7 +8,7 @@
     "required": ["term"],
     "properties": {
       "term": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/actor/searchTypeahead.json
+++ b/lexicons/app/bsky/actor/searchTypeahead.json
@@ -8,7 +8,7 @@
     "required": ["term"],
     "properties": {
       "term": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100}
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50}
     }
   },
   "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -8,7 +8,7 @@
     "required": ["author"],
     "properties": {
       "author": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/feed/getRepostedBy.json
+++ b/lexicons/app/bsky/feed/getRepostedBy.json
@@ -8,7 +8,7 @@
     "properties": {
       "uri": {"type": "string"},
       "cid": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -7,7 +7,7 @@
     "type": "object",
     "properties": {
       "algorithm": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/feed/getVotes.json
+++ b/lexicons/app/bsky/feed/getVotes.json
@@ -9,7 +9,7 @@
       "uri": {"type": "string"},
       "cid": {"type": "string"},
       "direction": {"type": "string", "enum": ["up", "down"]},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getAssertions.json
+++ b/lexicons/app/bsky/graph/getAssertions.json
@@ -10,7 +10,7 @@
       "subject": {"type": "string"},
       "assertion": {"type": "string"},
       "confirmed": {"type": "boolean"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -8,7 +8,7 @@
     "required": ["user"],
     "properties": {
       "user": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -8,7 +8,7 @@
     "required": ["user"],
     "properties": {
       "user": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getMembers.json
+++ b/lexicons/app/bsky/graph/getMembers.json
@@ -8,7 +8,7 @@
     "required": ["actor"],
     "properties": {
       "actor": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/graph/getMemberships.json
+++ b/lexicons/app/bsky/graph/getMemberships.json
@@ -8,7 +8,7 @@
     "required": ["actor"],
     "properties": {
       "actor": {"type": "string"},
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/app/bsky/notification/list.json
+++ b/lexicons/app/bsky/notification/list.json
@@ -5,7 +5,7 @@
   "parameters": {
     "type": "object",
     "properties": {
-      "limit": {"type": "integer", "maximum": 100},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
       "before": {"type": "string"}
     }
   },

--- a/lexicons/com/atproto/repo/listRecords.json
+++ b/lexicons/com/atproto/repo/listRecords.json
@@ -9,7 +9,7 @@
     "properties": {
       "user": {"type": "string", "description": "The handle or DID of the repo."},
       "collection": {"type": "string", "description": "The NSID of the record type."},
-      "limit": {"type": "integer", "minimum": 1, "default": 50, "description": "The number of records to return. TODO-max number?"},
+      "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50, "description": "The number of records to return."},
       "before": {"type": "string", "description": "A TID to filter the range of records returned."},
       "after": {"type": "string", "description": "A TID to filter the range of records returned."},
       "reverse": {"type": "boolean", "description": "Reverse the order of the returned records?"}

--- a/packages/api/src/client/schemas.ts
+++ b/packages/api/src/client/schemas.ts
@@ -505,8 +505,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         limit: {
           type: 'integer',
           minimum: 1,
+          maximum: 100,
           default: 50,
-          description: 'The number of records to return. TODO-max number?',
+          description: 'The number of records to return.',
         },
         before: {
           type: 'string',
@@ -1068,7 +1069,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       properties: {
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         cursor: {
           type: 'string',
@@ -1201,7 +1204,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -1326,7 +1331,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
       },
     },
@@ -1483,7 +1490,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2260,7 +2269,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2391,7 +2402,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2793,7 +2806,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3030,7 +3045,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3247,7 +3264,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3392,7 +3411,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3537,7 +3558,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3682,7 +3705,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3840,7 +3865,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       properties: {
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
    */
   collection: string;
   /**
-   * The number of records to return. TODO-max number?
+   * The number of records to return.
    */
   limit?: number;
   /**

--- a/packages/pds/src/lexicon/schemas.ts
+++ b/packages/pds/src/lexicon/schemas.ts
@@ -505,8 +505,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         limit: {
           type: 'integer',
           minimum: 1,
+          maximum: 100,
           default: 50,
-          description: 'The number of records to return. TODO-max number?',
+          description: 'The number of records to return.',
         },
         before: {
           type: 'string',
@@ -1068,7 +1069,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       properties: {
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         cursor: {
           type: 'string',
@@ -1201,7 +1204,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -1326,7 +1331,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
       },
     },
@@ -1483,7 +1490,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2260,7 +2269,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2391,7 +2402,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -2793,7 +2806,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3030,7 +3045,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3247,7 +3264,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3392,7 +3411,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3537,7 +3558,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3682,7 +3705,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
         },
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',
@@ -3840,7 +3865,9 @@ export const methodSchemaDict: Record<string, MethodSchema> = {
       properties: {
         limit: {
           type: 'integer',
+          minimum: 1,
           maximum: 100,
+          default: 50,
         },
         before: {
           type: 'string',

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
    */
   collection: string;
   /**
-   * The number of records to return. TODO-max number?
+   * The number of records to return.
    */
   limit?: number;
   /**


### PR DESCRIPTION
Most lexicons were missing a default value for limits used in pagination.  This standardizes all limits on min: 1, max: 100, default: 50.  We can tweak that, of course— just nabbed the values that were being used for the one query that already had a min/max/default.

Closes #370 