### PR TITLE
Small PDS and XRPC server fixes

### DIFF
--- a/packages/pds/src/logger.ts
+++ b/packages/pds/src/logger.ts
@@ -17,7 +17,7 @@ export const loggerMiddleware = pinoHttp({
       const authHeader = serialized.headers.authorization || ''
       let auth: string | undefined = undefined
       if (authHeader.startsWith('Bearer ')) {
-        const token = authHeader.slice(0, 'Bearer '.length)
+        const token = authHeader.slice('Bearer '.length)
         const sub = jwt.decode(token)?.sub
         if (sub) {
           auth = 'Bearer ' + sub

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -105,7 +105,15 @@ export function validateInput(
     def.input?.encoding &&
     (!inputEncoding || !isValidEncoding(def.input?.encoding, inputEncoding))
   ) {
-    throw new InvalidRequestError(`Invalid request encoding: ${inputEncoding}`)
+    if (!inputEncoding) {
+      throw new InvalidRequestError(
+        `Request encoding (Content-Type) required but not provided`,
+      )
+    } else {
+      throw new InvalidRequestError(
+        `Wrong request encoding (Content-Type): ${inputEncoding}`,
+      )
+    }
   }
 
   if (!inputEncoding) {
@@ -184,8 +192,9 @@ export function validateOutput(
 }
 
 export function normalizeMime(v: string) {
-  const fullType = mime.contentType(v)
   if (!v) return false
+  const fullType = mime.contentType(v)
+  if (!fullType) return false
   const shortType = fullType.split(';')[0]
   if (!shortType) return false
   return shortType


### PR DESCRIPTION
The PDS logging thing commit is simple. Was always displaying in logs as `Bearer Invalid` even for valid auth requests.

The XRPC server fix is mostly to improve error messages in responses. I ran across this while debugging blob uploads from golang code and was getting error messages like `Invalid request encoding: false` which was confusing.

In the second commit, in test coverage, I expect the error message indicated in the `TODO` line. I spent a while trying to get the test to pass that way but don't feel like I know `jest` or javascript internals well enough to figure out why it is `TypeError: fetch failed` instead and gave up.