### PR TITLE
Lexicon: optimize lex de/serialization

### DIFF
--- a/packages/common-web/src/ipld.ts
+++ b/packages/common-web/src/ipld.ts
@@ -19,7 +19,7 @@ export type IpldValue =
   | { [key: string]: IpldValue }
 
 // @NOTE avoiding use of check.is() here only because it makes
-// these implementations slow, and they often live it hot paths.
+// these implementations slow, and they often live in hot paths.
 
 export const jsonToIpld = (val: JsonValue): IpldValue => {
   // walk arrays

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -17,7 +17,7 @@ export type LexValue =
 export type RepoRecord = Record<string, LexValue>
 
 // @NOTE avoiding use of check.is() here only because it makes
-// these implementations slow, and they often live it hot paths.
+// these implementations slow, and they often live in hot paths.
 
 export const lexToIpld = (val: LexValue): IpldValue => {
   // walk arrays

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -4,8 +4,8 @@ import {
   ipldToJson,
   jsonToIpld,
   JsonValue,
-  schema,
 } from '@atproto/common-web'
+import { CID } from 'multiformats/cid'
 import { BlobRef, jsonBlobRef } from './blob-refs'
 
 export type LexValue =
@@ -16,53 +16,64 @@ export type LexValue =
 
 export type RepoRecord = Record<string, LexValue>
 
+// @NOTE avoiding use of check.is() here only because it makes
+// these implementations slow, and they often live it hot paths.
+
 export const lexToIpld = (val: LexValue): IpldValue => {
-  // convert blobs, leaving the original encoding so that we don't change CIDs on re-encode
-  if (val instanceof BlobRef) {
-    return val.original
-  }
-  // retain cids & bytes
-  if (check.is(val, schema.cid) || check.is(val, schema.bytes)) {
-    return val
-  }
-  // walk rest
-  if (check.is(val, schema.array)) {
+  // walk arrays
+  if (Array.isArray(val)) {
     return val.map((item) => lexToIpld(item))
   }
-  if (check.is(val, schema.map)) {
+  // objects
+  if (val && typeof val === 'object') {
+    // convert blobs, leaving the original encoding so that we don't change CIDs on re-encode
+    if (val instanceof BlobRef) {
+      return val.original
+    }
+    // retain cids & bytes
+    if (CID.asCID(val) || val instanceof Uint8Array) {
+      return val
+    }
+    // walk plain objects
     const toReturn = {}
     for (const key of Object.keys(val)) {
       toReturn[key] = lexToIpld(val[key])
     }
     return toReturn
-  } else {
-    return val
   }
+  // pass through
+  return val
 }
 
 export const ipldToLex = (val: IpldValue): LexValue => {
-  // convert blobs
-  if (check.is(val, jsonBlobRef)) {
-    return BlobRef.fromJsonRef(val)
-  }
-  // retain cids & bytes
-  if (check.is(val, schema.cid) || check.is(val, schema.bytes)) {
-    return val
-  }
-  // walk rest
-  if (check.is(val, schema.array)) {
+  // map arrays
+  if (Array.isArray(val)) {
     return val.map((item) => ipldToLex(item))
   }
-  if (check.is(val, schema.map)) {
+  // objects
+  if (val && typeof val === 'object') {
+    // convert blobs, using hints to avoid expensive is() check
+    if (
+      (val['$type'] === 'blob' ||
+        (typeof val['cid'] === 'string' &&
+          typeof val['mimeType'] === 'string')) &&
+      check.is(val, jsonBlobRef)
+    ) {
+      return BlobRef.fromJsonRef(val)
+    }
+    // retain cids, bytes
+    if (CID.asCID(val) || val instanceof Uint8Array) {
+      return val
+    }
+    // map plain objects
     const toReturn = {}
     for (const key of Object.keys(val)) {
       toReturn[key] = ipldToLex(val[key])
     }
     return toReturn
   }
-  {
-    return val
-  }
+  // pass through
+  return val
 }
 
 export const lexToJson = (val: LexValue): JsonValue => {


### PR DESCRIPTION
We were getting an unfriendly slowdown in the lex-refactor, and traced it down pretty exclusively to the new de/serialization processing.  By moving away from our `check.is()` system to simple checks wherever possible during de/serialization, we get a big speedup.