### PR TITLE
Ensure app-view is permissive of reindexing

### DIFF
--- a/packages/pds/src/app-view/services/indexing/plugins/assertion.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/assertion.ts
@@ -17,7 +17,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Assertion.Record,
-  timestamp?: string,
+  timestamp: string,
 ): Promise<IndexedAssertion | null> => {
   const inserted = await db
     .insertInto('assertion')
@@ -29,7 +29,7 @@ const insertFn = async (
       subjectDid: obj.subject.did,
       subjectDeclarationCid: obj.subject.declarationCid,
       createdAt: obj.createdAt,
-      indexedAt: timestamp || new Date().toISOString(),
+      indexedAt: timestamp,
       confirmUri: null,
       confirmCid: null,
       confirmCreated: null,

--- a/packages/pds/src/app-view/services/indexing/plugins/confirmation.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/confirmation.ts
@@ -16,7 +16,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Confirmation.Record,
-  timestamp?: string,
+  timestamp: string,
 ): Promise<IndexedAssertion | null> => {
   const updated = await db
     .updateTable('assertion')
@@ -27,7 +27,7 @@ const insertFn = async (
       confirmUri: uri.toString(),
       confirmCid: cid.toString(),
       confirmCreated: obj.createdAt,
-      confirmIndexed: timestamp || new Date().toISOString(),
+      confirmIndexed: timestamp,
     })
     .returningAll()
     .executeTakeFirst()

--- a/packages/pds/src/app-view/services/indexing/plugins/declaration.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/declaration.ts
@@ -16,7 +16,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Declaration.Record,
-  _timestamp?: string,
+  _timestamp: string,
 ): Promise<DidHandle | null> => {
   if (uri.rkey !== 'self') return null
   const updated = await db

--- a/packages/pds/src/app-view/services/indexing/plugins/follow.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/follow.ts
@@ -17,7 +17,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Follow.Record,
-  timestamp?: string,
+  timestamp: string,
 ): Promise<IndexedFollow | null> => {
   const inserted = await db
     .insertInto('follow')
@@ -28,7 +28,7 @@ const insertFn = async (
       subjectDid: obj.subject.did,
       subjectDeclarationCid: obj.subject.declarationCid,
       createdAt: obj.createdAt,
-      indexedAt: timestamp || new Date().toISOString(),
+      indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())
     .returningAll()

--- a/packages/pds/src/app-view/services/indexing/plugins/profile.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/profile.ts
@@ -16,6 +16,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Profile.Record,
+  timestamp: string,
 ): Promise<IndexedProfile | null> => {
   if (uri.rkey !== 'self') return null
   const inserted = await db
@@ -28,7 +29,7 @@ const insertFn = async (
       description: obj.description,
       avatarCid: obj.avatar?.cid,
       bannerCid: obj.banner?.cid,
-      indexedAt: new Date().toISOString(),
+      indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())
     .returningAll()

--- a/packages/pds/src/app-view/services/indexing/plugins/repost.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/repost.ts
@@ -17,7 +17,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Repost.Record,
-  timestamp?: string,
+  timestamp: string,
 ): Promise<IndexedRepost | null> => {
   const inserted = await db
     .insertInto('repost')
@@ -28,7 +28,7 @@ const insertFn = async (
       subject: obj.subject.uri,
       subjectCid: obj.subject.cid,
       createdAt: obj.createdAt,
-      indexedAt: timestamp || new Date().toISOString(),
+      indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())
     .returningAll()

--- a/packages/pds/src/app-view/services/indexing/plugins/vote.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/vote.ts
@@ -18,7 +18,7 @@ const insertFn = async (
   uri: AtUri,
   cid: CID,
   obj: Vote.Record,
-  timestamp?: string,
+  timestamp: string,
 ): Promise<IndexedVote | null> => {
   if (obj.direction === 'up' || obj.direction === 'down') {
     const inserted = await db
@@ -31,7 +31,7 @@ const insertFn = async (
         subject: obj.subject.uri,
         subjectCid: obj.subject.cid,
         createdAt: obj.createdAt,
-        indexedAt: timestamp || new Date().toISOString(),
+        indexedAt: timestamp,
       })
       .onConflict((oc) => oc.doNothing())
       .returningAll()

--- a/packages/pds/src/app-view/subscription/repo.ts
+++ b/packages/pds/src/app-view/subscription/repo.ts
@@ -70,7 +70,7 @@ export class RepoSubscription {
     for (const op of ops) {
       if (
         op.action === WriteOpAction.Create ||
-        op.action === WriteOpAction.Update
+        op.action === WriteOpAction.Update // @TODO ensure updates are indexed properly, unify updateProfile
       ) {
         await indexingTx.indexRecord(op.uri, op.cid, op.record, timestamp)
       } else if (op.action === WriteOpAction.Delete) {


### PR DESCRIPTION
This ensures that the app-view indexing logic allows reprocessing repo operations.  This will come in handy to fill-in any skipped events post-facto, replay history to fix buggy indexes, and just generally be prepared for the eventuality of consuming the same repo ops multiple times.

I also started starting requiring that a timestamp be provided for indexing, since that seems to be the core use-case and it makes the service more deterministic.