### PR TITLE
Crawler schemas

### DIFF
--- a/lexicons/com/atproto/sync/notifyOfUpdate.json
+++ b/lexicons/com/atproto/sync/notifyOfUpdate.json
@@ -1,0 +1,10 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.sync.notifyOfUpdate",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break."
+    }
+  }
+}

--- a/lexicons/com/atproto/sync/requestCrawl.json
+++ b/lexicons/com/atproto/sync/requestCrawl.json
@@ -4,7 +4,14 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Request a service to persistently crawl hosted repos."
+      "description": "Request a service to persistently crawl hosted repos.",
+      "parameters": {
+        "type": "params",
+        "required": ["hostname"],
+        "properties": {
+          "host": {"type": "string", "description": "Hostname of hte service that is reqeusting to be crawled."}
+        }
+      }
     }
   }
 }

--- a/lexicons/com/atproto/sync/requestCrawl.json
+++ b/lexicons/com/atproto/sync/requestCrawl.json
@@ -9,7 +9,7 @@
         "type": "params",
         "required": ["hostname"],
         "properties": {
-          "host": {"type": "string", "description": "Hostname of hte service that is reqeusting to be crawled."}
+          "host": {"type": "string", "description": "Hostname of the service that is requesting to be crawled."}
         }
       }
     }

--- a/lexicons/com/atproto/sync/requestCrawl.json
+++ b/lexicons/com/atproto/sync/requestCrawl.json
@@ -1,0 +1,10 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.sync.requestCrawl",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Request a service to persistently crawl hosted repos."
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -55,6 +55,8 @@ import * as ComAtprotoSyncGetCommitPath from './types/com/atproto/sync/getCommit
 import * as ComAtprotoSyncGetHead from './types/com/atproto/sync/getHead'
 import * as ComAtprotoSyncGetRecord from './types/com/atproto/sync/getRecord'
 import * as ComAtprotoSyncGetRepo from './types/com/atproto/sync/getRepo'
+import * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
+import * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 import * as ComAtprotoSyncSubscribeAllRepos from './types/com/atproto/sync/subscribeAllRepos'
 import * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
 import * as AppBskyActorGetProfiles from './types/app/bsky/actor/getProfiles'
@@ -143,6 +145,8 @@ export * as ComAtprotoSyncGetCommitPath from './types/com/atproto/sync/getCommit
 export * as ComAtprotoSyncGetHead from './types/com/atproto/sync/getHead'
 export * as ComAtprotoSyncGetRecord from './types/com/atproto/sync/getRecord'
 export * as ComAtprotoSyncGetRepo from './types/com/atproto/sync/getRepo'
+export * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
+export * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 export * as ComAtprotoSyncSubscribeAllRepos from './types/com/atproto/sync/subscribeAllRepos'
 export * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
 export * as AppBskyActorGetProfiles from './types/app/bsky/actor/getProfiles'
