### PR TITLE
Return on subscription abort

### DIFF
--- a/packages/pds/src/sequencer/outbox.ts
+++ b/packages/pds/src/sequencer/outbox.ts
@@ -35,6 +35,7 @@ export class Outbox {
     // catch up as much as we can
     if (backfillCursor !== undefined) {
       for await (const evt of this.getBackfill(backfillCursor, backFillTime)) {
+        if (signal?.aborted) return
         this.lastSeen = evt.seq
         yield evt
       }
@@ -81,6 +82,7 @@ export class Outbox {
     while (true) {
       try {
         for await (const evt of this.outBuffer.events()) {
+          if (signal?.aborted) return
           if (evt.seq > this.lastSeen) {
             this.lastSeen = evt.seq
             yield evt


### PR DESCRIPTION
If subscription has been aborted, return instead of continuing to yield event. Hopefully a fix for memory leak