### PR TITLE
Format invite codes with dashes

### DIFF
--- a/packages/pds/src/api/com/atproto/account/createInviteCode.ts
+++ b/packages/pds/src/api/com/atproto/account/createInviteCode.ts
@@ -10,9 +10,10 @@ export default function (server: Server, ctx: AppContext) {
       const { useCount } = input.body
 
       // generate a 5 char b32 invite code - preceded by the hostname
-      // ex: bsky.app-abc12
+      // with '.'s replaced by '-'s so it is not mistakable for a link
+      // ex: bsky-app-abc12
       const code =
-        ctx.cfg.publicHostname +
+        ctx.cfg.publicHostname.replaceAll('.', '-') +
         '-' +
         uint8arrays.toString(await crypto.randomBytes(5), 'base32').slice(0, 5)
 

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -78,9 +78,11 @@ describe('account', () => {
 
   it('creates an invite code', async () => {
     inviteCode = await createInviteCode(agent, 1)
-    const [host, code] = inviteCode.split('-')
+    const split = inviteCode.split('-')
+    const host = split.slice(0, -1).join('.')
+    const code = split.at(-1)
     expect(host).toBe('pds.public.url') // Hostname of public url
-    expect(code.length).toBe(5)
+    expect(code?.length).toBe(5)
   })
 
   it('serves the accounts system config', async () => {


### PR DESCRIPTION
Format invite codes with dashes instead of dots so that they are not mistaken for links:

`bsky.social-abc12 -> bsky-social-abc12`