### PR TITLE
Account for possible path prefix in cloudfront invalidation

### DIFF
--- a/packages/pds/service/index.js
+++ b/packages/pds/service/index.js
@@ -34,9 +34,6 @@ const main = async () => {
     schema: env.dbSchema,
   })
   const s3Blobstore = new S3BlobStore({ bucket: env.s3Bucket })
-  const cfInvalidator = new CloudfrontInvalidator({
-    distributionId: env.cfDistributionId,
-  })
   const repoSigningKey = await Secp256k1Keypair.import(env.repoSigningKey)
   const plcRotationKey = await KmsKeypair.load({
     keyId: env.plcRotationKeyId,
@@ -58,6 +55,10 @@ const main = async () => {
       username: env.smtpUsername,
       password: env.smtpPassword,
     }),
+  })
+  const cfInvalidator = new CloudfrontInvalidator({
+    distributionId: env.cfDistributionId,
+    pathPrefix: cfg.imgUriEndpoint && new URL(cfg.imgUriEndpoint).pathname,
   })
   const pds = PDS.create({
     db,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,17 @@
     pino "^8.6.1"
     zod "^3.14.2"
 
+"@atproto/crypto@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@atproto/crypto/-/crypto-0.1.0.tgz#bc73a479f9dbe06fa025301c182d7f7ab01bc568"
+  integrity sha512-9xgFEPtsCiJEPt9o3HtJT30IdFTGw5cQRSJVIy5CFhqBA4vDLcdXiRDLCjkzHEVbtNCsHUW6CrlfOgbeLPcmcg==
+  dependencies:
+    "@noble/secp256k1" "^1.7.0"
+    big-integer "^1.6.51"
+    multiformats "^9.6.4"
+    one-webcrypto "^1.0.3"
+    uint8arrays "3.0.0"
+
 "@aws-crypto/crc32@2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz"


### PR DESCRIPTION
The cloudfront CDN may serve images at a specific path prefix, depending on the deployment.  This accounts for that in the invalidation flow.