### PR TITLE
Lexicon tweaks: encoding and union $type discriminators

### DIFF
--- a/lexicons/app/bsky/feed/embed.json
+++ b/lexicons/app/bsky/feed/embed.json
@@ -12,7 +12,7 @@
           "type": "array",
           "items": {
             "type": "union",
-            "refs": ["#media", "#record", "#external", "#unknown"]
+            "refs": ["#media", "#record", "#external"]
           }
         }
       }
@@ -44,13 +44,6 @@
         "title": {"type": "string"},
         "description": {"type": "string"},
         "imageUri": {"type": "string"}
-      }
-    },
-    "unknown": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": {"type": "string"}
       }
     }
   }

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -56,7 +56,7 @@
       "required": ["uri", "notFound"],
       "properties": {
         "uri": {"type": "string"},
-        "notFound": {"type": "boolean"}
+        "notFound": {"type": "boolean", "const": true}
       }
     },
     "myState": {

--- a/lexicons/com/atproto/repo/batchWrite.json
+++ b/lexicons/com/atproto/repo/batchWrite.json
@@ -22,7 +22,7 @@
             },
             "writes": {
               "type": "array",
-              "items": {"type": "union", "refs": ["#create", "#update", "#delete"]}
+              "items": {"type": "union", "refs": ["#create", "#update", "#delete"], "closed": true}
             }
           }
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -245,6 +245,7 @@ export const lexicons: LexiconDoc[] = [
                     'lex:com.atproto.repo.batchWrite#update',
                     'lex:com.atproto.repo.batchWrite#delete',
                   ],
+                  closed: true,
                 },
               },
             },
@@ -1349,7 +1350,6 @@ export const lexicons: LexiconDoc[] = [
                 'lex:app.bsky.feed.embed#media',
                 'lex:app.bsky.feed.embed#record',
                 'lex:app.bsky.feed.embed#external',
-                'lex:app.bsky.feed.embed#unknown',
               ],
             },
           },
