### PR TITLE
Mod action and report params as integers rather than floats

### DIFF
--- a/lexicons/com/atproto/admin/getModerationAction.json
+++ b/lexicons/com/atproto/admin/getModerationAction.json
@@ -9,7 +9,7 @@
         "type": "params",
         "required": ["id"],
         "properties": {
-          "id": {"type": "number"}
+          "id": {"type": "integer"}
         }
       },
       "output": {

--- a/lexicons/com/atproto/admin/getModerationReport.json
+++ b/lexicons/com/atproto/admin/getModerationReport.json
@@ -9,7 +9,7 @@
         "type": "params",
         "required": ["id"],
         "properties": {
-          "id": {"type": "number"}
+          "id": {"type": "integer"}
         }
       },
       "output": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -302,7 +302,7 @@ export const schemaDict = {
           required: ['id'],
           properties: {
             id: {
-              type: 'number',
+              type: 'integer',
             },
           },
         },
@@ -374,7 +374,7 @@ export const schemaDict = {
           required: ['id'],
           properties: {
             id: {
-              type: 'number',
+              type: 'integer',
             },
           },
         },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -302,7 +302,7 @@ export const schemaDict = {
           required: ['id'],
           properties: {
             id: {
-              type: 'number',
+              type: 'integer',
             },
           },
         },
@@ -374,7 +374,7 @@ export const schemaDict = {
           required: ['id'],
           properties: {
             id: {
-              type: 'number',
+              type: 'integer',
             },
           },
         },


### PR DESCRIPTION
The `id` parameter for getting a mod action and reports was spec'ed as a `number` when it should have been an `integer`.