### PR TITLE
Add xrpc and lexicon support for param arrays

### DIFF
--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -259,7 +259,10 @@ export function genXrpcParams(
       genComment(
         iface.addProperty({
           name: `${paramKey}${req ? '' : '?'}`,
-          type: primitiveToType(paramDef),
+          type:
+            paramDef.type === 'array'
+              ? primitiveToType(paramDef.items) + '[]'
+              : primitiveToType(paramDef),
         }),
         paramDef,
       )

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -145,6 +145,13 @@ export const lexArray = z.object({
 })
 export type LexArray = z.infer<typeof lexArray>
 
+export const lexPrimitiveArray = lexArray.merge(
+  z.object({
+    items: lexPrimitive,
+  }),
+)
+export type LexPrimitiveArray = z.infer<typeof lexPrimitiveArray>
+
 export const lexToken = z.object({
   type: z.literal('token'),
   description: z.string().optional(),
@@ -168,7 +175,7 @@ export const lexXrpcParameters = z.object({
   type: z.literal('params'),
   description: z.string().optional(),
   required: z.string().array().optional(),
-  properties: z.record(lexPrimitive),
+  properties: z.record(z.union([lexPrimitive, lexPrimitiveArray])),
 })
 export type LexXrpcParameters = z.infer<typeof lexXrpcParameters>
 

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -53,11 +53,9 @@ export function validate(
 export function array(
   lexicons: Lexicons,
   path: string,
-  def: LexUserType,
+  def: LexArray,
   value: unknown,
 ): ValidationResult {
-  def = def as LexArray
-
   // type
   if (!Array.isArray(value)) {
     return {

--- a/packages/lexicon/src/validators/xrpc.ts
+++ b/packages/lexicon/src/validators/xrpc.ts
@@ -2,6 +2,7 @@ import { Lexicons } from '../lexicons'
 import { LexXrpcParameters, ValidationResult, ValidationError } from '../types'
 
 import * as PrimitiveValidators from './primitives'
+import { array } from './complex'
 
 export function params(
   lexicons: Lexicons,
@@ -9,8 +10,6 @@ export function params(
   def: LexXrpcParameters,
   value: unknown,
 ): ValidationResult {
-  def = def as LexXrpcParameters
-
   // type
   if (!value || typeof value !== 'object') {
     // in this case, we just fall back to an object
@@ -35,12 +34,11 @@ export function params(
       continue // skip- if required, will have already failed
     }
     const paramDef = def.properties[key]
-    const res = PrimitiveValidators.validate(
-      lexicons,
-      key,
-      paramDef,
-      (value as Record<string, unknown>)[key],
-    )
+    const val = (value as Record<string, unknown>)[key]
+    const res =
+      paramDef.type === 'array'
+        ? array(lexicons, key, paramDef, val)
+        : PrimitiveValidators.validate(lexicons, key, paramDef, val)
     if (!res.success) {
       return res
     }

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -65,6 +65,7 @@ export default [
             number: { type: 'number' },
             integer: { type: 'integer' },
             string: { type: 'string' },
+            array: { type: 'array', items: { type: 'string' } },
           },
         },
         output: {
@@ -89,6 +90,7 @@ export default [
             number: { type: 'number' },
             integer: { type: 'integer' },
             string: { type: 'string' },
+            array: { type: 'array', items: { type: 'string' } },
           },
         },
         input: {

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -367,6 +367,21 @@ describe('Record validation', () => {
     ).toThrow('Record/array must not have more than 4 elements')
   })
 
+  it('Applies array item constraints', () => {
+    expect(() =>
+      lex.assertValidRecord('com.example.arrayLength', {
+        $type: 'com.example.arrayLength',
+        array: [1, '2', 3],
+      }),
+    ).toThrow('Record/array/1 must be a number')
+    expect(() =>
+      lex.assertValidRecord('com.example.arrayLength', {
+        $type: 'com.example.arrayLength',
+        array: [1, undefined, 3],
+      }),
+    ).toThrow('Record/array/1 must be a number')
+  })
+
   it('Applies boolean const constraint', () => {
     lex.assertValidRecord('com.example.boolConst', {
       $type: 'com.example.boolConst',
@@ -560,12 +575,14 @@ describe('XRPC parameter validation', () => {
       number: 123.45,
       integer: 123,
       string: 'string',
+      array: ['x', 'y'],
     })
     lex.assertValidXrpcParams('com.example.procedure', {
       boolean: true,
       number: 123.45,
       integer: 123,
       string: 'string',
+      array: ['x', 'y'],
     })
   })
 
@@ -607,6 +624,15 @@ describe('XRPC parameter validation', () => {
         string: 'string',
       }),
     ).toThrow('number must be a number')
+    expect(() =>
+      lex.assertValidXrpcParams('com.example.query', {
+        boolean: true,
+        number: 123.45,
+        integer: 123,
+        string: 'string',
+        array: 'x',
+      }),
+    ).toThrow('array must be an array')
   })
 })
 

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -13,7 +13,9 @@ export type Options = {
 }
 
 export type UndecodedParams = typeof express.request['query']
-export type Params = Record<string, string | number | boolean | undefined>
+
+export type Primitive = string | number | boolean
+export type Params = Record<string, Primitive | Primitive[] | undefined>
 
 export const handlerInput = zod.object({
   encoding: zod.string(),

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -22,11 +22,19 @@ export function decodeQueryParams(
 ): Params {
   const decoded: Params = {}
   for (const k in params) {
-    if (def.parameters?.properties?.[k]) {
-      decoded[k] = decodeQueryParam(
-        def.parameters?.properties[k]?.type,
-        params[k],
-      )
+    const val = params[k]
+    const property = def.parameters?.properties?.[k]
+    if (property) {
+      if (property.type === 'array') {
+        const vals: typeof val[] = []
+        decoded[k] = val
+          ? vals
+              .concat(val) // Cast to array
+              .flatMap((v) => decodeQueryParam(property.items.type, v) ?? [])
+          : undefined
+      } else {
+        decoded[k] = decodeQueryParam(property.type, val)
+      }
     }
   }
   return decoded

--- a/packages/xrpc-server/tests/parameters.test.ts
+++ b/packages/xrpc-server/tests/parameters.test.ts
@@ -12,12 +12,13 @@ const LEXICONS = [
         type: 'query',
         parameters: {
           type: 'params',
-          required: ['str', 'int', 'num', 'bool'],
+          required: ['str', 'int', 'num', 'bool', 'arr'],
           properties: {
             str: { type: 'string', minLength: 2, maxLength: 10 },
             int: { type: 'integer', minimum: 2, maximum: 10 },
             num: { type: 'number', minimum: 2, maximum: 10 },
             bool: { type: 'boolean' },
+            arr: { type: 'array', items: { type: 'integer' }, maxLength: 2 },
           },
         },
         output: {
@@ -53,24 +54,28 @@ describe('Parameters', () => {
       int: 5,
       num: 5.5,
       bool: true,
+      arr: [1, 2],
     })
     expect(res1.success).toBeTruthy()
     expect(res1.data.str).toBe('valid')
     expect(res1.data.int).toBe(5)
     expect(res1.data.num).toBe(5.5)
     expect(res1.data.bool).toBe(true)
+    expect(res1.data.arr).toEqual([1, 2])
 
     const res2 = await client.call('io.example.paramTest', {
       str: 10,
       int: '5',
       num: '5.5',
       bool: 'foo',
+      arr: '3',
     })
     expect(res2.success).toBeTruthy()
     expect(res2.data.str).toBe('10')
     expect(res2.data.int).toBe(5)
     expect(res2.data.num).toBe(5.5)
     expect(res2.data.bool).toBe(true)
+    expect(res2.data.arr).toEqual([3])
 
     await expect(
       client.call('io.example.paramTest', {
@@ -78,6 +83,7 @@ describe('Parameters', () => {
         int: 5,
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('str must not be shorter than 2 characters')
     await expect(
@@ -86,6 +92,7 @@ describe('Parameters', () => {
         int: 5,
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('str must not be longer than 10 characters')
     await expect(
@@ -93,6 +100,7 @@ describe('Parameters', () => {
         int: 5,
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow(`Params must have the property "str"`)
 
@@ -102,6 +110,7 @@ describe('Parameters', () => {
         int: -1,
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('int can not be less than 2')
     await expect(
@@ -110,6 +119,7 @@ describe('Parameters', () => {
         int: 11,
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('int can not be greater than 10')
     await expect(
@@ -117,6 +127,7 @@ describe('Parameters', () => {
         str: 'valid',
         num: 5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow(`Params must have the property "int"`)
 
@@ -126,6 +137,7 @@ describe('Parameters', () => {
         int: 5,
         num: -5.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('num can not be less than 2')
     await expect(
@@ -134,6 +146,7 @@ describe('Parameters', () => {
         int: 5,
         num: 50.5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow('num can not be greater than 10')
     await expect(
@@ -141,6 +154,7 @@ describe('Parameters', () => {
         str: 'valid',
         int: 5,
         bool: true,
+        arr: [1],
       }),
     ).rejects.toThrow(`Params must have the property "num"`)
 
@@ -149,7 +163,27 @@ describe('Parameters', () => {
         str: 'valid',
         int: 5,
         num: 5.5,
+        arr: [1],
       }),
     ).rejects.toThrow(`Params must have the property "bool"`)
+
+    await expect(
+      client.call('io.example.paramTest', {
+        str: 'valid',
+        int: 5,
+        num: 5.5,
+        bool: true,
+        arr: [],
+      }),
+    ).rejects.toThrow('Error: Params must have the property "arr"')
+    await expect(
+      client.call('io.example.paramTest', {
+        str: 'valid',
+        int: 5,
+        num: 5.5,
+        bool: true,
+        arr: [1, 2, 3],
+      }),
+    ).rejects.toThrow('Error: arr must not have more than 2 elements')
   })
 })

--- a/packages/xrpc/src/util.ts
+++ b/packages/xrpc/src/util.ts
@@ -33,7 +33,17 @@ export function constructMethodCallUri(
         throw new Error(`Invalid query parameter: ${key}`)
       }
       if (value !== undefined) {
-        uri.searchParams.set(key, encodeQueryParam(paramSchema.type, value))
+        if (paramSchema.type === 'array') {
+          const vals: typeof value[] = []
+          vals.concat(value).forEach((val) => {
+            uri.searchParams.append(
+              key,
+              encodeQueryParam(paramSchema.items.type, val),
+            )
+          })
+        } else {
+          uri.searchParams.set(key, encodeQueryParam(paramSchema.type, value))
+        }
       }
     }
   }
@@ -42,7 +52,14 @@ export function constructMethodCallUri(
 }
 
 export function encodeQueryParam(
-  type: 'string' | 'number' | 'integer' | 'boolean' | 'datetime' | 'unknown',
+  type:
+    | 'string'
+    | 'number'
+    | 'integer'
+    | 'boolean'
+    | 'datetime'
+    | 'array'
+    | 'unknown',
   value: any,
 ): string {
   if (type === 'string' || type === 'unknown') {


### PR DESCRIPTION
TLDR: `?param=x&param=y` ↔️ `{ param: ['x', 'y'] }`

The XRPC query and procedure parameter lexicons are constrained by their encoding as a query string, so to date we only encode and validate primitives (i.e. strings, numbers, booleans) as params.  For example, query strings don't support nested objects as you could express using JSON.

However, query strings do have the ability to encode arrays of values.  For example, if you were to post an HTML form with a multi-select checkbox element in it named `param`, it might generate a query string of the format `?param=x&param=y`, which is intended to be interpreted as `{ param: ['x', 'y'] }`.  This is also illustrated by [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) support for multi-valued keys and use of the `append()` method, as well as node's builtin `querystring` module.

This work allows lexicon query/procedure parameters to use the `array` type as long as its `items` are a primitive type.  Includes integration across lexicon, lex-cli, xrpc-server, and xrpc.

(P.S. the failing test here will be resolved by #470)