### PR TITLE
API & client improvements

### DIFF
--- a/packages/api/src/client/types/app/bsky/actor/createScene.ts
+++ b/packages/api/src/client/types/app/bsky/actor/createScene.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {}

--- a/packages/api/src/client/types/app/bsky/actor/createScene.ts
+++ b/packages/api/src/client/types/app/bsky/actor/createScene.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {}

--- a/packages/api/src/client/types/app/bsky/actor/getProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfile.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -57,4 +59,8 @@ export function isMyState(v: unknown): v is MyState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.getProfile#myState'
   )
+}
+
+export function validateMyState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getProfile#myState', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/getProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfile.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -48,4 +49,12 @@ export interface MyState {
   member?: string
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isMyState(v: unknown): v is MyState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getProfile#myState'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -45,7 +46,23 @@ export interface Actor {
   [k: string]: unknown
 }
 
+export function isActor(v: unknown): v is Actor {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getSuggestions#actor'
+  )
+}
+
 export interface MyState {
   follow?: string
   [k: string]: unknown
+}
+
+export function isMyState(v: unknown): v is MyState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getSuggestions#myState'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -54,6 +56,10 @@ export function isActor(v: unknown): v is Actor {
   )
 }
 
+export function validateActor(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getSuggestions#actor', v)
+}
+
 export interface MyState {
   follow?: string
   [k: string]: unknown
@@ -65,4 +71,8 @@ export function isMyState(v: unknown): v is MyState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.getSuggestions#myState'
   )
+}
+
+export function validateMyState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getSuggestions#myState', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/profile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/profile.ts
@@ -1,10 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Record {
   displayName: string
   description?: string
   avatar?: { cid: string; mimeType: string; [k: string]: unknown }
   banner?: { cid: string; mimeType: string; [k: string]: unknown }
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.actor.profile#main' ||
+      v.$type === 'app.bsky.actor.profile')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/profile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/profile.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface Record {
   displayName: string
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.actor.profile#main' ||
       v.$type === 'app.bsky.actor.profile')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.profile#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/ref.ts
+++ b/packages/api/src/client/types/app/bsky/actor/ref.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface Main {
@@ -16,6 +18,10 @@ export function isMain(v: unknown): v is Main {
     hasProp(v, '$type') &&
     (v.$type === 'app.bsky.actor.ref#main' || v.$type === 'app.bsky.actor.ref')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#main', v)
 }
 
 export interface WithInfo {
@@ -34,6 +40,10 @@ export function isWithInfo(v: unknown): v is WithInfo {
   )
 }
 
+export function validateWithInfo(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#withInfo', v)
+}
+
 export interface ViewerState {
   muted?: boolean
   [k: string]: unknown
@@ -45,4 +55,8 @@ export function isViewerState(v: unknown): v is ViewerState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.ref#viewerState'
   )
+}
+
+export function validateViewerState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#viewerState', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/ref.ts
+++ b/packages/api/src/client/types/app/bsky/actor/ref.ts
@@ -1,12 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface Main {
   did: string
   declarationCid: string
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.actor.ref#main' || v.$type === 'app.bsky.actor.ref')
+  )
 }
 
 export interface WithInfo {
@@ -19,7 +28,21 @@ export interface WithInfo {
   [k: string]: unknown
 }
 
+export function isWithInfo(v: unknown): v is WithInfo {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.ref#withInfo'
+  )
+}
+
 export interface ViewerState {
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isViewerState(v: unknown): v is ViewerState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.ref#viewerState'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/search.ts
+++ b/packages/api/src/client/types/app/bsky/actor/search.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -50,4 +52,8 @@ export function isUser(v: unknown): v is User {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.search#user'
   )
+}
+
+export function validateUser(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.search#user', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/search.ts
+++ b/packages/api/src/client/types/app/bsky/actor/search.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -43,4 +44,10 @@ export interface User {
   description?: string
   indexedAt?: string
   [k: string]: unknown
+}
+
+export function isUser(v: unknown): v is User {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.search#user'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -48,4 +50,8 @@ export function isUser(v: unknown): v is User {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.searchTypeahead#user'
   )
+}
+
+export function validateUser(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.searchTypeahead#user', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -39,4 +40,12 @@ export interface User {
   displayName?: string
   avatar?: string
   [k: string]: unknown
+}
+
+export function isUser(v: unknown): v is User {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.searchTypeahead#user'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/embed/external.ts
+++ b/packages/api/src/client/types/app/bsky/embed/external.ts
@@ -1,9 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   external: External
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.embed.external#main' ||
+      v.$type === 'app.bsky.embed.external')
+  )
 }
 
 export interface External {
@@ -14,9 +25,25 @@ export interface External {
   [k: string]: unknown
 }
 
+export function isExternal(v: unknown): v is External {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#external'
+  )
+}
+
 export interface Presented {
   external: PresentedExternal
   [k: string]: unknown
+}
+
+export function isPresented(v: unknown): v is Presented {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#presented'
+  )
 }
 
 export interface PresentedExternal {
@@ -25,4 +52,12 @@ export interface PresentedExternal {
   description: string
   thumb?: string
   [k: string]: unknown
+}
+
+export function isPresentedExternal(v: unknown): v is PresentedExternal {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#presentedExternal'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/embed/external.ts
+++ b/packages/api/src/client/types/app/bsky/embed/external.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface Main {
   external: External
@@ -15,6 +17,10 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'app.bsky.embed.external#main' ||
       v.$type === 'app.bsky.embed.external')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#main', v)
 }
 
 export interface External {
@@ -33,6 +39,10 @@ export function isExternal(v: unknown): v is External {
   )
 }
 
+export function validateExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
 export interface Presented {
   external: PresentedExternal
   [k: string]: unknown
@@ -44,6 +54,10 @@ export function isPresented(v: unknown): v is Presented {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.external#presented'
   )
+}
+
+export function validatePresented(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#presented', v)
 }
 
 export interface PresentedExternal {
@@ -60,4 +74,8 @@ export function isPresentedExternal(v: unknown): v is PresentedExternal {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.external#presentedExternal'
   )
+}
+
+export function validatePresentedExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#presentedExternal', v)
 }

--- a/packages/api/src/client/types/app/bsky/embed/images.ts
+++ b/packages/api/src/client/types/app/bsky/embed/images.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface Main {
   images: Image[]
@@ -17,6 +19,10 @@ export function isMain(v: unknown): v is Main {
   )
 }
 
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#main', v)
+}
+
 export interface Image {
   image: { cid: string; mimeType: string; [k: string]: unknown }
   alt: string
@@ -27,6 +33,10 @@ export function isImage(v: unknown): v is Image {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#image'
   )
+}
+
+export function validateImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#image', v)
 }
 
 export interface Presented {
@@ -42,6 +52,10 @@ export function isPresented(v: unknown): v is Presented {
   )
 }
 
+export function validatePresented(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#presented', v)
+}
+
 export interface PresentedImage {
   thumb: string
   fullsize: string
@@ -55,4 +69,8 @@ export function isPresentedImage(v: unknown): v is PresentedImage {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.images#presentedImage'
   )
+}
+
+export function validatePresentedImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#presentedImage', v)
 }

--- a/packages/api/src/client/types/app/bsky/embed/images.ts
+++ b/packages/api/src/client/types/app/bsky/embed/images.ts
@@ -1,9 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   images: Image[]
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.embed.images#main' ||
+      v.$type === 'app.bsky.embed.images')
+  )
 }
 
 export interface Image {
@@ -12,9 +23,23 @@ export interface Image {
   [k: string]: unknown
 }
 
+export function isImage(v: unknown): v is Image {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#image'
+  )
+}
+
 export interface Presented {
   images: PresentedImage[]
   [k: string]: unknown
+}
+
+export function isPresented(v: unknown): v is Presented {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.images#presented'
+  )
 }
 
 export interface PresentedImage {
@@ -22,4 +47,12 @@ export interface PresentedImage {
   fullsize: string
   alt: string
   [k: string]: unknown
+}
+
+export function isPresentedImage(v: unknown): v is PresentedImage {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.images#presentedImage'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/feedViewPost.ts
+++ b/packages/api/src/client/types/app/bsky/feed/feedViewPost.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyFeedPost from './post'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -21,6 +23,10 @@ export function isMain(v: unknown): v is Main {
   )
 }
 
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#main', v)
+}
+
 export interface ReplyRef {
   root: AppBskyFeedPost.View
   parent: AppBskyFeedPost.View
@@ -33,6 +39,10 @@ export function isReplyRef(v: unknown): v is ReplyRef {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.feedViewPost#replyRef'
   )
+}
+
+export function validateReplyRef(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#replyRef', v)
 }
 
 export interface ReasonTrend {
@@ -49,6 +59,10 @@ export function isReasonTrend(v: unknown): v is ReasonTrend {
   )
 }
 
