### PR TITLE
Clean up Did-resolver

### DIFF
--- a/packages/bsky/src/api/blob-resolver.ts
+++ b/packages/bsky/src/api/blob-resolver.ts
@@ -5,7 +5,7 @@ import axios, { AxiosError } from 'axios'
 import { CID } from 'multiformats/cid'
 import { ensureValidDid } from '@atproto/identifier'
 import { VerifyCidTransform } from '@atproto/common'
-import { NoResolveDidError } from '@atproto/did-resolver'
+import { DidNotFoundError } from '@atproto/did-resolver'
 import AppContext from '../context'
 import { httpLogger as log } from '../logger'
 import { retryHttp } from '../util/retry'
@@ -30,7 +30,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
         return next(createError(400, 'Invalid cid'))
       }
 
-      const { pds } = await ctx.didResolver.resolveAtpData(did) // @TODO cache did info
+      const { pds } = await ctx.didResolver.resolveAtprotoData(did) // @TODO cache did info
       const blobResult = await retryHttp(() =>
         getBlob({ pds, did, cid: cidStr }),
       )
@@ -71,7 +71,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
         }
         return next(createError(404, 'Blob not found'))
       }
-      if (err instanceof NoResolveDidError) {
+      if (err instanceof DidNotFoundError) {
         return next(createError(404, 'Blob not found'))
       }
       return next(err)

--- a/packages/bsky/src/services/indexing/index.ts
+++ b/packages/bsky/src/services/indexing/index.ts
@@ -80,7 +80,7 @@ export class IndexingService {
     if (actor && !force) {
       return
     }
-    const { handle } = await this.didResolver.resolveAtpData(did)
+    const { handle } = await this.didResolver.resolveAtprotoData(did)
     const handleToDid = await resolveExternalHandle(handle)
     if (did !== handleToDid) {
       return // No bidirectional link between did and handle
@@ -104,7 +104,7 @@ export class IndexingService {
   async indexRepo(did: string, commit: string) {
     this.db.assertTransaction()
     const now = new Date().toISOString()
-    const { pds, signingKey } = await this.didResolver.resolveAtpData(did)
+    const { pds, signingKey } = await this.didResolver.resolveAtprotoData(did)
     const { api } = new AtpAgent({ service: pds })
 
     const { data: car } = await retryHttp(() =>
@@ -194,7 +194,7 @@ export class IndexingService {
   async tombstoneActor(did: string) {
     this.db.assertTransaction()
     const doc = await this.didResolver.resolveDid(did)
-    if (doc.didResolutionMetadata.error === 'notFound') {
+    if (doc === null) {
       await Promise.all([
         this.unindexActor(did),
         this.db.db.deleteFrom('actor').where('did', '=', did).execute(),

--- a/packages/crypto/src/sha.ts
+++ b/packages/crypto/src/sha.ts
@@ -1,5 +1,3 @@
-import crypto from 'crypto'
-import { Readable } from 'stream'
 import * as mf from 'multiformats/hashes/sha2'
 import * as uint8arrays from 'uint8arrays'
 
@@ -11,18 +9,4 @@ export const sha256 = async (
     typeof input === 'string' ? uint8arrays.fromString(input, 'utf8') : input
   const hash = await mf.sha256.digest(bytes)
   return hash.digest
-}
-
-export const sha256Stream = async (stream: Readable): Promise<Uint8Array> => {
-  const hash = crypto.createHash('sha256')
-  try {
-    for await (const chunk of stream) {
-      hash.write(chunk)
-    }
-  } catch (err) {
-    hash.end()
-    throw err
-  }
-  hash.end()
-  return hash.read()
 }

--- a/packages/dev-env/src/test-env.ts
+++ b/packages/dev-env/src/test-env.ts
@@ -226,13 +226,11 @@ const uniqueLockId = () => {
 export const mockNetworkUtilities = (pds: PdsServerInfo) => {
   // Map pds public url to its local url when resolving from plc
   const origResolveDid = DidResolver.prototype.resolveDid
-  DidResolver.prototype.resolveDid = async function (did, options) {
-    const result = await (origResolveDid.call(this, did, options) as ReturnType<
+  DidResolver.prototype.resolveDid = async function (did) {
+    const result = await (origResolveDid.call(this, did) as ReturnType<
       typeof origResolveDid
     >)
-    const service = result.didDocument?.service?.find(
-      (svc) => svc.id === '#atproto_pds',
-    )
+    const service = result?.service?.find((svc) => svc.id === '#atproto_pds')
     if (typeof service?.serviceEndpoint === 'string') {
       service.serviceEndpoint = service.serviceEndpoint.replace(
         pds.ctx.cfg.publicUrl,

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -23,7 +23,8 @@
     "@atproto/common": "*",
     "@atproto/crypto": "*",
     "axios": "^0.27.2",
-    "did-resolver": "^4.0.0"
+    "did-resolver": "^4.0.0",
+    "zod": "^3.14.2"
   },
   "devDependencies": {
     "@did-plc/lib": "^0.0.1",

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -20,10 +20,9 @@
     "postpublish": "npm run update-main-to-src"
   },
   "dependencies": {
-    "@atproto/common": "*",
+    "@atproto/common-web": "*",
     "@atproto/crypto": "*",
     "axios": "^0.27.2",
-    "did-resolver": "^4.0.0",
     "zod": "^3.14.2"
   },
   "devDependencies": {

--- a/packages/did-resolver/src/atproto-data.ts
+++ b/packages/did-resolver/src/atproto-data.ts
@@ -1,14 +1,7 @@
-import { DIDDocument } from 'did-resolver'
 import * as crypto from '@atproto/crypto'
+import { DidDocument, AtprotoData } from './types'
 
-export type AtprotoData = {
-  did: string
-  signingKey: string
-  handle: string
-  pds: string
-}
-
-export const getDid = (doc: DIDDocument): string => {
+export const getDid = (doc: DidDocument): string => {
   const id = doc.id
   if (typeof id !== 'string') {
     throw new Error('No `id` on document')
@@ -16,7 +9,7 @@ export const getDid = (doc: DIDDocument): string => {
   return id
 }
 
-export const getKey = (doc: DIDDocument): string | undefined => {
+export const getKey = (doc: DidDocument): string | undefined => {
   let keys = doc.verificationMethod
   if (!keys) return undefined
   if (typeof keys !== 'object') return undefined
@@ -39,7 +32,7 @@ export const getKey = (doc: DIDDocument): string | undefined => {
   return didKey
 }
 
-export const getHandle = (doc: DIDDocument): string | undefined => {
+export const getHandle = (doc: DidDocument): string | undefined => {
   const aka = doc.alsoKnownAs
   if (!aka) return undefined
   const found = aka.find((name) => name.startsWith('at://'))
@@ -48,7 +41,7 @@ export const getHandle = (doc: DIDDocument): string | undefined => {
   return found.slice(5)
 }
 
-export const getPds = (doc: DIDDocument): string | undefined => {
+export const getPds = (doc: DidDocument): string | undefined => {
   let services = doc.service
   if (!services) return undefined
   if (typeof services !== 'object') return undefined
@@ -67,7 +60,7 @@ export const getPds = (doc: DIDDocument): string | undefined => {
 }
 
 export const parseToAtprotoDocument = (
-  doc: DIDDocument,
+  doc: DidDocument,
 ): Partial<AtprotoData> => {
   const did = getDid(doc)
   return {
@@ -78,7 +71,7 @@ export const parseToAtprotoDocument = (
   }
 }
 
-export const ensureAtpDocument = (doc: DIDDocument): AtprotoData => {
+export const ensureAtpDocument = (doc: DidDocument): AtprotoData => {
   const { did, signingKey, handle, pds } = parseToAtprotoDocument(doc)
   if (!did) {
     throw new Error(`Could not parse id from doc: ${doc}`)

--- a/packages/did-resolver/src/base-resolver.ts
+++ b/packages/did-resolver/src/base-resolver.ts
@@ -2,19 +2,43 @@ import * as crypto from '@atproto/crypto'
 import { check } from '@atproto/common-web'
 import { AtprotoData, DidDocument, didDocument } from './types'
 import * as atprotoData from './atproto-data'
-import { DidNotFoundError } from './errors'
+import { DidNotFoundError, PoorlyFormattedDidDocumentError } from './errors'
+import { DidCache } from './did-cache'
 
 export abstract class BaseResolver {
+  constructor(public cache?: DidCache) {}
+
   abstract resolveDidNoCheck(did: string): Promise<unknown | null>
 
-  async resolveDid(did: string): Promise<DidDocument | null> {
+  async refreshCache(did: string): Promise<void> {
+    if (!this.cache) return
     const got = await this.resolveDidNoCheck(did)
-    if (got === null) return got
     if (check.is(got, didDocument)) {
-      return got
-    } else {
-      throw new Error()
+      await this.cache.cacheDid(did, got)
     }
+  }
+
+  async resolveDid(did: string): Promise<DidDocument | null> {
+    if (this.cache) {
+      const fromCache = await this.cache.checkCache(did)
+      if (fromCache?.expired) {
+        this.refreshCache(did) // done in background
+      }
+      if (fromCache) {
+        return fromCache.doc
+      }
+    }
+
+    const got = await this.resolveDidNoCheck(did)
+    if (got === null) return null
+    if (!check.is(got, didDocument)) {
+      throw new PoorlyFormattedDidDocumentError(did, got)
+    }
+    if (got.id !== did) {
+      throw new PoorlyFormattedDidDocumentError(did, got)
+    }
+    this.cache?.cacheDid(did, got) // done in background
+    return got
   }
 
   async ensureResolveDid(did: string): Promise<DidDocument> {

--- a/packages/did-resolver/src/base-resolver.ts
+++ b/packages/did-resolver/src/base-resolver.ts
@@ -37,7 +37,7 @@ export abstract class BaseResolver {
     if (this.cache && !forceRefresh) {
       const fromCache = await this.cache.checkCache(did)
       if (fromCache?.stale) {
-        this.refreshCache(did)
+        await this.refreshCache(did)
       }
       if (fromCache) {
         return fromCache.doc

--- a/packages/did-resolver/src/base-resolver.ts
+++ b/packages/did-resolver/src/base-resolver.ts
@@ -36,7 +36,7 @@ export abstract class BaseResolver {
   ): Promise<DidDocument | null> {
     if (this.cache && !forceRefresh) {
       const fromCache = await this.cache.checkCache(did)
-      if (fromCache?.expired) {
+      if (fromCache?.stale) {
         this.refreshCache(did)
       }
       if (fromCache) {

--- a/packages/did-resolver/src/base-resolver.ts
+++ b/packages/did-resolver/src/base-resolver.ts
@@ -45,7 +45,10 @@ export abstract class BaseResolver {
     }
 
     const got = await this.resolveDidNoCache(did)
-    if (got === null) return null
+    if (got === null) {
+      await this.cache?.clearEntry(did)
+      return null
+    }
     await this.cache?.cacheDid(did, got)
     return got
   }

--- a/packages/did-resolver/src/base-resolver.ts
+++ b/packages/did-resolver/src/base-resolver.ts
@@ -1,0 +1,52 @@
+import * as crypto from '@atproto/crypto'
+import { check } from '@atproto/common-web'
+import { AtprotoData, DidDocument, didDocument } from './types'
+import * as atprotoData from './atproto-data'
+import { DidNotFoundError } from './errors'
+
+export abstract class BaseResolver {
+  abstract resolveDidNoCheck(did: string): Promise<unknown | null>
+
+  async resolveDid(did: string): Promise<DidDocument | null> {
+    const got = await this.resolveDidNoCheck(did)
+    if (got === null) return got
+    if (check.is(got, didDocument)) {
+      return got
+    } else {
+      throw new Error()
+    }
+  }
+
+  async ensureResolveDid(did: string): Promise<DidDocument> {
+    const result = await this.resolveDid(did)
+    if (result === null) {
+      throw new DidNotFoundError(did)
+    }
+    return result
+  }
+
+  async resolveAtprotoData(did: string): Promise<AtprotoData> {
+    const didDocument = await this.ensureResolveDid(did)
+    return atprotoData.ensureAtpDocument(didDocument)
+  }
+
+  async resolveAtprotoKey(did: string): Promise<string> {
+    if (did.startsWith('did:key:')) {
+      return did
+    } else {
+      const data = await this.resolveAtprotoData(did)
+      return data.signingKey
+    }
+  }
+
+  async verifySignature(
+    did: string,
+    data: Uint8Array,
+    sig: Uint8Array,
+  ): Promise<boolean> {
+    const signingKey = await this.resolveAtprotoKey(did)
+    return crypto.verifySignature(signingKey, data, sig)
+  }
+}
+
+export default BaseResolver

--- a/packages/did-resolver/src/did-cache.ts
+++ b/packages/did-resolver/src/did-cache.ts
@@ -1,0 +1,7 @@
+import { CacheResult, DidDocument } from './types'
+
+export abstract class DidCache {
+  abstract cacheDid(did: string, doc: DidDocument): Promise<void>
+  abstract checkCache(did: string): Promise<CacheResult | null>
+  abstract clear(): Promise<void>
+}

--- a/packages/did-resolver/src/did-cache.ts
+++ b/packages/did-resolver/src/did-cache.ts
@@ -3,5 +3,9 @@ import { CacheResult, DidDocument } from './types'
 export abstract class DidCache {
   abstract cacheDid(did: string, doc: DidDocument): Promise<void>
   abstract checkCache(did: string): Promise<CacheResult | null>
+  abstract refreshCache(
+    did: string,
+    getDoc: () => Promise<DidDocument | null>,
+  ): Promise<void>
   abstract clear(): Promise<void>
 }

--- a/packages/did-resolver/src/did-cache.ts
+++ b/packages/did-resolver/src/did-cache.ts
@@ -7,5 +7,6 @@ export abstract class DidCache {
     did: string,
     getDoc: () => Promise<DidDocument | null>,
   ): Promise<void>
+  abstract clearEntry(did: string): Promise<void>
   abstract clear(): Promise<void>
 }

--- a/packages/did-resolver/src/errors.ts
+++ b/packages/did-resolver/src/errors.ts
@@ -15,3 +15,9 @@ export class UnsupportedDidMethodError extends Error {
     super(`Unsupported DID method: ${did}`)
   }
 }
+
+export class PoorlyFormattedDidDocumentError extends Error {
+  constructor(public did: string, public doc: unknown) {
+    super(`Poorly formatted DID Document: ${doc}`)
+  }
+}

--- a/packages/did-resolver/src/errors.ts
+++ b/packages/did-resolver/src/errors.ts
@@ -1,21 +1,17 @@
-import { DIDResolutionResult } from 'did-resolver'
-
-export const error = (errorType: string): DIDResolutionResult => {
-  return {
-    didResolutionMetadata: { error: errorType },
-    didDocument: null,
-    didDocumentMetadata: {},
+export class DidNotFoundError extends Error {
+  constructor(public did: string) {
+    super(`Could not resolve DID: ${did}`)
   }
 }
 
-export const notFound = (): DIDResolutionResult => {
-  return error('notFound')
+export class PoorlyFormattedDidError extends Error {
+  constructor(public did: string) {
+    super(`Poorly formatted DID: ${did}`)
+  }
 }
 
-export const invalidDid = (): DIDResolutionResult => {
-  return error('invalidDid')
-}
-
-export const unsupported = (): DIDResolutionResult => {
-  return error('unsupportedDidMethod')
+export class UnsupportedDidMethodError extends Error {
+  constructor(public did: string) {
+    super(`Unsupported DID method: ${did}`)
+  }
 }

--- a/packages/did-resolver/src/index.ts
+++ b/packages/did-resolver/src/index.ts
@@ -1,4 +1,6 @@
-export * as web from './web-resolver'
-export * as plc from './plc-resolver'
+export * from './web-resolver'
+export * from './plc-resolver'
 export * from './resolver'
 export * from './atproto-data'
+export * from './types'
+export * from './errors'

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -50,6 +50,10 @@ export class MemoryCache extends DidCache {
     }
   }
 
+  async clearEntry(did: string): Promise<void> {
+    this.cache.delete(did)
+  }
+
   async clear(): Promise<void> {
     this.cache.clear()
   }

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -20,11 +20,21 @@ export class MemoryCache extends DidCache {
     this.cache[did] = { doc, updatedAt: Date.now() }
   }
 
+  async refreshCache(
+    did: string,
+    getDoc: () => Promise<DidDocument | null>,
+  ): Promise<void> {
+    const doc = await getDoc()
+    if (doc) {
+      await this.cacheDid(did, doc)
+    }
+  }
+
   async checkCache(did: string): Promise<CacheResult | null> {
     const val = this.cache[did]
     if (!val) return null
     const now = Date.now()
-    const expired = val.updatedAt + this.ttl > now
+    const expired = now > val.updatedAt + this.ttl
     return {
       ...val,
       did,

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -1,0 +1,38 @@
+import { DAY } from '@atproto/common-web'
+import { DidCache } from './did-cache'
+import { CacheResult, DidDocument } from './types'
+
+type CacheVal = {
+  doc: DidDocument
+  updatedAt: number
+}
+
+export class MemoryCache extends DidCache {
+  public ttl: number
+  constructor(ttl?: number) {
+    super()
+    this.ttl = ttl ?? DAY
+  }
+
+  public cache: Record<string, CacheVal> = {}
+
+  async cacheDid(did: string, doc: DidDocument): Promise<void> {
+    this.cache[did] = { doc, updatedAt: Date.now() }
+  }
+
+  async checkCache(did: string): Promise<CacheResult | null> {
+    const val = this.cache[did]
+    if (!val) return null
+    const now = Date.now()
+    const expired = val.updatedAt > now + this.ttl
+    return {
+      ...val,
+      did,
+      expired,
+    }
+  }
+
+  async clear(): Promise<void> {
+    this.cache = {}
+  }
+}

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -24,7 +24,7 @@ export class MemoryCache extends DidCache {
     const val = this.cache[did]
     if (!val) return null
     const now = Date.now()
-    const expired = val.updatedAt > now + this.ttl
+    const expired = val.updatedAt + this.ttl > now
     return {
       ...val,
       did,

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -37,10 +37,7 @@ export class MemoryCache extends DidCache {
     if (!val) return null
     const now = Date.now()
     const expired = now > val.updatedAt + this.maxTTL
-    if (expired) {
-      this.cache.delete(did)
-      return null
-    }
+    if (expired) return null
 
     const stale = now > val.updatedAt + this.staleTTL
     return {

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -8,7 +8,7 @@ type CacheVal = {
 }
 
 export class MemoryCache extends DidCache {
-  public staleTTL
+  public staleTTL: number
   public maxTTL: number
   constructor(staleTTL?: number, maxTTL?: number) {
     super()

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -36,9 +36,13 @@ export class MemoryCache extends DidCache {
     const val = this.cache.get(did)
     if (!val) return null
     const now = Date.now()
-    const stale = now > val.updatedAt + this.staleTTL
     const expired = now > val.updatedAt + this.maxTTL
-    if (expired) return null
+    if (expired) {
+      this.cache.delete(did)
+      return null
+    }
+
+    const stale = now > val.updatedAt + this.staleTTL
     return {
       ...val,
       did,

--- a/packages/did-resolver/src/memory-cache.ts
+++ b/packages/did-resolver/src/memory-cache.ts
@@ -14,10 +14,10 @@ export class MemoryCache extends DidCache {
     this.ttl = ttl ?? DAY
   }
 
-  public cache: Record<string, CacheVal> = {}
+  public cache: Map<string, CacheVal> = new Map()
 
   async cacheDid(did: string, doc: DidDocument): Promise<void> {
-    this.cache[did] = { doc, updatedAt: Date.now() }
+    this.cache.set(did, { doc, updatedAt: Date.now() })
   }
 
   async refreshCache(
@@ -31,7 +31,7 @@ export class MemoryCache extends DidCache {
   }
 
   async checkCache(did: string): Promise<CacheResult | null> {
-    const val = this.cache[did]
+    const val = this.cache.get(did)
     if (!val) return null
     const now = Date.now()
     const expired = now > val.updatedAt + this.ttl
@@ -43,6 +43,6 @@ export class MemoryCache extends DidCache {
   }
 
   async clear(): Promise<void> {
-    this.cache = {}
+    this.cache.clear()
   }
 }

--- a/packages/did-resolver/src/plc-resolver.ts
+++ b/packages/did-resolver/src/plc-resolver.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios'
 import BaseResolver from './base-resolver'
 import { PlcResolverOpts } from './types'
 
-export class PlcResolver extends BaseResolver {
+export class DidPlcResolver extends BaseResolver {
   constructor(public opts: PlcResolverOpts) {
     super()
   }

--- a/packages/did-resolver/src/plc-resolver.ts
+++ b/packages/did-resolver/src/plc-resolver.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosError } from 'axios'
 import BaseResolver from './base-resolver'
 import { PlcResolverOpts } from './types'
+import { DidCache } from './did-cache'
 
 export class DidPlcResolver extends BaseResolver {
-  constructor(public opts: PlcResolverOpts) {
-    super()
+  constructor(public opts: PlcResolverOpts, public cache?: DidCache) {
+    super(cache)
   }
 
   async resolveDidNoCheck(did: string): Promise<unknown> {

--- a/packages/did-resolver/src/plc-resolver.ts
+++ b/packages/did-resolver/src/plc-resolver.ts
@@ -1,52 +1,26 @@
-import {
-  ParsedDID,
-  DIDResolutionOptions,
-  DIDResolutionResult,
-  DIDResolver,
-  Resolvable,
-  DIDDocument,
-} from 'did-resolver'
 import axios, { AxiosError } from 'axios'
-import * as errors from './errors'
+import BaseResolver from './base-resolver'
+import { PlcResolverOpts } from './types'
 
-export type PlcResolverOptions = {
-  timeout: number
-  plcUrl: string
-}
+export class PlcResolver extends BaseResolver {
+  constructor(public opts: PlcResolverOpts) {
+    super()
+  }
 
-export const makeResolver = (opts: PlcResolverOptions): DIDResolver => {
-  return async (
-    did: string,
-    parsed: ParsedDID,
-    _didResolver: Resolvable,
-    _options: DIDResolutionOptions,
-  ): Promise<DIDResolutionResult> => {
-    if (parsed.method !== 'plc') {
-      return errors.unsupported()
-    }
-
-    let didDocument: DIDDocument
+  async resolveDidNoCheck(did: string): Promise<unknown> {
     try {
-      const res = await axios.get(`${opts.plcUrl}/${encodeURIComponent(did)}`, {
-        timeout: opts.timeout,
-      })
-      didDocument = res.data
+      const res = await axios.get(
+        `${this.opts.plcUrl}/${encodeURIComponent(did)}`,
+        {
+          timeout: this.opts.timeout,
+        },
+      )
+      return res.data
     } catch (err) {
       if (err instanceof AxiosError && err.response?.status === 404) {
-        return errors.notFound() // Positively not found, versus due to e.g. network error
+        return null // Positively not found, versus due to e.g. network error
       }
       throw err
-    }
-
-    const docIdMatchesDid = didDocument?.id === did
-    if (!docIdMatchesDid) {
-      return errors.invalidDid()
-    }
-
-    return {
-      didResolutionMetadata: { contentType: 'application/did+ld+json' },
-      didDocument,
-      didDocumentMetadata: {},
     }
   }
 }

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -1,81 +1,32 @@
-import {
-  Resolver,
-  DIDDocument,
-  DIDResolutionOptions,
-  DIDResolutionResult,
-} from 'did-resolver'
-import * as crypto from '@atproto/crypto'
-import * as web from './web-resolver'
-import * as plc from './plc-resolver'
-import * as atpDid from './atproto-data'
-import log from './logger'
+import { WebResolver } from './web-resolver'
+import { PlcResolver } from './plc-resolver'
+import { DidResolverOpts } from './types'
+import BaseResolver from './base-resolver'
+import { PoorlyFormattedDidError, UnsupportedDidMethodError } from './errors'
 
-export type DidResolverOptions = {
-  timeout: number
-  plcUrl: string
-}
+export class DidResolver extends BaseResolver {
+  methods: Record<string, BaseResolver>
 
-export class DidResolver {
-  resolver: Resolver
-  constructor(opts: Partial<DidResolverOptions> = {}) {
-    // @TODO change to production url
-    const { timeout = 3000, plcUrl = 'http://localhost:2582' } = opts
-    this.resolver = new Resolver({
-      plc: plc.makeResolver({
-        timeout,
-        plcUrl,
-      }),
-      web: web.makeResolver({ timeout }),
-    })
-  }
-
-  async resolveDid(
-    did: string,
-    options: DIDResolutionOptions = {},
-  ): Promise<DIDResolutionResult> {
-    log.info({ did }, 'resolving did')
-    const res = await this.resolver.resolve(did, options)
-    log.info({ did, res }, 'resolved did')
-    return res
-  }
-
-  async ensureResolveDid(
-    did: string,
-    options: DIDResolutionOptions = {},
-  ): Promise<DIDDocument> {
-    const result = await this.resolveDid(did, options)
-    if (result.didResolutionMetadata.error || result.didDocument === null) {
-      const err = result.didResolutionMetadata.error || 'notFound'
-      log.info({ err, did }, 'could not resolve did')
-      throw new NoResolveDidError(`Could not resolve DID (${did}): ${err}`)
-    }
-    return result.didDocument
-  }
-
-  async resolveAtpData(did: string): Promise<atpDid.AtprotoData> {
-    const didDocument = await this.ensureResolveDid(did)
-    return atpDid.ensureAtpDocument(didDocument)
-  }
-
-  async resolveSigningKey(did: string): Promise<string> {
-    if (did.startsWith('did:key:')) {
-      return did
-    } else {
-      const data = await this.resolveAtpData(did)
-      return data.signingKey
+  constructor(opts: Partial<DidResolverOpts> = {}) {
+    super()
+    const { timeout = 3000, plcUrl = 'https://plc.directory' } = opts
+    this.methods = {
+      plc: new PlcResolver({ timeout, plcUrl }),
+      web: new WebResolver({ timeout }),
     }
   }
 
-  async verifySignature(
-    did: string,
-    data: Uint8Array,
-    sig: Uint8Array,
-  ): Promise<boolean> {
-    const signingKey = await this.resolveSigningKey(did)
-    return crypto.verifySignature(signingKey, data, sig)
+  async resolveDidNoCheck(did: string): Promise<unknown> {
+    const split = did.split(':')
+    if (split[0] !== 'did') {
+      throw new PoorlyFormattedDidError(did)
+    }
+    const method = this.methods[split[1]]
+    if (!method) {
+      throw new UnsupportedDidMethodError(did)
+    }
+    return method.resolveDidNoCheck(did)
   }
 }
 
-export const resolver = new DidResolver()
-
-export class NoResolveDidError extends Error {}
+export default DidResolver

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -3,13 +3,15 @@ import { DidPlcResolver } from './plc-resolver'
 import { DidResolverOpts } from './types'
 import BaseResolver from './base-resolver'
 import { PoorlyFormattedDidError, UnsupportedDidMethodError } from './errors'
+import { DidCache } from './did-cache'
 
 export class DidResolver extends BaseResolver {
   methods: Record<string, BaseResolver>
 
-  constructor(opts: Partial<DidResolverOpts> = {}) {
-    super()
+  constructor(opts: Partial<DidResolverOpts> = {}, cache?: DidCache) {
+    super(cache)
     const { timeout = 3000, plcUrl = 'https://plc.directory' } = opts
+    // do not pass cache to sub-methods or we will be double caching
     this.methods = {
       plc: new DidPlcResolver({ timeout, plcUrl }),
       web: new DidWebResolver({ timeout }),

--- a/packages/did-resolver/src/resolver.ts
+++ b/packages/did-resolver/src/resolver.ts
@@ -1,5 +1,5 @@
-import { WebResolver } from './web-resolver'
-import { PlcResolver } from './plc-resolver'
+import { DidWebResolver } from './web-resolver'
+import { DidPlcResolver } from './plc-resolver'
 import { DidResolverOpts } from './types'
 import BaseResolver from './base-resolver'
 import { PoorlyFormattedDidError, UnsupportedDidMethodError } from './errors'
@@ -11,8 +11,8 @@ export class DidResolver extends BaseResolver {
     super()
     const { timeout = 3000, plcUrl = 'https://plc.directory' } = opts
     this.methods = {
-      plc: new PlcResolver({ timeout, plcUrl }),
-      web: new WebResolver({ timeout }),
+      plc: new DidPlcResolver({ timeout, plcUrl }),
+      web: new DidWebResolver({ timeout }),
     }
   }
 

--- a/packages/did-resolver/src/types.ts
+++ b/packages/did-resolver/src/types.ts
@@ -25,7 +25,7 @@ export type CacheResult = {
   did: string
   doc: DidDocument
   updatedAt: number
-  expired: boolean
+  stale: boolean
 }
 
 export const verificationMethod = z.object({

--- a/packages/did-resolver/src/types.ts
+++ b/packages/did-resolver/src/types.ts
@@ -1,0 +1,44 @@
+import * as z from 'zod'
+
+export type DidResolverOpts = {
+  timeout: number
+  plcUrl: string
+}
+
+export type WebResolverOpts = {
+  timeout: number
+}
+
+export type PlcResolverOpts = {
+  timeout: number
+  plcUrl: string
+}
+
+export type AtprotoData = {
+  did: string
+  signingKey: string
+  handle: string
+  pds: string
+}
+
+export const verificationMethod = z.object({
+  id: z.string(),
+  type: z.string(),
+  controller: z.string(),
+  publicKeyMultibase: z.string().optional(),
+})
+
+export const service = z.object({
+  id: z.string(),
+  type: z.string(),
+  serviceEndpoint: z.union([z.string(), z.record(z.unknown())]),
+})
+
+export const didDocument = z.object({
+  id: z.string(),
+  alsoKnownAs: z.array(z.string()).optional(),
+  verificationMethod: z.array(verificationMethod).optional(),
+  service: z.array(service).optional(),
+})
+
+export type DidDocument = z.infer<typeof didDocument>

--- a/packages/did-resolver/src/types.ts
+++ b/packages/did-resolver/src/types.ts
@@ -21,6 +21,13 @@ export type AtprotoData = {
   pds: string
 }
 
+export type CacheResult = {
+  did: string
+  doc: DidDocument
+  updatedAt: number
+  expired: boolean
+}
+
 export const verificationMethod = z.object({
   id: z.string(),
   type: z.string(),

--- a/packages/did-resolver/src/web-resolver.ts
+++ b/packages/did-resolver/src/web-resolver.ts
@@ -2,12 +2,13 @@ import axios, { AxiosError } from 'axios'
 import BaseResolver from './base-resolver'
 import { WebResolverOpts } from './types'
 import { PoorlyFormattedDidError } from './errors'
+import { DidCache } from './did-cache'
 
 export const DOC_PATH = '/.well-known/did.json'
 
 export class DidWebResolver extends BaseResolver {
-  constructor(public opts: WebResolverOpts) {
-    super()
+  constructor(public opts: WebResolverOpts, public cache?: DidCache) {
+    super(cache)
   }
 
   async resolveDidNoCheck(did: string): Promise<unknown> {

--- a/packages/did-resolver/src/web-resolver.ts
+++ b/packages/did-resolver/src/web-resolver.ts
@@ -5,7 +5,7 @@ import { PoorlyFormattedDidError } from './errors'
 
 export const DOC_PATH = '/.well-known/did.json'
 
-export class WebResolver extends BaseResolver {
+export class DidWebResolver extends BaseResolver {
   constructor(public opts: WebResolverOpts) {
     super()
   }

--- a/packages/did-resolver/src/web-resolver.ts
+++ b/packages/did-resolver/src/web-resolver.ts
@@ -1,34 +1,21 @@
-import {
-  ParsedDID,
-  DIDResolutionOptions,
-  DIDResolutionResult,
-  DIDResolver,
-  Resolvable,
-  DIDDocument,
-} from 'did-resolver'
 import axios, { AxiosError } from 'axios'
-import * as errors from './errors'
+import BaseResolver from './base-resolver'
+import { WebResolverOpts } from './types'
+import { PoorlyFormattedDidError } from './errors'
 
 export const DOC_PATH = '/.well-known/did.json'
 
-export type WebResolverOptions = {
-  timeout: number
-}
+export class WebResolver extends BaseResolver {
+  constructor(public opts: WebResolverOpts) {
+    super()
+  }
 
-export const makeResolver = (opts: WebResolverOptions): DIDResolver => {
-  return async (
-    did: string,
-    parsed: ParsedDID,
-    _didResolver: Resolvable,
-    _options: DIDResolutionOptions,
-  ): Promise<DIDResolutionResult> => {
-    if (parsed.method !== 'web') {
-      return errors.unsupported()
-    }
-    const parts = parsed.id.split(':').map(decodeURIComponent)
+  async resolveDidNoCheck(did: string): Promise<unknown> {
+    const parsedId = did.split(':').slice(2).join(':')
+    const parts = parsedId.split(':').map(decodeURIComponent)
     let path: string
     if (parts.length < 1) {
-      return errors.invalidDid()
+      throw new PoorlyFormattedDidError(did)
     } else if (parts.length === 1) {
       path = parts[0] + DOC_PATH
     } else {
@@ -40,30 +27,17 @@ export const makeResolver = (opts: WebResolverOptions): DIDResolver => {
       url.protocol = 'http'
     }
 
-    let didDocument: DIDDocument
     try {
       const res = await axios.get(url.toString(), {
         responseType: 'json',
-        timeout: opts.timeout,
+        timeout: this.opts.timeout,
       })
-      didDocument = res.data
+      return res.data
     } catch (err) {
       if (err instanceof AxiosError && err.response) {
-        return errors.notFound() // Positively not found, versus due to e.g. network error
+        return null // Positively not found, versus due to e.g. network error
       }
       throw err
-    }
-
-    // @TODO: this excludes the use of query params
-    const docIdMatchesDid = didDocument?.id === did
-    if (!docIdMatchesDid) {
-      return errors.invalidDid()
-    }
-
-    return {
-      didResolutionMetadata: { contentType: 'application/did+ld+json' },
-      didDocument,
-      didDocumentMetadata: {},
     }
   }
 }

--- a/packages/did-resolver/tests/cache.test.ts
+++ b/packages/did-resolver/tests/cache.test.ts
@@ -1,0 +1,103 @@
+import getPort from 'get-port'
+import * as plc from '@did-plc/lib'
+import { Database as DidPlcDb, PlcServer } from '@did-plc/server'
+import { MemoryCache } from '../src/memory-cache'
+import { DidResolver } from '../src'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import { wait } from '@atproto/common-web'
+
+describe('cache', () => {
+  let close: () => Promise<void>
+  let plcUrl: string
+  let did: string
+
+  let didCache: MemoryCache
+  let didResolver: DidResolver
+
+  beforeAll(async () => {
+    const plcDB = DidPlcDb.mock()
+    const plcPort = await getPort()
+    const plcServer = PlcServer.create({ db: plcDB, port: plcPort })
+    await plcServer.start()
+
+    plcUrl = 'http://localhost:' + plcPort
+
+    const signingKey = await Secp256k1Keypair.create()
+    const rotationKey = await Secp256k1Keypair.create()
+    const plcClient = new plc.Client(plcUrl)
+    did = await plcClient.createDid({
+      signingKey: signingKey.did(),
+      handle: 'alice.test',
+      pds: 'https://bsky.social',
+      rotationKeys: [rotationKey.did()],
+      signer: rotationKey,
+    })
+
+    didCache = new MemoryCache()
+    didResolver = new DidResolver({ plcUrl }, didCache)
+
+    close = async () => {
+      await plcServer.destroy()
+    }
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('caches dids on lookup', async () => {
+    const resolved = await didResolver.resolveDid(did)
+    expect(resolved?.id).toBe(did)
+
+    const cached = await didResolver.cache?.checkCache(did)
+    expect(cached?.did).toBe(did)
+    expect(cached?.doc).toEqual(resolved)
+  })
+
+  it('clears cache and repopulates', async () => {
+    await didResolver.cache?.clear()
+    await didResolver.resolveDid(did)
+
+    const cached = await didResolver.cache?.checkCache(did)
+    expect(cached?.did).toBe(did)
+    expect(cached?.doc.id).toEqual(did)
+  })
+
+  it('accurately reports stale dids & refreshes the cache', async () => {
+    const didCache = new MemoryCache(1)
+    const shortCacheResolver = new DidResolver({ plcUrl }, didCache)
+    const doc = await shortCacheResolver.resolveDid(did)
+
+    // let's mess with the cached doc so we get something different
+    await didCache.cacheDid(did, { ...doc, id: 'did:example:alice' })
+    await wait(5)
+
+    // first check the cache & see that we have the stale value
+    const cached = await shortCacheResolver.cache?.checkCache(did)
+    expect(cached?.stale).toBe(true)
+    expect(cached?.doc.id).toEqual('did:example:alice')
+    // see that the resolver gives us the stale value while it revalidates
+    const staleGet = await shortCacheResolver.resolveDid(did)
+    expect(staleGet?.id).toEqual('did:example:alice')
+
+    // since it revalidated, ensure we have the new value
+    const updatedCache = await shortCacheResolver.cache?.checkCache(did)
+    expect(updatedCache?.doc.id).toEqual(did)
+    const updatedGet = await shortCacheResolver.resolveDid(did)
+    expect(updatedGet?.id).toEqual(did)
+  })
+
+  it('does not return expired dids & refreshes the cache', async () => {
+    const didCache = new MemoryCache(0, 1)
+    const shortExpireResolver = new DidResolver({ plcUrl }, didCache)
+    const doc = await shortExpireResolver.resolveDid(did)
+
+    // again, we mess with the cached doc so we get something different
+    await didCache.cacheDid(did, { ...doc, id: 'did:example:alice' })
+    await wait(5)
+
+    // see that the resolver does not return expired value & instead force refreshes
+    const staleGet = await shortExpireResolver.resolveDid(did)
+    expect(staleGet?.id).toEqual(did)
+  })
+})

--- a/packages/did-resolver/tests/resolver.test.ts
+++ b/packages/did-resolver/tests/resolver.test.ts
@@ -76,7 +76,7 @@ describe('resolver', () => {
   })
 
   it('resolve valid atpData from did:web', async () => {
-    const atpData = await resolver.resolveAtpData(webDid)
+    const atpData = await resolver.resolveAtprotoData(webDid)
     expect(atpData.did).toEqual(webDid)
     expect(atpData.handle).toEqual(handle)
     expect(atpData.pds).toEqual(pds)
@@ -96,7 +96,7 @@ describe('resolver', () => {
   })
 
   it('resolve valid atpData from did:plc', async () => {
-    const atpData = await resolver.resolveAtpData(plcDid)
+    const atpData = await resolver.resolveAtprotoData(plcDid)
     expect(atpData.did).toEqual(plcDid)
     expect(atpData.handle).toEqual(handle)
     expect(atpData.pds).toEqual(pds)

--- a/packages/did-resolver/tests/resolver.test.ts
+++ b/packages/did-resolver/tests/resolver.test.ts
@@ -1,11 +1,10 @@
 import getPort from 'get-port'
-import { DidResolver } from '../src'
-import { DidWebServer } from './web/server'
-import DidWebDb from './web/db'
+import { Secp256k1Keypair } from '@atproto/crypto'
 import * as plc from '@did-plc/lib'
 import { Database as DidPlcDb, PlcServer } from '@did-plc/server'
-import { DIDDocument } from 'did-resolver'
-import { Secp256k1Keypair } from '@atproto/crypto'
+import { DidResolver, DidDocument } from '../src'
+import { DidWebServer } from './web/server'
+import DidWebDb from './web/db'
 
 describe('resolver', () => {
   let close: () => Promise<void>
@@ -45,8 +44,8 @@ describe('resolver', () => {
   let rotationKey: Secp256k1Keypair
   let webDid: string
   let plcDid: string
-  let didWebDoc: DIDDocument
-  let didPlcDoc: DIDDocument
+  let didWebDoc: DidDocument
+  let didPlcDoc: DidDocument
 
   it('creates the did on did:web & did:plc', async () => {
     signingKey = await Secp256k1Keypair.create()

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -140,7 +140,7 @@ describe('account', () => {
   })
 
   it('generates a properly formatted PLC DID', async () => {
-    const didData = await didResolver.resolveAtpData(did)
+    const didData = await didResolver.resolveAtprotoData(did)
 
     expect(didData.did).toBe(did)
     expect(didData.handle).toBe(handle)

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -85,7 +85,7 @@ describe('handles', () => {
   })
 
   it('updates their did document', async () => {
-    const data = await didResolver.resolveAtpData(alice)
+    const data = await didResolver.resolveAtprotoData(alice)
     expect(data.handle).toBe(newHandle)
   })
 
@@ -136,7 +136,7 @@ describe('handles', () => {
   })
 
   it('if handle update fails, it does not update their did document', async () => {
-    const data = await didResolver.resolveAtpData(alice)
+    const data = await didResolver.resolveAtprotoData(alice)
     expect(data.handle).toBe(newHandle)
   })
 
@@ -198,7 +198,7 @@ describe('handles', () => {
     )
     expect(profile.data.handle).toBe('alice.external')
 
-    const data = await didResolver.resolveAtpData(alice)
+    const data = await didResolver.resolveAtprotoData(alice)
     expect(data.handle).toBe('alice.external')
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6213,11 +6213,6 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-did-resolver@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/did-resolver/-/did-resolver-4.0.0.tgz"
-  integrity sha512-/roxrDr9EnAmLs+s9T+8+gcpilMo+IkeytcsGO7dcxvTmVJ+0Rt60HtV8o0UXHhGBo0Q+paMH/0ffXz1rqGFYg==
-
 diff-sequences@^28.1.1:
   version "28.1.1"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz"


### PR DESCRIPTION
A few things here:
- no longer use the published did-resolver library. We weren't getting anything from it & was adding complexity to the codebase
- default plc url to the production plc service (`https://plc.directory`)
- add in flexible caching ability to the did-resolver
- better error handling
- remove node dependencies 
  - `@atproto/common` -> `@atproto/common-web`
  - remove the one node dep in `@atproto/crypto` around streaming sha256

Closes https://github.com/bluesky-social/atproto/issues/823
Partially addresses https://github.com/bluesky-social/atproto/issues/824 