### PR TITLE
Rework lexicon references to use a more consistent structure

### DIFF
--- a/lexicons/app/bsky/actor/createScene.json
+++ b/lexicons/app/bsky/actor/createScene.json
@@ -24,7 +24,7 @@
           "properties": {
             "handle": { "type": "string" },
             "did": { "type": "string" },
-            "declaration": "#declaration"
+            "declaration": {"type": "ref", "ref": "#declaration"}
           }
         }
       },

--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -18,7 +18,7 @@
           "required": ["did", "declaration", "handle", "creator", "followersCount", "followsCount", "membersCount", "postsCount"],
           "properties": {
             "did": {"type": "string"},
-            "declaration": "#declaration",
+            "declaration": {"type": "ref", "ref": "#declaration"},
             "handle": {"type": "string"},
             "creator": {"type": "string"},
             "displayName": {
@@ -33,7 +33,7 @@
             "followsCount": {"type": "integer"},
             "membersCount": {"type": "integer"},
             "postsCount": {"type": "integer"},
-            "myState": "#myState"
+            "myState": {"type": "ref", "ref": "#myState"}
           }
         }
       }

--- a/lexicons/app/bsky/actor/getSuggestions.json
+++ b/lexicons/app/bsky/actor/getSuggestions.json
@@ -21,7 +21,7 @@
             "cursor": {"type": "string"},
             "actors": {
               "type": "array",
-              "items": "#actor"
+              "items": {"type": "ref", "ref": "#actor"}
             }
           }
         }
@@ -32,7 +32,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -40,7 +40,7 @@
         },
         "description": {"type": "string"},
         "indexedAt": {"type": "datetime"},
-        "myState": "#myState"
+        "myState": {"type": "ref", "ref": "#myState"}
       }
     },
     "myState": {

--- a/lexicons/app/bsky/actor/search.json
+++ b/lexicons/app/bsky/actor/search.json
@@ -21,7 +21,7 @@
           "required": ["users"],
           "properties": {
             "cursor": {"type": "string"},
-            "users": {"type": "array", "items": "#user"}
+            "users": {"type": "array", "items": {"type" :"ref", "ref": "#user"}}
           }
         }
       }
@@ -31,7 +31,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/actor/searchTypeahead.json
+++ b/lexicons/app/bsky/actor/searchTypeahead.json
@@ -19,7 +19,7 @@
           "type": "object",
           "required": ["users"],
           "properties": {
-            "users": {"type": "array", "items": "#user"}
+            "users": {"type": "array", "items": {"type": "ref", "ref": "#user"}}
           }
         }
       }
@@ -29,7 +29,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -23,7 +23,7 @@
             "cursor": {"type": "string"},
             "feed": {
               "type": "array",
-              "items": "#feedItem"
+              "items": {"type": "ref", "ref": "#feedItem"}
             }
           }
         }
@@ -35,21 +35,17 @@
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string"},
-        "author": "#actor",
-        "trendedBy": "#actor",
-        "repostedBy": "#actor",
+        "author": {"type": "ref", "ref": "#actor"},
+        "trendedBy": {"type": "ref", "ref": "#actor"},
+        "repostedBy": {"type": "ref", "ref": "#actor"},
         "record": {"type": "unknown"},
-        "embed": [
-          "#recordEmbed",
-          "#externalEmbed",
-          "#unknownEmbed"
-        ],
+        "embed": {"type": "union", "refs": ["#recordEmbed", "#externalEmbed", "#unknownEmbed"]},
         "replyCount": {"type": "integer"},
         "repostCount": {"type": "integer"},
         "upvoteCount": {"type": "integer"},
         "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "datetime"},
-        "myState": "#myState"
+        "myState": {"type": "ref", "ref": "#myState"}
       }
     },
     "myState": {
@@ -65,7 +61,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -78,7 +74,7 @@
       "required": ["type", "author", "record"],
       "properties": {
         "type": {"type": "string", "const": "record"},
-        "author": "#actor",
+        "author": {"type": "ref", "ref": "#actor"},
         "record": {"type": "unknown"}
       }
     },

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -18,7 +18,10 @@
           "type": "object",
           "required": ["thread"],
           "properties": {
-            "thread": ["#post", "#notFoundPost"]
+            "thread": {
+              "type": "union",
+              "refs": ["#post", "#notFoundPost"]
+            }
           }
         }
       },
@@ -32,24 +35,20 @@
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string"},
-        "author": "#user",
+        "author": {"type": "ref", "ref": "#user"},
         "record": {"type": "unknown"},
-        "embed": [
-          "#recordEmbed",
-          "#externalEmbed",
-          "#unknownEmbed"
-        ],
-        "parent": ["#post", "#notFoundPost"],
+        "embed": {"type": "union", "refs": ["#recordEmbed", "#externalEmbed", "#unknownEmbed"]},
+        "parent": {"type": "union", "refs": ["#post", "#notFoundPost"]},
         "replyCount": {"type": "integer"},
         "replies": {
           "type": "array",
-          "items": ["#post", "#notFoundPost"]
+          "items": {"type": "union", "refs": ["#post", "#notFoundPost"]}
         },
         "repostCount": {"type": "integer"},
         "upvoteCount": {"type": "integer"},
         "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "datetime"},
-        "myState": "#myState"
+        "myState": {"type": "ref", "ref": "#myState"}
       }
     },
     "notFoundPost": {
@@ -73,7 +72,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -86,7 +85,7 @@
       "required": ["type", "author", "record"],
       "properties": {
         "type": {"type": "string", "const": "record"},
-        "author": "#user",
+        "author": {"type": "ref", "ref": "#user"},
         "record": {"type": "unknown"}
       }
     },

--- a/lexicons/app/bsky/feed/getRepostedBy.json
+++ b/lexicons/app/bsky/feed/getRepostedBy.json
@@ -25,7 +25,7 @@
             "cursor": {"type": "string"},
             "repostedBy": {
               "type": "array",
-              "items": "#repostedBy"
+              "items": {"type": "ref", "ref": "#repostedBy"}
             }
           }
         }
@@ -36,7 +36,7 @@
       "required": ["did", "declaration", "handle", "indexedAt"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -22,7 +22,7 @@
             "cursor": {"type": "string"},
             "feed": {
               "type": "array",
-              "items": "#feedItem"
+              "items": {"type": "ref", "ref": "#feedItem"}
             }
           }
         }
