### PR TITLE
Pkg bumps after #756

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/api",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/pds",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "src/index.ts",
   "bin": "dist/bin.ts",


### PR DESCRIPTION
Publishes new packages for https://github.com/bluesky-social/atproto/pull/756

- api@0.2.2
- pds@0.1.1