### PR TITLE
Minor query optimization for getBlocksForCommits()

### DIFF
--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -31,6 +31,11 @@ export const nullToZero = (ref: DbRef) => {
   return sql<number>`coalesce(${ref}, 0)`
 }
 
+// Can be useful for large where-in clauses, to get the db to use a hash lookup on the list
+export const valuesList = (vals: unknown[]) => {
+  return sql`(values (${sql.join(vals, sql`), (`)}))`
+}
+
 export const dummyDialect = {
   createAdapter() {
     return new SqliteAdapter()

--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -9,6 +9,7 @@ import {
 import { chunkArray } from '@atproto/common'
 import { CID } from 'multiformats/cid'
 import Database from './db'
+import { valuesList } from './db/util'
 import { IpldBlock } from './db/tables/ipld-block'
 import { RepoCommitBlock } from './db/tables/repo-commit-block'
 import { RepoCommitHistory } from './db/tables/repo-commit-history'
@@ -314,7 +315,7 @@ export class SqlRepoStorage extends RepoStorage {
     const res = await this.db.db
       .selectFrom('repo_commit_block')
       .where('repo_commit_block.creator', '=', this.did)
-      .where('repo_commit_block.commit', 'in', commitStrs)
+      .whereRef('repo_commit_block.commit', 'in', valuesList(commitStrs))
       .innerJoin('ipld_block', (join) =>
         join
           .onRef('ipld_block.cid', '=', 'repo_commit_block.block')

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -172,7 +172,7 @@ Array [
         "avatar": Object {
           "$type": "blob",
           "mimeType": "image/jpeg",
-          "ref": Object{
+          "ref": Object {
             "$link": "cids(0)",
           },
           "size": 3976,
@@ -196,7 +196,7 @@ Array [
         "avatar": Object {
           "$type": "blob",
           "mimeType": "image/jpeg",
-          "ref": Object{
+          "ref": Object {
             "$link": "cids(0)",
           },
           "size": 3976,
@@ -220,7 +220,7 @@ Array [
         "avatar": Object {
           "$type": "blob",
           "mimeType": "image/jpeg",
-          "ref": Object{
+          "ref": Object {
             "$link": "cids(0)",
           },
           "size": 3976,
@@ -254,7 +254,7 @@ Array [
         "avatar": Object {
           "$type": "blob",
           "mimeType": "image/jpeg",
-          "ref": Object{
+          "ref": Object {
             "$link": "cids(0)",
           },
           "size": 3976,
@@ -278,7 +278,7 @@ Array [
         "avatar": Object {
           "$type": "blob",
           "mimeType": "image/jpeg",
-          "ref": Object{
+          "ref": Object {
             "$link": "cids(0)",
           },
           "size": 3976,


### PR DESCRIPTION
By using a values list for the `where in (...commits)` clause, postgres is able to do a hash lookup on the commit list.  This is useful for long lists, which is common in `getBlocksForCommits()` via the `com.atproto.sync.getRepo` method.