### PR TITLE
Fix typo in NSID validation

### DIFF
--- a/packages/nsid/src/index.ts
+++ b/packages/nsid/src/index.ts
@@ -85,7 +85,7 @@ export const ensureValidNsid = (nsid: string): void => {
       throw new InvalidNsidError('NSID domain part too long (max 63 chars)')
     }
     if (l.length > 128 && i + 1 == labels.length) {
-      throw new InvalidNsidError('NSID name part too long (max 127 chars)')
+      throw new InvalidNsidError('NSID name part too long (max 128 chars)')
     }
     if (l.endsWith('-')) {
       throw new InvalidNsidError('NSID parts can not end with hyphen')


### PR DESCRIPTION
according to this if statement https://github.com/bluesky-social/atproto/blob/01b5971907dd63a04553c65dce3f334fc3ae8e5f/packages/nsid/src/index.ts#L87 and regular expression at https://github.com/bluesky-social/atproto/blob/01b5971907dd63a04553c65dce3f334fc3ae8e5f/packages/nsid/src/index.ts#L104

the `InvalidNsidError` exception should says that the max length is 128 chars instead of 127