### PR TITLE
embedsForPost fix

### DIFF
--- a/packages/pds/src/api/app/bsky/util/embeds.ts
+++ b/packages/pds/src/api/app/bsky/util/embeds.ts
@@ -13,6 +13,9 @@ export const embedsForPosts = async (
   imgUriBuilder: ImageUriBuilder,
   postUris: string[],
 ): Promise<FeedEmbeds> => {
+  if (postUris.length < 1) {
+    return {}
+  }
   const imgPromise = db
     .selectFrom('post_embed_image')
     .selectAll()


### PR DESCRIPTION
Fix for the case of an empty array being passed in to `embedsForPost`