### PR TITLE
CI: run on pull requests, not just pushes

### DIFF
--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -1,5 +1,12 @@
 name: repo
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The intent is to run basic CI against third-party PRs (aka, open source contributions).

This is helpful for us reviewing things, but raises security concerns, because it allows third party code to run under our CI context.

Quick background reading on the difference between `pull_request` and `pull_request_target`, and other PR security concerns:

- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://securitylab.github.com/research/github-actions-building-blocks/

I don't have admin on this repo (`atproto`), but the following changes should be checked (or updated) before merging this branch, under the "Settings > Actions" tab:

- "Fork pull request workflows from outside collaborators" -> Require approval for first time contributors. Seems like a good balance, a bit of friction on the first PR but we can do a quick scan before pushing a button to run CI
- "Workflow permissions": read only
- don't allow Github Actions to create and approve pull requests (at least for now)

I already made these change in the indigo repo, and have merged CI changes similar to this one: https://github.com/bluesky-social/indigo/pull/48

Worth reviewing carefully here, i'll copy the same CI change with any config notes to the `did-plc-method`, `atproto-website`, and any other public repos we expect contributions to.