### PR TITLE
Fix issue with duped blobs

### DIFF
--- a/packages/pds/src/repo/blobs.ts
+++ b/packages/pds/src/repo/blobs.ts
@@ -46,6 +46,12 @@ export const addUntetheredBlob = async (
       height: imgInfo?.height || null,
       createdAt: new Date().toISOString(),
     })
+    .onConflict((oc) =>
+      oc
+        .column('cid')
+        .doUpdateSet({ tempKey })
+        .where('blob.tempKey', 'is not', null),
+    )
     .execute()
   return cid
 }
@@ -151,7 +157,7 @@ export const verifyBlobAndMakePermanent = async (
     .executeTakeFirst()
   if (!found) {
     throw new InvalidRequestError(
-      `Could not found blob: ${blob.cid.toString()}`,
+      `Could not find blob: ${blob.cid.toString()}`,
       'BlobNotFound',
     )
   }


### PR DESCRIPTION
When blobs are uploaded, we keep track of some metadata in a `blob` table.  When the same blob is uploaded multiple times, we were seeing a db constraint issue while attempting to insert into this table.  The fix here is to update the record in the table if it already exists.

With regards to the `tempKey`, I was careful here to update it only if it wasn't `null`.  When `tempKey` is `null` it indicates the blob has been moved into permanent storage, so we don't want to indicate that the blob needs to be moved from temp to permanent storage again.  If `tempKey` is not `null` then we do update it, since the old `tempKey` could be stale (i.e. the temp blob already purged from temp storage).