@@ -1405,15 +1405,6 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
           },
           imageUri: {
-            type: 'string',
-          },
-        },
-      },
-      unknown: {
-        type: 'object',
-        required: ['type'],
-        properties: {
-          type: {
             type: 'string',
           },
         },
@@ -1659,6 +1650,7 @@ export const lexicons: LexiconDoc[] = [
           },
           notFound: {
             type: 'boolean',
+            const: true,
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/feed/embed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/embed.ts
@@ -5,7 +5,12 @@ import * as AppBskyActorRef from '../actor/ref'
 
 /** A list embeds in a post or document. */
 export interface Main {
-  items?: (Media | Record | External | { $type: string })[];
+  items?: (
+    | Media
+    | Record
+    | External
+    | { $type: string, [k: string]: unknown }
+  )[];
   [k: string]: unknown;
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/embed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/embed.ts
@@ -5,7 +5,7 @@ import * as AppBskyActorRef from '../actor/ref'
 
 /** A list embeds in a post or document. */
 export interface Main {
-  items?: (Media | Record | External | Unknown)[];
+  items?: (Media | Record | External | { $type: string })[];
   [k: string]: unknown;
 }
 
@@ -29,10 +29,5 @@ export interface External {
   title: string;
   description: string;
   imageUri: string;
-  [k: string]: unknown;
-}
-
-export interface Unknown {
-  type: string;
   [k: string]: unknown;
 }

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  thread: Post | NotFoundPost;
+  thread: Post | NotFoundPost | { $type: string };
   [k: string]: unknown;
 }
 
@@ -46,9 +46,9 @@ export interface Post {
   author: AppBskyActorRef.WithInfo;
   record: {};
   embed?: AppBskyFeedEmbed.Main;
-  parent?: Post | NotFoundPost;
+  parent?: Post | NotFoundPost | { $type: string };
   replyCount: number;
-  replies?: (Post | NotFoundPost)[];
+  replies?: (Post | NotFoundPost | { $type: string })[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;
@@ -59,7 +59,7 @@ export interface Post {
 
 export interface NotFoundPost {
   uri: string;
-  notFound: boolean;
+  notFound: true;
   [k: string]: unknown;
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  thread: Post | NotFoundPost | { $type: string };
+  thread: Post | NotFoundPost | { $type: string, [k: string]: unknown };
   [k: string]: unknown;
 }
 
@@ -46,9 +46,9 @@ export interface Post {
   author: AppBskyActorRef.WithInfo;
   record: {};
   embed?: AppBskyFeedEmbed.Main;
-  parent?: Post | NotFoundPost | { $type: string };
+  parent?: Post | NotFoundPost | { $type: string, [k: string]: unknown };
   replyCount: number;
-  replies?: (Post | NotFoundPost | { $type: string })[];
+  replies?: (Post | NotFoundPost | { $type: string, [k: string]: unknown })[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -529,17 +529,13 @@ function genClientXrpcCommon(
     opts.addProperty({ name: 'qp?', type: 'QueryParams' })
   }
   if (def.type === 'procedure' && def.input) {
-    if (Array.isArray(def.input.encoding)) {
-      opts.addProperty({
-        name: 'encoding',
-        type: def.input.encoding.map((v) => `'${v}'`).join(' | '),
-      })
-    } else if (typeof def.input.encoding === 'string') {
-      opts.addProperty({
-        name: 'encoding',
-        type: `'${def.input.encoding}'`,
-      })
-    }
+    opts.addProperty({
+      name: 'encoding',
+      type: def.input.encoding
+        .split(',')
+        .map((v) => `'${v.trim()}'`)
+        .join(' | '),
+    })
   }
 
   // export interface Response {...}
@@ -550,7 +546,7 @@ function genClientXrpcCommon(
   res.addProperty({ name: 'success', type: 'boolean' })
   res.addProperty({ name: 'headers', type: 'Headers' })
   if (def.output?.schema) {
-    if (Array.isArray(def.output.encoding)) {
+    if (def.output.encoding.includes(',')) {
       res.addProperty({ name: 'data', type: 'OutputSchema | Uint8Array' })
     } else {
       res.addProperty({ name: 'data', type: 'OutputSchema' })

--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -102,13 +102,15 @@ export function genObject(
       if (propDef.type === 'ref' || propDef.type === 'union') {
         //= propName: External|External
         const refs = propDef.type === 'union' ? propDef.refs : [propDef.ref]
+        const types = refs.map((ref) =>
+          refToType(ref, stripScheme(stripHash(lexUri)), imports),
+        )
+        if (propDef.type === 'union' && !propDef.closed) {
+          types.push('{$type: string}')
+        }
         iface.addProperty({
           name: `${propKey}${req ? '' : '?'}`,
-          type: refs
-            .map((ref) =>
-              refToType(ref, stripScheme(stripHash(lexUri)), imports),
-            )
-            .join('|'),
+          type: types.join('|'),
         })
         continue
       } else {
@@ -128,6 +130,9 @@ export function genObject(
             const types = propDef.items.refs.map((ref) =>
               refToType(ref, stripScheme(stripHash(lexUri)), imports),
             )
+            if (!propDef.items.closed) {
+              types.push('{$type: string}')
+            }
             propAst = iface.addProperty({
               name: `${propKey}${req ? '' : '?'}`,
               type: `(${types.join('|')})[]`,
@@ -196,6 +201,9 @@ export function genArray(
     const types = def.items.refs.map((ref) =>
       refToType(ref, stripScheme(stripHash(lexUri)), imports),
     )
+    if (!def.items.closed) {
+      types.push('{$type: string}')
+    }
     file.addTypeAlias({
       name: toTitleCase(getHash(lexUri)),
       type: `(${types.join('|')})[]`,
@@ -276,11 +284,15 @@ export function genXrpcInput(
         def.input.schema.type === 'union'
           ? def.input.schema.refs
           : [def.input.schema.ref]
+      const types = refs.map((ref) =>
+        refToType(ref, stripScheme(stripHash(lexUri)), imports),
+      )
+      if (def.input.schema.type === 'union' && !def.input.schema.closed) {
+        types.push('{$type: string}')
+      }
       file.addTypeAlias({
         name: 'InputSchema',
-        type: refs
-          .map((ref) => refToType(ref, stripScheme(stripHash(lexUri)), imports))
-          .join('|'),
+        type: types.join('|'),
         isExported: true,
       })
     } else {
@@ -325,11 +337,15 @@ export function genXrpcOutput(
         def.output.schema.type === 'union'
           ? def.output.schema.refs
           : [def.output.schema.ref]
+      const types = refs.map((ref) =>
+        refToType(ref, stripScheme(stripHash(lexUri)), imports),
+      )
+      if (def.output.schema.type === 'union' && !def.output.schema.closed) {
+        types.push('{$type: string}')
+      }
       file.addTypeAlias({
         name: 'OutputSchema',
-        type: refs
-          .map((ref) => refToType(ref, stripScheme(stripHash(lexUri)), imports))
-          .join('|'),
+        type: types.join('|'),
         isExported: true,
       })
     } else {

--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -106,7 +106,7 @@ export function genObject(
           refToType(ref, stripScheme(stripHash(lexUri)), imports),
         )
         if (propDef.type === 'union' && !propDef.closed) {
-          types.push('{$type: string}')
+          types.push('{$type: string; [k: string]: unknown}')
         }
         iface.addProperty({
           name: `${propKey}${req ? '' : '?'}`,
@@ -131,7 +131,7 @@ export function genObject(
               refToType(ref, stripScheme(stripHash(lexUri)), imports),
             )
             if (!propDef.items.closed) {
-              types.push('{$type: string}')
+              types.push('{$type: string; [k: string]: unknown}')
             }
             propAst = iface.addProperty({
               name: `${propKey}${req ? '' : '?'}`,
@@ -202,7 +202,7 @@ export function genArray(
       refToType(ref, stripScheme(stripHash(lexUri)), imports),
     )
     if (!def.items.closed) {
-      types.push('{$type: string}')
+      types.push('{$type: string; [k: string]: unknown}')
     }
     file.addTypeAlias({
       name: toTitleCase(getHash(lexUri)),
@@ -288,7 +288,7 @@ export function genXrpcInput(
         refToType(ref, stripScheme(stripHash(lexUri)), imports),
       )
       if (def.input.schema.type === 'union' && !def.input.schema.closed) {
-        types.push('{$type: string}')
+        types.push('{$type: string; [k: string]: unknown}')
       }
       file.addTypeAlias({
         name: 'InputSchema',
@@ -341,7 +341,7 @@ export function genXrpcOutput(
         refToType(ref, stripScheme(stripHash(lexUri)), imports),
       )
       if (def.output.schema.type === 'union' && !def.output.schema.closed) {
-        types.push('{$type: string}')
+        types.push('{$type: string; [k: string]: unknown}')
       }
       file.addTypeAlias({
         name: 'OutputSchema',

--- a/packages/lex-cli/src/codegen/server.ts
+++ b/packages/lex-cli/src/codegen/server.ts
@@ -295,19 +295,15 @@ function genServerXrpcCommon(
       isExported: true,
     })
 
-    if (Array.isArray(def.input.encoding)) {
-      handlerInput.addProperty({
-        name: 'encoding',
-        type: def.input.encoding.map((v) => `'${v}'`).join(' | '),
-      })
-    } else if (typeof def.input.encoding === 'string') {
-      handlerInput.addProperty({
-        name: 'encoding',
-        type: `'${def.input.encoding}'`,
-      })
-    }
+    handlerInput.addProperty({
+      name: 'encoding',
+      type: def.input.encoding
+        .split(',')
+        .map((v) => `'${v.trim()}'`)
+        .join(' | '),
+    })
     if (def.input.schema) {
-      if (Array.isArray(def.input.encoding)) {
+      if (def.input.encoding.includes(',')) {
         handlerInput.addProperty({
           name: 'body',
           type: 'InputSchema | Uint8Array',
@@ -334,19 +330,17 @@ function genServerXrpcCommon(
       name: 'HandlerSuccess',
       isExported: true,
     })
-    if (Array.isArray(def.output.encoding)) {
+    if (def.output.encoding) {
       handlerSuccess.addProperty({
         name: 'encoding',
-        type: def.output.encoding.map((v) => `'${v}'`).join(' | '),
-      })
-    } else if (typeof def.output.encoding === 'string') {
-      handlerSuccess.addProperty({
-        name: 'encoding',
-        type: `'${def.output.encoding}'`,
+        type: def.output.encoding
+          .split(',')
+          .map((v) => `'${v.trim()}'`)
+          .join(' | '),
       })
     }
     if (def.output?.schema) {
-      if (Array.isArray(def.output.encoding)) {
+      if (def.output.encoding.includes(',')) {
         handlerSuccess.addProperty({
           name: 'body',
           type: 'OutputSchema | Uint8Array',

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -173,7 +173,7 @@ export type LexXrpcParameters = z.infer<typeof lexXrpcParameters>
 
 export const lexXrpcBody = z.object({
   description: z.string().optional(),
-  encoding: z.union([z.string(), z.string().array()]),
+  encoding: z.string(),
   schema: z.union([lexRefVariant, lexObject]).optional(),
 })
 export type LexXrpcBody = z.infer<typeof lexXrpcBody>

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -82,6 +82,7 @@ export const lexRefUnion = z.object({
   type: z.literal('union'),
   description: z.string().optional(),
   refs: z.string().array(),
+  closed: z.boolean().optional(),
 })
 export type LexRefUnion = z.infer<typeof lexRefUnion>
 
@@ -285,6 +286,14 @@ export function hasProp<K extends PropertyKey>(
   prop: K,
 ): data is Record<K, unknown> {
   return prop in data
+}
+
+export const discriminatedObject = z.object({ $type: z.string() })
+export type DiscriminatedObject = z.infer<typeof discriminatedObject>
+export function isDiscriminatedObject(
+  value: unknown,
+): value is DiscriminatedObject {
+  return discriminatedObject.safeParse(value).success
 }
 
 export class LexiconDocMalformedError extends Error {

--- a/packages/lexicon/src/validation.ts
+++ b/packages/lexicon/src/validation.ts
@@ -1,6 +1,6 @@
 import { Lexicons } from './lexicons'
 import { LexRecord, LexXrpcProcedure, LexXrpcQuery } from './types'
-import { assertValidOneOf, toConcreteTypes } from './util'
+import { assertValidOneOf } from './util'
 
 import * as ComplexValidators from './validators/complex'
 import * as XrpcValidators from './validators/xrpc'
@@ -32,11 +32,7 @@ export function assertValidXrpcInput(
 ) {
   if (def.input?.schema) {
     // loop: all input schema definitions
-    assertValidOneOf(
-      'Input',
-      toConcreteTypes(lexicons, def.input.schema),
-      (def2) => ComplexValidators.object(lexicons, 'Input', def2, value),
-    )
+    assertValidOneOf(lexicons, 'Input', def.input.schema, value, true)
   }
 }
 
@@ -47,10 +43,6 @@ export function assertValidXrpcOutput(
 ) {
   if (def.output?.schema) {
     // loop: all output schema definitions
-    assertValidOneOf(
-      'Output',
-      toConcreteTypes(lexicons, def.output.schema),
-      (def2) => ComplexValidators.object(lexicons, 'Output', def2, value),
-    )
+    assertValidOneOf(lexicons, 'Output', def.output.schema, value, true)
   }
 }

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -3,11 +3,10 @@ import {
   LexArray,
   LexObject,
   LexUserType,
-  LexRefVariant,
   ValidationResult,
   ValidationError,
 } from '../types'
-import { validateOneOf, toConcreteTypes } from '../util'
+import { validateOneOf } from '../util'
 
 import * as Primitives from './primitives'
 import * as Blob from './blob'
@@ -92,13 +91,11 @@ export function array(
   }
 
   // items
-  const itemDefs = toConcreteTypes(lexicons, def.items)
+  const itemsDef = def.items
   for (let i = 0; i < (value as Array<unknown>).length; i++) {
-    const item = value[i]
+    const itemValue = value[i]
     const itemPath = `${path}/${i}`
-    const res = validateOneOf(itemPath, itemDefs, (itemDef) =>
-      validate(lexicons, itemPath, itemDef, item),
-    )
+    const res = validateOneOf(lexicons, itemPath, itemsDef, itemValue)
     if (!res.success) {
       return res
     }
@@ -138,14 +135,13 @@ export function object(
   // properties
   if (typeof def.properties === 'object') {
     for (const key in def.properties) {
-      if (typeof value[key] === 'undefined') {
+      const propValue = value[key]
+      if (typeof propValue === 'undefined') {
         continue // skip- if required, will have already failed
       }
-      const propDefs = toConcreteTypes(lexicons, def.properties[key])
+      const propDef = def.properties[key]
       const propPath = `${path}/${key}`
-      const res = validateOneOf(propPath, propDefs, (propDef) =>
-        validate(lexicons, propPath, propDef, value[key]),
-      )
+      const res = validateOneOf(lexicons, propPath, propDef, propValue)
       if (!res.success) {
         return res
       }

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -124,6 +124,38 @@ export default [
   },
   {
     lexicon: 1,
+    id: 'com.example.union',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'A record',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['unionOpen', 'unionClosed'],
+          properties: {
+            unionOpen: {
+              type: 'union',
+              refs: [
+                'com.example.kitchenSink#object',
+                'com.example.kitchenSink#subobject',
+              ],
+            },
+            unionClosed: {
+              type: 'union',
+              closed: true,
+              refs: [
+                'com.example.kitchenSink#object',
+                'com.example.kitchenSink#subobject',
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    lexicon: 1,
     id: 'com.example.unknown',
     defs: {
       main: {

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -223,6 +223,58 @@ describe('Record validation', () => {
     })
   })
 
+  it('Handles unions correctly', () => {
+    lex.assertValidRecord('com.example.union', {
+      $type: 'com.example.union',
+      unionOpen: {
+        $type: 'com.example.kitchenSink#object',
+        object: { boolean: true },
+        array: ['one', 'two'],
+        boolean: true,
+        number: 123.45,
+        integer: 123,
+        string: 'string',
+      },
+      unionClosed: {
+        $type: 'com.example.kitchenSink#subobject',
+        boolean: true,
+      },
+    })
+    lex.assertValidRecord('com.example.union', {
+      $type: 'com.example.union',
+      unionOpen: {
+        $type: 'com.example.other',
+      },
+      unionClosed: {
+        $type: 'com.example.kitchenSink#subobject',
+        boolean: true,
+      },
+    })
+    expect(() =>
+      lex.assertValidRecord('com.example.union', {
+        $type: 'com.example.union',
+        unionOpen: {},
+        unionClosed: {},
+      }),
+    ).toThrow(
+      'Record/unionOpen must be an object which includes the "$type" property',
+    )
+    expect(() =>
+      lex.assertValidRecord('com.example.union', {
+        $type: 'com.example.union',
+        unionOpen: {
+          $type: 'com.example.other',
+        },
+        unionClosed: {
+          $type: 'com.example.other',
+          boolean: true,
+        },
+      }),
+    ).toThrow(
+      'Record/unionClosed $type must be one of lex:com.example.kitchenSink#object, lex:com.example.kitchenSink#subobject',
+    )
+  })
+
   it('Handles unknowns correctly', () => {
     lex.assertValidRecord('com.example.unknown', {
       $type: 'com.example.unknown',
@@ -232,7 +284,7 @@ describe('Record validation', () => {
       lex.assertValidRecord('com.example.unknown', {
         $type: 'com.example.unknown',
       }),
-    ).toThrow('')
+    ).toThrow('Record must have the property "unknown"')
   })
 
   it('Applies array length constraints', () => {

--- a/packages/pds/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPostThread.ts
@@ -53,6 +53,7 @@ const getAncestors = async (
     .executeTakeFirst()
   if (!parentRes) {
     return {
+      $type: 'app.bsky.feed.getPostThread#notFoundPost',
       uri: parentUri,
       notFound: true,
     }
@@ -162,6 +163,7 @@ const rowToPost = (
   parent?: GetPostThread.Post,
 ): GetPostThread.Post => {
   return {
+    $type: 'app.bsky.feed.getPostThread#post',
     uri: row.uri,
     cid: row.cid,
     author: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -245,6 +245,7 @@ export const lexicons: LexiconDoc[] = [
                     'lex:com.atproto.repo.batchWrite#update',
                     'lex:com.atproto.repo.batchWrite#delete',
                   ],
+                  closed: true,
                 },
               },
             },
@@ -1349,7 +1350,6 @@ export const lexicons: LexiconDoc[] = [
                 'lex:app.bsky.feed.embed#media',
                 'lex:app.bsky.feed.embed#record',
                 'lex:app.bsky.feed.embed#external',
-                'lex:app.bsky.feed.embed#unknown',
               ],
             },
           },
@@ -1405,15 +1405,6 @@ export const lexicons: LexiconDoc[] = [
             type: 'string',
           },
           imageUri: {
-            type: 'string',
-          },
-        },
-      },
-      unknown: {
-        type: 'object',
-        required: ['type'],
-        properties: {
-          type: {
             type: 'string',
           },
         },
@@ -1659,6 +1650,7 @@ export const lexicons: LexiconDoc[] = [
           },
           notFound: {
             type: 'boolean',
+            const: true,
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/embed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/embed.ts
@@ -5,7 +5,12 @@ import * as AppBskyActorRef from '../actor/ref'
 
 /** A list embeds in a post or document. */
 export interface Main {
-  items?: (Media | Record | External | { $type: string })[];
+  items?: (
+    | Media
+    | Record
+    | External
+    | { $type: string, [k: string]: unknown }
+  )[];
   [k: string]: unknown;
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/embed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/embed.ts
@@ -5,7 +5,7 @@ import * as AppBskyActorRef from '../actor/ref'
 
 /** A list embeds in a post or document. */
 export interface Main {
-  items?: (Media | Record | External | Unknown)[];
+  items?: (Media | Record | External | { $type: string })[];
   [k: string]: unknown;
 }
 
@@ -29,10 +29,5 @@ export interface External {
   title: string;
   description: string;
   imageUri: string;
-  [k: string]: unknown;
-}
-
-export interface Unknown {
-  type: string;
   [k: string]: unknown;
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  thread: Post | NotFoundPost;
+  thread: Post | NotFoundPost | { $type: string };
   [k: string]: unknown;
 }
 
@@ -44,9 +44,9 @@ export interface Post {
   author: AppBskyActorRef.WithInfo;
   record: {};
   embed?: AppBskyFeedEmbed.Main;
-  parent?: Post | NotFoundPost;
+  parent?: Post | NotFoundPost | { $type: string };
   replyCount: number;
-  replies?: (Post | NotFoundPost)[];
+  replies?: (Post | NotFoundPost | { $type: string })[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;
@@ -57,7 +57,7 @@ export interface Post {
 
 export interface NotFoundPost {
   uri: string;
-  notFound: boolean;
+  notFound: true;
   [k: string]: unknown;
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  thread: Post | NotFoundPost | { $type: string };
+  thread: Post | NotFoundPost | { $type: string, [k: string]: unknown };
   [k: string]: unknown;
 }
 
@@ -44,9 +44,9 @@ export interface Post {
   author: AppBskyActorRef.WithInfo;
   record: {};
   embed?: AppBskyFeedEmbed.Main;
-  parent?: Post | NotFoundPost | { $type: string };
+  parent?: Post | NotFoundPost | { $type: string, [k: string]: unknown };
   replyCount: number;
-  replies?: (Post | NotFoundPost | { $type: string })[];
+  replies?: (Post | NotFoundPost | { $type: string, [k: string]: unknown })[];
   repostCount: number;
   upvoteCount: number;
   downvoteCount: number;

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`pds thread views fetches ancestors 1`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -18,6 +19,7 @@ Object {
     "repost": "record(4)",
   },
   "parent": Object {
+    "$type": "app.bsky.feed.getPostThread#post",
     "author": Object {
       "declaration": Object {
         "actorType": "app.bsky.system.actorUser",
@@ -32,6 +34,7 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "myState": Object {},
     "parent": Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -102,6 +105,7 @@ Object {
 
 exports[`pds thread views fetches deep post thread 1`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -124,6 +128,7 @@ Object {
   },
   "replies": Array [
     Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -137,6 +142,7 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "myState": Object {},
       "parent": Object {
+        "$type": "app.bsky.feed.getPostThread#post",
         "author": Object {
           "declaration": Object {
             "actorType": "app.bsky.system.actorUser",
@@ -184,6 +190,7 @@ Object {
       "uri": "record(2)",
     },
     Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -198,6 +205,7 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "myState": Object {},
       "parent": Object {
+        "$type": "app.bsky.feed.getPostThread#post",
         "author": Object {
           "declaration": Object {
             "actorType": "app.bsky.system.actorUser",
@@ -240,6 +248,7 @@ Object {
       },
       "replies": Array [
         Object {
+          "$type": "app.bsky.feed.getPostThread#post",
           "author": Object {
             "declaration": Object {
               "actorType": "app.bsky.system.actorUser",
@@ -256,6 +265,7 @@ Object {
             "repost": "record(5)",
           },
           "parent": Object {
+            "$type": "app.bsky.feed.getPostThread#post",
             "author": Object {
               "declaration": Object {
                 "actorType": "app.bsky.system.actorUser",
@@ -270,6 +280,7 @@ Object {
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "myState": Object {},
             "parent": Object {
+              "$type": "app.bsky.feed.getPostThread#post",
               "author": Object {
                 "declaration": Object {
                   "actorType": "app.bsky.system.actorUser",
@@ -352,6 +363,7 @@ Object {
 
 exports[`pds thread views fetches shallow post thread 1`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -374,6 +386,7 @@ Object {
   },
   "replies": Array [
     Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -387,6 +400,7 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "myState": Object {},
       "parent": Object {
+        "$type": "app.bsky.feed.getPostThread#post",
         "author": Object {
           "declaration": Object {
             "actorType": "app.bsky.system.actorUser",
@@ -433,6 +447,7 @@ Object {
       "uri": "record(2)",
     },
     Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -447,6 +462,7 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "myState": Object {},
       "parent": Object {
+        "$type": "app.bsky.feed.getPostThread#post",
         "author": Object {
           "declaration": Object {
             "actorType": "app.bsky.system.actorUser",
@@ -502,6 +518,7 @@ Object {
 
 exports[`pds thread views handles deleted posts correctly 1`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -522,6 +539,7 @@ Object {
   },
   "replies": Array [
     Object {
+      "$type": "app.bsky.feed.getPostThread#post",
       "author": Object {
         "declaration": Object {
           "actorType": "app.bsky.system.actorUser",
@@ -536,6 +554,7 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "myState": Object {},
       "parent": Object {
+        "$type": "app.bsky.feed.getPostThread#post",
         "author": Object {
           "declaration": Object {
             "actorType": "app.bsky.system.actorUser",
@@ -576,6 +595,7 @@ Object {
       },
       "replies": Array [
         Object {
+          "$type": "app.bsky.feed.getPostThread#post",
           "author": Object {
             "declaration": Object {
               "actorType": "app.bsky.system.actorUser",
@@ -590,6 +610,7 @@ Object {
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "myState": Object {},
           "parent": Object {
+            "$type": "app.bsky.feed.getPostThread#post",
             "author": Object {
               "declaration": Object {
                 "actorType": "app.bsky.system.actorUser",
@@ -604,6 +625,7 @@ Object {
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "myState": Object {},
             "parent": Object {
+              "$type": "app.bsky.feed.getPostThread#post",
               "author": Object {
                 "declaration": Object {
                   "actorType": "app.bsky.system.actorUser",
@@ -684,6 +706,7 @@ Object {
 
 exports[`pds thread views handles deleted posts correctly 2`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -712,6 +735,7 @@ Object {
 
 exports[`pds thread views handles deleted posts correctly 3`] = `
 Object {
+  "$type": "app.bsky.feed.getPostThread#post",
   "author": Object {
     "declaration": Object {
       "actorType": "app.bsky.system.actorUser",
@@ -726,6 +750,7 @@ Object {
   "indexedAt": "1970-01-01T00:00:00.000Z",
   "myState": Object {},
   "parent": Object {
+    "$type": "app.bsky.feed.getPostThread#notFoundPost",
     "notFound": true,
     "uri": "record(2)",
   },

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -151,13 +151,11 @@ export function normalizeMime(v: string) {
   return shortType
 }
 
-function isValidEncoding(possible: string | string[], value: string) {
+function isValidEncoding(possibleStr: string, value: string) {
+  const possible = possibleStr.split(',').map((v) => v.trim())
   const normalized = normalizeMime(value)
   if (!normalized) return false
-  if (Array.isArray(possible)) {
-    return possible.includes(normalized)
-  }
-  return possible === normalized
+  return possible.includes(normalized)
 }
 
 function hasBody(req: express.Request) {


### PR DESCRIPTION
Two more Lexicon updates to accommodate stricter programming languages:

- LexXrpcBody `.encoding` is now always a `string`. If multiple encodings must be specified, use a comma-separated list.
- Union discriminators
  - The `union` type now only supports object-values with a `$type` field.
  - The `$type` field must specify the lexicon ID being used.
  - The `union` def now has a `closed` field which, if true, will fail validation if a `$type` is provided which does not match the enumerated refs.