### PR TITLE
Lexicon: support separate images embed

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -10,12 +10,16 @@
         "cid": {"type": "string", "format": "cid"},
         "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
         "record": {"type": "unknown"},
+        "images": {
+          "type": "ref",
+          "ref": "app.bsky.embed.images#view"
+        },
         "embed": {
           "type": "union",
           "refs": [
-            "app.bsky.embed.images#view",
             "app.bsky.embed.external#view",
-            "app.bsky.embed.record#view"
+            "app.bsky.embed.record#view",
+            "app.bsky.embed.images#view"
           ]
         },
         "replyCount": {"type": "integer"},

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -18,8 +18,7 @@
           "type": "union",
           "refs": [
             "app.bsky.embed.external#view",
-            "app.bsky.embed.record#view",
-            "app.bsky.embed.images#view"
+            "app.bsky.embed.record#view"
           ]
         },
         "replyCount": {"type": "integer"},

--- a/lexicons/app/bsky/feed/post.json
+++ b/lexicons/app/bsky/feed/post.json
@@ -20,12 +20,16 @@
             "items": {"type": "ref", "ref": "app.bsky.richtext.facet"}
           },
           "reply": {"type": "ref", "ref": "#replyRef"},
+          "images": {
+            "type": "ref",
+            "ref": "app.bsky.embed.images"
+          },
           "embed": {
             "type": "union",
             "refs": [
-              "app.bsky.embed.images",
               "app.bsky.embed.external",
-              "app.bsky.embed.record"
+              "app.bsky.embed.record",
+              "app.bsky.embed.images"
             ]
           },
           "createdAt": {"type": "string", "format": "datetime"}

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3098,7 +3098,6 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.embed.external#view',
               'lex:app.bsky.embed.record#view',
-              'lex:app.bsky.embed.images#view',
             ],
           },
           replyCount: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3089,12 +3089,16 @@ export const schemaDict = {
           record: {
             type: 'unknown',
           },
+          images: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.images#view',
+          },
           embed: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.images#view',
               'lex:app.bsky.embed.external#view',
               'lex:app.bsky.embed.record#view',
+              'lex:app.bsky.embed.images#view',
             ],
           },
           replyCount: {
@@ -3550,12 +3554,16 @@ export const schemaDict = {
               type: 'ref',
               ref: 'lex:app.bsky.feed.post#replyRef',
             },
+            images: {
+              type: 'ref',
+              ref: 'lex:app.bsky.embed.images',
+            },
             embed: {
               type: 'union',
               refs: [
-                'lex:app.bsky.embed.images',
                 'lex:app.bsky.embed.external',
                 'lex:app.bsky.embed.record',
+                'lex:app.bsky.embed.images',
               ],
             },
             createdAt: {

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -15,10 +15,11 @@ export interface PostView {
   cid: string
   author: AppBskyActorDefs.WithInfo
   record: {}
+  images?: AppBskyEmbedImages.View
   embed?:
-    | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View
     | AppBskyEmbedRecord.View
+    | AppBskyEmbedImages.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -19,7 +19,6 @@ export interface PostView {
   embed?:
     | AppBskyEmbedExternal.View
     | AppBskyEmbedRecord.View
-    | AppBskyEmbedImages.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/api/src/client/types/app/bsky/feed/post.ts
+++ b/packages/api/src/client/types/app/bsky/feed/post.ts
@@ -17,10 +17,11 @@ export interface Record {
   entities?: Entity[]
   facets?: AppBskyRichtextFacet.Main[]
   reply?: ReplyRef
+  images?: AppBskyEmbedImages.Main
   embed?:
-    | AppBskyEmbedImages.Main
     | AppBskyEmbedExternal.Main
     | AppBskyEmbedRecord.Main
+    | AppBskyEmbedImages.Main
     | { $type: string; [k: string]: unknown }
   createdAt: string
   [k: string]: unknown

--- a/packages/pds/src/app-view/services/feed/types.ts
+++ b/packages/pds/src/app-view/services/feed/types.ts
@@ -1,9 +1,9 @@
-import { View as ViewImage } from '../../../lexicon/types/app/bsky/embed/images'
+import { View as ViewImages } from '../../../lexicon/types/app/bsky/embed/images'
 import { View as ViewExternal } from '../../../lexicon/types/app/bsky/embed/external'
 import { View as ViewRecord } from '../../../lexicon/types/app/bsky/embed/record'
 
 export type FeedEmbeds = {
-  [uri: string]: ViewImage | ViewExternal | ViewRecord
+  [uri: string]: { images?: ViewImages; other?: ViewExternal | ViewRecord }
 }
 
 export type PostInfo = {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3098,7 +3098,6 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.embed.external#view',
               'lex:app.bsky.embed.record#view',
-              'lex:app.bsky.embed.images#view',
             ],
           },
           replyCount: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3089,12 +3089,16 @@ export const schemaDict = {
           record: {
             type: 'unknown',
           },
+          images: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.images#view',
+          },
           embed: {
             type: 'union',
             refs: [
-              'lex:app.bsky.embed.images#view',
               'lex:app.bsky.embed.external#view',
               'lex:app.bsky.embed.record#view',
+              'lex:app.bsky.embed.images#view',
             ],
           },
           replyCount: {
@@ -3550,12 +3554,16 @@ export const schemaDict = {
               type: 'ref',
               ref: 'lex:app.bsky.feed.post#replyRef',
             },
+            images: {
+              type: 'ref',
+              ref: 'lex:app.bsky.embed.images',
+            },
             embed: {
               type: 'union',
               refs: [
-                'lex:app.bsky.embed.images',
                 'lex:app.bsky.embed.external',
                 'lex:app.bsky.embed.record',
+                'lex:app.bsky.embed.images',
               ],
             },
             createdAt: {

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -15,10 +15,11 @@ export interface PostView {
   cid: string
   author: AppBskyActorDefs.WithInfo
   record: {}
+  images?: AppBskyEmbedImages.View
   embed?:
-    | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View
     | AppBskyEmbedRecord.View
+    | AppBskyEmbedImages.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -19,7 +19,6 @@ export interface PostView {
   embed?:
     | AppBskyEmbedExternal.View
     | AppBskyEmbedRecord.View
-    | AppBskyEmbedImages.View
     | { $type: string; [k: string]: unknown }
   replyCount?: number
   repostCount?: number

--- a/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
@@ -17,10 +17,11 @@ export interface Record {
   entities?: Entity[]
   facets?: AppBskyRichtextFacet.Main[]
   reply?: ReplyRef
+  images?: AppBskyEmbedImages.Main
   embed?:
-    | AppBskyEmbedImages.Main
     | AppBskyEmbedExternal.Main
     | AppBskyEmbedRecord.Main
+    | AppBskyEmbedImages.Main
     | { $type: string; [k: string]: unknown }
   createdAt: string
   [k: string]: unknown

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -47,6 +47,7 @@ export const blobsForWrite = (record: any): PreparedBlobRef[] => {
   } else if (record.$type === lex.ids.AppBskyFeedPost) {
     const refs: PreparedBlobRef[] = []
     const embed = record?.embed
+    const imagesEmbed = record?.images
     if (embed?.$type === 'app.bsky.embed.images') {
       const doc = lex.schemaDict.AppBskyEmbedImages
       for (let i = 0; i < embed.images?.length || 0; i++) {
@@ -67,6 +68,17 @@ export const blobsForWrite = (record: any): PreparedBlobRef[] => {
         mimeType: embed.external.thumb.mimeType,
         constraints: doc.defs.external.properties.thumb,
       })
+    }
+    if (imagesEmbed) {
+      const doc = lex.schemaDict.AppBskyEmbedImages
+      for (let i = 0; i < imagesEmbed.images?.length || 0; i++) {
+        const img = imagesEmbed.images[i]
+        refs.push({
+          cid: img.image.ref,
+          mimeType: img.image.mimeType,
+          constraints: doc.defs.image.properties.image,
+        })
+      }
     }
     return refs
   }

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -391,8 +391,7 @@ Array [
         },
       },
       "cid": "cids(2)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -462,8 +461,7 @@ Array [
         },
       },
       "cid": "cids(7)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -477,8 +475,7 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -661,8 +658,7 @@ Array [
           },
         },
         "cid": "cids(7)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -676,8 +672,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -80,13 +80,44 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(8)",
+                    "following": "record(7)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(6)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(6)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -94,7 +125,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 4114,
                   },
@@ -105,7 +136,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(4)",
+                      "$link": "cids(5)",
                     },
                     "size": 12736,
                   },
@@ -159,7 +190,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -169,7 +200,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(6)",
+      "uri": "record(9)",
       "viewer": Object {},
     },
   },
