### PR TITLE
Lexicon: standardize record repo interfaces

### DIFF
--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -9,12 +9,12 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["did", "writes"],
+          "required": ["repo", "writes"],
           "properties": {
-            "did": {
+            "repo": {
               "type": "string",
-              "format": "did",
-              "description": "The DID of the repo."
+              "format": "at-identifier",
+              "description": "The handle or DID of the repo."
             },
             "validate": {
               "type": "boolean",

--- a/lexicons/com/atproto/repo/createRecord.json
+++ b/lexicons/com/atproto/repo/createRecord.json
@@ -9,12 +9,12 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["did", "collection", "record"],
+          "required": ["repo", "collection", "record"],
           "properties": {
-            "did": {
+            "repo": {
               "type": "string",
-              "format": "did",
-              "description": "The DID of the repo."
+              "format": "at-identifier",
+              "description": "The handle or DID of the repo."
             },
             "collection": {
               "type": "string",

--- a/lexicons/com/atproto/repo/deleteRecord.json
+++ b/lexicons/com/atproto/repo/deleteRecord.json
@@ -9,12 +9,12 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["did", "collection", "rkey"],
+          "required": ["repo", "collection", "rkey"],
           "properties": {
-            "did": {
+            "repo": {
               "type": "string",
-              "format": "did",
-              "description": "The DID of the repo."
+              "format": "at-identifier",
+              "description": "The handle or DID of the repo."
             },
             "collection": {
               "type": "string",

--- a/lexicons/com/atproto/repo/putRecord.json
+++ b/lexicons/com/atproto/repo/putRecord.json
@@ -9,13 +9,13 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["did", "collection", "rkey", "record"],
+          "required": ["repo", "collection", "rkey", "record"],
           "nullable": ["swapRecord"],
           "properties": {
-            "did": {
+            "repo": {
               "type": "string",
-              "format": "did",
-              "description": "The DID of the repo."
+              "format": "at-identifier",
+              "description": "The handle or DID of the repo."
             },
             "collection": {
               "type": "string",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1079,12 +1079,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'writes'],
+            required: ['repo', 'writes'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               validate: {
                 type: 'boolean',
@@ -1177,12 +1177,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'record'],
+            required: ['repo', 'collection', 'record'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',
@@ -1247,12 +1247,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'rkey'],
+            required: ['repo', 'collection', 'rkey'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',
@@ -1494,13 +1494,13 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'rkey', 'record'],
+            required: ['repo', 'collection', 'rkey', 'record'],
             nullable: ['swapRecord'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',

--- a/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
+++ b/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
@@ -10,8 +10,8 @@ import { CID } from 'multiformats/cid'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** Validate the records? */
   validate?: boolean
   writes: (Create | Update | Delete)[]

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -10,8 +10,8 @@ import { CID } from 'multiformats/cid'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
@@ -10,8 +10,8 @@ import { CID } from 'multiformats/cid'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/api/src/client/types/com/atproto/repo/putRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/putRecord.ts
@@ -10,8 +10,8 @@ import { CID } from 'multiformats/cid'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -92,7 +92,7 @@ export async function generateMockSetup(env: DevEnv) {
     user.agent.api.setHeader('Authorization', `Bearer ${res.data.accessJwt}`)
     user.did = res.data.did
     await user.agent.api.app.bsky.actor.profile.create(
-      { did: user.did },
+      { repo: user.did },
       {
         displayName: ucfirst(user.handle).slice(0, -5),
         description: `Test user ${_i++}`,
@@ -114,7 +114,7 @@ export async function generateMockSetup(env: DevEnv) {
   // everybody follows everybody
   const follow = async (author: User, subject: User) => {
     await author.agent.api.app.bsky.graph.follow.create(
-      { did: author.did },
+      { repo: author.did },
       {
         subject: subject.did,
         createdAt: date.next().value,
@@ -133,7 +133,7 @@ export async function generateMockSetup(env: DevEnv) {
   for (let i = 0; i < postTexts.length; i++) {
     const author = picka(users)
     const post = await author.agent.api.app.bsky.feed.post.create(
-      { did: author.did },
+      { repo: author.did },
       {
         text: postTexts[i],
         createdAt: date.next().value,
@@ -143,7 +143,7 @@ export async function generateMockSetup(env: DevEnv) {
     if (rand(10) === 0) {
       const reposter = picka(users)
       await reposter.agent.api.app.bsky.feed.repost.create(
-        { did: reposter.did },
+        { repo: reposter.did },
         {
           subject: picka(posts),
           createdAt: date.next().value,
@@ -174,7 +174,7 @@ export async function generateMockSetup(env: DevEnv) {
     const author = picka(users)
     posts.push(
       await author.agent.api.app.bsky.feed.post.create(
-        { did: author.did },
+        { repo: author.did },
         {
           text: picka(replyTexts),
           reply: {
@@ -192,7 +192,7 @@ export async function generateMockSetup(env: DevEnv) {
     for (const user of users) {
       if (rand(3) === 0) {
         await user.agent.api.app.bsky.feed.like.create(
-          { did: user.did },
+          { repo: user.did },
           {
             subject: post,
             createdAt: date.next().value,

--- a/packages/pds/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/getRecord.ts
@@ -6,8 +6,8 @@ import AppContext from '../../../../context'
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.getRecord(async ({ params }) => {
     const { repo, collection, rkey, cid } = params
-
     const did = await ctx.services.account(ctx.db).getDidForActor(repo)
+
     if (!did) {
       throw new InvalidRequestError(`Could not find repo: ${repo}`)
     }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1079,12 +1079,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'writes'],
+            required: ['repo', 'writes'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               validate: {
                 type: 'boolean',
@@ -1177,12 +1177,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'record'],
+            required: ['repo', 'collection', 'record'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',
@@ -1247,12 +1247,12 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'rkey'],
+            required: ['repo', 'collection', 'rkey'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',
@@ -1494,13 +1494,13 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['did', 'collection', 'rkey', 'record'],
+            required: ['repo', 'collection', 'rkey', 'record'],
             nullable: ['swapRecord'],
             properties: {
-              did: {
+              repo: {
                 type: 'string',
-                format: 'did',
-                description: 'The DID of the repo.',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
               },
               collection: {
                 type: 'string',

--- a/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -11,8 +11,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** Validate the records? */
   validate: boolean
   writes: (Create | Update | Delete)[]

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -11,8 +11,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -11,8 +11,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -11,8 +11,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  /** The DID of the repo. */
-  did: string
+  /** The handle or DID of the repo. */
+  repo: string
   /** The NSID of the record collection. */
   collection: string
   /** The key of the record. */

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -82,7 +82,7 @@ describe('crud operations', () => {
   let uri: AtUri
   it('creates records', async () => {
     const res = await aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.post',
       record: {
         $type: 'app.bsky.feed.post',
@@ -134,7 +134,7 @@ describe('crud operations', () => {
 
   it('deletes records', async () => {
     await aliceAgent.api.com.atproto.repo.deleteRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.post',
       rkey: uri.rkey,
     })
@@ -147,7 +147,7 @@ describe('crud operations', () => {
 
   it('CRUDs records with the semantic sugars', async () => {
     const res1 = await aliceAgent.api.app.bsky.feed.post.create(
-      { did: alice.did },
+      { repo: alice.did },
       {
         $type: 'app.bsky.feed.post',
         text: 'Hello, world!',
@@ -162,7 +162,7 @@ describe('crud operations', () => {
     expect(res2.records.length).toBe(1)
 
     await aliceAgent.api.app.bsky.feed.post.delete({
-      did: alice.did,
+      repo: alice.did,
       rkey: uri.rkey,
     })
 
@@ -186,7 +186,7 @@ describe('crud operations', () => {
     )
     // Associate image with post, image should be placed in blobstore
     const res = await aliceAgent.api.app.bsky.feed.post.create(
-      { did: alice.did },
+      { repo: alice.did },
       {
         $type: 'app.bsky.feed.post',
         text: "Here's a key!",
@@ -211,13 +211,13 @@ describe('crud operations', () => {
     // Cleanup
     await aliceAgent.api.app.bsky.feed.post.delete({
       rkey: postUri.rkey,
-      did: alice.did,
+      repo: alice.did,
     })
   })
 
   it('creates records with the correct key described by the schema', async () => {
     const res1 = await aliceAgent.api.app.bsky.actor.profile.create(
-      { did: alice.did },
+      { repo: alice.did },
       {
         displayName: 'alice',
         createdAt: new Date().toISOString(),
@@ -238,7 +238,7 @@ describe('crud operations', () => {
       const responses = await Promise.all(
         postTexts.map((text) =>
           aliceAgent.api.app.bsky.feed.post.create(
-            { did: alice.did },
+            { repo: alice.did },
             {
               text,
               createdAt: new Date().toISOString(),
@@ -265,7 +265,7 @@ describe('crud operations', () => {
       await Promise.all(
         uris.map((uri) =>
           aliceAgent.api.app.bsky.feed.post.delete({
-            did: alice.did,
+            repo: alice.did,
             rkey: uri.rkey,
           }),
         ),
@@ -292,7 +292,7 @@ describe('crud operations', () => {
     beforeAll(async () => {
       const createPost = async (text: string) => {
         const res = await aliceAgent.api.app.bsky.feed.post.create(
-          { did: alice.did },
+          { repo: alice.did },
           {
             $type: 'app.bsky.feed.post',
             text,
@@ -312,7 +312,7 @@ describe('crud operations', () => {
       await Promise.all(
         [uri1, uri2, uri3, uri4, uri5].map((uri) =>
           aliceAgent.api.app.bsky.feed.post.delete({
-            did: alice.did,
+            repo: alice.did,
             rkey: uri.rkey,
           }),
         ),
@@ -401,13 +401,13 @@ describe('crud operations', () => {
     it('deletes a record if it exists', async () => {
       const { repo } = aliceAgent.api.com.atproto
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: { text: 'post', createdAt: new Date().toISOString() },
       })
       const uri = new AtUri(post.uri)
       await repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
       })
@@ -422,13 +422,13 @@ describe('crud operations', () => {
     it("no-ops if record doesn't exist", async () => {
       const { repo } = aliceAgent.api.com.atproto
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: { text: 'post', createdAt: new Date().toISOString() },
       })
       const uri = new AtUri(post.uri)
       await repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
       })
@@ -439,7 +439,7 @@ describe('crud operations', () => {
       })
       await expect(checkPost).rejects.toThrow('Could not locate record')
       const attemptDelete = repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
       })
@@ -460,7 +460,7 @@ describe('crud operations', () => {
 
       const { data: put } = await repo.putRecord({
         ...profilePath,
-        did: bob.did,
+        repo: bob.did,
         record: {
           displayName: 'Robert',
         },
@@ -481,7 +481,7 @@ describe('crud operations', () => {
       const { repo } = bobAgent.api.com.atproto
       const { data: put } = await repo.putRecord({
         ...profilePath,
-        did: bob.did,
+        repo: bob.did,
         record: {
           displayName: 'Robert',
           description: 'Dog lover',
@@ -503,7 +503,7 @@ describe('crud operations', () => {
     it('temporarily only puts profile records', async () => {
       const { repo } = bobAgent.api.com.atproto
       const put = repo.putRecord({
-        did: bob.did,
+        repo: bob.did,
         collection: ids.AppBskyGraphFollow,
         rkey: TID.nextStr(),
         record: {
@@ -519,7 +519,7 @@ describe('crud operations', () => {
     it('fails on user mismatch', async () => {
       const { repo } = aliceAgent.api.com.atproto
       const put = repo.putRecord({
-        did: bob.did,
+        repo: bob.did,
         collection: ids.AppBskyGraphFollow,
         rkey: TID.nextStr(),
         record: {
@@ -527,14 +527,14 @@ describe('crud operations', () => {
           createdAt: new Date().toISOString(),
         },
       })
-      await expect(put).rejects.toThrow('Forbidden')
+      await expect(put).rejects.toThrow('Authentication Required')
     })
 
     it('fails on invalid record', async () => {
       const { repo } = bobAgent.api.com.atproto
       const put = repo.putRecord({
         ...profilePath,
-        did: bob.did,
+        repo: bob.did,
         record: {
           displayName: 'Robert',
           description: 3.141,
@@ -560,7 +560,7 @@ describe('crud operations', () => {
 
   it('defaults an undefined $type on records', async () => {
     const res = await aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.post',
       record: {
         text: 'blah',
@@ -578,7 +578,7 @@ describe('crud operations', () => {
 
   it('requires the schema to be known if validating', async () => {
     const prom = aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'com.example.foobar',
       record: { $type: 'com.example.foobar' },
     })
@@ -590,7 +590,7 @@ describe('crud operations', () => {
   it('requires the $type to match the schema', async () => {
     await expect(
       aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.feed.post',
         record: { $type: 'app.bsky.feed.like' },
       }),
@@ -602,7 +602,7 @@ describe('crud operations', () => {
   it('validates the record on write', async () => {
     await expect(
       aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.feed.post',
         record: { $type: 'app.bsky.feed.post' },
       }),
@@ -625,7 +625,7 @@ describe('crud operations', () => {
       const { repo, sync } = aliceAgent.api.com.atproto
       const { data: head } = await sync.getHead({ did: alice.did })
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         swapCommit: head.root,
         record: postRecord(),
@@ -644,12 +644,12 @@ describe('crud operations', () => {
       const { data: staleHead } = await sync.getHead({ did: alice.did })
       // Update repo, change head
       await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const attemptCreate = repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         swapCommit: staleHead.root,
         record: postRecord(),
@@ -660,14 +660,14 @@ describe('crud operations', () => {
     it('deleteRecord succeeds on proper commit cas', async () => {
       const { repo, sync } = aliceAgent.api.com.atproto
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const { data: head } = await sync.getHead({ did: alice.did })
       const uri = new AtUri(post.uri)
       await repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
         swapCommit: head.root,
@@ -684,13 +684,13 @@ describe('crud operations', () => {
       const { repo, sync } = aliceAgent.api.com.atproto
       const { data: staleHead } = await sync.getHead({ did: alice.did })
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const uri = new AtUri(post.uri)
       const attempDelete = repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
         swapCommit: staleHead.root,
@@ -707,13 +707,13 @@ describe('crud operations', () => {
     it('deleteRecord succeeds on proper record cas', async () => {
       const { repo } = aliceAgent.api.com.atproto
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const uri = new AtUri(post.uri)
       await repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
         swapRecord: post.cid,
@@ -729,13 +729,13 @@ describe('crud operations', () => {
     it('deleteRecord fails on bad record cas', async () => {
       const { repo } = aliceAgent.api.com.atproto
       const { data: post } = await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const uri = new AtUri(post.uri)
       const attempDelete = repo.deleteRecord({
-        did: uri.host,
+        repo: uri.host,
         collection: uri.collection,
         rkey: uri.rkey,
         swapRecord: (await cidForCbor({})).toString(),
@@ -753,7 +753,7 @@ describe('crud operations', () => {
       const { repo, sync } = aliceAgent.api.com.atproto
       const { data: head } = await sync.getHead({ did: alice.did })
       const { data: profile } = await repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapCommit: head.root,
@@ -772,12 +772,12 @@ describe('crud operations', () => {
       const { data: staleHead } = await sync.getHead({ did: alice.did })
       // Update repo, change head
       await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const attemptPut = repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapCommit: staleHead.root,
@@ -790,13 +790,13 @@ describe('crud operations', () => {
       const { repo } = aliceAgent.api.com.atproto
       // Start with missing profile record, to test swapRecord=null
       await repo.deleteRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
       })
       // Test swapRecord w/ null (ensures create)
       const { data: profile1 } = await repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapRecord: null,
@@ -810,7 +810,7 @@ describe('crud operations', () => {
       expect(checkProfile1.cid).toEqual(profile1.cid)
       // Test swapRecord w/ cid (ensures update)
       const { data: profile2 } = await repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapRecord: profile1.cid,
@@ -828,7 +828,7 @@ describe('crud operations', () => {
       const { repo } = aliceAgent.api.com.atproto
       // Test swapRecord w/ null (ensures create)
       const attemptPut1 = repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapRecord: null,
@@ -837,7 +837,7 @@ describe('crud operations', () => {
       await expect(attemptPut1).rejects.toThrow(putRecord.InvalidSwapError)
       // Test swapRecord w/ cid (ensures update)
       const attemptPut2 = repo.putRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         swapRecord: (await cidForCbor({})).toString(),
@@ -851,7 +851,7 @@ describe('crud operations', () => {
       const { data: head } = await sync.getHead({ did: alice.did })
       const rkey = TID.nextStr()
       await repo.applyWrites({
-        did: alice.did,
+        repo: alice.did,
         swapCommit: head.root,
         writes: [
           {
@@ -877,12 +877,12 @@ describe('crud operations', () => {
       const { data: staleHead } = await sync.getHead({ did: alice.did })
       // Update repo, change head
       await repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: ids.AppBskyFeedPost,
         record: postRecord(),
       })
       const attemptApplyWrite = repo.applyWrites({
-        did: alice.did,
+        repo: alice.did,
         swapCommit: staleHead.root,
         writes: [
           {
@@ -908,7 +908,7 @@ describe('crud operations', () => {
     const cidB = await cidForCbor({ post: 'b' })
 
     const { data: like1 } = await aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.like',
       record: {
         $type: 'app.bsky.feed.like',
@@ -917,7 +917,7 @@ describe('crud operations', () => {
       },
     })
     const { data: like2 } = await aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.like',
       record: {
         $type: 'app.bsky.feed.like',
@@ -926,7 +926,7 @@ describe('crud operations', () => {
       },
     })
     const { data: like3 } = await aliceAgent.api.com.atproto.repo.createRecord({
-      did: alice.did,
+      repo: alice.did,
       collection: 'app.bsky.feed.like',
       record: {
         $type: 'app.bsky.feed.like',
@@ -969,7 +969,7 @@ describe('crud operations', () => {
 
     const { data: repost1 } =
       await aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.feed.repost',
         record: {
           $type: 'app.bsky.feed.repost',
@@ -979,7 +979,7 @@ describe('crud operations', () => {
       })
     const { data: repost2 } =
       await aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.feed.repost',
         record: {
           $type: 'app.bsky.feed.repost',
@@ -989,7 +989,7 @@ describe('crud operations', () => {
       })
     const { data: repost3 } =
       await aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.feed.repost',
         record: {
           $type: 'app.bsky.feed.repost',
@@ -1028,7 +1028,7 @@ describe('crud operations', () => {
 
     const { data: follow1 } =
       await aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.graph.follow',
         record: {
           $type: 'app.bsky.graph.follow',
@@ -1037,7 +1037,7 @@ describe('crud operations', () => {
         },
       })
     const { data: follow2 } = await bobAgent.api.com.atproto.repo.createRecord({
-      did: bob.did,
+      repo: bob.did,
       collection: 'app.bsky.graph.follow',
       record: {
         $type: 'app.bsky.graph.follow',
@@ -1047,7 +1047,7 @@ describe('crud operations', () => {
     })
     const { data: follow3 } =
       await aliceAgent.api.com.atproto.repo.createRecord({
-        did: alice.did,
+        repo: alice.did,
         collection: 'app.bsky.graph.follow',
         record: {
           $type: 'app.bsky.graph.follow',
@@ -1086,7 +1086,7 @@ describe('crud operations', () => {
 
   it("doesn't serve taken-down record", async () => {
     const created = await aliceAgent.api.app.bsky.feed.post.create(
-      { did: alice.did },
+      { repo: alice.did },
       {
         $type: 'app.bsky.feed.post',
         text: 'Hello, world!',

--- a/packages/pds/tests/file-uploads.test.ts
+++ b/packages/pds/tests/file-uploads.test.ts
@@ -307,7 +307,7 @@ describe('file uploads', () => {
 
 async function updateProfile(agent: AtpAgent, record: Record<string, unknown>) {
   return await agent.api.com.atproto.repo.putRecord({
-    did: agent.session?.did ?? '',
+    repo: agent.session?.did ?? '',
     collection: ids.AppBskyActorProfile,
     rkey: 'self',
     record,

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -124,7 +124,7 @@ export class SeedClient {
 
     {
       const res = await this.agent.api.app.bsky.actor.profile.create(
-        { did: by },
+        { repo: by },
         {
           displayName,
           description,
@@ -144,7 +144,7 @@ export class SeedClient {
 
   async follow(from: string, to: string) {
     const res = await this.agent.api.app.bsky.graph.follow.create(
-      { did: from },
+      { repo: from },
       {
         subject: to,
         createdAt: new Date().toISOString(),
@@ -176,7 +176,7 @@ export class SeedClient {
         }
       : undefined
     const res = await this.agent.api.app.bsky.feed.post.create(
-      { did: by },
+      { repo: by },
       {
         text: text,
         facets,
@@ -199,7 +199,7 @@ export class SeedClient {
   async deletePost(by: string, uri: AtUri) {
     await this.agent.api.app.bsky.feed.post.delete(
       {
-        did: by,
+        repo: by,
         rkey: uri.rkey,
       },
       this.getHeaders(by),
@@ -221,7 +221,7 @@ export class SeedClient {
 
   async like(by: string, subject: RecordRef) {
     const res = await this.agent.api.app.bsky.feed.like.create(
-      { did: by },
+      { repo: by },
       { subject: subject.raw, createdAt: new Date().toISOString() },
       this.getHeaders(by),
     )
@@ -245,7 +245,7 @@ export class SeedClient {
         }
       : undefined
     const res = await this.agent.api.app.bsky.feed.post.create(
-      { did: by },
+      { repo: by },
       {
         text: text,
         reply: {
@@ -269,7 +269,7 @@ export class SeedClient {
 
   async repost(by: string, subject: RecordRef) {
     const res = await this.agent.api.app.bsky.feed.repost.create(
-      { did: by },
+      { repo: by },
       { subject: subject.raw, createdAt: new Date().toISOString() },
       this.getHeaders(by),
     )

--- a/packages/pds/tests/subscription/repo.test.ts
+++ b/packages/pds/tests/subscription/repo.test.ts
@@ -147,7 +147,7 @@ describe('sync', () => {
   ) {
     return await agent.api.com.atproto.repo.putRecord(
       {
-        did,
+        repo: did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         record,

--- a/packages/pds/tests/sync/sync.test.ts
+++ b/packages/pds/tests/sync/sync.test.ts
@@ -86,7 +86,7 @@ describe('repo sync', () => {
     for (let i = 0; i < DEL_COUNT; i++) {
       const uri = uris[i * 5]
       await agent.api.app.bsky.feed.post.delete({
-        did,
+        repo: did,
         collection: uri.collection,
         rkey: uri.rkey,
       })

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -283,7 +283,7 @@ describe('pds profile views', () => {
   ) {
     return await agent.api.com.atproto.repo.putRecord(
       {
-        did,
+        repo: did,
         collection: ids.AppBskyActorProfile,
         rkey: 'self',
         record,


### PR DESCRIPTION
This unifies all the `com.atproto.repo.*` xrpc methods so that the repo to read/write to is specified with a `repo` field, which can be an at-identifier (i.e. did or handle). Previously the write endpoints instead took a `did` field as an input, while the read endpoints a `repo`.