### PR TITLE
Create PDS with ServerConfig rather than ServerConfigValues

### DIFF
--- a/packages/dev-env/src/index.ts
+++ b/packages/dev-env/src/index.ts
@@ -4,6 +4,7 @@ import crytpo from 'crypto'
 import PDSServer, {
   Database as PDSDatabase,
   MemoryBlobStore,
+  ServerConfig as PDSServerConfig,
 } from '@atproto/pds'
 import * as plc from '@atproto/plc'
 import * as crypto from '@atproto/crypto'
@@ -80,7 +81,7 @@ export class DevEnvServer {
           db,
           blobstore,
           keypair,
-          cfg: {
+          config: new PDSServerConfig({
             debugMode: true,
             version: '0.0.0',
             scheme: 'http',
@@ -101,7 +102,7 @@ export class DevEnvServer {
               'f23ecd142835025f42c3db2cf25dd813956c178392760256211f9d315f8ab4d8',
             privacyPolicyUrl: 'https://example.com/privacy',
             termsOfServiceUrl: 'https://example.com/tos',
-          },
+          }),
         })
         await startServer(pds)
         this.inst = pds

--- a/packages/pds/src/bin.ts
+++ b/packages/pds/src/bin.ts
@@ -45,7 +45,7 @@ const run = async () => {
     blobstore = new MemoryBlobStore()
   }
 
-  const pds = PDS.create({ db, blobstore, keypair, cfg })
+  const pds = PDS.create({ db, blobstore, keypair, config: cfg })
   await pds.start()
   console.log(`🌞 ATP Data server is running at ${cfg.origin}`)
 }

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -17,7 +17,7 @@ import { ServerAuth } from './auth'
 import * as streamConsumers from './event-stream/consumers'
 import * as error from './error'
 import { loggerMiddleware } from './logger'
-import { ServerConfig, ServerConfigValues } from './config'
+import { ServerConfig } from './config'
 import { ServerMailer } from './mailer'
 import { createTransport } from 'nodemailer'
 import SqlMessageQueue from './event-stream/message-queue'
@@ -48,14 +48,13 @@ export class PDS {
     db: Database
     blobstore: BlobStore
     keypair: DidableKey
-    cfg: ServerConfigValues
+    config: ServerConfig
   }): PDS {
-    const { db, blobstore, keypair, cfg } = opts
-    const config = new ServerConfig(opts.cfg)
+    const { db, blobstore, keypair, config } = opts
     const didResolver = new DidResolver({ plcUrl: config.didPlcUrl })
     const auth = new ServerAuth({
-      jwtSecret: cfg.jwtSecret,
-      adminPass: cfg.adminPassword,
+      jwtSecret: config.jwtSecret,
+      adminPass: config.adminPassword,
       didResolver,
     })
 

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -85,7 +85,7 @@ export const runTestServer = async (
       ? await DiskBlobStore.create(cfg.blobstoreLocation, cfg.blobstoreTmp)
       : new MemoryBlobStore()
 
-  const pds = PDS.create({ db, blobstore, keypair, cfg: cfg })
+  const pds = PDS.create({ db, blobstore, keypair, config: cfg })
   const pdsServer = await pds.start()
   const pdsPort = (pdsServer.address() as AddressInfo).port
 


### PR DESCRIPTION
Just a small change to simplify the API of `PDS.create()`, and make it long-term compatible with `ServerConfig.fromEnv()`.