@@ -214,13 +245,44 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(8)",
+                    "following": "record(7)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(6)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(6)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -228,7 +290,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 4114,
                   },
@@ -239,7 +301,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(4)",
+                      "$link": "cids(5)",
                     },
                     "size": 12736,
                   },
@@ -307,7 +369,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(7)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -327,7 +389,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(7)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -391,6 +453,31 @@ Array [
         },
       },
       "cid": "cids(2)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "followedBy": "record(8)",
+              "following": "record(7)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(3)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(6)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -411,7 +498,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(3)",
+            "uri": "record(6)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -419,7 +512,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 4114,
               },
@@ -430,7 +523,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(4)",
+                  "$link": "cids(5)",
                 },
                 "size": 12736,
               },
@@ -443,7 +536,7 @@ Array [
       "repostCount": 0,
       "uri": "record(3)",
       "viewer": Object {
-        "like": "record(8)",
+        "like": "record(11)",
       },
     },
   },
@@ -455,12 +548,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(11)",
-          "following": "record(10)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(8)",
       "images": Object {
         "value": Array [
           Object {
@@ -483,7 +576,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 4114,
               },
@@ -504,7 +597,7 @@ Array [
       },
       "replyCount": 1,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -564,12 +657,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(11)",
-          "following": "record(10)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -579,7 +672,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(13)",
       "viewer": Object {},
     },
   },
@@ -591,12 +684,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(11)",
-          "following": "record(10)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(3)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -606,7 +699,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(13)",
+      "uri": "record(6)",
       "viewer": Object {},
     },
   },
