### PR TITLE
Lexicon: fix lingering references to recordRef

### DIFF
--- a/packages/common-web/src/async.ts
+++ b/packages/common-web/src/async.ts
@@ -74,6 +74,9 @@ export class AsyncBuffer<T> {
   private resolve: () => void
 
   constructor(public maxSize?: number) {
+    // Initializing to satisfy types/build, immediately reset by resetPromise()
+    this.promise = Promise.resolve()
+    this.resolve = () => null
     this.resetPromise()
   }
 

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -156,8 +156,9 @@ export async function generateMockSetup(env: DevEnv) {
         reasonType: picka([REASONSPAM, REASONOTHER]),
         reason: picka(["Didn't look right to me", undefined, undefined]),
         subject: {
-          $type: 'com.atproto.repo.recordRef',
+          $type: 'com.atproto.repo.strongRef',
           uri: post.uri,
+          cid: post.cid,
         },
       })
     }

--- a/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
@@ -45,7 +45,7 @@ export default function (server: Server, ctx: AppContext) {
 
         if (
           result.action === TAKEDOWN &&
-          result.subjectType === 'com.atproto.repo.recordRef' &&
+          result.subjectType === 'com.atproto.repo.strongRef' &&
           result.subjectUri
         ) {
           await moderationTxn.reverseTakedownRecord({

--- a/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
 
         if (
           result.action === TAKEDOWN &&
-          result.subjectType === 'com.atproto.repo.recordRef' &&
+          result.subjectType === 'com.atproto.repo.strongRef' &&
           result.subjectUri
         ) {
           await moderationTxn.takedownRecord({

--- a/packages/pds/src/api/com/atproto/moderation/util.ts
+++ b/packages/pds/src/api/com/atproto/moderation/util.ts
@@ -25,16 +25,15 @@ export const getSubject = (subject: SubjectInput) => {
     return { did: subject.did }
   }
   if (
-    subject.$type === 'com.atproto.repo.recordRef' &&
+    subject.$type === 'com.atproto.repo.strongRef' &&
     typeof subject.uri === 'string' &&
-    (subject.cid === undefined || typeof subject.cid === 'string')
+    typeof subject.cid === 'string'
   ) {
     return {
       uri: new AtUri(subject.uri),
-      cid: subject.cid ? parseCidParam(subject.cid) : undefined,
+      cid: parseCidParam(subject.cid),
     }
   }
-  console.log(subject)
   throw new InvalidRequestError('Invalid subject')
 }
 

--- a/packages/pds/src/db/tables/moderation.ts
+++ b/packages/pds/src/db/tables/moderation.ts
@@ -17,7 +17,7 @@ export const reportResolutionTableName = 'moderation_report_resolution'
 export interface ModerationAction {
   id: Generated<number>
   action: typeof TAKEDOWN | typeof FLAG | typeof ACKNOWLEDGE
-  subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.recordRef'
+  subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.strongRef'
   subjectDid: string
   subjectUri: string | null
   subjectCid: string | null
@@ -37,7 +37,7 @@ export interface ModerationActionSubjectBlob {
 
 export interface ModerationReport {
   id: Generated<number>
-  subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.recordRef'
+  subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.strongRef'
   subjectDid: string
   subjectUri: string | null
   subjectCid: string | null

--- a/packages/pds/src/services/moderation/index.ts
+++ b/packages/pds/src/services/moderation/index.ts
@@ -156,7 +156,7 @@ export class ModerationService {
         .where('subjectDid', '=', subject.did)
     } else if ('uri' in subject) {
       builder = builder
-        .where('subjectType', '=', 'com.atproto.repo.recordRef')
+        .where('subjectType', '=', 'com.atproto.repo.strongRef')
         .where('subjectUri', '=', subject.uri.toString())
     } else {
       const blobsForAction = this.db.db
@@ -175,7 +175,7 @@ export class ModerationService {
 
   async logAction(info: {
     action: ModerationActionRow['action']
-    subject: { did: string } | { uri: AtUri; cid?: CID }
+    subject: { did: string } | { uri: AtUri; cid: CID }
     subjectBlobCids?: CID[]
     reason: string
     createdBy: string
@@ -208,10 +208,10 @@ export class ModerationService {
     } else {
       const record = await this.services
         .record(this.db)
-        .getRecord(subject.uri, subject.cid?.toString() ?? null, true)
+        .getRecord(subject.uri, subject.cid.toString() ?? null, true)
       if (!record) throw new InvalidRequestError('Record not found')
       subjectInfo = {
-        subjectType: 'com.atproto.repo.recordRef',
+        subjectType: 'com.atproto.repo.strongRef',
         subjectDid: subject.uri.host,
         subjectUri: subject.uri.toString(),
         subjectCid: record.cid,
@@ -407,8 +407,8 @@ export class ModerationService {
         )
       }
       if (
-        action.subjectType === 'com.atproto.repo.recordRef' &&
-        report.subjectType === 'com.atproto.repo.recordRef' &&
+        action.subjectType === 'com.atproto.repo.strongRef' &&
+        report.subjectType === 'com.atproto.repo.strongRef' &&
         report.subjectUri !== action.subjectUri
       ) {
         // If report and action are both for a record, they must be for the same record
@@ -464,7 +464,7 @@ export class ModerationService {
         .getRecord(subject.uri, subject.cid?.toString() ?? null, true)
       if (!record) throw new InvalidRequestError('Record not found')
       subjectInfo = {
-        subjectType: 'com.atproto.repo.recordRef',
+        subjectType: 'com.atproto.repo.strongRef',
         subjectDid: subject.uri.host,
         subjectUri: subject.uri.toString(),
         subjectCid: record.cid,
@@ -499,7 +499,7 @@ export type SubjectInfo =
       subjectCid: null
     }
   | {
-      subjectType: 'com.atproto.repo.recordRef'
+      subjectType: 'com.atproto.repo.strongRef'
       subjectDid: string
       subjectUri: string
       subjectCid: string

--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -168,7 +168,7 @@ export class ModerationViews {
       this.db.db
         .selectFrom('moderation_action')
         .where('reversedAt', 'is', null)
-        .where('subjectType', '=', 'com.atproto.repo.recordRef')
+        .where('subjectType', '=', 'com.atproto.repo.strongRef')
         .where(
           'subjectUri',
           'in',
@@ -220,14 +220,14 @@ export class ModerationViews {
       this.record(result),
       this.db.db
         .selectFrom('moderation_report')
-        .where('subjectType', '=', 'com.atproto.repo.recordRef')
+        .where('subjectType', '=', 'com.atproto.repo.strongRef')
         .where('subjectUri', '=', result.uri)
         .orderBy('id', 'desc')
         .selectAll()
         .execute(),
       this.db.db
         .selectFrom('moderation_action')
-        .where('subjectType', '=', 'com.atproto.repo.recordRef')
+        .where('subjectType', '=', 'com.atproto.repo.strongRef')
         .where('subjectUri', '=', result.uri)
         .orderBy('id', 'desc')
         .selectAll()
@@ -462,7 +462,7 @@ export class ModerationViews {
       subject = await this.repo(repoResult)
       subject.$type = 'com.atproto.admin.repo#view'
     } else if (
-      result.subjectType === 'com.atproto.repo.recordRef' &&
+      result.subjectType === 'com.atproto.repo.strongRef' &&
       result.subjectUri !== null
     ) {
       const recordResult = await this.services

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -1106,8 +1106,9 @@ describe('crud operations', () => {
         {
           action: TAKEDOWN,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
-            uri: postUri.toString(),
+            $type: 'com.atproto.repo.strongRef',
+            uri: created.uri,
+            cid: created.cid,
           },
           createdBy: 'did:example:admin',
           reason: 'Y',

--- a/packages/pds/tests/moderation.test.ts
+++ b/packages/pds/tests/moderation.test.ts
@@ -96,8 +96,9 @@ describe('moderation', () => {
           {
             reasonType: REASONSPAM,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postA.uri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postA.uriStr,
+              cid: postA.cidStr,
             },
           },
           {
@@ -111,8 +112,8 @@ describe('moderation', () => {
             reasonType: REASONOTHER,
             reason: 'defamation',
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postB.uri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postB.uriStr,
               cid: postB.cidStr,
             },
           },
@@ -134,8 +135,9 @@ describe('moderation', () => {
         {
           reasonType: REASONSPAM,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: postUriBad.toString(),
+            cid: postA.cidStr,
           },
         },
         { headers: sc.getHeaders(sc.dids.alice), encoding: 'application/json' },
@@ -147,7 +149,7 @@ describe('moderation', () => {
           reasonType: REASONOTHER,
           reason: 'defamation',
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: postB.uri.toString(),
             cid: postA.cidStr, // bad cid
           },
@@ -181,8 +183,9 @@ describe('moderation', () => {
             reasonType: REASONOTHER,
             reason: 'defamation',
             subject: {
-              $type: 'com.atproto.repo.recordRef',
+              $type: 'com.atproto.repo.strongRef',
               uri: post.uri.toString(),
+              cid: post.cid.toString(),
             },
           },
           {
@@ -298,15 +301,16 @@ describe('moderation', () => {
     })
 
     it('does not resolve report for mismatching record.', async () => {
-      const postUri1 = sc.posts[sc.dids.alice][0].ref.uri
-      const postUri2 = sc.posts[sc.dids.bob][0].ref.uri
+      const postRef1 = sc.posts[sc.dids.alice][0].ref
+      const postRef2 = sc.posts[sc.dids.bob][0].ref
       const { data: report } =
         await agent.api.com.atproto.moderation.createReport(
           {
             reasonType: REASONSPAM,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri1.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef1.uriStr,
+              cid: postRef1.cidStr,
             },
           },
           {
@@ -319,8 +323,9 @@ describe('moderation', () => {
           {
             action: TAKEDOWN,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri2.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef2.uriStr,
+              cid: postRef2.cidStr,
             },
             createdBy: 'did:example:admin',
             reason: 'Y',
@@ -369,8 +374,9 @@ describe('moderation', () => {
           {
             action: FLAG,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
+              $type: 'com.atproto.repo.strongRef',
               uri: postRef1.uri.toString(),
+              cid: postRef1.cid.toString(),
             },
             createdBy: 'did:example:admin',
             reason: 'Y',
@@ -395,8 +401,9 @@ describe('moderation', () => {
           {
             action: ACKNOWLEDGE,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
+              $type: 'com.atproto.repo.strongRef',
               uri: postRef2.uri.toString(),
+              cid: postRef2.cid.toString(),
             },
             createdBy: 'did:example:admin',
             reason: 'Y',
@@ -442,14 +449,15 @@ describe('moderation', () => {
     })
 
     it('only allows record to have one current action.', async () => {
-      const postUri = sc.posts[sc.dids.alice][0].ref.uri
+      const postRef = sc.posts[sc.dids.alice][0].ref
       const { data: acknowledge } =
         await agent.api.com.atproto.admin.takeModerationAction(
           {
             action: ACKNOWLEDGE,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef.uriStr,
+              cid: postRef.cidStr,
             },
             createdBy: 'did:example:admin',
             reason: 'Y',
@@ -463,8 +471,9 @@ describe('moderation', () => {
         {
           action: FLAG,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
-            uri: postUri.toString(),
+            $type: 'com.atproto.repo.strongRef',
+            uri: postRef.uriStr,
+            cid: postRef.cidStr,
           },
           createdBy: 'did:example:admin',
           reason: 'Y',
@@ -495,8 +504,9 @@ describe('moderation', () => {
           {
             action: FLAG,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef.uriStr,
+              cid: postRef.cidStr,
             },
             createdBy: 'did:example:admin',
             reason: 'Y',
@@ -609,8 +619,9 @@ describe('moderation', () => {
           {
             action: ACKNOWLEDGE,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
+              $type: 'com.atproto.repo.strongRef',
               uri: postA.ref.uriStr,
+              cid: postA.ref.cidStr,
             },
             subjectBlobCids: [img.image.ref.toString()],
             createdBy: 'did:example:admin',
@@ -625,8 +636,9 @@ describe('moderation', () => {
         {
           action: FLAG,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: postB.ref.uriStr,
+            cid: postB.ref.cidStr,
           },
           subjectBlobCids: [img.image.ref.toString()],
           createdBy: 'did:example:admin',
@@ -657,8 +669,9 @@ describe('moderation', () => {
           {
             action: FLAG,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
+              $type: 'com.atproto.repo.strongRef',
               uri: postB.ref.uriStr,
+              cid: postB.ref.cidStr,
             },
             subjectBlobCids: [img.image.ref.toString()],
             createdBy: 'did:example:admin',
@@ -704,8 +717,9 @@ describe('moderation', () => {
         {
           action: TAKEDOWN,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: post.ref.uriStr,
+            cid: post.ref.cidStr,
           },
           subjectBlobCids: [blob.image.ref.toString()],
           createdBy: 'did:example:admin',

--- a/packages/pds/tests/views/admin/get-moderation-action.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-action.test.ts
@@ -44,8 +44,9 @@ describe('pds admin get moderation action view', () => {
       reasonType: REASONOTHER,
       reason: 'defamation',
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     const flagRepo = await sc.takeModerationAction({
@@ -58,8 +59,9 @@ describe('pds admin get moderation action view', () => {
     const takedownRecord = await sc.takeModerationAction({
       action: TAKEDOWN,
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     await sc.resolveReports({

--- a/packages/pds/tests/views/admin/get-moderation-actions.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-actions.test.ts
@@ -53,8 +53,9 @@ describe('pds admin get moderation actions view', () => {
         await sc.takeModerationAction({
           action: getAction(i),
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: post.ref.uriStr,
+            cid: post.ref.cidStr,
           },
         }),
       )
@@ -87,8 +88,9 @@ describe('pds admin get moderation actions view', () => {
         reportedBy: ab ? sc.dids.carol : sc.dids.alice,
         reasonType: ab ? REASONSPAM : REASONOTHER,
         subject: {
-          $type: 'com.atproto.repo.recordRef',
+          $type: 'com.atproto.repo.strongRef',
           uri: action.subject.uri,
+          cid: action.subject.cid,
         },
       })
       if (ab) {

--- a/packages/pds/tests/views/admin/get-moderation-report.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-report.test.ts
@@ -44,8 +44,9 @@ describe('pds admin get moderation action view', () => {
       reasonType: REASONOTHER,
       reason: 'defamation',
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     const flagRepo = await sc.takeModerationAction({
@@ -58,8 +59,9 @@ describe('pds admin get moderation action view', () => {
     const takedownRecord = await sc.takeModerationAction({
       action: TAKEDOWN,
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     await sc.resolveReports({

--- a/packages/pds/tests/views/admin/get-moderation-reports.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-reports.test.ts
@@ -54,8 +54,9 @@ describe('pds admin get moderation reports view', () => {
           reasonType: getReasonType(i),
           reportedBy: getReportedByDid(i),
           subject: {
-            $type: 'com.atproto.repo.recordRef',
+            $type: 'com.atproto.repo.strongRef',
             uri: post.ref.uriStr,
+            cid: post.ref.cidStr,
           },
         }),
       )
@@ -80,8 +81,9 @@ describe('pds admin get moderation reports view', () => {
       const action = await sc.takeModerationAction({
         action: getAction(i),
         subject: {
-          $type: 'com.atproto.repo.recordRef',
+          $type: 'com.atproto.repo.strongRef',
           uri: report.subject.uri,
+          cid: report.subject.cid,
         },
       })
       if (ab) {

--- a/packages/pds/tests/views/admin/get-record.test.ts
+++ b/packages/pds/tests/views/admin/get-record.test.ts
@@ -35,16 +35,18 @@ describe('pds admin get record view', () => {
     const acknowledge = await sc.takeModerationAction({
       action: ACKNOWLEDGE,
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     await sc.createReport({
       reportedBy: sc.dids.bob,
       reasonType: REASONSPAM,
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     await sc.createReport({
@@ -52,16 +54,18 @@ describe('pds admin get record view', () => {
       reasonType: REASONOTHER,
       reason: 'defamation',
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
     await sc.reverseModerationAction({ id: acknowledge.id })
     await sc.takeModerationAction({
       action: TAKEDOWN,
       subject: {
-        $type: 'com.atproto.repo.recordRef',
+        $type: 'com.atproto.repo.strongRef',
         uri: sc.posts[sc.dids.alice][0].ref.uriStr,
+        cid: sc.posts[sc.dids.alice][0].ref.cidStr,
       },
     })
   })

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -205,15 +205,16 @@ describe('pds author feed views', () => {
 
     expect(preBlock.feed.length).toBeGreaterThan(0)
 
-    const postUri = new AtUri(preBlock.feed[0].post.uri)
+    const post = preBlock.feed[0].post
 
     const { data: action } =
       await agent.api.com.atproto.admin.takeModerationAction(
         {
           action: TAKEDOWN,
           subject: {
-            $type: 'com.atproto.repo.recordRef',
-            uri: postUri.toString(),
+            $type: 'com.atproto.repo.strongRef',
+            uri: post.uri,
+            cid: post.cid,
           },
           createdBy: 'did:example:admin',
           reason: 'Y',
@@ -230,9 +231,7 @@ describe('pds author feed views', () => {
     )
 
     expect(postBlock.feed.length).toEqual(preBlock.feed.length - 1)
-    expect(postBlock.feed.map((item) => item.post.uri)).not.toContain(
-      postUri.toString(),
-    )
+    expect(postBlock.feed.map((item) => item.post.uri)).not.toContain(post.uri)
 
     // Cleanup
     await agent.api.com.atproto.admin.reverseModerationAction(

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -155,16 +155,17 @@ describe('pds notification views', () => {
   })
 
   it('fetches notifications omitting mentions and replies for taken-down posts', async () => {
-    const postUri1 = sc.replies[sc.dids.carol][0].ref.uri // Reply
-    const postUri2 = sc.posts[sc.dids.dan][1].ref.uri // Mention
+    const postRef1 = sc.replies[sc.dids.carol][0].ref // Reply
+    const postRef2 = sc.posts[sc.dids.dan][1].ref // Mention
     const actionResults = await Promise.all(
-      [postUri1, postUri2].map((postUri) =>
+      [postRef1, postRef2].map((postRef) =>
         agent.api.com.atproto.admin.takeModerationAction(
           {
             action: TAKEDOWN,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef.uriStr,
+              cid: postRef.cidStr,
             },
             createdBy: 'did:example:admin',
             reason: 'Y',

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -213,16 +213,17 @@ describe('timeline views', () => {
   })
 
   it('blocks posts, reposts, replies by record takedown.', async () => {
-    const postUri1 = sc.posts[dan][1].ref.uri // Repost
-    const postUri2 = sc.replies[bob][0].ref.uri // Post and reply parent
+    const postRef1 = sc.posts[dan][1].ref // Repost
+    const postRef2 = sc.replies[bob][0].ref // Post and reply parent
     const actionResults = await Promise.all(
-      [postUri1, postUri2].map((postUri) =>
+      [postRef1, postRef2].map((postRef) =>
         agent.api.com.atproto.admin.takeModerationAction(
           {
             action: TAKEDOWN,
             subject: {
-              $type: 'com.atproto.repo.recordRef',
-              uri: postUri.toString(),
+              $type: 'com.atproto.repo.strongRef',
+              uri: postRef.uriStr,
+              cid: postRef.cidStr,
             },
             createdBy: 'did:example:admin',
             reason: 'Y',


### PR DESCRIPTION
In the lex refactor's "big renaming" `com.atproto.repo.recordRef` was removed in favor of `strongRef`, but was still kicking around in the pds admin/moderation tooling.  This fixes that.  Also one tiny change to an unrelated utility to make some type checking happy.