### PR TITLE
Filter out self & follows from suggestions

### DIFF
--- a/lexicons/app/bsky/actor/getSuggestions.json
+++ b/lexicons/app/bsky/actor/getSuggestions.json
@@ -40,14 +40,7 @@
         },
         "description": {"type": "string"},
         "avatar": {"type": "string"},
-        "indexedAt": {"type": "datetime"},
-        "myState": {"type": "ref", "ref": "#myState"}
-      }
-    },
-    "myState": {
-      "type": "object",
-      "properties": {
-        "follow": {"type": "string"}
+        "indexedAt": {"type": "datetime"}
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2142,18 +2142,6 @@ export const schemaDict = {
           indexedAt: {
             type: 'datetime',
           },
-          myState: {
-            type: 'ref',
-            ref: 'lex:app.bsky.actor.getSuggestions#myState',
-          },
-        },
-      },
-      myState: {
-        type: 'object',
-        properties: {
-          follow: {
-            type: 'string',
-          },
         },
       },
     },

--- a/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
@@ -44,7 +44,6 @@ export interface Actor {
   description?: string
   avatar?: string
   indexedAt?: string
-  myState?: MyState
   [k: string]: unknown
 }
 
@@ -58,21 +57,4 @@ export function isActor(v: unknown): v is Actor {
 
 export function validateActor(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.getSuggestions#actor', v)
-}
-
-export interface MyState {
-  follow?: string
-  [k: string]: unknown
-}
-
-export function isMyState(v: unknown): v is MyState {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.getSuggestions#myState'
-  )
-}
-
-export function validateMyState(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.getSuggestions#myState', v)
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2142,18 +2142,6 @@ export const schemaDict = {
           indexedAt: {
             type: 'datetime',
           },
-          myState: {
-            type: 'ref',
-            ref: 'lex:app.bsky.actor.getSuggestions#myState',
-          },
-        },
-      },
-      myState: {
-        type: 'object',
-        properties: {
-          follow: {
-            type: 'string',
-          },
         },
       },
     },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -50,7 +50,6 @@ export interface Actor {
   description?: string
   avatar?: string
   indexedAt?: string
-  myState?: MyState
   [k: string]: unknown
 }
 
@@ -64,21 +63,4 @@ export function isActor(v: unknown): v is Actor {
 
 export function validateActor(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.getSuggestions#actor', v)
-}
-
-export interface MyState {
-  follow?: string
-  [k: string]: unknown
-}
-
-export function isMyState(v: unknown): v is MyState {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.getSuggestions#myState'
-  )
-}
-
-export function validateMyState(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.getSuggestions#myState', v)
 }


### PR DESCRIPTION
Update `app.bsky.actor.getSuggestions` to not return the requesting user or any users that they already follow.

Also remove `myState` from the lexicon because it is no longer used (since the follow will always be `undefined`).

Closes https://github.com/bluesky-social/atproto/issues/497