### PR TITLE
docs: fixed outdated usage

### DIFF
--- a/packages/identifier/README.md
+++ b/packages/identifier/README.md
@@ -7,11 +7,14 @@ Validation logic for AT identifiers - DIDs & Handles
 ```typescript
 import * as identifier from '@atproto/identifier'
 
-isValid('alice.test', ['.test']) // returns true
-ensureValid('alice.test', ['.test']) // returns void
+isValidHandle('alice.test') // returns true
+ensureValidHandle('alice.test') // returns void
 
-isValid('al!ce.test', ['.test']) // returns false
-ensureValid('al!ce.test', ['.test']) // throws
+isValidHandle('al!ce.test') // returns false
+ensureValidHandle('al!ce.test') // throws
+
+ensureValidDid('did:method:val') // returns void
+ensureValidDid(':did:method:val') // throws
 ```
 
 ## License


### PR DESCRIPTION
Hi amazing developers,

I found a commit that was recently merged into main that has not had the README fixed.

In `identifier`, `isValid` and `ensureValid` are no longer used, so I replaced them with the handle and did functions instead.