@@ -629,8 +722,8 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(7)",
-            "uri": "record(9)",
+            "cid": "cids(8)",
+            "uri": "record(12)",
           },
           "root": Object {
             "cid": "cids(0)",
@@ -652,12 +745,12 @@ Array [
           "displayName": "bobby",
           "handle": "bob.test",
           "viewer": Object {
-            "followedBy": "record(11)",
-            "following": "record(10)",
+            "followedBy": "record(8)",
+            "following": "record(7)",
             "muted": false,
           },
         },
-        "cid": "cids(7)",
+        "cid": "cids(8)",
         "images": Object {
           "value": Array [
             Object {
@@ -680,7 +773,7 @@ Array [
                   "$type": "blob",
                   "mimeType": "image/jpeg",
                   "ref": Object {
-                    "$link": "cids(3)",
+                    "$link": "cids(4)",
                   },
                   "size": 4114,
                 },
@@ -701,7 +794,7 @@ Array [
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(9)",
+        "uri": "record(12)",
         "viewer": Object {},
       },
       "root": Object {
@@ -774,7 +867,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(3)",
+                      "uri": "record(6)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -782,7 +881,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(3)",
+                            "$link": "cids(4)",
                           },
                           "size": 4114,
                         },
@@ -793,7 +892,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(4)",
+                            "$link": "cids(5)",
                           },
                           "size": 12736,
                         },

--- a/packages/pds/tests/seeds/basic.ts
+++ b/packages/pds/tests/seeds/basic.ts
@@ -30,7 +30,13 @@ export default async (sc: SeedClient, mq?: MessageQueue) => {
     'tests/image/fixtures/key-alt.jpg',
     'image/jpeg',
   )
-  await sc.post(carol, posts.carol[0], undefined, [img1, img2])
+  await sc.post(
+    carol,
+    posts.carol[0],
+    undefined,
+    [img1, img2], // Contains both images and a quote
+    sc.posts[bob][0].ref,
+  )
   await sc.post(dan, posts.dan[0])
   await sc.post(
     dan,

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -238,12 +238,6 @@ export class SeedClient {
     facets?: any,
     images?: ImageRef[],
   ) {
-    const embed = images
-      ? {
-          $type: 'app.bsky.embed.images',
-          images,
-        }
-      : undefined
     const res = await this.agent.api.app.bsky.feed.post.create(
       { did: by },
       {
@@ -253,7 +247,7 @@ export class SeedClient {
           parent: parent.raw,
         },
         facets,
-        embed,
+        images: images && { images },
         createdAt: new Date().toISOString(),
       },
       this.getHeaders(by),

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -163,24 +163,16 @@ export class SeedClient {
     images?: ImageRef[],
     quote?: RecordRef,
   ) {
-    if (images && quote) throw new Error("Can't embed images and a quote")
-    const embed = images
-      ? {
-          $type: 'app.bsky.embed.images',
-          images,
-        }
-      : quote
-      ? {
-          $type: 'app.bsky.embed.record',
-          record: { uri: quote.uriStr, cid: quote.cidStr },
-        }
-      : undefined
     const res = await this.agent.api.app.bsky.feed.post.create(
       { did: by },
       {
         text: text,
         facets,
-        embed,
+        images: images && { images },
+        embed: quote && {
+          $type: 'app.bsky.embed.record',
+          record: { uri: quote.uriStr, cid: quote.cidStr },
+        },
         createdAt: new Date().toISOString(),
       },
       this.getHeaders(by),

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -50,8 +50,7 @@ Array [
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -65,8 +64,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -315,8 +313,7 @@ Array [
         },
       },
       "cid": "cids(0)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -330,8 +327,7 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -339,7 +335,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(1)",
+                  "$link": "cids(2)",
                 },
                 "size": 4114,
               },
@@ -348,11 +344,11 @@ Array [
         },
         "reply": Object {
           "parent": Object {
-            "cid": "cids(2)",
+            "cid": "cids(1)",
             "uri": "record(1)",
           },
           "root": Object {
-            "cid": "cids(2)",
+            "cid": "cids(1)",
             "uri": "record(1)",
           },
         },
@@ -376,7 +372,7 @@ Array [
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -403,7 +399,7 @@ Array [
             "muted": false,
           },
         },
-        "cid": "cids(2)",
+        "cid": "cids(1)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -694,8 +690,7 @@ Array [
         },
       },
       "cid": "cids(1)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1116,8 +1111,7 @@ Array [
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1131,8 +1125,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -166,7 +166,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(7)",
+                      "uri": "record(11)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -185,7 +191,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(7)",
+                            "$link": "cids(8)",
                           },
                           "size": 12736,
                         },
@@ -282,7 +288,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -292,7 +298,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },
@@ -509,13 +515,43 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(3)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(2)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(2)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -523,7 +559,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(2)",
+                      "$link": "cids(3)",
                     },
                     "size": 4114,
                   },
@@ -534,7 +570,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 12736,
                   },
@@ -576,7 +612,7 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {
-        "repost": "record(2)",
+        "repost": "record(4)",
       },
     },
     "reason": Object {
@@ -600,7 +636,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(4)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -608,19 +644,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(5)",
-            "uri": "record(4)",
+            "cid": "cids(6)",
+            "uri": "record(6)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(4)",
+            "cid": "cids(6)",
+            "uri": "record(6)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(3)",
+      "uri": "record(5)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -631,12 +667,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(8)",
+            "following": "record(7)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -646,9 +682,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(4)",
+        "uri": "record(6)",
         "viewer": Object {
-          "like": "record(7)",
+          "like": "record(9)",
         },
       },
       "root": Object {
@@ -658,12 +694,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(8)",
+            "following": "record(7)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -673,9 +709,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(4)",
+        "uri": "record(6)",
         "viewer": Object {
-          "like": "record(7)",
+          "like": "record(9)",
         },
       },
     },
@@ -690,6 +726,30 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "followedBy": "record(3)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(2)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -710,7 +770,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(2)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -718,7 +784,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(2)",
+                  "$link": "cids(3)",
                 },
                 "size": 4114,
               },
@@ -729,7 +795,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 12736,
               },
@@ -827,13 +893,43 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "following": "record(7)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(6)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(6)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -841,7 +937,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 4114,
                   },
@@ -852,7 +948,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(4)",
+                      "$link": "cids(5)",
                     },
                     "size": 12736,
                   },
@@ -905,7 +1001,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -915,7 +1011,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(6)",
+      "uri": "record(8)",
       "viewer": Object {},
     },
   },
