### PR TITLE
Lexicon: optional aggregated fields on views

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -38,8 +38,7 @@
         "postsCount": {"type": "integer"},
         "creator": {"type": "string"},
         "indexedAt": {"type": "string", "format": "datetime"},
-        "viewer": {"type": "ref", "ref": "#viewerState"},
-        "myState": {"type": "ref", "ref": "#myState", "description": "Deprecated"}
+        "viewer": {"type": "ref", "ref": "#viewerState"}
       }
     },
     "profileViewBasic": {
@@ -67,14 +66,6 @@
         "muted": {"type": "boolean"},
         "following": {"type": "string", "format": "at-uri"},
         "followedBy": {"type": "string", "format": "at-uri"}
-      }
-    },
-    "myState": {
-      "type": "object",
-      "description": "Deprecated in favor of #viewerState",
-      "properties": {
-        "follow": {"type": "string", "format": "at-uri"},
-        "muted": {"type": "boolean"}
       }
     }
   }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -19,7 +19,7 @@
     },
     "profileView": {
       "type": "object",
-      "required": ["did", "handle", "creator", "followersCount", "followsCount", "postsCount"],
+      "required": ["did", "handle", "creator"],
       "properties": {
         "did": {"type": "string", "format": "did"},
         "handle": {"type": "string"},

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -4,7 +4,7 @@
   "defs": {
     "postView": {
       "type": "object",
-      "required": ["uri", "cid", "author", "record", "indexedAt", "viewer"],
+      "required": ["uri", "cid", "author", "record", "indexedAt"],
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string"},

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -4,7 +4,7 @@
   "defs": {
     "postView": {
       "type": "object",
-      "required": ["uri", "cid", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt", "viewer"],
+      "required": ["uri", "cid", "author", "record", "indexedAt", "viewer"],
       "properties": {
         "uri": {"type": "string"},
         "cid": {"type": "string"},

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2381,14 +2381,7 @@ export const schemaDict = {
       },
       profileView: {
         type: 'object',
-        required: [
-          'did',
-          'handle',
-          'creator',
-          'followersCount',
-          'followsCount',
-          'postsCount',
-        ],
+        required: ['did', 'handle', 'creator'],
         properties: {
           did: {
             type: 'string',
@@ -3011,17 +3004,7 @@ export const schemaDict = {
     defs: {
       postView: {
         type: 'object',
-        required: [
-          'uri',
-          'cid',
-          'author',
-          'record',
-          'replyCount',
-          'repostCount',
-          'likeCount',
-          'indexedAt',
-          'viewer',
-        ],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt', 'viewer'],
         properties: {
           uri: {
             type: 'string',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2424,11 +2424,6 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
           },
-          myState: {
-            type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#myState',
-            description: 'Deprecated',
-          },
         },
       },
       profileViewBasic: {
@@ -2476,19 +2471,6 @@ export const schemaDict = {
           followedBy: {
             type: 'string',
             format: 'at-uri',
-          },
-        },
-      },
-      myState: {
-        type: 'object',
-        description: 'Deprecated in favor of #viewerState',
-        properties: {
-          follow: {
-            type: 'string',
-            format: 'at-uri',
-          },
-          muted: {
-            type: 'boolean',
           },
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3004,7 +3004,7 @@ export const schemaDict = {
     defs: {
       postView: {
         type: 'object',
-        required: ['uri', 'cid', 'author', 'record', 'indexedAt', 'viewer'],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt'],
         properties: {
           uri: {
             type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -39,7 +39,6 @@ export interface ProfileView {
   creator: string
   indexedAt?: string
   viewer?: ViewerState
-  myState?: MyState
   [k: string]: unknown
 }
 
@@ -95,21 +94,4 @@ export function isViewerState(v: unknown): v is ViewerState {
 
 export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
-}
-
-/** Deprecated in favor of #viewerState */
-export interface MyState {
-  follow?: string
-  muted?: boolean
-  [k: string]: unknown
-}
-
-export function isMyState(v: unknown): v is MyState {
-  return (
-    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#myState'
-  )
-}
-
-export function validateMyState(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#myState', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -33,9 +33,9 @@ export interface ProfileView {
   description?: string
   avatar?: string
   banner?: string
-  followersCount: number
-  followsCount: number
-  postsCount: number
+  followersCount?: number
+  followsCount?: number
+  postsCount?: number
   creator: string
   indexedAt?: string
   viewer?: ViewerState

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -19,9 +19,9 @@ export interface PostView {
     | AppBskyEmbedExternal.Presented
     | AppBskyEmbedRecord.Presented
     | { $type: string; [k: string]: unknown }
-  replyCount: number
-  repostCount: number
-  likeCount: number
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   indexedAt: string
   viewer: ViewerState
   [k: string]: unknown

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -23,7 +23,7 @@ export interface PostView {
   repostCount?: number
   likeCount?: number
   indexedAt: string
-  viewer: ViewerState
+  viewer?: ViewerState
   [k: string]: unknown
 }
 

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -104,10 +104,6 @@ export class ActorViews {
           following: profileInfo?.requesterFollowing || undefined,
           followedBy: profileInfo?.requesterFollowedBy || undefined,
         },
-        myState: {
-          follow: profileInfo?.requesterFollowing || undefined,
-          muted: !!profileInfo?.requesterMuted,
-        },
       }
     })
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2381,14 +2381,7 @@ export const schemaDict = {
       },
       profileView: {
         type: 'object',
-        required: [
-          'did',
-          'handle',
-          'creator',
-          'followersCount',
-          'followsCount',
-          'postsCount',
-        ],
+        required: ['did', 'handle', 'creator'],
         properties: {
           did: {
             type: 'string',
@@ -3011,17 +3004,7 @@ export const schemaDict = {
     defs: {
       postView: {
         type: 'object',
-        required: [
-          'uri',
-          'cid',
-          'author',
-          'record',
-          'replyCount',
-          'repostCount',
-          'likeCount',
-          'indexedAt',
-          'viewer',
-        ],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt', 'viewer'],
         properties: {
           uri: {
             type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2424,11 +2424,6 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
           },
-          myState: {
-            type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#myState',
-            description: 'Deprecated',
-          },
         },
       },
       profileViewBasic: {
@@ -2476,19 +2471,6 @@ export const schemaDict = {
           followedBy: {
             type: 'string',
             format: 'at-uri',
-          },
-        },
-      },
-      myState: {
-        type: 'object',
-        description: 'Deprecated in favor of #viewerState',
-        properties: {
-          follow: {
-            type: 'string',
-            format: 'at-uri',
-          },
-          muted: {
-            type: 'boolean',
           },
         },
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3004,7 +3004,7 @@ export const schemaDict = {
     defs: {
       postView: {
         type: 'object',
-        required: ['uri', 'cid', 'author', 'record', 'indexedAt', 'viewer'],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt'],
         properties: {
           uri: {
             type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -39,7 +39,6 @@ export interface ProfileView {
   creator: string
   indexedAt?: string
   viewer?: ViewerState
-  myState?: MyState
   [k: string]: unknown
 }
 
@@ -95,21 +94,4 @@ export function isViewerState(v: unknown): v is ViewerState {
 
 export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
-}
-
-/** Deprecated in favor of #viewerState */
-export interface MyState {
-  follow?: string
-  muted?: boolean
-  [k: string]: unknown
-}
-
-export function isMyState(v: unknown): v is MyState {
-  return (
-    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#myState'
-  )
-}
-
-export function validateMyState(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#myState', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -33,9 +33,9 @@ export interface ProfileView {
   description?: string
   avatar?: string
   banner?: string
-  followersCount: number
-  followsCount: number
-  postsCount: number
+  followersCount?: number
+  followsCount?: number
+  postsCount?: number
   creator: string
   indexedAt?: string
   viewer?: ViewerState

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -19,9 +19,9 @@ export interface PostView {
     | AppBskyEmbedExternal.Presented
     | AppBskyEmbedRecord.Presented
     | { $type: string; [k: string]: unknown }
-  replyCount: number
-  repostCount: number
-  likeCount: number
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   indexedAt: string
   viewer: ViewerState
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -23,7 +23,7 @@ export interface PostView {
   repostCount?: number
   likeCount?: number
   indexedAt: string
-  viewer: ViewerState
+  viewer?: ViewerState
   [k: string]: unknown
 }
 

--- a/packages/pds/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/pds/tests/__snapshots__/indexing.test.ts.snap
@@ -121,9 +121,6 @@ Object {
   "followsCount": 0,
   "handle": "dan.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 0,
   "viewer": Object {
     "muted": false,
@@ -140,9 +137,6 @@ Object {
   "followsCount": 0,
   "handle": "dan.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 0,
   "viewer": Object {
     "muted": false,
@@ -157,9 +151,6 @@ Object {
   "followersCount": 0,
   "followsCount": 0,
   "handle": "dan.test",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 0,
   "viewer": Object {
     "muted": false,

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pds author feed views fetches full author feeds for self (sorted, minimal myState). 1`] = `
+exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 1`] = `
 Array [
   Object {
     "post": Object {
@@ -235,7 +235,7 @@ Array [
 ]
 `;
 
-exports[`pds author feed views fetches full author feeds for self (sorted, minimal myState). 2`] = `
+exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 2`] = `
 Array [
   Object {
     "post": Object {
@@ -403,7 +403,7 @@ Array [
 ]
 `;
 
-exports[`pds author feed views fetches full author feeds for self (sorted, minimal myState). 3`] = `
+exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 3`] = `
 Array [
   Object {
     "post": Object {
@@ -600,7 +600,7 @@ Array [
 ]
 `;
 
-exports[`pds author feed views fetches full author feeds for self (sorted, minimal myState). 4`] = `
+exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 4`] = `
 Array [
   Object {
     "post": Object {

--- a/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
@@ -9,9 +9,6 @@ Object {
   "followsCount": 1,
   "handle": "dan.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 2,
   "viewer": Object {
     "muted": false,
@@ -31,10 +28,6 @@ Array [
     "followsCount": 3,
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
-    "myState": Object {
-      "follow": "record(0)",
-      "muted": false,
-    },
     "postsCount": 4,
     "viewer": Object {
       "followedBy": "record(1)",
@@ -52,9 +45,6 @@ Array [
     "followsCount": 2,
     "handle": "bob.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
-    "myState": Object {
-      "muted": false,
-    },
     "postsCount": 3,
     "viewer": Object {
       "muted": false,
@@ -66,10 +56,6 @@ Array [
     "followersCount": 2,
     "followsCount": 1,
     "handle": "carol.test",
-    "myState": Object {
-      "follow": "record(2)",
-      "muted": false,
-    },
     "postsCount": 2,
     "viewer": Object {
       "following": "record(2)",
@@ -82,9 +68,6 @@ Array [
     "followersCount": 1,
     "followsCount": 1,
     "handle": "dan.test",
-    "myState": Object {
-      "muted": false,
-    },
     "postsCount": 2,
     "viewer": Object {
       "followedBy": "record(3)",
@@ -105,10 +88,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "follow": "record(0)",
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "followedBy": "record(1)",
@@ -125,9 +104,6 @@ Object {
   "followersCount": 1,
   "followsCount": 1,
   "handle": "dan.test",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 2,
   "viewer": Object {
     "followedBy": "record(0)",
@@ -147,9 +123,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "muted": false,
@@ -169,9 +142,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "muted": false,
@@ -190,9 +160,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "muted": false,
@@ -209,9 +176,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "muted": false,
@@ -230,9 +194,6 @@ Object {
   "followsCount": 3,
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
-  "myState": Object {
-    "muted": false,
-  },
   "postsCount": 4,
   "viewer": Object {
     "muted": false,

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -40,7 +40,7 @@ describe('pds author feed views', () => {
     await close()
   })
 
-  it('fetches full author feeds for self (sorted, minimal myState).', async () => {
+  it('fetches full author feeds for self (sorted, minimal viewer state).', async () => {
     const aliceForAlice = await agent.api.app.bsky.feed.getAuthorFeed(
       { actor: sc.accounts[alice].handle },
       {

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -264,7 +264,7 @@ describe('pds profile views', () => {
       { headers: sc.getHeaders(bob) },
     )
 
-    expect(initial.myState?.muted).toEqual(false)
+    expect(initial.viewer?.muted).toEqual(false)
 
     await agent.api.app.bsky.graph.muteActor(
       { actor: alice },
@@ -275,7 +275,7 @@ describe('pds profile views', () => {
       { headers: sc.getHeaders(bob) },
     )
 
-    expect(muted.myState?.muted).toEqual(true)
+    expect(muted.viewer?.muted).toEqual(true)
 
     const { data: fromBobUnrelated } =
       await agent.api.app.bsky.actor.getProfile(
@@ -288,8 +288,8 @@ describe('pds profile views', () => {
         { headers: sc.getHeaders(dan) },
       )
 
-    expect(fromBobUnrelated.myState?.muted).toEqual(false)
-    expect(toAliceUnrelated.myState?.muted).toEqual(false)
+    expect(fromBobUnrelated.viewer?.muted).toEqual(false)
+    expect(toAliceUnrelated.viewer?.muted).toEqual(false)
 
     await agent.api.app.bsky.graph.unmuteActor(
       { actor: alice },

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -33,7 +33,7 @@ describe('pds thread views', () => {
   })
 
   beforeAll(async () => {
-    // Add a repost of a reply so that we can confirm myState in the thread
+    // Add a repost of a reply so that we can confirm viewer state in the thread
     await sc.repost(bob, sc.replies[alice][0].ref)
   })
 


### PR DESCRIPTION
This makes the aggregated count fields on post and profile views (e.g. `post.likeCount`, `profile.followCount`) optional.   Also made `viewer` state optional on the post view, since it falls into a similar category and is already optional on other views.  Finally, I removed the deprecated `myState` field on the profile view.

Resolves #589 