### PR TITLE
Lexicon: notification reason fix

### DIFF
--- a/packages/pds/src/app-migrations/like-follow-notifications.ts
+++ b/packages/pds/src/app-migrations/like-follow-notifications.ts
@@ -46,7 +46,9 @@ async function main(tx: Database, _ctx: AppContext) {
   // Update uris for votes in notifications to likes
   const updatedLikeUris = await tx.db
     .updateTable('user_notification')
+    .where('reason', '=', 'vote')
     .set({
+      reason: 'like',
       recordUri: sql`replace("recordUri", ${`/${VOTE_LEX_ID}/`}, ${`/${ids.AppBskyFeedLike}/`})`,
     })
     .executeTakeFirst()


### PR DESCRIPTION
The app migration from #733 was intended to update the notification `reason` in addition to the record uris, for like notifications.