### PR TITLE
Bump node-postgres version

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -2,7 +2,7 @@
   "name": "@atproto/bsky",
   "version": "0.0.0",
   "license": "MIT",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
@@ -44,7 +44,7 @@
     "kysely": "^0.22.0",
     "multiformats": "^9.6.4",
     "p-queue": "^6.6.2",
-    "pg": "^8.8.0",
+    "pg": "^8.10.0",
     "pino": "^8.6.1",
     "pino-http": "^8.2.1",
     "sharp": "^0.31.2",
@@ -59,7 +59,7 @@
     "@did-plc/server": "^0.0.1",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
-    "@types/pg": "^8.6.5",
+    "@types/pg": "^8.6.6",
     "@types/sharp": "^0.31.0",
     "axios": "^0.27.2"
   }

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -2,7 +2,7 @@
   "name": "@atproto/bsky",
   "version": "0.0.0",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@atproto/api": "*",
+    "@atproto/bsky": "*",
     "@atproto/crypto": "*",
     "@atproto/did-resolver": "*",
     "@atproto/pds": "*",

--- a/packages/dev-env/tsconfig.json
+++ b/packages/dev-env/tsconfig.json
@@ -8,6 +8,7 @@
   "include": ["./src","__tests__/**/**.ts"],
   "references": [
     { "path": "../api/tsconfig.build.json" },
+    { "path": "../bsky/tsconfig.build.json" },
     { "path": "../crypto/tsconfig.build.json" },
     { "path": "../did-resolver/tsconfig.build.json" },
     { "path": "../pds/tsconfig.json" },

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -2,7 +2,7 @@
   "name": "@atproto/pds",
   "version": "0.1.4",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -2,7 +2,7 @@
   "name": "@atproto/pds",
   "version": "0.1.4",
   "license": "MIT",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
@@ -53,7 +53,7 @@
     "nodemailer": "^6.8.0",
     "nodemailer-html-to-text": "^3.2.0",
     "p-queue": "^6.6.2",
-    "pg": "^8.8.0",
+    "pg": "^8.10.0",
     "pino": "^8.6.1",
     "pino-http": "^8.2.1",
     "sharp": "^0.31.2",
@@ -68,7 +68,7 @@
     "@types/express": "^4.17.13",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/nodemailer": "^6.4.6",
-    "@types/pg": "^8.6.5",
+    "@types/pg": "^8.6.6",
     "@types/sharp": "^0.31.0",
     "axios": "^0.27.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,10 +4826,10 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/pg@^8.6.5":
-  version "8.6.5"
-  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz"
-  integrity sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==
+"@types/pg@^8.6.6":
+  version "8.6.6"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.6.tgz#21cdf873a3e345a6e78f394677e3b3b1b543cb80"
+  integrity sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==
   dependencies:
     "@types/node" "*"
     pg-protocol "*"
@@ -9743,12 +9743,12 @@ pg-pool@^3.5.2:
   resolved "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz"
   integrity sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==
 
-pg-protocol@*, pg-protocol@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz"
-  integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
+pg-pool@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.0.tgz#3190df3e4747a0d23e5e9e8045bcd99bda0a712e"
+  integrity sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==
 
-pg-protocol@^1.6.0:
+pg-protocol@*, pg-protocol@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
   integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
@@ -9764,16 +9764,16 @@ pg-types@^2.1.0, pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.8.0:
-  version "8.8.0"
-  resolved "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz"
-  integrity sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==
+pg@^8.10.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.10.0.tgz#5b8379c9b4a36451d110fc8cd98fc325fe62ad24"
+  integrity sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==
   dependencies:
     buffer-writer "2.0.0"
     packet-reader "1.0.0"
     pg-connection-string "^2.5.0"
-    pg-pool "^3.5.2"
-    pg-protocol "^1.5.0"
+    pg-pool "^3.6.0"
+    pg-protocol "^1.6.0"
     pg-types "^2.1.0"
     pgpass "1.x"
 


### PR DESCRIPTION
Bump node-postgres from 8.8.0 to 8.10.0

Specifically v8.10.0 includes a fix that has emits a "release" event when a client is returned to the pool:

https://github.com/brianc/node-postgres/pull/2845