### PR TITLE
Parse URLs after sentence dot corectly

### DIFF
--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -34,7 +34,7 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
   {
     // links
     const re =
-      /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+      /(^|\s|\(|\b)((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(?!\.https?:\/\/)(\.[a-z0-9]+)+)[\S]*))/gim
     while ((match = re.exec(text.utf16))) {
       let uri = match[2]
       if (!uri.startsWith('http')) {

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -31,6 +31,8 @@ describe('detectFacets', () => {
     'start middle https://end.com/foo/bar?baz=bux#hash',
     'https://newline1.com\nhttps://newline2.com',
     '👨‍👩‍👧‍👧 https://middle.com 👨‍👩‍👧‍👧',
+    'Check this out.https://afterdot.com',
+    'Check this out!https://afterdot.com',
 
     'start middle.com end',
     'start middle.com/foo/bar end',
@@ -119,6 +121,8 @@ describe('detectFacets', () => {
       ['https://newline2.com', 'https://newline2.com'],
     ],
     [['👨‍👩‍👧‍👧 '], ['https://middle.com', 'https://middle.com'], [' 👨‍👩‍👧‍👧']],
+    [['Check this out.'], ['https://afterdot.com', 'https://afterdot.com']],
+    [['Check this out!'], ['https://afterdot.com', 'https://afterdot.com']],
 
     [['start '], ['middle.com', 'https://middle.com'], [' end']],
     [


### PR DESCRIPTION
This fixes the parsing of URLs that are prefixed by a dot (`.`), i.e. when the user forgot a space between the end of a sentence and a link.

I noticed the problem [in this post](https://staging.bsky.app/profile/phillewis.bsky.social/post/3juec5butr62x) where the link should be clickable.

![image](https://user-images.githubusercontent.com/28510368/234915542-47503761-7746-40b9-b52c-aab66d692370.png)

The fix is done by preventing the second alternative capture group from having a domain end in `.https://` (which would be an invalid domain anyway), since that would capture `out.https` in the example message `Check this out.https://afterdot.com`.