### PR TITLE
Lexicon: facet features

### DIFF
--- a/lexicons/app/bsky/richtext/facet.json
+++ b/lexicons/app/bsky/richtext/facet.json
@@ -4,15 +4,18 @@
   "defs": {
     "main": {
       "type": "object",
-      "required": ["index", "value"],
+      "required": ["index", "features"],
       "properties": {
-        "index": {"type": "ref", "ref": "#textSlice"},
-        "value": {"type": "union", "refs": ["#mention", "#link"]}
+        "index": {"type": "ref", "ref": "#byteSlice"},
+        "features": {
+          "type": "array",
+          "items": {"type": "union", "refs": ["#mention", "#link"]}
+        }
       }
     },
     "mention": {
       "type": "object",
-      "description": "A facet value for actor mentions.",
+      "description": "A facet feature for actor mentions.",
       "required": ["did"],
       "properties": {
         "did": {"type": "string", "format": "did"}
@@ -20,19 +23,19 @@
     },
     "link": {
       "type": "object",
-      "description": "A facet value for links.",
+      "description": "A facet feature for links.",
       "required": ["uri"],
       "properties": {
         "uri": {"type": "string", "format": "uri"}
       }
     },
-    "textSlice": {
+    "byteSlice": {
       "type": "object",
       "description": "A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings.",
-      "required": ["start", "end"],
+      "required": ["byteStart", "byteEnd"],
       "properties": {
-        "start": {"type": "integer", "minimum": 0},
-        "end": {"type": "integer", "minimum": 0}
+        "byteStart": {"type": "integer", "minimum": 0},
+        "byteEnd": {"type": "integer", "minimum": 0}
       }
     }
   }

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -141,9 +141,9 @@ const postRecord = {
 let markdown = ''
 for (const segment of rt.segments()) {
   if (segment.isLink()) {
-    markdown += `[${segment.text}](${segment.facet?.value.uri})`
+    markdown += `[${segment.text}](${segment.link?.uri})`
   } else if (segment.isMention()) {
-    markdown += `[${segment.text}](https://my-bsky-app.com/user/${segment.facet?.value.did})`
+    markdown += `[${segment.text}](https://my-bsky-app.com/user/${segment.mention?.did})`
   } else {
     markdown += segment.text
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3969,24 +3969,27 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'object',
-        required: ['index', 'value'],
+        required: ['index', 'features'],
         properties: {
           index: {
             type: 'ref',
-            ref: 'lex:app.bsky.richtext.facet#textSlice',
+            ref: 'lex:app.bsky.richtext.facet#byteSlice',
           },
-          value: {
-            type: 'union',
-            refs: [
-              'lex:app.bsky.richtext.facet#mention',
-              'lex:app.bsky.richtext.facet#link',
-            ],
+          features: {
+            type: 'array',
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.richtext.facet#mention',
+                'lex:app.bsky.richtext.facet#link',
+              ],
+            },
           },
         },
       },
       mention: {
         type: 'object',
-        description: 'A facet value for actor mentions.',
+        description: 'A facet feature for actor mentions.',
         required: ['did'],
         properties: {
           did: {
@@ -3997,7 +4000,7 @@ export const schemaDict = {
       },
       link: {
         type: 'object',
-        description: 'A facet value for links.',
+        description: 'A facet feature for links.',
         required: ['uri'],
         properties: {
           uri: {
@@ -4006,17 +4009,17 @@ export const schemaDict = {
           },
         },
       },
-      textSlice: {
+      byteSlice: {
         type: 'object',
         description:
           'A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings.',
-        required: ['start', 'end'],
+        required: ['byteStart', 'byteEnd'],
         properties: {
-          start: {
+          byteStart: {
             type: 'integer',
             minimum: 0,
           },
-          end: {
+          byteEnd: {
             type: 'integer',
             minimum: 0,
           },

--- a/packages/api/src/client/types/app/bsky/richtext/facet.ts
+++ b/packages/api/src/client/types/app/bsky/richtext/facet.ts
@@ -7,8 +7,8 @@ import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
 
 export interface Main {
-  index: TextSlice
-  value: Mention | Link | { $type: string; [k: string]: unknown }
+  index: ByteSlice
+  features: (Mention | Link | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }
 
@@ -25,7 +25,7 @@ export function validateMain(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#main', v)
 }
 
-/** A facet value for actor mentions. */
+/** A facet feature for actor mentions. */
 export interface Mention {
   did: string
   [k: string]: unknown
@@ -43,7 +43,7 @@ export function validateMention(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#mention', v)
 }
 
-/** A facet value for links. */
+/** A facet feature for links. */
 export interface Link {
   uri: string
   [k: string]: unknown
@@ -62,20 +62,20 @@ export function validateLink(v: unknown): ValidationResult {
 }
 
 /** A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings. */
-export interface TextSlice {
-  start: number
-  end: number
+export interface ByteSlice {
+  byteStart: number
+  byteEnd: number
   [k: string]: unknown
 }
 
-export function isTextSlice(v: unknown): v is TextSlice {
+export function isByteSlice(v: unknown): v is ByteSlice {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.richtext.facet#textSlice'
+    v.$type === 'app.bsky.richtext.facet#byteSlice'
   )
 }
 
-export function validateTextSlice(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.richtext.facet#textSlice', v)
+export function validateByteSlice(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.richtext.facet#byteSlice', v)
 }

--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -19,13 +19,15 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
       facets.push({
         $type: 'app.bsky.richtext.facet',
         index: {
-          start: text.utf16IndexToUtf8Index(start),
-          end: text.utf16IndexToUtf8Index(start + match[3].length + 1),
+          byteStart: text.utf16IndexToUtf8Index(start),
+          byteEnd: text.utf16IndexToUtf8Index(start + match[3].length + 1),
         },
-        value: {
-          $type: 'app.bsky.richtext.facet#mention',
-          did: match[3], // must be resolved afterwards
-        },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#mention',
+            did: match[3], // must be resolved afterwards
+          },
+        ],
       })
     }
   }
@@ -55,13 +57,15 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
       }
       facets.push({
         index: {
-          start: text.utf16IndexToUtf8Index(index.start),
-          end: text.utf16IndexToUtf8Index(index.end),
+          byteStart: text.utf16IndexToUtf8Index(index.start),
+          byteEnd: text.utf16IndexToUtf8Index(index.end),
         },
-        value: {
-          type: 'app.bsky.richtext.facet#link',
-          uri,
-        },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#link',
+            uri,
+          },
+        ],
       })
     }
   }

--- a/packages/api/src/rich-text/unicode.ts
+++ b/packages/api/src/rich-text/unicode.ts
@@ -15,6 +15,7 @@ const decoder = new TextDecoder()
 export class UnicodeString {
   utf16: string
   utf8: Uint8Array
+  private _graphemeLen?: number | undefined
 
   constructor(utf16: string) {
     this.utf16 = utf16
@@ -26,7 +27,10 @@ export class UnicodeString {
   }
 
   get graphemeLength() {
-    return graphemeLen(this.utf16)
+    if (!this._graphemeLen) {
+      this._graphemeLen = graphemeLen(this.utf16)
+    }
+    return this._graphemeLen
   }
 
   slice(start?: number, end?: number): string {

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -214,8 +214,15 @@ function segmentToOutput(segment: RichTextSegment): string[] {
   if (segment.facet) {
     return [
       segment.text,
-      // @ts-ignore it's fine
-      segment.facet.value.did || segment.facet.value.uri,
+      segment.facet?.features.map((f) => {
+        if (f.did) {
+          return String(f.did)
+        }
+        if (f.uri) {
+          return String(f.uri)
+        }
+        return undefined
+      })?.[0] || '',
     ]
   }
   return [segment.text]

--- a/packages/api/tests/rich-text-sanitization.test.ts
+++ b/packages/api/tests/rich-text-sanitization.test.ts
@@ -115,10 +115,10 @@ describe('sanitizeRichText w/facets: cleanNewlines', () => {
     const input = new RichText({
       text: 'test\n\n\n\n\ntest\n\n\n\n\n\n\ntest\n\n\n\n\n\n\ntest\n\n\n\n\n\n\ntest',
       facets: [
-        { index: { start: 0, end: 13 }, value: { $type: '' } },
-        { index: { start: 13, end: 24 }, value: { $type: '' } },
-        { index: { start: 9, end: 15 }, value: { $type: '' } },
-        { index: { start: 4, end: 9 }, value: { $type: '' } },
+        { index: { byteStart: 0, byteEnd: 13 }, features: [{ $type: '' }] },
+        { index: { byteStart: 13, byteEnd: 24 }, features: [{ $type: '' }] },
+        { index: { byteStart: 9, byteEnd: 15 }, features: [{ $type: '' }] },
+        { index: { byteStart: 4, byteEnd: 9 }, features: [{ $type: '' }] },
       ],
     })
     const output = sanitizeRichText(input, { cleanNewlines: true })
@@ -157,9 +157,12 @@ describe('sanitizeRichText w/facets: cleanNewlines', () => {
     const makeFacet = (match: string) => {
       const i = str.utf16.indexOf(match, lastI)
       lastI = i + match.length
-      const start = str.utf16IndexToUtf8Index(i)
-      const end = start + new UnicodeString(match).length
-      return { index: { start, end }, value: { $type: '' } }
+      const byteStart = str.utf16IndexToUtf8Index(i)
+      const byteEnd = byteStart + new UnicodeString(match).length
+      return {
+        index: { byteStart, byteEnd },
+        features: [{ $type: '' }],
+      }
     }
 
     const input = new RichText({
@@ -204,5 +207,5 @@ function facetToStr(str: string, ent?: Facet) {
   if (!ent) {
     return ''
   }
-  return new UnicodeString(str).slice(ent.index.start, ent.index.end)
+  return new UnicodeString(str).slice(ent.index.byteStart, ent.index.byteEnd)
 }

--- a/packages/api/tests/rich-text.test.ts
+++ b/packages/api/tests/rich-text.test.ts
@@ -25,19 +25,23 @@ describe('RichText', () => {
     expect(rt.facets).toEqual([
       {
         $type: 'app.bsky.richtext.facet',
-        index: { start: 0, end: 1 },
-        value: {
-          $type: 'app.bsky.richtext.facet#link',
-          uri: 'https://example.com',
-        },
+        index: { byteStart: 0, byteEnd: 1 },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#link',
+            uri: 'https://example.com',
+          },
+        ],
       },
       {
         $type: 'app.bsky.richtext.facet',
-        index: { start: 1, end: 2 },
-        value: {
-          $type: 'app.bsky.richtext.facet#mention',
-          did: 'did:plc:1234',
-        },
+        index: { byteStart: 1, byteEnd: 2 },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#mention',
+            did: 'did:plc:1234',
+          },
+        ],
       },
     ])
   })
@@ -66,19 +70,23 @@ describe('RichText', () => {
     expect(rt.facets).toEqual([
       {
         $type: 'app.bsky.richtext.facet',
-        index: { start: 0, end: 25 },
-        value: {
-          $type: 'app.bsky.richtext.facet#link',
-          uri: 'https://example.com',
-        },
+        index: { byteStart: 0, byteEnd: 25 },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#link',
+            uri: 'https://example.com',
+          },
+        ],
       },
       {
         $type: 'app.bsky.richtext.facet',
-        index: { start: 25, end: 50 },
-        value: {
-          $type: 'app.bsky.richtext.facet#mention',
-          did: 'did:plc:1234',
-        },
+        index: { byteStart: 25, byteEnd: 50 },
+        features: [
+          {
+            $type: 'app.bsky.richtext.facet#mention',
+            did: 'did:plc:1234',
+          },
+        ],
       },
     ])
   })
@@ -105,18 +113,20 @@ describe('RichText', () => {
 describe('RichText#insert', () => {
   const input = new RichText({
     text: 'hello world',
-    facets: [{ index: { start: 2, end: 7 }, value: { $type: '' } }],
+    facets: [
+      { index: { byteStart: 2, byteEnd: 7 }, features: [{ $type: '' }] },
+    ],
   })
 
   it('correctly adjusts facets (scenario A - before)', () => {
     const output = input.clone().insert(0, 'test')
     expect(output.text).toEqual('testhello world')
-    expect(output.facets?.[0].index.start).toEqual(6)
-    expect(output.facets?.[0].index.end).toEqual(11)
+    expect(output.facets?.[0].index.byteStart).toEqual(6)
+    expect(output.facets?.[0].index.byteEnd).toEqual(11)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('llo w')
   })
@@ -124,12 +134,12 @@ describe('RichText#insert', () => {
   it('correctly adjusts facets (scenario B - inner)', () => {
     const output = input.clone().insert(4, 'test')
     expect(output.text).toEqual('helltesto world')
-    expect(output.facets?.[0].index.start).toEqual(2)
-    expect(output.facets?.[0].index.end).toEqual(11)
+    expect(output.facets?.[0].index.byteStart).toEqual(2)
+    expect(output.facets?.[0].index.byteEnd).toEqual(11)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('lltesto w')
   })
@@ -137,12 +147,12 @@ describe('RichText#insert', () => {
   it('correctly adjusts facets (scenario C - after)', () => {
     const output = input.clone().insert(8, 'test')
     expect(output.text).toEqual('hello wotestrld')
-    expect(output.facets?.[0].index.start).toEqual(2)
-    expect(output.facets?.[0].index.end).toEqual(7)
+    expect(output.facets?.[0].index.byteStart).toEqual(2)
+    expect(output.facets?.[0].index.byteEnd).toEqual(7)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('llo w')
   })
@@ -152,9 +162,9 @@ describe('RichText#insert w/fat unicode', () => {
   const input = new RichText({
     text: 'one👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧',
     facets: [
-      { index: { start: 0, end: 28 }, value: { $type: '' } },
-      { index: { start: 29, end: 57 }, value: { $type: '' } },
-      { index: { start: 58, end: 88 }, value: { $type: '' } },
+      { index: { byteStart: 0, byteEnd: 28 }, features: [{ $type: '' }] },
+      { index: { byteStart: 29, byteEnd: 57 }, features: [{ $type: '' }] },
+      { index: { byteStart: 58, byteEnd: 88 }, features: [{ $type: '' }] },
     ],
   })
 
@@ -163,20 +173,20 @@ describe('RichText#insert w/fat unicode', () => {
     expect(output.text).toEqual('testone👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('one👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[1].index.start,
-        output.facets?.[1].index.end,
+        output.facets?.[1].index.byteStart,
+        output.facets?.[1].index.byteEnd,
       ),
     ).toEqual('two👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[2].index.start,
-        output.facets?.[2].index.end,
+        output.facets?.[2].index.byteStart,
+        output.facets?.[2].index.byteEnd,
       ),
     ).toEqual('three👨‍👩‍👧‍👧')
   })
@@ -186,20 +196,20 @@ describe('RichText#insert w/fat unicode', () => {
     expect(output.text).toEqual('onetest👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('onetest👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[1].index.start,
-        output.facets?.[1].index.end,
+        output.facets?.[1].index.byteStart,
+        output.facets?.[1].index.byteEnd,
       ),
     ).toEqual('two👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[2].index.start,
-        output.facets?.[2].index.end,
+        output.facets?.[2].index.byteStart,
+        output.facets?.[2].index.byteEnd,
       ),
     ).toEqual('three👨‍👩‍👧‍👧')
   })
@@ -209,20 +219,20 @@ describe('RichText#insert w/fat unicode', () => {
     expect(output.text).toEqual('one👨‍👩‍👧‍👧test two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('one👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[1].index.start,
-        output.facets?.[1].index.end,
+        output.facets?.[1].index.byteStart,
+        output.facets?.[1].index.byteEnd,
       ),
     ).toEqual('two👨‍👩‍👧‍👧')
     expect(
       output.unicodeText.slice(
-        output.facets?.[2].index.start,
-        output.facets?.[2].index.end,
+        output.facets?.[2].index.byteStart,
+        output.facets?.[2].index.byteEnd,
       ),
     ).toEqual('three👨‍👩‍👧‍👧')
   })
@@ -231,7 +241,9 @@ describe('RichText#insert w/fat unicode', () => {
 describe('RichText#delete', () => {
   const input = new RichText({
     text: 'hello world',
-    facets: [{ index: { start: 2, end: 7 }, value: { $type: '' } }],
+    facets: [
+      { index: { byteStart: 2, byteEnd: 7 }, features: [{ $type: '' }] },
+    ],
   })
 
   it('correctly adjusts facets (scenario A - entirely outer)', () => {
@@ -243,12 +255,12 @@ describe('RichText#delete', () => {
   it('correctly adjusts facets (scenario B - entirely after)', () => {
     const output = input.clone().delete(7, 11)
     expect(output.text).toEqual('hello w')
-    expect(output.facets?.[0].index.start).toEqual(2)
-    expect(output.facets?.[0].index.end).toEqual(7)
+    expect(output.facets?.[0].index.byteStart).toEqual(2)
+    expect(output.facets?.[0].index.byteEnd).toEqual(7)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('llo w')
   })
@@ -256,12 +268,12 @@ describe('RichText#delete', () => {
   it('correctly adjusts facets (scenario C - partially after)', () => {
     const output = input.clone().delete(4, 11)
     expect(output.text).toEqual('hell')
-    expect(output.facets?.[0].index.start).toEqual(2)
-    expect(output.facets?.[0].index.end).toEqual(4)
+    expect(output.facets?.[0].index.byteStart).toEqual(2)
+    expect(output.facets?.[0].index.byteEnd).toEqual(4)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('ll')
   })
@@ -269,12 +281,12 @@ describe('RichText#delete', () => {
   it('correctly adjusts facets (scenario D - entirely inner)', () => {
     const output = input.clone().delete(3, 5)
     expect(output.text).toEqual('hel world')
-    expect(output.facets?.[0].index.start).toEqual(2)
-    expect(output.facets?.[0].index.end).toEqual(5)
+    expect(output.facets?.[0].index.byteStart).toEqual(2)
+    expect(output.facets?.[0].index.byteEnd).toEqual(5)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('l w')
   })
@@ -282,12 +294,12 @@ describe('RichText#delete', () => {
   it('correctly adjusts facets (scenario E - partially before)', () => {
     const output = input.clone().delete(1, 5)
     expect(output.text).toEqual('h world')
-    expect(output.facets?.[0].index.start).toEqual(1)
-    expect(output.facets?.[0].index.end).toEqual(3)
+    expect(output.facets?.[0].index.byteStart).toEqual(1)
+    expect(output.facets?.[0].index.byteEnd).toEqual(3)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual(' w')
   })
@@ -295,12 +307,12 @@ describe('RichText#delete', () => {
   it('correctly adjusts facets (scenario F - entirely before)', () => {
     const output = input.clone().delete(0, 2)
     expect(output.text).toEqual('llo world')
-    expect(output.facets?.[0].index.start).toEqual(0)
-    expect(output.facets?.[0].index.end).toEqual(5)
+    expect(output.facets?.[0].index.byteStart).toEqual(0)
+    expect(output.facets?.[0].index.byteEnd).toEqual(5)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('llo w')
   })
@@ -309,7 +321,9 @@ describe('RichText#delete', () => {
 describe('RichText#delete w/fat unicode', () => {
   const input = new RichText({
     text: 'one👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧',
-    facets: [{ index: { start: 29, end: 57 }, value: { $type: '' } }],
+    facets: [
+      { index: { byteStart: 29, byteEnd: 57 }, features: [{ $type: '' }] },
+    ],
   })
 
   it('correctly adjusts facets (scenario A - entirely outer)', () => {
@@ -321,12 +335,12 @@ describe('RichText#delete w/fat unicode', () => {
   it('correctly adjusts facets (scenario B - entirely after)', () => {
     const output = input.clone().delete(57, 88)
     expect(output.text).toEqual('one👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧')
-    expect(output.facets?.[0].index.start).toEqual(29)
-    expect(output.facets?.[0].index.end).toEqual(57)
+    expect(output.facets?.[0].index.byteStart).toEqual(29)
+    expect(output.facets?.[0].index.byteEnd).toEqual(57)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('two👨‍👩‍👧‍👧')
   })
@@ -334,12 +348,12 @@ describe('RichText#delete w/fat unicode', () => {
   it('correctly adjusts facets (scenario C - partially after)', () => {
     const output = input.clone().delete(31, 88)
     expect(output.text).toEqual('one👨‍👩‍👧‍👧 tw')
-    expect(output.facets?.[0].index.start).toEqual(29)
-    expect(output.facets?.[0].index.end).toEqual(31)
+    expect(output.facets?.[0].index.byteStart).toEqual(29)
+    expect(output.facets?.[0].index.byteEnd).toEqual(31)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('tw')
   })
@@ -347,12 +361,12 @@ describe('RichText#delete w/fat unicode', () => {
   it('correctly adjusts facets (scenario D - entirely inner)', () => {
     const output = input.clone().delete(30, 32)
     expect(output.text).toEqual('one👨‍👩‍👧‍👧 t👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
-    expect(output.facets?.[0].index.start).toEqual(29)
-    expect(output.facets?.[0].index.end).toEqual(55)
+    expect(output.facets?.[0].index.byteStart).toEqual(29)
+    expect(output.facets?.[0].index.byteEnd).toEqual(55)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('t👨‍👩‍👧‍👧')
   })
@@ -360,12 +374,12 @@ describe('RichText#delete w/fat unicode', () => {
   it('correctly adjusts facets (scenario E - partially before)', () => {
     const output = input.clone().delete(28, 31)
     expect(output.text).toEqual('one👨‍👩‍👧‍👧o👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
-    expect(output.facets?.[0].index.start).toEqual(28)
-    expect(output.facets?.[0].index.end).toEqual(54)
+    expect(output.facets?.[0].index.byteStart).toEqual(28)
+    expect(output.facets?.[0].index.byteEnd).toEqual(54)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('o👨‍👩‍👧‍👧')
   })
@@ -373,12 +387,12 @@ describe('RichText#delete w/fat unicode', () => {
   it('correctly adjusts facets (scenario F - entirely before)', () => {
     const output = input.clone().delete(0, 2)
     expect(output.text).toEqual('e👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧')
-    expect(output.facets?.[0].index.start).toEqual(27)
-    expect(output.facets?.[0].index.end).toEqual(55)
+    expect(output.facets?.[0].index.byteStart).toEqual(27)
+    expect(output.facets?.[0].index.byteEnd).toEqual(55)
     expect(
       output.unicodeText.slice(
-        output.facets?.[0].index.start,
-        output.facets?.[0].index.end,
+        output.facets?.[0].index.byteStart,
+        output.facets?.[0].index.byteEnd,
       ),
     ).toEqual('two👨‍👩‍👧‍👧')
   })
@@ -398,27 +412,37 @@ describe('RichText#segments', () => {
   it('produces 3 segments with 1 entity in the middle', () => {
     const input = new RichText({
       text: 'one two three',
-      facets: [{ index: { start: 4, end: 7 }, value: { $type: '' } }],
+      facets: [
+        { index: { byteStart: 4, byteEnd: 7 }, features: [{ $type: '' }] },
+      ],
     })
     expect(Array.from(input.segments())).toEqual([
       { text: 'one ' },
       {
         text: 'two',
-        facet: { index: { start: 4, end: 7 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 4, byteEnd: 7 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' three' },
     ])
   })
 
-  it('produces 2 segments with 1 entity in the start', () => {
+  it('produces 2 segments with 1 entity in the byteStart', () => {
     const input = new RichText({
       text: 'one two three',
-      facets: [{ index: { start: 0, end: 7 }, value: { $type: '' } }],
+      facets: [
+        { index: { byteStart: 0, byteEnd: 7 }, features: [{ $type: '' }] },
+      ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one two',
-        facet: { index: { start: 0, end: 7 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 7 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' three' },
     ])
@@ -427,13 +451,18 @@ describe('RichText#segments', () => {
   it('produces 2 segments with 1 entity in the end', () => {
     const input = new RichText({
       text: 'one two three',
-      facets: [{ index: { start: 4, end: 13 }, value: { $type: '' } }],
+      facets: [
+        { index: { byteStart: 4, byteEnd: 13 }, features: [{ $type: '' }] },
+      ],
     })
     expect(Array.from(input.segments())).toEqual([
       { text: 'one ' },
       {
         text: 'two three',
-        facet: { index: { start: 4, end: 13 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 4, byteEnd: 13 },
+          features: [{ $type: '' }],
+        },
       },
     ])
   })
@@ -441,12 +470,17 @@ describe('RichText#segments', () => {
   it('produces 1 segments with 1 entity around the entire string', () => {
     const input = new RichText({
       text: 'one two three',
-      facets: [{ index: { start: 0, end: 13 }, value: { $type: '' } }],
+      facets: [
+        { index: { byteStart: 0, byteEnd: 13 }, features: [{ $type: '' }] },
+      ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one two three',
-        facet: { index: { start: 0, end: 13 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 13 },
+          features: [{ $type: '' }],
+        },
       },
     ])
   })
@@ -455,25 +489,34 @@ describe('RichText#segments', () => {
     const input = new RichText({
       text: 'one two three',
       facets: [
-        { index: { start: 0, end: 3 }, value: { $type: '' } },
-        { index: { start: 4, end: 7 }, value: { $type: '' } },
-        { index: { start: 8, end: 13 }, value: { $type: '' } },
+        { index: { byteStart: 0, byteEnd: 3 }, features: [{ $type: '' }] },
+        { index: { byteStart: 4, byteEnd: 7 }, features: [{ $type: '' }] },
+        { index: { byteStart: 8, byteEnd: 13 }, features: [{ $type: '' }] },
       ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one',
-        facet: { index: { start: 0, end: 3 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 3 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' ' },
       {
         text: 'two',
-        facet: { index: { start: 4, end: 7 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 4, byteEnd: 7 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' ' },
       {
         text: 'three',
-        facet: { index: { start: 8, end: 13 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 8, byteEnd: 13 },
+          features: [{ $type: '' }],
+        },
       },
     ])
   })
@@ -482,25 +525,34 @@ describe('RichText#segments', () => {
     const input = new RichText({
       text: 'one👨‍👩‍👧‍👧 two👨‍👩‍👧‍👧 three👨‍👩‍👧‍👧',
       facets: [
-        { index: { start: 0, end: 28 }, value: { $type: '' } },
-        { index: { start: 29, end: 57 }, value: { $type: '' } },
-        { index: { start: 58, end: 88 }, value: { $type: '' } },
+        { index: { byteStart: 0, byteEnd: 28 }, features: [{ $type: '' }] },
+        { index: { byteStart: 29, byteEnd: 57 }, features: [{ $type: '' }] },
+        { index: { byteStart: 58, byteEnd: 88 }, features: [{ $type: '' }] },
       ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one👨‍👩‍👧‍👧',
-        facet: { index: { start: 0, end: 28 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 28 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' ' },
       {
         text: 'two👨‍👩‍👧‍👧',
-        facet: { index: { start: 29, end: 57 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 29, byteEnd: 57 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' ' },
       {
         text: 'three👨‍👩‍👧‍👧',
-        facet: { index: { start: 58, end: 88 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 58, byteEnd: 88 },
+          features: [{ $type: '' }],
+        },
       },
     ])
   })
@@ -510,20 +562,27 @@ describe('RichText#segments', () => {
       text: 'one two three',
       facets: [
         {
-          index: { start: 0, end: 3 },
-          value: {
-            $type: 'app.bsky.richtext.facet#mention',
-            did: 'did:plc:123',
-          },
+          index: { byteStart: 0, byteEnd: 3 },
+          features: [
+            {
+              $type: 'app.bsky.richtext.facet#mention',
+              did: 'did:plc:123',
+            },
+          ],
         },
         {
-          index: { start: 4, end: 7 },
-          value: {
-            $type: 'app.bsky.richtext.facet#link',
-            uri: 'https://example.com',
-          },
+          index: { byteStart: 4, byteEnd: 7 },
+          features: [
+            {
+              $type: 'app.bsky.richtext.facet#link',
+              uri: 'https://example.com',
+            },
+          ],
         },
-        { index: { start: 8, end: 13 }, value: { $type: 'other' } },
+        {
+          index: { byteStart: 8, byteEnd: 13 },
+          features: [{ $type: 'other' }],
+        },
       ],
     })
     const segments = Array.from(input.segments())
@@ -543,22 +602,28 @@ describe('RichText#segments', () => {
     const input = new RichText({
       text: 'one two three',
       facets: [
-        { index: { start: 0, end: 3 }, value: { $type: '' } },
-        { index: { start: 2, end: 9 }, value: { $type: '' } },
-        { index: { start: 8, end: 13 }, value: { $type: '' } },
+        { index: { byteStart: 0, byteEnd: 3 }, features: [{ $type: '' }] },
+        { index: { byteStart: 2, byteEnd: 9 }, features: [{ $type: '' }] },
+        { index: { byteStart: 8, byteEnd: 13 }, features: [{ $type: '' }] },
       ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one',
-        facet: { index: { start: 0, end: 3 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 3 },
+          features: [{ $type: '' }],
+        },
       },
       {
         text: ' two ',
       },
       {
         text: 'three',
-        facet: { index: { start: 8, end: 13 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 8, byteEnd: 13 },
+          features: [{ $type: '' }],
+        },
       },
     ])
   })
@@ -567,20 +632,26 @@ describe('RichText#segments', () => {
     const input = new RichText({
       text: 'one two three',
       facets: [
-        { index: { start: 0, end: 3 }, value: { $type: '' } },
-        { index: { start: 4, end: 9 }, value: { $type: '' } },
-        { index: { start: 8, end: 13 }, value: { $type: '' } },
+        { index: { byteStart: 0, byteEnd: 3 }, features: [{ $type: '' }] },
+        { index: { byteStart: 4, byteEnd: 9 }, features: [{ $type: '' }] },
+        { index: { byteStart: 8, byteEnd: 13 }, features: [{ $type: '' }] },
       ],
     })
     expect(Array.from(input.segments())).toEqual([
       {
         text: 'one',
-        facet: { index: { start: 0, end: 3 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 0, byteEnd: 3 },
+          features: [{ $type: '' }],
+        },
       },
       { text: ' ' },
       {
         text: 'two t',
-        facet: { index: { start: 4, end: 9 }, value: { $type: '' } },
+        facet: {
+          index: { byteStart: 4, byteEnd: 9 },
+          features: [{ $type: '' }],
+        },
       },
       {
         text: 'hree',

--- a/packages/pds/src/app-view/services/indexing/plugins/post.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/post.ts
@@ -61,21 +61,23 @@ const insertFn = async (
   if (!insertedPost) {
     return null // Post already indexed
   }
-  const facets = (obj.facets || []).flatMap((facet) => {
-    if (isMention(facet.value)) {
-      return {
-        type: 'mention' as const,
-        value: facet.value.did,
+  const facets = (obj.facets || [])
+    .flatMap((facet) => facet.features)
+    .flatMap((feature) => {
+      if (isMention(feature)) {
+        return {
+          type: 'mention' as const,
+          value: feature.did,
+        }
       }
-    }
-    if (isLink(facet.value)) {
-      return {
-        type: 'link' as const,
-        value: facet.value.uri,
+      if (isLink(feature)) {
+        return {
+          type: 'link' as const,
+          value: feature.uri,
+        }
       }
-    }
-    return []
-  })
+      return []
+    })
   // Embed indices
   const embeds: (PostEmbedImage[] | PostEmbedExternal | PostEmbedRecord)[] = []
   const postEmbeds = separateEmbeds(obj.embed)

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3969,24 +3969,27 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'object',
-        required: ['index', 'value'],
+        required: ['index', 'features'],
         properties: {
           index: {
             type: 'ref',
-            ref: 'lex:app.bsky.richtext.facet#textSlice',
+            ref: 'lex:app.bsky.richtext.facet#byteSlice',
           },
-          value: {
-            type: 'union',
-            refs: [
-              'lex:app.bsky.richtext.facet#mention',
-              'lex:app.bsky.richtext.facet#link',
-            ],
+          features: {
+            type: 'array',
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.richtext.facet#mention',
+                'lex:app.bsky.richtext.facet#link',
+              ],
+            },
           },
         },
       },
       mention: {
         type: 'object',
-        description: 'A facet value for actor mentions.',
+        description: 'A facet feature for actor mentions.',
         required: ['did'],
         properties: {
           did: {
@@ -3997,7 +4000,7 @@ export const schemaDict = {
       },
       link: {
         type: 'object',
-        description: 'A facet value for links.',
+        description: 'A facet feature for links.',
         required: ['uri'],
         properties: {
           uri: {
@@ -4006,17 +4009,17 @@ export const schemaDict = {
           },
         },
       },
-      textSlice: {
+      byteSlice: {
         type: 'object',
         description:
           'A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings.',
-        required: ['start', 'end'],
+        required: ['byteStart', 'byteEnd'],
         properties: {
-          start: {
+          byteStart: {
             type: 'integer',
             minimum: 0,
           },
-          end: {
+          byteEnd: {
             type: 'integer',
             minimum: 0,
           },

--- a/packages/pds/src/lexicon/types/app/bsky/richtext/facet.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/richtext/facet.ts
@@ -7,8 +7,8 @@ import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 
 export interface Main {
-  index: TextSlice
-  value: Mention | Link | { $type: string; [k: string]: unknown }
+  index: ByteSlice
+  features: (Mention | Link | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }
 
@@ -25,7 +25,7 @@ export function validateMain(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#main', v)
 }
 
-/** A facet value for actor mentions. */
+/** A facet feature for actor mentions. */
 export interface Mention {
   did: string
   [k: string]: unknown
@@ -43,7 +43,7 @@ export function validateMention(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#mention', v)
 }
 
-/** A facet value for links. */
+/** A facet feature for links. */
 export interface Link {
   uri: string
   [k: string]: unknown
@@ -62,20 +62,20 @@ export function validateLink(v: unknown): ValidationResult {
 }
 
 /** A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings. */
-export interface TextSlice {
-  start: number
-  end: number
+export interface ByteSlice {
+  byteStart: number
+  byteEnd: number
   [k: string]: unknown
 }
 
-export function isTextSlice(v: unknown): v is TextSlice {
+export function isByteSlice(v: unknown): v is ByteSlice {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.richtext.facet#textSlice'
+    v.$type === 'app.bsky.richtext.facet#byteSlice'
   )
 }
 
-export function validateTextSlice(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.richtext.facet#textSlice', v)
+export function validateByteSlice(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.richtext.facet#byteSlice', v)
 }

--- a/packages/pds/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/pds/tests/__snapshots__/indexing.test.ts.snap
@@ -22,13 +22,15 @@ Object {
         "createdAt": "1970-01-01T00:00:00.000Z",
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 9,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 9,
+              "byteStart": 0,
             },
           },
         ],
@@ -66,13 +68,15 @@ Object {
         "createdAt": "1970-01-01T00:00:00.000Z",
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 11,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 11,
+              "byteStart": 0,
             },
           },
         ],

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -167,13 +167,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -337,13 +339,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -943,13 +947,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(0)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],

--- a/packages/pds/tests/indexing.test.ts
+++ b/packages/pds/tests/indexing.test.ts
@@ -38,11 +38,13 @@ describe('indexing', () => {
         text: '@bob.test how are you?',
         facets: [
           {
-            index: { start: 0, end: 9 },
-            value: {
-              $type: `${ids.AppBskyRichtextFacet}#mention`,
-              did: sc.dids.bob,
-            },
+            index: { byteStart: 0, byteEnd: 9 },
+            features: [
+              {
+                $type: `${ids.AppBskyRichtextFacet}#mention`,
+                did: sc.dids.bob,
+              },
+            ],
           },
         ],
         createdAt,
@@ -58,11 +60,13 @@ describe('indexing', () => {
         text: '@carol.test how are you?',
         facets: [
           {
-            index: { start: 0, end: 11 },
-            value: {
-              $type: `${ids.AppBskyRichtextFacet}#mention`,
-              did: sc.dids.carol,
-            },
+            index: { byteStart: 0, byteEnd: 11 },
+            features: [
+              {
+                $type: `${ids.AppBskyRichtextFacet}#mention`,
+                did: sc.dids.carol,
+              },
+            ],
           },
         ],
         createdAt,

--- a/packages/pds/tests/seeds/basic.ts
+++ b/packages/pds/tests/seeds/basic.ts
@@ -43,11 +43,13 @@ export default async (sc: SeedClient, mq?: MessageQueue) => {
     posts.dan[1],
     [
       {
-        index: { start: 0, end: 18 },
-        value: {
-          $type: `${ids.AppBskyRichtextFacet}#mention`,
-          did: alice,
-        },
+        index: { byteStart: 0, byteEnd: 18 },
+        features: [
+          {
+            $type: `${ids.AppBskyRichtextFacet}#mention`,
+            did: alice,
+          },
+        ],
       },
     ],
     undefined,

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises'
 import AtpAgent from '@atproto/api'
+import { Main as Facet } from '@atproto/api/src/client/types/app/bsky/richtext/facet'
 import { InputSchema as TakeActionInput } from '@atproto/api/src/client/types/com/atproto/admin/takeModerationAction'
 import { InputSchema as CreateReportInput } from '@atproto/api/src/client/types/com/atproto/moderation/createReport'
 import { AtUri } from '@atproto/uri'
@@ -159,7 +160,7 @@ export class SeedClient {
   async post(
     by: string,
     text: string,
-    facets?: any,
+    facets?: Facet[],
     images?: ImageRef[],
     quote?: RecordRef,
   ) {
@@ -240,7 +241,7 @@ export class SeedClient {
     root: RecordRef,
     parent: RecordRef,
     text: string,
-    facets?: any,
+    facets?: Facet[],
     images?: ImageRef[],
   ) {
     const embed = images

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -223,13 +223,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(0)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],
@@ -608,13 +610,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -998,13 +1002,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -1169,13 +1175,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -1441,13 +1449,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(0)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -849,13 +849,15 @@ Array [
       },
       "facets": Array [
         Object {
+          "features": Array [
+            Object {
+              "$type": "app.bsky.richtext.facet#mention",
+              "did": "user(3)",
+            },
+          ],
           "index": Object {
-            "end": 18,
-            "start": 0,
-          },
-          "value": Object {
-            "$type": "app.bsky.richtext.facet#mention",
-            "did": "user(3)",
+            "byteEnd": 18,
+            "byteStart": 0,
           },
         },
       ],
@@ -1211,13 +1213,15 @@ Array [
       },
       "facets": Array [
         Object {
+          "features": Array [
+            Object {
+              "$type": "app.bsky.richtext.facet#mention",
+              "did": "user(3)",
+            },
+          ],
           "index": Object {
-            "end": 18,
-            "start": 0,
-          },
-          "value": Object {
-            "$type": "app.bsky.richtext.facet#mention",
-            "did": "user(3)",
+            "byteEnd": 18,
+            "byteStart": 0,
           },
         },
       ],

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -899,13 +899,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -1345,13 +1347,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(0)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],
@@ -1559,13 +1563,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -1889,13 +1895,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -2352,13 +2360,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(1)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(1)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],
@@ -2726,13 +2736,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(1)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(1)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -3071,13 +3083,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(1)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(1)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],
@@ -3577,13 +3591,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],
@@ -3907,13 +3923,15 @@ Array [
             },
             "facets": Array [
               Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
                 "index": Object {
-                  "end": 18,
-                  "start": 0,
-                },
-                "value": Object {
-                  "$type": "app.bsky.richtext.facet#mention",
-                  "did": "user(0)",
+                  "byteEnd": 18,
+                  "byteStart": 0,
                 },
               },
             ],
@@ -4094,13 +4112,15 @@ Array [
         },
         "facets": Array [
           Object {
+            "features": Array [
+              Object {
+                "$type": "app.bsky.richtext.facet#mention",
+                "did": "user(0)",
+              },
+            ],
             "index": Object {
-              "end": 18,
-              "start": 0,
-            },
-            "value": Object {
-              "$type": "app.bsky.richtext.facet#mention",
-              "did": "user(0)",
+              "byteEnd": 18,
+              "byteStart": 0,
             },
           },
         ],


### PR DESCRIPTION
Two changes to richtext facets:
 - Each facet can have multiple "features", rather than a single "value."
 - The slice within the facet now more clearly deals with utf8 bytes rather than e.g. javascript string indexes.