### PR TITLE
Return `XRPCError` instead of 404 if a handler errors

### DIFF
--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -203,13 +203,18 @@ export class Server {
         const locals: RequestLocals = req[kRequestLocals]
 
         // run the handler
-        const outputUnvalidated = await handler({
-          params,
-          input,
-          auth: locals.auth,
-          req,
-          res,
-        })
+        let outputUnvalidated: HandlerOutput | undefined
+        try {
+          outputUnvalidated = await handler({
+            params,
+            input,
+            auth: locals.auth,
+            req,
+            res,
+          })
+        } catch (err) {
+          throw XRPCError.fromError(err)
+        }
 
         if (isHandlerError(outputUnvalidated)) {
           throw XRPCError.fromError(outputUnvalidated)


### PR DESCRIPTION
Currently, if there is an uncaught error inside a handler, a 404 response is returned instead of the error itself. This fixes that.