### PR TITLE
Repo ops on sync stream

### DIFF
--- a/lexicons/com/atproto/sync/subscribeAllRepos.json
+++ b/lexicons/com/atproto/sync/subscribeAllRepos.json
@@ -17,7 +17,7 @@
       "message": {
         "schema": {
           "type": "object",
-          "required": ["seq", "event", "repo", "commit", "prev", "blocks", "blobs", "time"],
+          "required": ["seq", "event", "repo", "commit", "prev", "blocks", "ops", "blobs", "time"],
           "nullable": ["prev"],
           "properties": {
             "seq": {"type": "integer"},
@@ -32,7 +32,10 @@
             "commit": {"type": "string"},
             "prev": {"type": "string"},
             "blocks": {"type": "unknown"},
-            "ops": {"type": "ref", "ref": "#repoOp"},
+            "ops": {
+              "type": "array", 
+              "items": { "type": "ref", "ref": "#repoOp"}
+            },
             "blobs": {
               "type": "array",
               "items": {"type": "string"}
@@ -50,7 +53,8 @@
     },
     "repoOp": {
       "type": "object",
-      "required": ["action", "path"],
+      "required": ["action", "path", "cid"],
+      "nullable": ["cid"],
       "properties": {
         "action": {"type": "string"},
         "path": {"type": "string"},

--- a/lexicons/com/atproto/sync/subscribeAllRepos.json
+++ b/lexicons/com/atproto/sync/subscribeAllRepos.json
@@ -32,6 +32,7 @@
             "commit": {"type": "string"},
             "prev": {"type": "string"},
             "blocks": {"type": "unknown"},
+            "ops": {"type": "ref", "ref": "#repoOp"},
             "blobs": {
               "type": "array",
               "items": {"type": "string"}
@@ -46,6 +47,15 @@
       "errors": [
         {"name": "FutureCursor"}
       ]
+    },
+    "repoOp": {
+      "type": "object",
+      "required": ["action", "path"],
+      "properties": {
+        "action": {"type": "string"},
+        "path": {"type": "string"},
+        "cid": {"type": "string"}
+      }
     }
   }
 }

--- a/lexicons/com/atproto/sync/subscribeAllRepos.json
+++ b/lexicons/com/atproto/sync/subscribeAllRepos.json
@@ -56,7 +56,14 @@
       "required": ["action", "path", "cid"],
       "nullable": ["cid"],
       "properties": {
-        "action": {"type": "string"},
+        "action": {
+          "type": "string",
+          "knownValues": [
+            "create",
+            "update",
+            "delete"
+          ]
+        },
         "path": {"type": "string"},
         "cid": {"type": "string"}
       }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2250,6 +2250,7 @@ export const schemaDict = {
               'commit',
               'prev',
               'blocks',
+              'ops',
               'blobs',
               'time',
             ],
@@ -2275,8 +2276,11 @@ export const schemaDict = {
                 type: 'unknown',
               },
               ops: {
-                type: 'ref',
-                ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+                },
               },
               blobs: {
                 type: 'array',
@@ -2303,7 +2307,8 @@ export const schemaDict = {
       },
       repoOp: {
         type: 'object',
-        required: ['action', 'path'],
+        required: ['action', 'path', 'cid'],
+        nullable: ['cid'],
         properties: {
           action: {
             type: 'string',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2312,6 +2312,7 @@ export const schemaDict = {
         properties: {
           action: {
             type: 'string',
+            knownValues: ['create', 'update', 'delete'],
           },
           path: {
             type: 'string',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2274,6 +2274,10 @@ export const schemaDict = {
               blocks: {
                 type: 'unknown',
               },
+              ops: {
+                type: 'ref',
+                ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+              },
               blobs: {
                 type: 'array',
                 items: {
@@ -2296,6 +2300,21 @@ export const schemaDict = {
             name: 'FutureCursor',
           },
         ],
+      },
+      repoOp: {
+        type: 'object',
+        required: ['action', 'path'],
+        properties: {
+          action: {
+            type: 'string',
+          },
+          path: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+        },
       },
     },
   },

--- a/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
@@ -5,3 +5,22 @@ import { Headers, XRPCError } from '@atproto/xrpc'
 import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
+
+export interface RepoOp {
+  action: string
+  path: string
+  cid?: string
+  [k: string]: unknown
+}
+
+export function isRepoOp(v: unknown): v is RepoOp {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeAllRepos#repoOp'
+  )
+}
+
+export function validateRepoOp(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeAllRepos#repoOp', v)
+}

--- a/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
@@ -7,7 +7,7 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 
 export interface RepoOp {
-  action: string
+  action: 'create' | 'update' | 'delete' | (string & {})
   path: string
   cid: string | null
   [k: string]: unknown

--- a/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeAllRepos.ts
@@ -9,7 +9,7 @@ import { lexicons } from '../../../../lexicons'
 export interface RepoOp {
   action: string
   path: string
-  cid?: string
+  cid: string | null
   [k: string]: unknown
 }
 

--- a/packages/pds/src/api/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/api/com/atproto/sync/subscribeAllRepos.ts
@@ -31,13 +31,14 @@ export default function (server: Server, ctx: AppContext) {
     }
 
     for await (const evt of outbox.events(cursor, backfillTime)) {
-      const { seq, time, repo, commit, prev, blocks, blobs } = evt
+      const { seq, time, repo, commit, prev, blocks, ops, blobs } = evt
       const toYield: RepoEvent = {
         seq,
         event: 'repo_append',
         repo,
         commit,
         blocks,
+        ops,
         blobs,
         time,
         prev: prev ?? null,

--- a/packages/pds/src/db/database-schema.ts
+++ b/packages/pds/src/db/database-schema.ts
@@ -8,6 +8,7 @@ import * as record from './tables/record'
 import * as repoCommitBlock from './tables/repo-commit-block'
 import * as repoCommitHistory from './tables/repo-commit-history'
 import * as ipldBlock from './tables/ipld-block'
+import * as repoOp from './tables/repo-op'
 import * as inviteCode from './tables/invite-code'
 import * as notification from './tables/user-notification'
 import * as blob from './tables/blob'
@@ -30,6 +31,7 @@ export type DatabaseSchemaType = appView.DatabaseSchemaType &
   repoCommitBlock.PartialDB &
   repoCommitHistory.PartialDB &
   ipldBlock.PartialDB &
+  repoOp.PartialDB &
   repoCommitBlock.PartialDB &
   repoCommitHistory.PartialDB &
   inviteCode.PartialDB &

--- a/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
+++ b/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
@@ -1,0 +1,17 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('repo_op')
+    .addColumn('did', 'text', (col) => col.notNull())
+    .addColumn('commit', 'text', (col) => col.notNull())
+    .addColumn('action', 'text', (col) => col.notNull())
+    .addColumn('path', 'text', (col) => col.notNull())
+    .addColumn('cid', 'text', (col) => col.notNull())
+    .addPrimaryKeyConstraint('repo_op_pkey', ['did', 'commit', 'path'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('repo_op').execute()
+}

--- a/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
+++ b/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
@@ -1,6 +1,6 @@
 import { Kysely } from 'kysely'
 
-export async function up(db: Kysely<unknown>): Promise<void> {
+export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable('repo_op')
     .addColumn('did', 'text', (col) => col.notNull())
@@ -10,6 +10,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn('cid', 'text', (col) => col.notNull())
     .addPrimaryKeyConstraint('repo_op_pkey', ['did', 'commit', 'path'])
     .execute()
+
+  await db.deleteFrom('repo_seq').execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
+++ b/packages/pds/src/db/migrations/20230301T222603402Z-repo-ops.ts
@@ -7,7 +7,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('commit', 'text', (col) => col.notNull())
     .addColumn('action', 'text', (col) => col.notNull())
     .addColumn('path', 'text', (col) => col.notNull())
-    .addColumn('cid', 'text', (col) => col.notNull())
+    .addColumn('cid', 'text')
     .addPrimaryKeyConstraint('repo_op_pkey', ['did', 'commit', 'path'])
     .execute()
 

--- a/packages/pds/src/db/migrations/index.ts
+++ b/packages/pds/src/db/migrations/index.ts
@@ -21,3 +21,4 @@ export * as _20230208T081544325Z from './20230208T081544325Z-post-hydrate-indice
 export * as _20230208T222001557Z from './20230208T222001557Z-user-table-did-pkey'
 export * as _20230210T210132396Z from './20230210T210132396Z-post-hierarchy'
 export * as _20230214T172233550Z from './20230214T172233550Z-embed-records'
+export * as _20230301T222603402Z from './20230301T222603402Z-repo-ops'

--- a/packages/pds/src/db/tables/repo-op.ts
+++ b/packages/pds/src/db/tables/repo-op.ts
@@ -1,7 +1,9 @@
+import { WriteOpAction } from '@atproto/repo'
+
 export interface RepoOp {
   did: string
   commit: string
-  action: string
+  action: WriteOpAction
   path: string
   cid: string | null
 }

--- a/packages/pds/src/db/tables/repo-op.ts
+++ b/packages/pds/src/db/tables/repo-op.ts
@@ -1,0 +1,11 @@
+export interface RepoOp {
+  did: string
+  commit: string
+  action: string
+  path: string
+  cid: string | null
+}
+
+export const tableName = 'repo_op'
+
+export type PartialDB = { [tableName]: RepoOp }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2250,6 +2250,7 @@ export const schemaDict = {
               'commit',
               'prev',
               'blocks',
+              'ops',
               'blobs',
               'time',
             ],
@@ -2275,8 +2276,11 @@ export const schemaDict = {
                 type: 'unknown',
               },
               ops: {
-                type: 'ref',
-                ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+                },
               },
               blobs: {
                 type: 'array',
@@ -2303,7 +2307,8 @@ export const schemaDict = {
       },
       repoOp: {
         type: 'object',
-        required: ['action', 'path'],
+        required: ['action', 'path', 'cid'],
+        nullable: ['cid'],
         properties: {
           action: {
             type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2312,6 +2312,7 @@ export const schemaDict = {
         properties: {
           action: {
             type: 'string',
+            knownValues: ['create', 'update', 'delete'],
           },
           path: {
             type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2274,6 +2274,10 @@ export const schemaDict = {
               blocks: {
                 type: 'unknown',
               },
+              ops: {
+                type: 'ref',
+                ref: 'lex:com.atproto.sync.subscribeAllRepos#repoOp',
+              },
               blobs: {
                 type: 'array',
                 items: {
@@ -2296,6 +2300,21 @@ export const schemaDict = {
             name: 'FutureCursor',
           },
         ],
+      },
+      repoOp: {
+        type: 'object',
+        required: ['action', 'path'],
+        properties: {
+          action: {
+            type: 'string',
+          },
+          path: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+        },
       },
     },
   },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
@@ -19,6 +19,7 @@ export interface OutputSchema {
   commit: string
   prev: string | null
   blocks: {}
+  ops?: RepoOp
   blobs: string[]
   time: string
   [k: string]: unknown
@@ -32,3 +33,22 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
   params: QueryParams
   req: IncomingMessage
 }) => AsyncIterable<HandlerOutput>
+
+export interface RepoOp {
+  action: string
+  path: string
+  cid?: string
+  [k: string]: unknown
+}
+
+export function isRepoOp(v: unknown): v is RepoOp {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeAllRepos#repoOp'
+  )
+}
+
+export function validateRepoOp(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeAllRepos#repoOp', v)
+}

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
@@ -19,7 +19,7 @@ export interface OutputSchema {
   commit: string
   prev: string | null
   blocks: {}
-  ops?: RepoOp
+  ops: RepoOp[]
   blobs: string[]
   time: string
   [k: string]: unknown
@@ -37,7 +37,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 export interface RepoOp {
   action: string
   path: string
-  cid?: string
+  cid: string | null
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeAllRepos.ts
@@ -35,7 +35,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 }) => AsyncIterable<HandlerOutput>
 
 export interface RepoOp {
-  action: string
+  action: 'create' | 'update' | 'delete' | (string & {})
   path: string
   cid: string | null
   [k: string]: unknown

--- a/packages/pds/tests/sync/subscribe-all-repos.test.ts
+++ b/packages/pds/tests/sync/subscribe-all-repos.test.ts
@@ -9,7 +9,7 @@ import {
 import { randomStr } from '@atproto/crypto'
 import { DidResolver } from '@atproto/did-resolver'
 import * as repo from '@atproto/repo'
-import { MemoryBlockstore } from '@atproto/repo'
+import { getWriteLog, MemoryBlockstore, WriteOpAction } from '@atproto/repo'
 import { byFrame, ErrorFrame, Frame, InfoFrame } from '@atproto/xrpc-server'
 import { WebSocket } from 'ws'
 import { OutputSchema as RepoEvent } from '../../src/lexicon/types/com/atproto/sync/subscribeAllRepos'
@@ -82,11 +82,13 @@ describe('repo subscribe all repos', () => {
 
   const verifyRepo = async (did: string, evts: RepoEvent[]) => {
     const didRepo = await getRepo(did)
+    const writeLog = await getWriteLog(didRepo.storage, didRepo.cid, null)
     const commits = await didRepo.storage.getCommits(didRepo.cid, null)
     if (!commits) {
       return expect(commits !== null)
     }
     expect(evts.length).toBe(commits.length)
+    expect(evts.length).toBe(writeLog.length)
     for (let i = 0; i < commits.length; i++) {
       const commit = commits[i]
       const evt = evts[i]
@@ -96,6 +98,14 @@ describe('repo subscribe all repos', () => {
       const car = await repo.readCarWithRoot(evt.blocks as Uint8Array)
       expect(car.root.equals(commit.commit))
       expect(car.blocks.equals(commit.blocks))
+      const writes = writeLog[i].map((w) => ({
+        action: w.action,
+        path: w.collection + '/' + w.rkey,
+        cid: w.action === WriteOpAction.Delete ? null : w.cid.toString(),
+      }))
+      const sortedOps = evt.ops.sort((a, b) => a.path.localeCompare(b.path))
+      const sortedWrites = evt.ops.sort((a, b) => a.path.localeCompare(b.path))
+      expect(sortedOps).toEqual(sortedWrites)
     }
   }
 


### PR DESCRIPTION
Adds repo ops to sync stream.

We track ops alongside writes.

We don't bother backfilling old ops, instead we just reset the sequenced history (by deleting old rows)