### PR TITLE
Lexicon: remove float support

### DIFF
--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -73,7 +73,6 @@ export function genUserType(
     case 'bytes':
     case 'cid-link':
     case 'boolean':
-    case 'float':
     case 'integer':
     case 'string':
     case 'unknown':
@@ -504,7 +503,6 @@ export function primitiveToType(def: LexPrimitive): string {
         return JSON.stringify(def.const)
       }
       return 'string'
-    case 'float':
     case 'integer':
       if (def.enum) {
         return def.enum.map((v) => JSON.stringify(v)).join(' | ')

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -12,17 +12,6 @@ export const lexBoolean = z.object({
 })
 export type LexBoolean = z.infer<typeof lexBoolean>
 
-export const lexFloat = z.object({
-  type: z.literal('float'),
-  description: z.string().optional(),
-  default: z.number().optional(),
-  minimum: z.number().optional(),
-  maximum: z.number().optional(),
-  enum: z.number().array().optional(),
-  const: z.number().optional(),
-})
-export type LexFloat = z.infer<typeof lexFloat>
-
 export const lexInteger = z.object({
   type: z.literal('integer'),
   description: z.string().optional(),
@@ -69,7 +58,6 @@ export type LexUnknown = z.infer<typeof lexUnknown>
 
 export const lexPrimitive = z.union([
   lexBoolean,
-  lexFloat,
   lexInteger,
   lexString,
   lexUnknown,
@@ -255,7 +243,6 @@ export const lexUserType = z.union([
   lexObject,
 
   lexBoolean,
-  lexFloat,
   lexInteger,
   lexString,
   lexBytes,

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -20,8 +20,6 @@ export function validate(
   switch (def.type) {
     case 'boolean':
       return Primitives.boolean(lexicons, path, def, value)
-    case 'float':
-      return Primitives.float(lexicons, path, def, value)
     case 'integer':
       return Primitives.integer(lexicons, path, def, value)
     case 'string':

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -5,7 +5,6 @@ import * as formats from './formats'
 import {
   LexUserType,
   LexBoolean,
-  LexFloat,
   LexInteger,
   LexString,
   ValidationResult,
@@ -22,8 +21,6 @@ export function validate(
   switch (def.type) {
     case 'boolean':
       return boolean(lexicons, path, def, value)
-    case 'float':
-      return float(lexicons, path, def, value)
     case 'integer':
       return integer(lexicons, path, def, value)
     case 'string':
@@ -80,13 +77,13 @@ export function boolean(
   return { success: true, value }
 }
 
-export function float(
+export function integer(
   lexicons: Lexicons,
   path: string,
   def: LexUserType,
   value: unknown,
 ): ValidationResult {
-  def = def as LexFloat
+  def = def as LexInteger
 
   // type
   const type = typeof value
@@ -96,12 +93,12 @@ export function float(
     }
     return {
       success: false,
-      error: new ValidationError(`${path} must be a number`),
+      error: new ValidationError(`${path} must be an integer`),
     }
-  } else if (type !== 'number') {
+  } else if (!Number.isInteger(value)) {
     return {
       success: false,
-      error: new ValidationError(`${path} must be a number`),
+      error: new ValidationError(`${path} must be an integer`),
     }
   }
 
@@ -148,33 +145,6 @@ export function float(
           `${path} can not be less than ${def.minimum}`,
         ),
       }
-    }
-  }
-
-  return { success: true, value }
-}
-
-export function integer(
-  lexicons: Lexicons,
-  path: string,
-  def: LexUserType,
-  value: unknown,
-): ValidationResult {
-  def = def as LexInteger
-
-  // run number validation
-  const numRes = float(lexicons, path, def, value)
-  if (!numRes.success) {
-    return numRes
-  } else {
-    value = numRes.value
-  }
-
-  // whole numbers only
-  if (!Number.isInteger(value)) {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be an integer`),
     }
   }
 

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -13,7 +13,6 @@ export default [
             'object',
             'array',
             'boolean',
-            'float',
             'integer',
             'string',
             'bytes',
@@ -23,7 +22,6 @@ export default [
             object: { type: 'ref', ref: '#object' },
             array: { type: 'array', items: { type: 'string' } },
             boolean: { type: 'boolean' },
-            float: { type: 'float' },
             integer: { type: 'integer' },
             string: { type: 'string' },
             bytes: { type: 'bytes' },
@@ -33,12 +31,11 @@ export default [
       },
       object: {
         type: 'object',
-        required: ['object', 'array', 'boolean', 'float', 'integer', 'string'],
+        required: ['object', 'array', 'boolean', 'integer', 'string'],
         properties: {
           object: { type: 'ref', ref: '#subobject' },
           array: { type: 'array', items: { type: 'string' } },
           boolean: { type: 'boolean' },
-          float: { type: 'float' },
           integer: { type: 'integer' },
           string: { type: 'string' },
         },
@@ -61,10 +58,9 @@ export default [
         description: 'A query',
         parameters: {
           type: 'params',
-          required: ['boolean', 'float', 'integer'],
+          required: ['boolean', 'integer'],
           properties: {
             boolean: { type: 'boolean' },
-            float: { type: 'float' },
             integer: { type: 'integer' },
             string: { type: 'string' },
             array: { type: 'array', items: { type: 'string' } },
@@ -87,10 +83,9 @@ export default [
         description: 'A procedure',
         parameters: {
           type: 'params',
-          required: ['boolean', 'float', 'integer'],
+          required: ['boolean', 'integer'],
           properties: {
             boolean: { type: 'boolean' },
-            float: { type: 'float' },
             integer: { type: 'integer' },
             string: { type: 'string' },
             array: { type: 'array', items: { type: 'string' } },
@@ -119,7 +114,6 @@ export default [
             object: { type: 'ref', ref: 'com.example.kitchenSink#object' },
             array: { type: 'array', items: { type: 'string' } },
             boolean: { type: 'boolean' },
-            float: { type: 'float' },
             integer: { type: 'integer' },
             string: { type: 'string' },
           },
@@ -138,7 +132,6 @@ export default [
           required: ['boolean'],
           properties: {
             boolean: { type: 'boolean', default: false },
-            float: { type: 'float', default: 0 },
             integer: { type: 'integer', default: 0 },
             string: { type: 'string', default: '' },
             object: { type: 'ref', ref: '#object' },
@@ -149,7 +142,6 @@ export default [
         type: 'object',
         properties: {
           boolean: { type: 'boolean', default: true },
-          float: { type: 'float', default: 1.5 },
           integer: { type: 'integer', default: 1 },
           string: { type: 'string', default: 'x' },
         },
@@ -220,7 +212,7 @@ export default [
               type: 'array',
               minLength: 2,
               maxLength: 4,
-              items: { type: 'float' },
+              items: { type: 'integer' },
             },
           },
         },
@@ -239,61 +231,6 @@ export default [
             boolean: {
               type: 'boolean',
               const: false,
-            },
-          },
-        },
-      },
-    },
-  },
-  {
-    lexicon: 1,
-    id: 'com.example.floatRange',
-    defs: {
-      main: {
-        type: 'record',
-        record: {
-          type: 'object',
-          properties: {
-            float: {
-              type: 'float',
-              minimum: 2,
-              maximum: 4,
-            },
-          },
-        },
-      },
-    },
-  },
-  {
-    lexicon: 1,
-    id: 'com.example.floatEnum',
-    defs: {
-      main: {
-        type: 'record',
-        record: {
-          type: 'object',
-          properties: {
-            float: {
-              type: 'float',
-              enum: [1, 1.5, 2],
-            },
-          },
-        },
-      },
-    },
-  },
-  {
-    lexicon: 1,
-    id: 'com.example.floatConst',
-    defs: {
-      main: {
-        type: 'record',
-        record: {
-          type: 'object',
-          properties: {
-            float: {
-              type: 'float',
-              const: 0,
             },
           },
         },

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -41,13 +41,11 @@ describe('General validation', () => {
           object: { boolean: true },
           array: ['one', 'two'],
           boolean: true,
-          float: 123.45,
           integer: 123,
           string: 'string',
         },
         array: ['one', 'two'],
         boolean: true,
-        float: 123.45,
         integer: 123,
         string: 'string',
         datetime: new Date().toISOString(),
@@ -74,7 +72,6 @@ describe('General validation', () => {
         object: { boolean: true },
         array: ['one', 'two'],
         boolean: true,
-        float: 123.45,
         integer: 123,
         string: 'string',
       })
@@ -98,13 +95,11 @@ describe('Record validation', () => {
       object: { boolean: true },
       array: ['one', 'two'],
       boolean: true,
-      float: 123.45,
       integer: 123,
       string: 'string',
     },
     array: ['one', 'two'],
     boolean: true,
-    float: 123.45,
     integer: 123,
     string: 'string',
     bytes: new Uint8Array([0, 1, 2, 3]),
@@ -144,7 +139,6 @@ describe('Record validation', () => {
         $type: 'com.example.kitchenSink',
         array: ['one', 'two'],
         boolean: true,
-        float: 123.45,
         integer: 123,
         string: 'string',
         datetime: new Date().toISOString(),
@@ -190,15 +184,9 @@ describe('Record validation', () => {
     expect(() =>
       lex.assertValidRecord('com.example.kitchenSink', {
         ...passingSink,
-        float: 'string',
-      }),
-    ).toThrow('Record/float must be a number')
-    expect(() =>
-      lex.assertValidRecord('com.example.kitchenSink', {
-        ...passingSink,
         integer: true,
       }),
-    ).toThrow('Record/integer must be a number')
+    ).toThrow('Record/integer must be an integer')
     expect(() =>
       lex.assertValidRecord('com.example.kitchenSink', {
         ...passingSink,
@@ -234,12 +222,10 @@ describe('Record validation', () => {
       $type: 'com.example.default',
       boolean: false,
       integer: 0,
-      float: 0,
       string: '',
       object: {
         boolean: true,
         integer: 1,
-        float: 1.5,
         string: 'x',
       },
     })
@@ -254,7 +240,6 @@ describe('Record validation', () => {
         object: { boolean: true },
         array: ['one', 'two'],
         boolean: true,
-        float: 123.45,
         integer: 123,
         string: 'string',
       },
@@ -335,13 +320,13 @@ describe('Record validation', () => {
         $type: 'com.example.arrayLength',
         array: [1, '2', 3],
       }),
-    ).toThrow('Record/array/1 must be a number')
+    ).toThrow('Record/array/1 must be an integer')
     expect(() =>
       lex.assertValidRecord('com.example.arrayLength', {
         $type: 'com.example.arrayLength',
         array: [1, undefined, 3],
       }),
-    ).toThrow('Record/array/1 must be a number')
+    ).toThrow('Record/array/1 must be an integer')
   })
 
   it('Applies boolean const constraint', () => {
@@ -355,51 +340,6 @@ describe('Record validation', () => {
         boolean: true,
       }),
     ).toThrow('Record/boolean must be false')
-  })
-
-  it('Applies float range constraint', () => {
-    lex.assertValidRecord('com.example.floatRange', {
-      $type: 'com.example.floatRange',
-      float: 2.5,
-    })
-    expect(() =>
-      lex.assertValidRecord('com.example.floatRange', {
-        $type: 'com.example.floatRange',
-        float: 1,
-      }),
-    ).toThrow('Record/float can not be less than 2')
-    expect(() =>
-      lex.assertValidRecord('com.example.floatRange', {
-        $type: 'com.example.floatRange',
-        float: 5,
-      }),
-    ).toThrow('Record/float can not be greater than 4')
-  })
-
-  it('Applies float enum constraint', () => {
-    lex.assertValidRecord('com.example.floatEnum', {
-      $type: 'com.example.floatEnum',
-      float: 1.5,
-    })
-    expect(() =>
-      lex.assertValidRecord('com.example.floatEnum', {
-        $type: 'com.example.floatEnum',
-        float: 0,
-      }),
-    ).toThrow('Record/float must be one of (1|1.5|2)')
-  })
-
-  it('Applies float const constraint', () => {
-    lex.assertValidRecord('com.example.floatConst', {
-      $type: 'com.example.floatConst',
-      float: 0,
-    })
-    expect(() =>
-      lex.assertValidRecord('com.example.floatConst', {
-        $type: 'com.example.floatConst',
-        float: 1,
-      }),
-    ).toThrow('Record/float must be 0')
   })
 
   it('Applies integer range constraint', () => {
@@ -721,14 +661,12 @@ describe('XRPC parameter validation', () => {
   it('Passes valid parameters', () => {
     const queryResult = lex.assertValidXrpcParams('com.example.query', {
       boolean: true,
-      float: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
     })
     expect(queryResult).toEqual({
       boolean: true,
-      float: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
@@ -736,7 +674,6 @@ describe('XRPC parameter validation', () => {
     })
     const paramResult = lex.assertValidXrpcParams('com.example.procedure', {
       boolean: true,
-      float: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
@@ -744,7 +681,6 @@ describe('XRPC parameter validation', () => {
     })
     expect(paramResult).toEqual({
       boolean: true,
-      float: 123.45,
       integer: 123,
       string: 'string',
       array: ['x', 'y'],
@@ -755,19 +691,16 @@ describe('XRPC parameter validation', () => {
   it('Handles required correctly', () => {
     lex.assertValidXrpcParams('com.example.query', {
       boolean: true,
-      float: 123.45,
       integer: 123,
     })
     expect(() =>
       lex.assertValidXrpcParams('com.example.query', {
         boolean: true,
-        float: 123.45,
       }),
     ).toThrow('Params must have the property "integer"')
     expect(() =>
       lex.assertValidXrpcParams('com.example.query', {
         boolean: true,
-        float: 123.45,
         integer: undefined,
       }),
     ).toThrow('Params must have the property "integer"')
@@ -777,19 +710,10 @@ describe('XRPC parameter validation', () => {
     expect(() =>
       lex.assertValidXrpcParams('com.example.query', {
         boolean: 'string',
-        float: 123.45,
         integer: 123,
         string: 'string',
       }),
     ).toThrow('boolean must be a boolean')
-    expect(() =>
-      lex.assertValidXrpcParams('com.example.procedure', {
-        boolean: true,
-        float: true,
-        integer: 123,
-        string: 'string',
-      }),
-    ).toThrow('float must be a number')
     expect(() =>
       lex.assertValidXrpcParams('com.example.query', {
         boolean: true,

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -23,7 +23,7 @@ const LEXICONS = [
             required: ['foo'],
             properties: {
               foo: { type: 'string' },
-              bar: { type: 'float' },
+              bar: { type: 'integer' },
             },
           },
         },
@@ -34,7 +34,7 @@ const LEXICONS = [
             required: ['foo'],
             properties: {
               foo: { type: 'string' },
-              bar: { type: 'float' },
+              bar: { type: 'integer' },
             },
           },
         },
@@ -54,7 +54,7 @@ const LEXICONS = [
             required: ['foo'],
             properties: {
               foo: { type: 'string' },
-              bar: { type: 'float' },
+              bar: { type: 'integer' },
             },
           },
         },

--- a/packages/xrpc-server/tests/parameters.test.ts
+++ b/packages/xrpc-server/tests/parameters.test.ts
@@ -13,11 +13,10 @@ const LEXICONS = [
         type: 'query',
         parameters: {
           type: 'params',
-          required: ['str', 'int', 'num', 'bool', 'arr'],
+          required: ['str', 'int', 'bool', 'arr'],
           properties: {
             str: { type: 'string', minLength: 2, maxLength: 10 },
             int: { type: 'integer', minimum: 2, maximum: 10 },
-            num: { type: 'float', minimum: 2, maximum: 10 },
             bool: { type: 'boolean' },
             arr: { type: 'array', items: { type: 'integer' }, maxLength: 2 },
             def: { type: 'integer', default: 0 },
@@ -57,7 +56,6 @@ describe('Parameters', () => {
     const res1 = await client.call('io.example.paramTest', {
       str: 'valid',
       int: 5,
-      num: 5.5,
       bool: true,
       arr: [1, 2],
       def: 5,
@@ -65,7 +63,6 @@ describe('Parameters', () => {
     expect(res1.success).toBeTruthy()
     expect(res1.data.str).toBe('valid')
     expect(res1.data.int).toBe(5)
-    expect(res1.data.num).toBe(5.5)
     expect(res1.data.bool).toBe(true)
     expect(res1.data.arr).toEqual([1, 2])
     expect(res1.data.def).toEqual(5)
@@ -73,14 +70,12 @@ describe('Parameters', () => {
     const res2 = await client.call('io.example.paramTest', {
       str: 10,
       int: '5',
-      num: '5.5',
       bool: 'foo',
       arr: '3',
     })
     expect(res2.success).toBeTruthy()
     expect(res2.data.str).toBe('10')
     expect(res2.data.int).toBe(5)
-    expect(res2.data.num).toBe(5.5)
     expect(res2.data.bool).toBe(true)
     expect(res2.data.arr).toEqual([3])
     expect(res2.data.def).toEqual(0)
@@ -90,7 +85,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'n',
         int: 5,
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -99,7 +93,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'loooooooooooooong',
         int: 5,
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -107,7 +100,6 @@ describe('Parameters', () => {
     await expect(
       client.call('io.example.paramTest', {
         int: 5,
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -117,7 +109,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'valid',
         int: -1,
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -126,7 +117,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'valid',
         int: 11,
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -134,7 +124,6 @@ describe('Parameters', () => {
     await expect(
       client.call('io.example.paramTest', {
         str: 'valid',
-        num: 5.5,
         bool: true,
         arr: [1],
       }),
@@ -144,34 +133,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'valid',
         int: 5,
-        num: -5.5,
-        bool: true,
-        arr: [1],
-      }),
-    ).rejects.toThrow('num can not be less than 2')
-    await expect(
-      client.call('io.example.paramTest', {
-        str: 'valid',
-        int: 5,
-        num: 50.5,
-        bool: true,
-        arr: [1],
-      }),
-    ).rejects.toThrow('num can not be greater than 10')
-    await expect(
-      client.call('io.example.paramTest', {
-        str: 'valid',
-        int: 5,
-        bool: true,
-        arr: [1],
-      }),
-    ).rejects.toThrow(`Params must have the property "num"`)
-
-    await expect(
-      client.call('io.example.paramTest', {
-        str: 'valid',
-        int: 5,
-        num: 5.5,
         arr: [1],
       }),
     ).rejects.toThrow(`Params must have the property "bool"`)
@@ -180,7 +141,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'valid',
         int: 5,
-        num: 5.5,
         bool: true,
         arr: [],
       }),
@@ -189,7 +149,6 @@ describe('Parameters', () => {
       client.call('io.example.paramTest', {
         str: 'valid',
         int: 5,
-        num: 5.5,
         bool: true,
         arr: [1, 2, 3],
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,17 @@
     pino "^8.6.1"
     zod "^3.14.2"
 
+"@atproto/crypto@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@atproto/crypto/-/crypto-0.1.0.tgz#bc73a479f9dbe06fa025301c182d7f7ab01bc568"
+  integrity sha512-9xgFEPtsCiJEPt9o3HtJT30IdFTGw5cQRSJVIy5CFhqBA4vDLcdXiRDLCjkzHEVbtNCsHUW6CrlfOgbeLPcmcg==
+  dependencies:
+    "@noble/secp256k1" "^1.7.0"
+    big-integer "^1.6.51"
+    multiformats "^9.6.4"
+    one-webcrypto "^1.0.3"
+    uint8arrays "3.0.0"
+
 "@aws-crypto/crc32@2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz"


### PR DESCRIPTION
Remove support for floats from lexicon.

They will be added back at some point but we need to engage with a couple of issues first:
- the golang dag-cbor ipld library does not support floats at the moment
- floats cannot necessary safely make the transition from cbor -> json -> cbor (consider an integer in a float field)

Generally, floats are strongly discouraged from use in content-addressed data models. We need to tease out the complexities of their use before enabling them. Floats will likely be added back in at some point soon