### PR TITLE
Lexicon: declaration, assertion/confirmation, follow app migration

### DIFF
--- a/packages/pds/src/app-migrations/remove-declarations.ts
+++ b/packages/pds/src/app-migrations/remove-declarations.ts
@@ -41,7 +41,7 @@ async function main(tx: Database, ctx: AppContext) {
       'app.bsky.graph.assertion',
       'app.bsky.graph.confirmation',
     ])
-    .select(['did', 'collection', 'rkey'])
+    .select(['record.did as did', 'collection', 'rkey'])
     .execute()
 
   const deletionsByDid = recordsToDelete.reduce((collect, record) => {
@@ -49,16 +49,16 @@ async function main(tx: Database, ctx: AppContext) {
     collect[record.did].push(prepareDelete(record))
     return collect
   }, {} as Record<string, PreparedDelete[]>)
-
   const entries = Object.entries(deletionsByDid)
-  const chunks = chunkArray(entries, Math.ceil(entries.length / 50))
 
   console.log(
     SHORT_NAME,
     `${recordsToDelete.length} deletions across ${entries.length} dids`,
   )
+
   let didsComplete = 0
   let deletionsComplete = 0
+  const chunks = chunkArray(entries, Math.ceil(entries.length / 50))
 
   await Promise.all(
     chunks.map(async (chunk) => {

--- a/packages/pds/src/app-migrations/remove-declarations.ts
+++ b/packages/pds/src/app-migrations/remove-declarations.ts
@@ -1,7 +1,9 @@
 import { chunkArray } from '@atproto/common'
+import assert from 'assert'
 import AppContext from '../context'
 import Database from '../db'
 import { appMigration } from '../db/leader'
+import { countAll } from '../db/util'
 import { MessageDispatcher } from '../event-stream/message-queue'
 import { PreparedDelete, prepareDelete } from '../repo'
 import { RepoService } from '../services/repo'
@@ -35,7 +37,6 @@ async function main(tx: Database, ctx: AppContext) {
   // Should be 4-5k records
   const recordsToDelete = await tx.db
     .selectFrom('record')
-    .innerJoin('repo_root', 'repo_root.did', 'record.did') // Ignore any records not in a repo
     .where('collection', 'in', [
       'app.bsky.system.declaration',
       'app.bsky.graph.assertion',
@@ -49,16 +50,16 @@ async function main(tx: Database, ctx: AppContext) {
     collect[record.did].push(prepareDelete(record))
     return collect
   }, {} as Record<string, PreparedDelete[]>)
-  const entries = Object.entries(deletionsByDid)
+  const didDeletions = Object.entries(deletionsByDid)
 
   console.log(
     SHORT_NAME,
-    `${recordsToDelete.length} deletions across ${entries.length} dids`,
+    `${recordsToDelete.length} deletions across ${didDeletions.length} dids`,
   )
 
   let didsComplete = 0
   let deletionsComplete = 0
-  const chunks = chunkArray(entries, Math.ceil(entries.length / 50))
+  const chunks = chunkArray(didDeletions, Math.ceil(didDeletions.length / 50))
 
   await Promise.all(
     chunks.map(async (chunk) => {
@@ -68,11 +69,35 @@ async function main(tx: Database, ctx: AppContext) {
         deletionsComplete += deletions.length
         console.log(
           SHORT_NAME,
-          `(${didsComplete}/${entries.length}) dids, (${deletionsComplete}/${recordsToDelete.length}) records`,
+          `(${didsComplete}/${didDeletions.length}) dids, (${deletionsComplete}/${recordsToDelete.length}) records`,
         )
       }
     }),
   )
 
-  console.log(SHORT_NAME, 'complete')
+  console.log(SHORT_NAME, 'running dummy check')
+  await dummyCheck(tx)
+
+  console.log(
+    SHORT_NAME,
+    'complete in',
+    (Date.now() - Date.parse(now)) / 1000,
+    'sec',
+  )
+}
+
+async function dummyCheck(db: Database) {
+  const { count } = await db.db
+    .selectFrom('record')
+    .where('collection', 'in', [
+      'app.bsky.system.declaration',
+      'app.bsky.graph.assertion',
+      'app.bsky.graph.confirmation',
+    ])
+    .select(countAll.as('count'))
+    .executeTakeFirstOrThrow()
+  assert(
+    count === 0,
+    `${SHORT_NAME} dummy check failed: ${count} records remaining`,
+  )
 }

--- a/packages/pds/src/app-migrations/remove-declarations.ts
+++ b/packages/pds/src/app-migrations/remove-declarations.ts
@@ -1,0 +1,78 @@
+import { chunkArray } from '@atproto/common'
+import AppContext from '../context'
+import Database from '../db'
+import { appMigration } from '../db/leader'
+import { MessageDispatcher } from '../event-stream/message-queue'
+import { PreparedDelete, prepareDelete } from '../repo'
+import { RepoService } from '../services/repo'
+
+const MIGRATION_NAME = '2023-03-14-remove-declarations'
+const SHORT_NAME = 'remove-declarations'
+
+export async function removeDeclarationsMigration(ctx: AppContext) {
+  await appMigration(ctx.db, MIGRATION_NAME, (tx) => main(tx, ctx))
+}
+
+async function main(tx: Database, ctx: AppContext) {
+  console.log(SHORT_NAME, 'beginning')
+  tx.assertTransaction()
+  const now = new Date().toISOString()
+
+  // The message dispatcher usually ensures that the app view indexes these updates,
+  // but that has been taken care of via a db migration to remove the indexes entirely.
+  const noopDispatcher = new MessageDispatcher()
+  noopDispatcher.destroy()
+
+  const repoTx = new RepoService(
+    tx,
+    ctx.repoSigningKey,
+    noopDispatcher,
+    ctx.blobstore,
+  )
+
+  // For each user remove declaration, assertion, confirmation records.
+
+  // Should be 4-5k records
+  const recordsToDelete = await tx.db
+    .selectFrom('record')
+    .innerJoin('repo_root', 'repo_root.did', 'record.did') // Ignore any records not in a repo
+    .where('collection', 'in', [
+      'app.bsky.system.declaration',
+      'app.bsky.graph.assertion',
+      'app.bsky.graph.confirmation',
+    ])
+    .select(['did', 'collection', 'rkey'])
+    .execute()
+
+  const deletionsByDid = recordsToDelete.reduce((collect, record) => {
+    collect[record.did] ??= []
+    collect[record.did].push(prepareDelete(record))
+    return collect
+  }, {} as Record<string, PreparedDelete[]>)
+
+  const entries = Object.entries(deletionsByDid)
+  const chunks = chunkArray(entries, Math.ceil(entries.length / 50))
+
+  console.log(
+    SHORT_NAME,
+    `${recordsToDelete.length} deletions across ${entries.length} dids`,
+  )
+  let didsComplete = 0
+  let deletionsComplete = 0
+
+  await Promise.all(
+    chunks.map(async (chunk) => {
+      for (const [did, deletions] of chunk) {
+        await repoTx.processWrites(did, deletions, now)
+        didsComplete += 1
+        deletionsComplete += deletions.length
+        console.log(
+          SHORT_NAME,
+          `(${didsComplete}/${entries.length}) dids, (${deletionsComplete}/${recordsToDelete.length}) records`,
+        )
+      }
+    }),
+  )
+
+  console.log(SHORT_NAME, 'complete')
+}

--- a/packages/pds/src/app-migrations/update-follow-subjects.ts
+++ b/packages/pds/src/app-migrations/update-follow-subjects.ts
@@ -86,7 +86,9 @@ async function main(tx: Database, ctx: AppContext) {
           }),
         )
 
-        await repoTx.processWrites(did, updates, now)
+        if (updates.length) {
+          await repoTx.processWrites(did, updates, now)
+        }
 
         didsComplete += 1
         updatesComplete += follows.length

--- a/packages/pds/src/app-migrations/update-follow-subjects.ts
+++ b/packages/pds/src/app-migrations/update-follow-subjects.ts
@@ -48,7 +48,7 @@ async function main(tx: Database, ctx: AppContext) {
   let didsComplete = 0
   let updatesComplete = 0
   const updatesTurnedDeletes: string[] = []
-  const chunks = chunkArray(allDids, Math.ceil(allDids.length / 2))
+  const chunks = chunkArray(allDids, Math.ceil(allDids.length / 10))
 
   await Promise.all(
     chunks.map(async (dids) => {
@@ -90,7 +90,7 @@ async function main(tx: Database, ctx: AppContext) {
         updatesComplete += follows.length
         console.log(
           SHORT_NAME,
-          `(${didsComplete}/${dids.length}) dids, (${updatesComplete}/${followCount}) records`,
+          `(${didsComplete}/${allDids.length}) dids, (${updatesComplete}/${followCount}) records`,
         )
       }
     }),

--- a/packages/pds/src/app-migrations/update-follow-subjects.ts
+++ b/packages/pds/src/app-migrations/update-follow-subjects.ts
@@ -1,0 +1,129 @@
+import { cborBytesToRecord, chunkArray } from '@atproto/common'
+import { sql } from 'kysely'
+import AppContext from '../context'
+import Database from '../db'
+import { appMigration } from '../db/leader'
+import { MessageDispatcher } from '../event-stream/message-queue'
+import { ids } from '../lexicon/lexicons'
+import { prepareUpdate } from '../repo'
+import { RepoService } from '../services/repo'
+
+const MIGRATION_NAME = '2023-03-14-update-follow-subjects'
+const SHORT_NAME = 'update-follow-subjects'
+
+export async function updateFollowSubjectsMigration(ctx: AppContext) {
+  await appMigration(ctx.db, MIGRATION_NAME, (tx) => main(tx, ctx))
+}
+
+async function main(tx: Database, ctx: AppContext) {
+  console.log(SHORT_NAME, 'beginning')
+  tx.assertTransaction()
+  const { ref } = tx.db.dynamic
+  const now = new Date().toISOString()
+
+  // The message dispatcher usually ensures that the app view indexes these updates,
+  // but that has been taken care of via a db migration to remove the indexes entirely.
+  const noopDispatcher = new MessageDispatcher()
+  noopDispatcher.destroy()
+
+  const repoTx = new RepoService(
+    tx,
+    ctx.repoSigningKey,
+    noopDispatcher,
+    ctx.blobstore,
+  )
+
+  // For each user update follow records.
+
+  const [dids, followCount] = await Promise.all([
+    getActorDids(tx),
+    getFollowCount(tx),
+  ])
+  const chunks = chunkArray(dids, Math.ceil(dids.length / 2))
+
+  console.log(SHORT_NAME, `${followCount} updates across ${dids.length} dids`)
+  let didsComplete = 0
+  let updatesComplete = 0
+
+  await Promise.all(
+    chunks.map(async (dids) => {
+      for (const did of dids) {
+        const follows = await getFollows(tx, did)
+        console.log(SHORT_NAME, `${did} processing ${follows.length} updates`)
+
+        const updates = await Promise.all(
+          follows.map((follow) => {
+            const record = cborBytesToRecord(follow.bytes)
+            if (typeof record['subject']?.['did'] === 'string') {
+              // Map old app.bsky.actor.ref to did
+              record['subject'] = record['subject']['did']
+            }
+            return prepareUpdate({
+              did,
+              collection: ids.AppBskyGraphFollow,
+              rkey: follow.rkey,
+              record,
+            })
+          }),
+        )
+
+        await repoTx.processWrites(did, updates, now)
+
+        didsComplete += 1
+        updatesComplete += follows.length
+        console.log(
+          SHORT_NAME,
+          `(${didsComplete}/${dids.length}) dids, (${updatesComplete}/${followCount}) records`,
+        )
+      }
+    }),
+  )
+
+  // Update cids on indexed follows.
+
+  console.log(SHORT_NAME, 'updating follow cids in index')
+
+  const recordForFollowQb = tx.db
+    .selectFrom('record')
+    .whereRef('uri', '=', ref('follow.uri'))
+  const updated = await tx.db
+    .updateTable('follow')
+    .whereExists(recordForFollowQb.selectAll())
+    .set({ cid: recordForFollowQb.select('cid') })
+    .executeTakeFirst()
+
+  console.log(
+    SHORT_NAME,
+    `updated ${Number(updated.numUpdatedRows)} follow cids in index`,
+  )
+
+  console.log(SHORT_NAME, 'complete')
+}
+
+async function getActorDids(db: Database) {
+  const res = await db.db.selectFrom('did_handle').select('did').execute()
+  return res.map((row) => row.did)
+}
+
+async function getFollows(db: Database, did: string) {
+  return await db.db
+    .selectFrom('record')
+    .where('did', '=', did)
+    .where('collection', '=', ids.AppBskyGraphFollow)
+    .innerJoin('ipld_block', (join) =>
+      join
+        .onRef('ipld_block.cid', '=', 'record.cid')
+        .on('ipld_block.creator', '=', did),
+    )
+    .select(['ipld_block.content as bytes', 'rkey'])
+    .execute()
+}
+
+async function getFollowCount(db: Database) {
+  const { count } = await db.db
+    .selectFrom('record')
+    .select(sql`count(*)`.as('count'))
+    .where('collection', '=', ids.AppBskyGraphFollow)
+    .executeTakeFirstOrThrow()
+  return Number(count)
+}


### PR DESCRIPTION
Two app migrations contained here:
1. Remove declaration, assertion, and confirmation records.
2. Update follow records so that their `subject` is a did rather than an actor ref.  Invalid follow records are deleted.

In both we use the repo service, which takes care of updating repositories plus the generic `record` index.  If any app-view related changes are needed, those are handled at the end of the migrations— that would include updates to `duplicate_record` and `follow` tables.  A no-op `messageDispatcher` is used rather than a real one in order to avoid app-view indexing logic from kicking in.