### PR TITLE
More label lexicons

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -18,7 +18,7 @@
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {
           "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
         }
       }
     },
@@ -43,7 +43,7 @@
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {
           "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
         }
       }
     },
@@ -72,7 +72,7 @@
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {
           "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
         }
       }
     },

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -15,7 +15,11 @@
           "maxLength": 640
         },
         "avatar": { "type": "string" },
-        "viewer": {"type": "ref", "ref": "#viewerState"}
+        "viewer": {"type": "ref", "ref": "#viewerState"},
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+        }
       }
     },
     "profileView": {
@@ -36,7 +40,11 @@
         },
         "avatar": { "type": "string" },
         "indexedAt": {"type": "string", "format": "datetime"},
-        "viewer": {"type": "ref", "ref": "#viewerState"}
+        "viewer": {"type": "ref", "ref": "#viewerState"},
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+        }
       }
     },
     "profileViewDetailed": {
@@ -61,7 +69,11 @@
         "followsCount": {"type": "integer"},
         "postsCount": {"type": "integer"},
         "indexedAt": {"type": "string", "format": "datetime"},
-        "viewer": {"type": "ref", "ref": "#viewerState"}
+        "viewer": {"type": "ref", "ref": "#viewerState"},
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+        }
       }
     },
     "viewerState": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -26,7 +26,7 @@
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {
           "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
         }
       }
     },

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -23,7 +23,11 @@
         "repostCount": {"type": "integer"},
         "likeCount": {"type": "integer"},
         "indexedAt": {"type": "string", "format": "datetime"},
-        "viewer": {"type": "ref", "ref": "#viewerState"}
+        "viewer": {"type": "ref", "ref": "#viewerState"},
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+        }
       }
     },
     "viewerState": {

--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -44,7 +44,7 @@
         "indexedAt": {"type": "string", "format": "datetime"},
         "labels": {
           "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+          "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
         }
       }
     }

--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -41,7 +41,11 @@
         "reasonSubject": {"type": "string", "format": "at-uri"},
         "record": {"type": "unknown"},
         "isRead": {"type": "boolean"},
-        "indexedAt": {"type": "string", "format": "datetime"}
+        "indexedAt": {"type": "string", "format": "datetime"},
+        "labels": {
+          "type": "array",
+          "items": {"type": "ref", "ref": "com.atproto.label.label"}
+        }
       }
     }
   }

--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -16,6 +16,8 @@
           ]
         },
         "subjectBlobCids": {"type": "array", "items": {"type": "string"}},
+        "createLabelVals": {"type": "array", "items": {"type": "string"}},
+        "negateLabelVals": {"type": "array", "items": {"type": "string"}},
         "reason": {"type": "string"},
         "createdBy": {"type": "string", "format": "did"},
         "createdAt": {"type": "string", "format": "datetime"},
@@ -37,6 +39,8 @@
           ]
         },
         "subjectBlobs": {"type": "array", "items": {"type": "ref", "ref": "#blobView"}},
+        "createLabelVals": {"type": "array", "items": {"type": "string"}},
+        "negateLabelVals": {"type": "array", "items": {"type": "string"}},
         "reason": {"type": "string"},
         "createdBy": {"type": "string", "format": "did"},
         "createdAt": {"type": "string", "format": "datetime"},

--- a/lexicons/com/atproto/admin/takeModerationAction.json
+++ b/lexicons/com/atproto/admin/takeModerationAction.json
@@ -27,6 +27,8 @@
               ]
             },
             "subjectBlobCids": {"type": "array", "items": {"type": "string", "format": "cid"}},
+            "createLabelVals": {"type": "array", "items": {"type": "string"}},
+            "negateLabelVals": {"type": "array", "items": {"type": "string"}},
             "reason": {"type": "string"},
             "createdBy": {"type": "string", "format": "did"}
           }

