### PR TITLE
Do not give notifs for a deleted subject

### DIFF
--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -21,6 +21,16 @@ export default function (server: Server, ctx: AppContext) {
         .where(notSoftDeletedClause(ref('record')))
         .where(notSoftDeletedClause(ref('author')))
         .where('notif.did', '=', requester)
+        .where((clause) =>
+          clause
+            .where('reasonSubject', 'is', null)
+            .orWhereExists(
+              ctx.db.db
+                .selectFrom('record as subject')
+                .selectAll()
+                .whereRef('subject.uri', '=', ref('notif.reasonSubject')),
+            ),
+        )
         .select([
           'notif.recordUri as uri',
           'notif.recordCid as cid',

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -91,6 +91,28 @@ describe('notification views', () => {
     expect(notifCountBob.data.count).toBe(5)
   })
 
+  it('does not give notifs for a deleted subject', async () => {
+    const root = await sc.post(sc.dids.alice, 'root')
+    const first = await sc.reply(sc.dids.bob, root.ref, root.ref, 'first')
+    await sc.deletePost(sc.dids.alice, root.ref.uri)
+    const second = await sc.reply(sc.dids.carol, root.ref, first.ref, 'second')
+    await processAll(testEnv)
+
+    const notifsAlice = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.alice, true) },
+    )
+    const hasNotif = notifsAlice.data.notifications.some(
+      (notif) => notif.uri === second.ref.uriStr,
+    )
+    expect(hasNotif).toBe(false)
+
+    // cleanup
+    await sc.deletePost(sc.dids.bob, first.ref.uri)
+    await sc.deletePost(sc.dids.carol, second.ref.uri)
+    await processAll(testEnv)
+  })
+
   it('generates notifications for quotes', async () => {
     // Dan was quoted by alice
     const notifsDan = await agent.api.app.bsky.notification.listNotifications(

--- a/packages/pds/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/api/app/bsky/notification/listNotifications.ts
@@ -40,6 +40,16 @@ export default function (server: Server, ctx: AppContext) {
             .whereRef('did', '=', ref('notif.author'))
             .where('mutedByDid', '=', requester),
         )
+        .where((clause) =>
+          clause
+            .where('reasonSubject', 'is', null)
+            .orWhereExists(
+              ctx.db.db
+                .selectFrom('record as subject')
+                .selectAll()
+                .whereRef('subject.uri', '=', ref('notif.reasonSubject')),
+            ),
+        )
         .select([
           'notif.recordUri as uri',
           'notif.recordCid as cid',

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -92,6 +92,26 @@ describe('pds notification views', () => {
     expect(notifCountBob.data.count).toBe(5)
   })
 
+  it('does not give notifs for a deleted subject', async () => {
+    const root = await sc.post(sc.dids.alice, 'root')
+    const first = await sc.reply(sc.dids.bob, root.ref, root.ref, 'first')
+    await sc.deletePost(sc.dids.alice, root.ref.uri)
+    const second = await sc.reply(sc.dids.carol, root.ref, first.ref, 'second')
+
+    const notifsAlice = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.alice) },
+    )
+    const hasNotif = notifsAlice.data.notifications.some(
+      (notif) => notif.uri === second.ref.uriStr,
+    )
+    expect(hasNotif).toBe(false)
+
+    // cleanup
+    await sc.deletePost(sc.dids.bob, first.ref.uri)
+    await sc.deletePost(sc.dids.carol, second.ref.uri)
+  })
+
   it('generates notifications for quotes', async () => {
     // Dan was quoted by alice
     const notifsDan = await agent.api.app.bsky.notification.listNotifications(


### PR DESCRIPTION
From chat in https://github.com/bluesky-social/atproto/pull/839

Let's do the general solution of just not returning any notifications for a deleted subject