### PR TITLE
Lex: actor view semantics

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -3,7 +3,7 @@
   "id": "app.bsky.actor.defs",
   "description": "A reference to an actor in the network.",
   "defs": {
-    "withInfo": {
+    "profileViewBasic": {
       "type": "object",
       "required": ["did", "handle"],
       "properties": {
@@ -18,6 +18,25 @@
       }
     },
     "profileView": {
+      "type": "object",
+      "required": ["did", "handle"],
+      "properties": {
+        "did": {"type": "string", "format":"did"},
+        "handle": {"type": "string", "format":"handle"},
+        "displayName": {
+          "type": "string",
+          "maxLength": 64
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 256
+        },
+        "avatar": { "type": "string" },
+        "indexedAt": {"type": "string", "format": "datetime"},
+        "viewer": {"type": "ref", "ref": "#viewerState"}
+      }
+    },
+    "profileViewDetailed": {
       "type": "object",
       "required": ["did", "handle"],
       "properties": {
@@ -36,25 +55,6 @@
         "followersCount": {"type": "integer"},
         "followsCount": {"type": "integer"},
         "postsCount": {"type": "integer"},
-        "indexedAt": {"type": "string", "format": "datetime"},
-        "viewer": {"type": "ref", "ref": "#viewerState"}
-      }
-    },
-    "profileViewBasic": {
-      "type": "object",
-      "required": ["did", "handle"],
-      "properties": {
-        "did": {"type": "string", "format":"did"},
-        "handle": {"type": "string", "format":"handle"},
-        "displayName": {
-          "type": "string",
-          "maxLength": 64
-        },
-        "description": {
-          "type": "string",
-          "maxLength": 256
-        },
-        "avatar": { "type": "string" },
         "indexedAt": {"type": "string", "format": "datetime"},
         "viewer": {"type": "ref", "ref": "#viewerState"}
       }

--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -13,7 +13,7 @@
       },
       "output": {
         "encoding": "application/json",
-        "schema": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
+        "schema": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewDetailed"}
       }
     }
   }

--- a/lexicons/app/bsky/actor/getProfiles.json
+++ b/lexicons/app/bsky/actor/getProfiles.json
@@ -23,7 +23,7 @@
           "properties": {
             "profiles": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewDetailed"}
             }
           }
         }

--- a/lexicons/app/bsky/actor/getSuggestions.json
+++ b/lexicons/app/bsky/actor/getSuggestions.json
@@ -21,7 +21,7 @@
             "cursor": {"type": "string"},
             "actors": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/actor/searchActors.json
+++ b/lexicons/app/bsky/actor/searchActors.json
@@ -22,7 +22,7 @@
             "cursor": {"type": "string"},
             "actors": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/actor/searchActorsTypeahead.json
+++ b/lexicons/app/bsky/actor/searchActorsTypeahead.json
@@ -20,7 +20,7 @@
           "properties": {
             "actors": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"}
             }
           }
         }

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -23,7 +23,7 @@
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "cid": {"type": "string", "format": "cid"},
-        "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+        "author": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"},
         "record": {"type": "unknown"},
         "embeds": {
           "type": "array",

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -8,7 +8,7 @@
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "cid": {"type": "string", "format": "cid"},
-        "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+        "author": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"},
         "record": {"type": "unknown"},
         "embed": {
           "type": "union",
@@ -53,7 +53,7 @@
       "type": "object",
       "required": ["by", "indexedAt"],
       "properties": {
-        "by": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+        "by": {"type": "ref", "ref": "app.bsky.actor.defs#profileViewBasic"},
         "indexedAt": {"type": "string", "format": "datetime"}
       }
     },

--- a/lexicons/app/bsky/feed/getLikes.json
+++ b/lexicons/app/bsky/feed/getLikes.json
@@ -37,7 +37,7 @@
       "properties": {
         "indexedAt": {"type": "string", "format": "datetime"},
         "createdAt": {"type": "string", "format": "datetime"},
-        "actor": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+        "actor": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
       }
     }
   }

