### PR TITLE
Blocks

### DIFF
--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - blocks
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - blocks
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -80,8 +80,8 @@
       "type": "object",
       "properties": {
         "muted": {"type": "boolean"},
-        "blocking": {"type": "boolean"},
         "blockedBy": {"type": "boolean"},
+        "blocking": {"type": "string", "format": "at-uri"},
         "following": {"type": "string", "format": "at-uri"},
         "followedBy": {"type": "string", "format": "at-uri"}
       }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -80,8 +80,8 @@
       "type": "object",
       "properties": {
         "muted": {"type": "boolean"},
-        "blockedBy": {"type": "boolean"},
         "blocking": {"type": "boolean"},
+        "blockedBy": {"type": "boolean"},
         "following": {"type": "string", "format": "at-uri"},
         "followedBy": {"type": "string", "format": "at-uri"}
       }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -80,6 +80,8 @@
       "type": "object",
       "properties": {
         "muted": {"type": "boolean"},
+        "blockedBy": {"type": "boolean"},
+        "blocking": {"type": "boolean"},
         "following": {"type": "string", "format": "at-uri"},
         "followedBy": {"type": "string", "format": "at-uri"}
       }

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -14,7 +14,7 @@
       "type": "object",
       "required":  ["record"],
       "properties": {
-        "record": {"type": "union", "refs": ["#viewRecord", "#viewNotFound"]}
+        "record": {"type": "union", "refs": ["#viewRecord", "#viewNotFound", "#viewBlocked"]}
       }
     },
     "viewRecord": {
@@ -45,6 +45,13 @@
       }
     },
     "viewNotFound": {
+      "type": "object",
+      "required":  ["uri"],
+      "properties": {
+        "uri": {"type": "string", "format": "at-uri"}
+      }
+    },
+    "viewBlocked": {
       "type": "object",
       "required":  ["uri"],
       "properties": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -67,10 +67,10 @@
       "required": ["post"],
       "properties": {
         "post": {"type": "ref", "ref": "#postView"},
-        "parent": {"type": "union", "refs": ["#threadViewPost", "#notFoundPost"]},
+        "parent": {"type": "union", "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"]},
         "replies": {
           "type": "array",
-          "items": {"type": "union", "refs": ["#threadViewPost", "#notFoundPost"]}
+          "items": {"type": "union", "refs": ["#threadViewPost", "#notFoundPost", "#blockedPost"]}
         }
       }
     },
@@ -80,6 +80,14 @@
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "notFound": {"type": "boolean", "const": true}
+      }
+    },
+    "blockedPost": {
+      "type": "object",
+      "required": ["uri", "blocked"],
+      "properties": {
+        "uri": {"type": "string", "format": "at-uri"},
+        "blocked": {"type": "boolean", "const": true}
       }
     }
   }

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -27,7 +27,11 @@
             }
           }
         }
-      }
+      },
+      "errors": [
+        {"name": "BlockedActor"},
+        {"name": "BlockedByActor"}
+      ]
     }
   }
 }

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -20,7 +20,11 @@
           "properties": {
             "thread": {
               "type": "union",
-              "refs": ["app.bsky.feed.defs#threadViewPost", "app.bsky.feed.defs#notFoundPost"]
+              "refs": [
+                "app.bsky.feed.defs#threadViewPost",
+                "app.bsky.feed.defs#notFoundPost",
+                "app.bsky.feed.defs#blockedPost"
+              ]
             }
           }
         }

--- a/lexicons/app/bsky/graph/block.json
+++ b/lexicons/app/bsky/graph/block.json
@@ -1,0 +1,19 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.block",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A block.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {"type": "string", "format": "did"},
+          "createdAt": {"type": "string", "format": "datetime"}
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getBlocks.json
+++ b/lexicons/app/bsky/graph/getBlocks.json
@@ -1,0 +1,31 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getBlocks",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Who is the requester's account blocking?",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+          "cursor": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["blocks"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "blocks": {
+              "type": "array",
+              "items": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3394,6 +3394,12 @@ export const schemaDict = {
           muted: {
             type: 'boolean',
           },
+          blockedBy: {
+            type: 'boolean',
+          },
+          blocking: {
+            type: 'boolean',
+          },
           following: {
             type: 'string',
             format: 'at-uri',
@@ -3793,6 +3799,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.embed.record#viewRecord',
               'lex:app.bsky.embed.record#viewNotFound',
+              'lex:app.bsky.embed.record#viewBlocked',
             ],
           },
         },
@@ -3842,6 +3849,16 @@ export const schemaDict = {
         },
       },
       viewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+        },
