### PR TITLE
Update reason type in `feed.ts`

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/util/feed.ts
@@ -38,7 +38,7 @@ export const composeFeed = async (
     if (post && originator) {
       let reasonType: string | undefined
       if (row.type === 'repost') {
-        reasonType = 'app.bsky.feed.feedViewPost#reasonRepost'
+        reasonType = 'app.bsky.feed.defs#reasonRepost'
       }
       const replyParent = row.replyParent
         ? feedService.formatPostView(row.replyParent, actors, posts, embeds)

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -27,7 +27,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",
@@ -359,7 +359,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(2)",
         "handle": "carol.test",

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -632,7 +632,7 @@ Array [
       },
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(2)",
         "handle": "carol.test",
@@ -867,7 +867,7 @@ Array [
       },
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -326,7 +326,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",
@@ -759,7 +759,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",
@@ -919,7 +919,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(2)",
         "handle": "carol.test",
@@ -1915,7 +1915,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(2)",
         "handle": "carol.test",
@@ -2758,7 +2758,7 @@ Array [
       },
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(2)",
         "handle": "carol.test",
@@ -3312,7 +3312,7 @@ Array [
       },
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",
@@ -3690,7 +3690,7 @@ Array [
       "viewer": Object {},
     },
     "reason": Object {
-      "$type": "app.bsky.feed.feedViewPost#reasonRepost",
+      "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
         "did": "user(1)",
         "handle": "dan.test",


### PR DESCRIPTION
Missed a spot when refactoring feed definitions.
The old reference no longer exists.