### PR TITLE
Lexicon: embeds in record embeds

### DIFF
--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -17,7 +17,7 @@
       "type": "object",
       "required":  ["uri", "title", "description"],
       "properties": {
-        "uri": {"type": "string", "format": "at-uri"},
+        "uri": {"type": "string"},
         "title": {"type": "string"},
         "description": {"type": "string"},
         "thumb": {
@@ -29,21 +29,21 @@
         }
       }
     },
-    "presented": {
+    "view": {
       "type": "object",
       "required": ["external"],
       "properties": {
-        "external": {
+        "value": {
           "type": "ref",
-          "ref": "#presentedExternal"
+          "ref": "#viewExternal"
         }
       }
     },
-    "presentedExternal": {
+    "viewExternal": {
       "type": "object",
       "required":  ["uri", "title", "description"],
       "properties": {
-        "uri": {"type": "string", "format": "at-uri"},
+        "uri": {"type": "string"},
         "title": {"type": "string"},
         "description": {"type": "string"},
         "thumb": {"type": "string"}

--- a/lexicons/app/bsky/embed/images.json
+++ b/lexicons/app/bsky/embed/images.json
@@ -19,27 +19,27 @@
       "required": ["image", "alt"],
       "properties": {
         "image": {
-            "type": "image",
-            "accept": ["image/*"],
-            "maxWidth": 2000,
-            "maxHeight": 2000,
-            "maxSize": 1000000
+          "type": "image",
+          "accept": ["image/*"],
+          "maxWidth": 2000,
+          "maxHeight": 2000,
+          "maxSize": 1000000
         },
         "alt": {"type": "string"}
       }
     },
-    "presented": {
+    "view": {
       "type": "object",
-      "required": ["images"],
+      "required": ["value"],
       "properties": {
-        "images": {
+        "value": {
           "type": "array",
-          "items": {"type": "ref", "ref": "#presentedImage"},
+          "items": {"type": "ref", "ref": "#viewImage"},
           "maxLength": 4
         }
       }
     },
-    "presentedImage": {
+    "viewImage": {
       "type": "object",
       "required": ["thumb", "fullsize", "alt"],
       "properties": {

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -19,12 +19,24 @@
     },
     "viewRecord": {
       "type": "object",
-      "required":  ["uri", "cid", "author", "record"],
+      "required":  ["uri", "cid", "author", "record", "indexedAt"],
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "cid": {"type": "string", "format": "cid"},
         "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
-        "record": {"type": "unknown"}
+        "record": {"type": "unknown"},
+        "embeds": {
+          "type": "array",
+          "items": {
+            "type": "union",
+            "refs": [
+              "app.bsky.embed.images#view",
+              "app.bsky.embed.external#view",
+              "app.bsky.embed.record#view"
+            ]
+          }
+        },
+        "indexedAt": {"type": "string", "format": "datetime"}
       }
     },
     "viewNotFound": {

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -10,14 +10,14 @@
         "record": {"type": "ref", "ref": "com.atproto.repo.strongRef"}
       }
     },
-    "presented": {
+    "view": {
       "type": "object",
       "required":  ["record"],
       "properties": {
-        "record": {"type": "union", "refs": ["#presentedRecord", "#presentedNotFound"]}
+        "value": {"type": "union", "refs": ["#viewRecord", "#viewNotFound"]}
       }
     },
-    "presentedRecord": {
+    "viewRecord": {
       "type": "object",
       "required":  ["uri", "cid", "author", "record"],
       "properties": {
@@ -27,7 +27,7 @@
         "record": {"type": "unknown"}
       }
     },
-    "presentedNotFound": {
+    "viewNotFound": {
       "type": "object",
       "required":  ["uri"],
       "properties": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -13,9 +13,9 @@
         "embed": {
           "type": "union",
           "refs": [
-            "app.bsky.embed.images#presented",
-            "app.bsky.embed.external#presented",
-            "app.bsky.embed.record#presented"
+            "app.bsky.embed.images#view",
+            "app.bsky.embed.external#view",
+            "app.bsky.embed.record#view"
           ]
         },
         "replyCount": {"type": "integer"},

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -900,7 +900,7 @@ export class ProfileRecord {
     const res = await this._service.xrpc.call(
       'com.atproto.repo.createRecord',
       undefined,
-      { collection: 'app.bsky.actor.profile', ...params, record },
+      { collection: 'app.bsky.actor.profile', rkey: 'self', ...params, record },
       { encoding: 'application/json', headers },
     )
     return res.data

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -900,7 +900,7 @@ export class ProfileRecord {
     const res = await this._service.xrpc.call(
       'com.atproto.repo.createRecord',
       undefined,
-      { collection: 'app.bsky.actor.profile', rkey: 'self', ...params, record },
+      { collection: 'app.bsky.actor.profile', ...params, record },
       { encoding: 'application/json', headers },
     )
     return res.data

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2804,7 +2804,6 @@ export const schemaDict = {
         properties: {
           uri: {
             type: 'string',
-            format: 'at-uri',
           },
           title: {
             type: 'string',
@@ -2821,23 +2820,22 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
         required: ['external'],
         properties: {
-          external: {
+          value: {
             type: 'ref',
-            ref: 'lex:app.bsky.embed.external#presentedExternal',
+            ref: 'lex:app.bsky.embed.external#viewExternal',
           },
         },
       },
-      presentedExternal: {
+      viewExternal: {
         type: 'object',
         required: ['uri', 'title', 'description'],
         properties: {
           uri: {
             type: 'string',
-            format: 'at-uri',
           },
           title: {
             type: 'string',
@@ -2887,21 +2885,21 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
-        required: ['images'],
+        required: ['value'],
         properties: {
-          images: {
+          value: {
             type: 'array',
             items: {
               type: 'ref',
-              ref: 'lex:app.bsky.embed.images#presentedImage',
+              ref: 'lex:app.bsky.embed.images#viewImage',
             },
             maxLength: 4,
           },
         },
       },
-      presentedImage: {
+      viewImage: {
         type: 'object',
         required: ['thumb', 'fullsize', 'alt'],
         properties: {
@@ -2934,20 +2932,20 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
         required: ['record'],
         properties: {
-          record: {
+          value: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.record#presentedRecord',
-              'lex:app.bsky.embed.record#presentedNotFound',
+              'lex:app.bsky.embed.record#viewRecord',
+              'lex:app.bsky.embed.record#viewNotFound',
             ],
           },
         },
       },
-      presentedRecord: {
+      viewRecord: {
         type: 'object',
         required: ['uri', 'cid', 'author', 'record'],
         properties: {
@@ -2968,7 +2966,7 @@ export const schemaDict = {
           },
         },
       },
-      presentedNotFound: {
+      viewNotFound: {
         type: 'object',
         required: ['uri'],
         properties: {
@@ -3004,9 +3002,9 @@ export const schemaDict = {
           embed: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.images#presented',
-              'lex:app.bsky.embed.external#presented',
-              'lex:app.bsky.embed.record#presented',
+              'lex:app.bsky.embed.images#view',
+              'lex:app.bsky.embed.external#view',
+              'lex:app.bsky.embed.record#view',
             ],
           },
           replyCount: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2947,7 +2947,7 @@ export const schemaDict = {
       },
       viewRecord: {
         type: 'object',
-        required: ['uri', 'cid', 'author', 'record'],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt'],
         properties: {
           uri: {
             type: 'string',
@@ -2963,6 +2963,21 @@ export const schemaDict = {
           },
           record: {
             type: 'unknown',
+          },
+          embeds: {
+            type: 'array',
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.embed.images#view',
+                'lex:app.bsky.embed.external#view',
+                'lex:app.bsky.embed.record#view',
+              ],
+            },
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/embed/external.ts
+++ b/packages/api/src/client/types/app/bsky/embed/external.ts
@@ -43,24 +43,24 @@ export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
 }
 
-export interface Presented {
-  external: PresentedExternal
+export interface View {
+  value?: ViewExternal
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.external#presented'
+    v.$type === 'app.bsky.embed.external#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.external#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#view', v)
 }
 
-export interface PresentedExternal {
+export interface ViewExternal {
   uri: string
   title: string
   description: string
@@ -68,14 +68,14 @@ export interface PresentedExternal {
   [k: string]: unknown
 }
 
-export function isPresentedExternal(v: unknown): v is PresentedExternal {
+export function isViewExternal(v: unknown): v is ViewExternal {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.external#presentedExternal'
+    v.$type === 'app.bsky.embed.external#viewExternal'
   )
 }
 
-export function validatePresentedExternal(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.external#presentedExternal', v)
+export function validateViewExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#viewExternal', v)
 }

--- a/packages/api/src/client/types/app/bsky/embed/images.ts
+++ b/packages/api/src/client/types/app/bsky/embed/images.ts
@@ -39,38 +39,36 @@ export function validateImage(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.images#image', v)
 }
 
-export interface Presented {
-  images: PresentedImage[]
+export interface View {
+  value: ViewImage[]
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.images#presented'
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.images#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#view', v)
 }
 
-export interface PresentedImage {
+export interface ViewImage {
   thumb: string
   fullsize: string
   alt: string
   [k: string]: unknown
 }
 
-export function isPresentedImage(v: unknown): v is PresentedImage {
+export function isViewImage(v: unknown): v is ViewImage {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.images#presentedImage'
+    v.$type === 'app.bsky.embed.images#viewImage'
   )
 }
 
-export function validatePresentedImage(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.images#presentedImage', v)
+export function validateViewImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#viewImage', v)
 }

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -25,27 +25,22 @@ export function validateMain(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.record#main', v)
 }
 
-export interface Presented {
-  record:
-    | PresentedRecord
-    | PresentedNotFound
-    | { $type: string; [k: string]: unknown }
+export interface View {
+  value?: ViewRecord | ViewNotFound | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presented'
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.record#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#view', v)
 }
 
-export interface PresentedRecord {
+export interface ViewRecord {
   uri: string
   cid: string
   author: AppBskyActorDefs.WithInfo
@@ -53,31 +48,31 @@ export interface PresentedRecord {
   [k: string]: unknown
 }
 
-export function isPresentedRecord(v: unknown): v is PresentedRecord {
+export function isViewRecord(v: unknown): v is ViewRecord {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presentedRecord'
+    v.$type === 'app.bsky.embed.record#viewRecord'
   )
 }
 
-export function validatePresentedRecord(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presentedRecord', v)
+export function validateViewRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewRecord', v)
 }
 
-export interface PresentedNotFound {
+export interface ViewNotFound {
   uri: string
   [k: string]: unknown
 }
 
-export function isPresentedNotFound(v: unknown): v is PresentedNotFound {
+export function isViewNotFound(v: unknown): v is ViewNotFound {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presentedNotFound'
+    v.$type === 'app.bsky.embed.record#viewNotFound'
   )
 }
 
-export function validatePresentedNotFound(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presentedNotFound', v)
+export function validateViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewNotFound', v)
 }

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -6,6 +6,8 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyEmbedImages from './images'
+import * as AppBskyEmbedExternal from './external'
 
 export interface Main {
   record: ComAtprotoRepoStrongRef.Main
@@ -45,6 +47,13 @@ export interface ViewRecord {
   cid: string
   author: AppBskyActorDefs.WithInfo
   record: {}
+  embeds?: (
+    | AppBskyEmbedImages.View
+    | AppBskyEmbedExternal.View
+    | View
+    | { $type: string; [k: string]: unknown }
+  )[]
+  indexedAt: string
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -15,9 +15,9 @@ export interface PostView {
   author: AppBskyActorDefs.WithInfo
   record: {}
   embed?:
-    | AppBskyEmbedImages.Presented
-    | AppBskyEmbedExternal.Presented
-    | AppBskyEmbedRecord.Presented
+    | AppBskyEmbedImages.View
+    | AppBskyEmbedExternal.View
+    | AppBskyEmbedRecord.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -3,7 +3,7 @@ import * as common from '@atproto/common'
 import Database from '../../../db'
 import { countAll, notSoftDeletedClause } from '../../../db/util'
 import { ImageUriBuilder } from '../../../image/uri'
-import { isPresented as isPresentedImage } from '../../../lexicon/types/app/bsky/embed/images'
+import { isView as isViewImage } from '../../../lexicon/types/app/bsky/embed/images'
 import { PostView } from '../../../lexicon/types/app/bsky/feed/defs'
 import { ActorViewMap, FeedEmbeds, PostInfoMap, FeedItemType } from './types'
 
@@ -223,11 +223,11 @@ export class FeedService {
     ])
     let embeds = images.reduce((acc, cur) => {
       const embed = (acc[cur.postUri] ??= {
-        $type: 'app.bsky.embed.images#presented',
-        images: [],
+        $type: 'app.bsky.embed.images#view',
+        value: [],
       })
-      if (!isPresentedImage(embed)) return acc
-      embed.images.push({
+      if (!isViewImage(embed)) return acc
+      embed.value.push({
         thumb: this.imgUriBuilder.getCommonSignedUri(
           'feed_thumbnail',
           cur.imageCid,
@@ -243,8 +243,8 @@ export class FeedService {
     embeds = externals.reduce((acc, cur) => {
       if (!acc[cur.postUri]) {
         acc[cur.postUri] = {
-          $type: 'app.bsky.embed.external#presented',
-          external: {
+          $type: 'app.bsky.embed.external#view',
+          value: {
             uri: cur.uri,
             title: cur.title,
             description: cur.description,
@@ -268,17 +268,17 @@ export class FeedService {
           {},
         )
         acc[cur.postUri] = {
-          $type: 'app.bsky.embed.record#presented',
-          record: formatted
+          $type: 'app.bsky.embed.record#view',
+          value: formatted
             ? {
-                $type: 'app.bsky.embed.record#presentedRecord',
+                $type: 'app.bsky.embed.record#viewRecord',
                 uri: formatted.uri,
                 cid: formatted.cid,
                 author: formatted.author,
                 record: formatted.record,
               }
             : {
-                $type: 'app.bsky.embed.record#presentedNotFound',
+                $type: 'app.bsky.embed.record#viewNotFound',
                 uri: cur.uri,
               },
         }

--- a/packages/pds/src/app-view/services/feed/types.ts
+++ b/packages/pds/src/app-view/services/feed/types.ts
@@ -1,9 +1,9 @@
-import { Presented as PresentedImage } from '../../../lexicon/types/app/bsky/embed/images'
-import { Presented as PresentedExternal } from '../../../lexicon/types/app/bsky/embed/external'
-import { Presented as PresentedRecord } from '../../../lexicon/types/app/bsky/embed/record'
+import { View as ViewImage } from '../../../lexicon/types/app/bsky/embed/images'
+import { View as ViewExternal } from '../../../lexicon/types/app/bsky/embed/external'
+import { View as ViewRecord } from '../../../lexicon/types/app/bsky/embed/record'
 
 export type FeedEmbeds = {
-  [uri: string]: PresentedImage | PresentedExternal | PresentedRecord
+  [uri: string]: ViewImage | ViewExternal | ViewRecord
 }
 
 export type PostInfo = {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2804,7 +2804,6 @@ export const schemaDict = {
         properties: {
           uri: {
             type: 'string',
-            format: 'at-uri',
           },
           title: {
             type: 'string',
@@ -2821,23 +2820,22 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
         required: ['external'],
         properties: {
-          external: {
+          value: {
             type: 'ref',
-            ref: 'lex:app.bsky.embed.external#presentedExternal',
+            ref: 'lex:app.bsky.embed.external#viewExternal',
           },
         },
       },
-      presentedExternal: {
+      viewExternal: {
         type: 'object',
         required: ['uri', 'title', 'description'],
         properties: {
           uri: {
             type: 'string',
-            format: 'at-uri',
           },
           title: {
             type: 'string',
@@ -2887,21 +2885,21 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
-        required: ['images'],
+        required: ['value'],
         properties: {
-          images: {
+          value: {
             type: 'array',
             items: {
               type: 'ref',
-              ref: 'lex:app.bsky.embed.images#presentedImage',
+              ref: 'lex:app.bsky.embed.images#viewImage',
             },
             maxLength: 4,
           },
         },
       },
-      presentedImage: {
+      viewImage: {
         type: 'object',
         required: ['thumb', 'fullsize', 'alt'],
         properties: {
@@ -2934,20 +2932,20 @@ export const schemaDict = {
           },
         },
       },
-      presented: {
+      view: {
         type: 'object',
         required: ['record'],
         properties: {
-          record: {
+          value: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.record#presentedRecord',
-              'lex:app.bsky.embed.record#presentedNotFound',
+              'lex:app.bsky.embed.record#viewRecord',
+              'lex:app.bsky.embed.record#viewNotFound',
             ],
           },
         },
       },
-      presentedRecord: {
+      viewRecord: {
         type: 'object',
         required: ['uri', 'cid', 'author', 'record'],
         properties: {
@@ -2968,7 +2966,7 @@ export const schemaDict = {
           },
         },
       },
-      presentedNotFound: {
+      viewNotFound: {
         type: 'object',
         required: ['uri'],
         properties: {
@@ -3004,9 +3002,9 @@ export const schemaDict = {
           embed: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.images#presented',
-              'lex:app.bsky.embed.external#presented',
-              'lex:app.bsky.embed.record#presented',
+              'lex:app.bsky.embed.images#view',
+              'lex:app.bsky.embed.external#view',
+              'lex:app.bsky.embed.record#view',
             ],
           },
           replyCount: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2947,7 +2947,7 @@ export const schemaDict = {
       },
       viewRecord: {
         type: 'object',
-        required: ['uri', 'cid', 'author', 'record'],
+        required: ['uri', 'cid', 'author', 'record', 'indexedAt'],
         properties: {
           uri: {
             type: 'string',
@@ -2963,6 +2963,21 @@ export const schemaDict = {
           },
           record: {
             type: 'unknown',
+          },
+          embeds: {
+            type: 'array',
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.embed.images#view',
+                'lex:app.bsky.embed.external#view',
+                'lex:app.bsky.embed.record#view',
+              ],
+            },
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
@@ -43,24 +43,24 @@ export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
 }
 
-export interface Presented {
-  external: PresentedExternal
+export interface View {
+  value?: ViewExternal
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.external#presented'
+    v.$type === 'app.bsky.embed.external#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.external#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#view', v)
 }
 
-export interface PresentedExternal {
+export interface ViewExternal {
   uri: string
   title: string
   description: string
@@ -68,14 +68,14 @@ export interface PresentedExternal {
   [k: string]: unknown
 }
 
-export function isPresentedExternal(v: unknown): v is PresentedExternal {
+export function isViewExternal(v: unknown): v is ViewExternal {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.external#presentedExternal'
+    v.$type === 'app.bsky.embed.external#viewExternal'
   )
 }
 
-export function validatePresentedExternal(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.external#presentedExternal', v)
+export function validateViewExternal(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#viewExternal', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/images.ts
@@ -39,38 +39,36 @@ export function validateImage(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.images#image', v)
 }
 
-export interface Presented {
-  images: PresentedImage[]
+export interface View {
+  value: ViewImage[]
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.images#presented'
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.images#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.images#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#view', v)
 }
 
-export interface PresentedImage {
+export interface ViewImage {
   thumb: string
   fullsize: string
   alt: string
   [k: string]: unknown
 }
 
-export function isPresentedImage(v: unknown): v is PresentedImage {
+export function isViewImage(v: unknown): v is ViewImage {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.images#presentedImage'
+    v.$type === 'app.bsky.embed.images#viewImage'
   )
 }
 
-export function validatePresentedImage(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.images#presentedImage', v)
+export function validateViewImage(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.images#viewImage', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
@@ -6,6 +6,8 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
 import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyEmbedImages from './images'
+import * as AppBskyEmbedExternal from './external'
 
 export interface Main {
   record: ComAtprotoRepoStrongRef.Main
@@ -45,6 +47,13 @@ export interface ViewRecord {
   cid: string
   author: AppBskyActorDefs.WithInfo
   record: {}
+  embeds?: (
+    | AppBskyEmbedImages.View
+    | AppBskyEmbedExternal.View
+    | View
+    | { $type: string; [k: string]: unknown }
+  )[]
+  indexedAt: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
@@ -25,27 +25,22 @@ export function validateMain(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.record#main', v)
 }
 
-export interface Presented {
-  record:
-    | PresentedRecord
-    | PresentedNotFound
-    | { $type: string; [k: string]: unknown }
+export interface View {
+  value?: ViewRecord | ViewNotFound | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }
 
-export function isPresented(v: unknown): v is Presented {
+export function isView(v: unknown): v is View {
   return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presented'
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.embed.record#view'
   )
 }
 
-export function validatePresented(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presented', v)
+export function validateView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#view', v)
 }
 
-export interface PresentedRecord {
+export interface ViewRecord {
   uri: string
   cid: string
   author: AppBskyActorDefs.WithInfo
@@ -53,31 +48,31 @@ export interface PresentedRecord {
   [k: string]: unknown
 }
 
-export function isPresentedRecord(v: unknown): v is PresentedRecord {
+export function isViewRecord(v: unknown): v is ViewRecord {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presentedRecord'
+    v.$type === 'app.bsky.embed.record#viewRecord'
   )
 }
 
-export function validatePresentedRecord(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presentedRecord', v)
+export function validateViewRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewRecord', v)
 }
 
-export interface PresentedNotFound {
+export interface ViewNotFound {
   uri: string
   [k: string]: unknown
 }
 
-export function isPresentedNotFound(v: unknown): v is PresentedNotFound {
+export function isViewNotFound(v: unknown): v is ViewNotFound {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.embed.record#presentedNotFound'
+    v.$type === 'app.bsky.embed.record#viewNotFound'
   )
 }
 
-export function validatePresentedNotFound(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.embed.record#presentedNotFound', v)
+export function validateViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewNotFound', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -15,9 +15,9 @@ export interface PostView {
   author: AppBskyActorDefs.WithInfo
   record: {}
   embed?:
-    | AppBskyEmbedImages.Presented
-    | AppBskyEmbedExternal.Presented
-    | AppBskyEmbedRecord.Presented
+    | AppBskyEmbedImages.View
+    | AppBskyEmbedExternal.View
+    | AppBskyEmbedRecord.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -244,8 +244,8 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -307,8 +307,8 @@ Array [
       },
       "cid": "cids(7)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -502,8 +502,8 @@ Array [
         },
         "cid": "cids(7)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -583,9 +583,9 @@ Array [
       },
       "cid": "cids(11)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(1)",
             "handle": "dan.test",

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -50,11 +50,77 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "followedBy": "record(5)",
+              "following": "record(4)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(4)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(3)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(3)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -85,7 +151,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(2)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -95,7 +161,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(3)",
+      "uri": "record(6)",
       "viewer": Object {},
     },
   },
@@ -110,11 +176,77 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "followedBy": "record(5)",
+              "following": "record(4)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(4)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(3)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(3)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -159,7 +291,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(3)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -179,7 +311,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(6)",
+      "uri": "record(7)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -242,7 +374,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(4)",
+      "cid": "cids(2)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -269,14 +401,14 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(5)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
               "image": Object {
-                "cid": "cids(6)",
+                "cid": "cids(4)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -286,7 +418,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(7)",
+      "uri": "record(3)",
       "viewer": Object {
         "like": "record(8)",
       },
@@ -327,7 +459,7 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(5)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -522,7 +654,7 @@ Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
                 "image": Object {
-                  "cid": "cids(5)",
+                  "cid": "cids(3)",
                   "mimeType": "image/jpeg",
                 },
               },
@@ -595,9 +727,61 @@ Array [
             },
           },
           "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(2)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "followedBy": "record(5)",
+                    "following": "record(4)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(4)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(3)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(3)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {

--- a/packages/pds/tests/seeds/basic.ts
+++ b/packages/pds/tests/seeds/basic.ts
@@ -32,15 +32,21 @@ export default async (sc: SeedClient, mq?: MessageQueue) => {
   )
   await sc.post(carol, posts.carol[0], undefined, [img1, img2])
   await sc.post(dan, posts.dan[0])
-  await sc.post(dan, posts.dan[1], [
-    {
-      index: { start: 0, end: 18 },
-      value: {
-        $type: `${ids.AppBskyRichtextFacet}#mention`,
-        did: alice,
+  await sc.post(
+    dan,
+    posts.dan[1],
+    [
+      {
+        index: { start: 0, end: 18 },
+        value: {
+          $type: `${ids.AppBskyRichtextFacet}#mention`,
+          did: alice,
+        },
       },
-    },
-  ])
+    ],
+    undefined,
+    sc.posts[carol][0].ref, // This post contains an images embed
+  )
   await sc.post(alice, posts.alice[1])
   await sc.post(bob, posts.bob[1])
   await sc.post(
@@ -48,7 +54,7 @@ export default async (sc: SeedClient, mq?: MessageQueue) => {
     posts.alice[2],
     undefined,
     undefined,
-    sc.posts[dan][1].ref,
+    sc.posts[dan][1].ref, // This post contains a record embed which contains an images embed
   )
   await sc.like(bob, sc.posts[alice][1].ref)
   await sc.like(bob, sc.posts[alice][2].ref)

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -51,8 +51,8 @@ Array [
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -132,9 +132,9 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(2)",
             "handle": "dan.test",
@@ -252,8 +252,8 @@ Array [
       },
       "cid": "cids(0)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -555,8 +555,8 @@ Array [
       },
       "cid": "cids(3)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -824,8 +824,8 @@ Array [
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -911,9 +911,9 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(2)",
             "handle": "dan.test",

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -144,9 +144,61 @@ Array [
             },
           },
           "cid": "cids(5)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(3)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "followedBy": "record(10)",
+                    "following": "record(9)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(6)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(7)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(8)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(6)",
+                "uri": "record(8)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -220,7 +272,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -230,7 +282,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(8)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
   },
@@ -417,11 +469,75 @@ Array [
         },
       },
       "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(2)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(1)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(1)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -440,7 +556,7 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {
-        "repost": "record(1)",
+        "repost": "record(2)",
       },
     },
     "reason": Object {
@@ -464,7 +580,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(1)",
+      "cid": "cids(4)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -472,19 +588,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(2)",
-            "uri": "record(3)",
+            "cid": "cids(5)",
+            "uri": "record(4)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(3)",
+            "cid": "cids(5)",
+            "uri": "record(4)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(2)",
+      "uri": "record(3)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -495,12 +611,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -510,9 +626,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(3)",
+        "uri": "record(4)",
         "viewer": Object {
-          "like": "record(6)",
+          "like": "record(7)",
         },
       },
       "root": Object {
@@ -522,12 +638,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -537,9 +653,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(3)",
+        "uri": "record(4)",
         "viewer": Object {
-          "like": "record(6)",
+          "like": "record(7)",
         },
       },
     },
@@ -553,7 +669,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(3)",
+      "cid": "cids(1)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -580,14 +696,14 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(2)",
                 "mimeType": "image/jpeg",
               },
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
               "image": Object {
-                "cid": "cids(5)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -597,7 +713,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(7)",
+      "uri": "record(1)",
       "viewer": Object {},
     },
   },
@@ -656,11 +772,75 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(4)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(5)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(5)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -690,7 +870,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(2)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -700,7 +880,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(5)",
+      "uri": "record(6)",
       "viewer": Object {},
     },
   },
@@ -720,11 +900,76 @@ Array [
         },
       },
       "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "following": "record(3)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(2)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(2)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(2)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -755,7 +1000,7 @@ Array [
           "muted": true,
         },
       },
-      "cid": "cids(1)",
+      "cid": "cids(4)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -765,7 +1010,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(2)",
+      "uri": "record(4)",
       "viewer": Object {},
     },
   },
@@ -922,9 +1167,59 @@ Array [
             },
           },
           "cid": "cids(5)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(3)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(6)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(7)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(9)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(6)",
+                "uri": "record(9)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -960,7 +1255,7 @@ Array [
       "repostCount": 0,
       "uri": "record(7)",
       "viewer": Object {
-        "like": "record(9)",
+        "like": "record(10)",
       },
     },
   },
@@ -1006,7 +1301,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1016,7 +1311,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
   },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -806,6 +806,13 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
+      "embed": Object {
+        "$type": "app.bsky.embed.record",
+        "record": Object {
+          "cid": "cids(14)",
+          "uri": "record(18)",
+        },
+      },
       "facets": Array [
         Object {
           "index": Object {
@@ -834,7 +841,7 @@ Array [
         "muted": false,
       },
     },
-    "cid": "cids(14)",
+    "cid": "cids(15)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "isRead": true,
     "reason": "follow",
@@ -855,7 +862,7 @@ Array [
         "muted": false,
       },
     },
-    "cid": "cids(15)",
+    "cid": "cids(16)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "isRead": true,
     "reason": "follow",
@@ -1149,6 +1156,13 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
+      "embed": Object {
+        "$type": "app.bsky.embed.record",
+        "record": Object {
+          "cid": "cids(14)",
+          "uri": "record(18)",
+        },
+      },
       "facets": Array [
         Object {
           "index": Object {
@@ -1177,7 +1191,7 @@ Array [
         "muted": false,
       },
     },
-    "cid": "cids(14)",
+    "cid": "cids(15)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "isRead": false,
     "reason": "follow",
@@ -1198,7 +1212,7 @@ Array [
         "muted": false,
       },
     },
-    "cid": "cids(15)",
+    "cid": "cids(16)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "isRead": false,
     "reason": "follow",

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -143,8 +143,8 @@ Object {
         },
         "cid": "cids(1)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -279,8 +279,8 @@ Object {
         },
         "cid": "cids(1)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -376,8 +376,8 @@ Object {
       },
       "cid": "cids(2)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -543,8 +543,8 @@ Object {
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -714,8 +714,8 @@ Object {
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -1032,8 +1032,8 @@ Object {
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -711,11 +711,77 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "followedBy": "record(5)",
+              "following": "record(4)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(4)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(3)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(3)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -741,8 +807,8 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
@@ -760,7 +826,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(2)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -768,8 +834,8 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(3)",
-            "uri": "record(6)",
+            "cid": "cids(6)",
+            "uri": "record(7)",
           },
           "root": Object {
             "cid": "cids(0)",
@@ -780,7 +846,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(5)",
+      "uri": "record(6)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -791,12 +857,12 @@ Array [
           "displayName": "bobby",
           "handle": "bob.test",
           "viewer": Object {
-            "followedBy": "record(8)",
-            "following": "record(7)",
+            "followedBy": "record(9)",
+            "following": "record(8)",
             "muted": false,
           },
         },
-        "cid": "cids(3)",
+        "cid": "cids(6)",
         "embed": Object {
           "$type": "app.bsky.embed.images#view",
           "value": Array [
@@ -818,7 +884,7 @@ Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
                 "image": Object {
-                  "cid": "cids(4)",
+                  "cid": "cids(3)",
                   "mimeType": "image/jpeg",
                 },
               },
@@ -838,7 +904,7 @@ Array [
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {},
       },
       "root": Object {
@@ -872,12 +938,12 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(7)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -897,7 +963,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -957,12 +1023,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(8)",
-          "following": "record(7)",
+          "followedBy": "record(9)",
+          "following": "record(8)",
           "muted": false,
         },
       },
-      "cid": "cids(3)",
+      "cid": "cids(6)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -984,7 +1050,7 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -1004,7 +1070,7 @@ Array [
       },
       "replyCount": 1,
       "repostCount": 0,
-      "uri": "record(6)",
+      "uri": "record(7)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1067,7 +1133,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -1081,9 +1147,61 @@ Array [
             },
           },
           "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(2)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "followedBy": "record(5)",
+                    "following": "record(4)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(4)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(3)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(3)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -1117,7 +1235,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
   },
@@ -1129,12 +1247,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(8)",
-          "following": "record(7)",
+          "followedBy": "record(9)",
+          "following": "record(8)",
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1144,7 +1262,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },
@@ -1184,11 +1302,77 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "followedBy": "record(5)",
+              "following": "record(4)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(4)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(3)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(3)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -1219,7 +1403,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(10)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1229,7 +1413,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(13)",
       "viewer": Object {},
     },
   },
@@ -1239,12 +1423,12 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(2)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -1271,14 +1455,14 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
               "image": Object {
-                "cid": "cids(10)",
+                "cid": "cids(4)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -1288,7 +1472,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(13)",
+      "uri": "record(3)",
       "viewer": Object {
         "like": "record(14)",
       },
@@ -1302,8 +1486,8 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(8)",
-          "following": "record(7)",
+          "followedBy": "record(9)",
+          "following": "record(8)",
           "muted": false,
         },
       },
@@ -1362,11 +1546,76 @@ Array [
         },
       },
       "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "following": "record(3)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(2)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(2)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(2)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -1392,7 +1641,7 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "following": "record(2)",
+          "following": "record(3)",
           "muted": false,
         },
       },
@@ -1407,12 +1656,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(6)",
+          "following": "record(5)",
           "muted": false,
         },
       },
-      "cid": "cids(1)",
+      "cid": "cids(4)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1420,19 +1669,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(3)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(6)",
+            "cid": "cids(5)",
+            "uri": "record(7)",
           },
         },
         "text": "thanks bob",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(3)",
+      "uri": "record(4)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1446,7 +1695,7 @@ Array [
             "muted": false,
           },
         },
-        "cid": "cids(3)",
+        "cid": "cids(6)",
         "embed": Object {
           "$type": "app.bsky.embed.images#view",
           "value": Array [
@@ -1468,7 +1717,7 @@ Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
                 "image": Object {
-                  "cid": "cids(4)",
+                  "cid": "cids(2)",
                   "mimeType": "image/jpeg",
                 },
               },
@@ -1476,19 +1725,19 @@ Array [
           },
           "reply": Object {
             "parent": Object {
-              "cid": "cids(2)",
-              "uri": "record(6)",
+              "cid": "cids(5)",
+              "uri": "record(7)",
             },
             "root": Object {
-              "cid": "cids(2)",
-              "uri": "record(6)",
+              "cid": "cids(5)",
+              "uri": "record(7)",
             },
           },
           "text": "hear that",
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {},
       },
       "root": Object {
@@ -1498,12 +1747,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1513,9 +1762,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(9)",
         },
       },
     },
@@ -1526,11 +1775,11 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "following": "record(2)",
+          "following": "record(3)",
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(7)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1538,19 +1787,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(2)",
-            "uri": "record(6)",
+            "cid": "cids(5)",
+            "uri": "record(7)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(6)",
+            "cid": "cids(5)",
+            "uri": "record(7)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1561,12 +1810,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1576,9 +1825,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(9)",
         },
       },
       "root": Object {
@@ -1588,12 +1837,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1603,9 +1852,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(9)",
         },
       },
     },
@@ -1621,7 +1870,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(3)",
+      "cid": "cids(6)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -1643,7 +1892,7 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(2)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -1651,19 +1900,19 @@ Array [
         },
         "reply": Object {
           "parent": Object {
-            "cid": "cids(2)",
-            "uri": "record(6)",
+            "cid": "cids(5)",
+            "uri": "record(7)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(6)",
+            "cid": "cids(5)",
+            "uri": "record(7)",
           },
         },
         "text": "hear that",
       },
       "replyCount": 1,
       "repostCount": 0,
-      "uri": "record(7)",
+      "uri": "record(8)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1674,12 +1923,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1689,9 +1938,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(9)",
         },
       },
       "root": Object {
@@ -1701,12 +1950,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(6)",
+            "following": "record(5)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1716,9 +1965,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(9)",
         },
       },
     },
@@ -1731,12 +1980,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(6)",
+          "following": "record(5)",
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -1750,9 +1999,60 @@ Array [
             },
           },
           "cid": "cids(0)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(2)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "following": "record(3)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(1)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(2)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(2)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(1)",
+                "uri": "record(2)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -1786,9 +2086,9 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {
-        "like": "record(11)",
+        "like": "record(12)",
       },
     },
   },
@@ -1803,7 +2103,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1813,7 +2113,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(13)",
       "viewer": Object {},
     },
   },
@@ -1825,12 +2125,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(6)",
+          "following": "record(5)",
           "muted": false,
         },
       },
-      "cid": "cids(2)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 3,
       "record": Object {
@@ -1840,9 +2140,9 @@ Array [
       },
       "replyCount": 2,
       "repostCount": 1,
-      "uri": "record(6)",
+      "uri": "record(7)",
       "viewer": Object {
-        "like": "record(8)",
+        "like": "record(9)",
       },
     },
   },
@@ -1852,11 +2152,11 @@ Array [
         "did": "user(2)",
         "handle": "carol.test",
         "viewer": Object {
-          "following": "record(2)",
+          "following": "record(3)",
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(1)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -1883,14 +2183,14 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(2)",
                 "mimeType": "image/jpeg",
               },
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
               "image": Object {
-                "cid": "cids(9)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -1900,7 +2200,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(13)",
+      "uri": "record(2)",
       "viewer": Object {
         "like": "record(14)",
       },
@@ -1939,8 +2239,8 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(6)",
+          "following": "record(5)",
           "muted": false,
         },
       },
@@ -1973,11 +2273,75 @@ Array [
         },
       },
       "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(2)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(2)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(1)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(1)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -1996,7 +2360,7 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {
-        "repost": "record(1)",
+        "repost": "record(2)",
       },
     },
     "reason": Object {
@@ -2019,12 +2383,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
-      "cid": "cids(1)",
+      "cid": "cids(4)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2032,19 +2396,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(3)",
-            "uri": "record(6)",
+            "cid": "cids(6)",
+            "uri": "record(7)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(5)",
+            "cid": "cids(5)",
+            "uri": "record(6)",
           },
         },
         "text": "thanks bob",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(2)",
+      "uri": "record(3)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -2055,11 +2419,11 @@ Array [
           "displayName": "bobby",
           "handle": "bob.test",
           "viewer": Object {
-            "followedBy": "record(8)",
+            "followedBy": "record(9)",
             "muted": false,
           },
         },
-        "cid": "cids(3)",
+        "cid": "cids(6)",
         "embed": Object {
           "$type": "app.bsky.embed.images#view",
           "value": Array [
@@ -2081,7 +2445,7 @@ Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
                 "image": Object {
-                  "cid": "cids(4)",
+                  "cid": "cids(2)",
                   "mimeType": "image/jpeg",
                 },
               },
@@ -2089,19 +2453,19 @@ Array [
           },
           "reply": Object {
             "parent": Object {
-              "cid": "cids(2)",
-              "uri": "record(5)",
+              "cid": "cids(5)",
+              "uri": "record(6)",
             },
             "root": Object {
-              "cid": "cids(2)",
-              "uri": "record(5)",
+              "cid": "cids(5)",
+              "uri": "record(6)",
             },
           },
           "text": "hear that",
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(6)",
+        "uri": "record(7)",
         "viewer": Object {},
       },
       "root": Object {
@@ -2111,12 +2475,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(4)",
-            "following": "record(3)",
+            "followedBy": "record(5)",
+            "following": "record(4)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2126,9 +2490,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(5)",
+        "uri": "record(6)",
         "viewer": Object {
-          "like": "record(7)",
+          "like": "record(8)",
         },
       },
     },
@@ -2142,7 +2506,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(7)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2150,19 +2514,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(2)",
-            "uri": "record(5)",
+            "cid": "cids(5)",
+            "uri": "record(6)",
           },
           "root": Object {
-            "cid": "cids(2)",
-            "uri": "record(5)",
+            "cid": "cids(5)",
+            "uri": "record(6)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -2173,12 +2537,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(4)",
-            "following": "record(3)",
+            "followedBy": "record(5)",
+            "following": "record(4)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2188,9 +2552,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(5)",
+        "uri": "record(6)",
         "viewer": Object {
-          "like": "record(7)",
+          "like": "record(8)",
         },
       },
       "root": Object {
@@ -2200,12 +2564,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(4)",
-            "following": "record(3)",
+            "followedBy": "record(5)",
+            "following": "record(4)",
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(5)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2215,9 +2579,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(5)",
+        "uri": "record(6)",
         "viewer": Object {
-          "like": "record(7)",
+          "like": "record(8)",
         },
       },
     },
@@ -2230,12 +2594,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -2248,9 +2612,59 @@ Array [
             },
           },
           "cid": "cids(0)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(2)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(1)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(2)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(1)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(1)",
+                "uri": "record(1)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -2284,9 +2698,9 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {
-        "like": "record(11)",
+        "like": "record(12)",
       },
     },
   },
@@ -2298,12 +2712,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
-      "cid": "cids(2)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 3,
       "record": Object {
@@ -2313,9 +2727,9 @@ Array [
       },
       "replyCount": 2,
       "repostCount": 1,
-      "uri": "record(5)",
+      "uri": "record(6)",
       "viewer": Object {
-        "like": "record(7)",
+        "like": "record(8)",
       },
     },
   },
@@ -2328,7 +2742,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(1)",
       "embed": Object {
         "$type": "app.bsky.embed.images#view",
         "value": Array [
@@ -2355,14 +2769,14 @@ Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "image": Object {
-                "cid": "cids(4)",
+                "cid": "cids(2)",
                 "mimeType": "image/jpeg",
               },
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
               "image": Object {
-                "cid": "cids(8)",
+                "cid": "cids(3)",
                 "mimeType": "image/jpeg",
               },
             },
@@ -2372,7 +2786,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(1)",
       "viewer": Object {},
     },
   },
@@ -2384,8 +2798,8 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(4)",
-          "following": "record(3)",
+          "followedBy": "record(5)",
+          "following": "record(4)",
           "muted": false,
         },
       },
@@ -2598,11 +3012,75 @@ Array [
         },
       },
       "cid": "cids(4)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(3)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "muted": false,
+            },
+          },
+          "cid": "cids(5)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(2)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(6)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(8)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(5)",
+            "uri": "record(8)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -2632,7 +3110,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(7)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2642,7 +3120,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(8)",
+      "uri": "record(9)",
       "viewer": Object {},
     },
   },
