### PR TITLE
Appview proxying bugfixes

### DIFF
--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -270,6 +270,7 @@ export class AccountService {
     mutedBy: string,
     dids: string[],
   ): Promise<Record<string, boolean>> {
+    if (mutedBy.length === 0) return {}
     const res = await this.db.db
       .selectFrom('mute')
       .where('mutedByDid', '=', mutedBy)

--- a/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
@@ -1,0 +1,399 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds posts views fetches posts 1`] = `
+Array [
+  Object {
+    "author": Object {
+      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [],
+      "viewer": Object {
+        "muted": false,
+      },
+    },
+    "cid": "cids(0)",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 0,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "text": "hey there",
+    },
+    "replyCount": 0,
+    "repostCount": 0,
+    "uri": "record(0)",
+    "viewer": Object {},
+  },
+  Object {
+    "author": Object {
+      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [],
+      "viewer": Object {
+        "muted": false,
+      },
+    },
+    "cid": "cids(2)",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 3,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "text": "again",
+    },
+    "replyCount": 2,
+    "repostCount": 1,
+    "uri": "record(1)",
+    "viewer": Object {},
+  },
+  Object {
+    "author": Object {
+      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+      "did": "user(2)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+      "labels": Array [
+        Object {
+          "cid": "cids(4)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "did:example:labeler",
+          "uri": "record(5)",
+          "val": "test-label",
+        },
+      ],
+      "viewer": Object {
+        "followedBy": "record(4)",
+        "following": "record(3)",
+        "muted": false,
+      },
+    },
+    "cid": "cids(3)",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 0,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "text": "bob back at it again!",
+    },
+    "replyCount": 0,
+    "repostCount": 0,
+    "uri": "record(2)",
+    "viewer": Object {},
+  },
+  Object {
+    "author": Object {
+      "did": "user(4)",
+      "handle": "carol.test",
+      "labels": Array [],
+      "viewer": Object {
+        "followedBy": "record(8)",
+        "following": "record(7)",
+        "muted": false,
+      },
+    },
+    "cid": "cids(5)",
+    "embed": Object {
+      "$type": "app.bsky.embed.recordWithMedia#view",
+      "media": Object {
+        "$type": "app.bsky.embed.images#view",
+        "images": Array [
+          Object {
+            "alt": "tests/image/fixtures/key-landscape-small.jpg",
+            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(6)@jpeg",
+            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(6)@jpeg",
+          },
+          Object {
+            "alt": "tests/image/fixtures/key-alt.jpg",
+            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(7)@jpeg",
+            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(7)@jpeg",
+          },
+        ],
+      },
+      "record": Object {
+        "record": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "did": "user(2)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "labels": Array [
+              Object {
+                "cid": "cids(4)",
+                "cts": "1970-01-01T00:00:00.000Z",
+                "neg": false,
+                "src": "did:example:labeler",
+                "uri": "record(5)",
+                "val": "test-label",
+              },
+            ],
+            "viewer": Object {
+              "followedBy": "record(4)",
+              "following": "record(3)",
+            },
+          },
+          "cid": "cids(3)",
+          "embeds": Array [],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "uri": "record(2)",
+          "value": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "text": "bob back at it again!",
+          },
+        },
+      },
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 2,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "embed": Object {
+        "$type": "app.bsky.embed.recordWithMedia",
+        "media": Object {
+          "$type": "app.bsky.embed.images",
+          "images": Array [
+            Object {
+              "alt": "tests/image/fixtures/key-landscape-small.jpg",
+              "image": Object {
+                "$type": "blob",
+                "mimeType": "image/jpeg",
+                "ref": Object {
+                  "$link": "cids(6)",
+                },
+                "size": 4114,
+              },
+            },
+            Object {
+              "alt": "tests/image/fixtures/key-alt.jpg",
+              "image": Object {
+                "$type": "blob",
+                "mimeType": "image/jpeg",
+                "ref": Object {
+                  "$link": "cids(7)",
+                },
+                "size": 12736,
+              },
+            },
+          ],
+        },
+        "record": Object {
+          "record": Object {
+            "cid": "cids(3)",
+            "uri": "record(2)",
+          },
+        },
+      },
+      "text": "hi im carol",
+    },
+    "replyCount": 0,
+    "repostCount": 0,
+    "uri": "record(6)",
+    "viewer": Object {
+      "like": "record(9)",
+    },
+  },
+  Object {
+    "author": Object {
+      "did": "user(6)",
+      "handle": "dan.test",
+      "labels": Array [],
+      "viewer": Object {
+        "following": "record(11)",
+        "muted": false,
+      },
+    },
+    "cid": "cids(8)",
+    "embed": Object {
+      "$type": "app.bsky.embed.record#view",
+      "record": Object {
+        "$type": "app.bsky.embed.record#viewRecord",
+        "author": Object {
+          "did": "user(4)",
+          "handle": "carol.test",
+          "labels": Array [],
+          "viewer": Object {
+            "followedBy": "record(8)",
+            "following": "record(7)",
+          },
+        },
+        "cid": "cids(5)",
+        "embeds": Array [
+          Object {
+            "$type": "app.bsky.embed.recordWithMedia#view",
+            "media": Object {
+              "$type": "app.bsky.embed.images#view",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(6)@jpeg",
+                  "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(6)@jpeg",
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(7)@jpeg",
+                  "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(7)@jpeg",
+                },
+              ],
+            },
+            "record": Object {
+              "record": Object {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "author": Object {
+                  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+                  "did": "user(2)",
+                  "displayName": "bobby",
+                  "handle": "bob.test",
+                  "labels": Array [
+                    Object {
+                      "cid": "cids(4)",
+                      "cts": "1970-01-01T00:00:00.000Z",
+                      "neg": false,
+                      "src": "did:example:labeler",
+                      "uri": "record(5)",
+                      "val": "test-label",
+                    },
+                  ],
+                  "viewer": Object {
+                    "followedBy": "record(4)",
+                    "following": "record(3)",
+                  },
+                },
+                "cid": "cids(3)",
+                "indexedAt": "1970-01-01T00:00:00.000Z",
+                "uri": "record(2)",
+                "value": Object {
+                  "$type": "app.bsky.feed.post",
+                  "createdAt": "1970-01-01T00:00:00.000Z",
+                  "text": "bob back at it again!",
+                },
+              },
+            },
+          },
+        ],
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "uri": "record(6)",
+        "value": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "embed": Object {
+            "$type": "app.bsky.embed.recordWithMedia",
+            "media": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "$type": "blob",
+                    "mimeType": "image/jpeg",
+                    "ref": Object {
+                      "$link": "cids(6)",
+                    },
+                    "size": 4114,
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "$type": "blob",
+                    "mimeType": "image/jpeg",
+                    "ref": Object {
+                      "$link": "cids(7)",
+                    },
+                    "size": 12736,
+                  },
+                },
+              ],
+            },
+            "record": Object {
+              "record": Object {
+                "cid": "cids(3)",
+                "uri": "record(2)",
+              },
+            },
+          },
+          "text": "hi im carol",
+        },
+      },
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 0,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "embed": Object {
+        "$type": "app.bsky.embed.record",
+        "record": Object {
+          "cid": "cids(5)",
+          "uri": "record(6)",
+        },
+      },
+      "facets": Array [
+        Object {
+          "features": Array [
+            Object {
+              "$type": "app.bsky.richtext.facet#mention",
+              "did": "user(0)",
+            },
+          ],
+          "index": Object {
+            "byteEnd": 18,
+            "byteStart": 0,
+          },
+        },
+      ],
+      "text": "@alice.bluesky.xyz is the best",
+    },
+    "replyCount": 0,
+    "repostCount": 1,
+    "uri": "record(10)",
+    "viewer": Object {},
+  },
+  Object {
+    "author": Object {
+      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [],
+      "viewer": Object {
+        "muted": false,
+      },
+    },
+    "cid": "cids(9)",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 0,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "reply": Object {
+        "parent": Object {
+          "cid": "cids(10)",
+          "uri": "record(13)",
+        },
+        "root": Object {
+          "cid": "cids(2)",
+          "uri": "record(1)",
+        },
+      },
+      "text": "thanks bob",
+    },
+    "replyCount": 0,
+    "repostCount": 0,
+    "uri": "record(12)",
+    "viewer": Object {},
+  },
+]
+`;

--- a/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
@@ -143,6 +143,7 @@ Array [
           "cid": "cids(3)",
           "embeds": Array [],
           "indexedAt": "1970-01-01T00:00:00.000Z",
+          "labels": Array [],
           "uri": "record(2)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -271,6 +272,7 @@ Array [
                 },
                 "cid": "cids(3)",
                 "indexedAt": "1970-01-01T00:00:00.000Z",
+                "labels": Array [],
                 "uri": "record(2)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -282,6 +284,7 @@ Array [
           },
         ],
         "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
         "uri": "record(6)",
         "value": Object {
           "$type": "app.bsky.feed.post",

--- a/packages/pds/tests/proxied/posts.test.ts
+++ b/packages/pds/tests/proxied/posts.test.ts
@@ -1,25 +1,26 @@
 import AtpAgent from '@atproto/api'
-import { runTestServer, forSnapshot, TestServerInfo } from '../_util'
+import { TestEnvInfo, processAll, runTestEnv } from '@atproto/dev-env'
+import { forSnapshot } from '../_util'
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
 
 describe('pds posts views', () => {
-  let server: TestServerInfo
+  let testEnv: TestEnvInfo
   let agent: AtpAgent
   let sc: SeedClient
 
   beforeAll(async () => {
-    server = await runTestServer({
+    testEnv = await runTestEnv({
       dbPostgresSchema: 'views_posts',
     })
-    agent = new AtpAgent({ service: server.url })
+    agent = new AtpAgent({ service: testEnv.pds.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
-    await server.ctx.labeler.processAll()
+    await processAll(testEnv)
   })
 
   afterAll(async () => {
-    await server.close()
+    await testEnv.close()
   })
 
   it('fetches posts', async () => {


### PR DESCRIPTION
Two main ones here:
- proxy `feed.getPosts`
- when fetching mutes, handle the case of an empty array 