+export function validateReasonTrend(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#reasonTrend', v)
+}
+
 export interface ReasonRepost {
   by: AppBskyActorRef.WithInfo
   indexedAt: string
@@ -61,4 +75,8 @@ export function isReasonRepost(v: unknown): v is ReasonRepost {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.feedViewPost#reasonRepost'
   )
+}
+
+export function validateReasonRepost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#reasonRepost', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/feedViewPost.ts
+++ b/packages/api/src/client/types/app/bsky/feed/feedViewPost.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedPost from './post'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -11,10 +12,27 @@ export interface Main {
   [k: string]: unknown
 }
 
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.feedViewPost#main' ||
+      v.$type === 'app.bsky.feed.feedViewPost')
+  )
+}
+
 export interface ReplyRef {
   root: AppBskyFeedPost.View
   parent: AppBskyFeedPost.View
   [k: string]: unknown
+}
+
+export function isReplyRef(v: unknown): v is ReplyRef {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#replyRef'
+  )
 }
 
 export interface ReasonTrend {
@@ -23,8 +41,24 @@ export interface ReasonTrend {
   [k: string]: unknown
 }
 
+export function isReasonTrend(v: unknown): v is ReasonTrend {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#reasonTrend'
+  )
+}
+
 export interface ReasonRepost {
   by: AppBskyActorRef.WithInfo
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isReasonRepost(v: unknown): v is ReasonRepost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#reasonRepost'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyFeedPost from './post'
 
 export interface QueryParams {
@@ -65,6 +67,10 @@ export function isThreadViewPost(v: unknown): v is ThreadViewPost {
   )
 }
 
+export function validateThreadViewPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getPostThread#threadViewPost', v)
+}
+
 export interface NotFoundPost {
   uri: string
   notFound: true
@@ -77,4 +83,8 @@ export function isNotFoundPost(v: unknown): v is NotFoundPost {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.getPostThread#notFoundPost'
   )
+}
+
+export function validateNotFoundPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getPostThread#notFoundPost', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedPost from './post'
 
 export interface QueryParams {
@@ -56,8 +57,24 @@ export interface ThreadViewPost {
   [k: string]: unknown
 }
 
+export function isThreadViewPost(v: unknown): v is ThreadViewPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getPostThread#threadViewPost'
+  )
+}
+
 export interface NotFoundPost {
   uri: string
   notFound: true
   [k: string]: unknown
+}
+
+export function isNotFoundPost(v: unknown): v is NotFoundPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getPostThread#notFoundPost'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -55,4 +57,8 @@ export function isRepostedBy(v: unknown): v is RepostedBy {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.getRepostedBy#repostedBy'
   )
+}
+
+export function validateRepostedBy(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getRepostedBy#repostedBy', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -46,4 +47,12 @@ export interface RepostedBy {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isRepostedBy(v: unknown): v is RepostedBy {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getRepostedBy#repostedBy'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/app/bsky/feed/getVotes.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getVotes.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -51,4 +53,8 @@ export function isVote(v: unknown): v is Vote {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.getVotes#vote'
   )
+}
+
+export function validateVote(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getVotes#vote', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/getVotes.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getVotes.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -44,4 +45,10 @@ export interface Vote {
   createdAt: string
   actor: AppBskyActorRef.WithInfo
   [k: string]: unknown
+}
+
+export function isVote(v: unknown): v is Vote {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.getVotes#vote'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/post.ts
+++ b/packages/api/src/client/types/app/bsky/feed/post.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
@@ -18,10 +19,24 @@ export interface Record {
   [k: string]: unknown
 }
 
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.post#main' || v.$type === 'app.bsky.feed.post')
+  )
+}
+
 export interface ReplyRef {
   root: ComAtprotoRepoStrongRef.Main
   parent: ComAtprotoRepoStrongRef.Main
   [k: string]: unknown
+}
+
+export function isReplyRef(v: unknown): v is ReplyRef {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#replyRef'
+  )
 }
 
 export interface Entity {
@@ -32,11 +47,25 @@ export interface Entity {
   [k: string]: unknown
 }
 
+export function isEntity(v: unknown): v is Entity {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#entity'
+  )
+}
+
 /** A text segment. Start is inclusive, end is exclusive. */
 export interface TextSlice {
   start: number
   end: number
   [k: string]: unknown
+}
+
+export function isTextSlice(v: unknown): v is TextSlice {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.post#textSlice'
+  )
 }
 
 export interface View {
@@ -57,10 +86,24 @@ export interface View {
   [k: string]: unknown
 }
 
+export function isView(v: unknown): v is View {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#view'
+  )
+}
+
 export interface ViewerState {
   repost?: string
   upvote?: string
   downvote?: string
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isViewerState(v: unknown): v is ViewerState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.post#viewerState'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/post.ts
+++ b/packages/api/src/client/types/app/bsky/feed/post.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
@@ -27,6 +29,10 @@ export function isRecord(v: unknown): v is Record {
   )
 }
 
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#main', v)
+}
+
 export interface ReplyRef {
   root: ComAtprotoRepoStrongRef.Main
   parent: ComAtprotoRepoStrongRef.Main
@@ -37,6 +43,10 @@ export function isReplyRef(v: unknown): v is ReplyRef {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#replyRef'
   )
+}
+
+export function validateReplyRef(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#replyRef', v)
 }
 
 export interface Entity {
@@ -53,6 +63,10 @@ export function isEntity(v: unknown): v is Entity {
   )
 }
 
+export function validateEntity(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#entity', v)
+}
+
 /** A text segment. Start is inclusive, end is exclusive. */
 export interface TextSlice {
   start: number
@@ -66,6 +80,10 @@ export function isTextSlice(v: unknown): v is TextSlice {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.post#textSlice'
   )
+}
+
+export function validateTextSlice(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#textSlice', v)
 }
 
 export interface View {
@@ -92,6 +110,10 @@ export function isView(v: unknown): v is View {
   )
 }
 
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#view', v)
+}
+
 export interface ViewerState {
   repost?: string
   upvote?: string
@@ -106,4 +128,8 @@ export function isViewerState(v: unknown): v is ViewerState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.post#viewerState'
   )
+}
+
+export function validateViewerState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#viewerState', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/repost.ts
+++ b/packages/api/src/client/types/app/bsky/feed/repost.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.feed.repost#main' ||
       v.$type === 'app.bsky.feed.repost')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.repost#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/repost.ts
+++ b/packages/api/src/client/types/app/bsky/feed/repost.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
   subject: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.repost#main' ||
+      v.$type === 'app.bsky.feed.repost')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/setVote.ts
+++ b/packages/api/src/client/types/app/bsky/feed/setVote.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface QueryParams {}

--- a/packages/api/src/client/types/app/bsky/feed/setVote.ts
+++ b/packages/api/src/client/types/app/bsky/feed/setVote.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface QueryParams {}

--- a/packages/api/src/client/types/app/bsky/feed/trend.ts
+++ b/packages/api/src/client/types/app/bsky/feed/trend.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
   subject: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.trend#main' ||
+      v.$type === 'app.bsky.feed.trend')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/trend.ts
+++ b/packages/api/src/client/types/app/bsky/feed/trend.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.feed.trend#main' ||
       v.$type === 'app.bsky.feed.trend')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.trend#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/vote.ts
