### PR TITLE
Admin view of repo and record details

### DIFF
--- a/lexicons/com/atproto/admin/getRecord.json
+++ b/lexicons/com/atproto/admin/getRecord.json
@@ -1,0 +1,22 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.getRecord",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "View details about a record.",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {"type": "string"},
+          "cid": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {"type": "ref", "ref": "com.atproto.admin.record#viewDetail"}
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/admin/getRepo.json
+++ b/lexicons/com/atproto/admin/getRepo.json
@@ -1,0 +1,21 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.getRepo",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "View details about a repository.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {"type": "ref", "ref": "com.atproto.admin.repo#viewDetail"}
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/admin/record.json
+++ b/lexicons/com/atproto/admin/record.json
@@ -35,7 +35,7 @@
     },
     "moderationDetail": {
       "type": "object",
-      "required": [],
+      "required": ["actions", "reports"],
       "properties": {
         "actions": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationAction#view"}},
         "reports": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationReport#view"}},

--- a/lexicons/com/atproto/admin/repo.json
+++ b/lexicons/com/atproto/admin/repo.json
@@ -42,7 +42,7 @@
     },
     "moderationDetail": {
       "type": "object",
-      "required": [],
+      "required": ["actions", "reports"],
       "properties": {
         "actions": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationAction#view"}},
         "reports": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationReport#view"}},

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -12,6 +12,8 @@ import * as ComAtprotoAccountDelete from './types/com/atproto/account/delete'
 import * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 import * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 import * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
+import * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
+import * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 import * as ComAtprotoAdminModerationAction from './types/com/atproto/admin/moderationAction'
 import * as ComAtprotoAdminModerationReport from './types/com/atproto/admin/moderationReport'
 import * as ComAtprotoAdminRecord from './types/com/atproto/admin/record'
@@ -91,6 +93,8 @@ export * as ComAtprotoAccountDelete from './types/com/atproto/account/delete'
 export * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 export * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 export * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
+export * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
+export * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 export * as ComAtprotoAdminModerationAction from './types/com/atproto/admin/moderationAction'
 export * as ComAtprotoAdminModerationReport from './types/com/atproto/admin/moderationReport'
 export * as ComAtprotoAdminRecord from './types/com/atproto/admin/record'
@@ -330,6 +334,28 @@ export class AdminNS {
 
   constructor(service: ServiceClient) {
     this._service = service
+  }
+
+  getRecord(
+    params?: ComAtprotoAdminGetRecord.QueryParams,
+    opts?: ComAtprotoAdminGetRecord.CallOptions,
+  ): Promise<ComAtprotoAdminGetRecord.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.getRecord', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminGetRecord.toKnownErr(e)
+      })
+  }
+
+  getRepo(
+    params?: ComAtprotoAdminGetRepo.QueryParams,
+    opts?: ComAtprotoAdminGetRepo.CallOptions,
+  ): Promise<ComAtprotoAdminGetRepo.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.getRepo', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminGetRepo.toKnownErr(e)
+      })
   }
 
   resolveModerationReports(

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -478,7 +478,7 @@ export const schemaDict = {
       },
       moderationDetail: {
         type: 'object',
-        required: [],
+        required: ['actions', 'reports'],
         properties: {
           actions: {
             type: 'array',
@@ -595,7 +595,7 @@ export const schemaDict = {
       },
       moderationDetail: {
         type: 'object',
-        required: [],
+        required: ['actions', 'reports'],
         properties: {
           actions: {
             type: 'array',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -182,6 +182,61 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminGetRecord: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getRecord',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'View details about a record.',
+        parameters: {
+          type: 'params',
+          required: ['uri'],
+          properties: {
+            uri: {
+              type: 'string',
+            },
+            cid: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:com.atproto.admin.record#viewDetail',
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoAdminGetRepo: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getRepo',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'View details about a repository.',
+        parameters: {
+          type: 'params',
+          required: ['did'],
+          properties: {
+            did: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:com.atproto.admin.repo#viewDetail',
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminModerationAction: {
     lexicon: 1,
     id: 'com.atproto.admin.moderationAction',
@@ -3846,6 +3901,8 @@ export const ids = {
   ComAtprotoAccountRequestPasswordReset:
     'com.atproto.account.requestPasswordReset',
   ComAtprotoAccountResetPassword: 'com.atproto.account.resetPassword',
+  ComAtprotoAdminGetRecord: 'com.atproto.admin.getRecord',
+  ComAtprotoAdminGetRepo: 'com.atproto.admin.getRepo',
   ComAtprotoAdminModerationAction: 'com.atproto.admin.moderationAction',
   ComAtprotoAdminModerationReport: 'com.atproto.admin.moderationReport',
   ComAtprotoAdminRecord: 'com.atproto.admin.record',

--- a/packages/api/src/client/types/com/atproto/admin/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRecord.ts
@@ -1,0 +1,29 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import * as ComAtprotoAdminRecord from './record'
+
+export interface QueryParams {
+  uri: string
+  cid?: string
+}
+
+export type InputSchema = undefined
+export type OutputSchema = ComAtprotoAdminRecord.ViewDetail
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/admin/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRepo.ts
@@ -1,0 +1,28 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import * as ComAtprotoAdminRepo from './repo'
+
+export interface QueryParams {
+  did: string
+}
+
+export type InputSchema = undefined
+export type OutputSchema = ComAtprotoAdminRepo.ViewDetail
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/admin/record.ts
+++ b/packages/api/src/client/types/com/atproto/admin/record.ts
@@ -31,8 +31,8 @@ export interface Moderation {
 }
 
 export interface ModerationDetail {
-  actions?: ComAtprotoAdminModerationAction.View[]
-  reports?: ComAtprotoAdminModerationReport.View[]
+  actions: ComAtprotoAdminModerationAction.View[]
+  reports: ComAtprotoAdminModerationReport.View[]
   takedownId?: number
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/com/atproto/admin/repo.ts
+++ b/packages/api/src/client/types/com/atproto/admin/repo.ts
@@ -35,8 +35,8 @@ export interface Moderation {
 }
 
 export interface ModerationDetail {
-  actions?: ComAtprotoAdminModerationAction.View[]
-  reports?: ComAtprotoAdminModerationReport.View[]
+  actions: ComAtprotoAdminModerationAction.View[]
+  reports: ComAtprotoAdminModerationReport.View[]
   takedownId?: number
   [k: string]: unknown
 }

--- a/packages/pds/src/api/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRecord.ts
@@ -1,0 +1,22 @@
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+import { AtUri } from '@atproto/uri'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.getRecord({
+    auth: ctx.adminVerifier,
+    handler: async ({ params }) => {
+      const { db, services } = ctx
+      const { uri, cid } = params
+      const result = await services
+        .record(db)
+        .getRecord(new AtUri(uri), cid ?? null, true)
+      if (!result) throw new InvalidRequestError('Record not found')
+      return {
+        encoding: 'application/json',
+        body: await services.moderation(db).views.recordDetail(result),
+      }
+    },
+  })
+}

--- a/packages/pds/src/api/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRepo.ts
@@ -1,0 +1,19 @@
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.getRepo({
+    auth: ctx.adminVerifier,
+    handler: async ({ params }) => {
+      const { db, services } = ctx
+      const { did } = params
+      const result = await services.actor(db).getUser(did, true)
+      if (!result) throw new InvalidRequestError('Repo not found')
+      return {
+        encoding: 'application/json',
+        body: await services.moderation(db).views.repoDetail(result),
+      }
+    },
+  })
+}

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -4,6 +4,7 @@ import resolveModerationReports from './resolveModerationReports'
 import reverseModerationAction from './reverseModerationAction'
 import takeModerationAction from './takeModerationAction'
 import searchRepos from './searchRepos'
+import getRecord from './getRecord'
 import getRepo from './getRepo'
 
 export default function (server: Server, ctx: AppContext) {
@@ -11,5 +12,6 @@ export default function (server: Server, ctx: AppContext) {
   reverseModerationAction(server, ctx)
   takeModerationAction(server, ctx)
   searchRepos(server, ctx)
+  getRecord(server, ctx)
   getRepo(server, ctx)
 }

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -4,10 +4,12 @@ import resolveModerationReports from './resolveModerationReports'
 import reverseModerationAction from './reverseModerationAction'
 import takeModerationAction from './takeModerationAction'
 import searchRepos from './searchRepos'
+import getRepo from './getRepo'
 
 export default function (server: Server, ctx: AppContext) {
   resolveModerationReports(server, ctx)
   reverseModerationAction(server, ctx)
   takeModerationAction(server, ctx)
   searchRepos(server, ctx)
+  getRepo(server, ctx)
 }

--- a/packages/pds/src/api/com/atproto/admin/resolveModerationReports.ts
+++ b/packages/pds/src/api/com/atproto/admin/resolveModerationReports.ts
@@ -58,7 +58,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: await moderationService.formatActionView(moderationAction),
+        body: await moderationService.views.action(moderationAction),
       }
     },
   })

--- a/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
@@ -58,7 +58,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: await moderationService.formatActionView(moderationAction),
+        body: await moderationService.views.action(moderationAction),
       }
     },
   })

--- a/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
@@ -17,7 +17,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: await moderationService.formatActionView(moderationAction),
+        body: await moderationService.views.action(moderationAction),
       }
     },
   })

--- a/packages/pds/src/api/com/atproto/report.ts
+++ b/packages/pds/src/api/com/atproto/report.ts
@@ -29,7 +29,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: moderationService.formatReportView(report),
+        body: moderationService.views.reportPublic(report),
       }
     },
   })

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -14,6 +14,8 @@ import * as ComAtprotoAccountDelete from './types/com/atproto/account/delete'
 import * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 import * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 import * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