+      },
+      viewBlocked: {
         type: 'object',
         required: ['uri'],
         properties: {
@@ -4022,6 +4039,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.feed.defs#threadViewPost',
               'lex:app.bsky.feed.defs#notFoundPost',
+              'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
           replies: {
@@ -4031,6 +4049,7 @@ export const schemaDict = {
               refs: [
                 'lex:app.bsky.feed.defs#threadViewPost',
                 'lex:app.bsky.feed.defs#notFoundPost',
+                'lex:app.bsky.feed.defs#blockedPost',
               ],
             },
           },
@@ -4045,6 +4064,20 @@ export const schemaDict = {
             format: 'at-uri',
           },
           notFound: {
+            type: 'boolean',
+            const: true,
+          },
+        },
+      },
+      blockedPost: {
+        type: 'object',
+        required: ['uri', 'blocked'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          blocked: {
             type: 'boolean',
             const: true,
           },
@@ -4514,6 +4547,31 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphBlock: {
+    lexicon: 1,
+    id: 'app.bsky.graph.block',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'A block.',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['subject', 'createdAt'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'did',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphFollow: {
     lexicon: 1,
     id: 'app.bsky.graph.follow',
@@ -4533,6 +4591,49 @@ export const schemaDict = {
             createdAt: {
               type: 'string',
               format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphGetBlocks: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getBlocks',
+    defs: {
+      main: {
+        type: 'query',
+        description: "Who is the requester's account blocking?",
+        parameters: {
+          type: 'params',
+          properties: {
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['blocks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              blocks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
+                },
+              },
             },
           },
         },
@@ -5088,7 +5189,9 @@ export const ids = {
   AppBskyFeedLike: 'app.bsky.feed.like',
   AppBskyFeedPost: 'app.bsky.feed.post',
   AppBskyFeedRepost: 'app.bsky.feed.repost',
+  AppBskyGraphBlock: 'app.bsky.graph.block',
   AppBskyGraphFollow: 'app.bsky.graph.follow',
+  AppBskyGraphGetBlocks: 'app.bsky.graph.getBlocks',
   AppBskyGraphGetFollowers: 'app.bsky.graph.getFollowers',
   AppBskyGraphGetFollows: 'app.bsky.graph.getFollows',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4130,6 +4130,14 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'BlockedActor',
+          },
+          {
+            name: 'BlockedByActor',
+          },
+        ],
       },
     },
   },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4240,6 +4240,7 @@ export const schemaDict = {
                 refs: [
                   'lex:app.bsky.feed.defs#threadViewPost',
                   'lex:app.bsky.feed.defs#notFoundPost',
+                  'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
             },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3398,7 +3398,8 @@ export const schemaDict = {
             type: 'boolean',
           },
           blocking: {
-            type: 'boolean',
+            type: 'string',
+            format: 'at-uri',
           },
           following: {
             type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -84,7 +84,7 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 export interface ViewerState {
   muted?: boolean
   blockedBy?: boolean
-  blocking?: boolean
+  blocking?: string
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -83,6 +83,8 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 
 export interface ViewerState {
   muted?: boolean
+  blockedBy?: boolean
+  blocking?: boolean
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -31,7 +31,11 @@ export function validateMain(v: unknown): ValidationResult {
 }
 
 export interface View {
-  record: ViewRecord | ViewNotFound | { $type: string; [k: string]: unknown }
+  record:
+    | ViewRecord
+    | ViewNotFound
+    | ViewBlocked
+    | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }
 
@@ -89,4 +93,21 @@ export function isViewNotFound(v: unknown): v is ViewNotFound {
 
 export function validateViewNotFound(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.record#viewNotFound', v)
+}
+
+export interface ViewBlocked {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isViewBlocked(v: unknown): v is ViewBlocked {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.record#viewBlocked'
+  )
+}
+
+export function validateViewBlocked(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewBlocked', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -118,10 +118,12 @@ export interface ThreadViewPost {
   parent?:
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   replies?: (
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   )[]
   [k: string]: unknown
@@ -155,4 +157,22 @@ export function isNotFoundPost(v: unknown): v is NotFoundPost {
 
 export function validateNotFoundPost(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.defs#notFoundPost', v)
+}
+
+export interface BlockedPost {
+  uri: string
+  blocked: true
+  [k: string]: unknown
+}
+
+export function isBlockedPost(v: unknown): v is BlockedPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.defs#blockedPost'
+  )
+}
+
+export function validateBlockedPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.defs#blockedPost', v)
 }

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -32,8 +32,22 @@ export interface Response {
   data: OutputSchema
 }
 
+export class BlockedActorError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class BlockedByActorError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'BlockedActor') return new BlockedActorError(e)
+    if (e.error === 'BlockedByActor') return new BlockedByActorError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -19,6 +19,7 @@ export interface OutputSchema {
   thread:
     | AppBskyFeedDefs.ThreadViewPost
     | AppBskyFeedDefs.NotFoundPost
+    | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/app/bsky/graph/block.ts
+++ b/packages/api/src/client/types/app/bsky/graph/block.ts
@@ -1,0 +1,26 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+
+export interface Record {
+  subject: string
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.block#main' ||
+      v.$type === 'app.bsky.graph.block')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.block#main', v)
+}

--- a/packages/api/src/client/types/app/bsky/graph/getBlocks.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getBlocks.ts
@@ -1,0 +1,38 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+import * as AppBskyActorDefs from '../actor/defs'
+
+export interface QueryParams {
+  limit?: number
+  cursor?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  blocks: AppBskyActorDefs.ProfileView[]
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -75,6 +75,7 @@ import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy'
 import * as AppBskyFeedGetTimeline from './types/app/bsky/feed/getTimeline'
+import * as AppBskyGraphGetBlocks from './types/app/bsky/graph/getBlocks'
 import * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 import * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes'
@@ -786,6 +787,13 @@ export class GraphNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  getBlocks<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphGetBlocks.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.getBlocks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   getFollowers<AV extends AuthVerifier>(

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3398,7 +3398,8 @@ export const schemaDict = {
             type: 'boolean',
           },
           blocking: {
-            type: 'boolean',
+            type: 'string',
+            format: 'at-uri',
           },
           following: {
             type: 'string',
@@ -4130,6 +4131,14 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'BlockedActor',
+          },
+          {
+            name: 'BlockedByActor',
+          },
+        ],
       },
     },
   },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3394,6 +3394,12 @@ export const schemaDict = {
           muted: {
             type: 'boolean',
           },
+          blockedBy: {
+            type: 'boolean',
+          },
+          blocking: {
+            type: 'boolean',
+          },
           following: {
             type: 'string',
             format: 'at-uri',
@@ -3793,6 +3799,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.embed.record#viewRecord',
               'lex:app.bsky.embed.record#viewNotFound',
+              'lex:app.bsky.embed.record#viewBlocked',
             ],
           },
         },
@@ -3842,6 +3849,16 @@ export const schemaDict = {
         },
       },
       viewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+        },
+      },
+      viewBlocked: {
         type: 'object',
         required: ['uri'],
         properties: {
@@ -4022,6 +4039,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.feed.defs#threadViewPost',
               'lex:app.bsky.feed.defs#notFoundPost',
+              'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
           replies: {
@@ -4031,6 +4049,7 @@ export const schemaDict = {
               refs: [
                 'lex:app.bsky.feed.defs#threadViewPost',
                 'lex:app.bsky.feed.defs#notFoundPost',
+                'lex:app.bsky.feed.defs#blockedPost',
               ],
             },
           },
@@ -4045,6 +4064,20 @@ export const schemaDict = {
             format: 'at-uri',
           },
           notFound: {
+            type: 'boolean',
+            const: true,
+          },
+        },
+      },
+      blockedPost: {
+        type: 'object',
+        required: ['uri', 'blocked'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          blocked: {
             type: 'boolean',
             const: true,
           },
@@ -4207,6 +4240,7 @@ export const schemaDict = {
                 refs: [
                   'lex:app.bsky.feed.defs#threadViewPost',
                   'lex:app.bsky.feed.defs#notFoundPost',
+                  'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
             },
@@ -4514,6 +4548,31 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphBlock: {
+    lexicon: 1,
+    id: 'app.bsky.graph.block',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'A block.',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['subject', 'createdAt'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'did',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphFollow: {
     lexicon: 1,
     id: 'app.bsky.graph.follow',
@@ -4533,6 +4592,49 @@ export const schemaDict = {
             createdAt: {
               type: 'string',
               format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphGetBlocks: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getBlocks',
+    defs: {
+      main: {
+        type: 'query',
+        description: "Who is the requester's account blocking?",
+        parameters: {
+          type: 'params',
+          properties: {
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['blocks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              blocks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
+                },
+              },
             },
           },
         },
@@ -5088,7 +5190,9 @@ export const ids = {
   AppBskyFeedLike: 'app.bsky.feed.like',
   AppBskyFeedPost: 'app.bsky.feed.post',
   AppBskyFeedRepost: 'app.bsky.feed.repost',
+  AppBskyGraphBlock: 'app.bsky.graph.block',
   AppBskyGraphFollow: 'app.bsky.graph.follow',
+  AppBskyGraphGetBlocks: 'app.bsky.graph.getBlocks',
   AppBskyGraphGetFollowers: 'app.bsky.graph.getFollowers',
   AppBskyGraphGetFollows: 'app.bsky.graph.getFollows',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -84,7 +84,7 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 export interface ViewerState {
   muted?: boolean
   blockedBy?: boolean
-  blocking?: boolean
+  blocking?: string
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -83,6 +83,8 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 
 export interface ViewerState {
   muted?: boolean
+  blockedBy?: boolean
+  blocking?: boolean
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
@@ -31,7 +31,11 @@ export function validateMain(v: unknown): ValidationResult {
 }
 
 export interface View {
-  record: ViewRecord | ViewNotFound | { $type: string; [k: string]: unknown }
+  record:
+    | ViewRecord
+    | ViewNotFound
+    | ViewBlocked
+    | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }
 
@@ -89,4 +93,21 @@ export function isViewNotFound(v: unknown): v is ViewNotFound {
 
 export function validateViewNotFound(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.record#viewNotFound', v)
+}
+
+export interface ViewBlocked {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isViewBlocked(v: unknown): v is ViewBlocked {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.record#viewBlocked'
+  )
+}
+
+export function validateViewBlocked(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewBlocked', v)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -118,10 +118,12 @@ export interface ThreadViewPost {
   parent?:
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   replies?: (
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   )[]
   [k: string]: unknown
@@ -155,4 +157,22 @@ export function isNotFoundPost(v: unknown): v is NotFoundPost {
 
 export function validateNotFoundPost(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.defs#notFoundPost', v)
+}
+
+export interface BlockedPost {
+  uri: string
+  blocked: true
+  [k: string]: unknown
+}
+
+export function isBlockedPost(v: unknown): v is BlockedPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.defs#blockedPost'
+  )
+}
+
+export function validateBlockedPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.defs#blockedPost', v)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -33,6 +33,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'BlockedActor' | 'BlockedByActor'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -20,6 +20,7 @@ export interface OutputSchema {
   thread:
     | AppBskyFeedDefs.ThreadViewPost
     | AppBskyFeedDefs.NotFoundPost
+    | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/block.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/block.ts
@@ -1,0 +1,26 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+
+export interface Record {
+  subject: string
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.block#main' ||
+      v.$type === 'app.bsky.graph.block')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.block#main', v)
+}

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getBlocks.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as AppBskyActorDefs from '../actor/defs'
+
+export interface QueryParams {
+  limit: number
+  cursor?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  blocks: AppBskyActorDefs.ProfileView[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/common-web/src/types.ts
+++ b/packages/common-web/src/types.ts
@@ -42,3 +42,5 @@ export const def = {
 }
 
 export type ArrayEl<A> = A extends readonly (infer T)[] ? T : never
+
+export type NotEmptyArray<T> = [T, ...T[]]

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -44,7 +44,7 @@ export default function (server: Server, ctx: AppContext) {
         .views.profile(results, requester)
 
       const filtered = actors.filter(
-        (actor) => !actor.viewer?.blocking && actor.viewer?.blockedBy,
+        (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 
       return {

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -39,13 +39,19 @@ export default function (server: Server, ctx: AppContext) {
 
       const keyset = new SearchKeyset(sql``, sql``)
 
+      const actors = await services.appView
+        .actor(db)
+        .views.profile(results, requester)
+
+      const filtered = actors.filter(
+        (actor) => !actor.viewer?.blocking && actor.viewer?.blockedBy,
+      )
+
       return {
         encoding: 'application/json',
         body: {
           cursor: keyset.packFromResult(results),
-          actors: await services.appView
-            .actor(db)
-            .views.profile(results, requester),
+          actors: filtered,
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
         .views.profileBasic(results, requester)
 
       const filtered = actors.filter(
-        (actor) => !actor.viewer?.blocking && actor.viewer?.blockedBy,
+        (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 
       return {

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -34,12 +34,18 @@ export default function (server: Server, ctx: AppContext) {
           ? await getResultsPg(ctx.db, { term, limit })
           : await getResultsSqlite(ctx.db, { term, limit })
 
+      const actors = await services.appView
+        .actor(db)
+        .views.profileBasic(results, requester)
+
+      const filtered = actors.filter(
+        (actor) => !actor.viewer?.blocking && actor.viewer?.blockedBy,
+      )
+
       return {
         encoding: 'application/json',
         body: {
-          actors: await services.appView
-            .actor(db)
-            .views.profileBasic(results, requester),
+          actors: filtered,
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -12,6 +12,8 @@ export default function (server: Server, ctx: AppContext) {
       const { services, db } = ctx
       const { ref } = db.db.dynamic
 
+      const actorService = ctx.services.appView.actor(ctx.db)
+
       let builder = db.db
         .selectFrom('like')
         .where('like.subject', '=', uri)
@@ -22,6 +24,7 @@ export default function (server: Server, ctx: AppContext) {
           'like.creator',
         )
         .where(notSoftDeletedClause(ref('creator_repo')))
+        .whereNotExists(actorService.blockQb(requester, [ref('like.creator')]))
         .selectAll('creator')
         .select([
           'like.cid as cid',

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -12,6 +12,8 @@ export default function (server: Server, ctx: AppContext) {
       const { services, db } = ctx
       const { ref } = db.db.dynamic
 
+      const actorService = ctx.services.appView.actor(ctx.db)
+
       let builder = db.db
         .selectFrom('repost')
         .where('repost.subject', '=', uri)
@@ -22,6 +24,9 @@ export default function (server: Server, ctx: AppContext) {
           'repost.creator',
         )
         .where(notSoftDeletedClause(ref('creator_repo')))
+        .whereNotExists(
+          actorService.blockQb(requester, [ref('repost.creator')]),
+        )
         .selectAll('creator')
         .select(['repost.cid as cid', 'repost.createdAt as createdAt'])
 

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -21,6 +21,7 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const feedService = ctx.services.appView.feed(ctx.db)
+      const actorService = ctx.services.appView.actor(ctx.db)
       const labelService = ctx.services.appView.label(ctx.db)
 
       const followingIdsSubquery = db
@@ -46,6 +47,12 @@ export default function (server: Server, ctx: AppContext) {
             'in',
             sql`(${ref('post.creator')}, ${ref('originatorDid')})`,
           ),
+        )
+        .whereNotExists(
+          actorService.blockQb(requester, [
+            ref('post.creator'),
+            ref('originatorDid'),
+          ]),
         )
 
       const keyset = new FeedKeyset(

--- a/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
@@ -1,0 +1,59 @@
+import { Server } from '../../../../../lexicon'
+import { paginate, TimeCidKeyset } from '../../../../../db/pagination'
+import AppContext from '../../../../../context'
+import { notSoftDeletedClause } from '../../../../../db/util'
+
+export default function (server: Server, ctx: AppContext) {
+  server.app.bsky.graph.getBlocks({
+    auth: ctx.accessVerifier,
+    handler: async ({ params, auth }) => {
+      const { limit, cursor } = params
+      const requester = auth.credentials.did
+      const { services, db } = ctx
+      const { ref } = db.db.dynamic
+
+      let blocksReq = ctx.db.db
+        .selectFrom('actor_block')
+        .where('actor_block.creator', '=', requester)
+        .innerJoin(
+          'did_handle as subject',
+          'subject.did',
+          'actor_block.subjectDid',
+        )
+        .innerJoin(
+          'repo_root as subject_repo',
+          'subject_repo.did',
+          'actor_block.subjectDid',
+        )
+        .where(notSoftDeletedClause(ref('subject_repo')))
+        .selectAll('subject')
+        .select([
+          'actor_block.cid as cid',
+          'actor_block.createdAt as createdAt',
+        ])
+
+      const keyset = new TimeCidKeyset(
+        ref('follow.createdAt'),
+        ref('follow.cid'),
+      )
+      blocksReq = paginate(blocksReq, {
+        limit,
+        cursor,
+        keyset,
+      })
+
+      const followsRes = await blocksReq.execute()
+
+      const actorService = services.appView.actor(db)
+      const blocks = await actorService.views.profile(followsRes, requester)
+
+      return {
+        encoding: 'application/json',
+        body: {
+          blocks,
+          cursor: keyset.packFromResult(followsRes),
+        },
+      }
+    },
+  })
+}

--- a/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
@@ -33,8 +33,8 @@ export default function (server: Server, ctx: AppContext) {
         ])
 
       const keyset = new TimeCidKeyset(
-        ref('follow.createdAt'),
-        ref('follow.cid'),
+        ref('actor_block.createdAt'),
+        ref('actor_block.cid'),
       )
       blocksReq = paginate(blocksReq, {
         limit,
@@ -42,16 +42,16 @@ export default function (server: Server, ctx: AppContext) {
         keyset,
       })
 
-      const followsRes = await blocksReq.execute()
+      const blocksRes = await blocksReq.execute()
 
       const actorService = services.appView.actor(db)
-      const blocks = await actorService.views.profile(followsRes, requester)
+      const blocks = await actorService.views.profile(blocksRes, requester)
 
       return {
         encoding: 'application/json',
         body: {
           blocks,
-          cursor: keyset.packFromResult(followsRes),
+          cursor: keyset.packFromResult(blocksRes),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -30,6 +30,9 @@ export default function (server: Server, ctx: AppContext) {
           'follow.creator',
         )
         .where(notSoftDeletedClause(ref('creator_repo')))
+        .whereNotExists(
+          actorService.blockQb(requester, [ref('follow.subjectDid')]),
+        )
         .selectAll('creator')
         .select(['follow.cid as cid', 'follow.createdAt as createdAt'])
 

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -30,6 +30,9 @@ export default function (server: Server, ctx: AppContext) {
           'follow.subjectDid',
         )
         .where(notSoftDeletedClause(ref('subject_repo')))
+        .whereNotExists(
+          actorService.blockQb(requester, [ref('follow.creator')]),
+        )
         .selectAll('subject')
         .select(['follow.cid as cid', 'follow.createdAt as createdAt'])
 

--- a/packages/pds/src/app-view/api/app/bsky/index.ts
+++ b/packages/pds/src/app-view/api/app/bsky/index.ts
@@ -10,6 +10,7 @@ import getProfiles from './actor/getProfiles'
 import getRepostedBy from './feed/getRepostedBy'
 import getFollowers from './graph/getFollowers'
 import getFollows from './graph/getFollows'
+import getBlocks from './graph/getBlocks'
 import getUsersSearch from './actor/searchActors'
 import getUsersTypeahead from './actor/searchActorsTypeahead'
 import getSuggestions from './actor/getSuggestions'
@@ -28,6 +29,7 @@ export default function (server: Server, ctx: AppContext) {
   getRepostedBy(server, ctx)
   getFollowers(server, ctx)
   getFollows(server, ctx)
+  getBlocks(server, ctx)
   getUsersSearch(server, ctx)
   getUsersTypeahead(server, ctx)
   getSuggestions(server, ctx)

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -16,6 +16,7 @@ export default function (server: Server, ctx: AppContext) {
       const { ref } = db.dynamic
 
       const feedService = ctx.services.appView.feed(ctx.db)
+      const actorService = ctx.services.appView.actor(ctx.db)
       const labelService = ctx.services.appView.label(ctx.db)
 
       const postsQb = feedService
@@ -29,6 +30,7 @@ export default function (server: Server, ctx: AppContext) {
             .where('mutedByDid', '=', requester)
             .whereRef('did', '=', ref('post.creator')),
         )
+        .whereNotExists(actorService.blockQb(requester, [ref('post.creator')]))
 
       const keyset = new FeedKeyset(ref('sortAt'), ref('cid'))
 

--- a/packages/pds/src/app-view/db/index.ts
+++ b/packages/pds/src/app-view/db/index.ts
@@ -8,6 +8,7 @@ import * as postHierarchy from './tables/post-hierarchy'
 import * as repost from './tables/repost'
 import * as feedItem from './tables/feed-item'
 import * as follow from './tables/follow'
+import * as actorBlock from './tables/actor-block'
 import * as like from './tables/like'
 import * as subscription from './tables/subscription'
 
@@ -22,5 +23,6 @@ export type DatabaseSchemaType = duplicateRecords.PartialDB &
   repost.PartialDB &
   feedItem.PartialDB &
   follow.PartialDB &
+  actorBlock.PartialDB &
   like.PartialDB &
   subscription.PartialDB

--- a/packages/pds/src/app-view/db/tables/actor-block.ts
+++ b/packages/pds/src/app-view/db/tables/actor-block.ts
@@ -1,4 +1,4 @@
-export const tableName = 'actor-block'
+export const tableName = 'actor_block'
 export interface ActorBlock {
   uri: string
   cid: string

--- a/packages/pds/src/app-view/db/tables/actor-block.ts
+++ b/packages/pds/src/app-view/db/tables/actor-block.ts
@@ -1,0 +1,11 @@
+export const tableName = 'actor-block'
+export interface ActorBlock {
+  uri: string
+  cid: string
+  creator: string
+  subjectDid: string
+  createdAt: string
+  indexedAt: string
+}
+
+export type PartialDB = { [tableName]: ActorBlock }

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -64,6 +64,18 @@ export class ActorViews {
           .select('uri')
           .as('requesterFollowedBy'),
         this.db.db
+          .selectFrom('actor_block')
+          .where('creator', '=', viewer)
+          .whereRef('subjectDid', '=', ref('did_handle.did'))
+          .select('uri')
+          .as('requesterBlocking'),
+        this.db.db
+          .selectFrom('actor_block')
+          .whereRef('creator', '=', ref('did_handle.did'))
+          .where('subjectDid', '=', viewer)
+          .select('uri')
+          .as('requesterBlockedBy'),
+        this.db.db
           .selectFrom('mute')
           .whereRef('did', '=', ref('did_handle.did'))
           .where('mutedByDid', '=', viewer)
@@ -102,6 +114,8 @@ export class ActorViews {
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
           muted: !!profileInfo?.requesterMuted,
+          blocking: !!profileInfo.requesterBlocking,
+          blockedBy: !!profileInfo.requesterBlockedBy,
           following: profileInfo?.requesterFollowing || undefined,
           followedBy: profileInfo?.requesterFollowedBy || undefined,
         },
@@ -148,6 +162,18 @@ export class ActorViews {
           .select('uri')
           .as('requesterFollowedBy'),
         this.db.db
+          .selectFrom('actor_block')
+          .where('creator', '=', viewer)
+          .whereRef('subjectDid', '=', ref('did_handle.did'))
+          .select('uri')
+          .as('requesterBlocking'),
+        this.db.db
+          .selectFrom('actor_block')
+          .whereRef('creator', '=', ref('did_handle.did'))
+          .where('subjectDid', '=', viewer)
+          .select('uri')
+          .as('requesterBlockedBy'),
+        this.db.db
           .selectFrom('mute')
           .whereRef('did', '=', ref('did_handle.did'))
           .where('mutedByDid', '=', viewer)
@@ -179,6 +205,8 @@ export class ActorViews {
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
           muted: !!profileInfo?.requesterMuted,
+          blocking: !!profileInfo.requesterBlocking,
+          blockedBy: !!profileInfo.requesterBlockedBy,
           following: profileInfo?.requesterFollowing || undefined,
           followedBy: profileInfo?.requesterFollowedBy || undefined,
         },

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -114,8 +114,8 @@ export class ActorViews {
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
           muted: !!profileInfo?.requesterMuted,
-          blocking: !!profileInfo.requesterBlocking,
           blockedBy: !!profileInfo.requesterBlockedBy,
+          blocking: profileInfo.requesterBlocking || undefined,
           following: profileInfo?.requesterFollowing || undefined,
           followedBy: profileInfo?.requesterFollowedBy || undefined,
         },
@@ -205,8 +205,8 @@ export class ActorViews {
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
           muted: !!profileInfo?.requesterMuted,
-          blocking: !!profileInfo.requesterBlocking,
           blockedBy: !!profileInfo.requesterBlockedBy,
+          blocking: profileInfo.requesterBlocking || undefined,
           following: profileInfo?.requesterFollowing || undefined,
           followedBy: profileInfo?.requesterFollowedBy || undefined,
         },

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -140,8 +140,8 @@ export class FeedService {
             : undefined,
           viewer: {
             muted: !!cur?.requesterMuted,
-            blocking: !!cur?.requesterBlocking,
             blockedBy: !!cur?.requesterBlockedBy,
+            blocking: cur?.requesterBlocking || undefined,
             following: cur?.requesterFollowing || undefined,
             followedBy: cur?.requesterFollowedBy || undefined,
           },

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -103,6 +103,18 @@ export class FeedService {
             .select('uri')
             .as('requesterFollowedBy'),
           this.db.db
+            .selectFrom('actor_block')
+            .where('creator', '=', requester)
+            .whereRef('subjectDid', '=', ref('did_handle.did'))
+            .select('uri')
+            .as('requesterBlocking'),
+          this.db.db
+            .selectFrom('actor_block')
+            .whereRef('creator', '=', ref('did_handle.did'))
+            .where('subjectDid', '=', requester)
+            .select('uri')
+            .as('requesterBlockedBy'),
+          this.db.db
             .selectFrom('mute')
             .whereRef('did', '=', ref('did_handle.did'))
             .where('mutedByDid', '=', requester)
@@ -124,6 +136,8 @@ export class FeedService {
             : undefined,
           viewer: {
             muted: !!cur?.requesterMuted,
+            blocking: !!cur?.requesterBlocking,
+            blockedBy: !!cur?.requesterBlockedBy,
             following: cur?.requesterFollowing || undefined,
             followedBy: cur?.requesterFollowedBy || undefined,
           },

--- a/packages/pds/src/app-view/services/feed/types.ts
+++ b/packages/pds/src/app-view/services/feed/types.ts
@@ -29,8 +29,8 @@ export type ActorView = {
   avatar?: string
   viewer?: {
     muted?: boolean
-    blocking?: boolean
     blockedBy?: boolean
+    blocking?: string
     following?: string
     followedBy?: string
   }

--- a/packages/pds/src/app-view/services/feed/types.ts
+++ b/packages/pds/src/app-view/services/feed/types.ts
@@ -27,7 +27,13 @@ export type ActorView = {
   handle: string
   displayName?: string
   avatar?: string
-  viewer?: { muted: boolean }
+  viewer?: {
+    muted?: boolean
+    blocking?: boolean
+    blockedBy?: boolean
+    following?: string
+    followedBy?: string
+  }
 }
 export type ActorViewMap = { [did: string]: ActorView }
 

--- a/packages/pds/src/app-view/services/indexing/index.ts
+++ b/packages/pds/src/app-view/services/indexing/index.ts
@@ -8,6 +8,7 @@ import * as Post from './plugins/post'
 import * as Like from './plugins/like'
 import * as Repost from './plugins/repost'
 import * as Follow from './plugins/follow'
+import * as Block from './plugins/block'
 import * as Profile from './plugins/profile'
 import { BackgroundQueue } from '../../../event-stream/background-queue'
 
@@ -17,6 +18,7 @@ export class IndexingService {
     like: Like.PluginType
     repost: Repost.PluginType
     follow: Follow.PluginType
+    block: Block.PluginType
     profile: Profile.PluginType
   }
 
@@ -26,6 +28,7 @@ export class IndexingService {
       like: Like.makePlugin(this.db, backgroundQueue),
       repost: Repost.makePlugin(this.db, backgroundQueue),
       follow: Follow.makePlugin(this.db, backgroundQueue),
+      block: Block.makePlugin(this.db, backgroundQueue),
       profile: Profile.makePlugin(this.db, backgroundQueue),
     }
   }
@@ -101,6 +104,7 @@ export class IndexingService {
     ])
     await removeActorAggregates(this.db.db, did)
     await Promise.all([
+      this.db.db.deleteFrom('actor_block').where('creator', '=', did).execute(),
       this.db.db.deleteFrom('follow').where('creator', '=', did).execute(),
       this.db.db.deleteFrom('post').where('creator', '=', did).execute(),
       this.db.db.deleteFrom('profile').where('creator', '=', did).execute(),

--- a/packages/pds/src/app-view/services/indexing/plugins/block.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/block.ts
@@ -1,0 +1,96 @@
+import { AtUri } from '@atproto/uri'
+import { CID } from 'multiformats/cid'
+import * as Block from '../../../../lexicon/types/app/bsky/graph/block'
+import * as lex from '../../../../lexicon/lexicons'
+import Database from '../../../../db'
+import {
+  DatabaseSchema,
+  DatabaseSchemaType,
+} from '../../../../db/database-schema'
+import { BackgroundQueue } from '../../../../event-stream/background-queue'
+import RecordProcessor from '../processor'
+
+const lexId = lex.ids.AppBskyGraphBlock
+type IndexedBlock = DatabaseSchemaType['actor_block']
+
+const insertFn = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+  cid: CID,
+  obj: Block.Record,
+  timestamp: string,
+): Promise<IndexedBlock | null> => {
+  const inserted = await db
+    .insertInto('actor_block')
+    .values({
+      uri: uri.toString(),
+      cid: cid.toString(),
+      creator: uri.host,
+      subjectDid: obj.subject,
+      createdAt: obj.createdAt,
+      indexedAt: timestamp,
+    })
+    .onConflict((oc) => oc.doNothing())
+    .returningAll()
+    .executeTakeFirst()
+  return inserted || null
+}
+
+const findDuplicate = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+  obj: Block.Record,
+): Promise<AtUri | null> => {
+  const found = await db
+    .selectFrom('actor_block')
+    .where('creator', '=', uri.host)
+    .where('subjectDid', '=', obj.subject)
+    .selectAll()
+    .executeTakeFirst()
+  return found ? new AtUri(found.uri) : null
+}
+
+const notifsForInsert = () => {
+  return []
+}
+
+const deleteFn = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+): Promise<IndexedBlock | null> => {
+  const deleted = await db
+    .deleteFrom('actor_block')
+    .where('uri', '=', uri.toString())
+    .returningAll()
+    .executeTakeFirst()
+  return deleted || null
+}
+
+const notifsForDelete = (
+  deleted: IndexedBlock,
+  replacedBy: IndexedBlock | null,
+) => {
+  const toDelete = replacedBy ? [] : [deleted.uri]
+  return { notifs: [], toDelete }
+}
+
+const updateAggregates = async () => {}
+
+export type PluginType = RecordProcessor<Block.Record, IndexedBlock>
+
+export const makePlugin = (
+  db: Database,
+  backgroundQueue: BackgroundQueue,
+): PluginType => {
+  return new RecordProcessor(db, backgroundQueue, {
+    lexId,
+    insertFn,
+    findDuplicate,
+    deleteFn,
+    notifsForInsert,
+    notifsForDelete,
+    updateAggregates,
+  })
+}
+
+export default makePlugin

--- a/packages/pds/src/db/migrations/20230428T195614638Z-actor-block-init.ts
+++ b/packages/pds/src/db/migrations/20230428T195614638Z-actor-block-init.ts
@@ -1,0 +1,27 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('actor_block')
+    .addColumn('uri', 'varchar', (col) => col.primaryKey())
+    .addColumn('cid', 'varchar', (col) => col.notNull())
+    .addColumn('creator', 'varchar', (col) => col.notNull())
+    .addColumn('subjectDid', 'varchar', (col) => col.notNull())
+    .addColumn('createdAt', 'varchar', (col) => col.notNull())
+    .addColumn('indexedAt', 'varchar', (col) => col.notNull())
+    .addUniqueConstraint('actor_block_unique_subject', [
+      'creator',
+      'subjectDid',
+    ])
+    .execute()
+  await db.schema
+    .createIndex('actor_block_subjectdid_idx')
+    .on('actor_block')
+    .column('subjectDid')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('actor_block_subjectdid_idx').execute()
+  await db.schema.dropTable('actor_block').execute()
+}

--- a/packages/pds/src/db/migrations/index.ts
+++ b/packages/pds/src/db/migrations/index.ts
@@ -42,3 +42,4 @@ export * as _20230412T231807162Z from './20230412T231807162Z-moderation-action-l
 export * as _20230416T221236745Z from './20230416T221236745Z-app-specific-passwords'
 export * as _20230420T143821201Z from './20230420T143821201Z-post-profile-aggs'
 export * as _20230427T194652255Z from './20230427T194652255Z-notif-record-index'
+export * as _20230428T195614638Z from './20230428T195614638Z-actor-block-init'

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -75,6 +75,7 @@ import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy'
 import * as AppBskyFeedGetTimeline from './types/app/bsky/feed/getTimeline'
+import * as AppBskyGraphGetBlocks from './types/app/bsky/graph/getBlocks'
 import * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 import * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes'
@@ -786,6 +787,13 @@ export class GraphNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  getBlocks<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphGetBlocks.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.getBlocks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   getFollowers<AV extends AuthVerifier>(

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3394,6 +3394,12 @@ export const schemaDict = {
           muted: {
             type: 'boolean',
           },
+          blockedBy: {
+            type: 'boolean',
+          },
+          blocking: {
+            type: 'boolean',
+          },
           following: {
             type: 'string',
             format: 'at-uri',
@@ -3793,6 +3799,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.embed.record#viewRecord',
               'lex:app.bsky.embed.record#viewNotFound',
+              'lex:app.bsky.embed.record#viewBlocked',
             ],
           },
         },
@@ -3842,6 +3849,16 @@ export const schemaDict = {
         },
       },
       viewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+        },
+      },
+      viewBlocked: {
         type: 'object',
         required: ['uri'],
         properties: {
@@ -4022,6 +4039,7 @@ export const schemaDict = {
             refs: [
               'lex:app.bsky.feed.defs#threadViewPost',
               'lex:app.bsky.feed.defs#notFoundPost',
+              'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
           replies: {
@@ -4031,6 +4049,7 @@ export const schemaDict = {
               refs: [
                 'lex:app.bsky.feed.defs#threadViewPost',
                 'lex:app.bsky.feed.defs#notFoundPost',
+                'lex:app.bsky.feed.defs#blockedPost',
               ],
             },
           },
@@ -4045,6 +4064,20 @@ export const schemaDict = {
             format: 'at-uri',
           },
           notFound: {
+            type: 'boolean',
+            const: true,
+          },
+        },
+      },
+      blockedPost: {
+        type: 'object',
+        required: ['uri', 'blocked'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          blocked: {
             type: 'boolean',
             const: true,
           },
@@ -4514,6 +4547,31 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphBlock: {
+    lexicon: 1,
+    id: 'app.bsky.graph.block',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'A block.',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['subject', 'createdAt'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'did',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphFollow: {
     lexicon: 1,
     id: 'app.bsky.graph.follow',
@@ -4533,6 +4591,49 @@ export const schemaDict = {
             createdAt: {
               type: 'string',
               format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphGetBlocks: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getBlocks',
+    defs: {
+      main: {
+        type: 'query',
+        description: "Who is the requester's account blocking?",
+        parameters: {
+          type: 'params',
+          properties: {
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['blocks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              blocks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.actor.defs#profileView',
+                },
+              },
             },
           },
         },
@@ -5088,7 +5189,9 @@ export const ids = {
   AppBskyFeedLike: 'app.bsky.feed.like',
   AppBskyFeedPost: 'app.bsky.feed.post',
   AppBskyFeedRepost: 'app.bsky.feed.repost',
+  AppBskyGraphBlock: 'app.bsky.graph.block',
   AppBskyGraphFollow: 'app.bsky.graph.follow',
+  AppBskyGraphGetBlocks: 'app.bsky.graph.getBlocks',
   AppBskyGraphGetFollowers: 'app.bsky.graph.getFollowers',
   AppBskyGraphGetFollows: 'app.bsky.graph.getFollows',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4130,6 +4130,14 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'BlockedActor',
+          },
+          {
+            name: 'BlockedByActor',
+          },
+        ],
       },
     },
   },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4240,6 +4240,7 @@ export const schemaDict = {
                 refs: [
                   'lex:app.bsky.feed.defs#threadViewPost',
                   'lex:app.bsky.feed.defs#notFoundPost',
+                  'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
             },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3398,7 +3398,8 @@ export const schemaDict = {
             type: 'boolean',
           },
           blocking: {
-            type: 'boolean',
+            type: 'string',
+            format: 'at-uri',
           },
           following: {
             type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -84,7 +84,7 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 export interface ViewerState {
   muted?: boolean
   blockedBy?: boolean
-  blocking?: boolean
+  blocking?: string
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -83,6 +83,8 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 
 export interface ViewerState {
   muted?: boolean
+  blockedBy?: boolean
+  blocking?: boolean
   following?: string
   followedBy?: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
@@ -31,7 +31,11 @@ export function validateMain(v: unknown): ValidationResult {
 }
 
 export interface View {
-  record: ViewRecord | ViewNotFound | { $type: string; [k: string]: unknown }
+  record:
+    | ViewRecord
+    | ViewNotFound
+    | ViewBlocked
+    | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }
 
@@ -89,4 +93,21 @@ export function isViewNotFound(v: unknown): v is ViewNotFound {
 
 export function validateViewNotFound(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.record#viewNotFound', v)
+}
+
+export interface ViewBlocked {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isViewBlocked(v: unknown): v is ViewBlocked {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.record#viewBlocked'
+  )
+}
+
+export function validateViewBlocked(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.record#viewBlocked', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -118,10 +118,12 @@ export interface ThreadViewPost {
   parent?:
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   replies?: (
     | ThreadViewPost
     | NotFoundPost
+    | BlockedPost
     | { $type: string; [k: string]: unknown }
   )[]
   [k: string]: unknown
@@ -155,4 +157,22 @@ export function isNotFoundPost(v: unknown): v is NotFoundPost {
 
 export function validateNotFoundPost(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.defs#notFoundPost', v)
+}
+
+export interface BlockedPost {
+  uri: string
+  blocked: true
+  [k: string]: unknown
+}
+
+export function isBlockedPost(v: unknown): v is BlockedPost {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.defs#blockedPost'
+  )
+}
+
+export function validateBlockedPost(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.defs#blockedPost', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -33,6 +33,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'BlockedActor' | 'BlockedByActor'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -20,6 +20,7 @@ export interface OutputSchema {
   thread:
     | AppBskyFeedDefs.ThreadViewPost
     | AppBskyFeedDefs.NotFoundPost
+    | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/block.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/block.ts
@@ -1,0 +1,26 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+
+export interface Record {
+  subject: string
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.block#main' ||
+      v.$type === 'app.bsky.graph.block')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.block#main', v)
+}

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getBlocks.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as AppBskyActorDefs from '../actor/defs'
+
+export interface QueryParams {
+  limit: number
+  cursor?: string
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  blocks: AppBskyActorDefs.ProfileView[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type Handler<HA extends HandlerAuth = never> = (ctx: {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/pds/tests/__snapshots__/indexing.test.ts.snap
@@ -13,7 +13,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -63,7 +62,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -140,7 +138,6 @@ Object {
   "postsCount": 0,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -158,7 +155,6 @@ Object {
   "postsCount": 0,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -174,7 +170,6 @@ Object {
   "postsCount": 0,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }

--- a/packages/pds/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/pds/tests/__snapshots__/indexing.test.ts.snap
@@ -12,6 +12,8 @@ Object {
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -60,6 +62,8 @@ Object {
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -135,6 +139,8 @@ Object {
   "labels": Array [],
   "postsCount": 0,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -151,6 +157,8 @@ Object {
   "labels": Array [],
   "postsCount": 0,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -165,6 +173,8 @@ Object {
   "labels": Array [],
   "postsCount": 0,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -12,7 +12,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -46,7 +45,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -70,7 +68,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -86,7 +83,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -122,7 +118,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -229,7 +224,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -248,7 +242,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -286,7 +279,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -368,7 +360,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -396,7 +387,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -436,7 +426,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -463,7 +452,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -493,7 +481,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -576,7 +563,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -603,7 +589,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -633,7 +618,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -656,7 +640,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -673,7 +656,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "followedBy": "record(5)",
                     "following": "record(4)",
                     "muted": false,
@@ -798,7 +780,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -829,7 +810,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -864,7 +844,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -880,7 +859,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -916,7 +894,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -1032,7 +1009,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -1060,7 +1036,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1095,7 +1070,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(8)",
                 "following": "record(7)",
                 "muted": false,
@@ -1176,7 +1150,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1207,7 +1180,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -11,6 +11,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -43,6 +45,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -65,6 +69,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -79,6 +85,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -113,6 +121,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -218,6 +228,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -235,6 +247,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -271,6 +285,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -351,6 +367,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -377,6 +395,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -415,6 +435,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -440,6 +462,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -468,6 +492,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -549,6 +575,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -574,6 +602,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -602,6 +632,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -623,6 +655,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -638,6 +672,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "followedBy": "record(5)",
                     "following": "record(4)",
                     "muted": false,
@@ -761,6 +797,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -790,6 +828,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -823,6 +863,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -837,6 +879,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -871,6 +915,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -985,6 +1031,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -1011,6 +1059,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1044,6 +1094,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(8)",
                 "following": "record(7)",
                 "muted": false,
@@ -1123,6 +1175,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1152,6 +1206,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },

--- a/packages/pds/tests/seeds/client.ts
+++ b/packages/pds/tests/seeds/client.ts
@@ -164,6 +164,18 @@ export class SeedClient {
     return this.follows[from][to]
   }
 
+  async unfollow(from: string, to: string) {
+    const follow = this.follows[from][to]
+    if (!follow) {
+      throw new Error('follow does not exist')
+    }
+    await this.agent.api.app.bsky.graph.follow.delete(
+      { repo: from, rkey: follow.uri.rkey },
+      this.getHeaders(from),
+    )
+    delete this.follows[from][to]
+  }
+
   async post(
     by: string,
     text: string,

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -12,7 +12,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -50,7 +49,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(4)",
             "following": "record(3)",
             "muted": false,
@@ -132,7 +130,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -162,7 +159,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -185,7 +181,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(7)",
               "muted": false,
             },
@@ -202,7 +197,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "followedBy": "record(10)",
                     "following": "record(9)",
                     "muted": false,
@@ -327,7 +321,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -356,7 +349,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -390,7 +382,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -471,7 +462,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(3)",
             "following": "record(2)",
             "muted": false,
@@ -502,7 +492,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(3)",
             "following": "record(2)",
             "muted": false,
@@ -536,7 +525,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -565,7 +553,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -605,7 +592,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -620,7 +606,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -654,7 +639,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(3)",
                       "muted": false,
                     },
@@ -762,7 +746,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -777,7 +760,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -815,7 +797,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -846,7 +827,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -878,7 +858,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -911,7 +890,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(3)",
                 "muted": false,
               },
@@ -994,7 +972,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -1032,7 +1009,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1055,7 +1031,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1070,7 +1045,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -1104,7 +1078,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "following": "record(7)",
                       "muted": false,
                     },
@@ -1219,7 +1192,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1259,7 +1231,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": true,
         },
@@ -1275,7 +1246,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(3)",
               "muted": false,
             },
@@ -1310,7 +1280,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "muted": false,
                     },
                   },
@@ -1424,7 +1393,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": true,
         },
@@ -1459,7 +1427,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1499,7 +1466,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(6)",
             "muted": false,
           },
@@ -1580,7 +1546,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(2)",
             "following": "record(1)",
             "muted": false,
@@ -1614,7 +1579,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1639,7 +1603,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -1655,7 +1618,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "muted": false,
                   },
                 },
@@ -1780,7 +1742,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1813,7 +1774,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -11,6 +11,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -47,6 +49,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(4)",
             "following": "record(3)",
             "muted": false,
@@ -127,6 +131,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -155,6 +161,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -176,6 +184,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(7)",
               "muted": false,
             },
@@ -191,6 +201,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "followedBy": "record(10)",
                     "following": "record(9)",
                     "muted": false,
@@ -314,6 +326,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -341,6 +355,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -373,6 +389,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -452,6 +470,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(3)",
             "following": "record(2)",
             "muted": false,
@@ -481,6 +501,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(3)",
             "following": "record(2)",
             "muted": false,
@@ -513,6 +535,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -540,6 +564,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -578,6 +604,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -591,6 +619,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -623,6 +653,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(3)",
                       "muted": false,
                     },
@@ -729,6 +761,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -742,6 +776,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -778,6 +814,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -807,6 +845,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -837,6 +877,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -868,6 +910,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(3)",
                 "muted": false,
               },
@@ -949,6 +993,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -985,6 +1031,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1006,6 +1054,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1019,6 +1069,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -1051,6 +1103,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "following": "record(7)",
                       "muted": false,
                     },
@@ -1164,6 +1218,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1202,6 +1258,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(1)",
           "muted": true,
         },
@@ -1216,6 +1274,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(3)",
               "muted": false,
             },
@@ -1249,6 +1309,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "muted": false,
                     },
                   },
@@ -1361,6 +1423,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(1)",
           "muted": true,
         },
@@ -1394,6 +1458,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1432,6 +1498,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(6)",
             "muted": false,
           },
@@ -1511,6 +1579,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(2)",
             "following": "record(1)",
             "muted": false,
@@ -1543,6 +1613,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1566,6 +1638,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -1580,6 +1654,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "muted": false,
                   },
                 },
@@ -1703,6 +1779,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -1734,6 +1812,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,

--- a/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
@@ -1,5 +1,120 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pds views with blocking blocks record embeds 1`] = `
+Object {
+  "thread": Object {
+    "$type": "app.bsky.feed.defs#threadViewPost",
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [],
+        "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.record#view",
+        "record": Object {
+          "$type": "app.bsky.embed.record#viewRecord",
+          "author": Object {
+            "did": "user(1)",
+            "handle": "dan.test",
+            "labels": Array [
+              Object {
+                "cts": "1970-01-01T00:00:00.000Z",
+                "neg": false,
+                "src": "did:example:labeler",
+                "uri": "user(1)",
+                "val": "repo-action-label",
+              },
+            ],
+            "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embeds": Array [
+            Object {
+              "$type": "app.bsky.embed.record#view",
+              "record": Object {
+                "$type": "app.bsky.embed.record#viewBlocked",
+                "uri": "record(3)",
+              },
+            },
+          ],
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "labels": Array [],
+          "uri": "record(2)",
+          "value": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.record",
+              "record": Object {
+                "cid": "cids(2)",
+                "uri": "record(3)",
+              },
+            },
+            "facets": Array [
+              Object {
+                "features": Array [
+                  Object {
+                    "$type": "app.bsky.richtext.facet#mention",
+                    "did": "user(0)",
+                  },
+                ],
+                "index": Object {
+                  "byteEnd": 18,
+                  "byteStart": 0,
+                },
+              },
+            ],
+            "text": "@alice.bluesky.xyz is the best",
+          },
+        },
+      },
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(0)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "did:example:labeler",
+          "uri": "record(0)",
+          "val": "test-label",
+        },
+      ],
+      "likeCount": 2,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.record",
+          "record": Object {
+            "cid": "cids(1)",
+            "uri": "record(2)",
+          },
+        },
+        "text": "yoohoo label_me",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(0)",
+      "viewer": Object {},
+    },
+  },
+}
+`;
+
 exports[`pds views with blocking blocks thread parent 1`] = `
 Object {
   "thread": Object {

--- a/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
@@ -1,0 +1,184 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pds views with blocking blocks thread parent 1`] = `
+Object {
+  "thread": Object {
+    "$type": "app.bsky.feed.defs#threadViewPost",
+    "parent": Object {
+      "$type": "app.bsky.feed.defs#blockedPost",
+      "blocked": true,
+      "uri": "record(3)",
+    },
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [],
+        "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
+          "followedBy": "record(2)",
+          "following": "record(1)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(0)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "reply": Object {
+          "parent": Object {
+            "cid": "cids(1)",
+            "uri": "record(3)",
+          },
+          "root": Object {
+            "cid": "cids(1)",
+            "uri": "record(3)",
+          },
+        },
+        "text": "alice replies to dan",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(0)",
+      "viewer": Object {},
+    },
+    "replies": Array [],
+  },
+}
+`;
+
+exports[`pds views with blocking blocks thread reply 1`] = `
+Object {
+  "thread": Object {
+    "$type": "app.bsky.feed.defs#threadViewPost",
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [],
+        "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
+      },
+      "cid": "cids(0)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 3,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "text": "again",
+      },
+      "replyCount": 2,
+      "repostCount": 1,
+      "uri": "record(0)",
+      "viewer": Object {
+        "like": "record(3)",
+        "repost": "record(2)",
+      },
+    },
+    "replies": Array [
+      Object {
+        "$type": "app.bsky.feed.defs#blockedPost",
+        "blocked": true,
+        "uri": "record(4)",
+      },
+      Object {
+        "$type": "app.bsky.feed.defs#threadViewPost",
+        "post": Object {
+          "author": Object {
+            "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+            "did": "user(1)",
+            "displayName": "bobby",
+            "handle": "bob.test",
+            "labels": Array [],
+            "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
+              "following": "record(6)",
+              "muted": false,
+            },
+          },
+          "cid": "cids(1)",
+          "embed": Object {
+            "$type": "app.bsky.embed.images#view",
+            "images": Array [
+              Object {
+                "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+              },
+            ],
+          },
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "labels": Array [
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "did:example:labeler",
+              "uri": "record(5)",
+              "val": "test-label",
+            },
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "did:example:labeler",
+              "uri": "record(5)",
+              "val": "test-label-2",
+            },
+          ],
+          "likeCount": 0,
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "embed": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "$type": "blob",
+                    "mimeType": "image/jpeg",
+                    "ref": Object {
+                      "$link": "cids(2)",
+                    },
+                    "size": 4114,
+                  },
+                },
+              ],
+            },
+            "reply": Object {
+              "parent": Object {
+                "cid": "cids(0)",
+                "uri": "record(0)",
+              },
+              "root": Object {
+                "cid": "cids(0)",
+                "uri": "record(0)",
+              },
+            },
+            "text": "hear that label_me label_me_2",
+          },
+          "replyCount": 1,
+          "repostCount": 0,
+          "uri": "record(5)",
+          "viewer": Object {},
+        },
+      },
+    ],
+  },
+}
+`;

--- a/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
@@ -13,7 +13,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -37,7 +36,6 @@ Object {
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -133,7 +131,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,
@@ -181,7 +178,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -220,7 +216,6 @@ Object {
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(6)",
               "muted": false,
             },

--- a/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
@@ -13,6 +13,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -27,6 +29,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -41,6 +45,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -56,6 +62,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -75,6 +83,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -89,6 +99,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -103,6 +115,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -118,6 +132,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -137,6 +153,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -151,6 +169,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -165,6 +185,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -179,6 +201,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -194,6 +218,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -213,6 +239,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -227,6 +255,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -240,6 +270,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -261,6 +293,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -275,6 +309,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -289,6 +325,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -302,6 +340,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -323,6 +363,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -336,6 +378,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -357,6 +401,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -371,6 +417,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -384,6 +432,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -405,6 +455,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -419,6 +471,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -433,6 +487,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -447,6 +503,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -462,6 +520,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -481,6 +541,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -495,6 +557,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -508,6 +572,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -529,6 +595,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -542,6 +610,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -563,6 +633,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -577,6 +649,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -591,6 +665,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -604,6 +680,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -625,6 +703,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -639,6 +719,8 @@ Object {
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -652,6 +734,8 @@ Object {
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,

--- a/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/follows.test.ts.snap
@@ -14,7 +14,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -30,7 +29,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -46,7 +44,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -63,7 +60,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -84,7 +80,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -100,7 +95,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -116,7 +110,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -133,7 +126,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -154,7 +146,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -170,7 +161,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -186,7 +176,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -202,7 +191,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -219,7 +207,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -240,7 +227,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -256,7 +242,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -271,7 +256,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -294,7 +278,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -310,7 +293,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -326,7 +308,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -341,7 +322,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -364,7 +344,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -379,7 +358,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -402,7 +380,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -418,7 +395,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -433,7 +409,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -456,7 +431,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(1)",
         "following": "record(0)",
         "muted": false,
@@ -472,7 +446,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -488,7 +461,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -504,7 +476,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -521,7 +492,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -542,7 +512,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -558,7 +527,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -573,7 +541,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -596,7 +563,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -611,7 +577,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -634,7 +599,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -650,7 +614,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(5)",
         "following": "record(4)",
         "muted": false,
@@ -666,7 +629,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -681,7 +643,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -704,7 +665,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(3)",
         "following": "record(2)",
         "muted": false,
@@ -720,7 +680,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -735,7 +694,6 @@ Object {
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,

--- a/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
@@ -11,7 +11,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -33,7 +32,6 @@ Object {
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -48,7 +46,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(3)",
           "following": "record(2)",
           "muted": false,
@@ -68,7 +65,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -93,7 +89,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,

--- a/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/likes.test.ts.snap
@@ -10,6 +10,8 @@ Object {
         "handle": "eve.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -30,6 +32,8 @@ Object {
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -43,6 +47,8 @@ Object {
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(3)",
           "following": "record(2)",
           "muted": false,
@@ -61,6 +67,8 @@ Object {
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -84,6 +92,8 @@ Object {
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(2)",
           "following": "record(1)",
           "muted": false,

--- a/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
@@ -10,6 +10,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },
@@ -21,6 +23,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },
@@ -29,6 +33,8 @@ Array [
     "handle": "nicolas-krajcik10.test",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },
@@ -40,6 +46,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },
@@ -51,6 +59,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },
@@ -62,6 +72,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": true,
     },
   },

--- a/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/mutes.test.ts.snap
@@ -11,7 +11,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },
@@ -24,7 +23,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },
@@ -34,7 +32,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },
@@ -47,7 +44,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },
@@ -60,7 +56,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },
@@ -73,7 +68,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": true,
     },
   },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -9,7 +9,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -53,7 +52,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -85,7 +83,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -162,7 +159,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -190,7 +186,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -219,7 +214,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -252,7 +246,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -285,7 +278,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -318,7 +310,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -343,7 +334,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -377,7 +367,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -450,7 +439,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -483,7 +471,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -516,7 +503,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -546,7 +532,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -590,7 +575,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -618,7 +602,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -658,7 +641,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -735,7 +717,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -763,7 +744,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -792,7 +772,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -825,7 +804,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -858,7 +836,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -895,7 +872,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -944,7 +920,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -969,7 +944,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -999,7 +973,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1043,7 +1016,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1071,7 +1043,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1111,7 +1082,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1188,7 +1158,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1216,7 +1185,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1245,7 +1213,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1278,7 +1245,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1311,7 +1277,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1348,7 +1313,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1397,7 +1361,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1422,7 +1385,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1454,7 +1416,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1485,7 +1446,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(3)",
           "muted": false,
         },
@@ -1530,7 +1490,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(3)",
           "muted": false,
         },

--- a/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/notifications.test.ts.snap
@@ -8,6 +8,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -50,6 +52,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -80,6 +84,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -155,6 +161,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -181,6 +189,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -208,6 +218,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -239,6 +251,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -270,6 +284,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -301,6 +317,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(9)",
         "following": "record(8)",
         "muted": false,
@@ -324,6 +342,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -356,6 +376,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -427,6 +449,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -458,6 +482,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -489,6 +515,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -517,6 +545,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -559,6 +589,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -585,6 +617,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -623,6 +657,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -698,6 +734,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -724,6 +762,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -751,6 +791,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -782,6 +824,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -813,6 +857,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -848,6 +894,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -895,6 +943,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -918,6 +968,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -946,6 +998,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -988,6 +1042,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1014,6 +1070,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1052,6 +1110,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1127,6 +1187,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1153,6 +1215,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1180,6 +1244,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1211,6 +1277,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1242,6 +1310,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1277,6 +1347,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(6)",
         "muted": false,
       },
@@ -1324,6 +1396,8 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(10)",
         "following": "record(9)",
         "muted": false,
@@ -1347,6 +1421,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1377,6 +1453,8 @@ Object {
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1406,6 +1484,8 @@ Object {
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(3)",
           "muted": false,
         },
@@ -1449,6 +1529,8 @@ Object {
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(3)",
           "muted": false,
         },

--- a/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
@@ -10,6 +10,8 @@ Array [
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -35,6 +37,8 @@ Array [
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },
@@ -60,6 +64,8 @@ Array [
       "handle": "bob.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(4)",
         "following": "record(3)",
         "muted": false,
@@ -85,6 +91,8 @@ Array [
       "handle": "carol.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -118,6 +126,8 @@ Array [
             "handle": "bob.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(4)",
               "following": "record(3)",
               "muted": false,
@@ -201,6 +211,8 @@ Array [
         },
       ],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "following": "record(10)",
         "muted": false,
       },
@@ -215,6 +227,8 @@ Array [
           "handle": "carol.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -249,6 +263,8 @@ Array [
                   "handle": "bob.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "followedBy": "record(4)",
                     "following": "record(3)",
                     "muted": false,
@@ -355,6 +371,8 @@ Array [
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "muted": false,
       },
     },

--- a/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
@@ -11,7 +11,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -38,7 +37,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },
@@ -65,7 +63,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(4)",
         "following": "record(3)",
         "muted": false,
@@ -92,7 +89,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(7)",
         "following": "record(6)",
         "muted": false,
@@ -127,7 +123,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(4)",
               "following": "record(3)",
               "muted": false,
@@ -212,7 +207,6 @@ Array [
       ],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "following": "record(10)",
         "muted": false,
       },
@@ -228,7 +222,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -264,7 +257,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "followedBy": "record(4)",
                     "following": "record(3)",
                     "muted": false,
@@ -372,7 +364,6 @@ Array [
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "muted": false,
       },
     },

--- a/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
@@ -20,7 +20,6 @@ Object {
   "postsCount": 2,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -41,7 +40,6 @@ Array [
     "postsCount": 4,
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -60,7 +58,6 @@ Array [
     "postsCount": 3,
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -73,7 +70,6 @@ Array [
     "postsCount": 2,
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "following": "record(2)",
       "muted": false,
     },
@@ -95,7 +91,6 @@ Array [
     "postsCount": 2,
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(3)",
       "muted": false,
     },
@@ -117,7 +112,6 @@ Object {
   "postsCount": 4,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "followedBy": "record(1)",
     "following": "record(0)",
     "muted": false,
@@ -143,7 +137,6 @@ Object {
   "postsCount": 2,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "followedBy": "record(0)",
     "muted": false,
   },
@@ -164,7 +157,6 @@ Object {
   "postsCount": 4,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -185,7 +177,6 @@ Object {
   "postsCount": 4,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -202,7 +193,6 @@ Object {
   "postsCount": 4,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }
@@ -222,7 +212,6 @@ Object {
   "postsCount": 4,
   "viewer": Object {
     "blockedBy": false,
-    "blocking": false,
     "muted": false,
   },
 }

--- a/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/profile.test.ts.snap
@@ -19,6 +19,8 @@ Object {
   ],
   "postsCount": 2,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -38,6 +40,8 @@ Array [
     "labels": Array [],
     "postsCount": 4,
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(1)",
       "following": "record(0)",
       "muted": false,
@@ -55,6 +59,8 @@ Array [
     "labels": Array [],
     "postsCount": 3,
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -66,6 +72,8 @@ Array [
     "labels": Array [],
     "postsCount": 2,
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "following": "record(2)",
       "muted": false,
     },
@@ -86,6 +94,8 @@ Array [
     ],
     "postsCount": 2,
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(3)",
       "muted": false,
     },
@@ -106,6 +116,8 @@ Object {
   "labels": Array [],
   "postsCount": 4,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "followedBy": "record(1)",
     "following": "record(0)",
     "muted": false,
@@ -130,6 +142,8 @@ Object {
   ],
   "postsCount": 2,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "followedBy": "record(0)",
     "muted": false,
   },
@@ -149,6 +163,8 @@ Object {
   "labels": Array [],
   "postsCount": 4,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -168,6 +184,8 @@ Object {
   "labels": Array [],
   "postsCount": 4,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -183,6 +201,8 @@ Object {
   "labels": Array [],
   "postsCount": 4,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }
@@ -201,6 +221,8 @@ Object {
   "labels": Array [],
   "postsCount": 4,
   "viewer": Object {
+    "blockedBy": false,
+    "blocking": false,
     "muted": false,
   },
 }

--- a/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
@@ -8,7 +8,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -26,7 +25,6 @@ Array [
     ],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "following": "record(0)",
       "muted": false,
     },
@@ -37,7 +35,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(2)",
       "following": "record(1)",
       "muted": false,
@@ -53,7 +50,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "followedBy": "record(4)",
       "following": "record(3)",
       "muted": false,
@@ -70,7 +66,6 @@ Array [
     "labels": Array [],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "muted": false,
     },
   },
@@ -88,7 +83,6 @@ Array [
     ],
     "viewer": Object {
       "blockedBy": false,
-      "blocking": false,
       "following": "record(0)",
       "muted": false,
     },

--- a/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/reposts.test.ts.snap
@@ -7,6 +7,8 @@ Array [
     "handle": "eve.test",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -23,6 +25,8 @@ Array [
       },
     ],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "following": "record(0)",
       "muted": false,
     },
@@ -32,6 +36,8 @@ Array [
     "handle": "carol.test",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(2)",
       "following": "record(1)",
       "muted": false,
@@ -46,6 +52,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "followedBy": "record(4)",
       "following": "record(3)",
       "muted": false,
@@ -61,6 +69,8 @@ Array [
     "handle": "eve.test",
     "labels": Array [],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "muted": false,
     },
   },
@@ -77,6 +87,8 @@ Array [
       },
     ],
     "viewer": Object {
+      "blockedBy": false,
+      "blocking": false,
       "following": "record(0)",
       "muted": false,
     },

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -17,7 +17,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -70,7 +69,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -118,7 +116,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -152,7 +149,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -235,7 +231,6 @@ Object {
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -287,7 +282,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -321,7 +315,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -414,7 +407,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(2)",
             "following": "record(1)",
             "muted": false,
@@ -447,7 +439,6 @@ Object {
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -529,7 +520,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -577,7 +567,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -609,7 +598,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -651,7 +639,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -734,7 +721,6 @@ Object {
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -786,7 +772,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -818,7 +803,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -859,7 +843,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -947,7 +930,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -979,7 +961,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1019,7 +1000,6 @@ Object {
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -1069,7 +1049,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1110,7 +1089,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1156,7 +1134,6 @@ Object {
       "labels": Array [],
       "viewer": Object {
         "blockedBy": false,
-        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": true,
@@ -1188,7 +1165,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -1230,7 +1206,6 @@ Object {
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1313,7 +1288,6 @@ Object {
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": true,

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -16,6 +16,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -67,6 +69,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -113,6 +117,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -145,6 +151,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -226,6 +234,8 @@ Object {
               "handle": "alice.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -276,6 +286,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -308,6 +320,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -399,6 +413,8 @@ Object {
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(2)",
             "following": "record(1)",
             "muted": false,
@@ -430,6 +446,8 @@ Object {
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -510,6 +528,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -556,6 +576,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -586,6 +608,8 @@ Object {
           "handle": "carol.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -626,6 +650,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -707,6 +733,8 @@ Object {
               "handle": "alice.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -757,6 +785,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -787,6 +817,8 @@ Object {
           "handle": "carol.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -826,6 +858,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -912,6 +946,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -942,6 +978,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -980,6 +1018,8 @@ Object {
               "handle": "alice.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": false,
@@ -1028,6 +1068,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1067,6 +1109,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": false,
@@ -1111,6 +1155,8 @@ Object {
       "handle": "alice.test",
       "labels": Array [],
       "viewer": Object {
+        "blockedBy": false,
+        "blocking": false,
         "followedBy": "record(2)",
         "following": "record(1)",
         "muted": true,
@@ -1141,6 +1187,8 @@ Object {
           "handle": "carol.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "following": "record(5)",
             "muted": false,
           },
@@ -1181,6 +1229,8 @@ Object {
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1262,6 +1312,8 @@ Object {
               "handle": "alice.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(2)",
                 "following": "record(1)",
                 "muted": true,

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -12,7 +12,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -46,7 +45,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -64,7 +62,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -103,7 +100,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -126,7 +122,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -212,7 +207,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -247,7 +241,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -311,7 +304,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -341,7 +333,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -375,7 +366,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -409,7 +399,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -427,7 +416,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -464,7 +452,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(6)",
           "following": "record(5)",
           "muted": false,
@@ -504,7 +491,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -531,7 +517,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -561,7 +546,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -613,7 +597,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(11)",
           "following": "record(10)",
           "muted": false,
@@ -644,7 +627,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -679,7 +661,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -707,7 +688,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(6)",
           "following": "record(5)",
           "muted": false,
@@ -742,7 +722,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(11)",
                 "following": "record(10)",
                 "muted": false,
@@ -841,7 +820,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(11)",
           "following": "record(10)",
           "muted": false,
@@ -881,7 +859,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -915,7 +892,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -949,7 +925,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -973,7 +948,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -989,7 +963,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -1025,7 +998,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -1150,7 +1122,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1169,7 +1140,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1207,7 +1177,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -1289,7 +1258,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1317,7 +1285,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1357,7 +1324,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1384,7 +1350,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1414,7 +1379,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1497,7 +1461,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1524,7 +1487,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -1554,7 +1516,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1577,7 +1538,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -1594,7 +1554,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "followedBy": "record(5)",
                     "following": "record(4)",
                     "muted": false,
@@ -1728,7 +1687,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1759,7 +1717,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -1794,7 +1751,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -1810,7 +1766,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -1846,7 +1801,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -1980,7 +1934,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -2008,7 +1961,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -2043,7 +1995,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(8)",
                 "following": "record(7)",
                 "muted": false,
@@ -2142,7 +2093,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -2182,7 +2132,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -2222,7 +2171,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -2238,7 +2186,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(3)",
               "muted": false,
             },
@@ -2273,7 +2220,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "muted": false,
                     },
                   },
@@ -2396,7 +2342,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -2414,7 +2359,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -2454,7 +2398,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -2534,7 +2477,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2566,7 +2508,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -2605,7 +2546,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2636,7 +2576,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2670,7 +2609,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -2751,7 +2689,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2782,7 +2719,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2816,7 +2752,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -2841,7 +2776,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(1)",
               "muted": false,
             },
@@ -2858,7 +2792,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "following": "record(3)",
                     "muted": false,
                   },
@@ -2993,7 +2926,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3022,7 +2954,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3053,7 +2984,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -3087,7 +3017,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "muted": false,
               },
             },
@@ -3184,7 +3113,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3222,7 +3150,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3264,7 +3191,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3279,7 +3205,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -3313,7 +3238,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(3)",
                       "muted": false,
                     },
@@ -3439,7 +3363,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3456,7 +3379,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3496,7 +3418,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(3)",
             "muted": false,
           },
@@ -3577,7 +3498,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3609,7 +3529,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3647,7 +3566,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3678,7 +3596,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3712,7 +3629,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3737,7 +3653,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -3753,7 +3668,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "muted": false,
                   },
                 },
@@ -3887,7 +3801,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3918,7 +3831,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -3951,7 +3863,6 @@ Array [
               "labels": Array [],
               "viewer": Object {
                 "blockedBy": false,
-                "blocking": false,
                 "followedBy": "record(3)",
                 "muted": false,
               },
@@ -4047,7 +3958,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -4083,7 +3993,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -4121,7 +4030,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4138,7 +4046,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4220,7 +4127,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(1)",
             "muted": false,
           },
@@ -4251,7 +4157,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(1)",
             "muted": false,
           },
@@ -4285,7 +4190,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4321,7 +4225,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4336,7 +4239,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "muted": false,
             },
           },
@@ -4370,7 +4272,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "following": "record(5)",
                       "muted": false,
                     },
@@ -4503,7 +4404,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4532,7 +4432,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4576,7 +4475,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4610,7 +4508,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -4628,7 +4525,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4666,7 +4562,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "followedBy": "record(5)",
             "following": "record(4)",
             "muted": true,
@@ -4748,7 +4643,6 @@ Array [
           "labels": Array [],
           "viewer": Object {
             "blockedBy": false,
-            "blocking": false,
             "muted": false,
           },
         },
@@ -4778,7 +4672,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4801,7 +4694,6 @@ Array [
             ],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -4818,7 +4710,6 @@ Array [
                   "labels": Array [],
                   "viewer": Object {
                     "blockedBy": false,
-                    "blocking": false,
                     "followedBy": "record(10)",
                     "following": "record(9)",
                     "muted": true,
@@ -4952,7 +4843,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },
@@ -4987,7 +4877,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -5003,7 +4892,6 @@ Array [
             "labels": Array [],
             "viewer": Object {
               "blockedBy": false,
-              "blocking": false,
               "followedBy": "record(10)",
               "following": "record(9)",
               "muted": true,
@@ -5039,7 +4927,6 @@ Array [
                     "labels": Array [],
                     "viewer": Object {
                       "blockedBy": false,
-                      "blocking": false,
                       "followedBy": "record(5)",
                       "following": "record(4)",
                       "muted": true,
@@ -5173,7 +5060,6 @@ Array [
         ],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -5203,7 +5089,6 @@ Array [
         "labels": Array [],
         "viewer": Object {
           "blockedBy": false,
-          "blocking": false,
           "muted": false,
         },
       },

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -11,6 +11,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -43,6 +45,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -59,6 +63,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -96,6 +102,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -117,6 +125,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -201,6 +211,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -234,6 +246,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -296,6 +310,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -324,6 +340,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -356,6 +374,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -388,6 +408,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -404,6 +426,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -439,6 +463,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(6)",
           "following": "record(5)",
           "muted": false,
@@ -477,6 +503,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -502,6 +530,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -530,6 +560,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -580,6 +612,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(11)",
           "following": "record(10)",
           "muted": false,
@@ -609,6 +643,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -642,6 +678,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -668,6 +706,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(6)",
           "following": "record(5)",
           "muted": false,
@@ -701,6 +741,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(11)",
                 "following": "record(10)",
                 "muted": false,
@@ -798,6 +840,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(11)",
           "following": "record(10)",
           "muted": false,
@@ -836,6 +880,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -868,6 +914,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -900,6 +948,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -922,6 +972,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -936,6 +988,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -970,6 +1024,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -1093,6 +1149,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1110,6 +1168,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1146,6 +1206,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(8)",
             "following": "record(7)",
             "muted": false,
@@ -1226,6 +1288,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1252,6 +1316,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1290,6 +1356,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1315,6 +1383,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1343,6 +1413,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1424,6 +1496,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1449,6 +1523,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -1477,6 +1553,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1498,6 +1576,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -1513,6 +1593,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "followedBy": "record(5)",
                     "following": "record(4)",
                     "muted": false,
@@ -1645,6 +1727,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -1674,6 +1758,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -1707,6 +1793,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -1721,6 +1809,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(5)",
               "following": "record(4)",
               "muted": false,
@@ -1755,6 +1845,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(8)",
                       "following": "record(7)",
                       "muted": false,
@@ -1887,6 +1979,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -1913,6 +2007,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(5)",
           "following": "record(4)",
           "muted": false,
@@ -1946,6 +2042,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(8)",
                 "following": "record(7)",
                 "muted": false,
@@ -2043,6 +2141,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(8)",
           "following": "record(7)",
           "muted": false,
@@ -2081,6 +2181,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -2119,6 +2221,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -2133,6 +2237,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(3)",
               "muted": false,
             },
@@ -2166,6 +2272,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "muted": false,
                     },
                   },
@@ -2287,6 +2395,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -2303,6 +2413,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -2341,6 +2453,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -2419,6 +2533,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2449,6 +2565,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -2486,6 +2604,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2515,6 +2635,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2547,6 +2669,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -2626,6 +2750,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2655,6 +2781,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -2687,6 +2815,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -2710,6 +2840,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(1)",
               "muted": false,
             },
@@ -2725,6 +2857,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "following": "record(3)",
                     "muted": false,
                   },
@@ -2858,6 +2992,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -2885,6 +3021,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -2914,6 +3052,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(3)",
           "muted": false,
         },
@@ -2946,6 +3086,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "muted": false,
               },
             },
@@ -3041,6 +3183,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3077,6 +3221,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3117,6 +3263,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3130,6 +3278,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -3162,6 +3312,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(3)",
                       "muted": false,
                     },
@@ -3286,6 +3438,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3301,6 +3455,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3339,6 +3495,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(3)",
             "muted": false,
           },
@@ -3418,6 +3576,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3448,6 +3608,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3484,6 +3646,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3513,6 +3677,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(7)",
             "following": "record(6)",
             "muted": false,
@@ -3545,6 +3711,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3568,6 +3736,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -3582,6 +3752,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "muted": false,
                   },
                 },
@@ -3714,6 +3886,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3743,6 +3917,8 @@ Array [
         "handle": "carol.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3774,6 +3950,8 @@ Array [
               "handle": "bob.test",
               "labels": Array [],
               "viewer": Object {
+                "blockedBy": false,
+                "blocking": false,
                 "followedBy": "record(3)",
                 "muted": false,
               },
@@ -3868,6 +4046,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(7)",
           "following": "record(6)",
           "muted": false,
@@ -3902,6 +4082,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "followedBy": "record(1)",
           "muted": false,
         },
@@ -3938,6 +4120,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -3953,6 +4137,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4033,6 +4219,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(1)",
             "muted": false,
           },
@@ -4062,6 +4250,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(1)",
             "muted": false,
           },
@@ -4094,6 +4284,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4128,6 +4320,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4141,6 +4335,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "muted": false,
             },
           },
@@ -4173,6 +4369,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "following": "record(5)",
                       "muted": false,
                     },
@@ -4304,6 +4502,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4331,6 +4531,8 @@ Array [
         "handle": "bob.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(5)",
           "muted": false,
         },
@@ -4373,6 +4575,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4405,6 +4609,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -4421,6 +4627,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4457,6 +4665,8 @@ Array [
           "handle": "bob.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "followedBy": "record(5)",
             "following": "record(4)",
             "muted": true,
@@ -4537,6 +4747,8 @@ Array [
           "handle": "alice.test",
           "labels": Array [],
           "viewer": Object {
+            "blockedBy": false,
+            "blocking": false,
             "muted": false,
           },
         },
@@ -4565,6 +4777,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4586,6 +4800,8 @@ Array [
               },
             ],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "following": "record(1)",
               "muted": false,
             },
@@ -4601,6 +4817,8 @@ Array [
                   "handle": "carol.test",
                   "labels": Array [],
                   "viewer": Object {
+                    "blockedBy": false,
+                    "blocking": false,
                     "followedBy": "record(10)",
                     "following": "record(9)",
                     "muted": true,
@@ -4733,6 +4951,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },
@@ -4766,6 +4986,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -4780,6 +5002,8 @@ Array [
             "handle": "carol.test",
             "labels": Array [],
             "viewer": Object {
+              "blockedBy": false,
+              "blocking": false,
               "followedBy": "record(10)",
               "following": "record(9)",
               "muted": true,
@@ -4814,6 +5038,8 @@ Array [
                     "handle": "bob.test",
                     "labels": Array [],
                     "viewer": Object {
+                      "blockedBy": false,
+                      "blocking": false,
                       "followedBy": "record(5)",
                       "following": "record(4)",
                       "muted": true,
@@ -4946,6 +5172,8 @@ Array [
           },
         ],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "following": "record(1)",
           "muted": false,
         },
@@ -4974,6 +5202,8 @@ Array [
         "handle": "alice.test",
         "labels": Array [],
         "viewer": Object {
+          "blockedBy": false,
+          "blocking": false,
           "muted": false,
         },
       },

--- a/packages/pds/tests/views/actor-search.test.ts
+++ b/packages/pds/tests/views/actor-search.test.ts
@@ -230,7 +230,7 @@ const snapTypeaheadPg = [
   {
     did: 'user(0)',
     handle: 'cara-wiegand69.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -238,7 +238,7 @@ const snapTypeaheadPg = [
     displayName: 'Carol Littel',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -246,7 +246,7 @@ const snapTypeaheadPg = [
     displayName: 'Sadie Carter',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -254,13 +254,13 @@ const snapTypeaheadPg = [
     displayName: 'Carlton Abernathy IV',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(4)',
     handle: 'carlos6.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -268,7 +268,7 @@ const snapTypeaheadPg = [
     displayName: 'Latoya Windler',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -276,7 +276,7 @@ const snapTypeaheadPg = [
     displayName: 'Rachel Kshlerin',
     handle: 'cayla-marquardt39.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -287,19 +287,19 @@ const snapTypeaheadSqlite = [
     displayName: 'Carlton Abernathy IV',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(1)',
     handle: 'cara-wiegand69.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(2)',
     handle: 'carlos6.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -307,7 +307,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Latoya Windler',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -315,7 +315,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Carol Littel',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -323,7 +323,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Sadie Carter',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -332,7 +332,7 @@ const snapSearchPg = [
   {
     did: 'user(0)',
     handle: 'cara-wiegand69.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -341,7 +341,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -350,7 +350,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -359,13 +359,13 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(4)',
     handle: 'carlos6.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -374,7 +374,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -383,7 +383,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'cayla-marquardt39.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -395,19 +395,19 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(1)',
     handle: 'cara-wiegand69.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(2)',
     handle: 'carlos6.test',
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -416,7 +416,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -425,7 +425,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -434,7 +434,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { muted: false },
+    viewer: { blocking: false, blockedBy: false, muted: false },
     labels: [],
   },
 ]

--- a/packages/pds/tests/views/actor-search.test.ts
+++ b/packages/pds/tests/views/actor-search.test.ts
@@ -230,7 +230,7 @@ const snapTypeaheadPg = [
   {
     did: 'user(0)',
     handle: 'cara-wiegand69.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -238,7 +238,7 @@ const snapTypeaheadPg = [
     displayName: 'Carol Littel',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -246,7 +246,7 @@ const snapTypeaheadPg = [
     displayName: 'Sadie Carter',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -254,13 +254,13 @@ const snapTypeaheadPg = [
     displayName: 'Carlton Abernathy IV',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(4)',
     handle: 'carlos6.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -268,7 +268,7 @@ const snapTypeaheadPg = [
     displayName: 'Latoya Windler',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -276,7 +276,7 @@ const snapTypeaheadPg = [
     displayName: 'Rachel Kshlerin',
     handle: 'cayla-marquardt39.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -287,19 +287,19 @@ const snapTypeaheadSqlite = [
     displayName: 'Carlton Abernathy IV',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(1)',
     handle: 'cara-wiegand69.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(2)',
     handle: 'carlos6.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -307,7 +307,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Latoya Windler',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -315,7 +315,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Carol Littel',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -323,7 +323,7 @@ const snapTypeaheadSqlite = [
     displayName: 'Sadie Carter',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -332,7 +332,7 @@ const snapSearchPg = [
   {
     did: 'user(0)',
     handle: 'cara-wiegand69.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -341,7 +341,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -350,7 +350,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -359,13 +359,13 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(4)',
     handle: 'carlos6.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -374,7 +374,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -383,7 +383,7 @@ const snapSearchPg = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'cayla-marquardt39.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
 ]
@@ -395,19 +395,19 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'aliya-hodkiewicz.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(1)',
     handle: 'cara-wiegand69.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
     did: 'user(2)',
     handle: 'carlos6.test',
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -416,7 +416,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'carolina-mcdermott77.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -425,7 +425,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'eudora-dietrich4.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
   {
@@ -434,7 +434,7 @@ const snapSearchSqlite = [
     indexedAt: '1970-01-01T00:00:00.000Z',
     handle: 'shane-torphy52.test',
     avatar,
-    viewer: { blocking: false, blockedBy: false, muted: false },
+    viewer: { blockedBy: false, muted: false },
     labels: [],
   },
 ]

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -234,4 +234,62 @@ describe('pds views with blocking', () => {
       resDan.data.notifications.some((notif) => notif.author.did === carol),
     ).toBeFalsy()
   })
+
+  it('does not return blocked accounts in actor search', async () => {
+    const resCarol = await agent.api.app.bsky.actor.searchActors(
+      {
+        term: 'dan.test',
+      },
+      { headers: sc.getHeaders(carol) },
+    )
+    expect(resCarol.data.actors.some((actor) => actor.did === dan)).toBeFalsy()
+
+    const resDan = await agent.api.app.bsky.actor.searchActors(
+      {
+        term: 'carol.test',
+      },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(resDan.data.actors.some((actor) => actor.did === carol)).toBeFalsy()
+  })
+
+  it('does not return blocked accounts in actor search typeahead', async () => {
+    const resCarol = await agent.api.app.bsky.actor.searchActorsTypeahead(
+      {
+        term: 'dan.test',
+      },
+      { headers: sc.getHeaders(carol) },
+    )
+    expect(resCarol.data.actors.some((actor) => actor.did === dan)).toBeFalsy()
+
+    const resDan = await agent.api.app.bsky.actor.searchActorsTypeahead(
+      {
+        term: 'carol.test',
+      },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(resDan.data.actors.some((actor) => actor.did === carol)).toBeFalsy()
+  })
+
+  it('does not return blocked accounts in get suggestions', async () => {
+    // unfollow so they _would_ show up in suggestions if not for block
+    await sc.unfollow(carol, dan)
+    await sc.unfollow(dan, carol)
+
+    const resCarol = await agent.api.app.bsky.actor.getSuggestions(
+      {
+        limit: 100,
+      },
+      { headers: sc.getHeaders(carol) },
+    )
+    expect(resCarol.data.actors.some((actor) => actor.did === dan)).toBeFalsy()
+
+    const resDan = await agent.api.app.bsky.actor.getSuggestions(
+      {
+        limit: 100,
+      },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(resDan.data.actors.some((actor) => actor.did === carol)).toBeFalsy()
+  })
 })

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -83,4 +83,14 @@ describe('pds views with blocking', () => {
     )
     expect(forSnapshot(thread)).toMatchSnapshot()
   })
+
+  it('blocks record embeds', async () => {
+    const { alice, dan } = sc.dids
+    // Contains a deep embed of carol's post, blocked by dan
+    const { data: thread } = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 0, uri: sc.posts[alice][2].ref.uriStr },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(forSnapshot(thread)).toMatchSnapshot()
+  })
 })

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -182,14 +182,14 @@ describe('pds views with blocking', () => {
       { actor: dan },
       { headers: sc.getHeaders(carol) },
     )
-    expect(resCarol.data.viewer?.blocking).toBe(false)
+    expect(resCarol.data.viewer?.blocking).toBeUndefined
     expect(resCarol.data.viewer?.blockedBy).toBe(true)
 
     const resDan = await agent.api.app.bsky.actor.getProfile(
       { actor: carol },
       { headers: sc.getHeaders(dan) },
     )
-    expect(resDan.data.viewer?.blocking).toBe(true)
+    expect(resDan.data.viewer?.blocking).toBeDefined
     expect(resDan.data.viewer?.blockedBy).toBe(false)
   })
 
@@ -198,18 +198,18 @@ describe('pds views with blocking', () => {
       { actors: [alice, dan] },
       { headers: sc.getHeaders(carol) },
     )
-    expect(resCarol.data.profiles[0].viewer?.blocking).toBe(false)
+    expect(resCarol.data.profiles[0].viewer?.blocking).toBeUndefined()
     expect(resCarol.data.profiles[0].viewer?.blockedBy).toBe(false)
-    expect(resCarol.data.profiles[1].viewer?.blocking).toBe(false)
+    expect(resCarol.data.profiles[1].viewer?.blocking).toBeUndefined()
     expect(resCarol.data.profiles[1].viewer?.blockedBy).toBe(true)
 
     const resDan = await agent.api.app.bsky.actor.getProfiles(
       { actors: [alice, carol] },
       { headers: sc.getHeaders(dan) },
     )
-    expect(resDan.data.profiles[0].viewer?.blocking).toBe(false)
+    expect(resDan.data.profiles[0].viewer?.blocking).toBeUndefined()
     expect(resDan.data.profiles[0].viewer?.blockedBy).toBe(false)
-    expect(resDan.data.profiles[1].viewer?.blocking).toBe(true)
+    expect(resDan.data.profiles[1].viewer?.blocking).toBeDefined()
     expect(resDan.data.profiles[1].viewer?.blockedBy).toBe(false)
   })
 

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -292,4 +292,36 @@ describe('pds views with blocking', () => {
     )
     expect(resDan.data.actors.some((actor) => actor.did === carol)).toBeFalsy()
   })
+
+  it('returns a list of blocks', async () => {
+    await agent.api.app.bsky.graph.block.create(
+      { repo: dan },
+      { createdAt: new Date().toISOString(), subject: alice },
+      sc.getHeaders(dan),
+    )
+
+    const res = await agent.api.app.bsky.graph.getBlocks(
+      {},
+      { headers: sc.getHeaders(dan) },
+    )
+    const dids = res.data.blocks.map((block) => block.did).sort()
+    expect(dids).toEqual([alice, carol].sort())
+  })
+
+  it('paginates getBlocks', async () => {
+    const full = await agent.api.app.bsky.graph.getBlocks(
+      {},
+      { headers: sc.getHeaders(dan) },
+    )
+    const first = await agent.api.app.bsky.graph.getBlocks(
+      { limit: 1 },
+      { headers: sc.getHeaders(dan) },
+    )
+    const second = await agent.api.app.bsky.graph.getBlocks(
+      { cursor: first.data.cursor },
+      { headers: sc.getHeaders(dan) },
+    )
+    const combined = [...first.data.blocks, ...second.data.blocks]
+    expect(combined).toEqual(full.data.blocks)
+  })
 })

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -1,0 +1,86 @@
+import AtpAgent from '@atproto/api'
+import { runTestServer, CloseFn, TestServerInfo, forSnapshot } from '../_util'
+import { SeedClient } from '../seeds/client'
+import basicSeed from '../seeds/basic'
+import { RecordRef } from '@atproto/bsky/tests/seeds/client'
+
+describe('pds views with blocking', () => {
+  let server: TestServerInfo
+  let agent: AtpAgent
+  let close: CloseFn
+  let sc: SeedClient
+  let aliceReplyToDan: { ref: RecordRef }
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'views_block',
+    })
+    close = server.close
+    agent = new AtpAgent({ service: server.url })
+    sc = new SeedClient(agent)
+    await basicSeed(sc)
+    // dan blocks carol
+    await agent.api.app.bsky.graph.block.create(
+      { repo: sc.dids.dan },
+      { createdAt: new Date().toISOString(), subject: sc.dids.carol },
+      sc.getHeaders(sc.dids.dan),
+    )
+    aliceReplyToDan = await sc.reply(
+      sc.dids.alice,
+      sc.posts[sc.dids.dan][0].ref,
+      sc.posts[sc.dids.dan][0].ref,
+      'alice replies to dan',
+    )
+    await server.ctx.backgroundQueue.processAll()
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('blocks thread post', async () => {
+    const { carol, dan } = sc.dids
+    const { data: threadAlice } = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 1, uri: sc.posts[carol][0].ref.uriStr },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(threadAlice).toEqual({
+      thread: {
+        $type: 'app.bsky.feed.defs#blockedPost',
+        uri: sc.posts[carol][0].ref.uriStr,
+        blocked: true,
+      },
+    })
+    const { data: threadCarol } = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 1, uri: sc.posts[dan][0].ref.uriStr },
+      { headers: sc.getHeaders(carol) },
+    )
+    expect(threadCarol).toEqual({
+      thread: {
+        $type: 'app.bsky.feed.defs#blockedPost',
+        uri: sc.posts[dan][0].ref.uriStr,
+        blocked: true,
+      },
+    })
+  })
+
+  it('blocks thread reply', async () => {
+    const { alice, dan } = sc.dids
+    // Contains reply by carol
+    const { data: thread } = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 1, uri: sc.posts[alice][1].ref.uriStr },
+      { headers: sc.getHeaders(dan) },
+    )
+    expect(forSnapshot(thread)).toMatchSnapshot()
+  })
+
+  it('blocks thread parent', async () => {
+    const { carol } = sc.dids
+    // Parent is a post by dan
+    const { data: thread } = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 1, uri: aliceReplyToDan.ref.uriStr },
+      { headers: sc.getHeaders(carol) },
+    )
+    expect(forSnapshot(thread)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Implements blocks as a new record type - symmetric to follows

Blocks are enforced on the server for most routes:
- stripped out of feeds, search & aggregate views
- annotated on `getProfile` in viewer state
- throws when trying to `getAuthorFeed` 