### PR TITLE
Remove extraneous info on getRecord

### DIFF
--- a/packages/dev-env/src/test-env.ts
+++ b/packages/dev-env/src/test-env.ts
@@ -136,6 +136,8 @@ export const runPds = async (cfg: PdsConfig): Promise<PdsServerInfo> => {
     dbPostgresUrl: cfg.dbPostgresUrl,
     maxSubscriptionBuffer: 200,
     repoBackfillLimitMs: 1000 * 60 * 60, // 1hr
+    labelerDid: 'did:example:labeler',
+    labelerKeywords: { label_me: 'test-label', label_me_2: 'test-label-2' },
   })
 
   const blobstore = new pds.MemoryBlobStore()

--- a/packages/pds/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/getRecord.ts
@@ -20,7 +20,11 @@ export default function (server: Server, ctx: AppContext) {
     }
     return {
       encoding: 'application/json',
-      body: record,
+      body: {
+        uri: record.uri,
+        cid: record.cid,
+        value: record.value,
+      },
     }
   })
 }


### PR DESCRIPTION
Remove `indexedAt` & `takedownId` from `getRecord`. These are returned by an internal service & were not being properly stripped out

closes https://github.com/bluesky-social/atproto/issues/831