### PR TITLE
Admin view of moderation action and report history

### DIFF
--- a/lexicons/com/atproto/admin/getModerationActions.json
+++ b/lexicons/com/atproto/admin/getModerationActions.json
@@ -1,0 +1,29 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.getModerationActions",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List moderation actions related to a subject.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "subject": {"type": "string"},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+          "before": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["actions"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "actions": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationAction#view"}}
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/admin/getModerationReports.json
+++ b/lexicons/com/atproto/admin/getModerationReports.json
@@ -1,0 +1,30 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.getModerationReports",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List moderation reports related to a subject.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "subject": {"type": "string"},
+          "resolved": {"type": "boolean"},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+          "before": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["reports"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "reports": {"type": "array", "items": {"type": "ref", "ref": "com.atproto.admin.moderationReport#view"}}
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -13,7 +13,9 @@ import * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 import * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 import * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
 import * as ComAtprotoAdminGetModerationAction from './types/com/atproto/admin/getModerationAction'
+import * as ComAtprotoAdminGetModerationActions from './types/com/atproto/admin/getModerationActions'
 import * as ComAtprotoAdminGetModerationReport from './types/com/atproto/admin/getModerationReport'
+import * as ComAtprotoAdminGetModerationReports from './types/com/atproto/admin/getModerationReports'
 import * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
 import * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 import * as ComAtprotoAdminModerationAction from './types/com/atproto/admin/moderationAction'
@@ -96,7 +98,9 @@ export * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 export * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 export * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
 export * as ComAtprotoAdminGetModerationAction from './types/com/atproto/admin/getModerationAction'
+export * as ComAtprotoAdminGetModerationActions from './types/com/atproto/admin/getModerationActions'
 export * as ComAtprotoAdminGetModerationReport from './types/com/atproto/admin/getModerationReport'
+export * as ComAtprotoAdminGetModerationReports from './types/com/atproto/admin/getModerationReports'
 export * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
 export * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 export * as ComAtprotoAdminModerationAction from './types/com/atproto/admin/moderationAction'
@@ -351,6 +355,17 @@ export class AdminNS {
       })
   }
 
