### PR TITLE
Skip locked repos instead of waiting for lock

### DIFF
--- a/packages/pds/tests/sync/subscribe-repos.test.ts
+++ b/packages/pds/tests/sync/subscribe-repos.test.ts
@@ -142,16 +142,16 @@ describe('repo subscribe repos', () => {
     }
   }
 
-  const randomPost = async (by: string) => sc.post(by, randomStr(8, 'base32'))
+  const randomPost = (by: string) => sc.post(by, randomStr(8, 'base32'))
   const makePosts = async () => {
-    const promises: Promise<unknown>[] = []
-    for (let i = 0; i < 10; i++) {
-      promises.push(randomPost(alice))
-      promises.push(randomPost(bob))
-      promises.push(randomPost(carol))
-      promises.push(randomPost(dan))
+    for (let i = 0; i < 3; i++) {
+      await Promise.all([
+        randomPost(alice),
+        randomPost(bob),
+        randomPost(carol),
+        randomPost(dan),
+      ])
     }
-    await Promise.all(promises)
   }
 
   const readTillCaughtUp = async <T>(
@@ -223,7 +223,7 @@ describe('repo subscribe repos', () => {
 
     ws.terminate()
 
-    expect(evts.length).toBe(40)
+    expect(evts.length).toBe(12)
 
     await wait(100) // Let cleanup occur on server
     expect(ctx.sequencer.listeners('events').length).toEqual(0)
@@ -352,7 +352,7 @@ describe('repo subscribe repos', () => {
     expect(info.header.t).toBe('#info')
     const body = info.body as Record<string, unknown>
     expect(body.name).toEqual('OutdatedCursor')
-    expect(evts.length).toBe(40)
+    expect(evts.length).toBe(12)
   })
 
   it('errors on future cursor', async () => {

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -159,30 +159,6 @@ describe('pds profile views', () => {
     expect(forSnapshot(danForDan.data)).toMatchSnapshot()
   })
 
-  it('handles racing updates', async () => {
-    const descriptions: string[] = []
-    const COUNT = 10
-    for (let i = 0; i < COUNT; i++) {
-      descriptions.push(`description-${i}`)
-    }
-    await Promise.all(
-      descriptions.map(async (description) => {
-        await updateProfile(agent, alice, { description })
-      }),
-    )
-
-    const profile = await agent.api.app.bsky.actor.getProfile(
-      { actor: alice },
-      { headers: sc.getHeaders(alice) },
-    )
-
-    // doesn't matter which request wins race, but one of them should win
-    const descripExists = descriptions.some(
-      (descrip) => profile.data.description === descrip,
-    )
-    expect(descripExists).toBeTruthy()
-  })
-
   it('fetches profile by handle', async () => {
     const byDid = await agent.api.app.bsky.actor.getProfile(
       { actor: alice },


### PR DESCRIPTION
We have to linearize writes to repos as they come in.

Right now we do that by taking out a row lock with SELECT FOR UPDATE.

However, many operations against the same repo can result in lock contention which spikes cpu & hogs connections in the pool.

Instead we:
- do a SELECT FOR UPDATE SKIP LOCKED
- if we skip over a locked row, then we wait 200ms, in the hopes that the previous operation will succeed & then try again
- if it fails again, we through a 400 error for attempting too many concurrent updates

Clients that have legitimate reasons for doing large writes can do so with `applyWrites` or serialize their write requests.

We can tweak this approach as we go. perhaps with more checks and/or a shorter wait period.