### PR TITLE
Return email in mod views according to lexicon

### DIFF
--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -94,7 +94,7 @@ export class ModerationViews {
       return {
         did: r.did,
         handle: r.handle,
-        account: email ? { email } : undefined,
+        account: email ?? undefined,
         relatedRecords,
         indexedAt: r.indexedAt,
         moderation: {

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-action.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-action.test.ts.snap
@@ -37,9 +37,7 @@ Object {
       },
     },
     "repo": Object {
-      "account": Object {
-        "email": "alice@test.com",
-      },
+      "account": "alice@test.com",
       "did": "user(0)",
       "handle": "alice.test",
       "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -116,9 +114,7 @@ Object {
   },
   "subject": Object {
     "$type": "com.atproto.admin.defs#repoView",
-    "account": Object {
-      "email": "alice@test.com",
-    },
+    "account": "alice@test.com",
     "did": "user(0)",
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-report.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-report.test.ts.snap
@@ -58,9 +58,7 @@ Object {
       },
     },
     "repo": Object {
-      "account": Object {
-        "email": "alice@test.com",
-      },
+      "account": "alice@test.com",
       "did": "user(1)",
       "handle": "alice.test",
       "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -122,9 +120,7 @@ Object {
   ],
   "subject": Object {
     "$type": "com.atproto.admin.defs#repoView",
-    "account": Object {
-      "email": "alice@test.com",
-    },
+    "account": "alice@test.com",
     "did": "user(1)",
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/admin/__snapshots__/get-record.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-record.test.ts.snap
@@ -76,9 +76,7 @@ Object {
     ],
   },
   "repo": Object {
-    "account": Object {
-      "email": "alice@test.com",
-    },
+    "account": "alice@test.com",
     "did": "user(0)",
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -184,9 +182,7 @@ Object {
     ],
   },
   "repo": Object {
-    "account": Object {
-      "email": "alice@test.com",
-    },
+    "account": "alice@test.com",
     "did": "user(0)",
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -309,9 +305,7 @@ Object {
     ],
   },
   "repo": Object {
-    "account": Object {
-      "email": "alice@test.com",
-    },
+    "account": "alice@test.com",
     "did": "user(0)",
     "handle": "alice.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-repo.test.ts.snap
@@ -2,9 +2,7 @@
 
 exports[`pds admin get repo view gets a repo by did, even when taken down. 1`] = `
 Object {
-  "account": Object {
-    "email": "alice@test.com",
-  },
+  "account": "alice@test.com",
   "did": "user(0)",
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -94,9 +92,7 @@ Object {
 
 exports[`pds admin get repo view serves labels. 1`] = `
 Object {
-  "account": Object {
-    "email": "alice@test.com",
-  },
+  "account": "alice@test.com",
   "did": "user(0)",
   "handle": "alice.test",
   "indexedAt": "1970-01-01T00:00:00.000Z",

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -293,9 +293,7 @@ Array [
 const snapSqlite = `
 Array [
   Object {
-    "account": Object {
-      "email": "aliya-hodkiewicz.test@bsky.app",
-    },
+    "account": "aliya-hodkiewicz.test@bsky.app",
     "did": "user(0)",
     "handle": "aliya-hodkiewicz.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -317,9 +315,7 @@ Array [
     ],
   },
   Object {
-    "account": Object {
-      "email": "cara-wiegand69.test@bsky.app",
-    },
+    "account": "cara-wiegand69.test@bsky.app",
     "did": "user(1)",
     "handle": "cara-wiegand69.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -332,9 +328,7 @@ Array [
     "relatedRecords": Array [],
   },
   Object {
-    "account": Object {
-      "email": "carlos6.test@bsky.app",
-    },
+    "account": "carlos6.test@bsky.app",
     "did": "user(2)",
     "handle": "carlos6.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -342,9 +336,7 @@ Array [
     "relatedRecords": Array [],
   },
   Object {
-    "account": Object {
-      "email": "carolina-mcdermott77.test@bsky.app",
-    },
+    "account": "carolina-mcdermott77.test@bsky.app",
     "did": "user(3)",
     "handle": "carolina-mcdermott77.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -366,9 +358,7 @@ Array [
     ],
   },
   Object {
-    "account": Object {
-      "email": "eudora-dietrich4.test@bsky.app",
-    },
+    "account": "eudora-dietrich4.test@bsky.app",
     "did": "user(4)",
     "handle": "eudora-dietrich4.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
@@ -390,9 +380,7 @@ Array [
     ],
   },
   Object {
-    "account": Object {
-      "email": "shane-torphy52.test@bsky.app",
-    },
+    "account": "shane-torphy52.test@bsky.app",
     "did": "user(5)",
     "handle": "shane-torphy52.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",


### PR DESCRIPTION
We did not update the impl to match the new lexicon for these. Return email as a property instead of nested under "account"