### PR TITLE
Improve admin invite code views

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -129,11 +129,7 @@
         "relatedRecords": {"type": "array", "items": {"type": "unknown"}},
         "indexedAt": {"type": "string", "format": "datetime"},
         "moderation": {"type": "ref", "ref": "#moderation"},
-        "invitedBy": {"type": "ref", "ref": "com.atproto.server.defs#inviteCode"},
-        "invites": {
-          "type": "array",
-          "items": {"type": "ref", "ref": "com.atproto.server.defs#inviteCode"}
-        }
+        "invitedBy": {"type": "ref", "ref": "com.atproto.server.defs#inviteCode"}
       }
     },
     "repoViewDetail": {

--- a/packages/pds/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchRepos.ts
@@ -10,12 +10,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params }) => {
       const { db, services } = ctx
       const moderationService = services.moderation(db)
-      const { term = '', limit = 50, cursor } = params
+      const { term = '', limit = 50, cursor, invitedBy } = params
 
       if (!term) {
         const results = await services
           .account(db)
-          .list({ limit, cursor, includeSoftDeleted: true })
+          .list({ limit, cursor, includeSoftDeleted: true, invitedBy })
         const keyset = new ListKeyset(sql``, sql``)
 
         return {

--- a/packages/pds/src/services/util/search.ts
+++ b/packages/pds/src/services/util/search.ts
@@ -12,6 +12,7 @@ export const getUserSearchQueryPg = (
     limit: number
     cursor?: string
     includeSoftDeleted?: boolean
+    invitedBy?: string
   },
 ) => {
   const { ref } = db.db.dynamic

--- a/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
@@ -8,6 +8,7 @@ Object {
   "did": "user(0)",
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
+  "invites": Array [],
   "moderation": Object {
     "actions": Array [
       Object {

--- a/packages/pds/tests/views/admin/invites.test.ts
+++ b/packages/pds/tests/views/admin/invites.test.ts
@@ -152,4 +152,26 @@ describe('pds admin invite views', () => {
     const combined = [...first.data.codes, ...second.data.codes]
     expect(combined).toEqual(full.data.codes)
   })
+
+  it('filters admin.searchRepos by invitedBy', async () => {
+    const searchView = await agent.api.com.atproto.admin.searchRepos(
+      { invitedBy: alice },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(searchView.data.repos.length).toBe(2)
+    expect(searchView.data.repos[0].invitedBy?.available).toBe(1)
+    expect(searchView.data.repos[0].invitedBy?.uses.length).toBe(1)
+    expect(searchView.data.repos[1].invitedBy?.available).toBe(1)
+    expect(searchView.data.repos[1].invitedBy?.uses.length).toBe(1)
+  })
+
+  it('hydrates invites into admin.getRepo', async () => {
+    const aliceView = await agent.api.com.atproto.admin.getRepo(
+      { did: alice },
+      { headers: { authorization: adminAuth() } },
+    )
+    expect(aliceView.data.invitedBy?.available).toBe(10)
+    expect(aliceView.data.invitedBy?.uses.length).toBe(2)
+    expect(aliceView.data.invites?.length).toBe(6)
+  })
 })


### PR DESCRIPTION
A few things:
- add filter by `invitedBy` on search
  - this only works on a _blank_ term, otherwise we were having to jam a bunch of invite logic into our search functionality which didn't feel great. & also doesn't seem like a common usecase
- add some tests for admin views
- makes searchRepos only return `invitedBy` & getRepo return `invitedBy` & `invites`. since `invites` is a larger value, we may not want to run it on every search