### PR TITLE
Use TypedArrays instead of ArrayBuffers with WebCrypto

### DIFF
--- a/packages/crypto/src/p256/keypair.ts
+++ b/packages/crypto/src/p256/keypair.ts
@@ -67,7 +67,7 @@ export class EcdsaKeypair implements Keypair {
     const buf = await webcrypto.subtle.sign(
       { name: 'ECDSA', hash: { name: 'SHA-256' } },
       this.keypair.privateKey,
-      msg.buffer,
+      new Uint8Array(msg),
     )
     return new Uint8Array(buf)
   }

--- a/packages/crypto/src/p256/operations.ts
+++ b/packages/crypto/src/p256/operations.ts
@@ -46,8 +46,8 @@ export const verify = async (
   return webcrypto.subtle.verify(
     { name: 'ECDSA', hash: { name: 'SHA-256' } },
     importedKey,
-    sig,
-    data,
+    new Uint8Array(sig),
+    new Uint8Array(data),
   )
 }
 
@@ -56,7 +56,7 @@ export const importEcdsaPublicKey = async (
 ): Promise<CryptoKey> => {
   return webcrypto.subtle.importKey(
     'raw',
-    keyBytes,
+    new Uint8Array(keyBytes),
     { name: 'ECDSA', namedCurve: 'P-256' },
     true,
     ['verify'],

--- a/packages/crypto/tests/keypairs.test.ts
+++ b/packages/crypto/tests/keypairs.test.ts
@@ -2,13 +2,14 @@ import EcdsaKeypair from '../src/p256/keypair'
 import Secp256k1Keypair from '../src/secp256k1/keypair'
 import * as p256 from '../src/p256/operations'
 import * as secp from '../src/secp256k1/operations'
+import { randomBytes } from '../src'
 
-describe('exports and reimports keys', () => {
+describe('keypairs', () => {
   describe('secp256k1', () => {
     let keypair: Secp256k1Keypair
     let imported: Secp256k1Keypair
 
-    it('has the same DID', async () => {
+    it('has the same DID on import', async () => {
       keypair = await Secp256k1Keypair.create({ exportable: true })
       const exported = await keypair.export()
       imported = await Secp256k1Keypair.import(exported, { exportable: true })
@@ -24,13 +25,23 @@ describe('exports and reimports keys', () => {
 
       expect(validSig).toBeTruthy()
     })
+
+    it('produces a valid signature on a typed array of a large arraybuffer', async () => {
+      const bytes = await randomBytes(8192)
+      const arrBuf = bytes.buffer
+      const sliceView = new Uint8Array(arrBuf, 1024, 1024)
+      expect(sliceView.buffer.byteLength).toBe(8192)
+      const sig = await imported.sign(sliceView)
+      const validSig = await secp.verifyDidSig(keypair.did(), sliceView, sig)
+      expect(validSig).toBeTruthy()
+    })
   })
 
   describe('P-256', () => {
     let keypair: EcdsaKeypair
     let imported: EcdsaKeypair
 
-    it('has the same DID', async () => {
+    it('has the same DID on import', async () => {
       keypair = await EcdsaKeypair.create({ exportable: true })
       const exported = await keypair.export()
       imported = await EcdsaKeypair.import(exported, { exportable: true })
@@ -44,6 +55,16 @@ describe('exports and reimports keys', () => {
 
       const validSig = await p256.verifyDidSig(keypair.did(), data, sig)
 
+      expect(validSig).toBeTruthy()
+    })
+
+    it('produces a valid signature on a typed array of a large arraybuffer', async () => {
+      const bytes = await randomBytes(8192)
+      const arrBuf = bytes.buffer
+      const sliceView = new Uint8Array(arrBuf, 1024, 1024)
+      expect(sliceView.buffer.byteLength).toBe(8192)
+      const sig = await imported.sign(sliceView)
+      const validSig = await p256.verifyDidSig(keypair.did(), sliceView, sig)
       expect(validSig).toBeTruthy()
     })
   })


### PR DESCRIPTION
The fundamental problem here that we were passing in an underlying ArrayBuffer from the cbor decoding library to webcrypto instead of the typed array.

For context: A TypedArray (Uint8Array or Buffer) in node is a _view_ into an underlying ArrayBuffer. The cbor encoding library must use ArrayBuffers under the hood & then pass back a slice of that ArrayBuffer as a Buffer. We then passed in the underlying ArrayBuffer which was larger than the actual data itself, thereby signing the wrong data.

The cbor decoding library would use an ArrayBuffer of size 128 as long as the data payload was <=128 & then 8kb if larger. A commit without a `prev` is <128 & a commit with a `prev` is > 128, thus why this was only happening on subsequent commits.

We were not running into this in the past because our commit objects were smaller (before the repov2 rewrite).

WebCrypto used to required ArrayBuffers to be passed in (it would not handle views), but it now allows either to be used. I thought I had updated all uses of this, but missed the one on `sign`. I've changed that to not pass in the underlying buffer,  wrapped every webcrypto input with `new UInt8Array` to ensure that we're not passing in any underlying arraybuffers and added some tests.

