### PR TITLE
Proposed com.atproto.label.label lexicon

### DIFF
--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.label.label",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Metadata tag on an atproto resource (eg, repo or record)",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["src", "uri", "val", "ts"],
+        "properties": {
+          "src": {"type": "string", "maxLength": 1024},
+          "uri": {"type": "string", "maxLength": 1024},
+          "cid": {"type": "string", "maxLength": 256},
+          "val": {"type": "string", "maxLength": 128},
+          "ts": {"type": "datetime"},
+          "labelUri": {"type": "string", "maxLength": 1024}
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -8,15 +8,39 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["src", "uri", "val", "ts"],
+        "required": ["src", "uri", "val", "cts"],
         "properties": {
-          "src": {"type": "string", "maxLength": 1024},
-          "uri": {"type": "string", "maxLength": 1024},
-          "cid": {"type": "string", "maxLength": 256},
-          "val": {"type": "string", "maxLength": 128},
-          "ts": {"type": "datetime"},
-          "labelUri": {"type": "string", "maxLength": 1024}
+          "src": {
+            "type": "string",
+            "description": "DID of the actor who created this label"
+          },
+          "uri": {
+            "type": "string",
+            "description": "AT URI of the record, repository (account), or other resource which this label applies to"
+          },
+          "cid": {
+            "type": "string",
+            "description": "optionally, CID specifying the specific version of 'uri' resource this label applies to"
+          },
+          "val": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "the short string name of the value or type of this label"
+          },
+          "cts": {
+            "type": "datetime",
+            "description": "timestamp when this label was created"
+          }
         }
+      }
+    },
+    "labelEvent": {
+      "type": "object",
+      "required": ["uri", "cid", "label"],
+      "properties": {
+          "uri": {"type": "string"},
+          "cid": {"type": "string"},
+          "label": {"type": "ref", "ref": "app.bsky.label.label#main"}
       }
     }
   }

--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -34,7 +34,7 @@
         }
       }
     },
-    "labelEvent": {
+    "view": {
       "type": "object",
       "required": ["uri", "cid", "label"],
       "properties": {


### PR DESCRIPTION
For persisting un-signed label objects in repositories. There will likely be a handful of XRPC query endpoints in the com.atproto.label namespace in the near future.

Haven't run JS/TS codegen tools locally for this.

The schema with short key names matches the earlier label proposal, and makes sense in the context of free-floating label objects (signed or unsigned), eg as provided in an event stream. But it doesn't fit in as elegantly with current Lexicon style. Not sure what the right thing to do is there.

In theory the `labelUri` field, which should point back to the location of this record, is duplicate information when stored in an actual repo. I kept it in the record lexicon so we can still use this type for event streams. Agnostic as to whether that field should be populated when actually stored in a repo.

I added `maxLength` on a bunch of these out of habit of being conservative, but probably should not. My thinking was that these limits could always be increased (but never constrained further), but I think with lexicons we don't actually have that kind of flexibility in the ecosystem. What I would sort of want is "don't produce records larger than X, but do accept records from the network up to Y", which would be a bit more future-proof. CBOR itself does give us some reasonable constraints, so a griefer couldn't just dump 1 GByte strings in these fields, I think.