### PR TITLE
Add email to createSession

### DIFF
--- a/lexicons/com/atproto/server/createSession.json
+++ b/lexicons/com/atproto/server/createSession.json
@@ -28,7 +28,8 @@
             "accessJwt": {"type": "string"},
             "refreshJwt": {"type": "string"},
             "handle": {"type": "string", "format": "handle"},
-            "did": {"type": "string", "format": "did"}
+            "did": {"type": "string", "format": "did"},
+            "email": {"type": "string"}
           }
         }
       },

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -95,6 +95,7 @@ export class AtpAgent {
         refreshJwt: res.data.refreshJwt,
         handle: res.data.handle,
         did: res.data.did,
+        email: opts.email,
       }
       return res
     } catch (e) {
@@ -125,6 +126,7 @@ export class AtpAgent {
         refreshJwt: res.data.refreshJwt,
         handle: res.data.handle,
         did: res.data.did,
+        email: res.data.email,
       }
       return res
     } catch (e) {
@@ -151,6 +153,8 @@ export class AtpAgent {
       if (!res.success || res.data.did !== this.session.did) {
         throw new Error('Invalid session')
       }
+      this.session.email = res.data.email
+      this.session.handle = res.data.handle
       return res
     } catch (e) {
       this.session = undefined

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1760,6 +1760,9 @@ export const schemaDict = {
                 type: 'string',
                 format: 'did',
               },
+              email: {
+                type: 'string',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/server/createSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/createSession.ts
@@ -21,6 +21,7 @@ export interface OutputSchema {
   refreshJwt: string
   handle: string
   did: string
+  email?: string
   [k: string]: unknown
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -11,6 +11,7 @@ export interface AtpSessionData {
   accessJwt: string
   handle: string
   did: string
+  email?: string
 }
 
 /**

--- a/packages/api/tests/agent.test.ts
+++ b/packages/api/tests/agent.test.ts
@@ -47,6 +47,7 @@ describe('agent', () => {
     expect(agent.session?.refreshJwt).toEqual(res.data.refreshJwt)
     expect(agent.session?.handle).toEqual(res.data.handle)
     expect(agent.session?.did).toEqual(res.data.did)
+    expect(agent.session?.email).toEqual('user1@test.com')
 
     const { data: sessionInfo } = await agent.api.com.atproto.server.getSession(
       {},
@@ -91,6 +92,7 @@ describe('agent', () => {
     expect(agent2.session?.refreshJwt).toEqual(res1.data.refreshJwt)
     expect(agent2.session?.handle).toEqual(res1.data.handle)
     expect(agent2.session?.did).toEqual(res1.data.did)
+    expect(agent2.session?.email).toEqual('user2@test.com')
 
     const { data: sessionInfo } =
       await agent2.api.com.atproto.server.getSession({})

--- a/packages/pds/src/api/com/atproto/server/createSession.ts
+++ b/packages/pds/src/api/com/atproto/server/createSession.ts
@@ -44,6 +44,7 @@ export default function (server: Server, ctx: AppContext) {
       body: {
         did: user.did,
         handle: user.handle,
+        email: user.email,
         accessJwt: access.jwt,
         refreshJwt: refresh.jwt,
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1760,6 +1760,9 @@ export const schemaDict = {
                 type: 'string',
                 format: 'did',
               },
+              email: {
+                type: 'string',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
@@ -22,6 +22,7 @@ export interface OutputSchema {
   refreshJwt: string
   handle: string
   did: string
+  email?: string
   [k: string]: unknown
 }
 

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -330,6 +330,7 @@ describe('account', () => {
     expect(typeof jwt).toBe('string')
     expect(res.data.handle).toBe('alice.test')
     expect(res.data.did).toBe(did)
+    expect(res.data.email).toBe(email)
   })
 
   it('can perform authenticated requests', async () => {


### PR DESCRIPTION
This PR:

- Adds an optional `email` to `com.atproto.server.createSession` response
- Updates the api package to store email in the session data it tracks