@@ -964,13 +1060,42 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(4)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(4)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -978,7 +1103,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(2)",
+                      "$link": "cids(3)",
                     },
                     "size": 4114,
                   },
@@ -989,7 +1114,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 12736,
                   },
@@ -1043,7 +1168,7 @@ Array [
           "muted": true,
         },
       },
-      "cid": "cids(4)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1053,7 +1178,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(4)",
+      "uri": "record(5)",
       "viewer": Object {},
     },
   },
@@ -1230,7 +1355,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(7)",
+                      "uri": "record(10)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1249,7 +1380,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(7)",
+                            "$link": "cids(8)",
                           },
                           "size": 12736,
                         },
@@ -1308,7 +1439,7 @@ Array [
       "repostCount": 0,
       "uri": "record(7)",
       "viewer": Object {
-        "like": "record(10)",
+        "like": "record(11)",
       },
     },
   },
@@ -1354,7 +1485,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1364,7 +1495,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -46,8 +46,7 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
-      "embed": Object {
-        "$type": "app.bsky.embed.images",
+      "images": Object {
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -329,8 +328,7 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
-      "embed": Object {
-        "$type": "app.bsky.embed.images",
+      "images": Object {
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -644,8 +642,7 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
-      "embed": Object {
-        "$type": "app.bsky.embed.images",
+      "images": Object {
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -998,8 +995,7 @@ Array [
     "record": Object {
       "$type": "app.bsky.feed.post",
       "createdAt": "1970-01-01T00:00:00.000Z",
-      "embed": Object {
-        "$type": "app.bsky.embed.images",
+      "images": Object {
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -142,8 +142,7 @@ Object {
           },
         },
         "cid": "cids(1)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -157,8 +156,7 @@ Object {
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -282,8 +280,7 @@ Object {
           },
         },
         "cid": "cids(1)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -297,8 +294,7 @@ Object {
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -383,8 +379,7 @@ Object {
         },
       },
       "cid": "cids(2)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -398,8 +393,7 @@ Object {
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -554,8 +548,7 @@ Object {
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -569,8 +562,7 @@ Object {
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -729,8 +721,7 @@ Object {
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -744,8 +735,7 @@ Object {
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1051,8 +1041,7 @@ Object {
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1066,8 +1055,7 @@ Object {
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -196,8 +196,7 @@ Array [
         },
       },
       "cid": "cids(6)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -565,8 +564,7 @@ Array [
         },
       },
       "cid": "cids(8)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -887,8 +885,7 @@ Array [
           },
         },
         "cid": "cids(6)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -902,8 +899,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1057,8 +1053,7 @@ Array [
         },
       },
       "cid": "cids(6)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1072,8 +1067,7 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1477,8 +1471,7 @@ Array [
         },
       },
       "cid": "cids(2)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1760,8 +1753,7 @@ Array [
           },
         },
         "cid": "cids(6)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1775,8 +1767,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1939,8 +1930,7 @@ Array [
         },
       },
       "cid": "cids(6)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1954,8 +1944,7 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2237,8 +2226,7 @@ Array [
         },
       },
       "cid": "cids(1)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2520,8 +2508,7 @@ Array [
           },
         },
         "cid": "cids(6)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2535,8 +2522,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2851,8 +2837,7 @@ Array [
         },
       },
       "cid": "cids(1)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2991,8 +2976,7 @@ Array [
         },
       },
       "cid": "cids(1)",
-      "embed": Object {
-        "$type": "app.bsky.embed.images#view",
+      "images": Object {
         "value": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3006,8 +2990,7 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3368,8 +3351,7 @@ Array [
           },
         },
         "cid": "cids(2)",
-        "embed": Object {
-          "$type": "app.bsky.embed.images#view",
+        "images": Object {
           "value": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3383,8 +3365,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.feed.post",
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "embed": Object {
-            "$type": "app.bsky.embed.images",
+          "images": Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -196,6 +196,13 @@ Array [
         },
       },
       "cid": "cids(6)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewNotFound",
+          "uri": "record(9)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -216,7 +223,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(7)",
+            "uri": "record(9)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -224,7 +237,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(7)",
+                  "$link": "cids(8)",
                 },
                 "size": 4114,
               },
@@ -235,7 +248,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(8)",
+                  "$link": "cids(9)",
                 },
                 "size": 12736,
               },
@@ -248,7 +261,7 @@ Array [
       "repostCount": 0,
       "uri": "record(8)",
       "viewer": Object {
-        "like": "record(9)",
+        "like": "record(10)",
       },
     },
   },
@@ -263,7 +276,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(10)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -273,7 +286,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
   },
@@ -564,6 +577,31 @@ Array [
         },
       },
       "cid": "cids(8)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "followedBy": "record(11)",
+              "following": "record(10)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(9)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(14)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -584,7 +622,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(9)",
+            "uri": "record(14)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -592,7 +636,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(9)",
+                  "$link": "cids(10)",
                 },
                 "size": 4114,
               },
@@ -603,7 +647,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(10)",
+                  "$link": "cids(11)",
                 },
                 "size": 12736,
               },
@@ -616,7 +660,7 @@ Array [
       "repostCount": 0,
       "uri": "record(13)",
       "viewer": Object {
-        "like": "record(14)",
+        "like": "record(15)",
       },
     },
   },
@@ -633,7 +677,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(11)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -643,7 +687,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(15)",
+      "uri": "record(14)",
       "viewer": Object {},
     },
   },
@@ -755,13 +799,44 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(8)",
+                    "following": "record(7)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(6)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(6)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -769,7 +844,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 4114,
                   },
