### PR TITLE
Api package fixes 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "jest.config.js",
     "babel.config.js",
     "build.js"
+    "update-pkg.js"
   ],
   "rules": {
     "no-var": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
     "jest.bench.config.js",
     "jest.config.js",
     "babel.config.js",
-    "build.js"
+    "build.js",
     "update-pkg.js"
   ],
   "rules": {

--- a/packages/api/build.js
+++ b/packages/api/build.js
@@ -1,21 +1,7 @@
-const pkgJson = require('@npmcli/package-json')
 const { nodeExternalsPlugin } = require('esbuild-node-externals')
 
 const buildShallow =
   process.argv.includes('--shallow') || process.env.ATP_BUILD_SHALLOW === 'true'
-
-if (process.argv.includes('--update-main-to-dist')) {
-  return pkgJson
-    .load(__dirname)
-    .then((pkg) => pkg.update({ main: 'dist/index.js' }))
-    .then((pkg) => pkg.save())
-}
-if (process.argv.includes('--update-main-to-src')) {
-  return pkgJson
-    .load(__dirname)
-    .then((pkg) => pkg.update({ main: 'src/index.ts' }))
-    .then((pkg) => pkg.save())
-}
 
 require('esbuild').build({
   logLevel: 'info',

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,9 +6,9 @@
     "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
-    "update-main-to-dist": "node ./build.js --update-main-to-dist",
-    "update-main-to-src": "node ./build.js --update-main-to-src",
-    "prepublish": "npm run update-main-to-dist && npm run build",
+    "update-main-to-dist": "node ./update-pkg.js --update-main-to-dist",
+    "update-main-to-src": "node ./update-pkg.js --update-main-to-src",
+    "prepublish": "npm run update-main-to-dist",
     "postpublish": "npm run update-main-to-src",
     "test": "jest"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/api/update-pkg.js
+++ b/packages/api/update-pkg.js
@@ -1,0 +1,14 @@
+const pkgJson = require('@npmcli/package-json')
+
+if (process.argv.includes('--update-main-to-dist')) {
+  return pkgJson
+    .load(__dirname)
+    .then((pkg) => pkg.update({ main: 'dist/index.js' }))
+    .then((pkg) => pkg.save())
+}
+if (process.argv.includes('--update-main-to-src')) {
+  return pkgJson
+    .load(__dirname)
+    .then((pkg) => pkg.update({ main: 'src/index.ts' }))
+    .then((pkg) => pkg.save())
+}


### PR DESCRIPTION
It _looks_ like running build in prepublish caused the d.ts files to get stripped, so I went ahead and separated out the update-pkg script. We could probably move that script into the root of the package but it's safer here when it's working off __dirname (no risk of using cwd and getting the wrong package json).

Related to https://github.com/bluesky-social/atproto/issues/438