### PR TITLE
Api package fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ packages/*/coverage
 test.sqlite
 .DS_Store
 *.log
+tsconfig.build.tsbuildinfo

--- a/packages/api/build.js
+++ b/packages/api/build.js
@@ -10,6 +10,12 @@ if (process.argv.includes('--update-main-to-dist')) {
     .then((pkg) => pkg.update({ main: 'dist/index.js' }))
     .then((pkg) => pkg.save())
 }
+if (process.argv.includes('--update-main-to-src')) {
+  return pkgJson
+    .load(__dirname)
+    .then((pkg) => pkg.update({ main: 'src/index.ts' }))
+    .then((pkg) => pkg.save())
+}
 
 require('esbuild').build({
   logLevel: 'info',

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,9 @@
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
     "update-main-to-dist": "node ./build.js --update-main-to-dist",
+    "update-main-to-src": "node ./build.js --update-main-to-src",
+    "prepublish": "npm run update-main-to-dist && npm run build",
+    "postpublish": "npm run update-main-to-src",
     "test": "jest"
   },
   "license": "MIT",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./dist", // Your outDir,
     "emitDeclarationOnly": true
   },


### PR DESCRIPTION
- Updates the API package to properly publish
- Bumps `@atproto/api` to 0.0.2

We'll need to make these updates to all the packages but I'm leaving that for now.