### PR TITLE
Disable output validation when not in debug mode

### DIFF
--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 
 export interface ServerConfigValues {
   version: string
+  debugMode?: boolean
   port?: number
   publicUrl?: string
   dbPostgresUrl: string
@@ -21,6 +22,7 @@ export class ServerConfig {
 
   static readEnv(overrides?: Partial<ServerConfigValues>) {
     const version = process.env.BSKY_VERSION || '0.0.0'
+    const debugMode = process.env.NODE_ENV !== 'production'
     const publicUrl = process.env.PUBLIC_URL || undefined
     const envPort = parseInt(process.env.PORT || '', 10)
     const port = isNaN(envPort) ? 2584 : envPort
@@ -39,6 +41,7 @@ export class ServerConfig {
     const repoProvider = process.env.REPO_PROVIDER // E.g. ws://abc.com:4000
     return new ServerConfig({
       version,
+      debugMode,
       port,
       publicUrl,
       dbPostgresUrl,
@@ -63,6 +66,10 @@ export class ServerConfig {
 
   get version() {
     return this.cfg.version
+  }
+
+  get debugMode() {
+    return !!this.cfg.debugMode
   }
 
   get port() {

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -73,6 +73,7 @@ export class BskyAppView {
     }
 
     let server = createServer({
+      validateResponse: config.debugMode,
       payload: {
         jsonLimit: 100 * 1024, // 100kb
         textLimit: 100 * 1024, // 100kb

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -173,7 +173,7 @@ export class ServerConfig {
   }
 
   get debugMode() {
-    return this.cfg.debugMode
+    return !!this.cfg.debugMode
   }
 
   get version() {

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -145,6 +145,7 @@ export class PDS {
     const appView = new AppView(ctx)
 
     let server = createServer({
+      validateResponse: !!config.debugMode,
       payload: {
         jsonLimit: 100 * 1024, // 100kb
         textLimit: 100 * 1024, // 100kb

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -145,7 +145,7 @@ export class PDS {
     const appView = new AppView(ctx)
 
     let server = createServer({
-      validateResponse: !!config.debugMode,
+      validateResponse: config.debugMode,
       payload: {
         jsonLimit: 100 * 1024, // 100kb
         textLimit: 100 * 1024, // 100kb


### PR DESCRIPTION
Output validation generally isn't needed outside of debug mode.  We may want to consider validating a sample output in the future when not in debug mode.