### PR TITLE
Admin update handle

### DIFF
--- a/lexicons/com/atproto/admin/updateAccountHandle.json
+++ b/lexicons/com/atproto/admin/updateAccountHandle.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Administrative action to update an accounts handle",
+      "description": "Administrative action to update an account's handle",
       "input": {
         "encoding": "application/json",
         "schema": {

--- a/lexicons/com/atproto/admin/updateAccountHandle.json
+++ b/lexicons/com/atproto/admin/updateAccountHandle.json
@@ -1,0 +1,21 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.updateAccountHandle",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Administrative action to update an accounts handle",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "handle"],
+          "properties": {
+            "did": {"type": "string", "format": "did"},
+            "handle": {"type": "string", "format": "handle"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -20,6 +20,7 @@ import * as ComAtprotoAdminResolveModerationReports from './types/com/atproto/ad
 import * as ComAtprotoAdminReverseModerationAction from './types/com/atproto/admin/reverseModerationAction'
 import * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRepos'
 import * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
+import * as ComAtprotoAdminUpdateAccountHandle from './types/com/atproto/admin/updateAccountHandle'
 import * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 import * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
 import * as ComAtprotoLabelDefs from './types/com/atproto/label/defs'
@@ -107,6 +108,7 @@ export * as ComAtprotoAdminResolveModerationReports from './types/com/atproto/ad
 export * as ComAtprotoAdminReverseModerationAction from './types/com/atproto/admin/reverseModerationAction'
 export * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRepos'
 export * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
+export * as ComAtprotoAdminUpdateAccountHandle from './types/com/atproto/admin/updateAccountHandle'
 export * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 export * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
 export * as ComAtprotoLabelDefs from './types/com/atproto/label/defs'
@@ -389,6 +391,17 @@ export class AdminNS {
       .call('com.atproto.admin.takeModerationAction', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoAdminTakeModerationAction.toKnownErr(e)
+      })
+  }
+
+  updateAccountHandle(
+    data?: ComAtprotoAdminUpdateAccountHandle.InputSchema,
+    opts?: ComAtprotoAdminUpdateAccountHandle.CallOptions,
+  ): Promise<ComAtprotoAdminUpdateAccountHandle.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.updateAccountHandle', opts?.qp, data, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminUpdateAccountHandle.toKnownErr(e)
       })
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1049,6 +1049,33 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminUpdateAccountHandle: {
+    lexicon: 1,
+    id: 'com.atproto.admin.updateAccountHandle',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Administrative action to update an accounts handle',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+              handle: {
+                type: 'string',
+                format: 'handle',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoIdentityResolveHandle: {
     lexicon: 1,
     id: 'com.atproto.identity.resolveHandle',
@@ -4734,6 +4761,7 @@ export const ids = {
     'com.atproto.admin.reverseModerationAction',
   ComAtprotoAdminSearchRepos: 'com.atproto.admin.searchRepos',
   ComAtprotoAdminTakeModerationAction: 'com.atproto.admin.takeModerationAction',
+  ComAtprotoAdminUpdateAccountHandle: 'com.atproto.admin.updateAccountHandle',
   ComAtprotoIdentityResolveHandle: 'com.atproto.identity.resolveHandle',
   ComAtprotoIdentityUpdateHandle: 'com.atproto.identity.updateHandle',
   ComAtprotoLabelDefs: 'com.atproto.label.defs',

--- a/packages/api/src/client/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/api/src/client/types/com/atproto/admin/updateAccountHandle.ts
@@ -1,0 +1,33 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  handle: string
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+  qp?: QueryParams
+  encoding: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -12,6 +12,7 @@ import getModerationReport from './getModerationReport'
 import getModerationReports from './getModerationReports'
 import disableInviteCodes from './disableInviteCodes'
 import getInviteCodes from './getInviteCodes'
+import updateAccountHandle from './updateAccountHandle'
 
 export default function (server: Server, ctx: AppContext) {
   resolveModerationReports(server, ctx)
@@ -26,4 +27,5 @@ export default function (server: Server, ctx: AppContext) {
   getModerationReports(server, ctx)
   disableInviteCodes(server, ctx)
   getInviteCodes(server, ctx)
+  updateAccountHandle(server, ctx)
 }

--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -21,8 +21,8 @@ export default function (server: Server, ctx: AppContext) {
           throw new InvalidRequestError(err.message, 'InvalidHandle')
         } else if (err instanceof ident.UnsupportedDomainError) {
           throw new InvalidRequestError(
-            'Unsupported account did',
-            'InvalidHandle',
+            'Unsupported domain',
+            'UnsupportedDomain',
           )
         } else if (err instanceof ident.ReservedHandleError) {
           throw new InvalidRequestError(err.message, 'HandleNotAvailable')
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
       )
       if (!isServiceDomain) {
         throw new InvalidRequestError(
-          `Account not on a domain we control: ${existingAccnt.handle}`,
+          `Account not on an available service domain: ${existingAccnt.handle}`,
         )
       }
 

--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -1,0 +1,59 @@
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import * as ident from '@atproto/identifier'
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+import { UserAlreadyExistsError } from '../../../../services/account'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.updateAccountHandle({
+    auth: ctx.adminVerifier,
+    handler: async ({ input }) => {
+      const { did } = input.body
+      let handle: string
+      try {
+        handle = ident.normalizeAndEnsureValidHandle(input.body.handle)
+        ident.ensureHandleServiceConstraints(
+          handle,
+          ctx.cfg.availableUserDomains,
+        )
+      } catch (err) {
+        if (err instanceof ident.InvalidHandleError) {
+          throw new InvalidRequestError(err.message, 'InvalidHandle')
+        } else if (err instanceof ident.UnsupportedDomainError) {
+          throw new InvalidRequestError(
+            'Unsupported account did',
+            'InvalidHandle',
+          )
+        } else if (err instanceof ident.ReservedHandleError) {
+          throw new InvalidRequestError(err.message, 'HandleNotAvailable')
+        } else {
+          throw err
+        }
+      }
+      const existingAccnt = await ctx.services.account(ctx.db).getAccount(did)
+      if (!existingAccnt) {
+        throw new InvalidRequestError(`Account not found: ${did}`)
+      }
+      const isServiceDomain = ctx.cfg.availableUserDomains.find((domain) =>
+        existingAccnt.handle.endsWith(domain),
+      )
+      if (!isServiceDomain) {
+        throw new InvalidRequestError(
+          `Account not on a domain we control: ${existingAccnt.handle}`,
+        )
+      }
+
+      await ctx.db.transaction(async (dbTxn) => {
+        try {
+          await ctx.services.account(dbTxn).updateHandle(did, handle)
+        } catch (err) {
+          if (err instanceof UserAlreadyExistsError) {
+            throw new InvalidRequestError(`Handle already taken: ${handle}`)
+          }
+          throw err
+        }
+        await ctx.plcClient.updateHandle(did, ctx.plcRotationKey, handle)
+      })
+    },
+  })
+}

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -21,6 +21,7 @@ import * as ComAtprotoAdminResolveModerationReports from './types/com/atproto/ad
 import * as ComAtprotoAdminReverseModerationAction from './types/com/atproto/admin/reverseModerationAction'
 import * as ComAtprotoAdminSearchRepos from './types/com/atproto/admin/searchRepos'
 import * as ComAtprotoAdminTakeModerationAction from './types/com/atproto/admin/takeModerationAction'
+import * as ComAtprotoAdminUpdateAccountHandle from './types/com/atproto/admin/updateAccountHandle'
 import * as ComAtprotoIdentityResolveHandle from './types/com/atproto/identity/resolveHandle'
 import * as ComAtprotoIdentityUpdateHandle from './types/com/atproto/identity/updateHandle'
 import * as ComAtprotoLabelQueryLabels from './types/com/atproto/label/queryLabels'
@@ -249,6 +250,16 @@ export class AdminNS {
     >,
   ) {
     const nsid = 'com.atproto.admin.takeModerationAction' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  updateAccountHandle<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminUpdateAccountHandle.Handler<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.updateAccountHandle' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1049,6 +1049,33 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminUpdateAccountHandle: {
+    lexicon: 1,
+    id: 'com.atproto.admin.updateAccountHandle',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Administrative action to update an accounts handle',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did', 'handle'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+              handle: {
+                type: 'string',
+                format: 'handle',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoIdentityResolveHandle: {
     lexicon: 1,
     id: 'com.atproto.identity.resolveHandle',
@@ -4734,6 +4761,7 @@ export const ids = {
     'com.atproto.admin.reverseModerationAction',
   ComAtprotoAdminSearchRepos: 'com.atproto.admin.searchRepos',
   ComAtprotoAdminTakeModerationAction: 'com.atproto.admin.takeModerationAction',
+  ComAtprotoAdminUpdateAccountHandle: 'com.atproto.admin.updateAccountHandle',
   ComAtprotoIdentityResolveHandle: 'com.atproto.identity.resolveHandle',
   ComAtprotoIdentityUpdateHandle: 'com.atproto.identity.updateHandle',
   ComAtprotoLabelDefs: 'com.atproto.label.defs',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
@@ -1,0 +1,36 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  handle: string
+  [k: string]: unknown
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -229,4 +229,72 @@ describe('handles', () => {
     )
     expect(profile.data.handle).toBe('alice.external')
   })
+
+  it('allows admin overrules of service domains', async () => {
+    await agent.api.com.atproto.admin.updateAccountHandle(
+      {
+        did: bob,
+        handle: 'bob-alt.test',
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+
+    const profile = await agent.api.app.bsky.actor.getProfile(
+      { actor: bob },
+      { headers: sc.getHeaders(bob) },
+    )
+    expect(profile.data.handle).toBe('bob-alt.test')
+  })
+
+  it('disallows admin overrules of off-service domains', async () => {
+    const attempt = agent.api.com.atproto.admin.updateAccountHandle(
+      {
+        did: alice,
+        handle: 'alice-alt.test',
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+    await expect(attempt).rejects.toThrow(
+      'Account not on an available service domain: alice.external',
+    )
+  })
+
+  it('disallows setting handle to an off-service domain', async () => {
+    const attempt = agent.api.com.atproto.admin.updateAccountHandle(
+      {
+        did: bob,
+        handle: 'bob.external',
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+    await expect(attempt).rejects.toThrow('Unsupported domain')
+  })
+
+  it('requires admin auth', async () => {
+    const attempt = agent.api.com.atproto.admin.updateAccountHandle(
+      {
+        did: bob,
+        handle: 'bob-alt.test',
+      },
+      {
+        headers: sc.getHeaders(bob),
+        encoding: 'application/json',
+      },
+    )
+    await expect(attempt).rejects.toThrow('Authentication Required')
+    const attempt2 = agent.api.com.atproto.admin.updateAccountHandle({
+      did: bob,
+      handle: 'bob-alt.test',
+    })
+    await expect(attempt2).rejects.toThrow('Authentication Required')
+  })
 })


### PR DESCRIPTION
Admin route for updating a handle of an account on service. Note: this only allows you to update a handle _currently on the service_ to another handle _also on the service_