@@ -34,21 +34,17 @@
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string"},
-        "author": "#actor",
-        "trendedBy": "#actor",
-        "repostedBy": "#actor",
+        "author": {"type": "ref", "ref": "#actor"},
+        "trendedBy": {"type": "ref", "ref": "#actor"},
+        "repostedBy": {"type": "ref", "ref": "#actor"},
         "record": {"type": "unknown"},
-        "embed": [
-          "#recordEmbed",
-          "#externalEmbed",
-          "#unknownEmbed"
-        ],
+        "embed": {"type": "union", "refs": ["#recordEmbed", "#externalEmbed", "#unknownEmbed"]},
         "replyCount": {"type": "integer"},
         "repostCount": {"type": "integer"},
         "upvoteCount": {"type": "integer"},
         "downvoteCount": {"type": "integer"},
         "indexedAt": {"type": "datetime"},
-        "myState": "#myState"
+        "myState": {"type": "ref", "ref": "#myState"}
       }
     },
     "myState": {
@@ -64,7 +60,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "actorType": {"type": "string"},
         "displayName": {
@@ -78,7 +74,7 @@
       "required": ["type", "author", "record"],
       "properties": {
         "type": {"type": "string", "const": "record"},
-        "author": "#actor",
+        "author": {"type": "ref", "ref": "#actor"},
         "record": {"type": "unknown"}
       }
     },

--- a/lexicons/app/bsky/feed/getVotes.json
+++ b/lexicons/app/bsky/feed/getVotes.json
@@ -26,7 +26,7 @@
             "cursor": {"type": "string"},
             "votes": {
               "type": "array",
-              "items": "#vote"
+              "items": {"type": "ref", "ref": "#vote"}
             }
           }
         }
@@ -39,7 +39,7 @@
         "direction": {"type": "string", "enum": ["up", "down"]},
         "indexedAt": {"type": "datetime"},
         "createdAt": {"type": "datetime"},
-        "actor": "#actor"
+        "actor": {"type": "ref", "ref": "#actor"}
       }
     },
     "actor": {
@@ -47,7 +47,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/feed/mediaEmbed.json
+++ b/lexicons/app/bsky/feed/mediaEmbed.json
@@ -7,7 +7,7 @@
       "description": "A list of media embedded in a post or document.",
       "required": ["media"],
       "properties": {
-        "media": {"type": "array", "items": "#mediaEmbed"}
+        "media": {"type": "array", "items": {"type": "ref", "ref": "#mediaEmbed"}}
       }
     },
     "mediaEmbed": {

--- a/lexicons/app/bsky/feed/post.json
+++ b/lexicons/app/bsky/feed/post.json
@@ -12,9 +12,9 @@
           "text": {"type": "string", "maxLength": 256},
           "entities": {
             "type": "array",
-            "items": "#entity"
+            "items": {"type": "ref", "ref": "#entity"}
           },
-          "reply": "#replyRef",
+          "reply": {"type": "ref", "ref": "#replyRef"},
           "createdAt": {"type": "datetime"}
         }
       }
@@ -23,8 +23,8 @@
       "type": "object",
       "required": ["root", "parent"],
       "properties": {
-        "root": "#postRef",
-        "parent": "#postRef"
+        "root": {"type": "ref", "ref": "#postRef"},
+        "parent": {"type": "ref", "ref": "#postRef"}
       }
     },
     "postRef": {
@@ -39,7 +39,7 @@
       "type": "object",
       "required": ["index", "type", "value"],
       "properties": {
-        "index": "#textSlice",
+        "index": {"type": "ref", "ref": "#textSlice"},
         "type": {
           "type": "string",
           "description": "Expected values are 'mention', 'hashtag', and 'link'."

--- a/lexicons/app/bsky/feed/repost.json
+++ b/lexicons/app/bsky/feed/repost.json
@@ -9,7 +9,7 @@
         "type": "object",
         "required": ["subject", "createdAt"],
         "properties": {
-          "subject": "#subject",
+          "subject": {"type": "ref", "ref": "#subject"},
           "createdAt": {"type": "datetime"}
         }
       }

--- a/lexicons/app/bsky/feed/setVote.json
+++ b/lexicons/app/bsky/feed/setVote.json
@@ -11,7 +11,7 @@
           "type": "object",
           "required": ["subject", "direction"],
           "properties": {
-            "subject": "#subject",
+            "subject": {"type": "ref", "ref": "#subject"},
             "direction": {
               "type": "string",
               "enum": ["up", "down", "none"]

--- a/lexicons/app/bsky/feed/trend.json
+++ b/lexicons/app/bsky/feed/trend.json
@@ -9,7 +9,7 @@
         "type": "object",
         "required": ["subject", "createdAt"],
         "properties": {
-          "subject": "#subject",
+          "subject": {"type": "ref", "ref": "#subject"},
           "createdAt": {"type": "datetime"}
         }
       }

--- a/lexicons/app/bsky/feed/vote.json
+++ b/lexicons/app/bsky/feed/vote.json
@@ -9,7 +9,7 @@
         "type": "object",
         "required": ["subject", "direction", "createdAt"],
         "properties": {
-          "subject": "#subject",
+          "subject": {"type": "ref", "ref": "#subject"},
           "direction": {"type": "string", "enum": ["up", "down"]},
           "createdAt": {"type": "datetime"}
         }

--- a/lexicons/app/bsky/graph/assertion.json
+++ b/lexicons/app/bsky/graph/assertion.json
@@ -10,7 +10,7 @@
         "required": ["assertion", "subject", "createdAt"],
         "properties": {
           "assertion": {"type": "string"},
-          "subject": "#subject",
+          "subject": {"type": "ref", "ref": "#subject"},
           "createdAt": {"type": "datetime"}
         }
       }

--- a/lexicons/app/bsky/graph/confirmation.json
+++ b/lexicons/app/bsky/graph/confirmation.json
@@ -9,8 +9,8 @@
         "type": "object",
         "required": ["originator", "assertion", "createdAt"],
         "properties": {
-          "originator": "#originator",
-          "assertion": "#assertion",
+          "originator": {"type": "ref", "ref": "#originator"},
+          "assertion": {"type": "ref", "ref": "#assertion"},
           "createdAt": {"type": "datetime"}
         }
       }

--- a/lexicons/app/bsky/graph/follow.json
+++ b/lexicons/app/bsky/graph/follow.json
@@ -10,7 +10,7 @@
         "type": "object",
         "required": ["subject", "createdAt"],
         "properties": {
-          "subject": "#subject",
+          "subject": {"type": "ref", "ref": "#subject"},
           "createdAt": {"type": "datetime"}
         }
       }

