### PR TITLE
Fix AtUri parse on hostnames that start with numbers

### DIFF
--- a/packages/uri/package.json
+++ b/packages/uri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/uri",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "src/index.ts",
   "scripts": {
     "test": "jest",

--- a/packages/uri/src/index.ts
+++ b/packages/uri/src/index.ts
@@ -1,8 +1,8 @@
 export * from './validation'
 
 export const ATP_URI_REGEX =
-  // proto-    --did--------------   --name-------------   --path----   --query--   --hash--
-  /^(at:\/\/)?((?:did:[a-z0-9:%-]+)|(?:[a-z][a-z0-9.:-]*))(\/[^?#\s]*)?(\?[^#\s]+)?(#[^\s]+)?$/i
+  // proto-    --did--------------   --name----------------   --path----   --query--   --hash--
+  /^(at:\/\/)?((?:did:[a-z0-9:%-]+)|(?:[a-z0-9][a-z0-9.:-]*))(\/[^?#\s]*)?(\?[^#\s]+)?(#[^\s]+)?$/i
 //                       --path-----   --query--  --hash--
 const RELATIVE_REGEX = /^(\/[^?#\s]*)?(\?[^#\s]+)?(#[^\s]+)?$/i
 

--- a/packages/uri/tests/uri.test.ts
+++ b/packages/uri/tests/uri.test.ts
@@ -235,6 +235,13 @@ describe('At Uris', () => {
         'foo=bar',
         '#hash',
       ],
+      [
+        'at://4513echo.bsky.social/app.bsky.feed.post/3jsrpdyf6ss23',
+        '4513echo.bsky.social',
+        '/app.bsky.feed.post/3jsrpdyf6ss23',
+        '',
+        '',
+      ],
     ]
     for (const [uri, hostname, pathname, search, hash] of TESTS) {
       const urip = new AtUri(uri)


### PR DESCRIPTION
Users with numbers in their handles are getting cryptic "Error: uri must be a valid at-uri" messages when the app tries to load their threads. Turns out I botched the grammar for hostnames here.