### PR TITLE
Add terms-of-service and privacy-policy links

### DIFF
--- a/lexicons/com/atproto/server/getAccountsConfig.json
+++ b/lexicons/com/atproto/server/getAccountsConfig.json
@@ -12,9 +12,17 @@
           "required": ["availableUserDomains"],
           "properties": {
             "inviteCodeRequired": {"type": "boolean"},
-            "availableUserDomains": {"type": "array", "items": {"type": "string"}}
+            "availableUserDomains": {"type": "array", "items": {"type": "string"}},
+            "links": {"type": "ref", "ref": "#links"}
           }
         }
+      }
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "privacyPolicy": {"type": "string"},
+        "termsOfService": {"type": "string"}
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -669,7 +669,22 @@ export const lexicons: LexiconDoc[] = [
                   type: 'string',
                 },
               },
+              links: {
+                type: 'ref',
+                ref: 'lex:com.atproto.server.getAccountsConfig#links',
+              },
             },
+          },
+        },
+      },
+      links: {
+        type: 'object',
+        properties: {
+          privacyPolicy: {
+            type: 'string',
+          },
+          termsOfService: {
+            type: 'string',
           },
         },
       },

--- a/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
@@ -10,6 +10,7 @@ export type InputSchema = undefined
 export interface OutputSchema {
   inviteCodeRequired?: boolean
   availableUserDomains: string[]
+  links?: Links
   [k: string]: unknown
 }
 
@@ -27,4 +28,10 @@ export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }
   return e
+}
+
+export interface Links {
+  privacyPolicy?: string
+  termsOfService?: string
+  [k: string]: unknown
 }

--- a/packages/dev-env/src/index.ts
+++ b/packages/dev-env/src/index.ts
@@ -84,6 +84,8 @@ export class DevEnvServer {
             emailNoReplyAddress: 'noreply@blueskyweb.xyz',
             adminPassword: 'password',
             inviteRequired: false,
+            privacyPolicyUrl: 'https://example.com/privacy',
+            termsOfServiceUrl: 'https://example.com/tos',
           }).listener,
         )
         break

--- a/packages/pds/src/api/com/atproto/account.ts
+++ b/packages/pds/src/api/com/atproto/account.ts
@@ -17,10 +17,16 @@ export default function (server: Server) {
 
     const availableUserDomains = cfg.availableUserDomains
     const inviteCodeRequired = cfg.inviteRequired
+    const privacyPolicy = cfg.privacyPolicyUrl
+    const termsOfService = cfg.termsOfServiceUrl
 
     return {
       encoding: 'application/json',
-      body: { availableUserDomains, inviteCodeRequired },
+      body: {
+        availableUserDomains,
+        inviteCodeRequired,
+        links: { privacyPolicy, termsOfService },
+      },
     }
   })
 

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -19,6 +19,8 @@ export interface ServerConfigValues {
   adminPassword: string
 
   inviteRequired: boolean
+  privacyPolicyUrl?: string
+  termsOfServiceUrl?: string
 
   blockstoreLocation?: string
   databaseLocation?: string
@@ -72,6 +74,8 @@ export class ServerConfig {
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin'
 
     const inviteRequired = process.env.INVITE_REQUIRED === 'true' ? true : false
+    const privacyPolicyUrl = process.env.PRIVACY_POLICY_URL
+    const termsOfServiceUrl = process.env.TERMS_OF_SERVICE_URL
 
     const blockstoreLocation = process.env.BLOCKSTORE_LOC
     const databaseLocation = process.env.DATABASE_LOC
@@ -106,6 +110,8 @@ export class ServerConfig {
       serverDid,
       adminPassword,
       inviteRequired,
+      privacyPolicyUrl,
+      termsOfServiceUrl,
       blockstoreLocation,
       databaseLocation,
       availableUserDomains,
@@ -184,6 +190,26 @@ export class ServerConfig {
 
   get inviteRequired() {
     return this.cfg.inviteRequired
+  }
+
+  get privacyPolicyUrl() {
+    if (
+      this.cfg.privacyPolicyUrl &&
+      this.cfg.privacyPolicyUrl.startsWith('/')
+    ) {
+      return this.publicUrl + this.cfg.privacyPolicyUrl
+    }
+    return this.cfg.privacyPolicyUrl
+  }
+
+  get termsOfServiceUrl() {
+    if (
+      this.cfg.termsOfServiceUrl &&
+      this.cfg.termsOfServiceUrl.startsWith('/')
+    ) {
+      return this.publicUrl + this.cfg.termsOfServiceUrl
+    }
+    return this.cfg.termsOfServiceUrl
   }
 
   get blockstoreLocation() {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -669,7 +669,22 @@ export const lexicons: LexiconDoc[] = [
                   type: 'string',
                 },
               },
+              links: {
+                type: 'ref',
+                ref: 'lex:com.atproto.server.getAccountsConfig#links',
+              },
             },
+          },
+        },
+      },
+      links: {
+        type: 'object',
+        properties: {
+          privacyPolicy: {
+            type: 'string',
+          },
+          termsOfService: {
+            type: 'string',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
@@ -11,6 +11,7 @@ export type InputSchema = undefined
 export interface OutputSchema {
   inviteCodeRequired?: boolean
   availableUserDomains: string[]
+  links?: Links
   [k: string]: unknown
 }
 
@@ -34,3 +35,9 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
   req: express.Request
   res: express.Response
 }) => Promise<HandlerOutput> | HandlerOutput
+
+export interface Links {
+  privacyPolicy?: string
+  termsOfService?: string
+  [k: string]: unknown
+}

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -45,6 +45,8 @@ describe('account', () => {
   beforeAll(async () => {
     const server = await util.runTestServer({
       inviteRequired: true,
+      termsOfServiceUrl: 'https://example.com/tos',
+      privacyPolicyUrl: '/privacy-policy',
       dbPostgresSchema: 'account',
     })
     close = server.close
@@ -86,6 +88,10 @@ describe('account', () => {
     expect(res.data.inviteCodeRequired).toBe(true)
     expect(res.data.availableUserDomains[0]).toBe('.test')
     expect(typeof res.data.inviteCodeRequired).toBe('boolean')
+    expect(res.data.links?.privacyPolicy).toBe(
+      'https://pds.public.url/privacy-policy',
+    )
+    expect(res.data.links?.termsOfService).toBe('https://example.com/tos')
   })
 
   it('fails on invalid handles', async () => {


### PR DESCRIPTION
- Adds `TERMS_OF_SERVICE_URL` and `PRIVACY_POLICY_URL` to config/env-vars
- Adds `links` object to the output of `com.atproto.server.getAccountsConfig` with the values of the policy urls