--- a/lexicons/app/bsky/graph/getAssertions.json
+++ b/lexicons/app/bsky/graph/getAssertions.json
@@ -25,7 +25,7 @@
             "cursor": {"type": "string"},
             "assertions": {
               "type": "array",
-              "items": "#assertion"
+              "items": {"type": "ref", "ref": "#assertion"}
             }
           }
         }
@@ -38,9 +38,9 @@
         "uri": {"type": "string"},
         "cid": {"type": "string"},
         "assertion": {"type": "string"},
-        "confirmation": "#confirmation",
-        "author": "#actor",
-        "subject": "#actor",
+        "confirmation": {"type": "ref", "ref": "#confirmation"},
+        "author": {"type": "ref", "ref": "#actor"},
+        "subject": {"type": "ref", "ref": "#actor"},
         "indexedAt": {"type": "datetime"},
         "createdAt": {"type": "datetime"}
       }
@@ -60,7 +60,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "followers"],
           "properties": {
-            "subject": "#subject",
+            "subject": {"type": "ref", "ref": "#subject"},
             "cursor": {"type": "string"},
             "followers": {
               "type": "array",
-              "items": "#follower"
+              "items": {"type": "ref", "ref": "#follower"}
             }
           }
         }
@@ -35,7 +35,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -48,7 +48,7 @@
       "required": ["did", "declaration", "handle", "indexedAt"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "follows"],
           "properties": {
-            "subject": "#subject",
+            "subject": {"type": "ref", "ref": "#subject"},
             "cursor": {"type": "string"},
             "follows": {
               "type": "array",
-              "items": "#follow"
+              "items": {"type": "ref", "ref": "#follow"}
             }
           }
         }
@@ -35,7 +35,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -48,7 +48,7 @@
       "required": ["did", "declaration", "handle", "indexedAt"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/graph/getMembers.json
+++ b/lexicons/app/bsky/graph/getMembers.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "members"],
           "properties": {
-            "subject": "#subject",
+            "subject": {"type": "ref", "ref": "#subject"},
             "cursor": {"type": "string"},
             "members": {
               "type": "array",
-              "items": "#member"
+              "items": {"type": "ref", "ref": "#member"}
             }
           }
         }
@@ -35,7 +35,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -48,7 +48,7 @@
       "required": ["did", "declaration", "handle", "indexedAt"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/graph/getMemberships.json
+++ b/lexicons/app/bsky/graph/getMemberships.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "memberships"],
           "properties": {
-            "subject": "#subject",
+            "subject": {"type": "ref", "ref": "#subject"},
             "cursor": {"type": "string"},
             "memberships": {
               "type": "array",
-              "items": "#membership"
+              "items": {"type": "ref", "ref": "#membership"}
             }
           }
         }
@@ -35,7 +35,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",
@@ -48,7 +48,7 @@
       "required": ["did", "declaration", "handle", "indexedAt"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/app/bsky/notification/list.json
+++ b/lexicons/app/bsky/notification/list.json
@@ -20,7 +20,7 @@
             "cursor": {"type": "string"},
             "notifications": {
               "type": "array",
-              "items": "#notification"
+              "items": {"type": "ref", "ref": "#notification"}
             }
           }
         }
@@ -32,7 +32,7 @@
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string" },
-        "author": "#author",
+        "author": {"type": "ref", "ref": "#author"},
         "reason": {
           "type": "string",
           "description": "Expected values are 'vote', 'repost', 'trend', 'follow', 'invite', 'mention' and 'reply'."
@@ -48,7 +48,7 @@
       "required": ["did", "declaration", "handle"],
       "properties": {
         "did": {"type": "string"},
-        "declaration": "#declaration",
+        "declaration": {"type": "ref", "ref": "#declaration"},
         "handle": {"type": "string"},
         "displayName": {
           "type": "string",

--- a/lexicons/com/atproto/repo/batchWrite.json
+++ b/lexicons/com/atproto/repo/batchWrite.json
@@ -22,7 +22,7 @@
             },
             "writes": {
               "type": "array",
-              "items": ["#create", "#update", "#delete"]
+              "items": {"type": "union", "refs": ["#create", "#update", "#delete"]}
             }
           }
         }

--- a/lexicons/com/atproto/repo/listRecords.json
+++ b/lexicons/com/atproto/repo/listRecords.json
@@ -26,7 +26,7 @@
             "cursor": {"type": "string"},
             "records": {
               "type": "array",
-              "items": "#record"
+              "items": {"type": "ref", "ref": "#record"}
             }
           }
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -238,11 +238,14 @@ export const lexicons: LexiconDoc[] = [
               },
               writes: {
                 type: 'array',
-                items: [
-                  'lex:com.atproto.repo.batchWrite#create',
-                  'lex:com.atproto.repo.batchWrite#update',
-                  'lex:com.atproto.repo.batchWrite#delete',
-                ],
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.batchWrite#create',
+                    'lex:com.atproto.repo.batchWrite#update',
+                    'lex:com.atproto.repo.batchWrite#delete',
+                  ],
+                },
               },
             },
           },
@@ -542,7 +545,10 @@ export const lexicons: LexiconDoc[] = [
               },
               records: {
                 type: 'array',
-                items: 'lex:com.atproto.repo.listRecords#record',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.repo.listRecords#record',
+                },
               },
             },
           },
@@ -877,7 +883,10 @@ export const lexicons: LexiconDoc[] = [
               did: {
                 type: 'string',
               },
-              declaration: 'lex:app.bsky.actor.createScene#declaration',
+              declaration: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.createScene#declaration',
+              },
             },
           },
         },
@@ -941,7 +950,10 @@ export const lexicons: LexiconDoc[] = [
               did: {
                 type: 'string',
               },
-              declaration: 'lex:app.bsky.actor.getProfile#declaration',
+              declaration: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.getProfile#declaration',
+              },
               handle: {
                 type: 'string',
               },
@@ -968,7 +980,10 @@ export const lexicons: LexiconDoc[] = [
               postsCount: {
                 type: 'integer',
               },
-              myState: 'lex:app.bsky.actor.getProfile#myState',
+              myState: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.getProfile#myState',
+              },
             },
           },
         },
@@ -1035,7 +1050,10 @@ export const lexicons: LexiconDoc[] = [
               },
               actors: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.getSuggestions#actor',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.getSuggestions#actor',
+                },
               },
             },
           },