--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -1,9 +1,9 @@
 {
   "lexicon": 1,
-  "id": "com.atproto.label.label",
+  "id": "com.atproto.label.defs",
   "defs": {
-    "main": {
-      "type": "record",
+    "label": {
+      "type": "object",
       "description": "Metadata tag on an atproto resource (eg, repo or record)",
       "key": "tid",
       "record": {

--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -30,6 +30,10 @@
             "maxLength": 128,
             "description": "the short string name of the value or type of this label"
           },
+          "neg": {
+            "type": "boolean",
+            "description": "if true, this is a negation label, overwriting a previous label"
+          },
           "cts": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.label",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Metadata tag on an atproto resource (eg, repo or record)",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["src", "uri", "val", "cts"],
+        "properties": {
+          "src": {
+            "type": "string",
+            "description": "DID of the actor who created this label"
+          },
+          "uri": {
+            "type": "string",
+            "description": "AT URI of the record, repository (account), or other resource which this label applies to"
+          },
+          "cid": {
+            "type": "string",
+            "description": "optionally, CID specifying the specific version of 'uri' resource this label applies to"
+          },
+          "val": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "the short string name of the value or type of this label"
+          },
+          "cts": {
+            "type": "datetime",
+            "description": "timestamp when this label was created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/label/label.json
+++ b/lexicons/com/atproto/label/label.json
@@ -12,14 +12,17 @@
         "properties": {
           "src": {
             "type": "string",
+            "format": "did",
             "description": "DID of the actor who created this label"
           },
           "uri": {
             "type": "string",
+            "format": "uri",
             "description": "AT URI of the record, repository (account), or other resource which this label applies to"
           },
           "cid": {
             "type": "string",
+            "format": "cid",
             "description": "optionally, CID specifying the specific version of 'uri' resource this label applies to"
           },
           "val": {
@@ -28,7 +31,8 @@
             "description": "the short string name of the value or type of this label"
           },
           "cts": {
-            "type": "datetime",
+            "type": "string",
+            "format": "datetime",
             "description": "timestamp when this label was created"
           }
         }

--- a/lexicons/com/atproto/label/query.json
+++ b/lexicons/com/atproto/label/query.json
@@ -1,0 +1,42 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.query",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Find labels relevant to the provided URI patterns.",
+      "parameters": {
+        "type": "params",
+        "required": ["uriPatterns"],
+        "properties": {
+          "uriPatterns": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "List of AT URI patterns to match. Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI"
+          },
+          "sources": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Optional list of label sources (DIDs) to filter on"
+          },
+          "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+          "cursor": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["labels"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "labels": {
+              "type": "array",
+              "items": {"type": "ref", "ref": "com.atproto.label.label"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/label/query.json
+++ b/lexicons/com/atproto/label/query.json
@@ -16,7 +16,7 @@
           },
           "sources": {
               "type": "array",
-              "items": {"type": "string"},
+              "items": {"type": "string", "format": "did"},
               "description": "Optional list of label sources (DIDs) to filter on"
           },
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},

--- a/lexicons/com/atproto/label/queryLabels.json
+++ b/lexicons/com/atproto/label/queryLabels.json
@@ -32,7 +32,7 @@
             "cursor": {"type": "string"},
             "labels": {
               "type": "array",
-              "items": {"type": "ref", "ref": "com.atproto.label.label"}
+              "items": {"type": "ref", "ref": "com.atproto.label.defs#label"}
             }
           }
         }

--- a/lexicons/com/atproto/label/queryLabels.json
+++ b/lexicons/com/atproto/label/queryLabels.json
@@ -12,14 +12,14 @@
           "uriPatterns": {
               "type": "array",
               "items": {"type": "string"},
-              "description": "List of AT URI patterns to match. Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI"
+              "description": "List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI"
           },
           "sources": {
               "type": "array",
               "items": {"type": "string", "format": "did"},
               "description": "Optional list of label sources (DIDs) to filter on"
           },
-          "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 250, "default": 50},
           "cursor": {"type": "string"}
         }
       },

--- a/lexicons/com/atproto/label/queryLabels.json
+++ b/lexicons/com/atproto/label/queryLabels.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "com.atproto.label.query",
+  "id": "com.atproto.label.queryLabels",
   "defs": {
     "main": {
       "type": "query",

--- a/lexicons/com/atproto/label/subscribeLabels.json
+++ b/lexicons/com/atproto/label/subscribeLabels.json
@@ -16,24 +16,40 @@
       },
       "message": {
         "schema": {
-          "type": "object",
-          "required": ["seq", "labels"],
-          "nullable": ["prev"],
-          "properties": {
-            "seq": {"type": "integer"},
-            "labels": {
-              "type": "array",
-              "items": { "type": "ref", "ref": "com.atproto.label.label" }
-            }
-          }
+          "type": "union",
+          "refs": [
+            "#labels",
+            "#info"
+          ]
         }
       },
-      "infos": [
-        {"name": "OutdatedCursor"}
-      ],
       "errors": [
         {"name": "FutureCursor"}
       ]
+    },
+    "labels": {
+      "type": "object",
+      "required": ["seq", "labels"],
+      "properties": {
+        "seq": {"type": "integer"},
+        "labels": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.label.label" }
+        }
+      }
+    },
+    "info": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "knownValues": ["OutdatedCursor"]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/lexicons/com/atproto/label/subscribeLabels.json
+++ b/lexicons/com/atproto/label/subscribeLabels.json
@@ -1,0 +1,39 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.subscribeLabels",
+  "defs": {
+    "main": {
+      "type": "subscription",
+      "description": "Subscribe to label updates",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "cursor": {
+            "type": "integer",
+            "description": "The last known event to backfill from."
+          }
+        }
+      },
+      "message": {
+        "schema": {
+          "type": "object",
+          "required": ["seq", "labels"],
+          "nullable": ["prev"],
+          "properties": {
+            "seq": {"type": "integer"},
+            "labels": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "com.atproto.label.label" }
+            }
+          }
+        }
+      },
+      "infos": [
+        {"name": "OutdatedCursor"}
+      ],
+      "errors": [
+        {"name": "FutureCursor"}
+      ]
+    }
+  }
+}

