### PR TITLE
Database notify/listen

### DIFF
--- a/packages/common/src/async.ts
+++ b/packages/common/src/async.ts
@@ -1,9 +1,9 @@
-export type Defferable = {
+export type Deferrable = {
   resolve: () => void
   complete: Promise<void>
 }
 
-export const createDeferrable = (): Defferable => {
+export const createDeferrable = (): Deferrable => {
   let resolve
   const promise: Promise<void> = new Promise((res) => {
     resolve = () => res()
@@ -11,14 +11,14 @@ export const createDeferrable = (): Defferable => {
   return { resolve, complete: promise }
 }
 
-export const createDeferrables = (count: number): Defferable[] => {
-  const list: Defferable[] = []
+export const createDeferrables = (count: number): Deferrable[] => {
+  const list: Deferrable[] = []
   for (let i = 0; i < count; i++) {
     list.push(createDeferrable())
   }
   return list
 }
 
-export const allComplete = async (defferables: Defferable[]): Promise<void> => {
-  await Promise.all(defferables.map((d) => d.complete))
+export const allComplete = async (deferrables: Deferrable[]): Promise<void> => {
+  await Promise.all(deferrables.map((d) => d.complete))
 }

--- a/packages/common/src/async.ts
+++ b/packages/common/src/async.ts
@@ -1,0 +1,24 @@
+export type Defferable = {
+  resolve: () => void
+  complete: Promise<void>
+}
+
+export const createDeferrable = (): Defferable => {
+  let resolve
+  const promise: Promise<void> = new Promise((res) => {
+    resolve = () => res()
+  })
+  return { resolve, complete: promise }
+}
+
+export const createDeferrables = (count: number): Defferable[] => {
+  const list: Defferable[] = []
+  for (let i = 0; i < count; i++) {
+    list.push(createDeferrable())
+  }
+  return list
+}
+
+export const allComplete = async (defferables: Defferable[]): Promise<void> => {
+  await Promise.all(defferables.map((d) => d.complete))
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,7 @@
 export * as check from './check'
 export * as util from './util'
 
+export * from './async'
 export * from './util'
 export * from './tid'
 export * from './ipld'

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atproto/pds",
   "version": "0.0.2",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atproto/pds",
   "version": "0.0.2",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
@@ -54,6 +54,7 @@
     "pino": "^8.6.1",
     "pino-http": "^8.2.1",
     "sharp": "^0.31.2",
+    "typed-emitter": "^2.1.0",
     "uint8arrays": "3.0.0"
   },
   "devDependencies": {

--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -124,6 +124,9 @@ export class Database {
   async close(): Promise<void> {
     this.notifyClient?.removeAllListeners()
     this.notifyClient?.release()
+    if (this.facets.dialect === 'pg') {
+      await this.facets.pool.end()
+    }
     await this.db.destroy()
   }
 
@@ -165,7 +168,6 @@ export type DialectFacets = PgFacets | SqliteFacets
 export type PgFacets = {
   dialect: 'pg'
   pool: PgPool
-  notifyClient?: PgPoolClient
   schema?: string
 }
 

--- a/packages/pds/tests/db-notify.test.ts
+++ b/packages/pds/tests/db-notify.test.ts
@@ -31,10 +31,10 @@ describe('db', () => {
 
   it('notifies', async () => {
     const sendCount = 5
-    const defferables = createDeferrables(sendCount)
+    const deferrables = createDeferrables(sendCount)
     let receivedCount = 0
     dbOne.channels.repo_seq.addListener('message', () => {
-      defferables[receivedCount]?.resolve()
+      deferrables[receivedCount]?.resolve()
       receivedCount++
     })
 
@@ -42,21 +42,21 @@ describe('db', () => {
       dbTwo.notify('repo_seq')
     }
 
-    await allComplete(defferables)
+    await allComplete(deferrables)
     expect(receivedCount).toBe(sendCount)
   })
 
   it('can notifies multiple listeners', async () => {
     const sendCount = 5
-    const defferables = createDeferrables(sendCount * 2)
+    const deferrables = createDeferrables(sendCount * 2)
     let receivedOne = 0
     let receivedTwo = 0
     dbOne.channels.repo_seq.addListener('message', () => {
-      defferables[receivedOne]?.resolve()
+      deferrables[receivedOne]?.resolve()
       receivedOne++
     })
     dbOne.channels.repo_seq.addListener('message', () => {
-      defferables[receivedTwo + sendCount]?.resolve()
+      deferrables[receivedTwo + sendCount]?.resolve()
       receivedTwo++
     })
 
@@ -64,7 +64,7 @@ describe('db', () => {
       dbTwo.notify('repo_seq')
     }
 
-    await allComplete(defferables)
+    await allComplete(deferrables)
     expect(receivedOne).toBe(sendCount)
     expect(receivedTwo).toBe(sendCount)
   })

--- a/packages/pds/tests/db-notify.test.ts
+++ b/packages/pds/tests/db-notify.test.ts
@@ -7,11 +7,11 @@ describe('db', () => {
 
   beforeAll(async () => {
     if (process.env.DB_POSTGRES_URL) {
-      dbOne = Database.postgres({
+      dbOne = await Database.postgres({
         url: process.env.DB_POSTGRES_URL,
         schema: 'db_notify',
       })
-      dbTwo = Database.postgres({
+      dbTwo = await Database.postgres({
         url: process.env.DB_POSTGRES_URL,
         schema: 'db_notify',
       })
@@ -30,15 +30,15 @@ describe('db', () => {
   it('notifies', async () => {
     const toSend = ['one', 'two', 'three', 'four', 'five']
     const received: string[] = []
-    await dbOne.listenFor('test', (msg) => {
+    dbOne.channels.repo_seq.addListener('message', (msg) => {
       received.push(msg || '')
     })
 
-    dbTwo.notify('otherchannel', 'blah')
+    dbTwo.notify('otherchannel' as any, 'blah')
     for (const msg of toSend) {
-      dbTwo.notify('test', msg)
+      dbTwo.notify('repo_seq', msg)
     }
-    dbTwo.notify('otherchannel', 'blah')
+    dbTwo.notify('otherchannel' as any, 'blah')
 
     await wait(200)
     expect(received.sort()).toEqual(toSend.sort())
@@ -48,18 +48,18 @@ describe('db', () => {
     const toSend = ['one', 'two', 'three', 'four', 'five']
     const receivedOne: string[] = []
     const receivedTwo: string[] = []
-    await dbOne.listenFor('test', (msg) => {
+    dbOne.channels.repo_seq.addListener('message', (msg) => {
       receivedOne.push(msg || '')
     })
-    await dbOne.listenFor('test', (msg) => {
+    dbOne.channels.repo_seq.addListener('message', (msg) => {
       receivedTwo.push(msg || '')
     })
 
-    dbTwo.notify('otherchannel', 'blah')
+    dbTwo.notify('otherchannel' as any, 'blah')
     for (const msg of toSend) {
-      dbTwo.notify('test', msg)
+      dbTwo.notify('repo_seq', msg)
     }
-    dbTwo.notify('otherchannel', 'blah')
+    dbTwo.notify('otherchannel' as any, 'blah')
 
     await wait(200)
     expect(receivedOne.sort()).toEqual(toSend.sort())

--- a/packages/pds/tests/db-notify.test.ts
+++ b/packages/pds/tests/db-notify.test.ts
@@ -1,0 +1,67 @@
+import { wait } from '@atproto/common'
+import { Database } from '../src'
+
+describe('db', () => {
+  let dbOne: Database
+  let dbTwo: Database
+
+  beforeAll(async () => {
+    if (process.env.DB_POSTGRES_URL) {
+      dbOne = Database.postgres({
+        url: process.env.DB_POSTGRES_URL,
+        schema: 'db_notify',
+      })
+      dbTwo = Database.postgres({
+        url: process.env.DB_POSTGRES_URL,
+        schema: 'db_notify',
+      })
+    } else {
+      dbOne = Database.memory()
+      dbTwo = dbOne
+    }
+  })
+
+  afterAll(async () => {
+    await dbOne.close()
+    await dbTwo.close()
+  })
+
+  it('notifies', async () => {
+    const toSend = ['one', 'two', 'three', 'four', 'five']
+    const received: string[] = []
+    await dbOne.listenFor('test', (msg) => {
+      received.push(msg || '')
+    })
+
+    dbTwo.notify('otherchannel', 'blah')
+    for (const msg of toSend) {
+      dbTwo.notify('test', msg)
+    }
+    dbTwo.notify('otherchannel', 'blah')
+
+    await wait(500)
+    expect(received.sort()).toEqual(toSend.sort())
+  })
+
+  it('can notifies multiple listeners', async () => {
+    const toSend = ['one', 'two', 'three', 'four', 'five']
+    const receivedOne: string[] = []
+    const receivedTwo: string[] = []
+    await dbOne.listenFor('test', (msg) => {
+      receivedOne.push(msg || '')
+    })
+    await dbOne.listenFor('test', (msg) => {
+      receivedTwo.push(msg || '')
+    })
+
+    dbTwo.notify('otherchannel', 'blah')
+    for (const msg of toSend) {
+      dbTwo.notify('test', msg)
+    }
+    dbTwo.notify('otherchannel', 'blah')
+
+    await wait(500)
+    expect(receivedOne.sort()).toEqual(toSend.sort())
+    expect(receivedTwo.sort()).toEqual(toSend.sort())
+  })
+})

--- a/packages/pds/tests/db-notify.test.ts
+++ b/packages/pds/tests/db-notify.test.ts
@@ -39,7 +39,7 @@ describe('db', () => {
     }
     dbTwo.notify('otherchannel', 'blah')
 
-    await wait(500)
+    await wait(200)
     expect(received.sort()).toEqual(toSend.sort())
   })
 
@@ -60,7 +60,7 @@ describe('db', () => {
     }
     dbTwo.notify('otherchannel', 'blah')
 
-    await wait(500)
+    await wait(200)
     expect(receivedOne.sort()).toEqual(toSend.sort())
     expect(receivedTwo.sort()).toEqual(toSend.sort())
   })

--- a/packages/pds/tests/db-notify.test.ts
+++ b/packages/pds/tests/db-notify.test.ts
@@ -16,6 +16,7 @@ describe('db', () => {
         schema: 'db_notify',
       })
     } else {
+      // in the sqlite case, we just use two references to the same db
       dbOne = Database.memory()
       dbTwo = dbOne
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10519,7 +10519,7 @@ type-is@~1.6.18:
 
 typed-emitter@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-2.1.0.tgz#ca78e3d8ef1476f228f548d62e04e3d4d3fd77fb"
   integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
   optionalDependencies:
     rxjs "^7.5.2"


### PR DESCRIPTION
Adding NOTIFY / LISTEN support to our database wrapper.

There are two cases:
- sqlite: this is a database that _only one_ application will be interacting with at any point in time. Therefore we handle notify/listen with in-process callbacks
- postgres: this is a database that _one or more_ applications may be interacting with. Therefore we handle postgres' [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) feature