### PR TITLE
Add hostname param to notifyOfUpdate

### DIFF
--- a/lexicons/com/atproto/sync/notifyOfUpdate.json
+++ b/lexicons/com/atproto/sync/notifyOfUpdate.json
@@ -4,7 +4,14 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break."
+      "description": "Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.",
+      "parameters": {
+        "type": "params",
+        "required": ["hostname"],
+        "properties": {
+          "hostname": {"type": "string", "description": "Hostname of the service that is notifying of update."}
+        }
+      }
     }
   }
 }

--- a/lexicons/com/atproto/sync/requestCrawl.json
+++ b/lexicons/com/atproto/sync/requestCrawl.json
@@ -9,7 +9,7 @@
         "type": "params",
         "required": ["hostname"],
         "properties": {
-          "host": {"type": "string", "description": "Hostname of the service that is requesting to be crawled."}
+          "hostname": {"type": "string", "description": "Hostname of the service that is requesting to be crawled."}
         }
       }
     }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2232,6 +2232,17 @@ export const schemaDict = {
         type: 'query',
         description:
           'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
+        parameters: {
+          type: 'params',
+          required: ['hostname'],
+          properties: {
+            hostname: {
+              type: 'string',
+              description:
+                'Hostname of the service that is notifying of update.',
+            },
+          },
+        },
       },
     },
   },
@@ -2246,7 +2257,7 @@ export const schemaDict = {
           type: 'params',
           required: ['hostname'],
           properties: {
-            host: {
+            hostname: {
               type: 'string',
               description:
                 'Hostname of the service that is requesting to be crawled.',

--- a/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
@@ -6,7 +6,10 @@ import { ValidationResult } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 
-export interface QueryParams {}
+export interface QueryParams {
+  /** Hostname of the service that is notifying of update. */
+  hostname: string
+}
 
 export type InputSchema = undefined
 

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -8,7 +8,7 @@ import { lexicons } from '../../../../lexicons'
 
 export interface QueryParams {
   /** Hostname of the service that is requesting to be crawled. */
-  host?: string
+  hostname: string
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2232,6 +2232,17 @@ export const schemaDict = {
         type: 'query',
         description:
           'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
+        parameters: {
+          type: 'params',
+          required: ['hostname'],
+          properties: {
+            hostname: {
+              type: 'string',
+              description:
+                'Hostname of the service that is notifying of update.',
+            },
+          },
+        },
       },
     },
   },
@@ -2246,7 +2257,7 @@ export const schemaDict = {
           type: 'params',
           required: ['hostname'],
           properties: {
-            host: {
+            hostname: {
               type: 'string',
               description:
                 'Hostname of the service that is requesting to be crawled.',

--- a/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -7,7 +7,10 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {}
+export interface QueryParams {
+  /** Hostname of the service that is notifying of update. */
+  hostname: string
+}
 
 export type InputSchema = undefined
 export type HandlerInput = undefined

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -9,7 +9,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {
   /** Hostname of the service that is requesting to be crawled. */
-  host?: string
+  hostname: string
 }
 
 export type InputSchema = undefined


### PR DESCRIPTION
Small tweak that adds `hostname` param to `com.atproto.sync.notifyOfUpdate`

Also the `required` value on `requestCrawl` was different from the property value so I standardized that on `hostname` as well