### PR TITLE
Chunk getRepo query

### DIFF
--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -4,7 +4,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import SqlRepoStorage from '../../../../sql-repo-storage'
 import AppContext from '../../../../context'
-import { byteIterableToStream } from '@atproto/common'
+import { byteIterableToStream, chunkArray } from '@atproto/common'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.sync.getRepo(async ({ params }) => {
@@ -17,10 +17,24 @@ export default function (server: Server, ctx: AppContext) {
     if (latest === null) {
       throw new InvalidRequestError(`Could not find repo for DID: ${did}`)
     }
-    const commits = repo.getCommits(storage, latest, earliest)
+    const commitPath = await storage.getCommitPath(latest, earliest)
+    if (commitPath === null) {
+      throw new InvalidRequestError(`Could not find shared history`)
+    }
+
+    const commitChunks = chunkArray(commitPath, 25)
+    const carStream = repo.writeCar(latest, async (car) => {
+      for (const chunk of commitChunks) {
+        const blocks = await storage.getAllBlocksForCommits(chunk)
+        for (const block of blocks) {
+          await car.put({ cid: block.cid, bytes: block.bytes })
+        }
+      }
+    })
+
     return {
       encoding: 'application/vnd.ipld.car',
-      body: byteIterableToStream(commits),
+      body: byteIterableToStream(carStream),
     }
   })
 }

--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -292,10 +292,9 @@ export class SqlRepoStorage extends RepoStorage {
       .execute()
     return res.map((row) => CID.parse(row.commit)).reverse()
   }
-  async getBlocksForCommits(
-    commits: CID[],
-  ): Promise<{ [commit: string]: BlockMap }> {
-    if (commits.length === 0) return {}
+
+  async getAllBlocksForCommits(commits: CID[]): Promise<BlockForCommit[]> {
+    if (commits.length === 0) return []
     const commitStrs = commits.map((commit) => commit.toString())
     const res = await this.db.db
       .selectFrom('repo_commit_block')
@@ -312,11 +311,21 @@ export class SqlRepoStorage extends RepoStorage {
         'ipld_block.content',
       ])
       .execute()
-    return res.reduce((acc, cur) => {
+    return res.map((row) => ({
+      cid: CID.parse(row.cid),
+      bytes: row.content,
+      commit: row.commit,
+    }))
+  }
+
+  async getBlocksForCommits(
+    commits: CID[],
+  ): Promise<{ [commit: string]: BlockMap }> {
+    const allBlocks = await this.getAllBlocksForCommits(commits)
+    return allBlocks.reduce((acc, cur) => {
       acc[cur.commit] ??= new BlockMap()
-      const cid = CID.parse(cur.cid)
-      acc[cur.commit].set(cid, cur.content)
-      this.cache.set(cid, cur.content)
+      acc[cur.commit].set(cur.cid, cur.bytes)
+      this.cache.set(cur.cid, cur.bytes)
       return acc
     }, {})
   }
@@ -324,6 +333,12 @@ export class SqlRepoStorage extends RepoStorage {
   async destroy(): Promise<void> {
     throw new Error('Destruction of SQL repo storage not allowed at runtime')
   }
+}
+
+type BlockForCommit = {
+  cid: CID
+  bytes: Uint8Array
+  commit: string
 }
 
 export default SqlRepoStorage


### PR DESCRIPTION
`sync.getRepo` is one of our longer running queries.

Here, we chunk it into 25 commits at a time. This keeps us from holding as many blocks in memory & should also help free up some connections in the connection pool

We can turn the knob of how big the chunks are. I opted to err on the side of smaller first for now