### PR TITLE
Speed up CI tests

### DIFF
--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -12,6 +12,9 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
   test:
+    strategy: 
+      matrix:
+        shard: [1/3, 2/3, 3/3]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,8 +22,12 @@ jobs:
         with:
           node-version: 18
           cache: "yarn"
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/jest_rt
+          key: ${{ hashFiles(**/yarn.lock) }}-${{ matrix.shard }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test
+      - run: yarn test:ci --maxWorkers=2 --shard=${{ matrix.shard }}
   verify:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "verify": "lerna run verify --stream",
     "prettier": "lerna run prettier",
     "build": "lerna run build",
-    "test": "NODE_ENV=development lerna run test --stream"
+    "test": "NODE_ENV=development lerna run test --stream",
+    "test:ci": "NODE_ENV=development lerna run test --stream --"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",


### PR DESCRIPTION
A few changes to our CI inspired by [this article](https://javascript.plainenglish.io/optimizing-jest-for-faster-ci-performance-with-github-actions-f4d7100c86c5)

- allow jest to cache things in between runs (this is a reported 50% speed up)
- set `maxWorkers` to `2`. GitHub Action VMs have 2 cores and jest by default only uses 1 of them
- shard jest across 3 different VMs to further parallelize