@@ -1048,7 +1066,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.getSuggestions#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.getSuggestions#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1062,7 +1083,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.actor.getSuggestions#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.getSuggestions#myState',
+          },
         },
       },
       myState: {
@@ -1151,7 +1175,10 @@ export const lexicons: LexiconDoc[] = [
               },
               users: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.search#user',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.search#user',
+                },
               },
             },
           },
@@ -1164,7 +1191,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.search#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.search#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1228,7 +1258,10 @@ export const lexicons: LexiconDoc[] = [
             properties: {
               users: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.searchTypeahead#user',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.searchTypeahead#user',
+                },
               },
             },
           },
@@ -1241,7 +1274,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.searchTypeahead#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.searchTypeahead#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1352,7 +1388,10 @@ export const lexicons: LexiconDoc[] = [
               },
               feed: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getAuthorFeed#feedItem',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getAuthorFeed#feedItem',
+                },
               },
             },
           },
@@ -1378,17 +1417,29 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getAuthorFeed#actor',
-          trendedBy: 'lex:app.bsky.feed.getAuthorFeed#actor',
-          repostedBy: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
+          trendedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
+          repostedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getAuthorFeed#recordEmbed',
-            'lex:app.bsky.feed.getAuthorFeed#externalEmbed',
-            'lex:app.bsky.feed.getAuthorFeed#unknownEmbed',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getAuthorFeed#recordEmbed',
+              'lex:app.bsky.feed.getAuthorFeed#externalEmbed',
+              'lex:app.bsky.feed.getAuthorFeed#unknownEmbed',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
@@ -1404,7 +1455,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getAuthorFeed#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#myState',
+          },
         },
       },
       myState: {
@@ -1428,7 +1482,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getAuthorFeed#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1446,7 +1503,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
           record: {
             type: 'unknown',
           },
@@ -1525,10 +1585,13 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['thread'],
             properties: {
-              thread: [
-                'lex:app.bsky.feed.getPostThread#post',
-                'lex:app.bsky.feed.getPostThread#notFoundPost',
-              ],
+              thread: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.getPostThread#post',
+                  'lex:app.bsky.feed.getPostThread#notFoundPost',
+                ],
+              },
             },
           },
         },
@@ -1558,28 +1621,40 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getPostThread#user',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#user',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getPostThread#recordEmbed',
-            'lex:app.bsky.feed.getPostThread#externalEmbed',
-            'lex:app.bsky.feed.getPostThread#unknownEmbed',
-          ],
-          parent: [
-            'lex:app.bsky.feed.getPostThread#post',
-            'lex:app.bsky.feed.getPostThread#notFoundPost',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getPostThread#recordEmbed',
+              'lex:app.bsky.feed.getPostThread#externalEmbed',
+              'lex:app.bsky.feed.getPostThread#unknownEmbed',
+            ],
+          },
+          parent: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getPostThread#post',
+              'lex:app.bsky.feed.getPostThread#notFoundPost',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
           replies: {
             type: 'array',
-            items: [
-              'lex:app.bsky.feed.getPostThread#post',
-              'lex:app.bsky.feed.getPostThread#notFoundPost',
-            ],
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.getPostThread#post',
+                'lex:app.bsky.feed.getPostThread#notFoundPost',
+              ],
+            },
           },
           repostCount: {
             type: 'integer',
@@ -1593,7 +1668,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getPostThread#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#myState',
+          },
         },
       },
       notFoundPost: {
@@ -1629,7 +1707,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getPostThread#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1647,7 +1728,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getPostThread#user',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#user',
+          },
           record: {
             type: 'unknown',
           },
@@ -1746,7 +1830,10 @@ export const lexicons: LexiconDoc[] = [
               },
               repostedBy: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getRepostedBy#repostedBy',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getRepostedBy#repostedBy',
+                },
               },
             },
           },
@@ -1759,7 +1846,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getRepostedBy#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getRepostedBy#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1828,7 +1918,10 @@ export const lexicons: LexiconDoc[] = [
               },
               feed: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getTimeline#feedItem',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getTimeline#feedItem',
+                },
               },
             },
           },
@@ -1854,17 +1947,29 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getTimeline#actor',
-          trendedBy: 'lex:app.bsky.feed.getTimeline#actor',
-          repostedBy: 'lex:app.bsky.feed.getTimeline#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
+          trendedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
+          repostedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getTimeline#recordEmbed',
-            'lex:app.bsky.feed.getTimeline#externalEmbed',
-            'lex:app.bsky.feed.getTimeline#unknownEmbed',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getTimeline#recordEmbed',
+              'lex:app.bsky.feed.getTimeline#externalEmbed',
+              'lex:app.bsky.feed.getTimeline#unknownEmbed',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
@@ -1880,7 +1985,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getTimeline#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#myState',
+          },
         },
       },
       myState: {
@@ -1904,7 +2012,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getTimeline#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1925,7 +2036,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getTimeline#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
           record: {
             type: 'unknown',
           },
@@ -2028,7 +2142,10 @@ export const lexicons: LexiconDoc[] = [
               },
               votes: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getVotes#vote',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getVotes#vote',
+                },
               },
             },
           },
@@ -2048,7 +2165,10 @@ export const lexicons: LexiconDoc[] = [
           createdAt: {
             type: 'datetime',
           },
-          actor: 'lex:app.bsky.feed.getVotes#actor',
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getVotes#actor',
+          },
         },
       },
       actor: {
@@ -2058,7 +2178,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getVotes#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getVotes#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2097,7 +2220,10 @@ export const lexicons: LexiconDoc[] = [
         properties: {
           media: {
             type: 'array',
-            items: 'lex:app.bsky.feed.mediaEmbed#mediaEmbed',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.mediaEmbed#mediaEmbed',
+            },
           },
         },
       },
@@ -2135,9 +2261,15 @@ export const lexicons: LexiconDoc[] = [
             },
             entities: {
               type: 'array',
-              items: 'lex:app.bsky.feed.post#entity',
+              items: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.post#entity',
+              },
             },
