### PR TITLE
Fix resolution of server did in com.atproto.handle.resolve

### DIFF
--- a/packages/pds/src/api/com/atproto/handles.ts
+++ b/packages/pds/src/api/com/atproto/handles.ts
@@ -7,7 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     const handle = params.handle
 
     let did = ''
-    if (!handle || handle === ctx.cfg.hostname) {
+    if (!handle || handle === ctx.cfg.publicHostname) {
       // self
       did = ctx.cfg.serverDid
     } else {

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -210,7 +210,7 @@ export class ServerConfig {
   }
 
   get serverDid() {
-    return this.cfg.recoveryKey
+    return this.cfg.serverDid
   }
 
   get recoveryKey() {

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -433,4 +433,18 @@ describe('account', () => {
       client.com.atproto.session.create({ handle, password }),
     ).resolves.toBeDefined()
   })
+
+  it('resolves did for account', async () => {
+    const resolved = await client.com.atproto.handle.resolve({ handle })
+    expect(resolved.data).toEqual({ did })
+  })
+
+  it('resolves did for server', async () => {
+    const resolvedImplicit = await client.com.atproto.handle.resolve({})
+    const resolvedExplicit = await client.com.atproto.handle.resolve({
+      handle: 'pds.public.url',
+    })
+    expect(resolvedImplicit.data).toEqual({ did: cfg.serverDid })
+    expect(resolvedExplicit.data).toEqual({ did: cfg.serverDid })
+  })
 })


### PR DESCRIPTION
This fixes two bugs with resolving the server's did from `com.atproto.handle.resolve`:
 - The recovery did key was being served rather than the server's PLC did.
 - Passing the public hostname of the PDS as `handle` would not resolve the server did, since it was expecting the private hostname.