### PR TITLE
Bugfix: Flaky readFromGenerator test

### DIFF
--- a/packages/common/tests/async.test.ts
+++ b/packages/common/tests/async.test.ts
@@ -10,12 +10,12 @@ describe('async', () => {
     }
 
     it('reads from generator with timeout', async () => {
-      const read = await readFromGenerator(waitToYield(100), undefined, 101)
+      const read = await readFromGenerator(waitToYield(100), undefined, 105)
       expect(read).toEqual([true, true, true, true, true])
     })
 
     it('stops reading at timeout', async () => {
-      const read = await readFromGenerator(waitToYield(100), undefined, 99)
+      const read = await readFromGenerator(waitToYield(100), undefined, 95)
       expect(read).toEqual([])
     })
   })


### PR DESCRIPTION
Just widened the thresholds here. If we continue to hit these, we may need a diff approach to timing tests

Closes https://github.com/bluesky-social/atproto/issues/557