+import * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
+import * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 import * as ComAtprotoAdminResolveModerationReports from './types/com/atproto/admin/resolveModerationReports'
 import * as ComAtprotoAdminReverseModerationAction from './types/com/atproto/admin/reverseModerationAction'
 import * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRepos'
@@ -191,6 +193,20 @@ export class AdminNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  getRecord<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoAdminGetRecord.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.admin.getRecord' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getRepo<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoAdminGetRepo.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.admin.getRepo' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   resolveModerationReports<AV extends AuthVerifier>(

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -478,7 +478,7 @@ export const schemaDict = {
       },
       moderationDetail: {
         type: 'object',
-        required: [],
+        required: ['actions', 'reports'],
         properties: {
           actions: {
             type: 'array',
@@ -595,7 +595,7 @@ export const schemaDict = {
       },
       moderationDetail: {
         type: 'object',
-        required: [],
+        required: ['actions', 'reports'],
         properties: {
           actions: {
             type: 'array',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -182,6 +182,61 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminGetRecord: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getRecord',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'View details about a record.',
+        parameters: {
+          type: 'params',
+          required: ['uri'],
+          properties: {
+            uri: {
+              type: 'string',
+            },
+            cid: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:com.atproto.admin.record#viewDetail',
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoAdminGetRepo: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getRepo',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'View details about a repository.',
+        parameters: {
+          type: 'params',
+          required: ['did'],
+          properties: {
+            did: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:com.atproto.admin.repo#viewDetail',
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminModerationAction: {
     lexicon: 1,
     id: 'com.atproto.admin.moderationAction',
@@ -3846,6 +3901,8 @@ export const ids = {
   ComAtprotoAccountRequestPasswordReset:
     'com.atproto.account.requestPasswordReset',
   ComAtprotoAccountResetPassword: 'com.atproto.account.resetPassword',
+  ComAtprotoAdminGetRecord: 'com.atproto.admin.getRecord',
+  ComAtprotoAdminGetRepo: 'com.atproto.admin.getRepo',
   ComAtprotoAdminModerationAction: 'com.atproto.admin.moderationAction',
   ComAtprotoAdminModerationReport: 'com.atproto.admin.moderationReport',
   ComAtprotoAdminRecord: 'com.atproto.admin.record',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getRecord.ts
@@ -1,0 +1,34 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoAdminRecord from './record'
+
+export interface QueryParams {
+  uri: string
+  cid?: string
+}
+
+export type InputSchema = undefined
+export type OutputSchema = ComAtprotoAdminRecord.ViewDetail
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getRepo.ts
@@ -1,0 +1,33 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoAdminRepo from './repo'
+
+export interface QueryParams {
+  did: string
+}
+
+export type InputSchema = undefined
+export type OutputSchema = ComAtprotoAdminRepo.ViewDetail
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/types/com/atproto/admin/record.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/record.ts
@@ -31,8 +31,8 @@ export interface Moderation {
 }
 
 export interface ModerationDetail {
-  actions?: ComAtprotoAdminModerationAction.View[]
-  reports?: ComAtprotoAdminModerationReport.View[]
+  actions: ComAtprotoAdminModerationAction.View[]
+  reports: ComAtprotoAdminModerationReport.View[]
   takedownId?: number
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/com/atproto/admin/repo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/repo.ts
@@ -35,8 +35,8 @@ export interface Moderation {
 }
 
 export interface ModerationDetail {
-  actions?: ComAtprotoAdminModerationAction.View[]
-  reports?: ComAtprotoAdminModerationReport.View[]
+  actions: ComAtprotoAdminModerationAction.View[]
+  reports: ComAtprotoAdminModerationReport.View[]
   takedownId?: number
   [k: string]: unknown
 }

--- a/packages/pds/src/services/actor.ts
+++ b/packages/pds/src/services/actor.ts
@@ -22,7 +22,7 @@ export class ActorService {
   async getUser(
     handleOrDid: string,
     includeSoftDeleted = false,
-  ): Promise<(User & DidHandle & { takedownId: number | null }) | null> {
+  ): Promise<(User & DidHandle & RepoRoot) | null> {
     const { ref } = this.db.db.dynamic
     let query = this.db.db
       .selectFrom('user')
@@ -33,7 +33,7 @@ export class ActorService {
       )
       .selectAll('user')
       .selectAll('did_handle')
-      .select('repo_root.takedownId')
+      .selectAll('repo_root')
     if (handleOrDid.startsWith('did:')) {
       query = query.where('did_handle.did', '=', handleOrDid)
     } else {

--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -1,8 +1,13 @@
+import { Selectable } from 'kysely'
 import { ipldBytesToRecord } from '@atproto/common'
 import Database from '../../db'
 import { DidHandle } from '../../db/tables/did-handle'
 import { RepoRoot } from '../../db/tables/repo-root'
 import { View as RepoView } from '../../lexicon/types/com/atproto/admin/repo'
+import { View as ActionView } from '../../lexicon/types/com/atproto/admin/moderationAction'
+import { View as ReportView } from '../../lexicon/types/com/atproto/admin/moderationReport'
+import { OutputSchema as ReportOutput } from '../../lexicon/types/com/atproto/report/create'
+import { ModerationAction, ModerationReport } from '../../db/tables/moderation'
 
 export class ModerationViews {
   constructor(private db: Database) {}
@@ -48,7 +53,7 @@ export class ModerationViews {
     )
 
     const views = results.map((r) => {
-      const { email, declarationBytes, profileBytes } = infoByDid[r.did]
+      const { email, declarationBytes, profileBytes } = infoByDid[r.did] ?? {}
       const relatedRecords: object[] = []
       if (declarationBytes) {
         relatedRecords.push(ipldBytesToRecord(declarationBytes))
@@ -68,8 +73,141 @@ export class ModerationViews {
 
     return Array.isArray(result) ? views : views[0]
   }
+
+  action(result: ActionResult): Promise<ActionView>
+  action(result: ActionResult[]): Promise<ActionView[]>
+  async action(
+    result: ActionResult | ActionResult[],
+  ): Promise<ActionView | ActionView[]> {
+    const results = Array.isArray(result) ? result : [result]
+    if (results.length === 0) return []
+
+    const resolutions = await this.db.db
+      .selectFrom('moderation_report_resolution')
+      .select(['reportId as id', 'actionId'])
+      .where(
+        'actionId',
+        'in',
+        results.map((r) => r.id),
+      )
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
+      .execute()
+
+    const reportIdsByActionId = resolutions.reduce((acc, cur) => {
+      acc[cur.actionId] ??= []
+      acc[cur.actionId].push(cur.id)
+      return acc
+    }, {} as Record<string, number[]>)
+
+    const views = results.map((res) => ({
+      id: res.id,
+      action: res.action,
+      subject:
+        res.subjectType === 'com.atproto.repo.repoRef'
+          ? {
+              $type: 'com.atproto.repo.repoRef',
+              did: res.subjectDid,
+            }
+          : {
+              $type: 'com.atproto.repo.strongRef',
+              uri: res.subjectUri,
+              cid: res.subjectCid,
+            },
+      reason: res.reason,
+      createdAt: res.createdAt,
+      createdBy: res.createdBy,
+      reversal:
+        res.reversedAt !== null &&
+        res.reversedBy !== null &&
+        res.reversedReason !== null
+          ? {
+              createdAt: res.reversedAt,
+              createdBy: res.reversedBy,
+              reason: res.reversedReason,
+            }
+          : undefined,
+      resolvedReportIds: reportIdsByActionId[res.id] ?? [],
+    }))
+
+    return Array.isArray(result) ? views : views[0]
+  }
+
+  report(result: ReportResult): Promise<ReportView>
+  report(result: ReportResult[]): Promise<ReportView[]>
+  async report(
+    result: ReportResult | ReportResult[],
+  ): Promise<ReportView | ReportView[]> {
+    const results = Array.isArray(result) ? result : [result]
+    if (results.length === 0) return []
+
+    const resolutions = await this.db.db
+      .selectFrom('moderation_report_resolution')
+      .select(['actionId as id', 'reportId'])
+      .where(
+        'reportId',
+        'in',
+        results.map((r) => r.id),
+      )
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
+      .execute()
+
+    const actionIdsByReportId = resolutions.reduce((acc, cur) => {
+      acc[cur.reportId] ??= []
+      acc[cur.reportId].push(cur.id)
+      return acc
+    }, {} as Record<string, number[]>)
+
+    const views: ReportView[] = results.map((res) => ({
+      id: res.id,
+      createdAt: res.createdAt,
+      reasonType: res.reasonType,
+      reason: res.reason ?? undefined,
+      reportedByDid: res.reportedByDid,
+      subject:
+        res.subjectType === 'com.atproto.repo.repoRef'
+          ? {
+              $type: 'com.atproto.repo.repoRef',
+              did: res.subjectDid,
+            }
+          : {
+              $type: 'com.atproto.repo.strongRef',
+              uri: res.subjectUri,
+              cid: res.subjectCid,
+            },
+      resolvedByActionIds: actionIdsByReportId[res.id] ?? [],
+    }))
+
+    return Array.isArray(result) ? views : views[0]
+  }
+
+  reportPublic(report: ReportResult): ReportOutput {
+    return {
+      id: report.id,
+      createdAt: report.createdAt,
+      reasonType: report.reasonType,
+      reason: report.reason ?? undefined,
+      reportedByDid: report.reportedByDid,
+      subject:
+        report.subjectType === 'com.atproto.repo.repoRef'
+          ? {
+              $type: 'com.atproto.repo.repoRef',
+              did: report.subjectDid,
+            }
+          : {
+              $type: 'com.atproto.repo.strongRef',
+              uri: report.subjectUri,
+              cid: report.subjectCid,
+            },
+    }
+  }
 }
 
 type RepoResult = DidHandle & RepoRoot
+
+type ActionResult = Selectable<ModerationAction>
+
+type ReportResult = Selectable<ModerationReport>
 
 type ArrayEl<A> = A extends readonly (infer T)[] ? T : never

--- a/packages/pds/src/services/record/index.ts
+++ b/packages/pds/src/services/record/index.ts
@@ -159,7 +159,13 @@ export class RecordService {
     uri: AtUri,
     cid: string | null,
     includeSoftDeleted = false,
-  ): Promise<{ uri: string; cid: string; value: object } | null> {
+  ): Promise<{
+    uri: string
+    cid: string
+    value: object
+    indexedAt: string
+    takedownId: number | null
+  } | null> {
     const { ref } = this.db.db.dynamic
     let builder = this.db.db
       .selectFrom('record')
@@ -178,6 +184,8 @@ export class RecordService {
       uri: record.uri,
       cid: record.cid,
       value: common.ipldBytesToRecord(record.content),
+      indexedAt: record.indexedAt,
+      takedownId: record.takedownId,
     }
   }
 

--- a/packages/pds/tests/views/admin/__snapshots__/get-record.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-record.test.ts.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds admin get record view gets a record by uri and cid. 1`] = `
+Object {
+  "cid": "cids(0)",
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "moderation": Object {
+    "actions": Array [
+      Object {
+        "action": "com.atproto.admin.moderationAction#takedown",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 2,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "action": "com.atproto.admin.moderationAction#acknowledge",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 1,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "reversal": Object {
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdBy": "Y",
+          "reason": "X",
+        },
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+    ],
+    "reports": Array [
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 2,
+        "reason": "defamation",
+        "reasonType": "com.atproto.report.reasonType#other",
+        "reportedByDid": "user(1)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 1,
+        "reasonType": "com.atproto.report.reasonType#spam",
+        "reportedByDid": "user(2)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+    ],
+    "takedownId": 2,
+  },
+  "repo": Object {
+    "account": Object {
+      "email": "alice@test.com",
+    },
+    "did": "user(0)",
+    "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "moderation": Object {},
+    "relatedRecords": Array [
+      Object {
+        "$type": "app.bsky.system.declaration",
+        "actorType": "app.bsky.system.actorUser",
+      },
+      Object {
+        "$type": "app.bsky.actor.profile",
+        "avatar": Object {
+          "cid": "cids(1)",
+          "mimeType": "image/jpeg",
+        },
+        "description": "its me!",
+        "displayName": "ali",
+      },
+    ],
+  },
+  "uri": "record(0)",
+  "value": Object {
+    "$type": "app.bsky.feed.post",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "text": "hey there",
+  },
+}
+`;
+
+exports[`pds admin get record view gets a record by uri, even when taken down. 1`] = `
+Object {
+  "cid": "cids(0)",
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "moderation": Object {
+    "actions": Array [
+      Object {
+        "action": "com.atproto.admin.moderationAction#takedown",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 2,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "action": "com.atproto.admin.moderationAction#acknowledge",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 1,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "reversal": Object {
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdBy": "Y",
+          "reason": "X",
+        },
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+    ],
+    "reports": Array [
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 2,
+        "reason": "defamation",
+        "reasonType": "com.atproto.report.reasonType#other",
+        "reportedByDid": "user(1)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 1,
+        "reasonType": "com.atproto.report.reasonType#spam",
+        "reportedByDid": "user(2)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+    ],
+    "takedownId": 2,
+  },
+  "repo": Object {
+    "account": Object {
+      "email": "alice@test.com",
+    },
+    "did": "user(0)",
+    "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "moderation": Object {},
+    "relatedRecords": Array [
+      Object {
+        "$type": "app.bsky.system.declaration",
+        "actorType": "app.bsky.system.actorUser",
+      },
+      Object {
+        "$type": "app.bsky.actor.profile",
+        "avatar": Object {
+          "cid": "cids(1)",
+          "mimeType": "image/jpeg",
+        },
+        "description": "its me!",
+        "displayName": "ali",
+      },
+    ],
+  },
+  "uri": "record(0)",
+  "value": Object {
+    "$type": "app.bsky.feed.post",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "text": "hey there",
+  },
+}
+`;

--- a/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pds admin get repo view gets a repo by did. 1`] = `
+exports[`pds admin get repo view gets a repo by did, even when taken down. 1`] = `
 Object {
   "account": Object {
     "email": "alice@test.com",

--- a/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds admin get repo view gets a repo by did. 1`] = `
+Object {
+  "account": Object {
+    "email": "alice@test.com",
+  },
+  "did": "user(0)",
+  "handle": "alice.test",
+  "indexedAt": "1970-01-01T00:00:00.000Z",
+  "moderation": Object {
+    "actions": Array [
+      Object {
+        "action": "com.atproto.admin.moderationAction#takedown",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 2,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.repoRef",
+          "did": "user(0)",
+        },
+      },
+      Object {
+        "action": "com.atproto.admin.moderationAction#acknowledge",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "Y",
+        "id": 1,
+        "reason": "X",
+        "resolvedReportIds": Array [],
+        "reversal": Object {
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdBy": "Y",
+          "reason": "X",
+        },
+        "subject": Object {
+          "$type": "com.atproto.repo.repoRef",
+          "did": "user(0)",
+        },
+      },
+    ],
+    "reports": Array [
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 2,
+        "reason": "defamation",
+        "reasonType": "com.atproto.report.reasonType#other",
+        "reportedByDid": "user(1)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.repoRef",
+          "did": "user(0)",
+        },
+      },
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 1,
+        "reasonType": "com.atproto.report.reasonType#spam",
+        "reportedByDid": "user(2)",
+        "resolvedByActionIds": Array [],
+        "subject": Object {
+          "$type": "com.atproto.repo.repoRef",
+          "did": "user(0)",
+        },
+      },
+    ],
+    "takedownId": 2,
+  },
+  "relatedRecords": Array [
+    Object {
+      "$type": "app.bsky.system.declaration",
+      "actorType": "app.bsky.system.actorUser",
+    },
+    Object {
+      "$type": "app.bsky.actor.profile",
+      "avatar": Object {
+        "cid": "cids(0)",
+        "mimeType": "image/jpeg",
+      },
+      "description": "its me!",
+      "displayName": "ali",
+    },
+  ],
+}
+`;

--- a/packages/pds/tests/views/admin/get-repo.test.ts
+++ b/packages/pds/tests/views/admin/get-repo.test.ts
@@ -1,0 +1,135 @@
+import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import {
+  ACKNOWLEDGE,
+  TAKEDOWN,
+} from '@atproto/api/src/client/types/com/atproto/admin/moderationAction'
+import {
+  OTHER,
+  SPAM,
+} from '../../../src/lexicon/types/com/atproto/report/reasonType'
+import { InputSchema as TakeActionInput } from '@atproto/api/src/client/types/com/atproto/admin/takeModerationAction'
+import { InputSchema as CreateReportInput } from '@atproto/api/src/client/types/com/atproto/report/create'
+import { runTestServer, forSnapshot, CloseFn, adminAuth } from '../../_util'
+import { SeedClient } from '../../seeds/client'
+import basicSeed from '../../seeds/basic'
+
+describe('pds admin get repo view', () => {
+  let client: AtpServiceClient
+  let close: CloseFn
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'views_admin_get_repo',
+    })
+    close = server.close
+    client = AtpApi.service(server.url)
+    sc = new SeedClient(client)
+    await basicSeed(sc)
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  beforeAll(async () => {
+    const acknowledge = await takeModerationAction({
+      action: ACKNOWLEDGE,
+      subject: {
+        $type: 'com.atproto.repo.repoRef',
+        did: sc.dids.alice,
+      },
+    })
+    await createReport({
+      reportedByDid: sc.dids.bob,
+      reasonType: SPAM,
+      subject: {
+        $type: 'com.atproto.repo.repoRef',
+        did: sc.dids.alice,
+      },
+    })
+    await createReport({
+      reportedByDid: sc.dids.carol,
+      reasonType: OTHER,
+      reason: 'defamation',
+      subject: {
+        $type: 'com.atproto.repo.repoRef',
+        did: sc.dids.alice,
+      },
+    })
+    await reverseModerationAction({ id: acknowledge.id })
+    await takeModerationAction({
+      action: TAKEDOWN,
+      subject: {
+        $type: 'com.atproto.repo.repoRef',
+        did: sc.dids.alice,
+      },
+    })
+  })
+
+  it('gets a repo by did.', async () => {
+    const result = await client.com.atproto.admin.getRepo(
+      { did: sc.dids.alice },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data)).toMatchSnapshot()
+  })
+
+  it('fails when repo does not exist.', async () => {
+    const promise = client.com.atproto.admin.getRepo(
+      { did: 'did:plc:doesnotexist' },
+      { headers: { authorization: adminAuth() } },
+    )
+    await expect(promise).rejects.toThrow('Repo not found')
+  })
+
+  async function takeModerationAction(opts: {
+    action: TakeActionInput['action']
+    subject: TakeActionInput['subject']
+    reason?: string
+    createdBy?: string
+  }) {
+    const { action, subject, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.takeModerationAction(
+      { action, subject, createdBy, reason },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function reverseModerationAction(opts: {
+    id: number
+    reason?: string
+    createdBy?: string
+  }) {
+    const { id, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.reverseModerationAction(
+      { id, reason, createdBy },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function createReport(opts: {
+    reasonType: CreateReportInput['reasonType']
+    subject: CreateReportInput['subject']
+    reason?: string
+    reportedByDid: string
+  }) {
+    const { reasonType, subject, reason, reportedByDid } = opts
+    const result = await client.com.atproto.report.create(
+      { reasonType, subject, reason },
+      {
+        encoding: 'application/json',
+        headers: sc.getHeaders(reportedByDid),
+      },
+    )
+    return result.data
+  }
+})

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -11,7 +11,7 @@ import { SeedClient } from '../../seeds/client'
 import usersBulkSeed from '../../seeds/users-bulk'
 import { Database } from '../../../src'
 
-describe('pds user search views', () => {
+describe('pds admin repo search view', () => {
   let client: AtpServiceClient
   let db: Database
   let close: CloseFn


### PR DESCRIPTION
Implements `com.atproto.admin.getRepo` and `com.atproto.admin.getRecord`, for admins to view details on repos and records such as their server moderation history.