### PR TITLE
Fix NSID name length error message typo

### DIFF
--- a/packages/nsid/src/index.ts
+++ b/packages/nsid/src/index.ts
@@ -85,7 +85,7 @@ export const ensureValidNsid = (nsid: string): void => {
       throw new InvalidNsidError('NSID domain part too long (max 63 chars)')
     }
     if (l.length > 128 && i + 1 == labels.length) {
-      throw new InvalidNsidError('NSID name part too long (max 127 chars)')
+      throw new InvalidNsidError('NSID name part too long (max 128 chars)')
     }
     if (l.endsWith('-')) {
       throw new InvalidNsidError('NSID parts can not end with hyphen')


### PR DESCRIPTION
The name length limit is 128 not 127.