### PR TITLE
Repo mutation diffs

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -36,6 +36,7 @@ const strToBool = z.string().transform((str) => str === 'true' || str === 't')
 
 export const def = {
   string: z.string(),
+  record: z.record(z.string(), z.unknown()),
   cid,
   strToCid,
   bytes,

--- a/packages/pds/src/api/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/api/app/bsky/actor/updateProfile.ts
@@ -7,6 +7,7 @@ import * as Profile from '../../../../lexicon/types/app/bsky/actor/profile'
 import * as common from '@atproto/common'
 import * as repo from '../../../../repo'
 import AppContext from '../../../../context'
+import { WriteOpAction } from '@atproto/repo'
 
 const profileNsid = lexicons.ids.AppBskyActorProfile
 
@@ -83,7 +84,7 @@ export default function (server: Server, ctx: AppContext) {
           await repoTxn.blobs.processWriteBlobs(did, commit, [write])
 
           let profileCid: CID
-          if (write.action === 'update') {
+          if (write.action === WriteOpAction.Update) {
             profileCid = write.cid
             // Update profile record
             await dbTxn.db
@@ -105,7 +106,7 @@ export default function (server: Server, ctx: AppContext) {
               })
               .where('uri', '=', uri.toString())
               .execute()
-          } else if (write.action === 'create') {
+          } else if (write.action === WriteOpAction.Create) {
             profileCid = write.cid
             await recordTxn.indexRecord(uri, profileCid, updated, now)
           } else {

--- a/packages/pds/src/api/com/atproto/repo.ts
+++ b/packages/pds/src/api/com/atproto/repo.ts
@@ -9,6 +9,7 @@ import {
   PreparedWrite,
 } from '../../../repo'
 import AppContext from '../../../context'
+import { WriteOpAction } from '@atproto/repo'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.describe(async ({ params }) => {
@@ -116,7 +117,9 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const authStore = ctx.getAuthstore(did)
-      const hasUpdate = tx.writes.some((write) => write.action === 'update')
+      const hasUpdate = tx.writes.some(
+        (write) => write.action === WriteOpAction.Update,
+      )
       if (hasUpdate) {
         throw new InvalidRequestError(`Updates are not yet supported.`)
       }
@@ -125,7 +128,7 @@ export default function (server: Server, ctx: AppContext) {
       try {
         writes = await Promise.all(
           tx.writes.map((write) => {
-            if (write.action === 'create') {
+            if (write.action === WriteOpAction.Create) {
               return repo.prepareCreate({
                 did,
                 collection: write.collection,
@@ -133,7 +136,7 @@ export default function (server: Server, ctx: AppContext) {
                 rkey: write.rkey,
                 validate,
               })
-            } else if (write.action === 'delete') {
+            } else if (write.action === WriteOpAction.Delete) {
               return repo.prepareDelete({
                 did,
                 collection: write.collection,

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -14,7 +14,7 @@ import {
 import * as lex from '../lexicon/lexicons'
 import { LexiconDefNotFoundError } from '@atproto/lexicon'
 import {
-  DeleteOp,
+  RecordDeleteOp,
   RecordCreateOp,
   RecordUpdateOp,
   RecordWriteOp,
@@ -186,7 +186,7 @@ export const updateWriteToOp = (write: PreparedUpdate): RecordUpdateOp => ({
   value: write.record,
 })
 
-export const deleteWriteToOp = (write: PreparedDelete): DeleteOp => ({
+export const deleteWriteToOp = (write: PreparedDelete): RecordDeleteOp => ({
   action: 'delete',
   collection: write.uri.collection,
   rkey: write.uri.rkey,

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -18,6 +18,7 @@ import {
   RecordCreateOp,
   RecordUpdateOp,
   RecordWriteOp,
+  WriteOpAction,
 } from '@atproto/repo'
 
 // @TODO do this dynamically off of schemas
@@ -131,7 +132,7 @@ export const prepareCreate = async (opts: {
   }
   const rkey = opts.rkey || determineRkey(collection)
   return {
-    action: 'create',
+    action: WriteOpAction.Create,
     uri: AtUri.make(did, collection, rkey),
     cid: await cidForData(record),
     record,
@@ -152,7 +153,7 @@ export const prepareUpdate = async (opts: {
     assertValidRecord(record)
   }
   return {
-    action: 'update',
+    action: WriteOpAction.Update,
     uri: AtUri.make(did, collection, rkey),
     cid: await cidForData(record),
     record,
@@ -167,38 +168,38 @@ export const prepareDelete = (opts: {
 }): PreparedDelete => {
   const { did, collection, rkey } = opts
   return {
-    action: 'delete',
+    action: WriteOpAction.Delete,
     uri: AtUri.make(did, collection, rkey),
   }
 }
 
 export const createWriteToOp = (write: PreparedCreate): RecordCreateOp => ({
-  action: 'create',
+  action: WriteOpAction.Create,
   collection: write.uri.collection,
   rkey: write.uri.rkey,
   value: write.record,
 })
 
 export const updateWriteToOp = (write: PreparedUpdate): RecordUpdateOp => ({
-  action: 'update',
+  action: WriteOpAction.Update,
   collection: write.uri.collection,
   rkey: write.uri.rkey,
   value: write.record,
 })
 
 export const deleteWriteToOp = (write: PreparedDelete): RecordDeleteOp => ({
-  action: 'delete',
+  action: WriteOpAction.Delete,
   collection: write.uri.collection,
   rkey: write.uri.rkey,
 })
 
 export const writeToOp = (write: PreparedWrite): RecordWriteOp => {
   switch (write.action) {
-    case 'create':
+    case WriteOpAction.Create:
       return createWriteToOp(write)
-    case 'update':
+    case WriteOpAction.Update:
       return updateWriteToOp(write)
-    case 'delete':
+    case WriteOpAction.Delete:
       return deleteWriteToOp(write)
     default:
       throw new Error(`Unrecognized action: ${write}`)

--- a/packages/pds/src/repo/types.ts
+++ b/packages/pds/src/repo/types.ts
@@ -1,5 +1,6 @@
 import { CID } from 'multiformats/cid'
 import { AtUri } from '@atproto/uri'
+import { WriteOpAction } from '@atproto/repo'
 
 export type ImageConstraint = {
   type: 'image'
@@ -26,7 +27,7 @@ export type BlobRef = {
 }
 
 export type PreparedCreate = {
-  action: 'create'
+  action: WriteOpAction.Create
   uri: AtUri
   cid: CID
   record: Record<string, unknown>
@@ -34,7 +35,7 @@ export type PreparedCreate = {
 }
 
 export type PreparedUpdate = {
-  action: 'update'
+  action: WriteOpAction.Update
   uri: AtUri
   cid: CID
   record: Record<string, unknown>
@@ -42,7 +43,7 @@ export type PreparedUpdate = {
 }
 
 export type PreparedDelete = {
-  action: 'delete'
+  action: WriteOpAction.Delete
   uri: AtUri
 }
 

--- a/packages/pds/src/services/repo/blobs.ts
+++ b/packages/pds/src/services/repo/blobs.ts
@@ -2,7 +2,7 @@ import stream from 'stream'
 import { CID } from 'multiformats/cid'
 import bytes from 'bytes'
 import { fromStream as fileTypeFromStream } from 'file-type'
-import { BlobStore } from '@atproto/repo'
+import { BlobStore, WriteOpAction } from '@atproto/repo'
 import { AtUri } from '@atproto/uri'
 import { sha256Stream } from '@atproto/crypto'
 import { cloneStream, sha256RawToCid, streamSize } from '@atproto/common'
@@ -53,7 +53,10 @@ export class RepoBlobs {
   async processWriteBlobs(did: string, commit: CID, writes: PreparedWrite[]) {
     const blobPromises: Promise<void>[] = []
     for (const write of writes) {
-      if (write.action === 'create' || write.action === 'update') {
+      if (
+        write.action === WriteOpAction.Create ||
+        write.action === WriteOpAction.Update
+      ) {
         for (const blob of write.blobs) {
           blobPromises.push(this.verifyBlobAndMakePermanent(blob))
           blobPromises.push(this.associateBlob(blob, write.uri, commit, did))

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -1,6 +1,6 @@
 import { CID } from 'multiformats/cid'
 import * as auth from '@atproto/auth'
-import { BlobStore, Repo } from '@atproto/repo'
+import { BlobStore, Repo, WriteOpAction } from '@atproto/repo'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import Database from '../../db'
 import { MessageQueue } from '../../event-stream/types'
@@ -94,9 +94,9 @@ export class RepoService {
     const recordTxn = new RecordService(this.db, this.messageQueue)
     await Promise.all(
       writes.map(async (write) => {
-        if (write.action === 'create') {
+        if (write.action === WriteOpAction.Create) {
           await recordTxn.indexRecord(write.uri, write.cid, write.record, now)
-        } else if (write.action === 'delete') {
+        } else if (write.action === WriteOpAction.Delete) {
           await recordTxn.deleteRecord(write.uri)
         }
       }),

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -85,7 +85,7 @@ export class RepoService {
     }
     const writeOps = writes.map(writeToOp)
     const repo = await Repo.load(storage, currRoot)
-    const updated = await repo.stageUpdate(writeOps).createCommit(authStore)
+    const updated = await repo.applyCommit(writeOps, authStore)
     return updated.cid
   }
 

--- a/packages/pds/tests/event-stream/sync.test.ts
+++ b/packages/pds/tests/event-stream/sync.test.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
-import { getWriteOpLog, RecordWriteOp } from '@atproto/repo'
+import { getWriteOpLog, RecordWriteOp, WriteOpAction } from '@atproto/repo'
 import SqlRepoStorage from '../../src/sql-repo-storage'
 import basicSeed from '../seeds/basic'
 import { SeedClient } from '../seeds/client'
@@ -92,21 +92,21 @@ describe('sync', () => {
     return Promise.all(
       ops.map((op) => {
         const { action } = op
-        if (action === 'create') {
+        if (action === WriteOpAction.Create) {
           return prepareCreate({
             did,
             collection: op.collection,
             rkey: op.rkey,
             record: op.value,
           })
-        } else if (action === 'update') {
+        } else if (action === WriteOpAction.Update) {
           return prepareUpdate({
             did,
             collection: op.collection,
             rkey: op.rkey,
             record: op.value,
           })
-        } else if (action === 'delete') {
+        } else if (action === WriteOpAction.Delete) {
           return prepareDelete({
             did,
             collection: op.collection,

--- a/packages/repo/bench/mst.bench.ts
+++ b/packages/repo/bench/mst.bench.ts
@@ -44,7 +44,7 @@ describe('MST Benchmarks', () => {
 
       const doneAdding = Date.now()
 
-      const root = await mst.stage()
+      const root = await util.saveMst(mst)
 
       const doneSaving = Date.now()
 
@@ -63,7 +63,7 @@ describe('MST Benchmarks', () => {
         let proofSize = 0
         for (const entry of path) {
           if (entry.isTree()) {
-            const bytes = await blockstore.getBytes(entry.pointer)
+            const bytes = await blockstore.guaranteeBytes(entry.pointer)
             proofSize += bytes.byteLength
           }
         }

--- a/packages/repo/bench/repo.bench.ts
+++ b/packages/repo/bench/repo.bench.ts
@@ -23,9 +23,10 @@ describe('Repo Benchmarks', () => {
       if (i % 500 === 0) {
         console.log(i)
       }
-      await repo
-        .stageUpdate({
-          action: 'create',
+
+      await repo.applyCommit(
+        {
+          action: 'create' as const,
           collection: 'app.bsky.post',
           rkey: TID.nextStr(),
           value: {
@@ -38,8 +39,9 @@ describe('Repo Benchmarks', () => {
             },
             createdAt: new Date().toISOString(),
           },
-        })
-        .createCommit(authStore)
+        },
+        authStore,
+      )
     }
 
     console.log('SIZE: ', await blockstore.sizeInBytes())

--- a/packages/repo/bench/repo.bench.ts
+++ b/packages/repo/bench/repo.bench.ts
@@ -1,6 +1,6 @@
 import * as auth from '@atproto/auth'
 import { TID } from '@atproto/common'
-import { MemoryBlockstore, Repo } from '../src'
+import { MemoryBlockstore, Repo, WriteOpAction } from '../src'
 import * as util from '../tests/_util'
 
 describe('Repo Benchmarks', () => {
@@ -26,7 +26,7 @@ describe('Repo Benchmarks', () => {
 
       await repo.applyCommit(
         {
-          action: 'create' as const,
+          action: WriteOpAction.Create,
           collection: 'app.bsky.post',
           rkey: TID.nextStr(),
           value: {

--- a/packages/repo/src/block-map.ts
+++ b/packages/repo/src/block-map.ts
@@ -1,0 +1,53 @@
+import { valueToIpldBlock } from '@atproto/common'
+import { CID } from 'multiformats/cid'
+
+export class BlockMap {
+  private map: Map<string, Uint8Array> = new Map()
+
+  async add(value: unknown): Promise<CID> {
+    const block = await valueToIpldBlock(value)
+    this.set(block.cid, block.bytes)
+    return block.cid
+  }
+
+  set(cid: CID, bytes: Uint8Array) {
+    this.map.set(cid.toString(), bytes)
+  }
+
+  get(cid: CID): Uint8Array | undefined {
+    return this.map.get(cid.toString())
+  }
+
+  has(cid: CID): boolean {
+    return this.map.has(cid.toString())
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+
+  forEach(cb: (bytes: Uint8Array, cid: CID) => void): void {
+    this.map.forEach((val, key) => cb(val, CID.parse(key)))
+  }
+
+  entries(): Entry[] {
+    const entries: Entry[] = []
+    this.forEach((bytes, cid) => {
+      entries.push({ cid, bytes })
+    })
+    return entries
+  }
+
+  addMap(toAdd: BlockMap) {
+    toAdd.forEach((bytes, cid) => {
+      this.set(cid, bytes)
+    })
+  }
+}
+
+type Entry = {
+  cid: CID
+  bytes: Uint8Array
+}
+
+export default BlockMap

--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -10,6 +10,7 @@ import {
   RecordCreateOp,
   RecordWriteOp,
   CommitData,
+  WriteOpAction,
 } from './types'
 import { streamToArray } from '@atproto/common'
 import { RepoStorage } from './storage'
@@ -153,15 +154,15 @@ export class Repo {
 
     let data = this.data
     for (const write of writes) {
-      if (write.action === 'create') {
+      if (write.action === WriteOpAction.Create) {
         const cid = await newBlocks.add(write.value)
         const dataKey = write.collection + '/' + write.rkey
         data = await data.add(dataKey, cid)
-      } else if (write.action === 'update') {
+      } else if (write.action === WriteOpAction.Update) {
         const cid = await newBlocks.add(write.value)
         const dataKey = write.collection + '/' + write.rkey
         data = await data.update(dataKey, cid)
-      } else if (write.action === 'delete') {
+      } else if (write.action === WriteOpAction.Delete) {
         const dataKey = write.collection + '/' + write.rkey
         data = await data.delete(dataKey)
       }

--- a/packages/repo/src/sync.ts
+++ b/packages/repo/src/sync.ts
@@ -4,12 +4,14 @@ import { RepoStorage } from './storage'
 import { DataDiff } from './mst'
 import Repo from './repo'
 import * as verify from './verify'
+import * as util from './util'
 
 export const loadRepoFromCar = async (
   carBytes: Uint8Array,
   storage: RepoStorage,
   verifier: auth.Verifier,
 ): Promise<Repo> => {
+  const car = await util.readCar(carBytes)
   const { root } = await storage.loadDiff(carBytes, (root: CID) => {
     return verify.verifyUpdates(storage, null, root, verifier)
   })

--- a/packages/repo/src/sync.ts
+++ b/packages/repo/src/sync.ts
@@ -4,14 +4,12 @@ import { RepoStorage } from './storage'
 import { DataDiff } from './mst'
 import Repo from './repo'
 import * as verify from './verify'
-import * as util from './util'
 
 export const loadRepoFromCar = async (
   carBytes: Uint8Array,
   storage: RepoStorage,
   verifier: auth.Verifier,
 ): Promise<Repo> => {
-  const car = await util.readCar(carBytes)
   const { root } = await storage.loadDiff(carBytes, (root: CID) => {
     return verify.verifyUpdates(storage, null, root, verifier)
   })

--- a/packages/repo/src/types.ts
+++ b/packages/repo/src/types.ts
@@ -26,22 +26,28 @@ const commit = z.object({
 })
 export type Commit = z.infer<typeof commit>
 
+export enum WriteOpAction {
+  Create = 'create',
+  Update = 'update',
+  Delete = 'delete',
+}
+
 export type RecordCreateOp = {
-  action: 'create'
+  action: WriteOpAction.Create
   collection: string
   rkey: string
   value: Record<string, unknown>
 }
 
 export type RecordUpdateOp = {
-  action: 'update'
+  action: WriteOpAction.Update
   collection: string
   rkey: string
   value: Record<string, unknown>
 }
 
 export type RecordDeleteOp = {
-  action: 'delete'
+  action: WriteOpAction.Delete
   collection: string
   rkey: string
 }

--- a/packages/repo/src/types.ts
+++ b/packages/repo/src/types.ts
@@ -30,14 +30,14 @@ export type RecordCreateOp = {
   action: 'create'
   collection: string
   rkey: string
-  value: unknown
+  value: Record<string, unknown>
 }
 
 export type RecordUpdateOp = {
   action: 'update'
   collection: string
   rkey: string
-  value: unknown
+  value: Record<string, unknown>
 }
 
 export type RecordDeleteOp = {

--- a/packages/repo/src/util.ts
+++ b/packages/repo/src/util.ts
@@ -1,4 +1,5 @@
 import { CID } from 'multiformats/cid'
+import { CarReader } from '@ipld/car/reader'
 import * as auth from '@atproto/auth'
 import { def } from '@atproto/common'
 import Repo from './repo'
@@ -6,7 +7,6 @@ import { DataDiff, MST } from './mst'
 import { RepoStorage } from './storage'
 import { DataStore, RecordWriteOp } from './types'
 import BlockMap from './block-map'
-import { CarReader } from '@ipld/car/reader'
 
 export const ucanForOperation = async (
   prevData: DataStore,
@@ -31,7 +31,7 @@ export const readCar = async (
   const root = roots[0]
   const blocks = new BlockMap()
   for await (const block of car.blocks()) {
-    blocks.set(block.cid, block.bytes)
+    await blocks.set(block.cid, block.bytes)
   }
   return {
     root,

--- a/packages/repo/src/util.ts
+++ b/packages/repo/src/util.ts
@@ -5,7 +5,14 @@ import { def } from '@atproto/common'
 import Repo from './repo'
 import { DataDiff, MST } from './mst'
 import { RepoStorage } from './storage'
-import { DataStore, RecordWriteOp } from './types'
+import {
+  DataStore,
+  RecordCreateOp,
+  RecordDeleteOp,
+  RecordUpdateOp,
+  RecordWriteOp,
+  WriteOpAction,
+} from './types'
 import BlockMap from './block-map'
 
 export const ucanForOperation = async (
@@ -67,16 +74,30 @@ export const diffToWriteOps = (
     ...diff.addList().map(async (add) => {
       const { collection, rkey } = parseRecordKey(add.key)
       const value = await storage.get(add.cid, def.record)
-      return { action: 'create' as const, collection, rkey, value }
+      return {
+        action: WriteOpAction.Create,
+        collection,
+        rkey,
+        value,
+      } as RecordCreateOp
     }),
     ...diff.updateList().map(async (upd) => {
       const { collection, rkey } = parseRecordKey(upd.key)
       const value = await storage.get(upd.cid, def.record)
-      return { action: 'update' as const, collection, rkey, value }
+      return {
+        action: WriteOpAction.Update,
+        collection,
+        rkey,
+        value,
+      } as RecordUpdateOp
     }),
     ...diff.deleteList().map((del) => {
       const { collection, rkey } = parseRecordKey(del.key)
-      return { action: 'delete' as const, collection, rkey }
+      return {
+        action: WriteOpAction.Delete,
+        collection,
+        rkey,
+      } as RecordDeleteOp
     }),
   ])
 }

--- a/packages/repo/src/util.ts
+++ b/packages/repo/src/util.ts
@@ -1,5 +1,6 @@
 import { CID } from 'multiformats/cid'
 import * as auth from '@atproto/auth'
+import { def } from '@atproto/common'
 import Repo from './repo'
 import { DataDiff, MST } from './mst'
 import { RepoStorage } from './storage'
@@ -65,12 +66,12 @@ export const diffToWriteOps = (
   return Promise.all([
     ...diff.addList().map(async (add) => {
       const { collection, rkey } = parseRecordKey(add.key)
-      const value = await storage.getUnchecked(add.cid)
+      const value = await storage.get(add.cid, def.record)
       return { action: 'create' as const, collection, rkey, value }
     }),
     ...diff.updateList().map(async (upd) => {
       const { collection, rkey } = parseRecordKey(upd.key)
-      const value = await storage.getUnchecked(upd.cid)
+      const value = await storage.get(upd.cid, def.record)
       return { action: 'update' as const, collection, rkey, value }
     }),
     ...diff.deleteList().map((del) => {

--- a/packages/repo/tests/_util.ts
+++ b/packages/repo/tests/_util.ts
@@ -5,7 +5,7 @@ import { Repo } from '../src/repo'
 import { RepoStorage } from '../src/storage'
 import { DataDiff, MST } from '../src/mst'
 import fs from 'fs'
-import { RecordWriteOp } from '../src'
+import { RecordWriteOp, WriteOpAction } from '../src'
 
 type IdMapping = Record<string, CID>
 
@@ -93,7 +93,7 @@ export const fillRepo = async (
       const rkey = TID.nextStr()
       collData[rkey] = object
       writes.push({
-        action: 'create',
+        action: WriteOpAction.Create,
         collection: collName,
         rkey,
         value: object,
@@ -130,7 +130,7 @@ export const editRepo = async (
       const rkey = TID.nextStr()
       collData[rkey] = object
       writes.push({
-        action: 'create',
+        action: WriteOpAction.Create,
         collection: collName,
         rkey,
         value: object,
@@ -142,7 +142,7 @@ export const editRepo = async (
       const object = generateObject()
       const rkey = toUpdate[i][0]
       writes.push({
-        action: 'update',
+        action: WriteOpAction.Update,
         collection: collName,
         rkey,
         value: object,
@@ -154,7 +154,7 @@ export const editRepo = async (
     for (let i = 0; i < toDelete.length; i++) {
       const rkey = toDelete[i][0]
       writes.push({
-        action: 'delete',
+        action: WriteOpAction.Delete,
         collection: collName,
         rkey,
       })

--- a/packages/repo/tests/_util.ts
+++ b/packages/repo/tests/_util.ts
@@ -1,21 +1,20 @@
 import { CID } from 'multiformats'
-import { TID } from '@atproto/common'
+import { cidForData, TID, valueToIpldBlock } from '@atproto/common'
 import * as auth from '@atproto/auth'
 import { Repo } from '../src/repo'
-import { RepoStorage, MemoryBlockstore } from '../src/storage'
+import { RepoStorage } from '../src/storage'
 import { DataDiff, MST } from '../src/mst'
 import fs from 'fs'
 import { RecordWriteOp } from '../src'
 
 type IdMapping = Record<string, CID>
 
-const fakeStorage = new MemoryBlockstore()
-
-export const randomCid = async (
-  storage: RepoStorage = fakeStorage,
-): Promise<CID> => {
-  const str = randomStr(50)
-  return storage.stage({ test: str })
+export const randomCid = async (storage?: RepoStorage): Promise<CID> => {
+  const block = await valueToIpldBlock({ test: randomStr(50) })
+  if (storage) {
+    await storage.putBlock(block.cid, block.bytes)
+  }
+  return block.cid
 }
 
 export const generateBulkTids = (count: number): TID[] => {
@@ -28,7 +27,7 @@ export const generateBulkTids = (count: number): TID[] => {
 
 export const generateBulkTidMapping = async (
   count: number,
-  blockstore: RepoStorage = fakeStorage,
+  blockstore?: RepoStorage,
 ): Promise<IdMapping> => {
   const ids = generateBulkTids(count)
   const obj: IdMapping = {}
@@ -102,7 +101,7 @@ export const fillRepo = async (
     }
     repoData[collName] = collData
   }
-  const updated = await repo.stageUpdate(writes).createCommit(authStore)
+  const updated = await repo.applyCommit(writes, authStore)
   return {
     repo: updated,
     data: repoData,
@@ -163,7 +162,7 @@ export const editRepo = async (
     }
     repoData[collName] = collData
   }
-  const updated = await repo.stageUpdate(writes).createCommit(authStore)
+  const updated = await repo.applyCommit(writes, authStore)
   return {
     repo: updated,
     data: repoData,
@@ -192,7 +191,7 @@ export const checkRepoDiff = async (
     const parts = key.split('/')
     const collection = parts[0]
     const obj = (data[collection] || {})[parts[1]]
-    return obj === undefined ? undefined : fakeStorage.stage(obj)
+    return obj === undefined ? undefined : cidForData(obj)
   }
 
   for (const add of diff.addList()) {
@@ -218,6 +217,12 @@ export const checkRepoDiff = async (
     expect(beforeCid).toEqual(del.cid)
     expect(afterCid).toBeUndefined()
   }
+}
+
+export const saveMst = async (mst: MST): Promise<CID> => {
+  const diff = await mst.blockDiff()
+  await mst.storage.putMany(diff.blocks)
+  return diff.root
 }
 
 // Logging

--- a/packages/repo/tests/mst.test.ts
+++ b/packages/repo/tests/mst.test.ts
@@ -90,8 +90,8 @@ describe('Merkle Search Tree', () => {
   })
 
   it('saves and loads from blockstore', async () => {
-    const cid = await mst.stage()
-    const loaded = await MST.load(blockstore, cid)
+    const root = await util.saveMst(mst)
+    const loaded = await MST.load(blockstore, root)
     const origNodes = await mst.allNodes()
     const loadedNodes = await loaded.allNodes()
     expect(origNodes.length).toBe(loadedNodes.length)
@@ -175,7 +175,7 @@ describe('Merkle Search Tree', () => {
     const layer = await mst.getLayer()
     expect(layer).toBe(1)
     mst = await mst.delete(layer1)
-    const root = await mst.stage()
+    const root = await util.saveMst(mst)
     const loaded = MST.load(blockstore, root)
     const loadedLayer = await loaded.getLayer()
     expect(loadedLayer).toBe(0)
@@ -224,7 +224,7 @@ describe('Merkle Search Tree', () => {
     const layer = await mst.getLayer()
     expect(layer).toBe(2)
 
-    const root = await mst.stage()
+    const root = await util.saveMst(mst)
     mst = MST.load(blockstore, root, { fanout: 32 })
 
     const allTids = [...layer0, ...layer1, layer2]
@@ -256,7 +256,7 @@ describe('Merkle Search Tree', () => {
     }
     mst = await mst.add(layer2, cid)
 
-    const root = await mst.stage()
+    const root = await util.saveMst(mst)
     mst = MST.load(blockstore, root, { fanout: 32 })
 
     const layer = await mst.getLayer()

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -4,6 +4,7 @@ import { Repo } from '../src/repo'
 import { MemoryBlockstore } from '../src/storage'
 import * as util from './_util'
 import { TID } from '@atproto/common'
+import { WriteOpAction } from '../src'
 
 describe('Repo', () => {
   const verifier = new auth.Verifier()
@@ -32,7 +33,7 @@ describe('Repo', () => {
     const record = util.generateObject()
     repo = await repo.applyCommit(
       {
-        action: 'create',
+        action: WriteOpAction.Create,
         collection: collName,
         rkey: rkey,
         value: record,
@@ -46,7 +47,7 @@ describe('Repo', () => {
     const updatedRecord = util.generateObject()
     repo = await repo.applyCommit(
       {
-        action: 'update',
+        action: WriteOpAction.Update,
         collection: collName,
         rkey: rkey,
         value: updatedRecord,
@@ -58,7 +59,7 @@ describe('Repo', () => {
 
     repo = await repo.applyCommit(
       {
-        action: 'delete',
+        action: WriteOpAction.Delete,
         collection: collName,
         rkey: rkey,
       },

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -30,37 +30,40 @@ describe('Repo', () => {
   it('does basic operations', async () => {
     const rkey = TID.nextStr()
     const record = util.generateObject()
-    repo = await repo
-      .stageUpdate({
+    repo = await repo.applyCommit(
+      {
         action: 'create',
         collection: collName,
         rkey: rkey,
         value: record,
-      })
-      .createCommit(authStore)
+      },
+      authStore,
+    )
 
     let got = await repo.getRecord(collName, rkey)
     expect(got).toEqual(record)
 
     const updatedRecord = util.generateObject()
-    repo = await repo
-      .stageUpdate({
+    repo = await repo.applyCommit(
+      {
         action: 'update',
         collection: collName,
         rkey: rkey,
         value: updatedRecord,
-      })
-      .createCommit(authStore)
+      },
+      authStore,
+    )
     got = await repo.getRecord(collName, rkey)
     expect(got).toEqual(updatedRecord)
 
-    repo = await repo
-      .stageUpdate({
+    repo = await repo.applyCommit(
+      {
         action: 'delete',
         collection: collName,
         rkey: rkey,
-      })
-      .createCommit(authStore)
+      },
+      authStore,
+    )
     got = await repo.getRecord(collName, rkey)
     expect(got).toBeNull()
   })


### PR DESCRIPTION
This adjusts the repo storage abstraction so that it understands commits.

Instead of having a staging section that then get's persisted, the application code is in charge of collecting new blocks for a commit & storage "applies a commit", saving the blocks, and associating them with some commit CID

I also snuck a change in here to the sql repo store which does some optimistic caching of repo blocks that are likely to change. This removes at least 3 (but often more) round trips to the DB on each mutation.