-            reply: 'lex:app.bsky.feed.post#replyRef',
+            reply: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.post#replyRef',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2148,8 +2280,14 @@ export const lexicons: LexiconDoc[] = [
         type: 'object',
         required: ['root', 'parent'],
         properties: {
-          root: 'lex:app.bsky.feed.post#postRef',
-          parent: 'lex:app.bsky.feed.post#postRef',
+          root: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#postRef',
+          },
+          parent: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#postRef',
+          },
         },
       },
       postRef: {
@@ -2168,7 +2306,10 @@ export const lexicons: LexiconDoc[] = [
         type: 'object',
         required: ['index', 'type', 'value'],
         properties: {
-          index: 'lex:app.bsky.feed.post#textSlice',
+          index: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#textSlice',
+          },
           type: {
             type: 'string',
             description:
@@ -2206,7 +2347,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.repost#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.repost#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2240,7 +2384,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'direction'],
             properties: {
-              subject: 'lex:app.bsky.feed.setVote#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.setVote#subject',
+              },
               direction: {
                 type: 'string',
                 enum: ['up', 'down', 'none'],
@@ -2288,7 +2435,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.trend#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.trend#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2320,7 +2470,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'direction', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.vote#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.vote#subject',
+            },
             direction: {
               type: 'string',
               enum: ['up', 'down'],
@@ -2381,7 +2534,10 @@ export const lexicons: LexiconDoc[] = [
             assertion: {
               type: 'string',
             },
-            subject: 'lex:app.bsky.graph.assertion#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.assertion#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2413,8 +2569,14 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['originator', 'assertion', 'createdAt'],
           properties: {
-            originator: 'lex:app.bsky.graph.confirmation#originator',
-            assertion: 'lex:app.bsky.graph.confirmation#assertion',
+            originator: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.confirmation#originator',
+            },
+            assertion: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.confirmation#assertion',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2459,7 +2621,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.graph.follow#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.follow#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2524,7 +2689,10 @@ export const lexicons: LexiconDoc[] = [
               },
               assertions: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getAssertions#assertion',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getAssertions#assertion',
+                },
               },
             },
           },
@@ -2551,9 +2719,18 @@ export const lexicons: LexiconDoc[] = [
           assertion: {
             type: 'string',
           },
-          confirmation: 'lex:app.bsky.graph.getAssertions#confirmation',
-          author: 'lex:app.bsky.graph.getAssertions#actor',
-          subject: 'lex:app.bsky.graph.getAssertions#actor',
+          confirmation: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#confirmation',
+          },
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#actor',
+          },
+          subject: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#actor',
+          },
           indexedAt: {
             type: 'datetime',
           },
@@ -2587,7 +2764,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getAssertions#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2646,13 +2826,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'followers'],
             properties: {
-              subject: 'lex:app.bsky.graph.getFollowers#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getFollowers#subject',
+              },
               cursor: {
                 type: 'string',
               },
               followers: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getFollowers#follower',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getFollowers#follower',
+                },
               },
             },
           },
@@ -2665,7 +2851,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollowers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollowers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2682,7 +2871,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollowers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollowers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2747,13 +2939,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'follows'],
             properties: {
-              subject: 'lex:app.bsky.graph.getFollows#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getFollows#subject',
+              },
               cursor: {
                 type: 'string',
               },
               follows: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getFollows#follow',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getFollows#follow',
+                },
               },
             },
           },
@@ -2766,7 +2964,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollows#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollows#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2783,7 +2984,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollows#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollows#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2848,13 +3052,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'members'],
             properties: {
-              subject: 'lex:app.bsky.graph.getMembers#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getMembers#subject',
+              },
               cursor: {
                 type: 'string',
               },
               members: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getMembers#member',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getMembers#member',
+                },
               },
             },
           },
@@ -2867,7 +3077,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMembers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMembers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2884,7 +3097,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMembers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMembers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2949,13 +3165,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'memberships'],
             properties: {
-              subject: 'lex:app.bsky.graph.getMemberships#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getMemberships#subject',
+              },
               cursor: {
                 type: 'string',
               },
               memberships: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getMemberships#membership',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getMemberships#membership',
+                },
               },
             },
           },
@@ -2968,7 +3190,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMemberships#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMemberships#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2985,7 +3210,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMemberships#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMemberships#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -3071,7 +3299,10 @@ export const lexicons: LexiconDoc[] = [
               },
               notifications: {
                 type: 'array',
-                items: 'lex:app.bsky.notification.list#notification',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.notification.list#notification',
+                },
               },
             },
           },
