### PR TITLE
Allow login using email

### DIFF
--- a/lexicons/com/atproto/session/create.json
+++ b/lexicons/com/atproto/session/create.json
@@ -11,7 +11,8 @@
           "type": "object",
           "required": ["handle", "password"],
           "properties": {
-            "handle": {"type": "string"},
+            "handle": {"type": "string", "description": "Handle of the authenticating user (deprecated)."},
+            "identifier": {"type": "string", "description": "Handle or other identifier supported by the server for the authenticating user."},
             "password": {"type": "string"}
           }
         }

--- a/lexicons/com/atproto/session/create.json
+++ b/lexicons/com/atproto/session/create.json
@@ -9,9 +9,8 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["handle", "password"],
+          "required": ["password"],
           "properties": {
-            "handle": {"type": "string", "description": "Handle of the authenticating user (deprecated)."},
             "identifier": {"type": "string", "description": "Handle or other identifier supported by the server for the authenticating user."},
             "password": {"type": "string"}
           }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1710,12 +1710,8 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['handle', 'password'],
+            required: ['password'],
             properties: {
-              handle: {
-                type: 'string',
-                description: 'Handle of the authenticating user (deprecated).',
-              },
               identifier: {
                 type: 'string',
                 description:

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1714,6 +1714,12 @@ export const schemaDict = {
             properties: {
               handle: {
                 type: 'string',
+                description: 'Handle of the authenticating user (deprecated).',
+              },
+              identifier: {
+                type: 'string',
+                description:
+                  'Handle or other identifier supported by the server for the authenticating user.',
               },
               password: {
                 type: 'string',

--- a/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
@@ -2,6 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoAdminModerationAction from './moderationAction'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
@@ -2,6 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoAdminModerationReport from './moderationReport'
 
 export interface QueryParams {

--- a/packages/api/src/client/types/com/atproto/session/create.ts
+++ b/packages/api/src/client/types/com/atproto/session/create.ts
@@ -9,8 +9,6 @@ import { lexicons } from '../../../../lexicons'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** Handle of the authenticating user (deprecated). */
-  handle: string
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier?: string
   password: string

--- a/packages/api/src/client/types/com/atproto/session/create.ts
+++ b/packages/api/src/client/types/com/atproto/session/create.ts
@@ -9,7 +9,10 @@ import { lexicons } from '../../../../lexicons'
 export interface QueryParams {}
 
 export interface InputSchema {
+  /** Handle of the authenticating user (deprecated). */
   handle: string
+  /** Handle or other identifier supported by the server for the authenticating user. */
+  identifier?: string
   password: string
   [k: string]: unknown
 }

--- a/packages/pds/src/api/com/atproto/session.ts
+++ b/packages/pds/src/api/com/atproto/session.ts
@@ -23,21 +23,28 @@ export default function (server: Server, ctx: AppContext) {
   })
 
   server.com.atproto.session.create(async ({ input }) => {
-    const { password } = input.body
-    const handle = input.body.handle.toLowerCase()
-    const validPass = await ctx.services
-      .actor(ctx.db)
-      .verifyUserPassword(handle, password)
-    if (!validPass) {
-      throw new AuthRequiredError('Invalid handle or password')
+    const { password, ...body } = input.body
+    const identifier = (body.identifier || body.handle).toLowerCase()
+    const authService = ctx.services.auth(ctx.db)
+    const actorService = ctx.services.actor(ctx.db)
+
+    const user = identifier.includes('@')
+      ? await actorService.getUserByEmail(identifier, true)
+      : await actorService.getUser(identifier, true)
+
+    if (!user) {
+      throw new AuthRequiredError('Invalid identifier or password')
     }
 
-    const user = await ctx.services.actor(ctx.db).getUser(handle, true)
-    if (!user) {
-      throw new InvalidRequestError(
-        `Could not find user info for account: ${handle}`,
-      )
+    const validPass = await actorService.verifyUserPassword(
+      user.handle,
+      password,
+    )
+
+    if (!validPass) {
+      throw new AuthRequiredError('Invalid identifier or password')
     }
+
     if (softDeleted(user)) {
       throw new AuthRequiredError(
         'Account has been taken down',
@@ -47,7 +54,7 @@ export default function (server: Server, ctx: AppContext) {
 
     const access = ctx.auth.createAccessToken(user.did)
     const refresh = ctx.auth.createRefreshToken(user.did)
-    await ctx.services.auth(ctx.db).grantRefreshToken(refresh.payload)
+    await authService.grantRefreshToken(refresh.payload)
 
     return {
       encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/session.ts
+++ b/packages/pds/src/api/com/atproto/session.ts
@@ -24,7 +24,11 @@ export default function (server: Server, ctx: AppContext) {
 
   server.com.atproto.session.create(async ({ input }) => {
     const { password, ...body } = input.body
-    const identifier = (body.identifier || body.handle).toLowerCase()
+    const identifier = (
+      body.identifier ||
+      (typeof body.handle === 'string' && body.handle) || // @TODO deprecated, see #493
+      ''
+    ).toLowerCase()
     const authService = ctx.services.auth(ctx.db)
     const actorService = ctx.services.actor(ctx.db)
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1710,12 +1710,8 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['handle', 'password'],
+            required: ['password'],
             properties: {
-              handle: {
-                type: 'string',
-                description: 'Handle of the authenticating user (deprecated).',
-              },
               identifier: {
                 type: 'string',
                 description:

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1714,6 +1714,12 @@ export const schemaDict = {
             properties: {
               handle: {
                 type: 'string',
+                description: 'Handle of the authenticating user (deprecated).',
+              },
+              identifier: {
+                type: 'string',
+                description:
+                  'Handle or other identifier supported by the server for the authenticating user.',
               },
               password: {
                 type: 'string',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
@@ -2,6 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as ComAtprotoAdminModerationAction from './moderationAction'
 

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
@@ -2,6 +2,9 @@
  * GENERATED CODE - DO NOT MODIFY
  */
 import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 import * as ComAtprotoAdminModerationReport from './moderationReport'
 

--- a/packages/pds/src/lexicon/types/com/atproto/session/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/create.ts
@@ -10,7 +10,10 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
+  /** Handle of the authenticating user (deprecated). */
   handle: string
+  /** Handle or other identifier supported by the server for the authenticating user. */
+  identifier?: string
   password: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/com/atproto/session/create.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/session/create.ts
@@ -10,8 +10,6 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** Handle of the authenticating user (deprecated). */
-  handle: string
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier?: string
   password: string

--- a/packages/pds/src/services/actor.ts
+++ b/packages/pds/src/services/actor.ts
@@ -46,7 +46,7 @@ export class ActorService {
   async getUserByEmail(
     email: string,
     includeSoftDeleted = false,
-  ): Promise<(User & DidHandle) | null> {
+  ): Promise<(User & DidHandle & RepoRoot) | null> {
     const { ref } = this.db.db.dynamic
     const found = await this.db.db
       .selectFrom('user')
@@ -55,8 +55,10 @@ export class ActorService {
       .if(!includeSoftDeleted, (qb) =>
         qb.where(notSoftDeletedClause(ref('repo_root'))),
       )
-      .selectAll()
       .where('email', '=', email.toLowerCase())
+      .selectAll('user')
+      .selectAll('did_handle')
+      .selectAll('repo_root')
       .executeTakeFirst()
     return found || null
   }

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -363,7 +363,7 @@ describe('account', () => {
     // Logs in with new password and not previous password
     await expect(
       client.com.atproto.session.create({ handle, password }),
-    ).rejects.toThrow('Invalid handle or password')
+    ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
       client.com.atproto.session.create({ handle, password: passwordAlt }),
@@ -392,7 +392,7 @@ describe('account', () => {
     // Logs in with new password and not previous password
     await expect(
       client.com.atproto.session.create({ handle, password: passwordAlt }),
-    ).rejects.toThrow('Invalid handle or password')
+    ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
       client.com.atproto.session.create({ handle, password }),
@@ -427,7 +427,7 @@ describe('account', () => {
     // Still logs in with previous password
     await expect(
       client.com.atproto.session.create({ handle, password: passwordAlt }),
-    ).rejects.toThrow('Invalid handle or password')
+    ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
       client.com.atproto.session.create({ handle, password }),

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -319,7 +319,10 @@ describe('account', () => {
   })
 
   it('logs in', async () => {
-    const res = await client.com.atproto.session.create({ handle, password })
+    const res = await client.com.atproto.session.create({
+      identifier: handle,
+      password,
+    })
     jwt = res.data.accessJwt
     expect(typeof jwt).toBe('string')
     expect(res.data.handle).toBe('alice.test')
@@ -362,11 +365,14 @@ describe('account', () => {
 
     // Logs in with new password and not previous password
     await expect(
-      client.com.atproto.session.create({ handle, password }),
+      client.com.atproto.session.create({ identifier: handle, password }),
     ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
-      client.com.atproto.session.create({ handle, password: passwordAlt }),
+      client.com.atproto.session.create({
+        identifier: handle,
+        password: passwordAlt,
+      }),
     ).resolves.toBeDefined()
   })
 
@@ -391,11 +397,14 @@ describe('account', () => {
 
     // Logs in with new password and not previous password
     await expect(
-      client.com.atproto.session.create({ handle, password: passwordAlt }),
+      client.com.atproto.session.create({
+        identifier: handle,
+        password: passwordAlt,
+      }),
     ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
-      client.com.atproto.session.create({ handle, password }),
+      client.com.atproto.session.create({ identifier: handle, password }),
     ).resolves.toBeDefined()
   })
 
@@ -426,11 +435,14 @@ describe('account', () => {
 
     // Still logs in with previous password
     await expect(
-      client.com.atproto.session.create({ handle, password: passwordAlt }),
+      client.com.atproto.session.create({
+        identifier: handle,
+        password: passwordAlt,
+      }),
     ).rejects.toThrow('Invalid identifier or password')
 
     await expect(
-      client.com.atproto.session.create({ handle, password }),
+      client.com.atproto.session.create({ identifier: handle, password }),
     ).resolves.toBeDefined()
   })
 

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -96,12 +96,23 @@ describe('auth', () => {
     )
   })
 
-  it('fails on session creation with a bad password', async () => {
+  it('allows session creation using email address.', async () => {
+    const session = await createSession({
+      handle: '', // Deprecated in favor of identifier but remains required
+      identifier: 'bob@TEST.com',
+      password: 'password',
+    })
+    expect(session.handle).toEqual('bob.test')
+  })
+
+  it('fails on session creation with a bad password.', async () => {
     const sessionPromise = createSession({
       handle: 'bob.test',
       password: 'wrong-pass',
     })
-    await expect(sessionPromise).rejects.toThrow('Invalid handle or password')
+    await expect(sessionPromise).rejects.toThrow(
+      'Invalid identifier or password',
+    )
   })
 
   it('provides valid access and refresh token on session refresh.', async () => {

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -77,7 +77,7 @@ describe('auth', () => {
       password: 'password',
     })
     const session = await createSession({
-      handle: 'bob.test',
+      identifier: 'bob.test',
       password: 'password',
     })
     // Valid access token
@@ -98,8 +98,15 @@ describe('auth', () => {
 
   it('allows session creation using email address.', async () => {
     const session = await createSession({
-      handle: '', // Deprecated in favor of identifier but remains required
       identifier: 'bob@TEST.com',
+      password: 'password',
+    })
+    expect(session.handle).toEqual('bob.test')
+  })
+
+  it('allows session creation using handle input (deprecated).', async () => {
+    const session = await createSession({
+      handle: 'bob.test', // Deprecated in favor of identifier, see #493
       password: 'password',
     })
     expect(session.handle).toEqual('bob.test')
@@ -107,7 +114,7 @@ describe('auth', () => {
 
   it('fails on session creation with a bad password.', async () => {
     const sessionPromise = createSession({
-      handle: 'bob.test',
+      identifier: 'bob.test',
       password: 'wrong-pass',
     })
     await expect(sessionPromise).rejects.toThrow(
@@ -207,7 +214,7 @@ describe('auth', () => {
       },
     )
     await expect(
-      createSession({ handle: 'iris.test', password: 'password' }),
+      createSession({ identifier: 'iris.test', password: 'password' }),
     ).rejects.toThrow(CreateSession.AccountTakedownError)
   })
 


### PR DESCRIPTION
This allow users to create a session using their email address (in addition to their handle).  I marked session.create's `handle` input as deprecated and added an optional `identifier` input— the PDS should be free to establish any identifier it wants with its users in addition to their handle.