### PR TITLE
Lexicon: votes to likes app migration

### DIFF
--- a/packages/pds/src/app-migrations/remove-declarations.ts
+++ b/packages/pds/src/app-migrations/remove-declarations.ts
@@ -1,5 +1,5 @@
-import { chunkArray } from '@atproto/common'
 import assert from 'assert'
+import { chunkArray } from '@atproto/common'
 import AppContext from '../context'
 import Database from '../db'
 import { appMigration } from '../db/leader'

--- a/packages/pds/src/app-migrations/update-follow-subjects.ts
+++ b/packages/pds/src/app-migrations/update-follow-subjects.ts
@@ -65,13 +65,6 @@ async function main(tx: Database, ctx: AppContext) {
             }
             try {
               assertValidRecord(record)
-              return prepareUpdate({
-                did,
-                collection: ids.AppBskyGraphFollow,
-                rkey: follow.rkey,
-                record,
-                validate: false,
-              })
             } catch {
               const del = prepareDelete({
                 did,
@@ -81,6 +74,13 @@ async function main(tx: Database, ctx: AppContext) {
               updatesTurnedDeletes.push(del.uri.toString())
               return del
             }
+            return prepareUpdate({
+              did,
+              collection: ids.AppBskyGraphFollow,
+              rkey: follow.rkey,
+              record,
+              validate: false, // Validated above
+            })
           }),
         )
 