@@ -3095,7 +3326,10 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.notification.list#author',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.notification.list#author',
+          },
           reason: {
             type: 'string',
             description:
@@ -3122,7 +3356,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.notification.list#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.notification.list#declaration',
+          },
           handle: {
             type: 'string',
           },

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -64,7 +64,7 @@ export class Lexicons {
     // WARNING
     // mutates the object
     // -prf
-    resolveDefUris(validatedDoc, uri)
+    resolveRefUris(validatedDoc, uri)
 
     this.docs.set(uri, validatedDoc)
     for (const [defUri, def] of iterDefs(validatedDoc)) {
@@ -180,23 +180,23 @@ function* iterDefs(doc: LexiconDoc): Generator<[string, LexUserType]> {
 // WARNING
 // this method mutates objects
 // -prf
-function resolveDefUris(obj: any, baseUri: string): any {
+function resolveRefUris(obj: any, baseUri: string): any {
   for (const k in obj) {
-    if (typeof obj[k] === 'string') {
-      if (obj[k].startsWith('#')) {
-        obj[k] = toLexUri(obj[k], baseUri)
-      }
+    if (obj.type === 'ref') {
+      obj.ref = toLexUri(obj.ref, baseUri)
+    } else if (obj.type === 'union') {
+      obj.refs = obj.refs.map((ref) => toLexUri(ref, baseUri))
     } else if (Array.isArray(obj[k])) {
       obj[k] = obj[k].map((item: any) => {
         if (typeof item === 'string') {
           return item.startsWith('#') ? toLexUri(item, baseUri) : item
         } else if (item && typeof item === 'object') {
-          return resolveDefUris(item, baseUri)
+          return resolveRefUris(item, baseUri)
         }
         return item
       })
     } else if (obj[k] && typeof obj[k] === 'object') {
-      obj[k] = resolveDefUris(obj[k], baseUri)
+      obj[k] = resolveRefUris(obj[k], baseUri)
     }
   }
   return obj

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -68,6 +68,26 @@ export const lexPrimitive = z.union([
 ])
 export type LexPrimitive = z.infer<typeof lexPrimitive>
 
+// references
+// =
+
+export const lexRef = z.object({
+  type: z.literal('ref'),
+  description: z.string().optional(),
+  ref: z.string(),
+})
+export type LexRef = z.infer<typeof lexRef>
+
+export const lexRefUnion = z.object({
+  type: z.literal('union'),
+  description: z.string().optional(),
+  refs: z.string().array(),
+})
+export type LexRefUnion = z.infer<typeof lexRefUnion>
+
+export const lexRefVariant = z.union([lexRef, lexRefUnion])
+export type LexRefVariant = z.infer<typeof lexRefVariant>
+
 // blobs
 // =
 
@@ -118,12 +138,7 @@ export type LexBlobVariant = z.infer<typeof lexBlobVariant>
 export const lexArray = z.object({
   type: z.literal('array'),
   description: z.string().optional(),
-  items: z.union([
-    lexPrimitive,
-    lexBlobVariant,
-    z.string(),
-    z.string().array(),
-  ]),
+  items: z.union([lexPrimitive, lexBlobVariant, lexRefVariant]),
   minLength: z.number().int().optional(),
   maxLength: z.number().int().optional(),
 })
@@ -140,15 +155,7 @@ export const lexObject = z.object({
   description: z.string().optional(),
   required: z.string().array().optional(),
   properties: z
-    .record(
-      z.union([
-        z.string(),
-        z.string().array(),
-        lexArray,
-        lexBlobVariant,
-        lexPrimitive,
-      ]),
-    )
+    .record(z.union([lexRefVariant, lexArray, lexBlobVariant, lexPrimitive]))
     .optional(),
 })
 export type LexObject = z.infer<typeof lexObject>
@@ -167,7 +174,7 @@ export type LexXrpcParameters = z.infer<typeof lexXrpcParameters>
 export const lexXrpcBody = z.object({
   description: z.string().optional(),
   encoding: z.union([z.string(), z.string().array()]),
-  schema: z.union([z.string(), z.string().array(), lexObject]).optional(),
+  schema: z.union([lexRefVariant, lexObject]).optional(),
 })
 export type LexXrpcBody = z.infer<typeof lexXrpcBody>
 

--- a/packages/lexicon/src/util.ts
+++ b/packages/lexicon/src/util.ts
@@ -1,5 +1,10 @@
 import { Lexicons } from './lexicons'
-import { LexUserType, ValidationError, ValidationResult } from './types'
+import {
+  LexUserType,
+  LexRefVariant,
+  ValidationError,
+  ValidationResult,
+} from './types'
 
 export function toLexUri(str: string, baseUri?: string): string {
   if (str.startsWith('lex:')) {
@@ -51,13 +56,13 @@ export function assertValidOneOf<T>(
 
 export function toConcreteTypes(
   lexicons: Lexicons,
-  defs: string | string[] | LexUserType,
+  def: LexRefVariant | LexUserType,
 ): LexUserType[] {
-  if (typeof defs === 'string') {
-    return [lexicons.getDefOrThrow(defs)]
-  } else if (Array.isArray(defs)) {
-    return defs.map((def) => lexicons.getDefOrThrow(def)).flat()
+  if (def.type === 'ref') {
+    return [lexicons.getDefOrThrow(def.ref)]
+  } else if (def.type === 'union') {
+    return def.refs.map((ref) => lexicons.getDefOrThrow(ref)).flat()
   } else {
-    return [defs]
+    return [def]
   }
 }

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -3,6 +3,7 @@ import {
   LexArray,
   LexObject,
   LexUserType,
+  LexRefVariant,
   ValidationResult,
   ValidationError,
 } from '../types'

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -19,7 +19,7 @@ export default [
             'datetime',
           ],
           properties: {
-            object: '#object',
+            object: { type: 'ref', ref: '#object' },
             array: { type: 'array', items: { type: 'string' } },
             boolean: { type: 'boolean' },
             number: { type: 'number' },
@@ -33,7 +33,7 @@ export default [
         type: 'object',
         required: ['object', 'array', 'boolean', 'number', 'integer', 'string'],
         properties: {
-          object: '#subobject',
+          object: { type: 'ref', ref: '#subobject' },
           array: { type: 'array', items: { type: 'string' } },
           boolean: { type: 'boolean' },
           number: { type: 'number' },
@@ -69,7 +69,7 @@ export default [
         },
         output: {
           encoding: 'application/json',
-          schema: 'com.example.kitchenSink#object',
+          schema: { type: 'ref', ref: 'com.example.kitchenSink#object' },
         },
       },
     },
@@ -93,11 +93,11 @@ export default [
         },
         input: {
           encoding: 'application/json',
-          schema: 'com.example.kitchenSink#object',
+          schema: { type: 'ref', ref: 'com.example.kitchenSink#object' },
         },
         output: {
           encoding: 'application/json',
-          schema: 'com.example.kitchenSink#object',
+          schema: { type: 'ref', ref: 'com.example.kitchenSink#object' },
         },
       },
     },
@@ -111,7 +111,7 @@ export default [
         record: {
           type: 'object',
           properties: {
-            object: 'com.example.kitchenSink#object',
+            object: { type: 'ref', ref: 'com.example.kitchenSink#object' },
             array: { type: 'array', items: { type: 'string' } },
             boolean: { type: 'boolean' },
             number: { type: 'number' },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -238,11 +238,14 @@ export const lexicons: LexiconDoc[] = [
               },
               writes: {
                 type: 'array',
-                items: [
-                  'lex:com.atproto.repo.batchWrite#create',
-                  'lex:com.atproto.repo.batchWrite#update',
-                  'lex:com.atproto.repo.batchWrite#delete',
-                ],
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.batchWrite#create',
+                    'lex:com.atproto.repo.batchWrite#update',
+                    'lex:com.atproto.repo.batchWrite#delete',
+                  ],
+                },
               },
             },
           },
@@ -542,7 +545,10 @@ export const lexicons: LexiconDoc[] = [
               },
               records: {
                 type: 'array',
-                items: 'lex:com.atproto.repo.listRecords#record',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.repo.listRecords#record',
+                },
               },
             },
           },
@@ -877,7 +883,10 @@ export const lexicons: LexiconDoc[] = [
               did: {
                 type: 'string',
               },
-              declaration: 'lex:app.bsky.actor.createScene#declaration',
+              declaration: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.createScene#declaration',
+              },
             },
           },
         },
@@ -941,7 +950,10 @@ export const lexicons: LexiconDoc[] = [
               did: {
                 type: 'string',
               },
-              declaration: 'lex:app.bsky.actor.getProfile#declaration',
+              declaration: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.getProfile#declaration',
+              },
               handle: {
                 type: 'string',
               },
@@ -968,7 +980,10 @@ export const lexicons: LexiconDoc[] = [
               postsCount: {
                 type: 'integer',
               },
-              myState: 'lex:app.bsky.actor.getProfile#myState',
+              myState: {
+                type: 'ref',
+                ref: 'lex:app.bsky.actor.getProfile#myState',
+              },
             },
           },
         },
