### PR TITLE
Temporarily disable PLC mutations

### DIFF
--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -22,7 +22,7 @@ jest.mock('dns/promises', () => {
   }
 })
 
-describe('handles', () => {
+describe.skip('handles', () => {
   let agent: AtpAgent
   let close: util.CloseFn
   let sc: SeedClient

--- a/packages/plc/src/server/routes.ts
+++ b/packages/plc/src/server/routes.ts
@@ -61,6 +61,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
     if (!check.is(op, t.def.operation)) {
       throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)
     }
+    if (op.type !== 'create') {
+      throw new Error('All ops apart from `create` are temporarily disabled')
+    }
     await ctx.db.validateAndAddOp(did, op)
     res.sendStatus(200)
   })

--- a/packages/plc/tests/server.test.ts
+++ b/packages/plc/tests/server.test.ts
@@ -6,7 +6,7 @@ import { cidForCbor } from '@atproto/common'
 import { AxiosError } from 'axios'
 import { Database } from '../src'
 
-describe.skip('PLC server', () => {
+describe('PLC server', () => {
   let handle = 'alice.example.com'
   let atpPds = 'example.com'
 
@@ -49,6 +49,8 @@ describe.skip('PLC server', () => {
     expect(doc.handle).toEqual(handle)
     expect(doc.atpPds).toEqual(atpPds)
   })
+
+  return
 
   it('can perform some updates', async () => {
     const newSigningKey = await EcdsaKeypair.create()

--- a/packages/plc/tests/server.test.ts
+++ b/packages/plc/tests/server.test.ts
@@ -6,7 +6,7 @@ import { cidForCbor } from '@atproto/common'
 import { AxiosError } from 'axios'
 import { Database } from '../src'
 
-describe('PLC server', () => {
+describe.skip('PLC server', () => {
   let handle = 'alice.example.com'
   let atpPds = 'example.com'
 


### PR DESCRIPTION
I'm currently refactoring the PLC data model.

Fortunately there are no currently existing operations on PLC apart from `create`s. 

We will no longer support the other currently implemented operations. 

This temporarily throws on every operation apart from a `create` until I wrap up the refactor.