### PR TITLE
Fixing typo in com.atproto.handle.resolve

### DIFF
--- a/lexicons/com/atproto/handle/resolve.json
+++ b/lexicons/com/atproto/handle/resolve.json
@@ -6,10 +6,7 @@
       "type": "query",
       "description": "Provides the DID of a repo.",
       "parameters": {
-        "type": "params",
-        "properties": {
-          "handle": {"type": "string", "description": "The handle to resolve. If not supplied, will resolve the host's own handle."}
-        }
+        "handle": {"type": "string", "description": "The handle to resolve. If not supplied, will resolve the host's own handle."}
       },
       "output": {
         "encoding": "application/json",


### PR DESCRIPTION
This looks like a copy/paste typo where parameters had some nested values that didn't align with the spec.