--- a/lexicons/com/atproto/label/subscribeLabels.json
+++ b/lexicons/com/atproto/label/subscribeLabels.json
@@ -34,7 +34,7 @@
         "seq": {"type": "integer"},
         "labels": {
           "type": "array",
-          "items": { "type": "ref", "ref": "com.atproto.label.label" }
+          "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
         }
       }
     },

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -20,6 +20,9 @@ import * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRep
 import * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
 import * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 import * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
+import * as ComAtprotoLabelDefs from './types/com/atproto/label/defs'
+import * as ComAtprotoLabelQueryLabels from './types/com/atproto/label/queryLabels'
+import * as ComAtprotoLabelSubscribeLabels from './types/com/atproto/label/subscribeLabels'
 import * as ComAtprotoModerationCreateReport from './types/com/atproto/moderation/createReport'
 import * as ComAtprotoModerationDefs from './types/com/atproto/moderation/defs'
 import * as ComAtprotoRepoApplyWrites from './types/com/atproto/repo/applyWrites'
@@ -98,6 +101,9 @@ export * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRep
 export * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
 export * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 export * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
+export * as ComAtprotoLabelDefs from './types/com/atproto/label/defs'
+export * as ComAtprotoLabelQueryLabels from './types/com/atproto/label/queryLabels'
+export * as ComAtprotoLabelSubscribeLabels from './types/com/atproto/label/subscribeLabels'
 export * as ComAtprotoModerationCreateReport from './types/com/atproto/moderation/createReport'
 export * as ComAtprotoModerationDefs from './types/com/atproto/moderation/defs'
 export * as ComAtprotoRepoApplyWrites from './types/com/atproto/repo/applyWrites'
@@ -217,6 +223,7 @@ export class AtprotoNS {
   _service: AtpServiceClient
   admin: AdminNS
   identity: IdentityNS
+  label: LabelNS
   moderation: ModerationNS
   repo: RepoNS
   server: ServerNS
@@ -226,6 +233,7 @@ export class AtprotoNS {
     this._service = service
     this.admin = new AdminNS(service)
     this.identity = new IdentityNS(service)
+    this.label = new LabelNS(service)
     this.moderation = new ModerationNS(service)
     this.repo = new RepoNS(service)
     this.server = new ServerNS(service)
@@ -377,6 +385,25 @@ export class IdentityNS {
       .call('com.atproto.identity.updateHandle', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoIdentityUpdateHandle.toKnownErr(e)
+      })
+  }
+}
+
+export class LabelNS {
+  _service: AtpServiceClient
+
+  constructor(service: AtpServiceClient) {
+    this._service = service
+  }
+
+  queryLabels(
+    params?: ComAtprotoLabelQueryLabels.QueryParams,
+    opts?: ComAtprotoLabelQueryLabels.CallOptions,
+  ): Promise<ComAtprotoLabelQueryLabels.Response> {
+    return this._service.xrpc
+      .call('com.atproto.label.queryLabels', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoLabelQueryLabels.toKnownErr(e)
       })
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -41,6 +41,18 @@ export const schemaDict = {
               type: 'string',
             },
           },
+          createLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          negateLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
           reason: {
             type: 'string',
           },
@@ -96,6 +108,18 @@ export const schemaDict = {
             items: {
               type: 'ref',
               ref: 'lex:com.atproto.admin.defs#blobView',
+            },
+          },
+          createLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          negateLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
             },
           },
           reason: {
@@ -891,6 +915,18 @@ export const schemaDict = {
                   format: 'cid',
                 },
               },
