### PR TITLE
A couple lexicon-related fixes

### DIFF
--- a/lexicons/app/bsky/actor/updateProfile.json
+++ b/lexicons/app/bsky/actor/updateProfile.json
@@ -49,7 +49,10 @@
         }
       },
       "errors": [
-        {"name": "InvalidBlob"}
+        {"name": "InvalidBlob"},
+        {"name": "BlobTooLarge"},
+        {"name": "InvalidMimeType"},
+        {"name": "InvalidImageDimensions"}
       ]
     }
   }

--- a/lexicons/app/bsky/actor/updateProfile.json
+++ b/lexicons/app/bsky/actor/updateProfile.json
@@ -47,7 +47,10 @@
             "record": {"type": "unknown"}
           }
         }
-      }
+      },
+      "errors": [
+        {"name": "InvalidBlob"}
+      ]
     }
   }
 }

--- a/lexicons/com/atproto/blob/upload.json
+++ b/lexicons/com/atproto/blob/upload.json
@@ -17,10 +17,7 @@
             "cid": {"type": "string"}
           }
         }
-      },
-      "errors": [
-        {"name": "InvalidBlob"}
-      ]
+      }
     }
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1419,6 +1419,15 @@ export const schemaDict = {
           {
             name: 'InvalidBlob',
           },
+          {
+            name: 'BlobTooLarge',
+          },
+          {
+            name: 'InvalidMimeType',
+          },
+          {
+            name: 'InvalidImageDimensions',
+          },
         ],
       },
     },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -205,11 +205,6 @@ export const schemaDict = {
             },
           },
         },
-        errors: [
-          {
-            name: 'InvalidBlob',
-          },
-        ],
       },
     },
   },
@@ -1420,6 +1415,11 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'InvalidBlob',
+          },
+        ],
       },
     },
   },

--- a/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
@@ -39,9 +39,31 @@ export class InvalidBlobError extends XRPCError {
   }
 }
 
+export class BlobTooLargeError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class InvalidMimeTypeError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class InvalidImageDimensionsError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
     if (e.error === 'InvalidBlob') return new InvalidBlobError(e)
+    if (e.error === 'BlobTooLarge') return new BlobTooLargeError(e)
+    if (e.error === 'InvalidMimeType') return new InvalidMimeTypeError(e)
+    if (e.error === 'InvalidImageDimensions')
+      return new InvalidImageDimensionsError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
@@ -33,8 +33,15 @@ export interface Response {
   data: OutputSchema
 }
 
+export class InvalidBlobError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'InvalidBlob') return new InvalidBlobError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/blob/upload.ts
+++ b/packages/api/src/client/types/com/atproto/blob/upload.ts
@@ -15,7 +15,7 @@ export interface OutputSchema {
 export interface CallOptions {
   headers?: Headers
   qp?: QueryParams
-  encoding: '*/*'
+  encoding: string
 }
 
 export interface Response {

--- a/packages/api/src/client/types/com/atproto/blob/upload.ts
+++ b/packages/api/src/client/types/com/atproto/blob/upload.ts
@@ -24,15 +24,8 @@ export interface Response {
   data: OutputSchema
 }
 
-export class InvalidBlobError extends XRPCError {
-  constructor(src: XRPCError) {
-    super(src.status, src.error, src.message)
-  }
-}
-
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidBlob') return new InvalidBlobError(e)
   }
   return e
 }

--- a/packages/api/tests/errors.test.ts
+++ b/packages/api/tests/errors.test.ts
@@ -1,0 +1,39 @@
+import {
+  CloseFn,
+  runTestServer,
+  TestServerInfo,
+} from '@atproto/pds/tests/_util'
+import {
+  sessionClient,
+  SessionServiceClient,
+  ComAtprotoAccountCreate,
+} from '..'
+
+describe('errors', () => {
+  let server: TestServerInfo
+  let client: SessionServiceClient
+  let close: CloseFn
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'known_errors',
+    })
+    client = sessionClient.service(server.url)
+    close = server.close
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('constructs the correct error instance', async () => {
+    const res = client.com.atproto.account.create({
+      handle: 'admin',
+      email: 'admin@test.com',
+      password: 'password',
+    })
+    await expect(res).rejects.toThrow(
+      ComAtprotoAccountCreate.InvalidHandleError,
+    )
+  })
+})

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -529,12 +529,16 @@ function genClientXrpcCommon(
     opts.addProperty({ name: 'qp?', type: 'QueryParams' })
   }
   if (def.type === 'procedure' && def.input) {
-    opts.addProperty({
-      name: 'encoding',
-      type: def.input.encoding
+    let encodingType = 'string'
+    if (def.input.encoding !== '*/*') {
+      encodingType = def.input.encoding
         .split(',')
         .map((v) => `'${v.trim()}'`)
-        .join(' | '),
+        .join(' | ')
+    }
+    opts.addProperty({
+      name: 'encoding',
+      type: encodingType,
     })
   }
 

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -31,6 +31,7 @@
     "@atproto/uri": "*",
     "@atproto/xrpc-server": "*",
     "better-sqlite3": "^7.6.2",
+    "bytes": "^3.1.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.17.2",

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1419,6 +1419,15 @@ export const schemaDict = {
           {
             name: 'InvalidBlob',
           },
+          {
+            name: 'BlobTooLarge',
+          },
+          {
+            name: 'InvalidMimeType',
+          },
+          {
+            name: 'InvalidImageDimensions',
+          },
         ],
       },
     },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -205,11 +205,6 @@ export const schemaDict = {
             },
           },
         },
-        errors: [
-          {
-            name: 'InvalidBlob',
-          },
-        ],
       },
     },
   },
@@ -1420,6 +1415,11 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'InvalidBlob',
+          },
+        ],
       },
     },
   },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
@@ -35,6 +35,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'InvalidBlob'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
@@ -35,7 +35,11 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'InvalidBlob'
+  error?:
+    | 'InvalidBlob'
+    | 'BlobTooLarge'
+    | 'InvalidMimeType'
+    | 'InvalidImageDimensions'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
@@ -27,7 +27,6 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'InvalidBlob'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,11 @@ bytes@3.1.2:
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+bytes@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
 cacache@^15.0.5, cacache@^15.2.0:
   version "15.3.0"
   resolved "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz"


### PR DESCRIPTION
- Fix the generated procedure call signature when an encoding is `*/*` (close #391)
- Fix the named error generation for `updateProfile()`
- Add a test for named error generation

EDIT:
- Add more named blob errors and make the blob error messages more human-friendly
  - The "friendlier" descriptions are so that I can just display that error directly. The other option would be to make XRPC errors more sophisticated so that they can carry data like `blobSize` and `maxBlobSize`, enabling the client to render its own error message.