### PR TITLE
Lexicon: fix to presentation of admin repo/record views

### DIFF
--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -460,7 +460,7 @@ export class ModerationViews {
         )
       }
       subject = await this.repo(repoResult)
-      subject.$type = 'com.atproto.admin.repo#view'
+      subject.$type = 'com.atproto.admin.defs#repoView'
     } else if (
       result.subjectType === 'com.atproto.repo.strongRef' &&
       result.subjectUri !== null
@@ -474,7 +474,7 @@ export class ModerationViews {
         )
       }
       subject = await this.record(recordResult)
-      subject.$type = 'com.atproto.admin.record#view'
+      subject.$type = 'com.atproto.admin.defs#recordView'
     } else {
       throw new Error(`Bad subject data: (${result.id}) ${result.subjectType}`)
     }

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-action.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-action.test.ts.snap
@@ -26,7 +26,7 @@ Object {
     },
   ],
   "subject": Object {
-    "$type": "com.atproto.admin.record#view",
+    "$type": "com.atproto.admin.defs#recordView",
     "blobCids": Array [],
     "cid": "cids(0)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -115,7 +115,7 @@ Object {
     "reason": "X",
   },
   "subject": Object {
-    "$type": "com.atproto.admin.repo#view",
+    "$type": "com.atproto.admin.defs#repoView",
     "account": Object {
       "email": "alice@test.com",
     },

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-report.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-report.test.ts.snap
@@ -47,7 +47,7 @@ Object {
     },
   ],
   "subject": Object {
-    "$type": "com.atproto.admin.record#view",
+    "$type": "com.atproto.admin.defs#recordView",
     "blobCids": Array [],
     "cid": "cids(0)",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -121,7 +121,7 @@ Object {
     },
   ],
   "subject": Object {
-    "$type": "com.atproto.admin.repo#view",
+    "$type": "com.atproto.admin.defs#repoView",
     "account": Object {
       "email": "alice@test.com",
     },


### PR DESCRIPTION
A lingering two NSIDs from the "big renaming" needed to be updated in the admin repo and record views.