--- a/packages/pds/src/app-migrations/update-follow-subjects.ts
+++ b/packages/pds/src/app-migrations/update-follow-subjects.ts
@@ -98,24 +98,26 @@ async function main(tx: Database, ctx: AppContext) {
 
   console.log(
     SHORT_NAME,
-    `${updatesTurnedDeletes.length} updates turned deletes`,
+    `${updatesTurnedDeletes.length} updates-turned-deletes`,
     updatesTurnedDeletes,
   )
 
   if (updatesTurnedDeletes.length > followCount / 1000) {
-    throw new Error('Too many updates turned deletes.')
+    throw new Error('Too many updates-turned-deletes.')
   }
 
   // Update indexes for deleted, invalid follows
 
-  await tx.db
-    .deleteFrom('follow')
-    .where('uri', 'in', updatesTurnedDeletes)
-    .executeTakeFirst()
-  await tx.db
-    .deleteFrom('duplicate_record')
-    .where('duplicateOf', 'in', updatesTurnedDeletes)
-    .executeTakeFirst()
+  if (updatesTurnedDeletes.length) {
+    await tx.db
+      .deleteFrom('follow')
+      .where('uri', 'in', updatesTurnedDeletes)
+      .executeTakeFirst()
+    await tx.db
+      .deleteFrom('duplicate_record')
+      .where('duplicateOf', 'in', updatesTurnedDeletes)
+      .executeTakeFirst()
+  }
 
   console.log(SHORT_NAME, 'updated indexes for updates-turned-deletes')
 

--- a/packages/pds/src/app-migrations/votes-to-likes.ts
+++ b/packages/pds/src/app-migrations/votes-to-likes.ts
@@ -23,7 +23,7 @@ async function main(tx: Database, ctx: AppContext) {
   const now = new Date().toISOString()
 
   // The message dispatcher usually ensures that the app view indexes these updates,
-  // but that has been taken care of via a db migration to remove the indexes entirely.
+  // but that has been taken care of with a db migration, plus the end of this migration.
   const noopDispatcher = new MessageDispatcher()
   noopDispatcher.destroy()
 

--- a/packages/pds/src/app-migrations/votes-to-likes.ts
+++ b/packages/pds/src/app-migrations/votes-to-likes.ts
@@ -1,0 +1,209 @@
+import { cborBytesToRecord, chunkArray } from '@atproto/common'
+import { sql } from 'kysely'
+import AppContext from '../context'
+import Database from '../db'
+import { appMigration } from '../db/leader'
+import { MessageDispatcher } from '../event-stream/message-queue'
+import { ids } from '../lexicon/lexicons'
+import { prepareCreate, prepareDelete, assertValidRecord } from '../repo'
+import { RepoService } from '../services/repo'
+
+const MIGRATION_NAME = '2023-03-15-votes-to-likes'
+const SHORT_NAME = 'votes-to-likes'
+const VOTE_LEX_ID = 'app.bsky.feed.vote'
+
+export async function votesToLikesMigration(ctx: AppContext) {
+  await appMigration(ctx.db, MIGRATION_NAME, (tx) => main(tx, ctx))
+}
+
+async function main(tx: Database, ctx: AppContext) {
+  console.log(SHORT_NAME, 'beginning')
+  tx.assertTransaction()
+  const { ref } = tx.db.dynamic
+  const now = new Date().toISOString()
+
+  // The message dispatcher usually ensures that the app view indexes these updates,
+  // but that has been taken care of via a db migration to remove the indexes entirely.
+  const noopDispatcher = new MessageDispatcher()
+  noopDispatcher.destroy()
+
+  const repoTx = new RepoService(
+    tx,
+    ctx.repoSigningKey,
+    noopDispatcher,
+    ctx.blobstore,
+  )
+
+  // For each user remove vote records and replace with new like records.
+
+  const [didsWithVotes, voteCount] = await Promise.all([
+    getDidsWithVotes(tx),
+    getVoteCount(tx),
+  ])
+
+  console.log(
+    SHORT_NAME,
+    `${voteCount} votes across ${didsWithVotes.length} dids`,
+  )
+
+  let didsComplete = 0
+  let votesComplete = 0
+  const createsTurnedDeletes: string[] = []
+  const chunks = chunkArray(didsWithVotes, Math.ceil(didsWithVotes.length / 5))
+
+  await Promise.all(
+    chunks.map(async (dids) => {
+      for (const did of dids) {
+        const votes = await getVotes(tx, did)
+        console.log(SHORT_NAME, `${did} processing ${votes.length} votes`)
+
+        const writeResults = await Promise.all(
+          votes.map(async (vote) => {
+            const record = cborBytesToRecord(vote.bytes)
+            const del = prepareDelete({
+              did,
+              collection: VOTE_LEX_ID,
+              rkey: vote.rkey,
+            })
+
+            if (record.direction !== 'up') {
+              return del // Delete downvotes
+            }
+
+            try {
+              record['$type'] = ids.AppBskyFeedLike
+              delete record['direction']
+              assertValidRecord(record)
+            } catch {
+              // Delete invalid votes that can't be mapped to a like
+              createsTurnedDeletes.push(del.uri.toString())
+              return del
+            }
+
+            // Delete vote and replace it with a valid like record
+            return [
+              del,
+              await prepareCreate({
+                did,
+                collection: ids.AppBskyFeedLike,
+                rkey: vote.rkey, // Maintain same rkey
+                record,
+                validate: false, // Validated above
+              }),
+            ]
+          }),
+        )
+
+        // Chunk to avoid hitting e.g. postgres param limits
+        for (const writeChunk of chunkArray(writeResults, 1000)) {
+          await repoTx.processWrites(did, writeChunk.flat(), now)
+        }
+
+        didsComplete += 1
+        votesComplete += votes.length
+        console.log(
+          SHORT_NAME,
+          `(${didsComplete}/${didsWithVotes.length}) dids, (${votesComplete}/${voteCount}) records`,
+        )
+      }
+    }),
+  )
+
+  console.log(
+    SHORT_NAME,
+    `${createsTurnedDeletes.length} creates-turned-deletes`,
+    createsTurnedDeletes,
+  )
+
+  if (createsTurnedDeletes.length > voteCount / 1000) {
+    throw new Error('Too many creates-turned-deletes.')
+  }
+
+  // Update indexes for deleted, invalid votes
+
+  if (createsTurnedDeletes.length) {
+    await tx.db
+      .deleteFrom('like')
+      .where('uri', 'in', createsTurnedDeletes)
+      .executeTakeFirst()
+    await tx.db
+      .deleteFrom('duplicate_record')
+      .where('duplicateOf', 'in', createsTurnedDeletes)
+      .executeTakeFirst()
+  }
+
+  console.log(SHORT_NAME, 'updated indexes for creates-turned-deletes')
+
+  // Updating uris in index
+  console.log(SHORT_NAME, 'updating uris in index')
+
+  const updatedUris = await tx.db
+    .updateTable('like')
+    .set({
+      uri: sql`replace(uri, ${`/${VOTE_LEX_ID}/`}, ${`/${ids.AppBskyFeedLike}/`})`,
+    })
+    .executeTakeFirst()
+
+  console.log(
+    SHORT_NAME,
+    `updated ${Number(updatedUris.numUpdatedRows)} like uris in index`,
+  )
+
+  // Update uris and cids in indexed likes.
+
+  console.log(SHORT_NAME, 'updating like cids in index')
+
+  const recordForLikeQb = tx.db
+    .selectFrom('record')
+    .whereRef('uri', '=', ref('like.uri'))
+  const updatedCids = await tx.db
+    .updateTable('like')
+    .whereExists(recordForLikeQb.selectAll())
+    .set({ cid: recordForLikeQb.select('cid') })
+    .executeTakeFirst()
+
+  console.log(
+    SHORT_NAME,
+    `updated ${Number(updatedCids.numUpdatedRows)} like cids in index`,
+  )
+
+  console.log(
+    SHORT_NAME,
+    'complete in',
+    (Date.now() - new Date(now).getTime()) / 1000,
+    'sec',
+  )
+}
+
+async function getDidsWithVotes(db: Database) {
+  const res = await db.db
+    .selectFrom('record')
+    .select('did')
+    .where('collection', '=', VOTE_LEX_ID)
+    .groupBy('did')
+    .execute()
+  return res.map((row) => row.did)
+}
+
+async function getVotes(db: Database, did: string) {
+  return await db.db
+    .selectFrom('record')
+    .where('did', '=', did)
+    .where('collection', '=', VOTE_LEX_ID)
+    .innerJoin('ipld_block', (join) =>
+      join
+        .onRef('ipld_block.cid', '=', 'record.cid')
+        .on('ipld_block.creator', '=', did),
+    )
+    .select(['ipld_block.content as bytes', 'rkey'])
+    .execute()
+}
+
+async function getVoteCount(db: Database) {
+  const { count } = await db.db
+    .selectFrom('record')
+    .select(sql`count(*)`.as('count'))
+    .where('collection', '=', VOTE_LEX_ID)
+    .executeTakeFirstOrThrow()
+  return Number(count)
+}

--- a/packages/pds/src/app-migrations/votes-to-likes.ts
+++ b/packages/pds/src/app-migrations/votes-to-likes.ts
@@ -100,7 +100,10 @@ async function main(tx: Database, ctx: AppContext) {
 
         // Chunk to avoid hitting e.g. postgres param limits
         for (const writeChunk of chunkArray(writeResults, 1000)) {
-          await repoTx.processWrites(did, writeChunk.flat(), now)
+          const writes = writeChunk.flat()
+          if (writes.length) {
+            await repoTx.processWrites(did, writes, now)
+          }
         }
 
         didsComplete += 1

--- a/packages/pds/src/app-migrations/votes-to-likes.ts
+++ b/packages/pds/src/app-migrations/votes-to-likes.ts
@@ -1,5 +1,6 @@
-import { cborBytesToRecord, chunkArray } from '@atproto/common'
+import assert from 'assert'
 import { sql } from 'kysely'
+import { cborBytesToRecord, chunkArray } from '@atproto/common'
 import AppContext from '../context'
 import Database from '../db'
 import { appMigration } from '../db/leader'
@@ -7,6 +8,7 @@ import { MessageDispatcher } from '../event-stream/message-queue'
 import { ids } from '../lexicon/lexicons'
 import { prepareCreate, prepareDelete, assertValidRecord } from '../repo'
 import { RepoService } from '../services/repo'
+import { countAll } from '../db/util'
 
 const MIGRATION_NAME = '2023-03-15-votes-to-likes'
 const SHORT_NAME = 'votes-to-likes'
@@ -48,8 +50,9 @@ async function main(tx: Database, ctx: AppContext) {
 
   let didsComplete = 0
   let votesComplete = 0
+  let processedDownvotes = 0
   const createsTurnedDeletes: string[] = []
-  const chunks = chunkArray(didsWithVotes, Math.ceil(didsWithVotes.length / 5))
+  const chunks = chunkArray(didsWithVotes, Math.ceil(didsWithVotes.length / 10))
 
   await Promise.all(
     chunks.map(async (dids) => {
@@ -67,6 +70,7 @@ async function main(tx: Database, ctx: AppContext) {
             })
 
             if (record.direction !== 'up') {
+              processedDownvotes++
               return del // Delete downvotes
             }
 
@@ -114,10 +118,6 @@ async function main(tx: Database, ctx: AppContext) {
     `${createsTurnedDeletes.length} creates-turned-deletes`,
     createsTurnedDeletes,
   )
-
-  if (createsTurnedDeletes.length > voteCount / 1000) {
-    throw new Error('Too many creates-turned-deletes.')
-  }
 
   // Update indexes for deleted, invalid votes
 
@@ -167,12 +167,102 @@ async function main(tx: Database, ctx: AppContext) {
     `updated ${Number(updatedCids.numUpdatedRows)} like cids in index`,
   )
 
+  console.log(SHORT_NAME, 'running dummy check')
+  await dummyCheck(tx, {
+    voteCount,
+    deleteInvalidCount: createsTurnedDeletes.length,
+    deleteDownvoteCount: processedDownvotes,
+  })
+
   console.log(
     SHORT_NAME,
     'complete in',
-    (Date.now() - new Date(now).getTime()) / 1000,
+    (Date.now() - Date.parse(now)) / 1000,
     'sec',
   )
+}
+
+async function dummyCheck(
+  db: Database,
+  original: {
+    voteCount: number
+    deleteInvalidCount: number
+    deleteDownvoteCount: number
+  },
+) {
+  // Check 1: rogue deletions
+  assert(
+    original.deleteInvalidCount < original.voteCount / 1000,
+    `${SHORT_NAME} dummy check failed: too many creates-turned-deletes.`,
+  )
+
+  // Check 2: record index size reflects creates/deletes
+  const { likeCount } = await db.db
+    .selectFrom('record')
+    .where('collection', '=', ids.AppBskyFeedLike)
+    .select(countAll.as('likeCount'))
+    .executeTakeFirstOrThrow()
+  const { voteCount } = await db.db
+    .selectFrom('record')
+    .where('collection', '=', VOTE_LEX_ID)
+    .select(countAll.as('voteCount'))
+    .executeTakeFirstOrThrow()
+  assert(
+    voteCount === 0,
+    `${SHORT_NAME} dummy check failed: ${voteCount} votes remain`,
+  )
+  assert(
+    likeCount ===
+      original.voteCount -
+        original.deleteInvalidCount -
+        original.deleteDownvoteCount,
+    `${SHORT_NAME} dummy check failed: ${likeCount} likes doesn't match ${JSON.stringify(
+      original,
+    )}`,
+  )
+
+  // Check 3. like index
+  const { indexMismatchedCount } = await db.db
+    .selectFrom('like')
+    .innerJoin('record', 'record.uri', 'like.uri')
+    .whereRef('like.cid', '!=', 'record.cid')
+    .orWhere('record.collection', '!=', ids.AppBskyFeedLike)
+    .select(countAll.as('indexMismatchedCount'))
+    .executeTakeFirstOrThrow()
+  assert(
+    indexMismatchedCount === 0,
+    `${SHORT_NAME} dummy check failed: ${indexMismatchedCount} mismatched records from like index`,
+  )
+
+  // Check 4: record cids and content
+  const pct = Math.min(50 / likeCount, 1) // Aim for around 50 random tests cases
+  const testCases = await db.db
+    .selectFrom('record')
+    .leftJoin('ipld_block', (join) =>
+      join
+        .onRef('ipld_block.cid', '=', 'record.cid')
+        .onRef('ipld_block.creator', '=', 'record.did'),
+    )
+    .where('collection', '=', ids.AppBskyFeedLike)
+    .where(sql`random()`, '<', pct)
+    .select(['uri', 'ipld_block.content as bytes'])
+    .execute()
+
+  console.log(`${SHORT_NAME} dummy check ${testCases.length} test cases`)
+
+  for (const { uri, bytes } of testCases) {
+    assert(bytes, `${SHORT_NAME} dummy check failed: ${uri} missing bytes`)
+    const record = cborBytesToRecord(bytes)
+    assert(
+      record['$type'] === ids.AppBskyFeedLike,
+      `${SHORT_NAME} dummy check failed: ${uri} bad record type`,
+    )
+    try {
+      assertValidRecord(record)
+    } catch {
+      throw new Error(`${SHORT_NAME} dummy check failed: ${uri} invalid record`)
+    }
+  }
 }
 
 async function getDidsWithVotes(db: Database) {
@@ -202,7 +292,7 @@ async function getVotes(db: Database, did: string) {
 async function getVoteCount(db: Database) {
   const { count } = await db.db
     .selectFrom('record')
-    .select(sql`count(*)`.as('count'))
+    .select(countAll.as('count'))
     .where('collection', '=', VOTE_LEX_ID)
     .executeTakeFirstOrThrow()
   return Number(count)


### PR DESCRIPTION
Contains the app migration to turn votes into likes.

Using the repo service here similar to #664, which takes care of updating repositories plus the generic record index. App-view related changes are handled at the end of the migrations— that would include updates to `duplicate_record` and `like` tables, in particular updating uris and cids.  A no-op `messageDispatcher` is used rather than a real one in order to avoid app-view indexing logic from kicking in.  The rkeys of the vote records are preserved into the like records.