+++ b/packages/api/src/client/types/app/bsky/feed/vote.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
@@ -8,4 +9,12 @@ export interface Record {
   direction: 'up' | 'down'
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.vote#main' || v.$type === 'app.bsky.feed.vote')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/feed/vote.ts
+++ b/packages/api/src/client/types/app/bsky/feed/vote.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     hasProp(v, '$type') &&
     (v.$type === 'app.bsky.feed.vote#main' || v.$type === 'app.bsky.feed.vote')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.vote#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/assertCreator.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertCreator.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 /** Assertion type: Creator. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertCreator#main'

--- a/packages/api/src/client/types/app/bsky/graph/assertCreator.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertCreator.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Assertion type: Creator. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertCreator#main'

--- a/packages/api/src/client/types/app/bsky/graph/assertMember.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertMember.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Assertion type: Member. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertMember#main'

--- a/packages/api/src/client/types/app/bsky/graph/assertMember.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertMember.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 /** Assertion type: Member. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertMember#main'

--- a/packages/api/src/client/types/app/bsky/graph/assertion.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertion.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
@@ -8,4 +9,13 @@ export interface Record {
   subject: AppBskyActorRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.assertion#main' ||
+      v.$type === 'app.bsky.graph.assertion')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/assertion.ts
+++ b/packages/api/src/client/types/app/bsky/graph/assertion.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.assertion#main' ||
       v.$type === 'app.bsky.graph.assertion')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.assertion#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/confirmation.ts
+++ b/packages/api/src/client/types/app/bsky/graph/confirmation.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -19,4 +21,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.confirmation#main' ||
       v.$type === 'app.bsky.graph.confirmation')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.confirmation#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/confirmation.ts
+++ b/packages/api/src/client/types/app/bsky/graph/confirmation.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -9,4 +10,13 @@ export interface Record {
   assertion: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.confirmation#main' ||
+      v.$type === 'app.bsky.graph.confirmation')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/follow.ts
+++ b/packages/api/src/client/types/app/bsky/graph/follow.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
   subject: AppBskyActorRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.follow#main' ||
+      v.$type === 'app.bsky.graph.follow')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/follow.ts
+++ b/packages/api/src/client/types/app/bsky/graph/follow.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.follow#main' ||
       v.$type === 'app.bsky.graph.follow')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.follow#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -58,6 +60,10 @@ export function isAssertion(v: unknown): v is Assertion {
   )
 }
 
+export function validateAssertion(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getAssertions#assertion', v)
+}
+
 export interface Confirmation {
   uri: string
   cid: string
@@ -72,4 +78,8 @@ export function isConfirmation(v: unknown): v is Confirmation {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getAssertions#confirmation'
   )
+}
+
+export function validateConfirmation(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getAssertions#confirmation', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getAssertions.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -49,10 +50,26 @@ export interface Assertion {
   [k: string]: unknown
 }
 
+export function isAssertion(v: unknown): v is Assertion {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getAssertions#assertion'
+  )
+}
+
 export interface Confirmation {
   uri: string
   cid: string
   indexedAt: string
   createdAt: string
   [k: string]: unknown
+}
+
+export function isConfirmation(v: unknown): v is Confirmation {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getAssertions#confirmation'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -54,4 +56,8 @@ export function isFollower(v: unknown): v is Follower {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getFollowers#follower'
   )
+}
+
+export function validateFollower(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getFollowers#follower', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -45,4 +46,12 @@ export interface Follower {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isFollower(v: unknown): v is Follower {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getFollowers#follower'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getFollows.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollows.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -44,4 +45,12 @@ export interface Follow {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isFollow(v: unknown): v is Follow {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getFollows#follow'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getFollows.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollows.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -53,4 +55,8 @@ export function isFollow(v: unknown): v is Follow {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getFollows#follow'
   )
+}
+
+export function validateFollow(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getFollows#follow', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMembers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMembers.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -44,4 +45,12 @@ export interface Member {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isMember(v: unknown): v is Member {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMembers#member'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMembers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMembers.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -53,4 +55,8 @@ export function isMember(v: unknown): v is Member {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMembers#member'
   )
+}
+
+export function validateMember(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMembers#member', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMemberships.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMemberships.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -53,4 +55,8 @@ export function isMembership(v: unknown): v is Membership {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMemberships#membership'
   )
+}
+
+export function validateMembership(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMemberships#membership', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMemberships.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMemberships.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -44,4 +45,12 @@ export interface Membership {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isMembership(v: unknown): v is Membership {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMemberships#membership'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMutes.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMutes.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -40,4 +41,12 @@ export interface Mute {
   displayName?: string
   createdAt: string
   [k: string]: unknown
+}
+
+export function isMute(v: unknown): v is Mute {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMutes#mute'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/graph/getMutes.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMutes.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
@@ -49,4 +51,8 @@ export function isMute(v: unknown): v is Mute {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMutes#mute'
   )
+}
+
+export function validateMute(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMutes#mute', v)
 }

--- a/packages/api/src/client/types/app/bsky/graph/mute.ts
+++ b/packages/api/src/client/types/app/bsky/graph/mute.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/graph/mute.ts
+++ b/packages/api/src/client/types/app/bsky/graph/mute.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/graph/unmute.ts
+++ b/packages/api/src/client/types/app/bsky/graph/unmute.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/graph/unmute.ts
+++ b/packages/api/src/client/types/app/bsky/graph/unmute.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/notification/getCount.ts
+++ b/packages/api/src/client/types/app/bsky/notification/getCount.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/notification/getCount.ts
+++ b/packages/api/src/client/types/app/bsky/notification/getCount.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/notification/list.ts
+++ b/packages/api/src/client/types/app/bsky/notification/list.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -52,4 +53,12 @@ export interface Notification {
   isRead: boolean
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isNotification(v: unknown): v is Notification {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.notification.list#notification'
+  )
 }

--- a/packages/api/src/client/types/app/bsky/notification/list.ts
+++ b/packages/api/src/client/types/app/bsky/notification/list.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
@@ -61,4 +63,8 @@ export function isNotification(v: unknown): v is Notification {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.notification.list#notification'
   )
+}
+
+export function validateNotification(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.notification.list#notification', v)
 }

--- a/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
+++ b/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
+++ b/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/app/bsky/system/actorScene.ts
+++ b/packages/api/src/client/types/app/bsky/system/actorScene.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Actor type: Scene. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorScene#main'

--- a/packages/api/src/client/types/app/bsky/system/actorScene.ts
+++ b/packages/api/src/client/types/app/bsky/system/actorScene.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 /** Actor type: Scene. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorScene#main'

--- a/packages/api/src/client/types/app/bsky/system/actorUser.ts
+++ b/packages/api/src/client/types/app/bsky/system/actorUser.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Actor type: User. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorUser#main'

--- a/packages/api/src/client/types/app/bsky/system/actorUser.ts
+++ b/packages/api/src/client/types/app/bsky/system/actorUser.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 /** Actor type: User. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorUser#main'

--- a/packages/api/src/client/types/app/bsky/system/declRef.ts
+++ b/packages/api/src/client/types/app/bsky/system/declRef.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** A reference to a app.bsky.system.declaration record. */
 export interface Main {
   cid: string
@@ -9,4 +11,13 @@ export interface Main {
     | 'app.bsky.system.actorScene'
     | (string & {})
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.system.declRef#main' ||
+      v.$type === 'app.bsky.system.declRef')
+  )
 }

--- a/packages/api/src/client/types/app/bsky/system/declRef.ts
+++ b/packages/api/src/client/types/app/bsky/system/declRef.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 /** A reference to a app.bsky.system.declaration record. */
 export interface Main {
@@ -20,4 +22,8 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'app.bsky.system.declRef#main' ||
       v.$type === 'app.bsky.system.declRef')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.system.declRef#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/system/declaration.ts
+++ b/packages/api/src/client/types/app/bsky/system/declaration.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface Record {
   actorType:
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.system.declaration#main' ||
       v.$type === 'app.bsky.system.declaration')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.system.declaration#main', v)
 }

--- a/packages/api/src/client/types/app/bsky/system/declaration.ts
+++ b/packages/api/src/client/types/app/bsky/system/declaration.ts
@@ -1,10 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Record {
   actorType:
     | 'app.bsky.system.actorUser'
     | 'app.bsky.system.actorScene'
     | (string & {})
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.system.declaration#main' ||
+      v.$type === 'app.bsky.system.declaration')
+  )
 }

--- a/packages/api/src/client/types/com/atproto/account/create.ts
+++ b/packages/api/src/client/types/com/atproto/account/create.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/create.ts
+++ b/packages/api/src/client/types/com/atproto/account/create.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/createInviteCode.ts
+++ b/packages/api/src/client/types/com/atproto/account/createInviteCode.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/createInviteCode.ts
+++ b/packages/api/src/client/types/com/atproto/account/createInviteCode.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/delete.ts
+++ b/packages/api/src/client/types/com/atproto/account/delete.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/delete.ts
+++ b/packages/api/src/client/types/com/atproto/account/delete.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/get.ts
+++ b/packages/api/src/client/types/com/atproto/account/get.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/get.ts
+++ b/packages/api/src/client/types/com/atproto/account/get.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/requestPasswordReset.ts
+++ b/packages/api/src/client/types/com/atproto/account/requestPasswordReset.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/requestPasswordReset.ts
+++ b/packages/api/src/client/types/com/atproto/account/requestPasswordReset.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/resetPassword.ts
+++ b/packages/api/src/client/types/com/atproto/account/resetPassword.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/account/resetPassword.ts
+++ b/packages/api/src/client/types/com/atproto/account/resetPassword.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/blob/upload.ts
+++ b/packages/api/src/client/types/com/atproto/blob/upload.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/blob/upload.ts
+++ b/packages/api/src/client/types/com/atproto/blob/upload.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/handle/resolve.ts
+++ b/packages/api/src/client/types/com/atproto/handle/resolve.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The handle to resolve. If not supplied, will resolve the host's own handle. */

