### PR TITLE
Remove trailing replacement character when utf8-truncating

### DIFF
--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -96,8 +96,8 @@ export class ActorViews {
       return {
         did: result.did,
         handle: result.handle,
-        displayName: profileInfo?.displayName || undefined,
-        description: profileInfo?.description || undefined,
+        displayName: truncateUtf8(profileInfo?.displayName, 64) || undefined,
+        description: truncateUtf8(profileInfo?.description, 256) || undefined,
         avatar,
         banner,
         followsCount: profileInfo?.followsCount ?? 0,
@@ -174,8 +174,8 @@ export class ActorViews {
       return {
         did: result.did,
         handle: result.handle,
-        displayName: profileInfo?.displayName || undefined,
-        description: profileInfo?.description || undefined,
+        displayName: truncateUtf8(profileInfo?.displayName, 64) || undefined,
+        description: truncateUtf8(profileInfo?.description, 256) || undefined,
         avatar,
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
@@ -206,7 +206,7 @@ export class ActorViews {
     const views = profiles.map((view) => ({
       did: view.did,
       handle: view.handle,
-      displayName: view.displayName,
+      displayName: truncateUtf8(view.displayName, 64) || undefined,
       avatar: view.avatar,
       viewer: view.viewer,
     }))
@@ -216,3 +216,12 @@ export class ActorViews {
 }
 
 type ActorResult = DidHandle
+
+function truncateUtf8(str: string | null | undefined, length: number) {
+  if (!str) return str
+  const encoder = new TextEncoder()
+  const decoder = new TextDecoder('utf-8', { fatal: false })
+  const utf8 = encoder.encode(str)
+  const truncated = utf8.length > length ? utf8.slice(0, length) : utf8
+  return decoder.decode(truncated)
+}

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -220,8 +220,11 @@ type ActorResult = DidHandle
 function truncateUtf8(str: string | null | undefined, length: number) {
   if (!str) return str
   const encoder = new TextEncoder()
-  const decoder = new TextDecoder('utf-8', { fatal: false })
   const utf8 = encoder.encode(str)
-  const truncated = utf8.length > length ? utf8.slice(0, length) : utf8
-  return decoder.decode(truncated)
+  if (utf8.length > length) {
+    const decoder = new TextDecoder('utf-8', { fatal: false })
+    const truncated = utf8.slice(0, length)
+    return decoder.decode(truncated).replace(/\uFFFD$/, '')
+  }
+  return str
 }

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -354,8 +354,11 @@ export class FeedService {
 function truncateUtf8(str: string | null | undefined, length: number) {
   if (!str) return str
   const encoder = new TextEncoder()
-  const decoder = new TextDecoder('utf-8', { fatal: false })
   const utf8 = encoder.encode(str)
-  const truncated = utf8.length > length ? utf8.slice(0, length) : utf8
-  return decoder.decode(truncated)
+  if (utf8.length > length) {
+    const decoder = new TextDecoder('utf-8', { fatal: false })
+    const truncated = utf8.slice(0, length)
+    return decoder.decode(truncated).replace(/\uFFFD$/, '')
+  }
+  return str
 }

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -109,7 +109,7 @@ export class FeedService {
         [cur.did]: {
           did: cur.did,
           handle: cur.handle,
-          displayName: cur.displayName || undefined,
+          displayName: truncateUtf8(cur.displayName, 64) || undefined,
           avatar: cur.avatarCid
             ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
             : undefined,
@@ -349,4 +349,13 @@ export class FeedService {
       },
     }
   }
+}
+
+function truncateUtf8(str: string | null | undefined, length: number) {
+  if (!str) return str
+  const encoder = new TextEncoder()
+  const decoder = new TextDecoder('utf-8', { fatal: false })
+  const utf8 = encoder.encode(str)
+  const truncated = utf8.length > length ? utf8.slice(0, length) : utf8
+  return decoder.decode(truncated)
 }


### PR DESCRIPTION
The trailing replacement character was allowing the output in certain cases to remain over the desired truncated length.