@@ -2658,7 +3136,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2668,7 +3146,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
   },
@@ -2856,9 +3334,61 @@ Array [
             },
           },
           "cid": "cids(5)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "did": "user(3)",
+                  "handle": "carol.test",
+                  "viewer": Object {
+                    "followedBy": "record(10)",
+                    "following": "record(9)",
+                    "muted": true,
+                  },
+                },
+                "cid": "cids(6)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "embed": Object {
+                    "$type": "app.bsky.embed.images",
+                    "images": Array [
+                      Object {
+                        "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                        "image": Object {
+                          "cid": "cids(3)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                      Object {
+                        "alt": "tests/image/fixtures/key-alt.jpg",
+                        "image": Object {
+                          "cid": "cids(7)",
+                          "mimeType": "image/jpeg",
+                        },
+                      },
+                    ],
+                  },
+                  "text": "hi im carol",
+                },
+                "uri": "record(8)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(6)",
+                "uri": "record(8)",
+              },
+            },
             "facets": Array [
               Object {
                 "index": Object {
@@ -2932,11 +3462,77 @@ Array [
         },
       },
       "cid": "cids(5)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(3)",
+            "handle": "carol.test",
+            "viewer": Object {
+              "followedBy": "record(10)",
+              "following": "record(9)",
+              "muted": true,
+            },
+          },
+          "cid": "cids(6)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.images#view",
+              "value": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                  "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                  "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                },
+              ],
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "cid": "cids(3)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "cid": "cids(7)",
+                    "mimeType": "image/jpeg",
+                  },
+                },
+              ],
+            },
+            "text": "hi im carol",
+          },
+          "uri": "record(8)",
+        },
+      },
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(6)",
+            "uri": "record(8)",
+          },
+        },
         "facets": Array [
           Object {
             "index": Object {
@@ -2967,7 +3563,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2977,7 +3573,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(8)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
   },
@@ -2992,7 +3588,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -3002,7 +3598,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -133,9 +133,9 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedNotFound",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewNotFound",
           "uri": "record(7)",
         },
       },
