### PR TITLE
Fix leaky database transactions

### DIFF
--- a/packages/bsky/src/db/index.ts
+++ b/packages/bsky/src/db/index.ts
@@ -145,7 +145,7 @@ class LeakyTxPlugin implements KyselyPlugin {
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
     if (this.txOver) {
-      throw new Error('tx is over')
+      throw new Error('tx already failed')
     }
     return args.node
   }

--- a/packages/bsky/tests/db.test.ts
+++ b/packages/bsky/tests/db.test.ts
@@ -100,6 +100,34 @@ describe('db', () => {
         expect(() => dbTxn.assertTransaction()).not.toThrow()
       })
     })
+
+    it('does not allow leaky transactions', async () => {
+      let leakedTx: Database | undefined
+
+      const tx = db.transaction(async (dbTxn) => {
+        leakedTx = dbTxn
+        await dbTxn.db
+          .insertInto('actor')
+          .values({ handle: 'a', did: 'a', indexedAt: 'bad-date' })
+          .execute()
+        throw new Error('test tx failed')
+      })
+      await expect(tx).rejects.toThrow('test tx failed')
+
+      const attempt = leakedTx?.db
+        .insertInto('actor')
+        .values({ handle: 'b', did: 'b', indexedAt: 'bad-date' })
+        .execute()
+      await expect(attempt).rejects.toThrow('tx already failed')
+
+      const res = await db.db
+        .selectFrom('actor')
+        .selectAll()
+        .where('did', 'in', ['a', 'b'])
+        .execute()
+
+      expect(res.length).toBe(0)
+    })
   })
 
   describe('Leader', () => {

--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -311,7 +311,7 @@ class LeakyTxPlugin implements KyselyPlugin {
 
   transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
     if (this.txOver) {
-      throw new Error('tx is over')
+      throw new Error('tx already failed')
     }
     return args.node
   }

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -130,7 +130,7 @@ export class RepoService {
           throw err
         }
         await wait(timeout)
-        await this.processWrites(toWrite, times - 1, timeout)
+        return this.processWrites(toWrite, times - 1, timeout)
       } else {
         throw err
       }

--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -167,7 +167,7 @@ export class SqlRepoStorage extends RepoStorage {
           .select('block.cid'),
       )
       .execute()
-    await this.updateHead(rebase.commit, null)
+    await this.updateHead(rebase.commit, rebase.rebased)
   }
 
   async indexCommits(commits: CommitData[]): Promise<void> {
@@ -237,9 +237,6 @@ export class SqlRepoStorage extends RepoStorage {
           root: cid.toString(),
           indexedAt: this.getTimestamp(),
         })
-        .onConflict((oc) =>
-          oc.column('did').doUpdateSet({ root: cid.toString() }),
-        )
         .execute()
     } else {
       const res = await this.db.db

--- a/packages/pds/tests/db.test.ts
+++ b/packages/pds/tests/db.test.ts
@@ -111,15 +111,15 @@ describe('db', () => {
           .insertInto('repo_root')
           .values({ root: 'a', did: 'a', indexedAt: 'bad-date' })
           .execute()
-        throw new Error('tx failed')
+        throw new Error('test tx failed')
       })
-      await expect(tx).rejects.toThrow('tx failed')
+      await expect(tx).rejects.toThrow('test tx failed')
 
       const attempt = leakedTx?.db
         .insertInto('repo_root')
         .values({ root: 'b', did: 'b', indexedAt: 'bad-date' })
         .execute()
-      await expect(attempt).rejects.toThrow()
+      await expect(attempt).rejects.toThrow('tx already failed')
 
       const res = await db.db
         .selectFrom('repo_root')

--- a/packages/pds/tests/db.test.ts
+++ b/packages/pds/tests/db.test.ts
@@ -101,6 +101,34 @@ describe('db', () => {
         expect(() => dbTxn.assertTransaction()).not.toThrow()
       })
     })
+
+    it('does not allow leaky transactions', async () => {
+      let leakedTx: Database | undefined
+
+      const tx = db.transaction(async (dbTxn) => {
+        leakedTx = dbTxn
+        await dbTxn.db
+          .insertInto('repo_root')
+          .values({ root: 'a', did: 'a', indexedAt: 'bad-date' })
+          .execute()
+        throw new Error('tx failed')
+      })
+      await expect(tx).rejects.toThrow('tx failed')
+
+      const attempt = leakedTx?.db
+        .insertInto('repo_root')
+        .values({ root: 'b', did: 'b', indexedAt: 'bad-date' })
+        .execute()
+      await expect(attempt).rejects.toThrow()
+
+      const res = await db.db
+        .selectFrom('repo_root')
+        .selectAll()
+        .where('did', 'in', ['a', 'b'])
+        .execute()
+
+      expect(res.length).toBe(0)
+    })
   })
 
   describe('Leader', () => {


### PR DESCRIPTION
We were having an issue with database transactions where statements were still being written to the connection after an error had thrown & the transaction had rolled back which was leading to inconsistent state in the database.

This fix uses kysely's plugin system. We add a check to the query executor such that if an error has been throwing during the transaction, every other statement on that transaction database will throw as well.

As far as I can tell, this is the last processing step before the statement is sent off to the database. The previous approach we discussed - of setting the underlying `DatabaseSchema` instance to null & throwing when you use it may still give a chance for a query to sneak in after the tx is dead