### PR TITLE
More aggressive backpressure on websocket writer

### DIFF
--- a/packages/pds/Dockerfile
+++ b/packages/pds/Dockerfile
@@ -46,7 +46,7 @@ ENV NODE_ENV=production
 
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
 USER node
-CMD ["node", "--enable-source-maps", "index.js"]
+CMD ["node", "--heapsnapshot-signal=SIGUSR2", "--enable-source-maps", "index.js"]
 
 LABEL org.opencontainers.image.source=https://github.com/bluesky-social/atproto
 LABEL org.opencontainers.image.description="ATP Personal Data Server (PDS)"

--- a/packages/xrpc-server/src/stream/server.ts
+++ b/packages/xrpc-server/src/stream/server.ts
@@ -20,16 +20,16 @@ export class XrpcStreamServer {
         })
         const safeFrames = wrapIterator(iterator)
         for await (const frame of safeFrames) {
-          if (frame instanceof ErrorFrame) {
-            await new Promise((res, rej) => {
-              socket.send(frame.toBytes(), { binary: true }, (err) => {
-                if (err) return rej(err)
-                res(undefined)
-              })
+          await new Promise((res, rej) => {
+            socket.send(frame.toBytes(), { binary: true }, (err) => {
+              // @TODO this callback may give more aggressive on backpressure than
+              // we ultimately want, but trying it out for the time being.
+              if (err) return rej(err)
+              res(undefined)
             })
+          })
+          if (frame instanceof ErrorFrame) {
             throw new DisconnectError(CloseCode.Policy, frame.body.error)
-          } else {
-            socket.send(frame.toBytes(), { binary: true })
           }
         }
       } catch (err) {


### PR DESCRIPTION
This adds some more aggressive backpressure on the websocket stream writer for xrpc subscriptions: we wait to drain each message before piling up additional messages, in case bad network causes a condition such as bad tcp buffering.