### PR TITLE
Patch external embed table type

### DIFF
--- a/packages/pds/src/db/records/post.ts
+++ b/packages/pds/src/db/records/post.ts
@@ -80,7 +80,7 @@ const insertFn = async (
         uri: external.uri,
         title: external.title,
         description: external.description,
-        thumbCid: external.thumb?.cid,
+        thumbCid: external.thumb?.cid || null,
       }
       await db.insertInto('post_embed_external').values(embed).execute()
     }

--- a/packages/pds/src/db/tables/post-embed-external.ts
+++ b/packages/pds/src/db/tables/post-embed-external.ts
@@ -5,7 +5,7 @@ export interface PostEmbedExternal {
   uri: string
   title: string
   description: string
-  thumbCid?: string
+  thumbCid: string | null
 }
 
 export type PartialDB = {


### PR DESCRIPTION
Kysely returns nulls, so our table types should match that