--- a/lexicons/app/bsky/feed/getRepostedBy.json
+++ b/lexicons/app/bsky/feed/getRepostedBy.json
@@ -25,7 +25,7 @@
             "cursor": {"type": "string"},
             "repostedBy": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "followers"],
           "properties": {
-            "subject": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+            "subject": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"},
             "cursor": {"type": "string"},
             "followers": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -20,11 +20,11 @@
           "type": "object",
           "required": ["subject", "follows"],
           "properties": {
-            "subject": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+            "subject": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"},
             "cursor": {"type": "string"},
             "follows": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/graph/getMutes.json
+++ b/lexicons/app/bsky/graph/getMutes.json
@@ -21,7 +21,7 @@
             "cursor": {"type": "string"},
             "mutes": {
               "type": "array",
-              "items": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"}
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
             }
           }
         }

--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -32,7 +32,7 @@
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "cid": {"type": "string", "format": "cid" },
-        "author": {"type": "ref", "ref": "app.bsky.actor.defs#withInfo"},
+        "author": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"},
         "reason": {
           "type": "string",
           "description": "Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'.",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2433,7 +2433,7 @@ export const schemaDict = {
     id: 'app.bsky.actor.defs',
     description: 'A reference to an actor in the network.',
     defs: {
-      withInfo: {
+      profileViewBasic: {
         type: 'object',
         required: ['did', 'handle'],
         properties: {
@@ -2481,18 +2481,6 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
-          banner: {
-            type: 'string',
-          },
-          followersCount: {
-            type: 'integer',
-          },
-          followsCount: {
-            type: 'integer',
-          },
-          postsCount: {
-            type: 'integer',
-          },
           indexedAt: {
             type: 'string',
             format: 'datetime',
@@ -2503,7 +2491,7 @@ export const schemaDict = {
           },
         },
       },
-      profileViewBasic: {
+      profileViewDetailed: {
         type: 'object',
         required: ['did', 'handle'],
         properties: {
@@ -2525,6 +2513,18 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          banner: {
+            type: 'string',
+          },
+          followersCount: {
+            type: 'integer',
+          },
+          followsCount: {
+            type: 'integer',
+          },
+          postsCount: {
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2574,7 +2574,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#profileView',
+            ref: 'lex:app.bsky.actor.defs#profileViewDetailed',
           },
         },
       },
@@ -2610,7 +2610,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileView',
+                  ref: 'lex:app.bsky.actor.defs#profileViewDetailed',
                 },
               },
             },
@@ -2654,7 +2654,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -2733,7 +2733,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -2773,7 +2773,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
                 },
               },
             },