@@ -780,7 +855,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(4)",
+                      "$link": "cids(5)",
                     },
                     "size": 12736,
                   },
@@ -848,7 +923,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -856,8 +931,8 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(6)",
-            "uri": "record(7)",
+            "cid": "cids(7)",
+            "uri": "record(10)",
           },
           "root": Object {
             "cid": "cids(0)",
@@ -868,7 +943,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(6)",
+      "uri": "record(9)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -879,12 +954,12 @@ Array [
           "displayName": "bobby",
           "handle": "bob.test",
           "viewer": Object {
-            "followedBy": "record(9)",
-            "following": "record(8)",
+            "followedBy": "record(8)",
+            "following": "record(7)",
             "muted": false,
           },
         },
-        "cid": "cids(6)",
+        "cid": "cids(7)",
         "images": Object {
           "value": Array [
             Object {
@@ -907,7 +982,7 @@ Array [
                   "$type": "blob",
                   "mimeType": "image/jpeg",
                   "ref": Object {
-                    "$link": "cids(3)",
+                    "$link": "cids(4)",
                   },
                   "size": 4114,
                 },
@@ -928,7 +1003,7 @@ Array [
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(7)",
+        "uri": "record(10)",
         "viewer": Object {},
       },
       "root": Object {
@@ -967,7 +1042,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -987,7 +1062,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1047,12 +1122,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(9)",
-          "following": "record(8)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(7)",
       "images": Object {
         "value": Array [
           Object {
@@ -1075,7 +1150,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 4114,
               },
@@ -1096,7 +1171,7 @@ Array [
       },
       "replyCount": 1,
       "repostCount": 0,
-      "uri": "record(7)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1159,7 +1234,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -1193,7 +1268,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(3)",
+                      "uri": "record(6)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1201,7 +1282,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(3)",
+                            "$link": "cids(4)",
                           },
                           "size": 4114,
                         },
@@ -1212,7 +1293,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(4)",
+                            "$link": "cids(5)",
                           },
                           "size": 12736,
                         },
@@ -1269,7 +1350,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },
@@ -1281,12 +1362,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(9)",
-          "following": "record(8)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(10)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1296,7 +1377,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(13)",
       "viewer": Object {},
     },
   },
@@ -1366,13 +1447,44 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(8)",
+                    "following": "record(7)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(6)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(6)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1380,7 +1492,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 4114,
                   },
@@ -1391,7 +1503,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(4)",
+                      "$link": "cids(5)",
                     },
                     "size": 12736,
                   },
@@ -1445,7 +1557,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(10)",
+      "cid": "cids(11)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1455,7 +1567,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(13)",
+      "uri": "record(14)",
       "viewer": Object {},
     },
   },
@@ -1471,6 +1583,31 @@ Array [
         },
       },
       "cid": "cids(2)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "followedBy": "record(8)",
+              "following": "record(7)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(3)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(6)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -1491,7 +1628,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(3)",
+            "uri": "record(6)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1499,7 +1642,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 4114,
               },
@@ -1510,7 +1653,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(4)",
+                  "$link": "cids(5)",
                 },
                 "size": 12736,
               },
@@ -1523,7 +1666,7 @@ Array [
       "repostCount": 0,
       "uri": "record(3)",
       "viewer": Object {
-        "like": "record(14)",
+        "like": "record(15)",
       },
     },
   },
@@ -1535,12 +1678,12 @@ Array [
         "displayName": "bobby",
         "handle": "bob.test",
         "viewer": Object {
-          "followedBy": "record(9)",
-          "following": "record(8)",
+          "followedBy": "record(8)",
+          "following": "record(7)",
           "muted": false,
         },
       },
-      "cid": "cids(11)",
+      "cid": "cids(3)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1550,7 +1693,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(15)",
+      "uri": "record(6)",
       "viewer": Object {},
     },
   },
@@ -1624,13 +1767,42 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(4)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(4)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -1638,7 +1810,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(2)",
+                      "$link": "cids(3)",
                     },
                     "size": 4114,
                   },
@@ -1649,7 +1821,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 12736,
                   },
@@ -1713,12 +1885,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(6)",
-          "following": "record(5)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(4)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1726,19 +1898,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(6)",
-            "uri": "record(8)",
+            "cid": "cids(7)",
+            "uri": "record(9)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
         },
         "text": "thanks bob",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(4)",
+      "uri": "record(5)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1752,7 +1924,7 @@ Array [
             "muted": false,
           },
         },
-        "cid": "cids(6)",
+        "cid": "cids(7)",
         "images": Object {
           "value": Array [
             Object {
@@ -1775,7 +1947,7 @@ Array [
                   "$type": "blob",
                   "mimeType": "image/jpeg",
                   "ref": Object {
-                    "$link": "cids(2)",
+                    "$link": "cids(3)",
                   },
                   "size": 4114,
                 },
@@ -1784,19 +1956,19 @@ Array [
           },
           "reply": Object {
             "parent": Object {
-              "cid": "cids(5)",
-              "uri": "record(7)",
+              "cid": "cids(6)",
+              "uri": "record(8)",
             },
             "root": Object {
-              "cid": "cids(5)",
-              "uri": "record(7)",
+              "cid": "cids(6)",
+              "uri": "record(8)",
             },
           },
           "text": "hear that",
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(8)",
+        "uri": "record(9)",
         "viewer": Object {},
       },
       "root": Object {
@@ -1806,12 +1978,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1821,9 +1993,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(9)",
+          "like": "record(10)",
         },
       },
     },
