### PR TITLE
Partition commit-history & commit-blocks by user did

### DIFF
--- a/packages/pds/src/db/migrations/20230118T223059239Z-repo-sync-data.ts
+++ b/packages/pds/src/db/migrations/20230118T223059239Z-repo-sync-data.ts
@@ -14,12 +14,22 @@ export async function up(db: DatabaseSchema): Promise<void> {
     .createTable(commitBlockTable)
     .addColumn('commit', 'varchar', (col) => col.notNull())
     .addColumn('block', 'varchar', (col) => col.notNull())
-    .addPrimaryKeyConstraint(`${commitBlockTable}_pkey`, ['commit', 'block'])
+    .addColumn('creator', 'varchar', (col) => col.notNull())
+    .addPrimaryKeyConstraint(`${commitBlockTable}_pkey`, [
+      'commit',
+      'block',
+      'creator',
+    ])
     .execute()
   await db.schema
     .createTable(commitHistoryTable)
-    .addColumn('commit', 'varchar', (col) => col.primaryKey())
+    .addColumn('commit', 'varchar', (col) => col.notNull())
     .addColumn('prev', 'varchar')
+    .addColumn('creator', 'varchar', (col) => col.notNull())
+    .addPrimaryKeyConstraint(`${commitHistoryTable}_pkey`, [
+      'commit',
+      'creator',
+    ])
     .execute()
 
   const migrateUser = async (did: string, root: CID) => {
@@ -51,11 +61,13 @@ export async function up(db: DatabaseSchema): Promise<void> {
         commitBlock.push({
           commit: commit.commit.toString(),
           block: cid.toString(),
+          creator: did,
         })
       })
       commitHistory.push({
         commit: commit.commit.toString(),
         prev: prev ? prev.commit.toString() : null,
+        creator: did,
       })
     }
     const promises: Promise<unknown>[] = []

--- a/packages/pds/src/db/tables/repo-commit-block.ts
+++ b/packages/pds/src/db/tables/repo-commit-block.ts
@@ -1,6 +1,7 @@
 export interface RepoCommitBlock {
   commit: string
   block: string
+  creator: string
 }
 
 export const tableName = 'repo_commit_block'

--- a/packages/pds/src/db/tables/repo-commit-history.ts
+++ b/packages/pds/src/db/tables/repo-commit-history.ts
@@ -1,6 +1,7 @@
 export interface RepoCommitHistory {
   commit: string
   prev: string | null
+  creator: string
 }
 
 export const tableName = 'repo_commit_history'


### PR DESCRIPTION
One more to sneak in here

It's useful to have the did that a given commit/block is associated with. This prevents us from having to do reference counts when doing deletes. I handled the case of putting `creator` on `ipld_block` itself in the upcoming account deletion branch, but I figured I should just get these in on this migration