### PR TITLE
Include the user's handle in the reset password email

### DIFF
--- a/packages/pds/src/api/com/atproto/password-reset.ts
+++ b/packages/pds/src/api/com/atproto/password-reset.ts
@@ -20,7 +20,10 @@ export default function (server: Server, ctx: AppContext) {
           passwordResetGrantedAt: grantedAt,
         })
         .execute()
-      await ctx.mailer.sendResetPassword({ token }, { to: user.email })
+      await ctx.mailer.sendResetPassword(
+        { handle: user.handle, token },
+        { to: user.email },
+      )
     }
   })
 

--- a/packages/pds/src/mailer/index.ts
+++ b/packages/pds/src/mailer/index.ts
@@ -33,7 +33,10 @@ export class ServerMailer {
     }
   }
 
-  async sendResetPassword(params: { token: string }, mailOpts: Mail.Options) {
+  async sendResetPassword(
+    params: { handle: string; token: string },
+    mailOpts: Mail.Options,
+  ) {
     return this.sendTemplate('resetPassword', params, {
       subject: 'Password Reset Requested',
       ...mailOpts,

--- a/packages/pds/src/mailer/templates/reset-password.hbs
+++ b/packages/pds/src/mailer/templates/reset-password.hbs
@@ -169,8 +169,7 @@
                                               class="text-teal-700"
                                               style="color: #13795b; padding-top: 0; padding-bottom: 0; font-weight: 500; vertical-align: baseline; font-size: 20px; line-height: 24px; margin: 0;"
                                               align="left"
-                                            >We received a request to reset your
-                                              account password.</h5>
+                                            >We received a request to reset the password for the account: {{handle}}</h5>
                                             <table
                                               class="s-5 w-full"
                                               role="presentation"

--- a/packages/pds/src/mailer/templates/reset-password.hbs
+++ b/packages/pds/src/mailer/templates/reset-password.hbs
@@ -169,7 +169,9 @@
                                               class="text-teal-700"
                                               style="color: #13795b; padding-top: 0; padding-bottom: 0; font-weight: 500; vertical-align: baseline; font-size: 20px; line-height: 24px; margin: 0;"
                                               align="left"
-                                            >We received a request to reset the password for the account: {{handle}}</h5>
+                                            >We received a request to reset the
+                                              password for the account:
+                                              {{handle}}</h5>
                                             <table
                                               class="s-5 w-full"
                                               role="presentation"

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -348,6 +348,7 @@ describe('account', () => {
 
     expect(mail.to).toEqual(email)
     expect(mail.html).toContain('Reset your password')
+    expect(mail.html).toContain('alice.test')
 
     const token = getTokenFromMail(mail)
 


### PR DESCRIPTION
Small tweak: include the user's handle in the password reset email, since people tend to forget it. Closes #486