+              createLabelVals: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+              negateLabelVals: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
               reason: {
                 type: 'string',
               },
@@ -968,6 +1004,178 @@ export const schemaDict = {
                 format: 'handle',
               },
             },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelDefs: {
+    lexicon: 1,
+    id: 'com.atproto.label.defs',
+    defs: {
+      label: {
+        type: 'object',
+        description: 'Metadata tag on an atproto resource (eg, repo or record)',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['src', 'uri', 'val', 'cts'],
+          properties: {
+            src: {
+              type: 'string',
+              format: 'did',
+              description: 'DID of the actor who created this label',
+            },
+            uri: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'AT URI of the record, repository (account), or other resource which this label applies to',
+            },
+            cid: {
+              type: 'string',
+              format: 'cid',
+              description:
+                "optionally, CID specifying the specific version of 'uri' resource this label applies to",
+            },
+            val: {
+              type: 'string',
+              maxLength: 128,
+              description:
+                'the short string name of the value or type of this label',
+            },
+            neg: {
+              type: 'boolean',
+              description:
+                'if true, this is a negation label, overwriting a previous label',
+            },
+            cts: {
+              type: 'string',
+              format: 'datetime',
+              description: 'timestamp when this label was created',
+            },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelQueryLabels: {
+    lexicon: 1,
+    id: 'com.atproto.label.queryLabels',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Find labels relevant to the provided URI patterns.',
+        parameters: {
+          type: 'params',
+          required: ['uriPatterns'],
+          properties: {
+            uriPatterns: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description:
+                "List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI",
+            },
+            sources: {
+              type: 'array',
+              items: {
+                type: 'string',
+                format: 'did',
+              },
+              description: 'Optional list of label sources (DIDs) to filter on',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 250,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['labels'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.label.defs#label',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelSubscribeLabels: {
+    lexicon: 1,
+    id: 'com.atproto.label.subscribeLabels',
+    defs: {
+      main: {
+        type: 'subscription',
+        description: 'Subscribe to label updates',
+        parameters: {
+          type: 'params',
+          properties: {
+            cursor: {
+              type: 'integer',
+              description: 'The last known event to backfill from.',
+            },
+          },
+        },
+        message: {
+          schema: {
+            type: 'union',
+            refs: [
+              'lex:com.atproto.label.subscribeLabels#labels',
+              'lex:com.atproto.label.subscribeLabels#info',
+            ],
+          },
+        },
+        errors: [
+          {
+            name: 'FutureCursor',
+          },
+        ],
+      },
+      labels: {
+        type: 'object',
+        required: ['seq', 'labels'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
+        },
+      },
+      info: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: {
+            type: 'string',
+            knownValues: ['OutdatedCursor'],
+          },
+          message: {
+            type: 'string',
           },
         },
       },
@@ -1434,12 +1642,12 @@ export const schemaDict = {
             rkeyStart: {
               type: 'string',
               description:
-                'The lowest sort-ordered rkey to start from (exclusive)',
+                'DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)',
             },
             rkeyEnd: {
               type: 'string',
               description:
-                'The highest sort-ordered rkey to stop at (exclusive)',
+                'DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)',
             },
             reverse: {
               type: 'boolean',
@@ -2549,6 +2757,13 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
           },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
         },
       },
       profileView: {
@@ -2583,6 +2798,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -2630,6 +2852,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -3178,6 +3407,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -4035,6 +4271,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
         },
       },
     },
@@ -4188,6 +4431,9 @@ export const ids = {
   ComAtprotoAdminTakeModerationAction: 'com.atproto.admin.takeModerationAction',
   ComAtprotoIdentityResolveHandle: 'com.atproto.identity.resolveHandle',
   ComAtprotoIdentityUpdateHandle: 'com.atproto.identity.updateHandle',
+  ComAtprotoLabelDefs: 'com.atproto.label.defs',
+  ComAtprotoLabelQueryLabels: 'com.atproto.label.queryLabels',
+  ComAtprotoLabelSubscribeLabels: 'com.atproto.label.subscribeLabels',
   ComAtprotoModerationCreateReport: 'com.atproto.moderation.createReport',
   ComAtprotoModerationDefs: 'com.atproto.moderation.defs',
   ComAtprotoRepoApplyWrites: 'com.atproto.repo.applyWrites',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -5,6 +5,7 @@ import { ValidationResult, BlobRef } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
+import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface ProfileViewBasic {
   did: string
@@ -12,6 +13,7 @@ export interface ProfileViewBasic {
   displayName?: string
   avatar?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 
@@ -35,6 +37,7 @@ export interface ProfileView {
   avatar?: string
   indexedAt?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 
@@ -62,6 +65,7 @@ export interface ProfileViewDetailed {
   postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -10,6 +10,7 @@ import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
 import * as AppBskyEmbedRecord from '../embed/record'
 import * as AppBskyEmbedRecordWithMedia from '../embed/recordWithMedia'
+import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface PostView {
   uri: string
@@ -27,6 +28,7 @@ export interface PostView {
   likeCount?: number
   indexedAt: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -7,6 +7,7 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
 import * as AppBskyActorDefs from '../actor/defs'
+import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface QueryParams {
   limit?: number
@@ -54,6 +55,7 @@ export interface Notification {
   record: {}
   isRead: boolean
   indexedAt: string
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/com/atproto/admin/defs.ts
+++ b/packages/api/src/client/types/com/atproto/admin/defs.ts
@@ -16,6 +16,8 @@ export interface ActionView {
     | ComAtprotoRepoStrongRef.Main
     | { $type: string; [k: string]: unknown }
   subjectBlobCids: string[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   createdAt: string
@@ -41,6 +43,8 @@ export interface ActionViewDetail {
   action: ActionType
   subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
   subjectBlobs: BlobView[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   createdAt: string

--- a/packages/api/src/client/types/com/atproto/admin/takeModerationAction.ts
+++ b/packages/api/src/client/types/com/atproto/admin/takeModerationAction.ts
@@ -22,6 +22,8 @@ export interface InputSchema {
     | ComAtprotoRepoStrongRef.Main
     | { $type: string; [k: string]: unknown }
   subjectBlobCids?: string[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   [k: string]: unknown

--- a/packages/api/src/client/types/com/atproto/label/defs.ts
+++ b/packages/api/src/client/types/com/atproto/label/defs.ts
@@ -1,0 +1,22 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+
+/** Metadata tag on an atproto resource (eg, repo or record) */
+export interface Label {}
+
+export function isLabel(v: unknown): v is Label {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.defs#label'
+  )
+}
+
+export function validateLabel(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.defs#label', v)
+}

--- a/packages/api/src/client/types/com/atproto/label/queryLabels.ts
+++ b/packages/api/src/client/types/com/atproto/label/queryLabels.ts
@@ -1,0 +1,42 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+import * as ComAtprotoLabelDefs from './defs'
+
+export interface QueryParams {
+  /** List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI */
+  uriPatterns: string[]
+  /** Optional list of label sources (DIDs) to filter on */
+  sources?: string[]
+  limit?: number
+  cursor?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/api/src/client/types/com/atproto/label/subscribeLabels.ts
+++ b/packages/api/src/client/types/com/atproto/label/subscribeLabels.ts
@@ -1,0 +1,45 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+import * as ComAtprotoLabelDefs from './defs'
+
+export interface Labels {
+  seq: number
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export function isLabels(v: unknown): v is Labels {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.subscribeLabels#labels'
+  )
+}
+
+export function validateLabels(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.subscribeLabels#labels', v)
+}
+
+export interface Info {
+  name: 'OutdatedCursor' | (string & {})
+  message?: string
+  [k: string]: unknown
+}
+
+export function isInfo(v: unknown): v is Info {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.subscribeLabels#info'
+  )
+}
+
+export function validateInfo(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.subscribeLabels#info', v)
+}

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -15,9 +15,9 @@ export interface QueryParams {
   /** The number of records to return. */
   limit?: number
   cursor?: string
-  /** The lowest sort-ordered rkey to start from (exclusive) */
+  /** DEPRECATED: The lowest sort-ordered rkey to start from (exclusive) */
   rkeyStart?: string
-  /** The highest sort-ordered rkey to stop at (exclusive) */
+  /** DEPRECATED: The highest sort-ordered rkey to stop at (exclusive) */
   rkeyEnd?: string
   /** Reverse the order of the returned records? */
   reverse?: boolean

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -21,6 +21,8 @@ import * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRep
 import * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
 import * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 import * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
+import * as ComAtprotoLabelQueryLabels from './types/com/atproto/label/queryLabels'
+import * as ComAtprotoLabelSubscribeLabels from './types/com/atproto/label/subscribeLabels'
 import * as ComAtprotoModerationCreateReport from './types/com/atproto/moderation/createReport'
 import * as ComAtprotoRepoApplyWrites from './types/com/atproto/repo/applyWrites'
 import * as ComAtprotoRepoCreateRecord from './types/com/atproto/repo/createRecord'
@@ -112,6 +114,7 @@ export class AtprotoNS {
   _server: Server
   admin: AdminNS
   identity: IdentityNS
+  label: LabelNS
   moderation: ModerationNS
   repo: RepoNS
   server: ServerNS
@@ -121,6 +124,7 @@ export class AtprotoNS {
     this._server = server
     this.admin = new AdminNS(server)
     this.identity = new IdentityNS(server)
+    this.label = new LabelNS(server)
     this.moderation = new ModerationNS(server)
     this.repo = new RepoNS(server)
     this.server = new ServerNS(server)
@@ -246,6 +250,28 @@ export class IdentityNS {
   ) {
     const nsid = 'com.atproto.identity.updateHandle' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
+  }
+}
+
+export class LabelNS {
+  _server: Server
+
+  constructor(server: Server) {
+    this._server = server
+  }
+
+  queryLabels<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoLabelQueryLabels.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.label.queryLabels' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  subscribeLabels<AV extends StreamAuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoLabelSubscribeLabels.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.label.subscribeLabels' // @ts-ignore
+    return this._server.xrpc.streamMethod(nsid, cfg)
   }
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -41,6 +41,18 @@ export const schemaDict = {
               type: 'string',
             },
           },
+          createLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          negateLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
           reason: {
             type: 'string',
           },
@@ -96,6 +108,18 @@ export const schemaDict = {
             items: {
               type: 'ref',
               ref: 'lex:com.atproto.admin.defs#blobView',
+            },
+          },
+          createLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          negateLabelVals: {
+            type: 'array',
+            items: {
+              type: 'string',
             },
           },
           reason: {
@@ -891,6 +915,18 @@ export const schemaDict = {
                   format: 'cid',
                 },
               },
+              createLabelVals: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+              negateLabelVals: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
               reason: {
                 type: 'string',
               },
@@ -968,6 +1004,178 @@ export const schemaDict = {
                 format: 'handle',
               },
             },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelDefs: {
+    lexicon: 1,
+    id: 'com.atproto.label.defs',
+    defs: {
+      label: {
+        type: 'object',
+        description: 'Metadata tag on an atproto resource (eg, repo or record)',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['src', 'uri', 'val', 'cts'],
+          properties: {
+            src: {
+              type: 'string',
+              format: 'did',
+              description: 'DID of the actor who created this label',
+            },
+            uri: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'AT URI of the record, repository (account), or other resource which this label applies to',
+            },
+            cid: {
+              type: 'string',
+              format: 'cid',
+              description:
+                "optionally, CID specifying the specific version of 'uri' resource this label applies to",
+            },
+            val: {
+              type: 'string',
+              maxLength: 128,
+              description:
+                'the short string name of the value or type of this label',
+            },
+            neg: {
+              type: 'boolean',
+              description:
+                'if true, this is a negation label, overwriting a previous label',
+            },
+            cts: {
+              type: 'string',
+              format: 'datetime',
+              description: 'timestamp when this label was created',
+            },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelQueryLabels: {
+    lexicon: 1,
+    id: 'com.atproto.label.queryLabels',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Find labels relevant to the provided URI patterns.',
+        parameters: {
+          type: 'params',
+          required: ['uriPatterns'],
+          properties: {
+            uriPatterns: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description:
+                "List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI",
+            },
+            sources: {
+              type: 'array',
+              items: {
+                type: 'string',
+                format: 'did',
+              },
+              description: 'Optional list of label sources (DIDs) to filter on',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 250,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['labels'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.label.defs#label',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoLabelSubscribeLabels: {
+    lexicon: 1,
+    id: 'com.atproto.label.subscribeLabels',
+    defs: {
+      main: {
+        type: 'subscription',
+        description: 'Subscribe to label updates',
+        parameters: {
+          type: 'params',
+          properties: {
+            cursor: {
+              type: 'integer',
+              description: 'The last known event to backfill from.',
+            },
+          },
+        },
+        message: {
+          schema: {
+            type: 'union',
+            refs: [
+              'lex:com.atproto.label.subscribeLabels#labels',
+              'lex:com.atproto.label.subscribeLabels#info',
+            ],
+          },
+        },
+        errors: [
+          {
+            name: 'FutureCursor',
+          },
+        ],
+      },
+      labels: {
+        type: 'object',
+        required: ['seq', 'labels'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
+        },
+      },
+      info: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: {
+            type: 'string',
+            knownValues: ['OutdatedCursor'],
+          },
+          message: {
+            type: 'string',
           },
         },
       },
@@ -1434,12 +1642,12 @@ export const schemaDict = {
             rkeyStart: {
               type: 'string',
               description:
-                'The lowest sort-ordered rkey to start from (exclusive)',
+                'DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)',
             },
             rkeyEnd: {
               type: 'string',
               description:
-                'The highest sort-ordered rkey to stop at (exclusive)',
+                'DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)',
             },
             reverse: {
               type: 'boolean',
@@ -2549,6 +2757,13 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
           },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
         },
       },
       profileView: {
@@ -2583,6 +2798,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -2630,6 +2852,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -3178,6 +3407,13 @@ export const schemaDict = {
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#viewerState',
+          },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
           },
         },
       },
@@ -4035,6 +4271,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          labels: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.label.defs#label',
+            },
+          },
         },
       },
     },
@@ -4188,6 +4431,9 @@ export const ids = {
   ComAtprotoAdminTakeModerationAction: 'com.atproto.admin.takeModerationAction',
   ComAtprotoIdentityResolveHandle: 'com.atproto.identity.resolveHandle',
   ComAtprotoIdentityUpdateHandle: 'com.atproto.identity.updateHandle',
+  ComAtprotoLabelDefs: 'com.atproto.label.defs',
+  ComAtprotoLabelQueryLabels: 'com.atproto.label.queryLabels',
+  ComAtprotoLabelSubscribeLabels: 'com.atproto.label.subscribeLabels',
   ComAtprotoModerationCreateReport: 'com.atproto.moderation.createReport',
   ComAtprotoModerationDefs: 'com.atproto.moderation.defs',
   ComAtprotoRepoApplyWrites: 'com.atproto.repo.applyWrites',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -5,6 +5,7 @@ import { ValidationResult, BlobRef } from '@atproto/lexicon'
 import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
+import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface ProfileViewBasic {
   did: string
@@ -12,6 +13,7 @@ export interface ProfileViewBasic {
   displayName?: string
   avatar?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 
@@ -35,6 +37,7 @@ export interface ProfileView {
   avatar?: string
   indexedAt?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 
@@ -62,6 +65,7 @@ export interface ProfileViewDetailed {
   postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -10,6 +10,7 @@ import * as AppBskyEmbedImages from '../embed/images'
 import * as AppBskyEmbedExternal from '../embed/external'
 import * as AppBskyEmbedRecord from '../embed/record'
 import * as AppBskyEmbedRecordWithMedia from '../embed/recordWithMedia'
+import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface PostView {
   uri: string
@@ -27,6 +28,7 @@ export interface PostView {
   likeCount?: number
   indexedAt: string
   viewer?: ViewerState
+  labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
@@ -16,6 +16,8 @@ export interface ActionView {
     | ComAtprotoRepoStrongRef.Main
     | { $type: string; [k: string]: unknown }
   subjectBlobCids: string[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   createdAt: string
@@ -41,6 +43,8 @@ export interface ActionViewDetail {
   action: ActionType
   subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
   subjectBlobs: BlobView[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   createdAt: string

--- a/packages/pds/src/lexicon/types/com/atproto/admin/takeModerationAction.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/takeModerationAction.ts
@@ -23,6 +23,8 @@ export interface InputSchema {
     | ComAtprotoRepoStrongRef.Main
     | { $type: string; [k: string]: unknown }
   subjectBlobCids?: string[]
+  createLabelVals?: string[]
+  negateLabelVals?: string[]
   reason: string
   createdBy: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/com/atproto/label/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/label/defs.ts
@@ -1,0 +1,22 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+
+/** Metadata tag on an atproto resource (eg, repo or record) */
+export interface Label {}
+
+export function isLabel(v: unknown): v is Label {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.defs#label'
+  )
+}
+
+export function validateLabel(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.defs#label', v)
+}

--- a/packages/pds/src/lexicon/types/com/atproto/label/queryLabels.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/label/queryLabels.ts
@@ -7,10 +7,13 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
-import * as AppBskyActorDefs from '../actor/defs'
-import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
+import * as ComAtprotoLabelDefs from './defs'
 
 export interface QueryParams {
+  /** List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI */
+  uriPatterns: string[]
+  /** Optional list of label sources (DIDs) to filter on */
+  sources?: string[]
   limit: number
   cursor?: string
 }
@@ -19,7 +22,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  notifications: Notification[]
+  labels: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
 }
 
@@ -43,39 +46,3 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
   req: express.Request
   res: express.Response
 }) => Promise<HandlerOutput> | HandlerOutput
-
-export interface Notification {
-  uri: string
-  cid: string
-  author: AppBskyActorDefs.ProfileView
-  /** Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'. */
-  reason:
-    | 'like'
-    | 'repost'
-    | 'follow'
-    | 'mention'
-    | 'reply'
-    | 'quote'
-    | (string & {})
-  reasonSubject?: string
-  record: {}
-  isRead: boolean
-  indexedAt: string
-  labels?: ComAtprotoLabelDefs.Label[]
-  [k: string]: unknown
-}
-
-export function isNotification(v: unknown): v is Notification {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.notification.listNotifications#notification'
-  )
-}
-
-export function validateNotification(v: unknown): ValidationResult {
-  return lexicons.validate(
-    'app.bsky.notification.listNotifications#notification',
-    v,
-  )
-}

--- a/packages/pds/src/lexicon/types/com/atproto/label/subscribeLabels.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/label/subscribeLabels.ts
@@ -1,0 +1,63 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth, ErrorFrame } from '@atproto/xrpc-server'
+import { IncomingMessage } from 'http'
+import * as ComAtprotoLabelDefs from './defs'
+
+export interface QueryParams {
+  /** The last known event to backfill from. */
+  cursor?: number
+}
+
+export type OutputSchema =
+  | Labels
+  | Info
+  | { $type: string; [k: string]: unknown }
+export type HandlerError = ErrorFrame<'FutureCursor'>
+export type HandlerOutput = HandlerError | OutputSchema
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  req: IncomingMessage
+}) => AsyncIterable<HandlerOutput>
+
+export interface Labels {
+  seq: number
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export function isLabels(v: unknown): v is Labels {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.subscribeLabels#labels'
+  )
+}
+
+export function validateLabels(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.subscribeLabels#labels', v)
+}
+
+export interface Info {
+  name: 'OutdatedCursor' | (string & {})
+  message?: string
+  [k: string]: unknown
+}
+
+export function isInfo(v: unknown): v is Info {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.label.subscribeLabels#info'
+  )
+}
+
+export function validateInfo(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.label.subscribeLabels#info', v)
+}

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -16,9 +16,9 @@ export interface QueryParams {
   /** The number of records to return. */
   limit: number
   cursor?: string
-  /** The lowest sort-ordered rkey to start from (exclusive) */
+  /** DEPRECATED: The lowest sort-ordered rkey to start from (exclusive) */
   rkeyStart?: string
-  /** The highest sort-ordered rkey to stop at (exclusive) */
+  /** DEPRECATED: The highest sort-ordered rkey to stop at (exclusive) */
   rkeyEnd?: string
   /** Reverse the order of the returned records? */
   reverse?: boolean


### PR DESCRIPTION
New endpoints:

- `com.atproto.label.query`: lookup labels on URI patterns. intended uses are to look up all labels on a specific repo or specific record; look up all labels on a specific repo and all labels on all posts by that repo (collection-level wildcard)
- `com.atproto.label.subscribeAllLabels`: an event stream similar to `subscribeAllRepos`

And adding arrays of labels to "views" of posts and profiles.

This branch is on top of the `com.atproto.label.label` branch (PR: https://github.com/bluesky-social/atproto/pull/525).

The description on the "uriPatterns" param is sort of terse, when I mean by "inclusive" is that `at://did:plc:abc123*` would match labels on `at://did:plc:abc123` (exact match) in addition to `at://did:plc:abc123/app.bsky.feed.post/abc123` (etc). That wouldn't be the case if you did `at://did:plc:abc123/*` (with the extra slash before the `*`).

Some things i'm looking for feedback on:

- should I be using the `#view` variant of label record to pull the CID and URI (of the label itself) in? that feels like it really commits us to labels-in-repos.
- intend to eventually add an additional optional `providers` array to the query endpoint, which would only return labels from the listed DIDs (`src` field in the label). Maybe I should just add that now?
- do I need to worry about what the "cursor" value will be for pagination of results? I don't think so. Would probably just be a table primary key encoded as base64 or something like that.
- I originally had a `get` variant of `query`, but I think that `query` is flexible to both.