### PR TITLE
Fix PDS build, updating main to dist in api package

### DIFF
--- a/packages/api/build.js
+++ b/packages/api/build.js
@@ -1,7 +1,15 @@
+const pkgJson = require('@npmcli/package-json')
 const { nodeExternalsPlugin } = require('esbuild-node-externals')
 
 const buildShallow =
   process.argv.includes('--shallow') || process.env.ATP_BUILD_SHALLOW === 'true'
+
+if (process.argv.includes('--update-main-to-dist')) {
+  return pkgJson
+    .load(__dirname)
+    .then((pkg) => pkg.update({ main: 'dist/index.js' }))
+    .then((pkg) => pkg.save())
+}
 
 require('esbuild').build({
   logLevel: 'info',


### PR DESCRIPTION
Now that the api package is used by the PDS, as of #555, the api package needs a little tweak to its build script.