@@ -1838,7 +2010,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -1846,19 +2018,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(5)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1869,12 +2041,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1884,9 +2056,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(9)",
+          "like": "record(10)",
         },
       },
       "root": Object {
@@ -1896,12 +2068,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1911,9 +2083,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(9)",
+          "like": "record(10)",
         },
       },
     },
@@ -1929,7 +2101,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(6)",
+      "cid": "cids(7)",
       "images": Object {
         "value": Array [
           Object {
@@ -1952,7 +2124,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(2)",
+                  "$link": "cids(3)",
                 },
                 "size": 4114,
               },
@@ -1961,19 +2133,19 @@ Array [
         },
         "reply": Object {
           "parent": Object {
-            "cid": "cids(5)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(7)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
         },
         "text": "hear that",
       },
       "replyCount": 1,
       "repostCount": 0,
-      "uri": "record(8)",
+      "uri": "record(9)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -1984,12 +2156,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -1999,9 +2171,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(9)",
+          "like": "record(10)",
         },
       },
       "root": Object {
@@ -2011,12 +2183,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(6)",
-            "following": "record(5)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2026,9 +2198,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(7)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(9)",
+          "like": "record(10)",
         },
       },
     },
@@ -2041,12 +2213,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(6)",
-          "following": "record(5)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -2079,7 +2251,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(2)",
+                      "uri": "record(4)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2087,7 +2265,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(2)",
+                            "$link": "cids(3)",
                           },
                           "size": 4114,
                         },
@@ -2098,7 +2276,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(3)",
+                            "$link": "cids(4)",
                           },
                           "size": 12736,
                         },
@@ -2155,130 +2333,9 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {
-        "like": "record(12)",
-      },
-    },
-  },
-  Object {
-    "post": Object {
-      "author": Object {
-        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
-        "did": "user(3)",
-        "displayName": "bobby",
-        "handle": "bob.test",
-        "viewer": Object {
-          "muted": false,
-        },
-      },
-      "cid": "cids(9)",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "likeCount": 0,
-      "record": Object {
-        "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "text": "bobby boy here",
-      },
-      "replyCount": 0,
-      "repostCount": 0,
-      "uri": "record(13)",
-      "viewer": Object {},
-    },
-  },
-  Object {
-    "post": Object {
-      "author": Object {
-        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "viewer": Object {
-          "followedBy": "record(6)",
-          "following": "record(5)",
-          "muted": false,
-        },
-      },
-      "cid": "cids(5)",
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "likeCount": 3,
-      "record": Object {
-        "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "text": "again",
-      },
-      "replyCount": 2,
-      "repostCount": 1,
-      "uri": "record(7)",
-      "viewer": Object {
-        "like": "record(9)",
-      },
-    },
-  },
-  Object {
-    "post": Object {
-      "author": Object {
-        "did": "user(2)",
-        "handle": "carol.test",
-        "viewer": Object {
-          "following": "record(3)",
-          "muted": false,
-        },
-      },
-      "cid": "cids(1)",
-      "images": Object {
-        "value": Array [
-          Object {
-            "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
-            "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
-          },
-          Object {
-            "alt": "tests/image/fixtures/key-alt.jpg",
-            "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
-            "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
-          },
-        ],
-      },
-      "indexedAt": "1970-01-01T00:00:00.000Z",
-      "likeCount": 2,
-      "record": Object {
-        "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
-        "embed": Object {
-          "$type": "app.bsky.embed.images",
-          "images": Array [
-            Object {
-              "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "image": Object {
-                "$type": "blob",
-                "mimeType": "image/jpeg",
-                "ref": Object {
-                  "$link": "cids(2)",
-                },
-                "size": 4114,
-              },
-            },
-            Object {
-              "alt": "tests/image/fixtures/key-alt.jpg",
-              "image": Object {
-                "$type": "blob",
-                "mimeType": "image/jpeg",
-                "ref": Object {
-                  "$link": "cids(3)",
-                },
-                "size": 12736,
-              },
-            },
-          ],
-        },
-        "text": "hi im carol",
-      },
-      "replyCount": 0,
-      "repostCount": 0,
-      "uri": "record(2)",
-      "viewer": Object {
-        "like": "record(14)",
+        "like": "record(13)",
       },
     },
   },
@@ -2299,11 +2356,11 @@ Array [
       "record": Object {
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
-        "text": "bob back at it again!",
+        "text": "bobby boy here",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(15)",
+      "uri": "record(14)",
       "viewer": Object {},
     },
   },
@@ -2315,8 +2372,158 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(6)",
-          "following": "record(5)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(6)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "likeCount": 3,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "text": "again",
+      },
+      "replyCount": 2,
+      "repostCount": 1,
+      "uri": "record(8)",
+      "viewer": Object {
+        "like": "record(10)",
+      },
+    },
+  },
+  Object {
+    "post": Object {
+      "author": Object {
+        "did": "user(2)",
+        "handle": "carol.test",
+        "viewer": Object {
+          "following": "record(3)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(4)",
+        },
+      },
+      "images": Object {
+        "value": Array [
+          Object {
+            "alt": "tests/image/fixtures/key-landscape-small.jpg",
+            "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+            "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+          },
+          Object {
+            "alt": "tests/image/fixtures/key-alt.jpg",
+            "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+            "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+          },
+        ],
+      },
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "likeCount": 2,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(4)",
+          },
+        },
+        "images": Object {
+          "images": Array [
+            Object {
+              "alt": "tests/image/fixtures/key-landscape-small.jpg",
+              "image": Object {
+                "$type": "blob",
+                "mimeType": "image/jpeg",
+                "ref": Object {
+                  "$link": "cids(3)",
+                },
+                "size": 4114,
+              },
+            },
+            Object {
+              "alt": "tests/image/fixtures/key-alt.jpg",
+              "image": Object {
+                "$type": "blob",
+                "mimeType": "image/jpeg",
+                "ref": Object {
+                  "$link": "cids(4)",
+                },
+                "size": 12736,
+              },
+            },
+          ],
+        },
+        "text": "hi im carol",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(2)",
+      "viewer": Object {
+        "like": "record(15)",
+      },
+    },
+  },
+  Object {
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(3)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+        "viewer": Object {
+          "muted": false,
+        },
+      },
+      "cid": "cids(2)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "likeCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "text": "bob back at it again!",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(4)",
+      "viewer": Object {},
+    },
+  },
+  Object {
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "viewer": Object {
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
@@ -2377,13 +2584,43 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(3)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(3)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(2)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(2)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(2)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2391,7 +2628,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(2)",
+                      "$link": "cids(3)",
                     },
                     "size": 4114,
                   },
