### PR TITLE
PDS moderator credentials

### DIFF
--- a/packages/pds/src/api/com/atproto/admin/getInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/admin/getInviteCodes.ts
@@ -10,7 +10,7 @@ import {
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getInviteCodes({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { sort, limit, cursor } = params
       const ref = ctx.db.db.dynamic.ref

--- a/packages/pds/src/api/com/atproto/admin/getModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationAction.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getModerationAction({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { id } = params

--- a/packages/pds/src/api/com/atproto/admin/getModerationActions.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationActions.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getModerationActions({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { subject, limit = 50, cursor } = params

--- a/packages/pds/src/api/com/atproto/admin/getModerationReport.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationReport.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getModerationReport({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { id } = params

--- a/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getModerationReports({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { subject, resolved, limit = 50, cursor } = params

--- a/packages/pds/src/api/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRecord.ts
@@ -5,7 +5,7 @@ import { AtUri } from '@atproto/uri'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getRecord({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { uri, cid } = params

--- a/packages/pds/src/api/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRepo.ts
@@ -4,7 +4,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getRepo({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const { did } = params

--- a/packages/pds/src/api/com/atproto/admin/resolveModerationReports.ts
+++ b/packages/pds/src/api/com/atproto/admin/resolveModerationReports.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.resolveModerationReports({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ input }) => {
       const { db, services } = ctx
       const moderationService = services.moderation(db)

--- a/packages/pds/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchRepos.ts
@@ -6,7 +6,7 @@ import { ListKeyset } from '../../../../services/account'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.searchRepos({
-    auth: ctx.adminVerifier,
+    auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
       const moderationService = services.moderation(db)

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -22,6 +22,7 @@ export interface ServerConfigValues {
   serverDid: string
   recoveryKey: string
   adminPassword: string
+  moderatorPassword?: string
 
   inviteRequired: boolean
   userInviteInterval: number | null
@@ -90,6 +91,7 @@ export class ServerConfig {
     }
 
     const adminPassword = process.env.ADMIN_PASSWORD || 'admin'
+    const moderatorPassword = process.env.MODERATOR_PASSWORD || undefined
 
     const inviteRequired = process.env.INVITE_REQUIRED === 'true' ? true : false
     const userInviteInterval = parseIntWithFallback(
@@ -160,6 +162,7 @@ export class ServerConfig {
       didPlcUrl,
       serverDid,
       adminPassword,
+      moderatorPassword,
       inviteRequired,
       userInviteInterval,
       privacyPolicyUrl,
@@ -255,6 +258,10 @@ export class ServerConfig {
 
   get adminPassword() {
     return this.cfg.adminPassword
+  }
+
+  get moderatorPassword() {
+    return this.cfg.moderatorPassword
   }
 
   get inviteRequired() {

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -72,6 +72,10 @@ export class AppContext {
     return auth.adminVerifier(this.auth)
   }
 
+  get moderatorVerifier() {
+    return auth.moderatorVerifier(this.auth)
+  }
+
   get imgUriBuilder(): ImageUriBuilder {
     return this.opts.imgUriBuilder
   }

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -70,6 +70,7 @@ export class PDS {
     const auth = new ServerAuth({
       jwtSecret: config.jwtSecret,
       adminPass: config.adminPassword,
+      moderatorPass: config.moderatorPassword,
     })
 
     const messageDispatcher = new MessageDispatcher()

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -16,6 +16,7 @@ import { HOUR } from '@atproto/common'
 import { lexToJson } from '@atproto/lexicon'
 
 const ADMIN_PASSWORD = 'admin-pass'
+const MODERATOR_PASSWORD = 'moderator-pass'
 
 export type CloseFn = () => Promise<void>
 export type TestServerInfo = {
@@ -77,6 +78,7 @@ export const runTestServer = async (
     serverDid,
     recoveryKey,
     adminPassword: ADMIN_PASSWORD,
+    moderatorPassword: MODERATOR_PASSWORD,
     inviteRequired: false,
     userInviteInterval: null,
     didPlcUrl: plcUrl,
@@ -138,10 +140,18 @@ export const runTestServer = async (
 }
 
 export const adminAuth = () => {
+  return basicAuth('admin', ADMIN_PASSWORD)
+}
+
+export const moderatorAuth = () => {
+  return basicAuth('admin', MODERATOR_PASSWORD)
+}
+
+const basicAuth = (username: string, password: string) => {
   return (
     'Basic ' +
     uint8arrays.toString(
-      uint8arrays.fromString('admin:' + ADMIN_PASSWORD, 'utf8'),
+      uint8arrays.fromString(`${username}:${password}`, 'utf8'),
       'base64pad',
     )
   )

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -198,6 +198,20 @@ describe('account', () => {
     expect(accnt2?.email).toBe(email)
   })
 
+  it('disallows non-admin moderators to perform email updates', async () => {
+    const attemptUpdate = agent.api.com.atproto.admin.updateAccountEmail(
+      {
+        account: handle,
+        email: 'new@email.com',
+      },
+      {
+        encoding: 'application/json',
+        headers: { authorization: util.moderatorAuth() },
+      },
+    )
+    await expect(attemptUpdate).rejects.toThrow('Authentication Required')
+  })
+
   it('disallows duplicate email addresses and handles', async () => {
     const inviteCode = await createInviteCode(agent, 2)
     const email = 'bob@test.com'

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -4,6 +4,7 @@ import { SeedClient } from './seeds/client'
 import basicSeed from './seeds/basic'
 import * as util from './_util'
 import { AppContext } from '../src'
+import { moderatorAuth } from './_util'
 
 // outside of suite so they can be used in mock
 let alice: string
@@ -296,5 +297,16 @@ describe('handles', () => {
       handle: 'bob-alt.test',
     })
     await expect(attempt2).rejects.toThrow('Authentication Required')
+    const attempt3 = agent.api.com.atproto.admin.updateAccountHandle(
+      {
+        did: bob,
+        handle: 'bob-alt.test',
+      },
+      {
+        headers: { authorization: moderatorAuth() },
+        encoding: 'application/json',
+      },
+    )
+    await expect(attempt3).rejects.toThrow('Authentication Required')
   })
 })

--- a/packages/pds/tests/views/admin/invites.test.ts
+++ b/packages/pds/tests/views/admin/invites.test.ts
@@ -176,14 +176,17 @@ describe('pds admin invite views', () => {
   })
 
   it('does not allow non-admin moderators to disable invites.', async () => {
-    const attemptCreateInvite = agent.api.com.atproto.admin.disableInviteCodes(
-      { codes: ['x'], accounts: [alice] },
-      {
-        encoding: 'application/json',
-        headers: { authorization: moderatorAuth() },
-      },
+    const attemptDisableInvites =
+      agent.api.com.atproto.admin.disableInviteCodes(
+        { codes: ['x'], accounts: [alice] },
+        {
+          encoding: 'application/json',
+          headers: { authorization: moderatorAuth() },
+        },
+      )
+    await expect(attemptDisableInvites).rejects.toThrow(
+      'Authentication Required',
     )
-    await expect(attemptCreateInvite).rejects.toThrow('Authentication Required')
   })
 
   it('does not allow non-admin moderators to create invites.', async () => {

--- a/packages/pds/tests/views/admin/invites.test.ts
+++ b/packages/pds/tests/views/admin/invites.test.ts
@@ -1,5 +1,5 @@
 import AtpAgent from '@atproto/api'
-import { runTestServer, CloseFn, adminAuth } from '../../_util'
+import { runTestServer, CloseFn, adminAuth, moderatorAuth } from '../../_util'
 import { randomStr } from '@atproto/crypto'
 
 describe('pds admin invite views', () => {
@@ -173,5 +173,27 @@ describe('pds admin invite views', () => {
     expect(aliceView.data.invitedBy?.available).toBe(10)
     expect(aliceView.data.invitedBy?.uses.length).toBe(2)
     expect(aliceView.data.invites?.length).toBe(6)
+  })
+
+  it('does not allow non-admin moderators to disable invites.', async () => {
+    const attemptCreateInvite = agent.api.com.atproto.admin.disableInviteCodes(
+      { codes: ['x'], accounts: [alice] },
+      {
+        encoding: 'application/json',
+        headers: { authorization: moderatorAuth() },
+      },
+    )
+    await expect(attemptCreateInvite).rejects.toThrow('Authentication Required')
+  })
+
+  it('does not allow non-admin moderators to create invites.', async () => {
+    const attemptCreateInvite = agent.api.com.atproto.server.createInviteCode(
+      { useCount: 5, forAccount: alice },
+      {
+        encoding: 'application/json',
+        headers: { authorization: moderatorAuth() },
+      },
+    )
+    await expect(attemptCreateInvite).rejects.toThrow('Authentication Required')
   })
 })


### PR DESCRIPTION
Simple extension to the PDS admin credentials, used for non-critical moderation tasks: primarily closing reports with flags or acknowledgements.  The following endpoints remain admin-only:
 - `com.atproto.server.createInviteCodes`
 - `com.atproto.server.createInviteCode`
 - `com.atproto.admin.reverseModerationAction`
 - `com.atproto.admin.updateAccountEmail`
 - `com.atproto.admin.disableInviteCodes`
 - `com.atproto.admin.updateAccountHandle`

Additionally, takedown actions and labeling is admin-only on `com.atproto.admin.takeModerationAction`.

Will likely port this to #840 as well.