### PR TITLE
Add exports to api package: blobref & lex/json converters

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -199,7 +199,7 @@ const agent = new AtpAgent({service: 'https://example.com'})
 
 ### Non-browser configuration
 
-In non-browser environments you'll need to specify a fetch polyfill.
+In non-browser environments you'll need to specify a fetch polyfill. [See the example react-native polyfill here.](./docs/rn-fetch-handler.ts)
 
 ```typescript
 import { BskyAgent } from '@atproto/api'

--- a/packages/api/docs/rn-fetch-handler.ts
+++ b/packages/api/docs/rn-fetch-handler.ts
@@ -1,0 +1,88 @@
+/**
+ * The following is the react-native fetch handler used currently in the bluesky app
+ * It's not our prettiest work, but it gets the job done
+ */
+
+import { BskyAgent, stringifyLex, jsonToLex } from '@atproto/api'
+import RNFS from 'react-native-fs'
+
+const GET_TIMEOUT = 15e3 // 15s
+const POST_TIMEOUT = 60e3 // 60s
+
+export function doPolyfill() {
+  BskyAgent.configure({ fetch: fetchHandler })
+}
+
+interface FetchHandlerResponse {
+  status: number
+  headers: Record<string, string>
+  body: ArrayBuffer | undefined
+}
+
+async function fetchHandler(
+  reqUri: string,
+  reqMethod: string,
+  reqHeaders: Record<string, string>,
+  reqBody: any,
+): Promise<FetchHandlerResponse> {
+  const reqMimeType = reqHeaders['Content-Type'] || reqHeaders['content-type']
+  if (reqMimeType && reqMimeType.startsWith('application/json')) {
+    reqBody = stringifyLex(reqBody)
+  } else if (
+    typeof reqBody === 'string' &&
+    (reqBody.startsWith('/') || reqBody.startsWith('file:'))
+  ) {
+    if (reqBody.endsWith('.jpeg') || reqBody.endsWith('.jpg')) {
+      // HACK
+      // React native has a bug that inflates the size of jpegs on upload
+      // we get around that by renaming the file ext to .bin
+      // see https://github.com/facebook/react-native/issues/27099
+      // -prf
+      const newPath = reqBody.replace(/\.jpe?g$/, '.bin')
+      await RNFS.moveFile(reqBody, newPath)
+      reqBody = newPath
+    }
+    // NOTE
+    // React native treats bodies with {uri: string} as file uploads to pull from cache
+    // -prf
+    reqBody = { uri: reqBody }
+  }
+
+  const controller = new AbortController()
+  const to = setTimeout(
+    () => controller.abort(),
+    reqMethod === 'post' ? POST_TIMEOUT : GET_TIMEOUT,
+  )
+
+  const res = await fetch(reqUri, {
+    method: reqMethod,
+    headers: reqHeaders,
+    body: reqBody,
+    signal: controller.signal,
+  })
+
+  const resStatus = res.status
+  const resHeaders: Record<string, string> = {}
+  res.headers.forEach((value: string, key: string) => {
+    resHeaders[key] = value
+  })
+  const resMimeType = resHeaders['Content-Type'] || resHeaders['content-type']
+  let resBody
+  if (resMimeType) {
+    if (resMimeType.startsWith('application/json')) {
+      resBody = jsonToLex(await res.json())
+    } else if (resMimeType.startsWith('text/')) {
+      resBody = await res.text()
+    } else {
+      throw new Error('TODO: non-textual response body')
+    }
+  }
+
+  clearTimeout(to)
+
+  return {
+    status: resStatus,
+    headers: resHeaders,
+    body: resBody,
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,11 @@
 export { AtUri } from '@atproto/uri'
+export {
+  BlobRef,
+  lexToJson,
+  stringifyLex,
+  jsonToLex,
+  jsonStringToLex,
+} from '@atproto/lexicon'
 export * from './types'
 export * from './client'
 export * from './agent'


### PR DESCRIPTION
These exports are needed for writing a custom fetch handler and generally if you're manipulating blob refs. I also updated the api docs for the other ~poor saps~ engineers using react native.