@@ -2402,7 +2639,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(3)",
+                      "$link": "cids(4)",
                     },
                     "size": 12736,
                   },
@@ -2444,7 +2681,7 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {
-        "repost": "record(2)",
+        "repost": "record(4)",
       },
     },
     "reason": Object {
@@ -2467,12 +2704,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(4)",
+      "cid": "cids(5)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2480,19 +2717,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(6)",
-            "uri": "record(7)",
+            "cid": "cids(7)",
+            "uri": "record(9)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(6)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
         },
         "text": "thanks bob",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(3)",
+      "uri": "record(5)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -2503,11 +2740,11 @@ Array [
           "displayName": "bobby",
           "handle": "bob.test",
           "viewer": Object {
-            "followedBy": "record(9)",
+            "followedBy": "record(3)",
             "muted": false,
           },
         },
-        "cid": "cids(6)",
+        "cid": "cids(7)",
         "images": Object {
           "value": Array [
             Object {
@@ -2530,7 +2767,7 @@ Array [
                   "$type": "blob",
                   "mimeType": "image/jpeg",
                   "ref": Object {
-                    "$link": "cids(2)",
+                    "$link": "cids(3)",
                   },
                   "size": 4114,
                 },
@@ -2539,19 +2776,19 @@ Array [
           },
           "reply": Object {
             "parent": Object {
-              "cid": "cids(5)",
-              "uri": "record(6)",
+              "cid": "cids(6)",
+              "uri": "record(8)",
             },
             "root": Object {
-              "cid": "cids(5)",
-              "uri": "record(6)",
+              "cid": "cids(6)",
+              "uri": "record(8)",
             },
           },
           "text": "hear that",
         },
         "replyCount": 1,
         "repostCount": 0,
-        "uri": "record(7)",
+        "uri": "record(9)",
         "viewer": Object {},
       },
       "root": Object {
@@ -2561,12 +2798,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2576,9 +2813,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(10)",
         },
       },
     },
@@ -2592,7 +2829,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2600,19 +2837,19 @@ Array [
         "createdAt": "1970-01-01T00:00:00.000Z",
         "reply": Object {
           "parent": Object {
-            "cid": "cids(5)",
-            "uri": "record(6)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
           "root": Object {
-            "cid": "cids(5)",
-            "uri": "record(6)",
+            "cid": "cids(6)",
+            "uri": "record(8)",
           },
         },
         "text": "of course",
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(11)",
       "viewer": Object {},
     },
     "reply": Object {
@@ -2623,12 +2860,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2638,9 +2875,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(10)",
         },
       },
       "root": Object {
@@ -2650,12 +2887,12 @@ Array [
           "displayName": "ali",
           "handle": "alice.test",
           "viewer": Object {
-            "followedBy": "record(5)",
-            "following": "record(4)",
+            "followedBy": "record(7)",
+            "following": "record(6)",
             "muted": false,
           },
         },
-        "cid": "cids(5)",
+        "cid": "cids(6)",
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "likeCount": 3,
         "record": Object {
@@ -2665,9 +2902,9 @@ Array [
         },
         "replyCount": 2,
         "repostCount": 1,
-        "uri": "record(6)",
+        "uri": "record(8)",
         "viewer": Object {
-          "like": "record(8)",
+          "like": "record(10)",
         },
       },
     },
@@ -2680,12 +2917,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "embed": Object {
         "$type": "app.bsky.embed.record#view",
         "value": Object {
@@ -2716,7 +2953,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(2)",
+                      "uri": "record(2)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2724,7 +2967,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(2)",
+                            "$link": "cids(3)",
                           },
                           "size": 4114,
                         },
@@ -2735,7 +2978,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(3)",
+                            "$link": "cids(4)",
                           },
                           "size": 12736,
                         },
@@ -2792,9 +3035,9 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {
-        "like": "record(12)",
+        "like": "record(13)",
       },
     },
   },
@@ -2806,12 +3049,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(5)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 3,
       "record": Object {
@@ -2821,9 +3064,9 @@ Array [
       },
       "replyCount": 2,
       "repostCount": 1,
-      "uri": "record(6)",
+      "uri": "record(8)",
       "viewer": Object {
-        "like": "record(8)",
+        "like": "record(10)",
       },
     },
   },
@@ -2837,6 +3080,30 @@ Array [
         },
       },
       "cid": "cids(1)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "value": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(3)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "viewer": Object {
