### PR TITLE
Allow unsetting profile images and description in updateProfile

### DIFF
--- a/lexicons/app/bsky/actor/updateProfile.json
+++ b/lexicons/app/bsky/actor/updateProfile.json
@@ -9,6 +9,7 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
+          "nullable": ["description", "avatar", "banner"],
           "properties": {
             "displayName": {
               "type": "string",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2751,6 +2751,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
+            nullable: ['description', 'avatar', 'banner'],
             properties: {
               displayName: {
                 type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/updateProfile.ts
@@ -10,9 +10,9 @@ export interface QueryParams {}
 
 export interface InputSchema {
   displayName?: string
-  description?: string
-  avatar?: { cid: string; mimeType: string; [k: string]: unknown }
-  banner?: { cid: string; mimeType: string; [k: string]: unknown }
+  description?: string | null
+  avatar?: { cid: string; mimeType: string; [k: string]: unknown } | null
+  banner?: { cid: string; mimeType: string; [k: string]: unknown } | null
   [k: string]: unknown
 }
 

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -162,6 +162,7 @@ export const lexObject = z.object({
   type: z.literal('object'),
   description: z.string().optional(),
   required: z.string().array().optional(),
+  nullable: z.string().array().optional(),
   properties: z
     .record(z.union([lexRefVariant, lexArray, lexBlobVariant, lexPrimitive]))
     .optional(),

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -130,12 +130,17 @@ export function object(
     }
   }
 
+  const nullable = new Set(def.nullable)
+
   // properties
   if (typeof def.properties === 'object') {
     for (const key in def.properties) {
       const propValue = value[key]
       if (typeof propValue === 'undefined') {
         continue // skip- if required, will have already failed
+      }
+      if (propValue === null && nullable.has(key)) {
+        continue
       }
       const propDef = def.properties[key]
       const propPath = `${path}/${key}`

--- a/packages/pds/src/api/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/api/app/bsky/actor/updateProfile.ts
@@ -34,21 +34,23 @@ export default function (server: Server, ctx: AppContext) {
               // @TODO need a way to get a profile out of a broken state
               throw new InvalidRequestError('could not parse current profile')
             }
-
             updated = {
               ...current,
               displayName: input.body.displayName || current.displayName,
-              description: input.body.description || current.description,
-              avatar: input.body.avatar || current.avatar,
-              banner: input.body.banner || current.banner,
+              description: unsetIfNull(
+                input.body.description,
+                current.description,
+              ),
+              avatar: unsetIfNull(input.body.avatar, current.avatar),
+              banner: unsetIfNull(input.body.banner, current.banner),
             }
           } else {
             updated = {
               $type: profileNsid,
               displayName: input.body.displayName,
-              description: input.body.description,
-              avatar: input.body.avatar,
-              banner: input.body.banner,
+              description: unsetIfNull(input.body.description),
+              avatar: unsetIfNull(input.body.avatar),
+              banner: unsetIfNull(input.body.banner),
             }
           }
           updated = common.noUndefinedVals(updated)
@@ -87,9 +89,9 @@ export default function (server: Server, ctx: AppContext) {
                 .set({
                   cid: profileCid.toString(),
                   displayName: updated.displayName,
-                  description: updated.description,
-                  avatarCid: updated.avatar?.cid,
-                  bannerCid: updated.banner?.cid,
+                  description: updated.description ?? null,
+                  avatarCid: updated.avatar?.cid ?? null,
+                  bannerCid: updated.banner?.cid ?? null,
                   indexedAt: now,
                 })
                 .where('uri', '=', uri.toString())
@@ -117,4 +119,9 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+function unsetIfNull<T>(x: T | null | undefined, y?: T): T | undefined {
+  if (x === null) return undefined
+  return x ?? y
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2751,6 +2751,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
+            nullable: ['description', 'avatar', 'banner'],
             properties: {
               displayName: {
                 type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/updateProfile.ts
@@ -11,9 +11,9 @@ export interface QueryParams {}
 
 export interface InputSchema {
   displayName?: string
-  description?: string
-  avatar?: { cid: string; mimeType: string; [k: string]: unknown }
-  banner?: { cid: string; mimeType: string; [k: string]: unknown }
+  description?: string | null
+  avatar?: { cid: string; mimeType: string; [k: string]: unknown } | null
+  banner?: { cid: string; mimeType: string; [k: string]: unknown } | null
   [k: string]: unknown
 }
 

--- a/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
@@ -196,6 +196,25 @@ Object {
 }
 `;
 
+exports[`pds profile views handles unsetting profile fields 1`] = `
+Object {
+  "creator": "user(0)",
+  "declaration": Object {
+    "actorType": "app.bsky.system.actorUser",
+    "cid": "cids(0)",
+  },
+  "did": "user(0)",
+  "displayName": "ali",
+  "followersCount": 2,
+  "followsCount": 3,
+  "handle": "alice.test",
+  "myState": Object {
+    "muted": false,
+  },
+  "postsCount": 4,
+}
+`;
+
 exports[`pds profile views updates profile 1`] = `
 Object {
   "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -146,6 +146,23 @@ describe('pds profile views', () => {
     expect(forSnapshot(aliceForAlice.data)).toMatchSnapshot()
   })
 
+  it('handles unsetting profile fields', async () => {
+    await agent.api.app.bsky.actor.updateProfile(
+      { description: null, avatar: null, banner: null },
+      { headers: sc.getHeaders(alice), encoding: 'application/json' },
+    )
+
+    const aliceForAlice = await agent.api.app.bsky.actor.getProfile(
+      { actor: alice },
+      { headers: sc.getHeaders(alice) },
+    )
+
+    expect(aliceForAlice.data.description).toBeUndefined()
+    expect(aliceForAlice.data.avatar).toBeUndefined()
+    expect(aliceForAlice.data.banner).toBeUndefined()
+    expect(forSnapshot(aliceForAlice.data)).toMatchSnapshot()
+  })
+
   it('creates new profile', async () => {
     await agent.api.app.bsky.actor.updateProfile(
       { displayName: 'danny boy' },


### PR DESCRIPTION
A few steps here, in order to allow unsetting profile images and descriptions in the `app.bsky.actor.updateProfile` method.
 - Add support for `nullable` on lexicon object types, spec'ed similarly to `required`.
 - Add `nullable` to codegen.
 - Alter lexicons and implementation of `updateProfile` to allow unsetting avatar, banner, and description.