@@ -1035,7 +1050,10 @@ export const lexicons: LexiconDoc[] = [
               },
               actors: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.getSuggestions#actor',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.getSuggestions#actor',
+                },
               },
             },
           },
@@ -1048,7 +1066,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.getSuggestions#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.getSuggestions#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1062,7 +1083,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.actor.getSuggestions#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.getSuggestions#myState',
+          },
         },
       },
       myState: {
@@ -1151,7 +1175,10 @@ export const lexicons: LexiconDoc[] = [
               },
               users: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.search#user',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.search#user',
+                },
               },
             },
           },
@@ -1164,7 +1191,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.search#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.search#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1228,7 +1258,10 @@ export const lexicons: LexiconDoc[] = [
             properties: {
               users: {
                 type: 'array',
-                items: 'lex:app.bsky.actor.searchTypeahead#user',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.searchTypeahead#user',
+                },
               },
             },
           },
@@ -1241,7 +1274,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.actor.searchTypeahead#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.searchTypeahead#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1352,7 +1388,10 @@ export const lexicons: LexiconDoc[] = [
               },
               feed: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getAuthorFeed#feedItem',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getAuthorFeed#feedItem',
+                },
               },
             },
           },
@@ -1378,17 +1417,29 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getAuthorFeed#actor',
-          trendedBy: 'lex:app.bsky.feed.getAuthorFeed#actor',
-          repostedBy: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
+          trendedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
+          repostedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getAuthorFeed#recordEmbed',
-            'lex:app.bsky.feed.getAuthorFeed#externalEmbed',
-            'lex:app.bsky.feed.getAuthorFeed#unknownEmbed',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getAuthorFeed#recordEmbed',
+              'lex:app.bsky.feed.getAuthorFeed#externalEmbed',
+              'lex:app.bsky.feed.getAuthorFeed#unknownEmbed',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
@@ -1404,7 +1455,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getAuthorFeed#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#myState',
+          },
         },
       },
       myState: {
@@ -1428,7 +1482,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getAuthorFeed#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1446,7 +1503,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getAuthorFeed#actor',
+          },
           record: {
             type: 'unknown',
           },
@@ -1525,10 +1585,13 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['thread'],
             properties: {
-              thread: [
-                'lex:app.bsky.feed.getPostThread#post',
-                'lex:app.bsky.feed.getPostThread#notFoundPost',
-              ],
+              thread: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.getPostThread#post',
+                  'lex:app.bsky.feed.getPostThread#notFoundPost',
+                ],
+              },
             },
           },
         },
@@ -1558,28 +1621,40 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getPostThread#user',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#user',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getPostThread#recordEmbed',
-            'lex:app.bsky.feed.getPostThread#externalEmbed',
-            'lex:app.bsky.feed.getPostThread#unknownEmbed',
-          ],
-          parent: [
-            'lex:app.bsky.feed.getPostThread#post',
-            'lex:app.bsky.feed.getPostThread#notFoundPost',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getPostThread#recordEmbed',
+              'lex:app.bsky.feed.getPostThread#externalEmbed',
+              'lex:app.bsky.feed.getPostThread#unknownEmbed',
+            ],
+          },
+          parent: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getPostThread#post',
+              'lex:app.bsky.feed.getPostThread#notFoundPost',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
           replies: {
             type: 'array',
-            items: [
-              'lex:app.bsky.feed.getPostThread#post',
-              'lex:app.bsky.feed.getPostThread#notFoundPost',
-            ],
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.getPostThread#post',
+                'lex:app.bsky.feed.getPostThread#notFoundPost',
+              ],
+            },
           },
           repostCount: {
             type: 'integer',
@@ -1593,7 +1668,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getPostThread#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#myState',
+          },
         },
       },
       notFoundPost: {
@@ -1629,7 +1707,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getPostThread#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1647,7 +1728,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getPostThread#user',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getPostThread#user',
+          },
           record: {
             type: 'unknown',
           },
@@ -1746,7 +1830,10 @@ export const lexicons: LexiconDoc[] = [
               },
               repostedBy: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getRepostedBy#repostedBy',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getRepostedBy#repostedBy',
+                },
               },
             },
           },
@@ -1759,7 +1846,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getRepostedBy#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getRepostedBy#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1828,7 +1918,10 @@ export const lexicons: LexiconDoc[] = [
               },
               feed: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getTimeline#feedItem',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getTimeline#feedItem',
+                },
               },
             },
           },
@@ -1854,17 +1947,29 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.feed.getTimeline#actor',
-          trendedBy: 'lex:app.bsky.feed.getTimeline#actor',
-          repostedBy: 'lex:app.bsky.feed.getTimeline#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
+          trendedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
+          repostedBy: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
           record: {
             type: 'unknown',
           },
-          embed: [
-            'lex:app.bsky.feed.getTimeline#recordEmbed',
-            'lex:app.bsky.feed.getTimeline#externalEmbed',
-            'lex:app.bsky.feed.getTimeline#unknownEmbed',
-          ],
+          embed: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.feed.getTimeline#recordEmbed',
+              'lex:app.bsky.feed.getTimeline#externalEmbed',
+              'lex:app.bsky.feed.getTimeline#unknownEmbed',
+            ],
+          },
           replyCount: {
             type: 'integer',
           },
@@ -1880,7 +1985,10 @@ export const lexicons: LexiconDoc[] = [
           indexedAt: {
             type: 'datetime',
           },
-          myState: 'lex:app.bsky.feed.getTimeline#myState',
+          myState: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#myState',
+          },
         },
       },
       myState: {
@@ -1904,7 +2012,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getTimeline#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -1925,7 +2036,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
             const: 'record',
           },
-          author: 'lex:app.bsky.feed.getTimeline#actor',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getTimeline#actor',
+          },
           record: {
             type: 'unknown',
           },
@@ -2028,7 +2142,10 @@ export const lexicons: LexiconDoc[] = [
               },
               votes: {
                 type: 'array',
-                items: 'lex:app.bsky.feed.getVotes#vote',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.getVotes#vote',
+                },
               },
             },
           },
@@ -2048,7 +2165,10 @@ export const lexicons: LexiconDoc[] = [
           createdAt: {
             type: 'datetime',
           },
-          actor: 'lex:app.bsky.feed.getVotes#actor',
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getVotes#actor',
+          },
         },
       },
       actor: {
@@ -2058,7 +2178,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.feed.getVotes#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.getVotes#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2097,7 +2220,10 @@ export const lexicons: LexiconDoc[] = [
         properties: {
           media: {
             type: 'array',
-            items: 'lex:app.bsky.feed.mediaEmbed#mediaEmbed',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.mediaEmbed#mediaEmbed',
+            },
           },
         },
       },
