### PR TITLE
Sync subscription tweaks

### DIFF
--- a/lexicons/com/atproto/sync/subscribeAllRepos.json
+++ b/lexicons/com/atproto/sync/subscribeAllRepos.json
@@ -17,7 +17,8 @@
       "message": {
         "schema": {
           "type": "object",
-          "required": ["seq", "event", "repo", "commit", "blocks", "blobs", "time"],
+          "required": ["seq", "event", "repo", "commit", "prev", "blocks", "blobs", "time"],
+          "nullable": ["prev"],
           "properties": {
             "seq": {"type": "integer"},
             "event": { 

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2248,10 +2248,12 @@ export const schemaDict = {
               'event',
               'repo',
               'commit',
+              'prev',
               'blocks',
               'blobs',
               'time',
             ],
+            nullable: ['prev'],
             properties: {
               seq: {
                 type: 'integer',

--- a/packages/pds/src/api/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/api/com/atproto/sync/subscribeAllRepos.ts
@@ -14,7 +14,7 @@ export default function (server: Server, ctx: AppContext) {
     const backfillTime = new Date(
       Date.now() - ctx.cfg.repoBackfillLimitMs,
     ).toISOString()
-    if (cursor) {
+    if (cursor !== undefined) {
       const [next, curr] = await Promise.all([
         ctx.sequencer.next(cursor),
         ctx.sequencer.curr(),
@@ -40,10 +40,7 @@ export default function (server: Server, ctx: AppContext) {
         blocks,
         blobs,
         time,
-      }
-      // Undefineds not allowed by dag-cbor encoding
-      if (prev !== undefined) {
-        toYield.prev = prev
+        prev: prev ?? null,
       }
       yield toYield
     }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2248,10 +2248,12 @@ export const schemaDict = {
               'event',
               'repo',
               'commit',
+              'prev',
               'blocks',
               'blobs',
               'time',
             ],
+            nullable: ['prev'],
             properties: {
               seq: {
                 type: 'integer',

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
@@ -17,7 +17,7 @@ export interface OutputSchema {
   event: 'repo_append' | 'rebase' | (string & {})
   repo: string
   commit: string
-  prev?: string
+  prev: string | null
   blocks: {}
   blobs: string[]
   time: string

--- a/packages/pds/tests/sync/subscribe-all-repos.test.ts
+++ b/packages/pds/tests/sync/subscribe-all-repos.test.ts
@@ -92,7 +92,7 @@ describe('repo subscribe all repos', () => {
       const evt = evts[i]
       expect(evt.repo).toEqual(did)
       expect(evt.commit).toEqual(commit.commit.toString())
-      expect(evt.prev).toEqual(commits[i - 1]?.commit?.toString())
+      expect(evt.prev).toEqual(commits[i - 1]?.commit?.toString() ?? null)
       const car = await repo.readCarWithRoot(evt.blocks as Uint8Array)
       expect(car.root.equals(commit.commit))
       expect(car.blocks.equals(commit.blocks))


### PR DESCRIPTION
Couple tweaks
- `prev` is nullable instead of optional
- `cursor` can be set to `0`

Closes https://github.com/bluesky-social/atproto/issues/577  