### PR TITLE
Record write descriptions

### DIFF
--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -177,14 +177,14 @@ export const createWriteToOp = (write: PreparedCreate): RecordCreateOp => ({
   action: WriteOpAction.Create,
   collection: write.uri.collection,
   rkey: write.uri.rkey,
-  value: write.record,
+  record: write.record,
 })
 
 export const updateWriteToOp = (write: PreparedUpdate): RecordUpdateOp => ({
   action: WriteOpAction.Update,
   collection: write.uri.collection,
   rkey: write.uri.rkey,
-  value: write.record,
+  record: write.record,
 })
 
 export const deleteWriteToOp = (write: PreparedDelete): RecordDeleteOp => ({

--- a/packages/pds/tests/event-stream/sync.test.ts
+++ b/packages/pds/tests/event-stream/sync.test.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
-import { getWriteOpLog, RecordWriteOp, WriteOpAction } from '@atproto/repo'
+import { getWriteLog, RecordWriteOp, WriteOpAction } from '@atproto/repo'
 import SqlRepoStorage from '../../src/sql-repo-storage'
 import basicSeed from '../seeds/basic'
 import { SeedClient } from '../seeds/client'
@@ -82,7 +82,7 @@ describe('sync', () => {
     const storage = new SqlRepoStorage(db, did)
     const root = await storage.getHead()
     if (!root) throw new Error('Missing repo root')
-    return await getWriteOpLog(storage, root, null)
+    return await getWriteLog(storage, root, null)
   }
 
   function prepareWrites(
@@ -97,14 +97,14 @@ describe('sync', () => {
             did,
             collection: op.collection,
             rkey: op.rkey,
-            record: op.value,
+            record: op.record,
           })
         } else if (action === WriteOpAction.Update) {
           return prepareUpdate({
             did,
             collection: op.collection,
             rkey: op.rkey,
-            record: op.value,
+            record: op.record,
           })
         } else if (action === WriteOpAction.Delete) {
           return prepareDelete({

--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -46,7 +46,7 @@ export class Repo extends ReadableRepo {
 
     let data = await MST.create(storage)
     for (const write of initialRecords) {
-      const cid = await newBlocks.add(write.value)
+      const cid = await newBlocks.add(write.record)
       const dataKey = write.collection + '/' + write.rkey
       data = await data.add(dataKey, cid)
     }
@@ -127,11 +127,11 @@ export class Repo extends ReadableRepo {
     let data = this.data
     for (const write of writes) {
       if (write.action === WriteOpAction.Create) {
-        const cid = await newBlocks.add(write.value)
+        const cid = await newBlocks.add(write.record)
         const dataKey = write.collection + '/' + write.rkey
         data = await data.add(dataKey, cid)
       } else if (write.action === WriteOpAction.Update) {
-        const cid = await newBlocks.add(write.value)
+        const cid = await newBlocks.add(write.record)
         const dataKey = write.collection + '/' + write.rkey
         data = await data.update(dataKey, cid)
       } else if (write.action === WriteOpAction.Delete) {

--- a/packages/repo/src/types.ts
+++ b/packages/repo/src/types.ts
@@ -64,14 +64,14 @@ export type RecordCreateOp = {
   action: WriteOpAction.Create
   collection: string
   rkey: string
-  value: Record<string, unknown>
+  record: Record<string, unknown>
 }
 
 export type RecordUpdateOp = {
   action: WriteOpAction.Update
   collection: string
   rkey: string
-  value: Record<string, unknown>
+  record: Record<string, unknown>
 }
 
 export type RecordDeleteOp = {
@@ -81,6 +81,26 @@ export type RecordDeleteOp = {
 }
 
 export type RecordWriteOp = RecordCreateOp | RecordUpdateOp | RecordDeleteOp
+
+export type RecordCreateDescript = RecordCreateOp & {
+  cid: CID
+}
+
+export type RecordUpdateDescript = RecordUpdateOp & {
+  prev: CID
+  cid: CID
+}
+
+export type RecordDeleteDescript = RecordDeleteOp & {
+  cid: CID
+}
+
+export type RecordWriteDescript =
+  | RecordCreateDescript
+  | RecordUpdateDescript
+  | RecordDeleteDescript
+
+export type WriteLog = RecordWriteDescript[][]
 
 // Updates/Commits
 // ---------------

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -33,8 +33,8 @@ describe('Repo', () => {
       {
         action: WriteOpAction.Create,
         collection: collName,
-        rkey: rkey,
-        value: record,
+        rkey,
+        record,
       },
       keypair,
     )
@@ -47,8 +47,8 @@ describe('Repo', () => {
       {
         action: WriteOpAction.Update,
         collection: collName,
-        rkey: rkey,
-        value: updatedRecord,
+        rkey,
+        record: updatedRecord,
       },
       keypair,
     )

--- a/packages/repo/tests/sync.test.ts
+++ b/packages/repo/tests/sync.test.ts
@@ -46,7 +46,7 @@ describe('Sync', () => {
     bobRepo = await Repo.load(syncBlockstore, loaded.root)
     const contents = await bobRepo.getContents()
     expect(contents).toEqual(repoData)
-    await util.verifyRepoDiff(loaded.ops, {}, repoData)
+    await util.verifyRepoDiff(loaded.writeLog, {}, repoData)
   })
 
   it('syncs a repo that is behind', async () => {
@@ -64,7 +64,7 @@ describe('Sync', () => {
     bobRepo = await Repo.load(syncBlockstore, loaded.root)
     const contents = await bobRepo.getContents()
     expect(contents).toEqual(repoData)
-    await util.verifyRepoDiff(loaded.ops, beforeData, repoData)
+    await util.verifyRepoDiff(loaded.writeLog, beforeData, repoData)
   })
 
   it('throws on a bad signature', async () => {


### PR DESCRIPTION
Adds a new type similar to `RecordWriteOp`: `RecordWriteDescript` which includes relevant CIDs to the operation. 

Generally "ops" are used when _making_ a change. "descripts" are used when _syncing_ a change.

Alongside this, commit-aware sync methods now return a `WriteLog` which is `RecordWriteDescript[][]` which can then be collapsed down into a single array of all writes that occurred over that range

Motivated by https://github.com/bluesky-social/atproto/pull/444#discussion_r1061677134