@@ -2957,7 +2957,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           record: {
             type: 'unknown',
@@ -3009,7 +3009,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           record: {
             type: 'unknown',
@@ -3092,7 +3092,7 @@ export const schemaDict = {
         properties: {
           by: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           indexedAt: {
             type: 'string',
@@ -3262,7 +3262,7 @@ export const schemaDict = {
           },
           actor: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileView',
           },
         },
       },
@@ -3361,7 +3361,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3624,7 +3624,7 @@ export const schemaDict = {
             properties: {
               subject: {
                 type: 'ref',
-                ref: 'lex:app.bsky.actor.defs#withInfo',
+                ref: 'lex:app.bsky.actor.defs#profileView',
               },
               cursor: {
                 type: 'string',
@@ -3633,7 +3633,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3676,7 +3676,7 @@ export const schemaDict = {
             properties: {
               subject: {
                 type: 'ref',
-                ref: 'lex:app.bsky.actor.defs#withInfo',
+                ref: 'lex:app.bsky.actor.defs#profileView',
               },
               cursor: {
                 type: 'string',
@@ -3685,7 +3685,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3728,7 +3728,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3866,7 +3866,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileView',
           },
           reason: {
             type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -6,7 +6,7 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
 
-export interface WithInfo {
+export interface ProfileViewBasic {
   did: string
   handle: string
   displayName?: string
@@ -15,16 +15,16 @@ export interface WithInfo {
   [k: string]: unknown
 }
 
-export function isWithInfo(v: unknown): v is WithInfo {
+export function isProfileViewBasic(v: unknown): v is ProfileViewBasic {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#withInfo'
+    v.$type === 'app.bsky.actor.defs#profileViewBasic'
   )
 }
 
-export function validateWithInfo(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#withInfo', v)
+export function validateProfileViewBasic(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#profileViewBasic', v)
 }
 
 export interface ProfileView {
@@ -33,10 +33,6 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
-  banner?: string
-  followersCount?: number
-  followsCount?: number
-  postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
   [k: string]: unknown
@@ -54,27 +50,31 @@ export function validateProfileView(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#profileView', v)
 }
 
-export interface ProfileViewBasic {
+export interface ProfileViewDetailed {
   did: string
   handle: string
   displayName?: string
   description?: string
   avatar?: string
+  banner?: string
+  followersCount?: number
+  followsCount?: number
+  postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
   [k: string]: unknown
 }
 
-export function isProfileViewBasic(v: unknown): v is ProfileViewBasic {
+export function isProfileViewDetailed(v: unknown): v is ProfileViewDetailed {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#profileViewBasic'
+    v.$type === 'app.bsky.actor.defs#profileViewDetailed'
   )
 }
 
-export function validateProfileViewBasic(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#profileViewBasic', v)
+export function validateProfileViewDetailed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#profileViewDetailed', v)
 }
 
 export interface ViewerState {

--- a/packages/api/src/client/types/app/bsky/actor/getProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfile.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
 }
 
 export type InputSchema = undefined
-export type OutputSchema = AppBskyActorDefs.ProfileView
+export type OutputSchema = AppBskyActorDefs.ProfileViewDetailed
 
 export interface CallOptions {
   headers?: Headers

--- a/packages/api/src/client/types/app/bsky/actor/getProfiles.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfiles.ts
@@ -15,7 +15,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  profiles: AppBskyActorDefs.ProfileView[]
+  profiles: AppBskyActorDefs.ProfileViewDetailed[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
@@ -17,7 +17,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.ProfileViewBasic[]
+  actors: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/actor/searchActors.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActors.ts
@@ -18,7 +18,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.ProfileViewBasic[]
+  actors: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -16,7 +16,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  actors: AppBskyActorDefs.WithInfo[]
+  actors: AppBskyActorDefs.ProfileViewBasic[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -46,7 +46,7 @@ export function validateView(v: unknown): ValidationResult {
 export interface ViewRecord {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileViewBasic
   record: {}
   embeds?: (
     | AppBskyEmbedImages.View

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -13,7 +13,7 @@ import * as AppBskyEmbedRecord from '../embed/record'
 export interface PostView {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileViewBasic
   record: {}
   embed?:
     | AppBskyEmbedImages.View
@@ -92,7 +92,7 @@ export function validateReplyRef(v: unknown): ValidationResult {
 }
 
 export interface ReasonRepost {
-  by: AppBskyActorDefs.WithInfo
+  by: AppBskyActorDefs.ProfileViewBasic
   indexedAt: string
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/app/bsky/feed/getLikes.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getLikes.ts
@@ -44,7 +44,7 @@ export function toKnownErr(e: any) {
 export interface Like {
   indexedAt: string
   createdAt: string
-  actor: AppBskyActorDefs.WithInfo
+  actor: AppBskyActorDefs.ProfileView
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
@@ -21,7 +21,7 @@ export interface OutputSchema {
   uri: string
   cid?: string
   cursor?: string
-  repostedBy: AppBskyActorDefs.WithInfo[]
+  repostedBy: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
@@ -17,9 +17,9 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  subject: AppBskyActorDefs.WithInfo
+  subject: AppBskyActorDefs.ProfileView
   cursor?: string
-  followers: AppBskyActorDefs.WithInfo[]
+  followers: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/graph/getFollows.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollows.ts
@@ -17,9 +17,9 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  subject: AppBskyActorDefs.WithInfo
+  subject: AppBskyActorDefs.ProfileView
   cursor?: string
-  follows: AppBskyActorDefs.WithInfo[]
+  follows: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/graph/getMutes.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMutes.ts
@@ -17,7 +17,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  mutes: AppBskyActorDefs.WithInfo[]
+  mutes: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -40,7 +40,7 @@ export function toKnownErr(e: any) {
 export interface Notification {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileView
   /** Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'. */
   reason:
     | 'like'

--- a/packages/pds/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMutes.ts
@@ -40,7 +40,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           cursor: keyset.packFromResult(mutesRes),
-          mutes: await actorService.views.actorWithInfo(mutesRes, requester),
+          mutes: await actorService.views.profile(mutesRes, requester),
         },
       }
     },

--- a/packages/pds/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/api/app/bsky/notification/listNotifications.ts
@@ -76,7 +76,7 @@ export default function (server: Server, ctx: AppContext) {
 
       // @NOTE calling into app-view, will eventually be replaced
       const actorService = ctx.services.appView.actor(ctx.db)
-      const authors = await actorService.views.actorWithInfo(
+      const authors = await actorService.views.profile(
         notifs.map((notif) => ({
           did: notif.authorDid,
           handle: notif.authorHandle,

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: await actorService.views.profile(actorRes, requester),
+        body: await actorService.views.profileDetailed(actorRes, requester),
       }
     },
   })

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
@@ -15,7 +15,10 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: {
-          profiles: await actorService.views.profile(actorsRes, requester),
+          profiles: await actorService.views.profileDetailed(
+            actorsRes,
+            requester,
+          ),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
@@ -60,7 +60,7 @@ export default function (server: Server, ctx: AppContext) {
           cursor: keyset.packFromResult(suggestionsRes),
           actors: await services.appView
             .actor(ctx.db)
-            .views.profileBasic(suggestionsRes, requester),
+            .views.profile(suggestionsRes, requester),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -45,7 +45,7 @@ export default function (server: Server, ctx: AppContext) {
           cursor: keyset.packFromResult(results),
           actors: await services.appView
             .actor(db)
-            .views.profileBasic(results, requester),
+            .views.profile(results, requester),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
         body: {
           actors: await services.appView
             .actor(db)
-            .views.actorWithInfo(results, requester),
+            .views.profileBasic(results, requester),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -43,7 +43,7 @@ export default function (server: Server, ctx: AppContext) {
       const likesRes = await builder.execute()
       const actors = await services.appView
         .actor(db)
-        .views.actorWithInfo(likesRes, requester)
+        .views.profile(likesRes, requester)
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -42,7 +42,7 @@ export default function (server: Server, ctx: AppContext) {
       const repostedByRes = await builder.execute()
       const repostedBy = await services.appView
         .actor(db)
-        .views.actorWithInfo(repostedByRes, requester)
+        .views.profile(repostedByRes, requester)
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -45,8 +45,8 @@ export default function (server: Server, ctx: AppContext) {
 
       const followersRes = await followersReq.execute()
       const [followers, subject] = await Promise.all([
-        actorService.views.actorWithInfo(followersRes, requester),
-        actorService.views.actorWithInfo(subjectRes, requester),
+        actorService.views.profile(followersRes, requester),
+        actorService.views.profile(subjectRes, requester),
       ])
 
       return {

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -45,8 +45,8 @@ export default function (server: Server, ctx: AppContext) {
 
       const followsRes = await followsReq.execute()
       const [follows, subject] = await Promise.all([
-        actorService.views.actorWithInfo(followsRes, requester),
-        actorService.views.actorWithInfo(creatorRes, requester),
+        actorService.views.profile(followsRes, requester),
+        actorService.views.profile(creatorRes, requester),
       ])
 
       return {

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -1,6 +1,6 @@
 import { ArrayEl } from '@atproto/common'
-import { WithInfo as ActorWithInfo } from '../../../lexicon/types/app/bsky/actor/defs'
 import {
+  ProfileViewDetailed,
   ProfileView,
   ProfileViewBasic,
 } from '../../../lexicon/types/app/bsky/actor/defs'
@@ -12,12 +12,18 @@ import { ImageUriBuilder } from '../../../image/uri'
 export class ActorViews {
   constructor(private db: Database, private imgUriBuilder: ImageUriBuilder) {}
 
-  profile(result: ActorResult, viewer: string): Promise<ProfileView>
-  profile(result: ActorResult[], viewer: string): Promise<ProfileView[]>
-  async profile(
+  profileDetailed(
+    result: ActorResult,
+    viewer: string,
+  ): Promise<ProfileViewDetailed>
+  profileDetailed(
+    result: ActorResult[],
+    viewer: string,
+  ): Promise<ProfileViewDetailed[]>
+  async profileDetailed(
     result: ActorResult | ActorResult[],
     viewer: string,
-  ): Promise<ProfileView | ProfileView[]> {
+  ): Promise<ProfileViewDetailed | ProfileViewDetailed[]> {
     const results = Array.isArray(result) ? result : [result]
     if (results.length === 0) return []
 
@@ -109,15 +115,12 @@ export class ActorViews {
     return Array.isArray(result) ? views : views[0]
   }
 
-  profileBasic(result: ActorResult, viewer: string): Promise<ProfileViewBasic>
-  profileBasic(
-    result: ActorResult[],
-    viewer: string,
-  ): Promise<ProfileViewBasic[]>
-  async profileBasic(
+  profile(result: ActorResult, viewer: string): Promise<ProfileView>
+  profile(result: ActorResult[], viewer: string): Promise<ProfileView[]>
+  async profile(
     result: ActorResult | ActorResult[],
     viewer: string,
-  ): Promise<ProfileViewBasic | ProfileViewBasic[]> {
+  ): Promise<ProfileView | ProfileView[]> {
     const results = Array.isArray(result) ? result : [result]
     if (results.length === 0) return []
 
@@ -187,16 +190,19 @@ export class ActorViews {
   }
 
   // @NOTE keep in sync with feedService.getActorViews()
-  actorWithInfo(result: ActorResult, viewer: string): Promise<ActorWithInfo>
-  actorWithInfo(result: ActorResult[], viewer: string): Promise<ActorWithInfo[]>
-  async actorWithInfo(
+  profileBasic(result: ActorResult, viewer: string): Promise<ProfileViewBasic>
+  profileBasic(
+    result: ActorResult[],
+    viewer: string,
+  ): Promise<ProfileViewBasic[]>
+  async profileBasic(
     result: ActorResult | ActorResult[],
     viewer: string,
-  ): Promise<ActorWithInfo | ActorWithInfo[]> {
+  ): Promise<ProfileViewBasic | ProfileViewBasic[]> {
     const results = Array.isArray(result) ? result : [result]
     if (results.length === 0) return []
 
-    const profiles = await this.profileBasic(results, viewer)
+    const profiles = await this.profile(results, viewer)
     const views = profiles.map((view) => ({
       did: view.did,
       handle: view.handle,

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -64,7 +64,7 @@ export class FeedService {
       ])
   }
 
-  // @NOTE keep in sync with actorService.views.actorWithInfo()
+  // @NOTE keep in sync with actorService.views.profile()
   async getActorViews(
     dids: string[],
     requester: string,

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2433,7 +2433,7 @@ export const schemaDict = {
     id: 'app.bsky.actor.defs',
     description: 'A reference to an actor in the network.',
     defs: {
-      withInfo: {
+      profileViewBasic: {
         type: 'object',
         required: ['did', 'handle'],
         properties: {
@@ -2481,18 +2481,6 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
-          banner: {
-            type: 'string',
-          },
-          followersCount: {
-            type: 'integer',
-          },
-          followsCount: {
-            type: 'integer',
-          },
-          postsCount: {
-            type: 'integer',
-          },
           indexedAt: {
             type: 'string',
             format: 'datetime',
@@ -2503,7 +2491,7 @@ export const schemaDict = {
           },
         },
       },
-      profileViewBasic: {
+      profileViewDetailed: {
         type: 'object',
         required: ['did', 'handle'],
         properties: {
@@ -2525,6 +2513,18 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          banner: {
+            type: 'string',
+          },
+          followersCount: {
+            type: 'integer',
+          },
+          followsCount: {
+            type: 'integer',
+          },
+          postsCount: {
+            type: 'integer',
           },
           indexedAt: {
             type: 'string',
@@ -2574,7 +2574,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#profileView',
+            ref: 'lex:app.bsky.actor.defs#profileViewDetailed',
           },
         },
       },
@@ -2610,7 +2610,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileView',
+                  ref: 'lex:app.bsky.actor.defs#profileViewDetailed',
                 },
               },
             },
@@ -2654,7 +2654,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -2733,7 +2733,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -2773,7 +2773,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileViewBasic',
                 },
               },
             },
@@ -2957,7 +2957,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           record: {
             type: 'unknown',
@@ -3009,7 +3009,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           record: {
             type: 'unknown',
@@ -3092,7 +3092,7 @@ export const schemaDict = {
         properties: {
           by: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
           },
           indexedAt: {
             type: 'string',
@@ -3262,7 +3262,7 @@ export const schemaDict = {
           },
           actor: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileView',
           },
         },
       },
@@ -3361,7 +3361,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3624,7 +3624,7 @@ export const schemaDict = {
             properties: {
               subject: {
                 type: 'ref',
-                ref: 'lex:app.bsky.actor.defs#withInfo',
+                ref: 'lex:app.bsky.actor.defs#profileView',
               },
               cursor: {
                 type: 'string',
@@ -3633,7 +3633,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3676,7 +3676,7 @@ export const schemaDict = {
             properties: {
               subject: {
                 type: 'ref',
-                ref: 'lex:app.bsky.actor.defs#withInfo',
+                ref: 'lex:app.bsky.actor.defs#profileView',
               },
               cursor: {
                 type: 'string',
@@ -3685,7 +3685,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3728,7 +3728,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#withInfo',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
             },
@@ -3866,7 +3866,7 @@ export const schemaDict = {
           },
           author: {
             type: 'ref',
-            ref: 'lex:app.bsky.actor.defs#withInfo',
+            ref: 'lex:app.bsky.actor.defs#profileView',
           },
           reason: {
             type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -6,7 +6,7 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 
-export interface WithInfo {
+export interface ProfileViewBasic {
   did: string
   handle: string
   displayName?: string
@@ -15,16 +15,16 @@ export interface WithInfo {
   [k: string]: unknown
 }
 
-export function isWithInfo(v: unknown): v is WithInfo {
+export function isProfileViewBasic(v: unknown): v is ProfileViewBasic {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#withInfo'
+    v.$type === 'app.bsky.actor.defs#profileViewBasic'
   )
 }
 
-export function validateWithInfo(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#withInfo', v)
+export function validateProfileViewBasic(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#profileViewBasic', v)
 }
 
 export interface ProfileView {
@@ -33,10 +33,6 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
-  banner?: string
-  followersCount?: number
-  followsCount?: number
-  postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
   [k: string]: unknown
@@ -54,27 +50,31 @@ export function validateProfileView(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#profileView', v)
 }
 
-export interface ProfileViewBasic {
+export interface ProfileViewDetailed {
   did: string
   handle: string
   displayName?: string
   description?: string
   avatar?: string
+  banner?: string
+  followersCount?: number
+  followsCount?: number
+  postsCount?: number
   indexedAt?: string
   viewer?: ViewerState
   [k: string]: unknown
 }
 
-export function isProfileViewBasic(v: unknown): v is ProfileViewBasic {
+export function isProfileViewDetailed(v: unknown): v is ProfileViewDetailed {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#profileViewBasic'
+    v.$type === 'app.bsky.actor.defs#profileViewDetailed'
   )
 }
 
-export function validateProfileViewBasic(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#profileViewBasic', v)
+export function validateProfileViewDetailed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#profileViewDetailed', v)
 }
 
 export interface ViewerState {

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -14,7 +14,7 @@ export interface QueryParams {
 }
 
 export type InputSchema = undefined
-export type OutputSchema = AppBskyActorDefs.ProfileView
+export type OutputSchema = AppBskyActorDefs.ProfileViewDetailed
 export type HandlerInput = undefined
 
 export interface HandlerSuccess {

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfiles.ts
@@ -16,7 +16,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  profiles: AppBskyActorDefs.ProfileView[]
+  profiles: AppBskyActorDefs.ProfileViewDetailed[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -18,7 +18,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.ProfileViewBasic[]
+  actors: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -19,7 +19,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.ProfileViewBasic[]
+  actors: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -17,7 +17,7 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  actors: AppBskyActorDefs.WithInfo[]
+  actors: AppBskyActorDefs.ProfileViewBasic[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
@@ -46,7 +46,7 @@ export function validateView(v: unknown): ValidationResult {
 export interface ViewRecord {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileViewBasic
   record: {}
   embeds?: (
     | AppBskyEmbedImages.View

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -13,7 +13,7 @@ import * as AppBskyEmbedRecord from '../embed/record'
 export interface PostView {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileViewBasic
   record: {}
   embed?:
     | AppBskyEmbedImages.View
@@ -92,7 +92,7 @@ export function validateReplyRef(v: unknown): ValidationResult {
 }
 
 export interface ReasonRepost {
-  by: AppBskyActorDefs.WithInfo
+  by: AppBskyActorDefs.ProfileViewBasic
   indexedAt: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -50,7 +50,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 export interface Like {
   indexedAt: string
   createdAt: string
-  actor: AppBskyActorDefs.WithInfo
+  actor: AppBskyActorDefs.ProfileView
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -22,7 +22,7 @@ export interface OutputSchema {
   uri: string
   cid?: string
   cursor?: string
-  repostedBy: AppBskyActorDefs.WithInfo[]
+  repostedBy: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -18,9 +18,9 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  subject: AppBskyActorDefs.WithInfo
+  subject: AppBskyActorDefs.ProfileView
   cursor?: string
-  followers: AppBskyActorDefs.WithInfo[]
+  followers: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -18,9 +18,9 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  subject: AppBskyActorDefs.WithInfo
+  subject: AppBskyActorDefs.ProfileView
   cursor?: string
-  follows: AppBskyActorDefs.WithInfo[]
+  follows: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -18,7 +18,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  mutes: AppBskyActorDefs.WithInfo[]
+  mutes: AppBskyActorDefs.ProfileView[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -46,7 +46,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 export interface Notification {
   uri: string
   cid: string
-  author: AppBskyActorDefs.WithInfo
+  author: AppBskyActorDefs.ProfileView
   /** Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'. */
   reason:
     | 'like'

--- a/packages/pds/tests/seeds/follows.ts
+++ b/packages/pds/tests/seeds/follows.ts
@@ -7,7 +7,7 @@ export default async (sc: SeedClient) => {
   await sc.createAccount('dan', users.dan)
   await sc.createAccount('eve', users.eve)
   for (const name in sc.dids) {
-    await sc.createProfile(sc.dids[name], '', '')
+    await sc.createProfile(sc.dids[name], `display-${name}`, `descript-${name}`)
   }
   const alice = sc.dids.alice
   const bob = sc.dids.bob

--- a/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
@@ -6,8 +6,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(1)",
         "following": "record(0)",
@@ -16,8 +19,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(2)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -26,8 +32,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(3)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -37,8 +46,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-alice",
     "did": "user(0)",
+    "displayName": "display-alice",
     "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": false,
     },
@@ -52,8 +64,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(1)",
         "following": "record(0)",
@@ -62,8 +77,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(2)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -72,8 +90,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(3)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -83,8 +104,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-alice",
     "did": "user(0)",
+    "displayName": "display-alice",
     "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": false,
     },
@@ -98,8 +122,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(1)",
         "following": "record(0)",
@@ -108,8 +135,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-dan",
       "did": "user(2)",
+      "displayName": "display-dan",
       "handle": "dan.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -118,8 +148,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(3)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -128,8 +161,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(4)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(7)",
         "following": "record(6)",
@@ -139,8 +175,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-alice",
     "did": "user(0)",
+    "displayName": "display-alice",
     "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": false,
     },
@@ -154,8 +193,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-dan",
       "did": "user(1)",
+      "displayName": "display-dan",
       "handle": "dan.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -164,8 +206,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(2)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -173,8 +218,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-bob",
     "did": "user(0)",
+    "displayName": "display-bob",
     "handle": "bob.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -190,8 +238,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -200,8 +251,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(2)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -210,8 +264,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(3)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -219,8 +276,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-carol",
     "did": "user(0)",
+    "displayName": "display-carol",
     "handle": "carol.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -236,8 +296,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(1)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -245,8 +308,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-dan",
     "did": "user(0)",
+    "displayName": "display-dan",
     "handle": "dan.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -262,8 +328,11 @@ Object {
   "followers": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-dan",
       "did": "user(1)",
+      "displayName": "display-dan",
       "handle": "dan.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -272,8 +341,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(2)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -281,8 +353,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-eve",
     "did": "user(0)",
+    "displayName": "display-eve",
     "handle": "eve.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -298,8 +373,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(1)",
         "following": "record(0)",
@@ -308,8 +386,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-dan",
       "did": "user(2)",
+      "displayName": "display-dan",
       "handle": "dan.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -318,8 +399,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(3)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -328,8 +412,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(4)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(7)",
         "following": "record(6)",
@@ -339,8 +426,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-alice",
     "did": "user(0)",
+    "displayName": "display-alice",
     "handle": "alice.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": false,
     },
@@ -354,8 +444,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(1)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -364,8 +457,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(2)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -373,8 +469,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-bob",
     "did": "user(0)",
+    "displayName": "display-bob",
     "handle": "bob.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -390,8 +489,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(1)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -399,8 +501,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-carol",
     "did": "user(0)",
+    "displayName": "display-carol",
     "handle": "carol.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -416,8 +521,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-eve",
       "did": "user(1)",
+      "displayName": "display-eve",
       "handle": "eve.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -426,8 +534,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-bob",
       "did": "user(2)",
+      "displayName": "display-bob",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -436,8 +547,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(3)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -445,8 +559,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-dan",
     "did": "user(0)",
+    "displayName": "display-dan",
     "handle": "dan.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",
@@ -462,8 +579,11 @@ Object {
   "follows": Array [
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-carol",
       "did": "user(1)",
+      "displayName": "display-carol",
       "handle": "carol.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(3)",
         "following": "record(2)",
@@ -472,8 +592,11 @@ Object {
     },
     Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "descript-alice",
       "did": "user(2)",
+      "displayName": "display-alice",
       "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "muted": false,
       },
@@ -481,8 +604,11 @@ Object {
   ],
   "subject": Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "descript-eve",
     "did": "user(0)",
+    "displayName": "display-eve",
     "handle": "eve.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(1)",
       "following": "record(0)",

--- a/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
@@ -43,9 +43,11 @@ Object {
     Object {
       "actor": Object {
         "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "description": "hi im bob",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
         "viewer": Object {
           "followedBy": "record(5)",
           "following": "record(4)",

--- a/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
@@ -7,6 +7,7 @@ Array [
     "did": "user(0)",
     "displayName": "Dr. Lowell DuBuque",
     "handle": "elta48.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": true,
     },
@@ -16,6 +17,7 @@ Array [
     "did": "user(1)",
     "displayName": "Sally Funk",
     "handle": "magnus53.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": true,
     },
@@ -32,6 +34,7 @@ Array [
     "did": "user(3)",
     "displayName": "Patrick Sawayn",
     "handle": "jeffrey-sawayn87.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": true,
     },
@@ -41,6 +44,7 @@ Array [
     "did": "user(4)",
     "displayName": "Kim Streich",
     "handle": "adrienne49.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": true,
     },
@@ -50,6 +54,7 @@ Array [
     "did": "user(5)",
     "displayName": "Carlton Abernathy IV",
     "handle": "aliya-hodkiewicz.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "muted": true,
     },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -29,9 +29,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(1)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -153,9 +155,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(1)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -180,9 +184,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(1)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -207,9 +213,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(1)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(5)",
         "following": "record(4)",
@@ -312,9 +320,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(9)",
         "following": "record(8)",
@@ -436,9 +446,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(9)",
         "following": "record(8)",
@@ -463,9 +475,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(9)",
         "following": "record(8)",
@@ -490,9 +504,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(9)",
         "following": "record(8)",
@@ -627,9 +643,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -751,9 +769,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -778,9 +798,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -844,9 +866,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -981,9 +1005,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -1105,9 +1131,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -1132,9 +1160,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -1198,9 +1228,11 @@ Array [
   Object {
     "author": Object {
       "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "description": "hi im bob",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
       "viewer": Object {
         "followedBy": "record(10)",
         "following": "record(9)",
@@ -1272,9 +1304,11 @@ Object {
     Object {
       "author": Object {
         "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "description": "its me!",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
         "viewer": Object {
           "followedBy": "record(3)",
           "muted": false,
@@ -1302,9 +1336,11 @@ Object {
     Object {
       "author": Object {
         "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "description": "its me!",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
         "viewer": Object {
           "followedBy": "record(3)",
           "muted": false,

--- a/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
@@ -28,9 +28,11 @@ Array [
   },
   Object {
     "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+    "description": "hi im bob",
     "did": "user(3)",
     "displayName": "bobby",
     "handle": "bob.test",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
     "viewer": Object {
       "followedBy": "record(4)",
       "following": "record(3)",


### PR DESCRIPTION
This renames `actor.def#withInfo` & standardizes on 3 different profile view options:
- `#profileViewBasic`: previous `#withInfo`. used in feeds & search when we don't want to be too verbose
- `#profileView`: also includes description & indexedAt time. used in lists of accounts like `getLikes`, `getFollows`, etc
- `#profileViewDetailed`: full profile info. used in getProfile & getProfiles