@@ -762,6 +766,28 @@ export class SyncNS {
       .call('com.atproto.sync.getRepo', params, undefined, opts)
       .catch((e) => {
         throw ComAtprotoSyncGetRepo.toKnownErr(e)
+      })
+  }
+
+  notifyOfUpdate(
+    params?: ComAtprotoSyncNotifyOfUpdate.QueryParams,
+    opts?: ComAtprotoSyncNotifyOfUpdate.CallOptions,
+  ): Promise<ComAtprotoSyncNotifyOfUpdate.Response> {
+    return this._service.xrpc
+      .call('com.atproto.sync.notifyOfUpdate', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoSyncNotifyOfUpdate.toKnownErr(e)
+      })
+  }
+
+  requestCrawl(
+    params?: ComAtprotoSyncRequestCrawl.QueryParams,
+    opts?: ComAtprotoSyncRequestCrawl.CallOptions,
+  ): Promise<ComAtprotoSyncRequestCrawl.Response> {
+    return this._service.xrpc
+      .call('com.atproto.sync.requestCrawl', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoSyncRequestCrawl.toKnownErr(e)
       })
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2249,7 +2249,7 @@ export const schemaDict = {
             host: {
               type: 'string',
               description:
-                'Hostname of hte service that is reqeusting to be crawled.',
+                'Hostname of the service that is requesting to be crawled.',
             },
           },
         },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2242,6 +2242,17 @@ export const schemaDict = {
       main: {
         type: 'query',
         description: 'Request a service to persistently crawl hosted repos.',
+        parameters: {
+          type: 'params',
+          required: ['hostname'],
+          properties: {
+            host: {
+              type: 'string',
+              description:
+                'Hostname of hte service that is reqeusting to be crawled.',
+            },
+          },
+        },
       },
     },
   },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2224,6 +2224,27 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoSyncNotifyOfUpdate: {
+    lexicon: 1,
+    id: 'com.atproto.sync.notifyOfUpdate',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
+      },
+    },
+  },
+  ComAtprotoSyncRequestCrawl: {
+    lexicon: 1,
+    id: 'com.atproto.sync.requestCrawl',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Request a service to persistently crawl hosted repos.',
+      },
+    },
+  },
   ComAtprotoSyncSubscribeAllRepos: {
     lexicon: 1,
     id: 'com.atproto.sync.subscribeAllRepos',
@@ -4118,6 +4139,8 @@ export const ids = {
   ComAtprotoSyncGetHead: 'com.atproto.sync.getHead',
   ComAtprotoSyncGetRecord: 'com.atproto.sync.getRecord',
   ComAtprotoSyncGetRepo: 'com.atproto.sync.getRepo',
+  ComAtprotoSyncNotifyOfUpdate: 'com.atproto.sync.notifyOfUpdate',
+  ComAtprotoSyncRequestCrawl: 'com.atproto.sync.requestCrawl',
   ComAtprotoSyncSubscribeAllRepos: 'com.atproto.sync.subscribeAllRepos',
   AppBskyActorGetProfile: 'app.bsky.actor.getProfile',
   AppBskyActorGetProfiles: 'app.bsky.actor.getProfiles',

--- a/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
@@ -1,0 +1,26 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+
+export interface QueryParams {}
+
+export type InputSchema = undefined
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -1,0 +1,26 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+
+export interface QueryParams {}
+
+export type InputSchema = undefined
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -6,7 +6,10 @@ import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 
-export interface QueryParams {}
+export interface QueryParams {
+  /** Hostname of hte service that is reqeusting to be crawled. */
+  host?: string
+}
 
 export type InputSchema = undefined
 

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -7,7 +7,7 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
-  /** Hostname of hte service that is reqeusting to be crawled. */
+  /** Hostname of the service that is requesting to be crawled. */
   host?: string
 }
 

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -48,6 +48,8 @@ import * as ComAtprotoSyncGetCommitPath from './types/com/atproto/sync/getCommit
 import * as ComAtprotoSyncGetHead from './types/com/atproto/sync/getHead'
 import * as ComAtprotoSyncGetRecord from './types/com/atproto/sync/getRecord'
 import * as ComAtprotoSyncGetRepo from './types/com/atproto/sync/getRepo'
+import * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
+import * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 import * as ComAtprotoSyncSubscribeAllRepos from './types/com/atproto/sync/subscribeAllRepos'
 import * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
 import * as AppBskyActorGetProfiles from './types/app/bsky/actor/getProfiles'
@@ -510,6 +512,20 @@ export class SyncNS {
     cfg: ConfigOf<AV, ComAtprotoSyncGetRepo.Handler<ExtractAuth<AV>>>,
   ) {
     const nsid = 'com.atproto.sync.getRepo' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  notifyOfUpdate<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoSyncNotifyOfUpdate.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.sync.notifyOfUpdate' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  requestCrawl<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoSyncRequestCrawl.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.sync.requestCrawl' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2249,7 +2249,7 @@ export const schemaDict = {
             host: {
               type: 'string',
               description:
-                'Hostname of hte service that is reqeusting to be crawled.',
+                'Hostname of the service that is requesting to be crawled.',
             },
           },
         },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2242,6 +2242,17 @@ export const schemaDict = {
       main: {
         type: 'query',
         description: 'Request a service to persistently crawl hosted repos.',
+        parameters: {
+          type: 'params',
+          required: ['hostname'],
+          properties: {
+            host: {
+              type: 'string',
+              description:
+                'Hostname of hte service that is reqeusting to be crawled.',
+            },
+          },
+        },
       },
     },
   },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2224,6 +2224,27 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoSyncNotifyOfUpdate: {
+    lexicon: 1,
+    id: 'com.atproto.sync.notifyOfUpdate',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
+      },
+    },
+  },
+  ComAtprotoSyncRequestCrawl: {
+    lexicon: 1,
+    id: 'com.atproto.sync.requestCrawl',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Request a service to persistently crawl hosted repos.',
+      },
+    },
+  },
   ComAtprotoSyncSubscribeAllRepos: {
     lexicon: 1,
     id: 'com.atproto.sync.subscribeAllRepos',
@@ -4118,6 +4139,8 @@ export const ids = {
   ComAtprotoSyncGetHead: 'com.atproto.sync.getHead',
   ComAtprotoSyncGetRecord: 'com.atproto.sync.getRecord',
   ComAtprotoSyncGetRepo: 'com.atproto.sync.getRepo',
+  ComAtprotoSyncNotifyOfUpdate: 'com.atproto.sync.notifyOfUpdate',
+  ComAtprotoSyncRequestCrawl: 'com.atproto.sync.requestCrawl',
   ComAtprotoSyncSubscribeAllRepos: 'com.atproto.sync.subscribeAllRepos',
   AppBskyActorGetProfile: 'app.bsky.actor.getProfile',
   AppBskyActorGetProfiles: 'app.bsky.actor.getProfiles',

--- a/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -1,0 +1,27 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export type InputSchema = undefined
+export type HandlerInput = undefined
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -1,0 +1,27 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export type InputSchema = undefined
+export type HandlerInput = undefined
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -8,7 +8,7 @@ import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {
-  /** Hostname of hte service that is reqeusting to be crawled. */
+  /** Hostname of the service that is requesting to be crawled. */
   host?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -7,7 +7,10 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {}
+export interface QueryParams {
+  /** Hostname of hte service that is reqeusting to be crawled. */
+  host?: string
+}
 
 export type InputSchema = undefined
 export type HandlerInput = undefined


### PR DESCRIPTION
Two very simple sync routes:
- `requestCrawl` for a service to crawl you until further notice
- `notifyOfUpdate`: "dingdong". let a disconnected crawler know that you have an update waiting for them