### PR TITLE
Refactor repo indexing

### DIFF
--- a/packages/pds/src/api/app/bsky/feed/setVote.ts
+++ b/packages/pds/src/api/app/bsky/feed/setVote.ts
@@ -67,10 +67,7 @@ export default function (server: Server, ctx: AppContext) {
           writes.push(create)
         }
 
-        await Promise.all([
-          await repoTxn.writeToRepo(requester, writes, now),
-          await repoTxn.indexWrites(writes, now),
-        ])
+        await repoTxn.processCreatesAndDeletes(requester, writes, now)
 
         return create?.uri.toString()
       })

--- a/packages/pds/src/api/com/atproto/account/create.ts
+++ b/packages/pds/src/api/com/atproto/account/create.ts
@@ -129,7 +129,6 @@ export default function (server: Server, ctx: AppContext) {
 
       // Setup repo root
       await repoTxn.createRepo(did, [write], now)
-      await repoTxn.indexWrites([write], now)
 
       const declarationCid = await cidForCbor(declaration)
       const access = ctx.auth.createAccessToken(did)

--- a/packages/pds/src/api/com/atproto/repo.ts
+++ b/packages/pds/src/api/com/atproto/repo.ts
@@ -155,7 +155,7 @@ export default function (server: Server, ctx: AppContext) {
       await ctx.db.transaction(async (dbTxn) => {
         const now = new Date().toISOString()
         const repoTxn = ctx.services.repo(dbTxn)
-        await repoTxn.processWrites(did, writes, now)
+        await repoTxn.processCreatesAndDeletes(did, writes, now)
       })
     },
   })
@@ -198,7 +198,7 @@ export default function (server: Server, ctx: AppContext) {
 
       await ctx.db.transaction(async (dbTxn) => {
         const repoTxn = ctx.services.repo(dbTxn)
-        await repoTxn.processWrites(did, [write], now)
+        await repoTxn.processCreatesAndDeletes(did, [write], now)
       })
 
       return {
@@ -224,7 +224,9 @@ export default function (server: Server, ctx: AppContext) {
       const now = new Date().toISOString()
       const write = await repo.prepareDelete({ did, collection, rkey })
       await ctx.db.transaction(async (dbTxn) => {
-        await ctx.services.repo(dbTxn).processWrites(did, [write], now)
+        await ctx.services
+          .repo(dbTxn)
+          .processCreatesAndDeletes(did, [write], now)
       })
     },
   })

--- a/packages/pds/tests/event-stream/sync.test.ts
+++ b/packages/pds/tests/event-stream/sync.test.ts
@@ -65,7 +65,7 @@ describe('sync', () => {
       const now = new Date(ts++).toISOString()
       const writes = await prepareWrites(op.did, op.ops)
       await db.transaction((dbTxn) =>
-        services.repo(dbTxn).indexWrites(writes, now),
+        services.repo(dbTxn).indexCreatesAndDeletes(writes, now),
       )
     }
     await messageQueue.processAll()

--- a/packages/pds/tests/migrations/repo-sync-data.test.ts
+++ b/packages/pds/tests/migrations/repo-sync-data.test.ts
@@ -37,7 +37,7 @@ describe('repo sync data migration', () => {
 
   it('fills the db with some repo data', async () => {
     for (let i = 0; i < 100; i++) {
-      repo = await repo.applyCommit(
+      repo = await repo.applyWrites(
         {
           action: WriteOpAction.Create,
           collection: randomStr(8, 'base32'),

--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -115,7 +115,7 @@ export class Repo extends ReadableRepo {
     })
   }
 
-  async createCommit(
+  async formatCommit(
     toWrite: RecordWriteOp | RecordWriteOp[],
     keypair: crypto.Keypair,
   ): Promise<CommitData> {
@@ -175,13 +175,17 @@ export class Repo extends ReadableRepo {
     }
   }
 
-  async applyCommit(
+  async applyCommit(commitData: CommitData): Promise<Repo> {
+    await this.storage.applyCommit(commitData)
+    return Repo.load(this.storage, commitData.commit)
+  }
+
+  async applyWrites(
     toWrite: RecordWriteOp | RecordWriteOp[],
     keypair: crypto.Keypair,
   ): Promise<Repo> {
-    const commit = await this.createCommit(toWrite, keypair)
-    await this.storage.applyCommit(commit)
-    return Repo.load(this.storage, commit.commit)
+    const commit = await this.formatCommit(toWrite, keypair)
+    return this.applyCommit(commit)
   }
 }
 

--- a/packages/repo/tests/_util.ts
+++ b/packages/repo/tests/_util.ts
@@ -110,7 +110,7 @@ export const fillRepo = async (
     }
     repoData[collName] = collData
   }
-  const updated = await repo.applyCommit(writes, keypair)
+  const updated = await repo.applyWrites(writes, keypair)
   return {
     repo: updated,
     data: repoData,
@@ -137,7 +137,7 @@ export const editRepo = async (
       const object = generateObject()
       const rkey = TID.nextStr()
       collData[rkey] = object
-      repo = await repo.applyCommit(
+      repo = await repo.applyWrites(
         {
           action: WriteOpAction.Create,
           collection: collName,
@@ -152,7 +152,7 @@ export const editRepo = async (
     for (let i = 0; i < toUpdate.length; i++) {
       const object = generateObject()
       const rkey = toUpdate[i][0]
-      repo = await repo.applyCommit(
+      repo = await repo.applyWrites(
         {
           action: WriteOpAction.Update,
           collection: collName,
@@ -167,7 +167,7 @@ export const editRepo = async (
     const toDelete = shuffled.slice(updates, deletes)
     for (let i = 0; i < toDelete.length; i++) {
       const rkey = toDelete[i][0]
-      repo = await repo.applyCommit(
+      repo = await repo.applyWrites(
         {
           action: WriteOpAction.Delete,
           collection: collName,

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -29,7 +29,7 @@ describe('Repo', () => {
   it('does basic operations', async () => {
     const rkey = TID.nextStr()
     const record = util.generateObject()
-    repo = await repo.applyCommit(
+    repo = await repo.applyWrites(
       {
         action: WriteOpAction.Create,
         collection: collName,
@@ -43,7 +43,7 @@ describe('Repo', () => {
     expect(got).toEqual(record)
 
     const updatedRecord = util.generateObject()
-    repo = await repo.applyCommit(
+    repo = await repo.applyWrites(
       {
         action: WriteOpAction.Update,
         collection: collName,
@@ -55,7 +55,7 @@ describe('Repo', () => {
     got = await repo.getRecord(collName, rkey)
     expect(got).toEqual(updatedRecord)
 
-    repo = await repo.applyCommit(
+    repo = await repo.applyWrites(
       {
         action: WriteOpAction.Delete,
         collection: collName,


### PR DESCRIPTION
This mostly just moves things around in the PDS's repo indexing in the hopes of avoiding a few footguns.

Using it in https://github.com/bluesky-social/atproto/pull/518 where I was adding another step to processing & realizing it could be very easily glossed over & cause some footguns

Also refigures the `@atproto/repo` package just a bit to knock out a `@TODO` that's been there for some time