@@ -197,8 +197,8 @@ Array [
       },
       "cid": "cids(6)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -443,9 +443,9 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedNotFound",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewNotFound",
           "uri": "record(8)",
         },
       },
@@ -558,8 +558,8 @@ Array [
       },
       "cid": "cids(8)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -798,8 +798,8 @@ Array [
         },
         "cid": "cids(3)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -964,8 +964,8 @@ Array [
       },
       "cid": "cids(3)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -1069,9 +1069,9 @@ Array [
       },
       "cid": "cids(6)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(1)",
             "handle": "dan.test",
@@ -1246,8 +1246,8 @@ Array [
       },
       "cid": "cids(9)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -1448,8 +1448,8 @@ Array [
         },
         "cid": "cids(3)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -1623,8 +1623,8 @@ Array [
       },
       "cid": "cids(3)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -1738,9 +1738,9 @@ Array [
       },
       "cid": "cids(6)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(0)",
             "handle": "dan.test",
@@ -1858,8 +1858,8 @@ Array [
       },
       "cid": "cids(8)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -2061,8 +2061,8 @@ Array [
         },
         "cid": "cids(3)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -2237,9 +2237,9 @@ Array [
       },
       "cid": "cids(6)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(0)",
             "handle": "dan.test",
@@ -2330,8 +2330,8 @@ Array [
       },
       "cid": "cids(7)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -2462,8 +2462,8 @@ Array [
       },
       "cid": "cids(1)",
       "embed": Object {
-        "$type": "app.bsky.embed.images#presented",
-        "images": Array [
+        "$type": "app.bsky.embed.images#view",
+        "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
             "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -2763,8 +2763,8 @@ Array [
         },
         "cid": "cids(2)",
         "embed": Object {
-          "$type": "app.bsky.embed.images#presented",
-          "images": Array [
+          "$type": "app.bsky.embed.images#view",
+          "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
               "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
@@ -2844,9 +2844,9 @@ Array [
       },
       "cid": "cids(4)",
       "embed": Object {
-        "$type": "app.bsky.embed.record#presented",
-        "record": Object {
-          "$type": "app.bsky.embed.record#presentedRecord",
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
             "did": "user(1)",
             "handle": "dan.test",


### PR DESCRIPTION
A few changes to record embeds in here:
 - Embed view lexicons are named as `#view` rather than `#presented`, for consistency.
 - Embed views now have a standard wrapper shape `{ $type, value }`, whereas before we had different keys `{ $type, record }`, `{ $type, external }`, etc.  That wasn't necessary since `$type` acts as a discriminator for the wrapped value.  One small upside there is that the record under a record embed is now `(embed.value).record` rather than `(embed.record).record`, which feels a little nicer to write.
 - Record embed views now contain `embeds` which can include one or more views of embeds found within the record.  If there are multiple, it would be up to the consumer to distinguish them by inspecting `embed.value.record`.  Embeds are only hydrated one level deep.
 - Fixes to external embeds: the `uri` field was marked as an at-uri, whereas it's actually not limited to `at://` (most likely will be a web uri `https://`).

Resolves #619 