### PR TITLE
Feed and search query perf tuning

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -42,7 +42,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const keyset = new FeedKeyset(ref('cursor'), ref('postCid'))
       let feedItemsQb = db
-        .selectFrom(postsQb.union(repostsQb).as('feed_items'))
+        .selectFrom(postsQb.unionAll(repostsQb).as('feed_items'))
         .selectAll()
       feedItemsQb = paginate(feedItemsQb, {
         limit,

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -55,7 +55,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const keyset = new FeedKeyset(ref('cursor'), ref('postCid'))
       let feedItemsQb = db
-        .selectFrom(postsQb.union(repostsQb).as('feed_items'))
+        .selectFrom(postsQb.unionAll(repostsQb).as('feed_items'))
         .selectAll()
       feedItemsQb = paginate(feedItemsQb, {
         limit,

--- a/packages/pds/src/services/util/search.ts
+++ b/packages/pds/src/services/util/search.ts
@@ -65,8 +65,8 @@ export const getUserSearchQueryPg = (
   const resultsQb = db.db
     .selectFrom(
       emptyQb
-        .union(sql`${accountsQb}`) // The sql`` is adding parens
-        .union(sql`${profilesQb}`)
+        .unionAll(sql`${accountsQb}`) // The sql`` is adding parens
+        .unionAll(sql`${profilesQb}`)
         .as('accounts_and_profiles'),
     )
     .selectAll()


### PR DESCRIPTION
In the author feed, timeline feed, and user search there are cases where we're using UNION where we can be using UNION ALLs, which tells the database it doesn't need to do the work of deduping the result set.  Here's why we can switch them in each case:
 - The timeline feed unions posts and reposts, and they each have a fixed `type` column which is either `'post'` or `'repost'`.  So we know ahead of time that there will not be duplicates across the result sets, as the `type` can't match.
 - The author feed works the same as the timeline in this respect 👆 
 - The user search queries union accounts and profiles, then chooses the best result from their combination.  In this case we are already deduping after the union using a `distinct on`, so we don't need to ask postgres to do the work of deduping the union.