### PR TITLE
Allow syncing a commit range

### DIFF
--- a/lexicons/com/atproto/sync/getRepo.json
+++ b/lexicons/com/atproto/sync/getRepo.json
@@ -10,7 +10,8 @@
         "required": ["did"],
         "properties": {
           "did": {"type": "string", "description": "The DID of the repo."},
-          "from": {"type": "string", "description": "A past commit CID."}
+          "earliest": {"type": "string", "description": "The earliest commit in the commit range (not inclusive)"},
+          "latest": {"type": "string", "description": "The latest commit you in the commit range (inclusive"}
         }
       },
       "output": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2155,9 +2155,15 @@ export const schemaDict = {
               type: 'string',
               description: 'The DID of the repo.',
             },
-            from: {
+            earliest: {
               type: 'string',
-              description: 'A past commit CID.',
+              description:
+                'The earliest commit in the commit range (not inclusive)',
+            },
+            latest: {
+              type: 'string',
+              description:
+                'The latest commit you in the commit range (inclusive',
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/sync/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRepo.ts
@@ -9,8 +9,10 @@ import { lexicons } from '../../../../lexicons'
 export interface QueryParams {
   /** The DID of the repo. */
   did: string
-  /** A past commit CID. */
-  from?: string
+  /** The earliest commit in the commit range (not inclusive) */
+  earliest?: string
+  /** The latest commit you in the commit range (inclusive */
+  latest?: string
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2155,9 +2155,15 @@ export const schemaDict = {
               type: 'string',
               description: 'The DID of the repo.',
             },
-            from: {
+            earliest: {
               type: 'string',
-              description: 'A past commit CID.',
+              description:
+                'The earliest commit in the commit range (not inclusive)',
+            },
+            latest: {
+              type: 'string',
+              description:
+                'The latest commit you in the commit range (inclusive',
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -11,8 +11,10 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {
   /** The DID of the repo. */
   did: string
-  /** A past commit CID. */
-  from?: string
+  /** The earliest commit in the commit range (not inclusive) */
+  earliest?: string
+  /** The latest commit you in the commit range (inclusive */
+  latest?: string
 }
 
 export type InputSchema = undefined


### PR DESCRIPTION
`com.atproto.sync.getRepo` now takes a commit range: `earliest` (exclusive) to `latest` (inclusive)

closes https://github.com/bluesky-social/atproto/issues/516