+              "followedBy": "record(3)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(2)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+          "uri": "record(2)",
+        },
+      },
       "images": Object {
         "value": Array [
           Object {
@@ -2857,7 +3124,13 @@ Array [
         "$type": "app.bsky.feed.post",
         "createdAt": "1970-01-01T00:00:00.000Z",
         "embed": Object {
-          "$type": "app.bsky.embed.images",
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(2)",
+            "uri": "record(2)",
+          },
+        },
+        "images": Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -2865,7 +3138,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(2)",
+                  "$link": "cids(3)",
                 },
                 "size": 4114,
               },
@@ -2876,7 +3149,7 @@ Array [
                 "$type": "blob",
                 "mimeType": "image/jpeg",
                 "ref": Object {
-                  "$link": "cids(3)",
+                  "$link": "cids(4)",
                 },
                 "size": 12736,
               },
@@ -2899,12 +3172,12 @@ Array [
         "displayName": "ali",
         "handle": "alice.test",
         "viewer": Object {
-          "followedBy": "record(5)",
-          "following": "record(4)",
+          "followedBy": "record(7)",
+          "following": "record(6)",
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(10)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -2914,7 +3187,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(13)",
+      "uri": "record(14)",
       "viewer": Object {},
     },
   },
@@ -3143,13 +3416,43 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(2)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "following": "record(5)",
+                    "muted": false,
+                  },
+                },
+                "cid": "cids(6)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(9)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(6)",
+                "uri": "record(9)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3168,7 +3471,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(6)",
+                      "$link": "cids(7)",
                     },
                     "size": 12736,
                   },
@@ -3221,7 +3524,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(7)",
+      "cid": "cids(8)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -3231,7 +3534,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(9)",
+      "uri": "record(10)",
       "viewer": Object {},
     },
   },
@@ -3247,7 +3550,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(6)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -3257,7 +3560,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(10)",
+      "uri": "record(9)",
       "viewer": Object {},
     },
   },
@@ -3467,7 +3770,13 @@ Array [
                   "$type": "app.bsky.feed.post",
                   "createdAt": "1970-01-01T00:00:00.000Z",
                   "embed": Object {
-                    "$type": "app.bsky.embed.images",
+                    "$type": "app.bsky.embed.record",
+                    "record": Object {
+                      "cid": "cids(7)",
+                      "uri": "record(11)",
+                    },
+                  },
+                  "images": Object {
                     "images": Array [
                       Object {
                         "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3486,7 +3795,7 @@ Array [
                           "$type": "blob",
                           "mimeType": "image/jpeg",
                           "ref": Object {
-                            "$link": "cids(7)",
+                            "$link": "cids(8)",
                           },
                           "size": 12736,
                         },
@@ -3613,13 +3922,44 @@ Array [
                 },
               ],
             },
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "value": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                  "did": "user(2)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "viewer": Object {
+                    "followedBy": "record(5)",
+                    "following": "record(4)",
+                    "muted": true,
+                  },
+                },
+                "cid": "cids(7)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "record": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+                "uri": "record(11)",
+              },
+            },
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "record": Object {
             "$type": "app.bsky.feed.post",
             "createdAt": "1970-01-01T00:00:00.000Z",
             "embed": Object {
-              "$type": "app.bsky.embed.images",
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(7)",
+                "uri": "record(11)",
+              },
+            },
+            "images": Object {
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
@@ -3638,7 +3978,7 @@ Array [
                     "$type": "blob",
                     "mimeType": "image/jpeg",
                     "ref": Object {
-                      "$link": "cids(7)",
+                      "$link": "cids(8)",
                     },
                     "size": 12736,
                   },
@@ -3692,7 +4032,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(8)",
+      "cid": "cids(9)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -3702,7 +4042,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(11)",
+      "uri": "record(12)",
       "viewer": Object {},
     },
   },
@@ -3717,7 +4057,7 @@ Array [
           "muted": false,
         },
       },
-      "cid": "cids(9)",
+      "cid": "cids(10)",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "likeCount": 0,
       "record": Object {
@@ -3727,7 +4067,7 @@ Array [
       },
       "replyCount": 0,
       "repostCount": 0,
-      "uri": "record(12)",
+      "uri": "record(13)",
       "viewer": Object {},
     },
   },

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -62,7 +62,7 @@ describe('pds notification views', () => {
       { headers: sc.getHeaders(sc.dids.bob) },
     )
 
-    expect(notifCountBob.data.count).toBe(3)
+    expect(notifCountBob.data.count).toBe(4)
   })
 
   it('generates notifications for all reply ancestors', async () => {
@@ -89,7 +89,7 @@ describe('pds notification views', () => {
       { headers: sc.getHeaders(sc.dids.bob) },
     )
 
-    expect(notifCountBob.data.count).toBe(4)
+    expect(notifCountBob.data.count).toBe(5)
   })
 
   it('generates notifications for quotes', async () => {


### PR DESCRIPTION
This enables quote posts to contain their own image embeds.  It's achieved by allowing any post to have an images embed separate from other embeds.  In the case that a post contains two images embeds, the one in the `images` field is the one that should be presented to the user.
 - Add `images` field to post record, containing an images embed.
 - Add `images` field to post view, containing an images embed view.
 - Remove images embed view from post view `embed` field, to remove ambiguity from client.
 - Handle uploads and indexing of post `images`.
 - Ensure multiple embeds make it into a record embed view's `embeds` field, e.g. when a post contains both a quote and images.

Two things to look at here:
1. In the post view lexicon I sort of force image embeds to be presented in the `images` field, even though in legacy cases they could be stored in the post record's `embed` field.  I thought this was the right call to avoid ambiguity, but it was also a hard decision.
2. Slight awkwardness around the post record's `images` field since it contains an images embed, which also has a single `images` field.  So one might write `postRecord.images.images`.  On the view it looks like `postView.images.value` as of #691.