### PR TITLE
Lexicon: notify users when they are quoted

### DIFF
--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -35,8 +35,8 @@
         "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
         "reason": {
           "type": "string",
-          "description": "Expected values are 'like', 'repost', 'follow', 'mention' and 'reply'.",
-          "knownValues": ["like", "repost", "follow", "mention", "reply"]
+          "description": "Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'.",
+          "knownValues": ["like", "repost", "follow", "mention", "reply", "quote"]
         },
         "reasonSubject": {"type": "string", "format": "at-uri"},
         "record": {"type": "unknown"},

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3886,8 +3886,15 @@ export const schemaDict = {
           reason: {
             type: 'string',
             description:
-              "Expected values are 'like', 'repost', 'follow', 'mention' and 'reply'.",
-            knownValues: ['like', 'repost', 'follow', 'mention', 'reply'],
+              "Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'.",
+            knownValues: [
+              'like',
+              'repost',
+              'follow',
+              'mention',
+              'reply',
+              'quote',
+            ],
           },
           reasonSubject: {
             type: 'string',

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -40,8 +40,15 @@ export interface Notification {
   uri: string
   cid: string
   author: AppBskyActorDefs.WithInfo
-  /** Expected values are 'like', 'repost', 'follow', 'mention' and 'reply'. */
-  reason: 'like' | 'repost' | 'follow' | 'mention' | 'reply' | (string & {})
+  /** Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'. */
+  reason:
+    | 'like'
+    | 'repost'
+    | 'follow'
+    | 'mention'
+    | 'reply'
+    | 'quote'
+    | (string & {})
   reasonSubject?: string
   record: {}
   isRead: boolean

--- a/packages/pds/src/event-stream/messages.ts
+++ b/packages/pds/src/event-stream/messages.ts
@@ -71,6 +71,7 @@ export type NotificationReason =
   | 'follow'
   | 'mention'
   | 'reply'
+  | 'quote'
 
 export type DeleteNotifications = {
   type: 'delete_notifications'

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3886,8 +3886,15 @@ export const schemaDict = {
           reason: {
             type: 'string',
             description:
-              "Expected values are 'like', 'repost', 'follow', 'mention' and 'reply'.",
-            knownValues: ['like', 'repost', 'follow', 'mention', 'reply'],
+              "Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'.",
+            knownValues: [
+              'like',
+              'repost',
+              'follow',
+              'mention',
+              'reply',
+              'quote',
+            ],
           },
           reasonSubject: {
             type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -46,8 +46,15 @@ export interface Notification {
   uri: string
   cid: string
   author: AppBskyActorDefs.WithInfo
-  /** Expected values are 'like', 'repost', 'follow', 'mention' and 'reply'. */
-  reason: 'like' | 'repost' | 'follow' | 'mention' | 'reply' | (string & {})
+  /** Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'. */
+  reason:
+    | 'like'
+    | 'repost'
+    | 'follow'
+    | 'mention'
+    | 'reply'
+    | 'quote'
+    | (string & {})
   reasonSubject?: string
   record: {}
   isRead: boolean

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -1225,3 +1225,86 @@ Array [
   },
 ]
 `;
+
+exports[`pds notification views generates notifications for quotes 1`] = `
+Object {
+  "cursor": "0000000000000::bafycid",
+  "notifications": Array [
+    Object {
+      "author": Object {
+        "did": "user(0)",
+        "handle": "carol.test",
+        "viewer": Object {
+          "muted": false,
+        },
+      },
+      "cid": "cids(0)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "isRead": false,
+      "reason": "repost",
+      "reasonSubject": "record(1)",
+      "record": Object {
+        "$type": "app.bsky.feed.repost",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "subject": Object {
+          "cid": "cids(1)",
+          "uri": "record(1)",
+        },
+      },
+      "uri": "record(0)",
+    },
+    Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "viewer": Object {
+          "followedBy": "record(3)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(2)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "isRead": false,
+      "reason": "quote",
+      "reasonSubject": "record(1)",
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(1)",
+          },
+        },
+        "text": "yoohoo",
+      },
+      "uri": "record(2)",
+    },
+    Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "viewer": Object {
+          "followedBy": "record(3)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(3)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "isRead": false,
+      "reason": "follow",
+      "record": Object {
+        "$type": "app.bsky.graph.follow",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "subject": "user(2)",
+      },
+      "uri": "record(3)",
+    },
+  ],
+}
+`;

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -92,6 +92,15 @@ describe('pds notification views', () => {
     expect(notifCountBob.data.count).toBe(4)
   })
 
+  it('generates notifications for quotes', async () => {
+    // Dan was quoted by alice
+    const notifsDan = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.dan) },
+    )
+    expect(forSnapshot(notifsDan.data)).toMatchSnapshot()
+  })
+
   it('fetches notifications without a last-seen', async () => {
     const notifRes = await agent.api.app.bsky.notification.listNotifications(
       {},


### PR DESCRIPTION
When users are quoted via a record embed they receive a `quote` notification.

Resolves #619 in concert w/ #691 