--- a/packages/api/src/client/types/com/atproto/handle/resolve.ts
+++ b/packages/api/src/client/types/com/atproto/handle/resolve.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The handle to resolve. If not supplied, will resolve the host's own handle. */

--- a/packages/api/src/client/types/com/atproto/repo/batchWrite.ts
+++ b/packages/api/src/client/types/com/atproto/repo/batchWrite.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 
@@ -39,6 +40,14 @@ export interface Create {
   [k: string]: unknown
 }
 
+export function isCreate(v: unknown): v is Create {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#create'
+  )
+}
+
 export interface Update {
   action: 'update'
   collection: string
@@ -47,9 +56,25 @@ export interface Update {
   [k: string]: unknown
 }
 
+export function isUpdate(v: unknown): v is Update {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#update'
+  )
+}
+
 export interface Delete {
   action: 'delete'
   collection: string
   rkey: string
   [k: string]: unknown
+}
+
+export function isDelete(v: unknown): v is Delete {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#delete'
+  )
 }

--- a/packages/api/src/client/types/com/atproto/repo/batchWrite.ts
+++ b/packages/api/src/client/types/com/atproto/repo/batchWrite.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 
@@ -48,6 +50,10 @@ export function isCreate(v: unknown): v is Create {
   )
 }
 
+export function validateCreate(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#create', v)
+}
+
 export interface Update {
   action: 'update'
   collection: string
@@ -64,6 +70,10 @@ export function isUpdate(v: unknown): v is Update {
   )
 }
 
+export function validateUpdate(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#update', v)
+}
+
 export interface Delete {
   action: 'delete'
   collection: string
@@ -77,4 +87,8 @@ export function isDelete(v: unknown): v is Delete {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.repo.batchWrite#delete'
   )
+}
+
+export function validateDelete(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#delete', v)
 }

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/describe.ts
+++ b/packages/api/src/client/types/com/atproto/repo/describe.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/repo/describe.ts
+++ b/packages/api/src/client/types/com/atproto/repo/describe.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/repo/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/getRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/repo/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/getRecord.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */
@@ -56,4 +58,8 @@ export function isRecord(v: unknown): v is Record {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.repo.listRecords#record'
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.listRecords#record', v)
 }

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The handle or DID of the repo. */
@@ -47,4 +48,12 @@ export interface Record {
   cid: string
   value: {}
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.listRecords#record'
+  )
 }

--- a/packages/api/src/client/types/com/atproto/repo/putRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/putRecord.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/putRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/putRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/repo/strongRef.ts
+++ b/packages/api/src/client/types/com/atproto/repo/strongRef.ts
@@ -1,7 +1,9 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface Main {
   uri: string
@@ -16,4 +18,8 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'com.atproto.repo.strongRef#main' ||
       v.$type === 'com.atproto.repo.strongRef')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.strongRef#main', v)
 }

--- a/packages/api/src/client/types/com/atproto/repo/strongRef.ts
+++ b/packages/api/src/client/types/com/atproto/repo/strongRef.ts
@@ -1,8 +1,19 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   uri: string
   cid: string
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'com.atproto.repo.strongRef#main' ||
+      v.$type === 'com.atproto.repo.strongRef')
+  )
 }

--- a/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 
@@ -34,4 +35,12 @@ export interface Links {
   privacyPolicy?: string
   termsOfService?: string
   [k: string]: unknown
+}
+
+export function isLinks(v: unknown): v is Links {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.getAccountsConfig#links'
+  )
 }

--- a/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/api/src/client/types/com/atproto/server/getAccountsConfig.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 
@@ -43,4 +45,8 @@ export function isLinks(v: unknown): v is Links {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.server.getAccountsConfig#links'
   )
+}
+
+export function validateLinks(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.getAccountsConfig#links', v)
 }

--- a/packages/api/src/client/types/com/atproto/session/create.ts
+++ b/packages/api/src/client/types/com/atproto/session/create.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/create.ts
+++ b/packages/api/src/client/types/com/atproto/session/create.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/delete.ts
+++ b/packages/api/src/client/types/com/atproto/session/delete.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/delete.ts
+++ b/packages/api/src/client/types/com/atproto/session/delete.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/get.ts
+++ b/packages/api/src/client/types/com/atproto/session/get.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/get.ts
+++ b/packages/api/src/client/types/com/atproto/session/get.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/refresh.ts
+++ b/packages/api/src/client/types/com/atproto/session/refresh.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/session/refresh.ts
+++ b/packages/api/src/client/types/com/atproto/session/refresh.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {}
 

