### PR TITLE
Do not give notifications for replies to ancestors that have been deleted 

### DIFF
--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -91,6 +91,28 @@ describe('notification views', () => {
     expect(notifCountBob.data.count).toBe(5)
   })
 
+  it('does not give notifs for an an ancestor that has been deleted', async () => {
+    const root = await sc.post(sc.dids.alice, 'root')
+    const first = await sc.reply(sc.dids.bob, root.ref, root.ref, 'first')
+    await sc.deletePost(sc.dids.alice, root.ref.uri)
+    const second = await sc.reply(sc.dids.carol, root.ref, first.ref, 'second')
+    await processAll(testEnv)
+
+    const notifsAlice = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.alice, true) },
+    )
+    const hasNotif = notifsAlice.data.notifications.some(
+      (notif) => notif.uri === second.ref.uriStr,
+    )
+    expect(hasNotif).toBe(false)
+
+    // cleanup
+    await sc.deletePost(sc.dids.bob, first.ref.uri)
+    await sc.deletePost(sc.dids.carol, second.ref.uri)
+    await processAll(testEnv)
+  })
+
   it('generates notifications for quotes', async () => {
     // Dan was quoted by alice
     const notifsDan = await agent.api.app.bsky.notification.listNotifications(

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -92,6 +92,26 @@ describe('pds notification views', () => {
     expect(notifCountBob.data.count).toBe(5)
   })
 
+  it('does not give notifs for an an ancestor that has been deleted', async () => {
+    const root = await sc.post(sc.dids.alice, 'root')
+    const first = await sc.reply(sc.dids.bob, root.ref, root.ref, 'first')
+    await sc.deletePost(sc.dids.alice, root.ref.uri)
+    const second = await sc.reply(sc.dids.carol, root.ref, first.ref, 'second')
+
+    const notifsAlice = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.alice) },
+    )
+    const hasNotif = notifsAlice.data.notifications.some(
+      (notif) => notif.uri === second.ref.uriStr,
+    )
+    expect(hasNotif).toBe(false)
+
+    // cleanup
+    await sc.deletePost(sc.dids.bob, first.ref.uri)
+    await sc.deletePost(sc.dids.carol, second.ref.uri)
+  })
+
   it('generates notifications for quotes', async () => {
     // Dan was quoted by alice
     const notifsDan = await agent.api.app.bsky.notification.listNotifications(


### PR DESCRIPTION
We were basing notifications for threads off of our post_hierarchy (ancestor) table.

However that structure stays around even after a post has been deleted.

Before sending a notification for a post to an ancestor, first ensure that that ancestor is still around

Changes made to both PDS & AppView