### PR TITLE
Maintain a cache of session-clients for a service and reuse them

### DIFF
--- a/packages/api/src/session.ts
+++ b/packages/api/src/session.ts
@@ -20,10 +20,26 @@ const DELETE_SESSION = 'com.atproto.session.delete'
 const CREATE_ACCOUNT = 'com.atproto.account.create'
 
 export class SessionClient extends Client {
+  private cache: Map<string, SessionServiceClient> = new Map()
+
   service(serviceUri: string | URL): SessionServiceClient {
+    const cacheKey = toCacheKey(serviceUri)
+    const inst = this.cache.get(cacheKey)
+    if (inst) {
+      return inst
+    }
     const xrpcService = new SessionXrpcServiceClient(this.xrpc, serviceUri)
-    return new SessionServiceClient(this, xrpcService)
+    const service = new SessionServiceClient(this, xrpcService)
+    this.cache.set(cacheKey, service)
+    return service
   }
+}
+
+function toCacheKey(uri: string | URL) {
+  if (typeof uri === 'string') {
+    uri = new URL(uri)
+  }
+  return uri.hostname
 }
 
 const defaultInst = new SessionClient()

--- a/packages/api/tests/session.test.ts
+++ b/packages/api/tests/session.test.ts
@@ -236,4 +236,8 @@ describe('session', () => {
     expect(sessions[1]).toEqual(undefined)
     expect(client.sessionManager.active()).toEqual(false)
   })
+
+  it('reuses the client object across calls', () => {
+    expect(client).toEqual(sessionClient.service(server.url))
+  })
 })


### PR DESCRIPTION
This PR updates the API so that

```typescript
import {sessionClient} from '@atproto/api`

sessionClient.service("https://foo.com") === sessionClient.service("https://foo.com")
```

The reason for this change is to ensure that the access tokens used to control the sessions are unified across all clients. This is useful because a refresh token will invalidate if it is ever used, meaning a client needs to be careful to only attempt a refresh just once. The social app has to create multiple instances for various reasons and coordinating the sessions between them was proving too difficult. Caching and reusing instances helps to ensure no mistakes will occur.