### PR TITLE
Lengthen token lifetimes

### DIFF
--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -64,7 +64,7 @@ export class ServerAuth {
     return {
       payload: payload as RefreshToken, // exp set by sign()
       jwt: jwt.sign(payload, this._secret, {
-        expiresIn: expiresIn ?? '7days',
+        expiresIn: expiresIn ?? '90days',
         mutatePayload: true,
       }),
     }

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -49,7 +49,7 @@ export class ServerAuth {
     return {
       payload: payload as AuthToken, // exp set by sign()
       jwt: jwt.sign(payload, this._secret, {
-        expiresIn: expiresIn ?? '15mins',
+        expiresIn: expiresIn ?? '120mins',
         mutatePayload: true,
       }),
     }


### PR DESCRIPTION
The refresh token lifetime can be much longer, particularly because they are rotated on each use.  This bumps their lifetime up from 7 to 90 days.

Our access token lifetimes were also quite conservative, and have been lengthened for more practical/everyday usage.  This bumps their lifetime up from 15 to 120 mins.