### PR TITLE
More forgiving config for empty db schema

### DIFF
--- a/packages/bsky/service/index.js
+++ b/packages/bsky/service/index.js
@@ -55,7 +55,7 @@ const getEnv = () => ({
   dbPostgresUrl: process.env.DB_POSTGRES_URL,
   dbMigratePostgresUrl:
     process.env.DB_MIGRATE_POSTGRES_URL || process.env.DB_POSTGRES_URL,
-  dbPostgresSchema: process.env.DB_POSTGRES_SCHEMA,
+  dbPostgresSchema: process.env.DB_POSTGRES_SCHEMA || undefined,
   publicUrl: process.env.PUBLIC_URL,
   didPlcUrl: process.env.DID_PLC_URL,
   imgUriSalt: process.env.IMG_URI_SALT,

--- a/packages/bsky/src/db/index.ts
+++ b/packages/bsky/src/db/index.ts
@@ -25,7 +25,7 @@ export class Database {
     pgTypes.setTypeParser(pgTypes.builtins.INT8, (n) => parseInt(n, 10))
 
     // Setup schema usage, primarily for test parallelism (each test suite runs in its own pg schema)
-    if (schema !== undefined) {
+    if (schema) {
       if (!/^[a-z_]+$/i.test(schema)) {
         throw new Error(
           `Postgres schema must only contain [A-Za-z_]: ${schema}`,
@@ -72,7 +72,7 @@ export class Database {
   }
 
   async migrateToOrThrow(migration: string) {
-    if (this.schema !== undefined) {
+    if (this.schema) {
       await this.db.schema.createSchema(this.schema).ifNotExists().execute()
     }
     const { error, results } = await this.migrator.migrateTo(migration)
@@ -86,7 +86,7 @@ export class Database {
   }
 
   async migrateToLatestOrThrow() {
-    if (this.schema !== undefined) {
+    if (this.schema) {
       await this.db.schema.createSchema(this.schema).ifNotExists().execute()
     }
     const { error, results } = await this.migrator.migrateToLatest()

--- a/packages/pds/service/index.js
+++ b/packages/pds/service/index.js
@@ -33,6 +33,8 @@ const main = async () => {
     url: pgUrl(env.dbCreds),
     schema: env.dbSchema,
     poolSize: env.dbPoolSize,
+    poolMaxUses: env.dbPoolMaxUses,
+    poolIdleTimeoutMs: env.dbPoolIdleTimeoutMs,
   })
   const s3Blobstore = new S3BlobStore({ bucket: env.s3Bucket })
   const repoSigningKey = await Secp256k1Keypair.import(env.repoSigningKey)
@@ -100,6 +102,8 @@ const getEnv = () => ({
   dbMigrateCreds: JSON.parse(process.env.DB_MIGRATE_CREDS_JSON),
   dbSchema: process.env.DB_SCHEMA,
   dbPoolSize: maybeParseInt(process.env.DB_POOL_SIZE),
+  dbPoolMaxUses: maybeParseInt(process.env.DB_POOL_MAX_USES),
+  dbPoolIdleTimeoutMs: maybeParseInt(process.env.DB_POOL_IDLE_TIMEOUT_MS),
   smtpHost: process.env.SMTP_HOST,
   smtpUsername: process.env.SMTP_USERNAME,
   smtpPassword: process.env.SMTP_PASSWORD,

--- a/packages/pds/service/index.js
+++ b/packages/pds/service/index.js
@@ -100,7 +100,7 @@ const getEnv = () => ({
   recoveryKeyId: process.env.RECOVERY_KEY_ID,
   dbCreds: JSON.parse(process.env.DB_CREDS_JSON),
   dbMigrateCreds: JSON.parse(process.env.DB_MIGRATE_CREDS_JSON),
-  dbSchema: process.env.DB_SCHEMA,
+  dbSchema: process.env.DB_SCHEMA || undefined,
   dbPoolSize: maybeParseInt(process.env.DB_POOL_SIZE),
   dbPoolMaxUses: maybeParseInt(process.env.DB_POOL_MAX_USES),
   dbPoolIdleTimeoutMs: maybeParseInt(process.env.DB_POOL_IDLE_TIMEOUT_MS),

--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -46,7 +46,13 @@ export class Database {
   static postgres(opts: PgOptions): Database {
     const { schema, url } = opts
     const pool =
-      opts.pool ?? new PgPool({ connectionString: url, max: opts.poolSize })
+      opts.pool ??
+      new PgPool({
+        connectionString: url,
+        max: opts.poolSize,
+        maxUses: opts.poolMaxUses,
+        idleTimeoutMillis: opts.poolIdleTimeoutMs,
+      })
 
     // Select count(*) and other pg bigints as js integer
     pgTypes.setTypeParser(pgTypes.builtins.INT8, (n) => parseInt(n, 10))
@@ -248,6 +254,8 @@ type PgOptions = {
   pool?: PgPool
   schema?: string
   poolSize?: number
+  poolMaxUses?: number
+  poolIdleTimeoutMs?: number
 }
 
 type ChannelEvents = {

--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -58,7 +58,7 @@ export class Database {
     pgTypes.setTypeParser(pgTypes.builtins.INT8, (n) => parseInt(n, 10))
 
     // Setup schema usage, primarily for test parallelism (each test suite runs in its own pg schema)
-    if (schema !== undefined) {
+    if (schema) {
       if (!/^[a-z_]+$/i.test(schema)) {
         throw new Error(
           `Postgres schema must only contain [A-Za-z_]: ${schema}`,
@@ -201,7 +201,7 @@ export class Database {
   }
 
   async migrateToOrThrow(migration: string) {
-    if (this.schema !== undefined) {
+    if (this.schema) {
       await this.db.schema.createSchema(this.schema).ifNotExists().execute()
     }
     const { error, results } = await this.migrator.migrateTo(migration)
@@ -215,7 +215,7 @@ export class Database {
   }
 
   async migrateToLatestOrThrow() {
-    if (this.schema !== undefined) {
+    if (this.schema) {
       await this.db.schema.createSchema(this.schema).ifNotExists().execute()
     }
     const { error, results } = await this.migrator.migrateToLatest()


### PR DESCRIPTION
Followup to #867— also making config of an empty db schema more forgiving, i.e. handling unset versus empty string the same way.