### PR TITLE
minor Makefile tweak: run-dev-pds, not run-pds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ test: ## Run all tests
 run-dev-env: ## Run a "development environment" shell
 	cd packages/dev-env; yarn run start
 
-.PHONY: run-pds
-run-pds: ## Run PDS locally
+.PHONY: run-dev-pds
+run-dev-pds: ## Run PDS locally
 	if [ ! -f "packages/pds/.dev.env" ]; then cp packages/pds/example.dev.env packages/pds/.dev.env; fi
 	cd packages/pds; ENV=dev yarn run start | yarn exec pino-pretty
 


### PR DESCRIPTION
low-priority, but indigo and PLC both have the `run-dev-*` format, and I keep typo-ing when doing integration tests.