### PR TITLE
Fix README.md

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -57,7 +57,7 @@ const res1 = await agent.api.com.atproto.repo.createRecord(
     }
   }
 )
-const res2 = await agent.api.com.atproto.repo.listRecords({did: alice.did, type: 'app.bsky.feed.post'})
+const res2 = await agent.api.com.atproto.repo.listRecords({user: alice.did, collection: 'app.bsky.feed.post'})
 
 // repo record methods
 const res3 = await agent.api.app.bsky.feed.post.create({did: alice.did}, {


### PR DESCRIPTION
The correct required keys for `agent.api.com.atproto.repo.listRecords` are `user` and `collection`.

ref: https://atproto.com/lexicons/com-atproto-repo#comatprotorepolistrecords