### PR TITLE
Fix XRPC fetch usage for newly required duplex option

### DIFF
--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -137,11 +137,15 @@ async function defaultFetchHandler(
   httpReqBody: unknown,
 ): Promise<FetchHandlerResponse> {
   try {
-    const res = await fetch(httpUri, {
+    // The duplex field is now required for streaming bodies, but not yet reflected
+    // anywhere in docs or types. See whatwg/fetch#1438, nodejs/node#46221.
+    const reqInit: RequestInit & { duplex: string } = {
       method: httpMethod,
       headers: httpHeaders,
       body: encodeMethodCallBody(httpHeaders, httpReqBody),
-    })
+      duplex: 'half',
+    }
+    const res = await fetch(httpUri, reqInit)
     const resBody = await res.arrayBuffer()
     return {
       status: res.status,


### PR DESCRIPTION
As of node v18.13.0 a change to the fetch spec is now reflected in node's fetch implementation.  In short, for streaming request bodies the option `duplex: 'half'` must explicitly be passed to `fetch()`.  Part of the trickiness here is that this change to the spec is not reflected in docs such as MDN yet, nor in Typescript's lib.dom types.

Refs:
Issue as surfaced in node: https://github.com/nodejs/node/issues/46221
Spec discussion: https://github.com/whatwg/fetch/issues/1438
Implementation in node: https://github.com/nodejs/undici/pull/1681
Docs on `duplex`: https://fetch.spec.whatwg.org/#ref-for-dom-requestinit-duplex
Use node's types for fetch rather than typescript's lib.dom: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924