+  getModerationActions(
+    params?: ComAtprotoAdminGetModerationActions.QueryParams,
+    opts?: ComAtprotoAdminGetModerationActions.CallOptions,
+  ): Promise<ComAtprotoAdminGetModerationActions.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.getModerationActions', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminGetModerationActions.toKnownErr(e)
+      })
+  }
+
   getModerationReport(
     params?: ComAtprotoAdminGetModerationReport.QueryParams,
     opts?: ComAtprotoAdminGetModerationReport.CallOptions,
@@ -359,6 +374,17 @@ export class AdminNS {
       .call('com.atproto.admin.getModerationReport', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoAdminGetModerationReport.toKnownErr(e)
+      })
+  }
+
+  getModerationReports(
+    params?: ComAtprotoAdminGetModerationReports.QueryParams,
+    opts?: ComAtprotoAdminGetModerationReports.CallOptions,
+  ): Promise<ComAtprotoAdminGetModerationReports.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.getModerationReports', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminGetModerationReports.toKnownErr(e)
       })
   }
 

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -208,6 +208,52 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminGetModerationActions: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getModerationActions',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'List moderation actions related to a subject.',
+        parameters: {
+          type: 'params',
+          properties: {
+            subject: {
+              type: 'string',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            before: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['actions'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              actions: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.admin.moderationAction#view',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminGetModerationReport: {
     lexicon: 1,
     id: 'com.atproto.admin.getModerationReport',
@@ -229,6 +275,55 @@ export const schemaDict = {
           schema: {
             type: 'ref',
             ref: 'lex:com.atproto.admin.moderationReport#viewDetail',
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoAdminGetModerationReports: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getModerationReports',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'List moderation reports related to a subject.',
+        parameters: {
+          type: 'params',
+          properties: {
+            subject: {
+              type: 'string',
+            },
+            resolved: {
+              type: 'boolean',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            before: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['reports'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              reports: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.admin.moderationReport#view',
+                },
+              },
+            },
           },
         },
       },
@@ -4010,7 +4105,9 @@ export const ids = {
     'com.atproto.account.requestPasswordReset',
   ComAtprotoAccountResetPassword: 'com.atproto.account.resetPassword',
   ComAtprotoAdminGetModerationAction: 'com.atproto.admin.getModerationAction',
+  ComAtprotoAdminGetModerationActions: 'com.atproto.admin.getModerationActions',
   ComAtprotoAdminGetModerationReport: 'com.atproto.admin.getModerationReport',
+  ComAtprotoAdminGetModerationReports: 'com.atproto.admin.getModerationReports',
   ComAtprotoAdminGetRecord: 'com.atproto.admin.getRecord',
   ComAtprotoAdminGetRepo: 'com.atproto.admin.getRepo',
   ComAtprotoAdminModerationAction: 'com.atproto.admin.moderationAction',

--- a/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
@@ -1,0 +1,35 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import * as ComAtprotoAdminModerationAction from './moderationAction'
+
+export interface QueryParams {
+  subject?: string
+  limit?: number
+  before?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  actions: ComAtprotoAdminModerationAction.View[]
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
@@ -1,0 +1,36 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import * as ComAtprotoAdminModerationReport from './moderationReport'
+
+export interface QueryParams {
+  subject?: string
+  resolved?: boolean
+  limit?: number
+  before?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  reports: ComAtprotoAdminModerationReport.View[]
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/pds/src/api/com/atproto/admin/getModerationActions.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationActions.ts
@@ -1,0 +1,25 @@
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.getModerationActions({
+    auth: ctx.adminVerifier,
+    handler: async ({ params }) => {
+      const { db, services } = ctx
+      const { subject, limit = 50, before } = params
+      const moderationService = services.moderation(db)
+      const results = await moderationService.getActions({
+        subject,
+        limit,
+        before,
+      })
+      return {
+        encoding: 'application/json',
+        body: {
+          cursor: results.at(-1)?.id.toString() ?? undefined,
+          actions: await moderationService.views.action(results),
+        },
+      }
+    },
+  })
+}

--- a/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
@@ -1,0 +1,26 @@
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.getModerationReports({
+    auth: ctx.adminVerifier,
+    handler: async ({ params }) => {
+      const { db, services } = ctx
+      const { subject, resolved, limit = 50, before } = params
+      const moderationService = services.moderation(db)
+      const results = await moderationService.getReports({
+        subject,
+        resolved,
+        limit,
+        before,
+      })
+      return {
+        encoding: 'application/json',
+        body: {
+          cursor: results.at(-1)?.id.toString() ?? undefined,
+          reports: await moderationService.views.report(results),
+        },
+      }
+    },
+  })
+}

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -7,7 +7,9 @@ import searchRepos from './searchRepos'
 import getRecord from './getRecord'
 import getRepo from './getRepo'
 import getModerationAction from './getModerationAction'
+import getModerationActions from './getModerationActions'
 import getModerationReport from './getModerationReport'
+import getModerationReports from './getModerationReports'
 
 export default function (server: Server, ctx: AppContext) {
   resolveModerationReports(server, ctx)
@@ -17,5 +19,7 @@ export default function (server: Server, ctx: AppContext) {
   getRecord(server, ctx)
   getRepo(server, ctx)
   getModerationAction(server, ctx)
+  getModerationActions(server, ctx)
   getModerationReport(server, ctx)
+  getModerationReports(server, ctx)
 }

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -15,7 +15,9 @@ import * as ComAtprotoAccountGet from './types/com/atproto/account/get'
 import * as ComAtprotoAccountRequestPasswordReset from './types/com/atproto/account/requestPasswordReset'
 import * as ComAtprotoAccountResetPassword from './types/com/atproto/account/resetPassword'
 import * as ComAtprotoAdminGetModerationAction from './types/com/atproto/admin/getModerationAction'
+import * as ComAtprotoAdminGetModerationActions from './types/com/atproto/admin/getModerationActions'
 import * as ComAtprotoAdminGetModerationReport from './types/com/atproto/admin/getModerationReport'
+import * as ComAtprotoAdminGetModerationReports from './types/com/atproto/admin/getModerationReports'
 import * as ComAtprotoAdminGetRecord from './types/com/atproto/admin/getRecord'
 import * as ComAtprotoAdminGetRepo from './types/com/atproto/admin/getRepo'
 import * as ComAtprotoAdminResolveModerationReports from './types/com/atproto/admin/resolveModerationReports'
@@ -207,6 +209,16 @@ export class AdminNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
+  getModerationActions<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminGetModerationActions.Handler<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.getModerationActions' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   getModerationReport<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -214,6 +226,16 @@ export class AdminNS {
     >,
   ) {
     const nsid = 'com.atproto.admin.getModerationReport' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModerationReports<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminGetModerationReports.Handler<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.getModerationReports' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -208,6 +208,52 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminGetModerationActions: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getModerationActions',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'List moderation actions related to a subject.',
+        parameters: {
+          type: 'params',
+          properties: {
+            subject: {
+              type: 'string',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            before: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['actions'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              actions: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.admin.moderationAction#view',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminGetModerationReport: {
     lexicon: 1,
     id: 'com.atproto.admin.getModerationReport',
@@ -229,6 +275,55 @@ export const schemaDict = {
           schema: {
             type: 'ref',
             ref: 'lex:com.atproto.admin.moderationReport#viewDetail',
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoAdminGetModerationReports: {
+    lexicon: 1,
+    id: 'com.atproto.admin.getModerationReports',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'List moderation reports related to a subject.',
+        parameters: {
+          type: 'params',
+          properties: {
+            subject: {
+              type: 'string',
+            },
+            resolved: {
+              type: 'boolean',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            before: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['reports'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              reports: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.admin.moderationReport#view',
+                },
+              },
+            },
           },
         },
       },
@@ -4010,7 +4105,9 @@ export const ids = {
     'com.atproto.account.requestPasswordReset',
   ComAtprotoAccountResetPassword: 'com.atproto.account.resetPassword',
   ComAtprotoAdminGetModerationAction: 'com.atproto.admin.getModerationAction',
+  ComAtprotoAdminGetModerationActions: 'com.atproto.admin.getModerationActions',
   ComAtprotoAdminGetModerationReport: 'com.atproto.admin.getModerationReport',
+  ComAtprotoAdminGetModerationReports: 'com.atproto.admin.getModerationReports',
   ComAtprotoAdminGetRecord: 'com.atproto.admin.getRecord',
   ComAtprotoAdminGetRepo: 'com.atproto.admin.getRepo',
   ComAtprotoAdminModerationAction: 'com.atproto.admin.moderationAction',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
@@ -1,0 +1,41 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoAdminModerationAction from './moderationAction'
+
+export interface QueryParams {
+  subject?: string
+  limit?: number
+  before?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  actions: ComAtprotoAdminModerationAction.View[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
@@ -1,0 +1,42 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoAdminModerationReport from './moderationReport'
+
+export interface QueryParams {
+  subject?: string
+  resolved?: boolean
+  limit?: number
+  before?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  reports: ComAtprotoAdminModerationReport.View[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-actions.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-actions.test.ts.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds admin get moderation actions view gets all moderation actions for a record. 1`] = `
+Array [
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 1,
+    "reason": "X",
+    "resolvedReportIds": Array [
+      1,
+    ],
+    "reversal": Object {
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdBy": "Y",
+      "reason": "X",
+    },
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation actions view gets all moderation actions for a repo. 1`] = `
+Array [
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 5,
+    "reason": "X",
+    "resolvedReportIds": Array [
+      3,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#acknowledge",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 2,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 1,
+    "reason": "X",
+    "resolvedReportIds": Array [
+      1,
+    ],
+    "reversal": Object {
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdBy": "Y",
+      "reason": "X",
+    },
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation actions view gets all moderation actions. 1`] = `
+Array [
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 8,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 7,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(1)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#acknowledge",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 6,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(2)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 5,
+    "reason": "X",
+    "resolvedReportIds": Array [
+      3,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(3)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 4,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 3,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#acknowledge",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 2,
+    "reason": "X",
+    "resolvedReportIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(2)",
+      "uri": "record(2)",
+    },
+  },
+  Object {
+    "action": "com.atproto.admin.moderationAction#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "Y",
+    "id": 1,
+    "reason": "X",
+    "resolvedReportIds": Array [
+      1,
+    ],
+    "reversal": Object {
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdBy": "Y",
+      "reason": "X",
+    },
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(3)",
+      "uri": "record(3)",
+    },
+  },
+]
+`;

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-reports.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-reports.test.ts.snap
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds admin get moderation reports view gets all moderation reports for a record. 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 1,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      1,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation reports view gets all moderation reports for a repo. 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 5,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      5,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 2,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(1)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 1,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      1,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation reports view gets all moderation reports. 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 8,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(1)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 7,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(2)",
+    "resolvedByActionIds": Array [
+      7,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(3)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 6,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 5,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(2)",
+    "resolvedByActionIds": Array [
+      5,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(2)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 4,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 3,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(2)",
+    "resolvedByActionIds": Array [
+      3,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 2,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(2)",
+      "uri": "record(2)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 1,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(2)",
+    "resolvedByActionIds": Array [
+      1,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(3)",
+      "uri": "record(3)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation reports view gets all resolved/unresolved moderation reports. 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 7,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      7,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(1)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 5,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      5,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 3,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      3,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 1,
+    "reasonType": "com.atproto.report.reasonType#other",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [
+      1,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+]
+`;
+
+exports[`pds admin get moderation reports view gets all resolved/unresolved moderation reports. 2`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 8,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(1)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 6,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.repoRef",
+      "did": "user(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 4,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 2,
+    "reasonType": "com.atproto.report.reasonType#spam",
+    "reportedByDid": "user(0)",
+    "resolvedByActionIds": Array [],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(1)",
+      "uri": "record(1)",
+    },
+  },
+]
+`;

--- a/packages/pds/tests/views/admin/get-moderation-action.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-action.test.ts
@@ -7,8 +7,6 @@ import {
   OTHER,
   SPAM,
 } from '../../../src/lexicon/types/com/atproto/report/reasonType'
-import { InputSchema as TakeActionInput } from '@atproto/api/src/client/types/com/atproto/admin/takeModerationAction'
-import { InputSchema as CreateReportInput } from '@atproto/api/src/client/types/com/atproto/report/create'
 import { runTestServer, forSnapshot, CloseFn, adminAuth } from '../../_util'
 import { SeedClient } from '../../seeds/client'
 import basicSeed from '../../seeds/basic'
@@ -33,7 +31,7 @@ describe('pds admin get moderation action view', () => {
   })
 
   beforeAll(async () => {
-    const reportRepo = await createReport({
+    const reportRepo = await sc.createReport({
       reportedByDid: sc.dids.bob,
       reasonType: SPAM,
       subject: {
@@ -41,7 +39,7 @@ describe('pds admin get moderation action view', () => {
         did: sc.dids.alice,
       },
     })
-    const reportRecord = await createReport({
+    const reportRecord = await sc.createReport({
       reportedByDid: sc.dids.carol,
       reasonType: OTHER,
       reason: 'defamation',
@@ -50,29 +48,29 @@ describe('pds admin get moderation action view', () => {
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
       },
     })
-    const flagRepo = await takeModerationAction({
+    const flagRepo = await sc.takeModerationAction({
       action: FLAG,
       subject: {
         $type: 'com.atproto.repo.repoRef',
         did: sc.dids.alice,
       },
     })
-    const takedownRecord = await takeModerationAction({
+    const takedownRecord = await sc.takeModerationAction({
       action: TAKEDOWN,
       subject: {
         $type: 'com.atproto.repo.recordRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
       },
     })
-    await resolveReports({
+    await sc.resolveReports({
       actionId: flagRepo.id,
       reportIds: [reportRepo.id, reportRecord.id],
     })
-    await resolveReports({
+    await sc.resolveReports({
       actionId: takedownRecord.id,
       reportIds: [reportRecord.id],
     })
-    await reverseModerationAction({ id: flagRepo.id })
+    await sc.reverseModerationAction({ id: flagRepo.id })
   })
 
   it('gets moderation action for a repo.', async () => {
@@ -98,70 +96,4 @@ describe('pds admin get moderation action view', () => {
     )
     await expect(promise).rejects.toThrow('Action not found')
   })
-
-  async function takeModerationAction(opts: {
-    action: TakeActionInput['action']
-    subject: TakeActionInput['subject']
-    reason?: string
-    createdBy?: string
-  }) {
-    const { action, subject, reason = 'X', createdBy = 'Y' } = opts
-    const result = await client.com.atproto.admin.takeModerationAction(
-      { action, subject, createdBy, reason },
-      {
-        encoding: 'application/json',
-        headers: { authorization: adminAuth() },
-      },
-    )
-    return result.data
-  }
-
-  async function reverseModerationAction(opts: {
-    id: number
-    reason?: string
-    createdBy?: string
-  }) {
-    const { id, reason = 'X', createdBy = 'Y' } = opts
-    const result = await client.com.atproto.admin.reverseModerationAction(
-      { id, reason, createdBy },
-      {
-        encoding: 'application/json',
-        headers: { authorization: adminAuth() },
-      },
-    )
-    return result.data
-  }
-
-  async function resolveReports(opts: {
-    actionId: number
-    reportIds: number[]
-    createdBy?: string
-  }) {
-    const { actionId, reportIds, createdBy = 'Y' } = opts
-    const result = await client.com.atproto.admin.resolveModerationReports(
-      { actionId, createdBy, reportIds },
-      {
-        encoding: 'application/json',
-        headers: { authorization: adminAuth() },
-      },
-    )
-    return result.data
-  }
-
-  async function createReport(opts: {
-    reasonType: CreateReportInput['reasonType']
-    subject: CreateReportInput['subject']
-    reason?: string
-    reportedByDid: string
-  }) {
-    const { reasonType, subject, reason, reportedByDid } = opts
-    const result = await client.com.atproto.report.create(
-      { reasonType, subject, reason },
-      {
-        encoding: 'application/json',
-        headers: sc.getHeaders(reportedByDid),
-      },
-    )
-    return result.data
-  }
 })

--- a/packages/pds/tests/views/admin/get-moderation-actions.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-actions.test.ts
@@ -1,0 +1,235 @@
+import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import {
+  ACKNOWLEDGE,
+  FLAG,
+  TAKEDOWN,
+} from '@atproto/api/src/client/types/com/atproto/admin/moderationAction'
+import {
+  OTHER,
+  SPAM,
+} from '../../../src/lexicon/types/com/atproto/report/reasonType'
+import { InputSchema as TakeActionInput } from '@atproto/api/src/client/types/com/atproto/admin/takeModerationAction'
+import { InputSchema as CreateReportInput } from '@atproto/api/src/client/types/com/atproto/report/create'
+import {
+  runTestServer,
+  forSnapshot,
+  CloseFn,
+  adminAuth,
+  paginateAll,
+} from '../../_util'
+import { SeedClient } from '../../seeds/client'
+import basicSeed from '../../seeds/basic'
+
+describe('pds admin get moderation actions view', () => {
+  let client: AtpServiceClient
+  let close: CloseFn
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'views_admin_get_moderation_actions',
+    })
+    close = server.close
+    client = AtpApi.service(server.url)
+    sc = new SeedClient(client)
+    await basicSeed(sc)
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  beforeAll(async () => {
+    const oneIn = (n) => (_, i) => i % n === 0
+    const getAction = (i) => [FLAG, ACKNOWLEDGE, TAKEDOWN][i % 3]
+    const posts = Object.values(sc.posts)
+      .flatMap((x) => x)
+      .filter(oneIn(2))
+    const dids = Object.values(sc.dids).filter(oneIn(2))
+    // Take actions on records
+    const recordActions: Awaited<ReturnType<typeof takeModerationAction>>[] = []
+    for (let i = 0; i < posts.length; ++i) {
+      const post = posts[i]
+      recordActions.push(
+        await takeModerationAction({
+          action: getAction(i),
+          subject: {
+            $type: 'com.atproto.repo.recordRef',
+            uri: post.ref.uriStr,
+          },
+        }),
+      )
+    }
+    // Reverse an action
+    await reverseModerationAction({
+      id: recordActions[0].id,
+    })
+    // Take actions on repos
+    const repoActions: Awaited<ReturnType<typeof takeModerationAction>>[] = []
+    for (let i = 0; i < dids.length; ++i) {
+      const did = dids[i]
+      repoActions.push(
+        await takeModerationAction({
+          action: getAction(i),
+          subject: {
+            $type: 'com.atproto.repo.repoRef',
+            did,
+          },
+        }),
+      )
+    }
+    // Back some of the actions with a report, possibly resolved
+    const someRecordActions = recordActions.filter(oneIn(2))
+    for (let i = 0; i < someRecordActions.length; ++i) {
+      const action = someRecordActions[i]
+      const ab = oneIn(2)(action, i)
+      const report = await createReport({
+        reportedByDid: ab ? sc.dids.carol : sc.dids.alice,
+        reasonType: ab ? SPAM : OTHER,
+        subject: {
+          $type: 'com.atproto.repo.recordRef',
+          uri: action.subject.uri,
+        },
+      })
+      if (ab) {
+        await resolveReports({
+          actionId: action.id,
+          reportIds: [report.id],
+        })
+      }
+    }
+    const someRepoActions = repoActions.filter(oneIn(2))
+    for (let i = 0; i < someRepoActions.length; ++i) {
+      const action = someRepoActions[i]
+      const ab = oneIn(2)(action, i)
+      const report = await createReport({
+        reportedByDid: ab ? sc.dids.carol : sc.dids.alice,
+        reasonType: ab ? SPAM : OTHER,
+        subject: {
+          $type: 'com.atproto.repo.repoRef',
+          did: action.subject.did,
+        },
+      })
+      if (ab) {
+        await resolveReports({
+          actionId: action.id,
+          reportIds: [report.id],
+        })
+      }
+    }
+  })
+
+  it('gets all moderation actions.', async () => {
+    const result = await client.com.atproto.admin.getModerationActions(
+      {},
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.actions)).toMatchSnapshot()
+  })
+
+  it('gets all moderation actions for a repo.', async () => {
+    const result = await client.com.atproto.admin.getModerationActions(
+      { subject: Object.values(sc.dids)[0] },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.actions)).toMatchSnapshot()
+  })
+
+  it('gets all moderation actions for a record.', async () => {
+    const result = await client.com.atproto.admin.getModerationActions(
+      { subject: Object.values(sc.posts)[0][0].ref.uriStr },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.actions)).toMatchSnapshot()
+  })
+
+  it('paginates.', async () => {
+    const results = (results) => results.flatMap((res) => res.actions)
+    const paginator = async (cursor?: string) => {
+      const res = await client.com.atproto.admin.getModerationActions(
+        { before: cursor, limit: 3 },
+        { headers: { authorization: adminAuth() } },
+      )
+      return res.data
+    }
+
+    const paginatedAll = await paginateAll(paginator)
+    paginatedAll.forEach((res) =>
+      expect(res.actions.length).toBeLessThanOrEqual(3),
+    )
+
+    const full = await client.com.atproto.admin.getModerationActions(
+      {},
+      { headers: { authorization: adminAuth() } },
+    )
+
+    expect(full.data.actions.length).toEqual(8)
+    expect(results(paginatedAll)).toEqual(results([full.data]))
+  })
+
+  async function takeModerationAction(opts: {
+    action: TakeActionInput['action']
+    subject: TakeActionInput['subject']
+    reason?: string
+    createdBy?: string
+  }) {
+    const { action, subject, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.takeModerationAction(
+      { action, subject, createdBy, reason },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function reverseModerationAction(opts: {
+    id: number
+    reason?: string
+    createdBy?: string
+  }) {
+    const { id, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.reverseModerationAction(
+      { id, reason, createdBy },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function resolveReports(opts: {
+    actionId: number
+    reportIds: number[]
+    createdBy?: string
+  }) {
+    const { actionId, reportIds, createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.resolveModerationReports(
+      { actionId, createdBy, reportIds },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function createReport(opts: {
+    reasonType: CreateReportInput['reasonType']
+    subject: CreateReportInput['subject']
+    reason?: string
+    reportedByDid: string
+  }) {
+    const { reasonType, subject, reason, reportedByDid } = opts
+    const result = await client.com.atproto.report.create(
+      { reasonType, subject, reason },
+      {
+        encoding: 'application/json',
+        headers: sc.getHeaders(reportedByDid),
+      },
+    )
+    return result.data
+  }
+})

--- a/packages/pds/tests/views/admin/get-moderation-reports.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-reports.test.ts
@@ -1,0 +1,249 @@
+import AtpApi, { ServiceClient as AtpServiceClient } from '@atproto/api'
+import {
+  ACKNOWLEDGE,
+  FLAG,
+  TAKEDOWN,
+} from '@atproto/api/src/client/types/com/atproto/admin/moderationAction'
+import {
+  OTHER,
+  SPAM,
+} from '../../../src/lexicon/types/com/atproto/report/reasonType'
+import { InputSchema as TakeActionInput } from '@atproto/api/src/client/types/com/atproto/admin/takeModerationAction'
+import { InputSchema as CreateReportInput } from '@atproto/api/src/client/types/com/atproto/report/create'
+import {
+  runTestServer,
+  forSnapshot,
+  CloseFn,
+  adminAuth,
+  paginateAll,
+} from '../../_util'
+import { SeedClient } from '../../seeds/client'
+import basicSeed from '../../seeds/basic'
+
+describe('pds admin get moderation reports view', () => {
+  let client: AtpServiceClient
+  let close: CloseFn
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'views_admin_get_moderation_reports',
+    })
+    close = server.close
+    client = AtpApi.service(server.url)
+    sc = new SeedClient(client)
+    await basicSeed(sc)
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  beforeAll(async () => {
+    const oneIn = (n) => (_, i) => i % n === 0
+    const getAction = (i) => [FLAG, ACKNOWLEDGE, TAKEDOWN][i % 3]
+    const getReasonType = (i) => [OTHER, SPAM][i % 2]
+    const getReportedByDid = (i) => [sc.dids.alice, sc.dids.carol][i % 2]
+    const posts = Object.values(sc.posts)
+      .flatMap((x) => x)
+      .filter(oneIn(2))
+    const dids = Object.values(sc.dids).filter(oneIn(2))
+    const recordReports: Awaited<ReturnType<typeof createReport>>[] = []
+    for (let i = 0; i < posts.length; ++i) {
+      const post = posts[i]
+      recordReports.push(
+        await createReport({
+          reasonType: getReasonType(i),
+          reportedByDid: getReportedByDid(i),
+          subject: {
+            $type: 'com.atproto.repo.recordRef',
+            uri: post.ref.uriStr,
+          },
+        }),
+      )
+    }
+    const repoReports: Awaited<ReturnType<typeof createReport>>[] = []
+    for (let i = 0; i < posts.length; ++i) {
+      const did = dids[i]
+      repoReports.push(
+        await createReport({
+          reasonType: getReasonType(i),
+          reportedByDid: getReportedByDid(i),
+          subject: {
+            $type: 'com.atproto.repo.repoRef',
+            did,
+          },
+        }),
+      )
+    }
+    for (let i = 0; i < recordReports.length; ++i) {
+      const report = recordReports[i]
+      const ab = oneIn(2)(report, i)
+      const action = await takeModerationAction({
+        action: getAction(i),
+        subject: {
+          $type: 'com.atproto.repo.recordRef',
+          uri: report.subject.uri,
+        },
+      })
+      if (ab) {
+        await resolveReports({
+          actionId: action.id,
+          reportIds: [report.id],
+        })
+      } else {
+        await reverseModerationAction({
+          id: action.id,
+        })
+      }
+    }
+    for (let i = 0; i < repoReports.length; ++i) {
+      const report = repoReports[i]
+      const ab = oneIn(2)(report, i)
+      const action = await takeModerationAction({
+        action: getAction(i),
+        subject: {
+          $type: 'com.atproto.repo.repoRef',
+          did: report.subject.did,
+        },
+      })
+      if (ab) {
+        await resolveReports({
+          actionId: action.id,
+          reportIds: [report.id],
+        })
+      } else {
+        await reverseModerationAction({
+          id: action.id,
+        })
+      }
+    }
+  })
+
+  it('gets all moderation reports.', async () => {
+    const result = await client.com.atproto.admin.getModerationReports(
+      {},
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.reports)).toMatchSnapshot()
+  })
+
+  it('gets all moderation reports for a repo.', async () => {
+    const result = await client.com.atproto.admin.getModerationReports(
+      { subject: Object.values(sc.dids)[0] },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.reports)).toMatchSnapshot()
+  })
+
+  it('gets all moderation reports for a record.', async () => {
+    const result = await client.com.atproto.admin.getModerationReports(
+      { subject: Object.values(sc.posts)[0][0].ref.uriStr },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(result.data.reports)).toMatchSnapshot()
+  })
+
+  it('gets all resolved/unresolved moderation reports.', async () => {
+    const resolved = await client.com.atproto.admin.getModerationReports(
+      { resolved: true },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(resolved.data.reports)).toMatchSnapshot()
+    const unresolved = await client.com.atproto.admin.getModerationReports(
+      { resolved: false },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(forSnapshot(unresolved.data.reports)).toMatchSnapshot()
+  })
+
+  it('paginates.', async () => {
+    const results = (results) => results.flatMap((res) => res.reports)
+    const paginator = async (cursor?: string) => {
+      const res = await client.com.atproto.admin.getModerationReports(
+        { before: cursor, limit: 3 },
+        { headers: { authorization: adminAuth() } },
+      )
+      return res.data
+    }
+
+    const paginatedAll = await paginateAll(paginator)
+    paginatedAll.forEach((res) =>
+      expect(res.reports.length).toBeLessThanOrEqual(3),
+    )
+
+    const full = await client.com.atproto.admin.getModerationReports(
+      {},
+      { headers: { authorization: adminAuth() } },
+    )
+
+    expect(full.data.reports.length).toEqual(8)
+    expect(results(paginatedAll)).toEqual(results([full.data]))
+  })
+
+  async function takeModerationAction(opts: {
+    action: TakeActionInput['action']
+    subject: TakeActionInput['subject']
+    reason?: string
+    createdBy?: string
+  }) {
+    const { action, subject, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.takeModerationAction(
+      { action, subject, createdBy, reason },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function reverseModerationAction(opts: {
+    id: number
+    reason?: string
+    createdBy?: string
+  }) {
+    const { id, reason = 'X', createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.reverseModerationAction(
+      { id, reason, createdBy },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function resolveReports(opts: {
+    actionId: number
+    reportIds: number[]
+    createdBy?: string
+  }) {
+    const { actionId, reportIds, createdBy = 'Y' } = opts
+    const result = await client.com.atproto.admin.resolveModerationReports(
+      { actionId, createdBy, reportIds },
+      {
+        encoding: 'application/json',
+        headers: { authorization: adminAuth() },
+      },
+    )
+    return result.data
+  }
+
+  async function createReport(opts: {
+    reasonType: CreateReportInput['reasonType']
+    subject: CreateReportInput['subject']
+    reason?: string
+    reportedByDid: string
+  }) {
+    const { reasonType, subject, reason, reportedByDid } = opts
+    const result = await client.com.atproto.report.create(
+      { reasonType, subject, reason },
+      {
+        encoding: 'application/json',
+        headers: sc.getHeaders(reportedByDid),
+      },
+    )
+    return result.data
+  }
+})

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -35,21 +35,13 @@ describe('pds admin repo search view', () => {
   })
 
   beforeAll(async () => {
-    await client.com.atproto.admin.takeModerationAction(
-      {
-        action: TAKEDOWN,
-        subject: {
-          $type: 'com.atproto.repo.repoRef',
-          did: sc.dids['cara-wiegand69.test'],
-        },
-        createdBy: 'X',
-        reason: 'Y',
+    await sc.takeModerationAction({
+      action: TAKEDOWN,
+      subject: {
+        $type: 'com.atproto.repo.repoRef',
+        did: sc.dids['cara-wiegand69.test'],
       },
-      {
-        encoding: 'application/json',
-        headers: { authorization: adminAuth() },
-      },
-    )
+    })
   })
 
   it('gives relevant results', async () => {

--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -127,11 +127,15 @@ async function defaultFetchHandler(
   httpReqBody: unknown,
 ): Promise<FetchHandlerResponse> {
   try {
-    const res = await fetch(httpUri, {
+    // The duplex field is now required for streaming bodies, but not yet reflected
+    // anywhere in docs or types. See whatwg/fetch#1438, nodejs/node#46221.
+    const reqInit: RequestInit & { duplex: string } = {
       method: httpMethod,
       headers: httpHeaders,
       body: encodeMethodCallBody(httpHeaders, httpReqBody),
-    })
+      duplex: 'half',
+    }
+    const res = await fetch(httpUri, reqInit)
     const resBody = await res.arrayBuffer()
     return {
       status: res.status,


### PR DESCRIPTION
Implements `com.atproto.admin.getModerationActions` and `com.atproto.admin.getModerationReports`, for admins to be able to browse and sort through moderation-related history.  Each supports filtering by subject, and `getModerationReports` allows filtering by whether or not the report is resolved.