### PR TITLE
Deterministic DNS handle resolution

### DIFF
--- a/packages/bsky/src/util/identity.ts
+++ b/packages/bsky/src/util/identity.ts
@@ -1,4 +1,8 @@
-import { NoHandleRecordError, resolveDns } from '@atproto/identifier'
+import {
+  ManyHandleRecordsError,
+  NoHandleRecordError,
+  resolveDns,
+} from '@atproto/identifier'
 import { httpLogger } from '../logger'
 import { AtpAgent } from '@atproto/api'
 import { retryHttp } from './retry'
@@ -10,7 +14,10 @@ export const resolveExternalHandle = async (
     const did = await resolveDns(handle)
     return did
   } catch (err) {
-    if (err instanceof NoHandleRecordError) {
+    if (
+      err instanceof NoHandleRecordError ||
+      err instanceof ManyHandleRecordsError
+    ) {
       // no worries it's just not found
     } else {
       httpLogger.error({ err, handle }, 'could not resolve dns handle')

--- a/packages/identifier/src/resolve.ts
+++ b/packages/identifier/src/resolve.ts
@@ -15,9 +15,11 @@ export const resolveDns = async (handle: string): Promise<string> => {
     throw err
   }
   const results = chunkedResults.map((chunks) => chunks.join(''))
-  const found = results.find((i) => i.startsWith(PREFIX))
-  if (!found) throw new NoHandleRecordError()
-  return found.slice(PREFIX.length)
+  const found = results.filter((i) => i.startsWith(PREFIX))
+  if (found.length !== 1) {
+    throw new NoHandleRecordError()
+  }
+  return found[0].slice(PREFIX.length)
 }
 
 export class NoHandleRecordError extends Error {}

--- a/packages/identifier/src/resolve.ts
+++ b/packages/identifier/src/resolve.ts
@@ -10,16 +10,27 @@ export const resolveDns = async (handle: string): Promise<string> => {
     chunkedResults = await dns.resolveTxt(`${SUBDOMAIN}.${handle}`)
   } catch (err) {
     if (isErrnoException(err) && err.code === 'ENOTFOUND') {
-      throw new NoHandleRecordError()
+      throw new NoHandleRecordError(handle)
     }
     throw err
   }
   const results = chunkedResults.map((chunks) => chunks.join(''))
   const found = results.filter((i) => i.startsWith(PREFIX))
-  if (found.length !== 1) {
-    throw new NoHandleRecordError()
+  if (found.length < 1) {
+    throw new NoHandleRecordError(handle)
+  } else if (found.length > 1) {
+    throw new ManyHandleRecordsError(handle, found)
   }
   return found[0].slice(PREFIX.length)
 }
 
-export class NoHandleRecordError extends Error {}
+export class NoHandleRecordError extends Error {
+  constructor(public handle: string) {
+    super(`No record found at ${handle}`)
+  }
+}
+export class ManyHandleRecordsError extends Error {
+  constructor(public handle: string, records: string[]) {
+    super(`Many records found at record found at ${handle}: ${records}`)
+  }
+}

--- a/packages/pds/src/api/com/atproto/identity/util.ts
+++ b/packages/pds/src/api/com/atproto/identity/util.ts
@@ -10,7 +10,10 @@ export const resolveExternalHandle = async (
     const did = await ident.resolveDns(handle)
     return did
   } catch (err) {
-    if (err instanceof ident.NoHandleRecordError) {
+    if (
+      err instanceof ident.NoHandleRecordError ||
+      err instanceof ident.ManyHandleRecordsError
+    ) {
       // no worries it's just not found
     } else {
       log.error({ err, handle }, 'could not resolve dns handle')


### PR DESCRIPTION
DNS allows for multiple TXT records & is non-deterministic in it's return order.

If a user has two dids listed, we do not allow them to use either such that handle resolution is deterministic

Closes https://github.com/bluesky-social/atproto/issues/837