### PR TITLE
Apply lexicon defaults

### DIFF
--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -511,8 +511,8 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
         const lexUri = `${lexiconDoc.id}#${defId}`
         if (defId === 'main') {
           if (def.type === 'query' || def.type === 'procedure') {
-            genXrpcParams(file, lexicons, lexUri)
-            genXrpcInput(file, imports, lexicons, lexUri)
+            genXrpcParams(file, lexicons, lexUri, false)
+            genXrpcInput(file, imports, lexicons, lexUri, false)
             genXrpcOutput(file, imports, lexicons, lexUri)
             genClientXrpcCommon(file, lexicons, lexUri)
           } else if (def.type === 'subscription') {

--- a/packages/lex-cli/src/codegen/server.ts
+++ b/packages/lex-cli/src/codegen/server.ts
@@ -343,11 +343,11 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
           if (def.type === 'query' || def.type === 'procedure') {
             genXrpcParams(file, lexicons, lexUri)
             genXrpcInput(file, imports, lexicons, lexUri)
-            genXrpcOutput(file, imports, lexicons, lexUri)
+            genXrpcOutput(file, imports, lexicons, lexUri, false)
             genServerXrpcMethod(file, lexicons, lexUri)
           } else if (def.type === 'subscription') {
             genXrpcParams(file, lexicons, lexUri)
-            genXrpcOutput(file, imports, lexicons, lexUri)
+            genXrpcOutput(file, imports, lexicons, lexUri, false)
             genServerXrpcStreaming(file, lexicons, lexUri)
           } else if (def.type === 'record') {
             genServerRecord(file, imports, lexicons, lexUri)

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -159,7 +159,7 @@ export class Lexicons {
         `Invalid $type: must be ${lexUri}, got ${$type}`,
       )
     }
-    assertValidRecord(this, def as LexRecord, value)
+    return assertValidRecord(this, def as LexRecord, value)
   }
 
   /**
@@ -172,7 +172,7 @@ export class Lexicons {
       'procedure',
       'subscription',
     ])
-    assertValidXrpcParams(
+    return assertValidXrpcParams(
       this,
       def as LexXrpcProcedure | LexXrpcQuery | LexXrpcSubscription,
       value,
@@ -185,7 +185,7 @@ export class Lexicons {
   assertValidXrpcInput(lexUri: string, value: unknown) {
     lexUri = toLexUri(lexUri)
     const def = this.getDefOrThrow(lexUri, ['procedure'])
-    assertValidXrpcInput(this, def as LexXrpcProcedure, value)
+    return assertValidXrpcInput(this, def as LexXrpcProcedure, value)
   }
 
   /**
@@ -194,7 +194,11 @@ export class Lexicons {
   assertValidXrpcOutput(lexUri: string, value: unknown) {
     lexUri = toLexUri(lexUri)
     const def = this.getDefOrThrow(lexUri, ['query', 'procedure'])
-    assertValidXrpcOutput(this, def as LexXrpcProcedure | LexXrpcQuery, value)
+    return assertValidXrpcOutput(
+      this,
+      def as LexXrpcProcedure | LexXrpcQuery,
+      value,
+    )
   }
 
   /**

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -336,10 +336,15 @@ export class LexiconDocMalformedError extends Error {
   }
 }
 
-export interface ValidationResult {
-  success: boolean
-  error?: ValidationError
-}
+export type ValidationResult =
+  | {
+      success: true
+      value: unknown
+    }
+  | {
+      success: false
+      error: ValidationError
+    }
 
 export class ValidationError extends Error {}
 export class InvalidLexiconError extends Error {}

--- a/packages/lexicon/src/util.ts
+++ b/packages/lexicon/src/util.ts
@@ -49,7 +49,7 @@ export function validateOneOf(
           ),
         }
       }
-      return { success: true }
+      return { success: true, value }
     } else {
       concreteDefs = toConcreteTypes(lexicons, {
         type: 'ref',
@@ -88,9 +88,8 @@ export function assertValidOneOf(
   mustBeObj = false,
 ) {
   const res = validateOneOf(lexicons, path, def, value, mustBeObj)
-  if (!res.success) {
-    throw res.error
-  }
+  if (!res.success) throw res.error
+  return res.value
 }
 
 export function toConcreteTypes(

--- a/packages/lexicon/src/validation.ts
+++ b/packages/lexicon/src/validation.ts
@@ -17,6 +17,7 @@ export function assertValidRecord(
 ) {
   const res = ComplexValidators.object(lexicons, 'Record', def.record, value)
   if (!res.success) throw res.error
+  return res.value
 }
 
 export function assertValidXrpcParams(
@@ -27,6 +28,7 @@ export function assertValidXrpcParams(
   if (def.parameters) {
     const res = XrpcValidators.params(lexicons, 'Params', def.parameters, value)
     if (!res.success) throw res.error
+    return res.value
   }
 }
 
@@ -37,7 +39,7 @@ export function assertValidXrpcInput(
 ) {
   if (def.input?.schema) {
     // loop: all input schema definitions
-    assertValidOneOf(lexicons, 'Input', def.input.schema, value, true)
+    return assertValidOneOf(lexicons, 'Input', def.input.schema, value, true)
   }
 }
 
@@ -48,6 +50,6 @@ export function assertValidXrpcOutput(
 ) {
   if (def.output?.schema) {
     // loop: all output schema definitions
-    assertValidOneOf(lexicons, 'Output', def.output.schema, value, true)
+    return assertValidOneOf(lexicons, 'Output', def.output.schema, value, true)
   }
 }

--- a/packages/lexicon/src/validators/blob.ts
+++ b/packages/lexicon/src/validators/blob.ts
@@ -26,7 +26,7 @@ export function blob(
       error: new ValidationError(`${path}/mimeType should be a string`),
     }
   }
-  return { success: true }
+  return { success: true, value }
 }
 
 export function image(

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -99,7 +99,7 @@ export function array(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function object(
@@ -118,33 +118,36 @@ export function object(
     }
   }
 
-  // required
-  if (Array.isArray(def.required)) {
-    for (const key of def.required) {
-      if (typeof value[key] === 'undefined') {
+  const requiredProps = new Set(def.required ?? [])
+
+  // properties
+  let resultValue = value
+  if (typeof def.properties === 'object') {
+    for (const key in def.properties) {
+      const propDef = def.properties[key]
+      const propPath = `${path}/${key}`
+      const validated = validateOneOf(lexicons, propPath, propDef, value[key])
+      const propValue = validated.success ? validated.value : value[key]
+      const propIsUndefined = typeof propValue === 'undefined'
+      // Return error for bad validation, giving required rule precedence
+      if (propIsUndefined && requiredProps.has(key)) {
         return {
           success: false,
           error: new ValidationError(`${path} must have the property "${key}"`),
         }
+      } else if (!propIsUndefined && !validated.success) {
+        return validated
+      }
+      // Adjust value based on e.g. applied defaults, cloning shallowly if there was a changed value
+      if (propValue !== value[key]) {
+        if (resultValue === value) {
+          // Lazy shallow clone
+          resultValue = { ...value }
+        }
+        resultValue[key] = propValue
       }
     }
   }
 
-  // properties
-  if (typeof def.properties === 'object') {
-    for (const key in def.properties) {
-      const propValue = value[key]
-      if (typeof propValue === 'undefined') {
-        continue // skip- if required, will have already failed
-      }
-      const propDef = def.properties[key]
-      const propPath = `${path}/${key}`
-      const res = validateOneOf(lexicons, propPath, propDef, propValue)
-      if (!res.success) {
-        return res
-      }
-    }
-  }
-
-  return { success: true }
+  return { success: true, value: resultValue }
 }

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -48,9 +48,9 @@ export function boolean(
 
   // type
   const type = typeof value
-  if (type == 'undefined') {
+  if (type === 'undefined') {
     if (typeof def.default === 'boolean') {
-      return { success: true }
+      return { success: true, value: def.default }
     }
     return {
       success: false,
@@ -73,7 +73,7 @@ export function boolean(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function number(
@@ -86,9 +86,9 @@ export function number(
 
   // type
   const type = typeof value
-  if (type == 'undefined') {
+  if (type === 'undefined') {
     if (typeof def.default === 'number') {
-      return { success: true }
+      return { success: true, value: def.default }
     }
     return {
       success: false,
@@ -147,7 +147,7 @@ export function number(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function integer(
@@ -162,6 +162,8 @@ export function integer(
   const numRes = number(lexicons, path, def, value)
   if (!numRes.success) {
     return numRes
+  } else {
+    value = numRes.value
   }
 
   // whole numbers only
@@ -172,7 +174,7 @@ export function integer(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function string(
@@ -185,9 +187,9 @@ export function string(
 
   // type
   const type = typeof value
-  if (type == 'undefined') {
+  if (type === 'undefined') {
     if (typeof def.default === 'string') {
-      return { success: true }
+      return { success: true, value: def.default }
     }
     return {
       success: false,
@@ -246,7 +248,7 @@ export function string(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function datetime(
@@ -279,7 +281,7 @@ export function datetime(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }
 
 export function unknown(
@@ -296,5 +298,5 @@ export function unknown(
     }
   }
 
-  return { success: true }
+  return { success: true, value }
 }

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -66,6 +66,7 @@ export default [
             integer: { type: 'integer' },
             string: { type: 'string' },
             array: { type: 'array', items: { type: 'string' } },
+            def: { type: 'integer', default: 0 },
           },
         },
         output: {
@@ -120,6 +121,36 @@ export default [
             integer: { type: 'integer' },
             string: { type: 'string' },
           },
+        },
+      },
+    },
+  },
+  {
+    lexicon: 1,
+    id: 'com.example.default',
+    defs: {
+      main: {
+        type: 'record',
+        record: {
+          type: 'object',
+          required: ['boolean'],
+          properties: {
+            boolean: { type: 'boolean', default: false },
+            number: { type: 'number', default: 0 },
+            integer: { type: 'integer', default: 0 },
+            string: { type: 'string', default: '' },
+            datetime: { type: 'datetime' },
+            object: { type: 'ref', ref: '#object' },
+          },
+        },
+      },
+      object: {
+        type: 'object',
+        properties: {
+          boolean: { type: 'boolean', default: true },
+          number: { type: 'number', default: 1.5 },
+          integer: { type: 'integer', default: 1 },
+          string: { type: 'string', default: 'x' },
         },
       },
     },

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -56,6 +56,7 @@ describe('General validation', () => {
     {
       const res = lex.validate('com.example.kitchenSink', {})
       expect(res.success).toBe(false)
+      if (res.success) throw new Error('Asserted')
       expect(res.error?.message).toBe('Record must have the property "object"')
     }
   })
@@ -74,6 +75,7 @@ describe('General validation', () => {
     {
       const res = lex.validate('com.example.kitchenSink#object', {})
       expect(res.success).toBe(false)
+      if (res.success) throw new Error('Asserted')
       expect(res.error?.message).toBe('Object must have the property "object"')
     }
   })
@@ -282,6 +284,27 @@ describe('Record validation', () => {
     lex.assertValidRecord('com.example.optional', {
       $type: 'com.example.optional',
     })
+  })
+
+  it('Handles default properties correctly', () => {
+    const result = lex.assertValidRecord('com.example.default', {
+      $type: 'com.example.default',
+      object: {},
+    })
+    expect(result).toEqual({
+      $type: 'com.example.default',
+      boolean: false,
+      integer: 0,
+      number: 0,
+      string: '',
+      object: {
+        boolean: true,
+        integer: 1,
+        number: 1.5,
+        string: 'x',
+      },
+    })
+    expect(result).not.toHaveProperty('datetime')
   })
 
   it('Handles unions correctly', () => {
@@ -570,19 +593,36 @@ describe('XRPC parameter validation', () => {
   const lex = new Lexicons(LexiconDocs)
 
   it('Passes valid parameters', () => {
-    lex.assertValidXrpcParams('com.example.query', {
+    const queryResult = lex.assertValidXrpcParams('com.example.query', {
       boolean: true,
       number: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
     })
-    lex.assertValidXrpcParams('com.example.procedure', {
+    expect(queryResult).toEqual({
       boolean: true,
       number: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
+      def: 0,
+    })
+    const paramResult = lex.assertValidXrpcParams('com.example.procedure', {
+      boolean: true,
+      number: 123.45,
+      integer: 123,
+      string: 'string',
+      array: ['x', 'y'],
+      def: 1,
+    })
+    expect(paramResult).toEqual({
+      boolean: true,
+      number: 123.45,
+      integer: 123,
+      string: 'string',
+      array: ['x', 'y'],
+      def: 1,
     })
   })
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  limit?: number
+  limit: number
   cursor?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/search.ts
@@ -10,7 +10,7 @@ import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
   term?: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchTypeahead.ts
@@ -10,7 +10,7 @@ import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
   term?: string
-  limit?: number
+  limit: number
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -10,7 +10,7 @@ import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {
   author: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -11,7 +11,7 @@ import * as AppBskySystemDeclRef from '../system/declRef'
 export interface QueryParams {
   uri: string
   cid?: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -10,7 +10,7 @@ import * as AppBskyFeedFeedViewPost from './feedViewPost'
 
 export interface QueryParams {
   algorithm?: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getVotes.ts
@@ -12,7 +12,7 @@ export interface QueryParams {
   uri: string
   cid?: string
   direction?: 'up' | 'down'
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -11,7 +11,7 @@ import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
   user: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -11,7 +11,7 @@ import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
   user: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskySystemDeclRef from '../system/declRef'
 
 export interface QueryParams {
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/list.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyActorRef from '../actor/ref'
 
 export interface QueryParams {
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationActions.ts
@@ -10,7 +10,7 @@ import * as ComAtprotoAdminModerationAction from './moderationAction'
 
 export interface QueryParams {
   subject?: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
@@ -11,7 +11,7 @@ import * as ComAtprotoAdminModerationReport from './moderationReport'
 export interface QueryParams {
   subject?: string
   resolved?: boolean
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/searchRepos.ts
@@ -10,7 +10,7 @@ import * as ComAtprotoAdminRepo from './repo'
 
 export interface QueryParams {
   term?: string
-  limit?: number
+  limit: number
   before?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/batchWrite.ts
@@ -13,7 +13,7 @@ export interface InputSchema {
   /** The DID of the repo. */
   did: string
   /** Validate the records? */
-  validate?: boolean
+  validate: boolean
   writes: (Create | Update | Delete)[]
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -15,7 +15,7 @@ export interface InputSchema {
   /** The NSID of the record collection. */
   collection: string
   /** Validate the record? */
-  validate?: boolean
+  validate: boolean
   /** The record to create. */
   record: {}
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
   /** The NSID of the record type. */
   collection: string
   /** The number of records to return. */
-  limit?: number
+  limit: number
   /** A TID to filter the range of records returned. */
   before?: string
   /** A TID to filter the range of records returned. */

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -17,7 +17,7 @@ export interface InputSchema {
   /** The TID of the record. */
   rkey: string
   /** Validate the record? */
-  validate?: boolean
+  validate: boolean
   /** The record to create. */
   record: {}
   [k: string]: unknown

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -26,6 +26,7 @@ import {
   Options,
   XRPCStreamHandlerConfig,
   XRPCStreamHandler,
+  Params,
 } from './types'
 import {
   decodeQueryParams,
@@ -184,9 +185,9 @@ export class Server {
     return async function (req, res, next) {
       try {
         // validate request
-        const params = decodeQueryParams(def, req.query)
+        let params = decodeQueryParams(def, req.query)
         try {
-          assertValidXrpcParams(params)
+          params = assertValidXrpcParams(params) as Params
         } catch (e) {
           throw new InvalidRequestError(String(e))
         }
@@ -260,9 +261,9 @@ export class Server {
               throw XRPCError.fromError(auth)
             }
             // validate request
-            const params = decodeQueryParams(def, getQueryParams(req.url))
+            let params = decodeQueryParams(def, getQueryParams(req.url))
             try {
-              assertValidXrpcParams(params)
+              params = assertValidXrpcParams(params) as Params
             } catch (e) {
               throw new InvalidRequestError(String(e))
             }

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -116,7 +116,7 @@ export function validateInput(
   // if input schema, validate
   if (def.input?.schema) {
     try {
-      lexicons.assertValidXrpcInput(nsid, req.body)
+      req.body = lexicons.assertValidXrpcInput(nsid, req.body)
     } catch (e) {
       throw new InvalidRequestError(e instanceof Error ? e.message : String(e))
     }
@@ -174,7 +174,10 @@ export function validateOutput(
   // output schema
   if (def.output?.schema) {
     try {
-      lexicons.assertValidXrpcOutput(nsid, output?.body)
+      const result = lexicons.assertValidXrpcOutput(nsid, output?.body)
+      if (output) {
+        output.body = result
+      }
     } catch (e) {
       throw new InternalServerError(e instanceof Error ? e.message : String(e))
     }

--- a/packages/xrpc-server/tests/parameters.test.ts
+++ b/packages/xrpc-server/tests/parameters.test.ts
@@ -19,6 +19,7 @@ const LEXICONS = [
             num: { type: 'number', minimum: 2, maximum: 10 },
             bool: { type: 'boolean' },
             arr: { type: 'array', items: { type: 'integer' }, maxLength: 2 },
+            def: { type: 'integer', default: 0 },
           },
         },
         output: {
@@ -55,6 +56,7 @@ describe('Parameters', () => {
       num: 5.5,
       bool: true,
       arr: [1, 2],
+      def: 5,
     })
     expect(res1.success).toBeTruthy()
     expect(res1.data.str).toBe('valid')
@@ -62,6 +64,7 @@ describe('Parameters', () => {
     expect(res1.data.num).toBe(5.5)
     expect(res1.data.bool).toBe(true)
     expect(res1.data.arr).toEqual([1, 2])
+    expect(res1.data.def).toEqual(5)
 
     const res2 = await client.call('io.example.paramTest', {
       str: 10,
@@ -76,7 +79,9 @@ describe('Parameters', () => {
     expect(res2.data.num).toBe(5.5)
     expect(res2.data.bool).toBe(true)
     expect(res2.data.arr).toEqual([3])
+    expect(res2.data.def).toEqual(0)
 
+    // @TODO test sending blatantly bad types
     await expect(
       client.call('io.example.paramTest', {
         str: 'n',


### PR DESCRIPTION
The `default` values for number, integer, string, and boolean types are now applied during validation in xrpc-server.  Codegen has been updated to reflect that properties with a default are present.

Fixes #299 #526 