### PR TITLE
appview: tweak repo error log line to not clobber 'service'

### DIFF
--- a/packages/pds/src/app-view/subscription/repo.ts
+++ b/packages/pds/src/app-view/subscription/repo.ts
@@ -58,10 +58,10 @@ export class RepoSubscription {
           {
             err,
             seq: msg?.seq,
-            repo: msg?.repo,
-            commit: msg?.commit,
+            repoDid: msg?.repo,
+            repoCommit: msg?.commit,
             time: msg?.time,
-            service: this.service,
+            subscriptionUrl: this.service,
           },
           'repo subscription errored',
         )


### PR DESCRIPTION
Somehow the output of this log line has been ending up in datadog under the wrong 'service' (with the 'service' being an "wss://"-prefixed URL, not "pds" or "bav" or whatever expected).

Tweaks the 'service' key, and some others that might have conflict.