@@ -2135,9 +2261,15 @@ export const lexicons: LexiconDoc[] = [
             },
             entities: {
               type: 'array',
-              items: 'lex:app.bsky.feed.post#entity',
+              items: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.post#entity',
+              },
             },
-            reply: 'lex:app.bsky.feed.post#replyRef',
+            reply: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.post#replyRef',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2148,8 +2280,14 @@ export const lexicons: LexiconDoc[] = [
         type: 'object',
         required: ['root', 'parent'],
         properties: {
-          root: 'lex:app.bsky.feed.post#postRef',
-          parent: 'lex:app.bsky.feed.post#postRef',
+          root: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#postRef',
+          },
+          parent: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#postRef',
+          },
         },
       },
       postRef: {
@@ -2168,7 +2306,10 @@ export const lexicons: LexiconDoc[] = [
         type: 'object',
         required: ['index', 'type', 'value'],
         properties: {
-          index: 'lex:app.bsky.feed.post#textSlice',
+          index: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.post#textSlice',
+          },
           type: {
             type: 'string',
             description:
@@ -2206,7 +2347,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.repost#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.repost#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2240,7 +2384,10 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'direction'],
             properties: {
-              subject: 'lex:app.bsky.feed.setVote#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.setVote#subject',
+              },
               direction: {
                 type: 'string',
                 enum: ['up', 'down', 'none'],
@@ -2288,7 +2435,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.trend#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.trend#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2320,7 +2470,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'direction', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.feed.vote#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.feed.vote#subject',
+            },
             direction: {
               type: 'string',
               enum: ['up', 'down'],
@@ -2381,7 +2534,10 @@ export const lexicons: LexiconDoc[] = [
             assertion: {
               type: 'string',
             },
-            subject: 'lex:app.bsky.graph.assertion#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.assertion#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2413,8 +2569,14 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['originator', 'assertion', 'createdAt'],
           properties: {
-            originator: 'lex:app.bsky.graph.confirmation#originator',
-            assertion: 'lex:app.bsky.graph.confirmation#assertion',
+            originator: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.confirmation#originator',
+            },
+            assertion: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.confirmation#assertion',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2459,7 +2621,10 @@ export const lexicons: LexiconDoc[] = [
           type: 'object',
           required: ['subject', 'createdAt'],
           properties: {
-            subject: 'lex:app.bsky.graph.follow#subject',
+            subject: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.follow#subject',
+            },
             createdAt: {
               type: 'datetime',
             },
@@ -2524,7 +2689,10 @@ export const lexicons: LexiconDoc[] = [
               },
               assertions: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getAssertions#assertion',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getAssertions#assertion',
+                },
               },
             },
           },
@@ -2551,9 +2719,18 @@ export const lexicons: LexiconDoc[] = [
           assertion: {
             type: 'string',
           },
-          confirmation: 'lex:app.bsky.graph.getAssertions#confirmation',
-          author: 'lex:app.bsky.graph.getAssertions#actor',
-          subject: 'lex:app.bsky.graph.getAssertions#actor',
+          confirmation: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#confirmation',
+          },
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#actor',
+          },
+          subject: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#actor',
+          },
           indexedAt: {
             type: 'datetime',
           },
@@ -2587,7 +2764,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getAssertions#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getAssertions#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2646,13 +2826,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'followers'],
             properties: {
-              subject: 'lex:app.bsky.graph.getFollowers#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getFollowers#subject',
+              },
               cursor: {
                 type: 'string',
               },
               followers: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getFollowers#follower',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getFollowers#follower',
+                },
               },
             },
           },
@@ -2665,7 +2851,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollowers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollowers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2682,7 +2871,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollowers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollowers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2747,13 +2939,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'follows'],
             properties: {
-              subject: 'lex:app.bsky.graph.getFollows#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getFollows#subject',
+              },
               cursor: {
                 type: 'string',
               },
               follows: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getFollows#follow',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getFollows#follow',
+                },
               },
             },
           },
@@ -2766,7 +2964,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollows#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollows#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2783,7 +2984,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getFollows#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getFollows#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2848,13 +3052,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'members'],
             properties: {
-              subject: 'lex:app.bsky.graph.getMembers#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getMembers#subject',
+              },
               cursor: {
                 type: 'string',
               },
               members: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getMembers#member',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getMembers#member',
+                },
               },
             },
           },
@@ -2867,7 +3077,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMembers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMembers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2884,7 +3097,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMembers#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMembers#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2949,13 +3165,19 @@ export const lexicons: LexiconDoc[] = [
             type: 'object',
             required: ['subject', 'memberships'],
             properties: {
-              subject: 'lex:app.bsky.graph.getMemberships#subject',
+              subject: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.getMemberships#subject',
+              },
               cursor: {
                 type: 'string',
               },
               memberships: {
                 type: 'array',
-                items: 'lex:app.bsky.graph.getMemberships#membership',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getMemberships#membership',
+                },
               },
             },
           },
@@ -2968,7 +3190,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMemberships#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMemberships#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -2985,7 +3210,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.graph.getMemberships#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.getMemberships#declaration',
+          },
           handle: {
             type: 'string',
           },
@@ -3071,7 +3299,10 @@ export const lexicons: LexiconDoc[] = [
               },
               notifications: {
                 type: 'array',
-                items: 'lex:app.bsky.notification.list#notification',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.notification.list#notification',
+                },
               },
             },
           },
@@ -3095,7 +3326,10 @@ export const lexicons: LexiconDoc[] = [
           cid: {
             type: 'string',
           },
-          author: 'lex:app.bsky.notification.list#author',
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.notification.list#author',
+          },
           reason: {
             type: 'string',
             description:
@@ -3122,7 +3356,10 @@ export const lexicons: LexiconDoc[] = [
           did: {
             type: 'string',
           },
-          declaration: 'lex:app.bsky.notification.list#declaration',
+          declaration: {
+            type: 'ref',
+            ref: 'lex:app.bsky.notification.list#declaration',
+          },
           handle: {
             type: 'string',
           },


### PR DESCRIPTION
Followup to https://github.com/bluesky-social/atproto/pull/379

Modifies the reference and reference-union structure to be easier for languages like Go.