### PR TITLE
Fix README of handle package

### DIFF
--- a/packages/handle/README.md
+++ b/packages/handle/README.md
@@ -11,7 +11,7 @@ isValid('alice.test', ['.test']) // returns true
 ensureValid('alice.test', ['.test']) // returns void
 
 isValid('al!ce.test', ['.test']) // returns false
-isValid('al!ce.test', ['.test']) // throws
+ensureValid('al!ce.test', ['.test']) // throws
 ```
 
 ## License


### PR DESCRIPTION
It seems that 4th example is meant to demonstrate  unhappy path of `ensureValid`, but not `isValid`.