### PR TITLE
Improve getPopular

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -5,6 +5,7 @@ import AppContext from '../../../../context'
 import { FeedRow, FeedItemType } from '../../../services/feed'
 import { sql } from 'kysely'
 import { FeedViewPost } from '../../../../lexicon/types/app/bsky/feed/defs'
+import { countAll } from '../../../../db/util'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
 export default function (server: Server, ctx: AppContext) {
@@ -19,21 +20,22 @@ export default function (server: Server, ctx: AppContext) {
       const feedService = ctx.services.appView.feed(ctx.db)
 
       const postsQb = ctx.db.db
-        .with('like_counts', (qb) =>
-          qb
-            .selectFrom('like')
-            .groupBy('like.subject')
-            .select([sql`count(*)`.as('count'), 'like.subject']),
-        )
         .selectFrom('post')
-        .innerJoin('like_counts', 'like_counts.subject', 'post.uri')
         .leftJoin('repost', (join) =>
           // this works well for one curating user. reassess if adding more
           join
             .on('repost.creator', '=', 'did:plc:ea2eqamjmtuo6f4rvhl3g6ne')
             .onRef('repost.subject', '=', 'post.uri'),
         )
-        .where('like_counts.count', '>=', 5)
+        .where(
+          (qb) =>
+            qb
+              .selectFrom('like')
+              .whereRef('like.subject', '=', 'post.uri')
+              .select(countAll.as('count')),
+          '>=',
+          5,
+        )
         .orWhere('repost.creator', 'is not', null)
         .select([
           sql<FeedItemType>`${'post'}`.as('type'),


### PR DESCRIPTION
Some SQL changes to speed up getPopular.

Does a count check in a where clause instead of joining on a count table. Some quick testing suggests a ~3-4x improvement.