### PR TITLE
Fix lexicon validation, do not allow undefined when required

### DIFF
--- a/lexicons/app/bsky/actor/search.json
+++ b/lexicons/app/bsky/actor/search.json
@@ -7,7 +7,6 @@
       "description": "Find users matching search criteria.",
       "parameters": {
         "type": "params",
-        "required": ["term"],
         "properties": {
           "term": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},

--- a/lexicons/app/bsky/actor/searchTypeahead.json
+++ b/lexicons/app/bsky/actor/searchTypeahead.json
@@ -7,7 +7,6 @@
       "description": "Find user suggestions for a search term.",
       "parameters": {
         "type": "params",
-        "required": ["term"],
         "properties": {
           "term": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50}

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1241,7 +1241,6 @@ export const schemaDict = {
         description: 'Find users matching search criteria.',
         parameters: {
           type: 'params',
-          required: ['term'],
           properties: {
             term: {
               type: 'string',
@@ -1317,7 +1316,6 @@ export const schemaDict = {
         description: 'Find user suggestions for a search term.',
         parameters: {
           type: 'params',
-          required: ['term'],
           properties: {
             term: {
               type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/search.ts
+++ b/packages/api/src/client/types/app/bsky/actor/search.ts
@@ -8,7 +8,7 @@ import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  term: string
+  term?: string
   limit?: number
   before?: string
 }

--- a/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchTypeahead.ts
@@ -8,7 +8,7 @@ import { lexicons } from '../../../../lexicons'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  term: string
+  term?: string
   limit?: number
 }
 

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -123,7 +123,7 @@ export function object(
   // required
   if (Array.isArray(def.required)) {
     for (const key of def.required) {
-      if (!(key in value)) {
+      if (typeof value[key] === 'undefined') {
         return {
           success: false,
           error: new ValidationError(`${path} must have the property "${key}"`),

--- a/packages/lexicon/src/validators/xrpc.ts
+++ b/packages/lexicon/src/validators/xrpc.ts
@@ -20,7 +20,7 @@ export function params(
   // required
   if (Array.isArray(def.required)) {
     for (const key of def.required) {
-      if (!(key in (value as Record<string, unknown>))) {
+      if (typeof (value as Record<string, unknown>)[key] === 'undefined') {
         return {
           success: false,
           error: new ValidationError(`${path} must have the property "${key}"`),

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -135,6 +135,18 @@ describe('Record validation', () => {
         datetime: new Date().toISOString(),
       }),
     ).toThrow('Record must have the property "object"')
+    expect(() =>
+      lex.assertValidRecord('com.example.kitchenSink', {
+        $type: 'com.example.kitchenSink',
+        object: undefined,
+        array: ['one', 'two'],
+        boolean: true,
+        number: 123.45,
+        integer: 123,
+        string: 'string',
+        datetime: new Date().toISOString(),
+      }),
+    ).toThrow('Record must have the property "object"')
   })
 
   it('Fails incorrect types', () => {
@@ -567,6 +579,13 @@ describe('XRPC parameter validation', () => {
       lex.assertValidXrpcParams('com.example.query', {
         boolean: true,
         number: 123.45,
+      }),
+    ).toThrow('Params must have the property "integer"')
+    expect(() =>
+      lex.assertValidXrpcParams('com.example.query', {
+        boolean: true,
+        number: 123.45,
+        integer: undefined,
       }),
     ).toThrow('Params must have the property "integer"')
   })

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1241,7 +1241,6 @@ export const schemaDict = {
         description: 'Find users matching search criteria.',
         parameters: {
           type: 'params',
-          required: ['term'],
           properties: {
             term: {
               type: 'string',
@@ -1317,7 +1316,6 @@ export const schemaDict = {
         description: 'Find user suggestions for a search term.',
         parameters: {
           type: 'params',
-          required: ['term'],
           properties: {
             term: {
               type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  term: string
+  term?: string
   limit?: number
   before?: string
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  term: string
+  term?: string
   limit?: number
 }
 


### PR DESCRIPTION
I saw `app.bsky.feed.getAuthorFeed` 500ing when passed the parameter `?author=`.  This parameter is considered missing, so it's mapped to `undefined`, and it turns out there's a little bug in the lexicon validation for catching these `undefined`s, so I pulled together this little fix.