### PR TITLE
MST util bug fixes for sync

### DIFF
--- a/packages/repo/src/data-diff.ts
+++ b/packages/repo/src/data-diff.ts
@@ -9,6 +9,7 @@ export class DataDiff {
   deletes: Record<string, DataDelete> = {}
 
   newCids: CidSet = new CidSet()
+  removedCids: CidSet = new CidSet()
 
   static async of(curr: DataStore, prev: DataStore | null): Promise<DataDiff> {
     if (curr instanceof MST && (prev === null || prev instanceof MST)) {
@@ -32,7 +33,19 @@ export class DataDiff {
   }
 
   recordNewCid(cid: CID): void {
-    this.newCids.add(cid)
+    if (this.removedCids.has(cid)) {
+      this.removedCids.delete(cid)
+    } else {
+      this.newCids.add(cid)
+    }
+  }
+
+  recordRemovedCid(cid: CID): void {
+    if (this.newCids.has(cid)) {
+      this.newCids.delete(cid)
+    } else {
+      this.removedCids.add(cid)
+    }
   }
 
   addDiff(diff: DataDiff) {

--- a/packages/repo/src/mst/diff.ts
+++ b/packages/repo/src/mst/diff.ts
@@ -43,6 +43,8 @@ export const mstDiff = async (
       const node = leftWalker.status.curr
       if (node.isLeaf()) {
         diff.recordDelete(node.key, node.value)
+      } else {
+        diff.recordRemovedCid(node.pointer)
       }
       await leftWalker.advance()
       continue
@@ -83,6 +85,7 @@ export const mstDiff = async (
         }
         await rightWalker.advance()
       } else {
+        diff.recordRemovedCid(left.pointer)
         await leftWalker.stepInto()
       }
       continue
@@ -90,6 +93,8 @@ export const mstDiff = async (
       if (right.isLeaf()) {
         if (left.isLeaf()) {
           diff.recordDelete(left.key, left.value)
+        } else {
+          diff.recordRemovedCid(left.pointer)
         }
         await leftWalker.advance()
       } else {
@@ -107,6 +112,7 @@ export const mstDiff = async (
         await rightWalker.stepOver()
       } else {
         diff.recordNewCid(right.pointer)
+        diff.recordRemovedCid(left.pointer)
         await leftWalker.stepInto()
         await rightWalker.stepInto()
       }
@@ -115,10 +121,11 @@ export const mstDiff = async (
 
     // finally, if one pointer is a tree and the other is a leaf, simply step into the tree
     if (left.isLeaf() && right.isTree()) {
-      await diff.recordNewCid(right.pointer)
+      diff.recordNewCid(right.pointer)
       await rightWalker.stepInto()
       continue
     } else if (left.isTree() && right.isLeaf()) {
+      diff.recordRemovedCid(left.pointer)
       await leftWalker.stepInto()
       continue
     }

--- a/packages/repo/src/mst/mst.ts
+++ b/packages/repo/src/mst/mst.ts
@@ -689,7 +689,7 @@ export class MST implements DataStore {
     for (const entry of entries) {
       if (entry.isTree()) {
         try {
-          for await (const e of entry.walk()) {
+          for await (const e of entry.walkReachable()) {
             yield e
           }
         } catch (err) {


### PR DESCRIPTION
Two fixes in here: 
- fixes the problem with finding records in proofs
  - we were recursing into `walk` instead of `walkReachable` which was throwing
- fixes an issue with overeager diffs
  - we were tracking "new cids" that weren't actually "new", they were just in a different location in the MST. so now we track "removed" cids as well & dedupe this in a similar way to how we handle adds + deletes

Closes https://github.com/bluesky-social/atproto/issues/543