### PR TITLE
pds sql: add indices for feed and post aggregations

### DIFF
--- a/packages/pds/src/db/migrations/20230208T081544325Z-post-hydrate-indices.ts
+++ b/packages/pds/src/db/migrations/20230208T081544325Z-post-hydrate-indices.ts
@@ -1,0 +1,54 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // for, eg, "upvoteCount" on posts in feed views
+  await db.schema
+    .createIndex('vote_subject_direction_idx')
+    .on('vote')
+    .columns(['subject', 'direction'])
+    .execute()
+
+  // for, eg, "repostCount" on posts in feed views
+  await db.schema
+    .createIndex('repost_subject_idx')
+    .on('repost')
+    .column('subject')
+    .execute()
+
+  // for, eg, "replyCount" on posts in feed views
+  await db.schema
+    .createIndex('post_replyparent_idx')
+    .on('post')
+    .column('replyParent')
+    .execute()
+
+  // for, eg, "followersCount" on profile views
+  await db.schema
+    .createIndex('follow_subjectdid_idx')
+    .on('follow')
+    .column('subjectDid')
+    .execute()
+
+  // for, eg, "postsCount" on profile views
+  await db.schema
+    .createIndex('post_creator_idx')
+    .on('post')
+    .column('creator')
+    .execute()
+
+  // for, eg, profile views
+  await db.schema
+    .createIndex('profile_creator_idx')
+    .on('profile')
+    .column('creator')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('vote_subject_direction_idx')
+  await db.schema.dropIndex('repost_subject_idx')
+  await db.schema.dropIndex('post_replyparent_idx')
+  await db.schema.dropIndex('follow_subjectdid_idx')
+  await db.schema.dropIndex('post_creator_idx')
+  await db.schema.dropIndex('profile_creator_idx')
+}

--- a/packages/pds/src/db/migrations/20230208T081544325Z-post-hydrate-indices.ts
+++ b/packages/pds/src/db/migrations/20230208T081544325Z-post-hydrate-indices.ts
@@ -45,10 +45,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await db.schema.dropIndex('vote_subject_direction_idx')
-  await db.schema.dropIndex('repost_subject_idx')
-  await db.schema.dropIndex('post_replyparent_idx')
-  await db.schema.dropIndex('follow_subjectdid_idx')
-  await db.schema.dropIndex('post_creator_idx')
-  await db.schema.dropIndex('profile_creator_idx')
+  await db.schema.dropIndex('vote_subject_direction_idx').execute()
+  await db.schema.dropIndex('repost_subject_idx').execute()
+  await db.schema.dropIndex('post_replyparent_idx').execute()
+  await db.schema.dropIndex('follow_subjectdid_idx').execute()
+  await db.schema.dropIndex('post_creator_idx').execute()
+  await db.schema.dropIndex('profile_creator_idx').execute()
 }

--- a/packages/pds/src/db/migrations/index.ts
+++ b/packages/pds/src/db/migrations/index.ts
@@ -17,3 +17,4 @@ export * as _20230202T170426672Z from './20230202T170426672Z-user-partitioned-ci
 export * as _20230202T170435937Z from './20230202T170435937Z-delete-account-token'
 export * as _20230202T172831900Z from './20230202T172831900Z-moderation-subject-blob'
 export * as _20230202T213952826Z from './20230202T213952826Z-repo-seq'
+export * as _20230208T081544325Z from './20230208T081544325Z-post-hydrate-indices'


### PR DESCRIPTION
NOTE: the name of the migration might need to change, as there are other PRs in flight.

I wrote this pretty quickly and have no prior experience with `kysely`, should be reviewed carefully before pushing this out.

These are some high-priority indices that yielded around a 5x improvement on single-threaded query latency in my local (laptop) testing on a small database for important XRPC endpoints like "getTimeline", "getPostThread", "getProfile", and fetching notifications (list or count).

These endpoints still seem pretty slow to me (tens of millis SQL execution time), but the speedup is quite cheap (there aren't many indices on these tables yet, and index creation should be fairly fast). We may refactor the aggregation stuff in the near future, but until then I think these are helpful.