--- a/packages/api/src/client/types/com/atproto/sync/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRepo.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/sync/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRepo.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/sync/getRoot.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRoot.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/sync/getRoot.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRoot.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/sync/updateRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/updateRepo.ts
@@ -2,7 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/types/com/atproto/sync/updateRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/updateRepo.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { isObj, hasProp } from '../../../../util'
 
 export interface QueryParams {
   /** The DID of the repo. */

--- a/packages/api/src/client/util.ts
+++ b/packages/api/src/client/util.ts
@@ -1,0 +1,13 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+export function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+export function hasProp<K extends PropertyKey>(
+  data: object,
+  prop: K,
+): data is Record<K, unknown> {
+  return prop in data
+}

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -12,7 +12,7 @@ import {
   LexRecord,
 } from '@atproto/lexicon'
 import { NSID } from '@atproto/nsid'
-import { gen, lexiconsTs } from './common'
+import { gen, utilTs, lexiconsTs } from './common'
 import { GeneratedAPI } from '../types'
 import {
   genImports,
@@ -21,6 +21,7 @@ import {
   genXrpcParams,
   genXrpcInput,
   genXrpcOutput,
+  genObjTypeGuard,
 } from './lex-gen'
 import {
   lexiconsToDefTree,
@@ -54,6 +55,7 @@ export async function genClientApi(
   for (const lexiconDoc of lexiconDocs) {
     api.files.push(await lexiconTs(project, lexicons, lexiconDoc))
   }
+  api.files.push(await utilTs(project))
   api.files.push(await lexiconsTs(project, lexiconDocs))
   api.files.push(await indexTs(project, lexiconDocs, nsidTree, nsidTokens))
   return api
@@ -488,6 +490,16 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
         xrpcImport.addNamedImports([{ name: 'Headers' }, { name: 'XRPCError' }])
       }
 
+      //= import {isObj, hasProp} from '../../util.ts'
+      file
+        .addImportDeclaration({
+          moduleSpecifier: `${lexiconDoc.id
+            .split('.')
+            .map((_str) => '..')
+            .join('/')}/util`,
+        })
+        .addNamedImports([{ name: 'isObj' }, { name: 'hasProp' }])
+
       for (const defId in lexiconDoc.defs) {
         const def = lexiconDoc.defs[defId]
         const lexUri = `${lexiconDoc.id}#${defId}`
@@ -605,4 +617,6 @@ function genClientRecord(
 
   //= export interface Record {...}
   genObject(file, imports, lexUri, def.record, 'Record')
+  //= export function isRecord(v: unknown): v is Record {...}
+  genObjTypeGuard(file, lexUri, 'Record')
 }

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -21,7 +21,7 @@ import {
   genXrpcParams,
   genXrpcInput,
   genXrpcOutput,
-  genObjTypeGuard,
+  genObjHelpers,
 } from './lex-gen'
 import {
   lexiconsToDefTree,
@@ -489,7 +489,12 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
         })
         xrpcImport.addNamedImports([{ name: 'Headers' }, { name: 'XRPCError' }])
       }
-
+      //= import {ValidationResult} from '@atproto/lexicon'
+      file
+        .addImportDeclaration({
+          moduleSpecifier: '@atproto/lexicon',
+        })
+        .addNamedImports([{ name: 'ValidationResult' }])
       //= import {isObj, hasProp} from '../../util.ts'
       file
         .addImportDeclaration({
@@ -499,6 +504,15 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
             .join('/')}/util`,
         })
         .addNamedImports([{ name: 'isObj' }, { name: 'hasProp' }])
+      //= import {lexicons} from '../../lexicons.ts'
+      file
+        .addImportDeclaration({
+          moduleSpecifier: `${lexiconDoc.id
+            .split('.')
+            .map((_str) => '..')
+            .join('/')}/lexicons`,
+        })
+        .addNamedImports([{ name: 'lexicons' }])
 
       for (const defId in lexiconDoc.defs) {
         const def = lexiconDoc.defs[defId]
@@ -618,5 +632,5 @@ function genClientRecord(
   //= export interface Record {...}
   genObject(file, imports, lexUri, def.record, 'Record')
   //= export function isRecord(v: unknown): v is Record {...}
-  genObjTypeGuard(file, lexUri, 'Record')
+  genObjHelpers(file, lexUri, 'Record')
 }

--- a/packages/lex-cli/src/codegen/common.ts
+++ b/packages/lex-cli/src/codegen/common.ts
@@ -11,6 +11,22 @@ const PRETTIER_OPTS = {
   trailingComma: 'all' as const,
 }
 
+export const utilTs = (project) =>
+  gen(project, '/util.ts', async (file) => {
+    file.replaceWithText(`
+  export function isObj(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null
+  }
+  
+  export function hasProp<K extends PropertyKey>(
+    data: object,
+    prop: K,
+  ): data is Record<K, unknown> {
+    return prop in data
+  }
+  `)
+  })
+
 export const lexiconsTs = (project, lexicons: LexiconDoc[]) =>
   gen(project, '/lexicons.ts', async (file) => {
     const nsidToEnum = (nsid: string): string => {

--- a/packages/lex-cli/src/codegen/server.ts
+++ b/packages/lex-cli/src/codegen/server.ts
@@ -21,7 +21,7 @@ import {
   genXrpcParams,
   genXrpcInput,
   genXrpcOutput,
-  genObjTypeGuard,
+  genObjHelpers,
 } from './lex-gen'
 import {
   lexiconsToDefTree,
@@ -295,7 +295,21 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
           })
         }
       }
-
+      //= import {ValidationResult} from '@atproto/lexicon'
+      file
+        .addImportDeclaration({
+          moduleSpecifier: '@atproto/lexicon',
+        })
+        .addNamedImports([{ name: 'ValidationResult' }])
+      //= import {lexicons} from '../../lexicons.ts'
+      file
+        .addImportDeclaration({
+          moduleSpecifier: `${lexiconDoc.id
+            .split('.')
+            .map((_str) => '..')
+            .join('/')}/lexicons`,
+        })
+        .addNamedImports([{ name: 'lexicons' }])
       //= import {isObj, hasProp} from '../../util.ts'
       file
         .addImportDeclaration({
@@ -458,5 +472,5 @@ function genServerRecord(
   //= export interface Record {...}
   genObject(file, imports, lexUri, def.record, 'Record')
   //= export function isRecord(v: unknown): v is Record {...}
-  genObjTypeGuard(file, lexUri, 'Record')
+  genObjHelpers(file, lexUri, 'Record')
 }

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -124,7 +124,7 @@ export class Lexicons {
   /**
    * Validate a record or object.
    */
-  validate(lexUri, value: unknown): ValidationResult {
+  validate(lexUri: string, value: unknown): ValidationResult {
     lexUri = toLexUri(lexUri)
     const def = this.getDefOrThrow(lexUri, ['record', 'object'])
     if (!isObj(value)) {

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -9,6 +9,7 @@ import {
   LexiconDocMalformedError,
   LexiconDefNotFoundError,
   InvalidLexiconError,
+  ValidationResult,
   ValidationError,
   isObj,
   hasProp,
@@ -20,6 +21,7 @@ import {
   assertValidXrpcOutput,
 } from './validation'
 import { toLexUri } from './util'
+import * as ComplexValidators from './validators/complex'
 
 /**
  * A collection of compiled lexicons.
@@ -117,6 +119,25 @@ export class Lexicons {
       )
     }
     return def
+  }
+
+  /**
+   * Validate a record or object.
+   */
+  validate(lexUri, value: unknown): ValidationResult {
+    lexUri = toLexUri(lexUri)
+    const def = this.getDefOrThrow(lexUri, ['record', 'object'])
+    if (!isObj(value)) {
+      throw new ValidationError(`Value must be an object`)
+    }
+    if (def.type === 'record') {
+      return ComplexValidators.object(this, 'Record', def.record, value)
+    } else if (def.type === 'object') {
+      return ComplexValidators.object(this, 'Object', def, value)
+    } else {
+      // shouldnt happen
+      throw new InvalidLexiconError('Definition must be a record or object')
+    }
   }
 
   /**

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -278,7 +278,7 @@ export function isValidLexiconDoc(v: unknown): v is LexiconDoc {
 }
 
 export function isObj(obj: unknown): obj is Record<string, unknown> {
-  return !!obj && typeof obj === 'object'
+  return obj !== null && typeof obj === 'object'
 }
 
 export function hasProp<K extends PropertyKey>(

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -30,6 +30,55 @@ describe('Lexicons collection', () => {
   })
 })
 
+describe('General validation', () => {
+  const lex = new Lexicons(LexiconDocs)
+  it('Validates records correctly', () => {
+    {
+      const res = lex.validate('com.example.kitchenSink', {
+        $type: 'com.example.kitchenSink',
+        object: {
+          object: { boolean: true },
+          array: ['one', 'two'],
+          boolean: true,
+          number: 123.45,
+          integer: 123,
+          string: 'string',
+        },
+        array: ['one', 'two'],
+        boolean: true,
+        number: 123.45,
+        integer: 123,
+        string: 'string',
+        datetime: new Date().toISOString(),
+      })
+      expect(res.success).toBe(true)
+    }
+    {
+      const res = lex.validate('com.example.kitchenSink', {})
+      expect(res.success).toBe(false)
+      expect(res.error?.message).toBe('Record must have the property "object"')
+    }
+  })
+  it('Validates objects correctly', () => {
+    {
+      const res = lex.validate('com.example.kitchenSink#object', {
+        object: { boolean: true },
+        array: ['one', 'two'],
+        boolean: true,
+        number: 123.45,
+        integer: 123,
+        string: 'string',
+      })
+      expect(res.success).toBe(true)
+    }
+    {
+      const res = lex.validate('com.example.kitchenSink#object', {})
+      expect(res.success).toBe(false)
+      expect(res.error?.message).toBe('Object must have the property "object"')
+    }
+  })
+})
+
 describe('Record validation', () => {
   const lex = new Lexicons(LexiconDocs)
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/createScene.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/createScene.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'

--- a/packages/pds/src/lexicon/types/app/bsky/actor/createScene.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/createScene.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -63,4 +65,8 @@ export function isMyState(v: unknown): v is MyState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.getProfile#myState'
   )
+}
+
+export function validateMyState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getProfile#myState', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -54,4 +55,12 @@ export interface MyState {
   member?: string
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isMyState(v: unknown): v is MyState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getProfile#myState'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -60,6 +62,10 @@ export function isActor(v: unknown): v is Actor {
   )
 }
 
+export function validateActor(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getSuggestions#actor', v)
+}
+
 export interface MyState {
   follow?: string
   [k: string]: unknown
@@ -71,4 +77,8 @@ export function isMyState(v: unknown): v is MyState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.getSuggestions#myState'
   )
+}
+
+export function validateMyState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.getSuggestions#myState', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -51,7 +52,23 @@ export interface Actor {
   [k: string]: unknown
 }
 
+export function isActor(v: unknown): v is Actor {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getSuggestions#actor'
+  )
+}
+
 export interface MyState {
   follow?: string
   [k: string]: unknown
+}
+
+export function isMyState(v: unknown): v is MyState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.getSuggestions#myState'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/profile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/profile.ts
@@ -1,10 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Record {
   displayName: string
   description?: string
   avatar?: { cid: string; mimeType: string; [k: string]: unknown }
   banner?: { cid: string; mimeType: string; [k: string]: unknown }
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.actor.profile#main' ||
+      v.$type === 'app.bsky.actor.profile')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/profile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/profile.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 export interface Record {
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.actor.profile#main' ||
       v.$type === 'app.bsky.actor.profile')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.profile#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/ref.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/ref.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -16,6 +18,10 @@ export function isMain(v: unknown): v is Main {
     hasProp(v, '$type') &&
     (v.$type === 'app.bsky.actor.ref#main' || v.$type === 'app.bsky.actor.ref')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#main', v)
 }
 
 export interface WithInfo {
@@ -34,6 +40,10 @@ export function isWithInfo(v: unknown): v is WithInfo {
   )
 }
 
+export function validateWithInfo(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#withInfo', v)
+}
+
 export interface ViewerState {
   muted?: boolean
   [k: string]: unknown
@@ -45,4 +55,8 @@ export function isViewerState(v: unknown): v is ViewerState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.ref#viewerState'
   )
+}
+
+export function validateViewerState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.ref#viewerState', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/ref.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/ref.ts
@@ -1,12 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface Main {
   did: string
   declarationCid: string
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.actor.ref#main' || v.$type === 'app.bsky.actor.ref')
+  )
 }
 
 export interface WithInfo {
@@ -19,7 +28,21 @@ export interface WithInfo {
   [k: string]: unknown
 }
 
+export function isWithInfo(v: unknown): v is WithInfo {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.ref#withInfo'
+  )
+}
+
 export interface ViewerState {
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isViewerState(v: unknown): v is ViewerState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.ref#viewerState'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -56,4 +58,8 @@ export function isUser(v: unknown): v is User {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.search#user'
   )
+}
+
+export function validateUser(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.search#user', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -49,4 +50,10 @@ export interface User {
   description?: string
   indexedAt?: string
   [k: string]: unknown
+}
+
+export function isUser(v: unknown): v is User {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.search#user'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -54,4 +56,8 @@ export function isUser(v: unknown): v is User {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.actor.searchTypeahead#user'
   )
+}
+
+export function validateUser(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.searchTypeahead#user', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -45,4 +46,12 @@ export interface User {
   displayName?: string
   avatar?: string
   [k: string]: unknown
+}
+
+export function isUser(v: unknown): v is User {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.searchTypeahead#user'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
@@ -1,9 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   external: External
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.embed.external#main' ||
+      v.$type === 'app.bsky.embed.external')
+  )
 }
 
 export interface External {
@@ -14,9 +25,25 @@ export interface External {
   [k: string]: unknown
 }
 
+export function isExternal(v: unknown): v is External {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#external'
+  )
+}
+
 export interface Presented {
   external: PresentedExternal
   [k: string]: unknown
+}
+
+export function isPresented(v: unknown): v is Presented {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#presented'
+  )
 }
 
 export interface PresentedExternal {
@@ -25,4 +52,12 @@ export interface PresentedExternal {
   description: string
   thumb?: string
   [k: string]: unknown
+}
+
+export function isPresentedExternal(v: unknown): v is PresentedExternal {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#presentedExternal'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 export interface Main {
@@ -15,6 +17,10 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'app.bsky.embed.external#main' ||
       v.$type === 'app.bsky.embed.external')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#main', v)
 }
 
 export interface External {
@@ -33,6 +39,10 @@ export function isExternal(v: unknown): v is External {
   )
 }
 
+export function validateExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
 export interface Presented {
   external: PresentedExternal
   [k: string]: unknown
@@ -44,6 +54,10 @@ export function isPresented(v: unknown): v is Presented {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.external#presented'
   )
+}
+
+export function validatePresented(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#presented', v)
 }
 
 export interface PresentedExternal {
@@ -60,4 +74,8 @@ export function isPresentedExternal(v: unknown): v is PresentedExternal {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.external#presentedExternal'
   )
+}
+
+export function validatePresentedExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#presentedExternal', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 export interface Main {
@@ -17,6 +19,10 @@ export function isMain(v: unknown): v is Main {
   )
 }
 
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#main', v)
+}
+
 export interface Image {
   image: { cid: string; mimeType: string; [k: string]: unknown }
   alt: string
@@ -27,6 +33,10 @@ export function isImage(v: unknown): v is Image {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#image'
   )
+}
+
+export function validateImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#image', v)
 }
 
 export interface Presented {
@@ -42,6 +52,10 @@ export function isPresented(v: unknown): v is Presented {
   )
 }
 
+export function validatePresented(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#presented', v)
+}
+
 export interface PresentedImage {
   thumb: string
   fullsize: string
@@ -55,4 +69,8 @@ export function isPresentedImage(v: unknown): v is PresentedImage {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.embed.images#presentedImage'
   )
+}
+
+export function validatePresentedImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#presentedImage', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
@@ -1,9 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   images: Image[]
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.embed.images#main' ||
+      v.$type === 'app.bsky.embed.images')
+  )
 }
 
 export interface Image {
@@ -12,9 +23,23 @@ export interface Image {
   [k: string]: unknown
 }
 
+export function isImage(v: unknown): v is Image {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#image'
+  )
+}
+
 export interface Presented {
   images: PresentedImage[]
   [k: string]: unknown
+}
+
+export function isPresented(v: unknown): v is Presented {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.images#presented'
+  )
 }
 
 export interface PresentedImage {
@@ -22,4 +47,12 @@ export interface PresentedImage {
   fullsize: string
   alt: string
   [k: string]: unknown
+}
+
+export function isPresentedImage(v: unknown): v is PresentedImage {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.images#presentedImage'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/feedViewPost.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/feedViewPost.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedPost from './post'
 import * as AppBskyActorRef from '../actor/ref'
@@ -21,6 +23,10 @@ export function isMain(v: unknown): v is Main {
   )
 }
 
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#main', v)
+}
+
 export interface ReplyRef {
   root: AppBskyFeedPost.View
   parent: AppBskyFeedPost.View
@@ -33,6 +39,10 @@ export function isReplyRef(v: unknown): v is ReplyRef {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.feedViewPost#replyRef'
   )
+}
+
+export function validateReplyRef(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#replyRef', v)
 }
 
 export interface ReasonTrend {
@@ -49,6 +59,10 @@ export function isReasonTrend(v: unknown): v is ReasonTrend {
   )
 }
 
+export function validateReasonTrend(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#reasonTrend', v)
+}
+
 export interface ReasonRepost {
   by: AppBskyActorRef.WithInfo
   indexedAt: string
@@ -61,4 +75,8 @@ export function isReasonRepost(v: unknown): v is ReasonRepost {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.feedViewPost#reasonRepost'
   )
+}
+
+export function validateReasonRepost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.feedViewPost#reasonRepost', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/feedViewPost.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/feedViewPost.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyFeedPost from './post'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -11,10 +12,27 @@ export interface Main {
   [k: string]: unknown
 }
 
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.feedViewPost#main' ||
+      v.$type === 'app.bsky.feed.feedViewPost')
+  )
+}
+
 export interface ReplyRef {
   root: AppBskyFeedPost.View
   parent: AppBskyFeedPost.View
   [k: string]: unknown
+}
+
+export function isReplyRef(v: unknown): v is ReplyRef {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#replyRef'
+  )
 }
 
 export interface ReasonTrend {
@@ -23,8 +41,24 @@ export interface ReasonTrend {
   [k: string]: unknown
 }
 
+export function isReasonTrend(v: unknown): v is ReasonTrend {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#reasonTrend'
+  )
+}
+
 export interface ReasonRepost {
   by: AppBskyActorRef.WithInfo
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isReasonRepost(v: unknown): v is ReasonRepost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.feedViewPost#reasonRepost'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedPost from './post'
 
@@ -56,8 +57,24 @@ export interface ThreadViewPost {
   [k: string]: unknown
 }
 
+export function isThreadViewPost(v: unknown): v is ThreadViewPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getPostThread#threadViewPost'
+  )
+}
+
 export interface NotFoundPost {
   uri: string
   notFound: true
   [k: string]: unknown
+}
+
+export function isNotFoundPost(v: unknown): v is NotFoundPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getPostThread#notFoundPost'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedPost from './post'
@@ -65,6 +67,10 @@ export function isThreadViewPost(v: unknown): v is ThreadViewPost {
   )
 }
 
+export function validateThreadViewPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getPostThread#threadViewPost', v)
+}
+
 export interface NotFoundPost {
   uri: string
   notFound: true
@@ -77,4 +83,8 @@ export function isNotFoundPost(v: unknown): v is NotFoundPost {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.getPostThread#notFoundPost'
   )
+}
+
+export function validateNotFoundPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getPostThread#notFoundPost', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -61,4 +63,8 @@ export function isRepostedBy(v: unknown): v is RepostedBy {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.getRepostedBy#repostedBy'
   )
+}
+
+export function validateRepostedBy(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getRepostedBy#repostedBy', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -52,4 +53,12 @@ export interface RepostedBy {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isRepostedBy(v: unknown): v is RepostedBy {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.getRepostedBy#repostedBy'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedFeedViewPost from './feedViewPost'
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -57,4 +59,8 @@ export function isVote(v: unknown): v is Vote {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.getVotes#vote'
   )
+}
+
+export function validateVote(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.getVotes#vote', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -50,4 +51,10 @@ export interface Vote {
   createdAt: string
   actor: AppBskyActorRef.WithInfo
   [k: string]: unknown
+}
+
+export function isVote(v: unknown): v is Vote {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.getVotes#vote'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
@@ -27,6 +29,10 @@ export function isRecord(v: unknown): v is Record {
   )
 }
 
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#main', v)
+}
+
 export interface ReplyRef {
   root: ComAtprotoRepoStrongRef.Main
   parent: ComAtprotoRepoStrongRef.Main
@@ -37,6 +43,10 @@ export function isReplyRef(v: unknown): v is ReplyRef {
   return (
     isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#replyRef'
   )
+}
+
+export function validateReplyRef(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#replyRef', v)
 }
 
 export interface Entity {
@@ -53,6 +63,10 @@ export function isEntity(v: unknown): v is Entity {
   )
 }
 
+export function validateEntity(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#entity', v)
+}
+
 /** A text segment. Start is inclusive, end is exclusive. */
 export interface TextSlice {
   start: number
@@ -66,6 +80,10 @@ export function isTextSlice(v: unknown): v is TextSlice {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.post#textSlice'
   )
+}
+
+export function validateTextSlice(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#textSlice', v)
 }
 
 export interface View {
@@ -92,6 +110,10 @@ export function isView(v: unknown): v is View {
   )
 }
 
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#view', v)
+}
+
 export interface ViewerState {
   repost?: string
   upvote?: string
@@ -106,4 +128,8 @@ export function isViewerState(v: unknown): v is ViewerState {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.feed.post#viewerState'
   )
+}
+
+export function validateViewerState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.post#viewerState', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
@@ -18,10 +19,24 @@ export interface Record {
   [k: string]: unknown
 }
 
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.post#main' || v.$type === 'app.bsky.feed.post')
+  )
+}
+
 export interface ReplyRef {
   root: ComAtprotoRepoStrongRef.Main
   parent: ComAtprotoRepoStrongRef.Main
   [k: string]: unknown
+}
+
+export function isReplyRef(v: unknown): v is ReplyRef {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#replyRef'
+  )
 }
 
 export interface Entity {
@@ -32,11 +47,25 @@ export interface Entity {
   [k: string]: unknown
 }
 
+export function isEntity(v: unknown): v is Entity {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#entity'
+  )
+}
+
 /** A text segment. Start is inclusive, end is exclusive. */
 export interface TextSlice {
   start: number
   end: number
   [k: string]: unknown
+}
+
+export function isTextSlice(v: unknown): v is TextSlice {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.post#textSlice'
+  )
 }
 
 export interface View {
@@ -57,10 +86,24 @@ export interface View {
   [k: string]: unknown
 }
 
+export function isView(v: unknown): v is View {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.feed.post#view'
+  )
+}
+
 export interface ViewerState {
   repost?: string
   upvote?: string
   downvote?: string
   muted?: boolean
   [k: string]: unknown
+}
+
+export function isViewerState(v: unknown): v is ViewerState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.post#viewerState'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/repost.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/repost.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.feed.repost#main' ||
       v.$type === 'app.bsky.feed.repost')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.repost#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/repost.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/repost.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
   subject: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.repost#main' ||
+      v.$type === 'app.bsky.feed.repost')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/setVote.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/setVote.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/setVote.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/setVote.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'

--- a/packages/pds/src/lexicon/types/app/bsky/feed/trend.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/trend.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
   subject: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.trend#main' ||
+      v.$type === 'app.bsky.feed.trend')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/trend.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/trend.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.feed.trend#main' ||
       v.$type === 'app.bsky.feed.trend')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.trend#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/vote.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/vote.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     hasProp(v, '$type') &&
     (v.$type === 'app.bsky.feed.vote#main' || v.$type === 'app.bsky.feed.vote')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.vote#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/vote.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/vote.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
 export interface Record {
@@ -8,4 +9,12 @@ export interface Record {
   direction: 'up' | 'down'
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.feed.vote#main' || v.$type === 'app.bsky.feed.vote')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertCreator.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertCreator.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 /** Assertion type: Creator. Defined for app.bsky.graph.assertions's assertion. */

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertCreator.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertCreator.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Assertion type: Creator. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertCreator#main'

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertMember.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertMember.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Assertion type: Member. Defined for app.bsky.graph.assertions's assertion. */
 export const MAIN = 'app.bsky.graph.assertMember#main'

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertMember.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertMember.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 /** Assertion type: Member. Defined for app.bsky.graph.assertions's assertion. */

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertion.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertion.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
@@ -8,4 +9,13 @@ export interface Record {
   subject: AppBskyActorRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.assertion#main' ||
+      v.$type === 'app.bsky.graph.assertion')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/assertion.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/assertion.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.assertion#main' ||
       v.$type === 'app.bsky.graph.assertion')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.assertion#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/confirmation.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/confirmation.ts
@@ -1,6 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 
@@ -9,4 +10,13 @@ export interface Record {
   assertion: ComAtprotoRepoStrongRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.confirmation#main' ||
+      v.$type === 'app.bsky.graph.confirmation')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/confirmation.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/confirmation.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
@@ -19,4 +21,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.confirmation#main' ||
       v.$type === 'app.bsky.graph.confirmation')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.confirmation#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/follow.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/follow.ts
@@ -1,10 +1,20 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface Record {
   subject: AppBskyActorRef.Main
   createdAt: string
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.follow#main' ||
+      v.$type === 'app.bsky.graph.follow')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/follow.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/follow.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -17,4 +19,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.graph.follow#main' ||
       v.$type === 'app.bsky.graph.follow')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.follow#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -64,6 +66,10 @@ export function isAssertion(v: unknown): v is Assertion {
   )
 }
 
+export function validateAssertion(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getAssertions#assertion', v)
+}
+
 export interface Confirmation {
   uri: string
   cid: string
@@ -78,4 +84,8 @@ export function isConfirmation(v: unknown): v is Confirmation {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getAssertions#confirmation'
   )
+}
+
+export function validateConfirmation(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getAssertions#confirmation', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getAssertions.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -55,10 +56,26 @@ export interface Assertion {
   [k: string]: unknown
 }
 
+export function isAssertion(v: unknown): v is Assertion {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getAssertions#assertion'
+  )
+}
+
 export interface Confirmation {
   uri: string
   cid: string
   indexedAt: string
   createdAt: string
   [k: string]: unknown
+}
+
+export function isConfirmation(v: unknown): v is Confirmation {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getAssertions#confirmation'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -51,4 +52,12 @@ export interface Follower {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isFollower(v: unknown): v is Follower {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getFollowers#follower'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -60,4 +62,8 @@ export function isFollower(v: unknown): v is Follower {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getFollowers#follower'
   )
+}
+
+export function validateFollower(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getFollowers#follower', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -50,4 +51,12 @@ export interface Follow {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isFollow(v: unknown): v is Follow {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getFollows#follow'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -59,4 +61,8 @@ export function isFollow(v: unknown): v is Follow {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getFollows#follow'
   )
+}
+
+export function validateFollow(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getFollows#follow', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMembers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMembers.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -50,4 +51,12 @@ export interface Member {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isMember(v: unknown): v is Member {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMembers#member'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMembers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMembers.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -59,4 +61,8 @@ export function isMember(v: unknown): v is Member {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMembers#member'
   )
+}
+
+export function validateMember(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMembers#member', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMemberships.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMemberships.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -59,4 +61,8 @@ export function isMembership(v: unknown): v is Membership {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMemberships#membership'
   )
+}
+
+export function validateMembership(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMemberships#membership', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMemberships.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMemberships.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -50,4 +51,12 @@ export interface Membership {
   createdAt?: string
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isMembership(v: unknown): v is Membership {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMemberships#membership'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
@@ -55,4 +57,8 @@ export function isMute(v: unknown): v is Mute {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.graph.getMutes#mute'
   )
+}
+
+export function validateMute(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.getMutes#mute', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
@@ -46,4 +47,12 @@ export interface Mute {
   displayName?: string
   createdAt: string
   [k: string]: unknown
+}
+
+export function isMute(v: unknown): v is Mute {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.getMutes#mute'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/mute.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/mute.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/app/bsky/graph/mute.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/mute.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/unmute.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/unmute.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/app/bsky/graph/unmute.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/unmute.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/app/bsky/notification/getCount.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/getCount.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/app/bsky/notification/getCount.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/getCount.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 
@@ -58,4 +59,12 @@ export interface Notification {
   isRead: boolean
   indexedAt: string
   [k: string]: unknown
+}
+
+export function isNotification(v: unknown): v is Notification {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.notification.list#notification'
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
@@ -67,4 +69,8 @@ export function isNotification(v: unknown): v is Notification {
     hasProp(v, '$type') &&
     v.$type === 'app.bsky.notification.list#notification'
   )
+}
+
+export function validateNotification(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.notification.list#notification', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/app/bsky/system/actorScene.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/actorScene.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Actor type: Scene. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorScene#main'

--- a/packages/pds/src/lexicon/types/app/bsky/system/actorScene.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/actorScene.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 /** Actor type: Scene. Defined for app.bsky.system.declaration's actorType. */

--- a/packages/pds/src/lexicon/types/app/bsky/system/actorUser.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/actorUser.ts
@@ -1,5 +1,7 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** Actor type: User. Defined for app.bsky.system.declaration's actorType. */
 export const MAIN = 'app.bsky.system.actorUser#main'

--- a/packages/pds/src/lexicon/types/app/bsky/system/actorUser.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/actorUser.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 /** Actor type: User. Defined for app.bsky.system.declaration's actorType. */

--- a/packages/pds/src/lexicon/types/app/bsky/system/declRef.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/declRef.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 /** A reference to a app.bsky.system.declaration record. */
 export interface Main {
   cid: string
@@ -9,4 +11,13 @@ export interface Main {
     | 'app.bsky.system.actorScene'
     | (string & {})
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.system.declRef#main' ||
+      v.$type === 'app.bsky.system.declRef')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/system/declRef.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/declRef.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 /** A reference to a app.bsky.system.declaration record. */
@@ -20,4 +22,8 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'app.bsky.system.declRef#main' ||
       v.$type === 'app.bsky.system.declRef')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.system.declRef#main', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/system/declaration.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/declaration.ts
@@ -1,10 +1,21 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Record {
   actorType:
     | 'app.bsky.system.actorUser'
     | 'app.bsky.system.actorScene'
     | (string & {})
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.system.declaration#main' ||
+      v.$type === 'app.bsky.system.declaration')
+  )
 }

--- a/packages/pds/src/lexicon/types/app/bsky/system/declaration.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/system/declaration.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 export interface Record {
@@ -18,4 +20,8 @@ export function isRecord(v: unknown): v is Record {
     (v.$type === 'app.bsky.system.declaration#main' ||
       v.$type === 'app.bsky.system.declaration')
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.system.declaration#main', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/account/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/create.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/create.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/account/createInviteCode.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/createInviteCode.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/createInviteCode.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/createInviteCode.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/account/delete.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/delete.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/delete.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/delete.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/account/get.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/get.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/get.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/get.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/account/requestPasswordReset.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/requestPasswordReset.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/requestPasswordReset.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/requestPasswordReset.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/account/resetPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/resetPassword.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/account/resetPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/account/resetPassword.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
@@ -3,6 +3,8 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/blob/upload.ts
@@ -3,6 +3,7 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/handle/resolve.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/handle/resolve.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/types/com/atproto/handle/resolve.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/handle/resolve.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}
@@ -42,6 +43,14 @@ export interface Create {
   [k: string]: unknown
 }
 
+export function isCreate(v: unknown): v is Create {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#create'
+  )
+}
+
 export interface Update {
   action: 'update'
   collection: string
@@ -50,9 +59,25 @@ export interface Update {
   [k: string]: unknown
 }
 
+export function isUpdate(v: unknown): v is Update {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#update'
+  )
+}
+
 export interface Delete {
   action: 'delete'
   collection: string
   rkey: string
   [k: string]: unknown
+}
+
+export function isDelete(v: unknown): v is Delete {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.batchWrite#delete'
+  )
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
@@ -51,6 +53,10 @@ export function isCreate(v: unknown): v is Create {
   )
 }
 
+export function validateCreate(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#create', v)
+}
+
 export interface Update {
   action: 'update'
   collection: string
@@ -67,6 +73,10 @@ export function isUpdate(v: unknown): v is Update {
   )
 }
 
+export function validateUpdate(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#update', v)
+}
+
 export interface Delete {
   action: 'delete'
   collection: string
@@ -80,4 +90,8 @@ export function isDelete(v: unknown): v is Delete {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.repo.batchWrite#delete'
   )
+}
+
+export function validateDelete(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.batchWrite#delete', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/describe.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/describe.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/types/com/atproto/repo/describe.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/describe.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {
@@ -53,4 +54,12 @@ export interface Record {
   cid: string
   value: {}
   [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.listRecords#record'
+  )
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
@@ -62,4 +64,8 @@ export function isRecord(v: unknown): v is Record {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.repo.listRecords#record'
   )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.listRecords#record', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/strongRef.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/strongRef.ts
@@ -1,6 +1,8 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 
 export interface Main {
@@ -16,4 +18,8 @@ export function isMain(v: unknown): v is Main {
     (v.$type === 'com.atproto.repo.strongRef#main' ||
       v.$type === 'com.atproto.repo.strongRef')
   )
+}
+
+export function validateMain(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.strongRef#main', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/strongRef.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/strongRef.ts
@@ -1,8 +1,19 @@
 /**
  * GENERATED CODE - DO NOT MODIFY
  */
+import { isObj, hasProp } from '../../../../util'
+
 export interface Main {
   uri: string
   cid: string
   [k: string]: unknown
+}
+
+export function isMain(v: unknown): v is Main {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'com.atproto.repo.strongRef#main' ||
+      v.$type === 'com.atproto.repo.strongRef')
+  )
 }

--- a/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
@@ -49,4 +51,8 @@ export function isLinks(v: unknown): v is Links {
     hasProp(v, '$type') &&
     v.$type === 'com.atproto.server.getAccountsConfig#links'
   )
+}
+
+export function validateLinks(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.getAccountsConfig#links', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getAccountsConfig.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}
@@ -40,4 +41,12 @@ export interface Links {
   privacyPolicy?: string
   termsOfService?: string
   [k: string]: unknown
+}
+
+export function isLinks(v: unknown): v is Links {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.getAccountsConfig#links'
+  )
 }

--- a/packages/pds/src/lexicon/types/com/atproto/session/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/create.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/session/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/create.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/session/delete.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/delete.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/session/delete.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/delete.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/session/get.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/get.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/session/get.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/get.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/session/refresh.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/refresh.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}

--- a/packages/pds/src/lexicon/types/com/atproto/session/refresh.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/refresh.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -3,6 +3,8 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -3,6 +3,7 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRoot.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRoot.ts
@@ -2,6 +2,7 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRoot.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRoot.ts
@@ -2,6 +2,8 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/updateRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/updateRepo.ts
@@ -3,6 +3,8 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/updateRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/updateRepo.ts
@@ -3,6 +3,7 @@
  */
 import express from 'express'
 import stream from 'stream'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {

--- a/packages/pds/src/lexicon/util.ts
+++ b/packages/pds/src/lexicon/util.ts
@@ -1,0 +1,13 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+export function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+export function hasProp<K extends PropertyKey>(
+  data: object,
+  prop: K,
+): data is Record<K, unknown> {
+  return prop in data
+}

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -135,8 +135,11 @@ export class Server {
   ): RequestHandler {
     const validateReqInput = (req: express.Request) =>
       validateInput(nsid, def, req, this.options, this.lex)
-    const validateResOutput = (output?: HandlerSuccess) =>
-      validateOutput(nsid, def, output, this.lex)
+    const validateResOutput =
+      this.options.validateResponse === false
+        ? (output?: HandlerSuccess) => output
+        : (output?: HandlerSuccess) =>
+            validateOutput(nsid, def, output, this.lex)
     const assertValidXrpcParams = (params: unknown) =>
       this.lex.assertValidXrpcParams(nsid, params)
     return async function (req, res, next) {

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -4,6 +4,7 @@ import zod from 'zod'
 import { ResponseType, ResponseTypeStrings } from '@atproto/xrpc'
 
 export type Options = {
+  validateResponse?: boolean
   payload?: {
     jsonLimit?: number
     blobLimit?: number

--- a/packages/xrpc/src/types.ts
+++ b/packages/xrpc/src/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ValidationError } from '@atproto/lexicon'
 
 export type QueryParams = Record<string, any>
 export type Headers = Record<string, string>
@@ -94,5 +95,19 @@ export class XRPCError extends Error {
     if (!this.error) {
       this.error = ResponseTypeNames[status]
     }
+  }
+}
+
+export class XRPCInvalidResponseError extends XRPCError {
+  constructor(
+    public lexiconNsid: string,
+    public validationError: ValidationError,
+    public responseBody: unknown,
+  ) {
+    super(
+      ResponseType.InvalidResponse,
+      ResponseTypeStrings[ResponseType.InvalidResponse],
+      `The server gave an invalid response and may be out of date.`,
+    )
   }
 }


### PR DESCRIPTION
Updates:

- Adds typeguard helpers to generated code (eg `isRecord(v: unknown): v is Record`)
- Adds validation helpers to generated code (eg `validateRecord(v: unknown): ValidationResult`)
- Adds a general `validate()` method to the `Lexicons` class.
- Adds a `validateResponse` option to xrpc-server which can be set to `false` to disable validation of responses
- Adds client-side validation of XRPC responses along with a new `XRPCInvalidResponseError` for failed validation.

Basically this PR is tackling a set of tasks we've had queued up in this space. The type-guard and validation helpers are something I've been needing in the app. The client-side validation is to begin to address issues with "faulty" servers.