### PR TITLE
Format commits outside of tx

### DIFF
--- a/packages/bsky/tests/indexing.test.ts
+++ b/packages/bsky/tests/indexing.test.ts
@@ -295,25 +295,21 @@ describe('indexing', () => {
       const { db, services } = testEnv.bsky.ctx
       const { db: pdsDb, services: pdsServices } = testEnv.pds.ctx
       // Create a good and a bad post record
-      const writes = await pdsDb.transaction(async (tx) => {
-        const now = new Date().toISOString()
-        const repoTxn = pdsServices.repo(tx)
-        const writes = await Promise.all([
-          pdsRepo.prepareCreate({
-            did: sc.dids.alice,
-            collection: ids.AppBskyFeedPost,
-            record: { text: 'valid', createdAt: new Date().toISOString() },
-          }),
-          pdsRepo.prepareCreate({
-            did: sc.dids.alice,
-            collection: ids.AppBskyFeedPost,
-            record: { text: 0 },
-            validate: false,
-          }),
-        ])
-        await repoTxn.processWrites(sc.dids.alice, writes, now)
-        return writes
-      })
+      const repoTxn = pdsServices.repo(pdsDb)
+      const writes = await Promise.all([
+        pdsRepo.prepareCreate({
+          did: sc.dids.alice,
+          collection: ids.AppBskyFeedPost,
+          record: { text: 'valid', createdAt: new Date().toISOString() },
+        }),
+        pdsRepo.prepareCreate({
+          did: sc.dids.alice,
+          collection: ids.AppBskyFeedPost,
+          record: { text: 0 },
+          validate: false,
+        }),
+      ])
+      await repoTxn.processWrites({ did: sc.dids.alice, writes }, 1)
       // Index
       const { data: head } = await pdsAgent.api.com.atproto.sync.getHead({
         did: sc.dids.alice,

--- a/packages/bsky/tests/indexing.test.ts
+++ b/packages/bsky/tests/indexing.test.ts
@@ -295,7 +295,6 @@ describe('indexing', () => {
       const { db, services } = testEnv.bsky.ctx
       const { db: pdsDb, services: pdsServices } = testEnv.pds.ctx
       // Create a good and a bad post record
-      const repoTxn = pdsServices.repo(pdsDb)
       const writes = await Promise.all([
         pdsRepo.prepareCreate({
           did: sc.dids.alice,
@@ -309,7 +308,9 @@ describe('indexing', () => {
           validate: false,
         }),
       ])
-      await repoTxn.processWrites({ did: sc.dids.alice, writes }, 1)
+      await pdsServices
+        .repo(pdsDb)
+        .processWrites({ did: sc.dids.alice, writes }, 1)
       // Index
       const { data: head } = await pdsAgent.api.com.atproto.sync.getHead({
         did: sc.dids.alice,

--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -13,6 +13,7 @@ import {
   PreparedWrite,
 } from '../../../../repo'
 import AppContext from '../../../../context'
+import { ConcurrentWriteError } from '../../../../services/repo'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.applyWrites({
@@ -79,10 +80,12 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .processWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 10)
       } catch (err) {
         if (err instanceof BadCommitSwapError) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')
+        } else if (err instanceof ConcurrentWriteError) {
+          throw new InvalidRequestError(err.message, 'ConcurrentWrites')
         } else {
           throw err
         }

--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -79,7 +79,7 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 5, 100)
       } catch (err) {
         if (err instanceof BadCommitSwapError) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -60,7 +60,7 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 5, 100)
       } catch (err) {
         if (err instanceof BadCommitSwapError) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')

--- a/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
@@ -40,7 +40,7 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 5, 100)
       } catch (err) {
         if (
           err instanceof BadCommitSwapError ||

--- a/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
@@ -19,7 +19,6 @@ export default function (server: Server, ctx: AppContext) {
         throw new AuthRequiredError()
       }
 
-      const now = new Date().toISOString()
       const swapCommitCid = swapCommit ? CID.parse(swapCommit) : undefined
       const swapRecordCid = swapRecord ? CID.parse(swapRecord) : undefined
 
@@ -29,27 +28,29 @@ export default function (server: Server, ctx: AppContext) {
         rkey,
         swapCid: swapRecordCid,
       })
+      const record = await ctx.services
+        .record(ctx.db)
+        .getRecord(write.uri, null, true)
+      if (!record) {
+        return // No-op if record already doesn't exist
+      }
 
-      await ctx.db.transaction(async (dbTxn) => {
-        const repoTxn = ctx.services.repo(dbTxn)
-        const recordTxn = ctx.services.record(dbTxn)
-        const record = await recordTxn.getRecord(write.uri, null, true)
-        if (!record) {
-          return // No-op if record already doesn't exist
+      const writes = [write]
+
+      try {
+        await ctx.services
+          .repo(ctx.db)
+          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+      } catch (err) {
+        if (
+          err instanceof BadCommitSwapError ||
+          err instanceof BadRecordSwapError
+        ) {
+          throw new InvalidRequestError(err.message, 'InvalidSwap')
+        } else {
+          throw err
         }
-        try {
-          await repoTxn.processWrites(did, [write], now, swapCommitCid)
-        } catch (err) {
-          if (
-            err instanceof BadCommitSwapError ||
-            err instanceof BadRecordSwapError
-          ) {
-            throw new InvalidRequestError(err.message, 'InvalidSwap')
-          } else {
-            throw err
-          }
-        }
-      })
+      }
     },
   })
 }

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -80,7 +80,7 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 5, 100)
       } catch (err) {
         if (
           err instanceof BadCommitSwapError ||

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -46,52 +46,51 @@ export default function (server: Server, ctx: AppContext) {
         )
       }
 
-      const now = new Date().toISOString()
       const uri = AtUri.make(did, collection, rkey)
       const swapCommitCid = swapCommit ? CID.parse(swapCommit) : undefined
       const swapRecordCid =
         typeof swapRecord === 'string' ? CID.parse(swapRecord) : swapRecord
 
-      const write = await ctx.db.transaction(async (dbTxn) => {
-        const repoTxn = ctx.services.repo(dbTxn)
-        const recordTxn = ctx.services.record(dbTxn)
+      const current = await ctx.services
+        .record(ctx.db)
+        .getRecord(uri, null, true)
+      const writeInfo = {
+        did,
+        collection,
+        rkey,
+        record,
+        swapCid: swapRecordCid,
+        validate,
+      }
 
-        const current = await recordTxn.getRecord(uri, null, true)
-        const writeInfo = {
-          did,
-          collection,
-          rkey,
-          record,
-          swapCid: swapRecordCid,
-          validate,
+      let write: PreparedCreate | PreparedUpdate
+      try {
+        write = current
+          ? await prepareUpdate(writeInfo)
+          : await prepareCreate(writeInfo)
+      } catch (err) {
+        if (err instanceof InvalidRecordError) {
+          throw new InvalidRequestError(err.message)
         }
+        throw err
+      }
 
-        let write: PreparedCreate | PreparedUpdate
-        try {
-          write = current
-            ? await prepareUpdate(writeInfo)
-            : await prepareCreate(writeInfo)
-        } catch (err) {
-          if (err instanceof InvalidRecordError) {
-            throw new InvalidRequestError(err.message)
-          }
+      const writes = [write]
+
+      try {
+        await ctx.services
+          .repo(ctx.db)
+          .attemptWrites({ did, writes, swapCommitCid }, 5, 100)
+      } catch (err) {
+        if (
+          err instanceof BadCommitSwapError ||
+          err instanceof BadRecordSwapError
+        ) {
+          throw new InvalidRequestError(err.message, 'InvalidSwap')
+        } else {
           throw err
         }
-
-        try {
-          await repoTxn.processWrites(did, [write], now, swapCommitCid)
-        } catch (err) {
-          if (
-            err instanceof BadCommitSwapError ||
-            err instanceof BadRecordSwapError
-          ) {
-            throw new InvalidRequestError(err.message, 'InvalidSwap')
-          } else {
-            throw err
-          }
-        }
-        return write
-      })
+      }
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -12,6 +12,7 @@ import {
   PreparedCreate,
   PreparedUpdate,
 } from '../../../../repo'
+import { ConcurrentWriteError } from '../../../../services/repo'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.putRecord({
@@ -80,13 +81,15 @@ export default function (server: Server, ctx: AppContext) {
       try {
         await ctx.services
           .repo(ctx.db)
-          .processWrites({ did, writes, swapCommitCid }, 5, 100)
+          .processWrites({ did, writes, swapCommitCid }, 10)
       } catch (err) {
         if (
           err instanceof BadCommitSwapError ||
           err instanceof BadRecordSwapError
         ) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')
+        } else if (err instanceof ConcurrentWriteError) {
+          throw new InvalidRequestError(err.message, 'ConcurrentWrites')
         } else {
           throw err
         }

--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -176,6 +176,10 @@ export class Database {
     assert(this.isTransaction, 'Transaction required')
   }
 
+  assertNotTransaction() {
+    assert(!this.isTransaction, 'Cannot be in a transaction')
+  }
+
   async close(): Promise<void> {
     if (this.destroyed) return
     if (this.channelClient) {

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -22,6 +22,7 @@ import { createWriteToOp, writeToOp } from '../../repo'
 import { RecordService } from '../record'
 import { sequenceCommit, sequenceRebase } from '../../sequencer'
 import { Labeler } from '../../labeler'
+import { wait } from '@atproto/common'
 
 export class RepoService {
   blobs: RepoBlobs
@@ -50,6 +51,22 @@ export class RepoService {
     record: RecordService.creator(this.messageDispatcher),
   }
 
+  private async serviceTx<T>(
+    fn: (srvc: RepoService) => Promise<T>,
+  ): Promise<T> {
+    this.db.assertNotTransaction()
+    return this.db.transaction((dbTxn) => {
+      const srvc = new RepoService(
+        dbTxn,
+        this.repoSigningKey,
+        this.messageDispatcher,
+        this.blobstore,
+        this.labeler,
+      )
+      return fn(srvc)
+    })
+  }
+
   async createRepo(did: string, writes: PreparedCreate[], now: string) {
     this.db.assertTransaction()
     const storage = new SqlRepoStorage(this.db, did, now)
@@ -70,12 +87,15 @@ export class RepoService {
   async processWrites(
     did: string,
     writes: PreparedWrite[],
+    commitData: CommitData,
     now: string,
-    swapCommit?: CID,
   ) {
     this.db.assertTransaction()
     const storage = new SqlRepoStorage(this.db, did, now)
-    const commitData = await this.formatCommit(storage, did, writes, swapCommit)
+    const locked = await storage.lockHead()
+    if (!locked || !locked.equals(commitData.prev)) {
+      throw new ConcurrentWriteError(did)
+    }
     await Promise.all([
       // persist the commit to repo storage
       storage.applyCommit(commitData),
@@ -86,13 +106,43 @@ export class RepoService {
     ])
   }
 
-  private async formatCommit(
-    storage: SqlRepoStorage,
+  async attemptWrites(
+    toWrite: { did: string; writes: PreparedWrite[]; swapCommitCid?: CID },
+    times: number,
+    timeout = 100,
+  ) {
+    this.db.assertNotTransaction()
+    const { did, writes, swapCommitCid } = toWrite
+    const commit = await this.formatCommit(did, writes, swapCommitCid)
+    try {
+      await this.serviceTx(async (srvcTx) => {
+        await srvcTx.processWrites(
+          did,
+          writes,
+          commit,
+          new Date().toISOString(),
+        )
+      })
+    } catch (err) {
+      if (err instanceof ConcurrentWriteError) {
+        if (times <= 1) {
+          throw err
+        }
+        await wait(timeout)
+        await this.attemptWrites(toWrite, times - 1, timeout)
+      } else {
+        throw err
+      }
+    }
+  }
+
+  async formatCommit(
     did: string,
     writes: PreparedWrite[],
     swapCommit?: CID,
   ): Promise<CommitData> {
-    const currRoot = await storage.getHead(true)
+    const storage = new SqlRepoStorage(this.db, did)
+    const currRoot = await storage.getHead()
     if (!currRoot) {
       throw new InvalidRequestError(
         `${did} is not a registered repo on this server`,
@@ -215,5 +265,11 @@ export class RepoService {
       this.db.db.deleteFrom('repo_seq').where('did', '=', did).execute(),
       this.blobs.deleteForUser(did),
     ])
+  }
+}
+
+export class ConcurrentWriteError extends Error {
+  constructor(public did: string) {
+    super(`concurrent write on repo ${did}`)
   }
 }

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -225,7 +225,7 @@ export class RepoService {
   async rebaseRepo(did: string, now: string, swapCommit?: CID) {
     this.db.assertTransaction()
     const storage = new SqlRepoStorage(this.db, did, now)
-    const currRoot = await storage.getHead(true)
+    const currRoot = await storage.lockHead()
     if (!currRoot) {
       throw new InvalidRequestError(
         `${did} is not a registered repo on this server`,

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -94,7 +94,7 @@ export class RepoService {
     const storage = new SqlRepoStorage(this.db, did, now)
     const locked = await storage.lockHead()
     if (!locked || !locked.equals(commitData.prev)) {
-      throw new ConcurrentWriteError(did)
+      throw new ConcurrentWriteError()
     }
     await Promise.all([
       // persist the commit to repo storage
@@ -270,7 +270,7 @@ export class RepoService {
 }
 
 export class ConcurrentWriteError extends Error {
-  constructor(public did: string) {
-    super(`concurrent write on repo ${did}`)
+  constructor() {
+    super('too many concurrent writes')
   }
 }

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -113,7 +113,8 @@ export class RepoService {
   ) {
     this.db.assertNotTransaction()
     const { did, writes, swapCommitCid } = toWrite
-    const commit = await this.formatCommit(did, writes, swapCommitCid)
+    const storage = new SqlRepoStorage(this.db, did)
+    const commit = await this.formatCommit(storage, did, writes, swapCommitCid)
     try {
       await this.serviceTx(async (srvcTx) => {
         await srvcTx.processCommit(
@@ -137,11 +138,11 @@ export class RepoService {
   }
 
   async formatCommit(
+    storage: SqlRepoStorage,
     did: string,
     writes: PreparedWrite[],
     swapCommit?: CID,
   ): Promise<CommitData> {
-    const storage = new SqlRepoStorage(this.db, did)
     const currRoot = await storage.getHead()
     if (!currRoot) {
       throw new InvalidRequestError(

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -84,7 +84,7 @@ export class RepoService {
     ])
   }
 
-  async processWrites(
+  async processCommit(
     did: string,
     writes: PreparedWrite[],
     commitData: CommitData,
@@ -106,7 +106,7 @@ export class RepoService {
     ])
   }
 
-  async attemptWrites(
+  async processWrites(
     toWrite: { did: string; writes: PreparedWrite[]; swapCommitCid?: CID },
     times: number,
     timeout = 100,
@@ -116,7 +116,7 @@ export class RepoService {
     const commit = await this.formatCommit(did, writes, swapCommitCid)
     try {
       await this.serviceTx(async (srvcTx) => {
-        await srvcTx.processWrites(
+        await srvcTx.processCommit(
           did,
           writes,
           commit,
@@ -129,7 +129,7 @@ export class RepoService {
           throw err
         }
         await wait(timeout)
-        await this.attemptWrites(toWrite, times - 1, timeout)
+        await this.processWrites(toWrite, times - 1, timeout)
       } else {
         throw err
       }

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -227,9 +227,7 @@ export class RepoService {
     const storage = new SqlRepoStorage(this.db, did, now)
     const currRoot = await storage.lockHead()
     if (!currRoot) {
-      throw new InvalidRequestError(
-        `${did} is not a registered repo on this server`,
-      )
+      throw new ConcurrentWriteError()
     }
     if (swapCommit && !currRoot.equals(swapCommit)) {
       throw new BadCommitSwapError(currRoot)

--- a/packages/pds/tests/indexing.test.ts
+++ b/packages/pds/tests/indexing.test.ts
@@ -79,11 +79,9 @@ describe('indexing', () => {
     })
 
     // Create
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.alice, [createRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.alice, writes: [createRecord] }, 1)
 
     const getAfterCreate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -93,11 +91,9 @@ describe('indexing', () => {
     const createNotifications = await getNotifications(db, uri)
 
     // Update
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.alice, [updateRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.alice, writes: [updateRecord] }, 1)
 
     const getAfterUpdate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -107,11 +103,9 @@ describe('indexing', () => {
     const updateNotifications = await getNotifications(db, uri)
 
     // Delete
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.alice, [deleteRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.alice, writes: [deleteRecord] }, 1)
 
     const getAfterDelete = agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -157,11 +151,9 @@ describe('indexing', () => {
     })
 
     // Create
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.dan, [createRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.dan, writes: [createRecord] }, 1)
 
     const getAfterCreate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -171,11 +163,9 @@ describe('indexing', () => {
     const createNotifications = await getNotifications(db, uri)
 
     // Update
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.dan, [updateRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.dan, writes: [updateRecord] }, 1)
 
     const getAfterUpdate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -185,11 +175,9 @@ describe('indexing', () => {
     const updateNotifications = await getNotifications(db, uri)
 
     // Delete
-    await db.transaction(async (tx) => {
-      await services
-        .repo(tx)
-        .processWrites(sc.dids.dan, [deleteRecord], new Date().toISOString())
-    })
+    await services
+      .repo(db)
+      .processWrites({ did: sc.dids.dan, writes: [deleteRecord] }, 1)
 
     const getAfterDelete = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },

--- a/packages/pds/tests/races.test.ts
+++ b/packages/pds/tests/races.test.ts
@@ -106,18 +106,4 @@ describe('crud operations', () => {
       createdPost.cid.toString(),
     )
   })
-
-  it('throws an error if the racing operation takes too long to finish', async () => {
-    const { write, commit } = await formatWrite()
-    const processPromise = processCommitWithWait(did, [write], commit, 1500)
-
-    const attempt = agent.api.app.bsky.feed.post.create(
-      { repo: did },
-      { text: 'two', createdAt: new Date().toISOString() },
-    )
-
-    await expect(attempt).rejects.toThrow('too many concurrent writes')
-
-    await processPromise
-  })
 })

--- a/packages/pds/tests/races.test.ts
+++ b/packages/pds/tests/races.test.ts
@@ -1,0 +1,40 @@
+import AtpAgent from '@atproto/api'
+import { CloseFn, runTestServer } from './_util'
+import AppContext from '../src/context'
+
+describe('crud operations', () => {
+  let ctx: AppContext
+  let agent: AtpAgent
+  let close: CloseFn
+
+  beforeAll(async () => {
+    const server = await runTestServer({
+      dbPostgresSchema: 'races',
+    })
+    ctx = server.ctx
+    close = server.close
+    agent = new AtpAgent({ service: server.url })
+    await agent.createAccount({
+      email: 'alice@test.com',
+      handle: 'alice.test',
+      password: 'alice-pass',
+    })
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('handles races in record routes', async () => {
+    let promises: Promise<unknown>[] = []
+    for (let i = 0; i < 10; i++) {
+      promises.push(
+        agent.api.app.bsky.feed.post.create(
+          { repo: agent.session?.did },
+          { text: 'blah', createdAt: new Date().toISOString() },
+        ),
+      )
+    }
+    await Promise.all(promises)
+  })
+})

--- a/packages/pds/tests/races.test.ts
+++ b/packages/pds/tests/races.test.ts
@@ -1,10 +1,16 @@
 import AtpAgent from '@atproto/api'
 import { CloseFn, runTestServer } from './_util'
 import AppContext from '../src/context'
+import { PreparedWrite, prepareCreate } from '../src/repo'
+import { TID, wait } from '@atproto/common'
+import SqlRepoStorage from '../src/sql-repo-storage'
+import { CommitData, MemoryBlockstore, loadFullRepo } from '@atproto/repo'
+import { ConcurrentWriteError } from '../src/services/repo'
 
 describe('crud operations', () => {
   let ctx: AppContext
   let agent: AtpAgent
+  let did: string
   let close: CloseFn
 
   beforeAll(async () => {
@@ -19,22 +25,99 @@ describe('crud operations', () => {
       handle: 'alice.test',
       password: 'alice-pass',
     })
+    did = agent.session?.did || ''
   })
 
   afterAll(async () => {
     await close()
   })
 
+  const formatWrite = async () => {
+    const write = await prepareCreate({
+      did,
+      collection: 'app.bsky.feed.post',
+      record: {
+        text: 'one',
+        createdAt: new Date().toISOString(),
+      },
+      rkey: TID.nextStr(),
+      validate: true,
+    })
+    const storage = new SqlRepoStorage(ctx.db, did)
+    const commit = await ctx.services
+      .repo(ctx.db)
+      .formatCommit(storage, did, [write])
+    return { write, commit }
+  }
+
+  const processCommitWithWait = async (
+    did: string,
+    writes: PreparedWrite[],
+    commitData: CommitData,
+    waitMs: number,
+  ) => {
+    const now = new Date().toISOString()
+    await ctx.db.transaction(async (dbTxn) => {
+      const storage = new SqlRepoStorage(dbTxn, did, now)
+      const locked = await storage.lockHead()
+      if (!locked || !locked.equals(commitData.prev)) {
+        throw new ConcurrentWriteError()
+      }
+      await wait(waitMs)
+      const srvc = ctx.services.repo(dbTxn)
+      await Promise.all([
+        // persist the commit to repo storage
+        storage.applyCommit(commitData),
+        // & send to indexing
+        srvc.indexWrites(writes, now),
+        // do any other processing needed after write
+        srvc.afterWriteProcessing(did, commitData, writes),
+      ])
+    })
+  }
+
   it('handles races in record routes', async () => {
-    let promises: Promise<unknown>[] = []
-    for (let i = 0; i < 10; i++) {
-      promises.push(
-        agent.api.app.bsky.feed.post.create(
-          { repo: agent.session?.did },
-          { text: 'blah', createdAt: new Date().toISOString() },
-        ),
-      )
-    }
-    await Promise.all(promises)
+    const { write, commit } = await formatWrite()
+    const processPromise = processCommitWithWait(did, [write], commit, 500)
+
+    const createdPost = await agent.api.app.bsky.feed.post.create(
+      { repo: did },
+      { text: 'two', createdAt: new Date().toISOString() },
+    )
+
+    await processPromise
+
+    const listed = await agent.api.app.bsky.feed.post.list({ repo: did })
+    expect(listed.records.length).toBe(2)
+
+    const repoCar = await agent.api.com.atproto.sync.getRepo({ did })
+    const storage = new MemoryBlockstore()
+    const verified = await loadFullRepo(
+      storage,
+      repoCar.data,
+      did,
+      ctx.repoSigningKey.did(),
+    )
+    // it split writes over 2 commits
+    expect(verified.writeLog[1].length).toBe(1)
+    expect(verified.writeLog[2].length).toBe(1)
+    expect(verified.writeLog[1][0].cid.equals(write.cid)).toBeTruthy()
+    expect(verified.writeLog[2][0].cid.toString()).toEqual(
+      createdPost.cid.toString(),
+    )
+  })
+
+  it('throws an error if the racing operation takes too long to finish', async () => {
+    const { write, commit } = await formatWrite()
+    const processPromise = processCommitWithWait(did, [write], commit, 1500)
+
+    const attempt = agent.api.app.bsky.feed.post.create(
+      { repo: did },
+      { text: 'two', createdAt: new Date().toISOString() },
+    )
+
+    await expect(attempt).rejects.toThrow('too many concurrent writes')
+
+    await processPromise
   })
 })

--- a/packages/pds/tests/sql-repo-storage.test.ts
+++ b/packages/pds/tests/sql-repo-storage.test.ts
@@ -1,4 +1,4 @@
-import { range, dataToCborBlock, cidForCbor, wait } from '@atproto/common'
+import { range, dataToCborBlock } from '@atproto/common'
 import { def } from '@atproto/repo'
 import BlockMap from '@atproto/repo/src/block-map'
 import { Database } from '../src'
@@ -111,39 +111,5 @@ describe('sql repo storage', () => {
     expect(commitData[0].blocks.equals(blocks0)).toBeTruthy()
     expect(commitData[1].commit.equals(commits[1].cid)).toBeTruthy()
     expect(commitData[1].blocks.equals(blocks1)).toBeTruthy()
-  })
-
-  const acquireLockAndWait = async (did: string, waitFor: number) => {
-    await db.transaction(async (dbTxn) => {
-      const storage = new SqlRepoStorage(dbTxn, did)
-      await storage.getHead(true)
-      await wait(waitFor)
-    })
-  }
-
-  it('throws when encountering a locked repo head', async () => {
-    if (db.dialect === 'sqlite') return
-    const did = 'did:example:alice'
-    const storage = new SqlRepoStorage(db, did)
-    const cid = await cidForCbor({ test: 123 })
-    await storage.updateHead(cid, null)
-
-    const promise1 = acquireLockAndWait(did, 1000)
-    const promise2 = acquireLockAndWait(did, 50)
-    await expect(promise2).rejects.toThrow(
-      'too many attempted concurrent updates',
-    )
-    await promise1
-  })
-
-  it('retries to get locked repo head before throwing', async () => {
-    const did = 'did:example:bob'
-    const storage = new SqlRepoStorage(db, did)
-    const cid = await cidForCbor({ test: 123 })
-    await storage.updateHead(cid, null)
-
-    const promise1 = acquireLockAndWait(did, 50)
-    const promise2 = acquireLockAndWait(did, 50)
-    await Promise.all([promise1, promise2])
   })
 })


### PR DESCRIPTION
This moves formatting of commits outside of the write transactions so that they do not hold up connections from the pool.

For each write, we attempt up to 10 times with a 100ms delay between each. Each attempt only takes some short reprocessing where we replay the commit on top of the current state of the repo (if the lock is up). We use a persistent `SqlRepoStorage` instance between attempts so that already computed blocks can be cached & not re-fetched from storage