### PR TITLE
Fix typo: AptAgentFetchHandler

### DIFF
--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -12,7 +12,7 @@ import {
   AtpSessionData,
   AtpAgentCreateAccountOpts,
   AtpAgentLoginOpts,
-  AptAgentFetchHandler,
+  AtpAgentFetchHandler,
   AtpAgentFetchHandlerResponse,
   AtpAgentGlobalOpts,
   AtpPersistSessionHandler,
@@ -37,7 +37,7 @@ export class AtpAgent {
   /**
    * The `fetch` implementation; must be implemented for your platform.
    */
-  static fetch: AptAgentFetchHandler | undefined = defaultFetchHandler
+  static fetch: AtpAgentFetchHandler | undefined = defaultFetchHandler
 
   /**
    * Configures the API globally.

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -56,7 +56,7 @@ export interface AtpAgentFetchHandlerResponse {
   headers: Record<string, string>
   body: any
 }
-export type AptAgentFetchHandler = (
+export type AtpAgentFetchHandler = (
   httpUri: string,
   httpMethod: string,
   httpHeaders: AtpAgentFetchHeaders,
@@ -67,5 +67,5 @@ export type AptAgentFetchHandler = (
  * AtpAgent global config opts
  */
 export interface AtpAgentGlobalOpts {
-  fetch: AptAgentFetchHandler
+  fetch: AtpAgentFetchHandler
 }


### PR DESCRIPTION
Fixed a typo in the type name `AptAgentFetchHandler`, to `AtpAgentFetchHandler`.