### PR TITLE
Change esbuild version to explicitly target 0.14.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^28.1.2",
     "dotenv": "^16.0.3",
-    "esbuild": "^0.14.48",
+    "esbuild": "0.14.50",
     "esbuild-node-externals": "^1.5.0",
     "esbuild-plugin-copy": "^1.6.0",
     "eslint": "^8.24.0",


### PR DESCRIPTION
Not an npm guy, so this might be user error, but just had a fresh build fail on me due to an unavailable version of esbuild:

`error https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz: getaddrinfo EAI_AGAIN registry.yarnpkg.com`

This is on node:18-alpine so not sure why it's looking for a 32 bit package, but that version of esbuild appears to be unavailable for download for any architechture.

This changes `package.json` to explicitly target a version which is still available.