### PR TITLE
Prevent app pass sessions deleting app passwords

### DIFF
--- a/packages/pds/src/api/com/atproto/server/revokeAppPassword.ts
+++ b/packages/pds/src/api/com/atproto/server/revokeAppPassword.ts
@@ -3,7 +3,7 @@ import { Server } from '../../../../lexicon'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.revokeAppPassword({
-    auth: ctx.accessVerifier,
+    auth: ctx.accessVerifierNotAppPassword,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
       const { name } = input.body

--- a/packages/pds/tests/app-passwords.test.ts
+++ b/packages/pds/tests/app-passwords.test.ts
@@ -52,6 +52,14 @@ describe('app_passwords', () => {
     expect(decoded?.scope).toEqual('com.atproto.appPass')
   })
 
+  it('doesn’t allow revocation of app-specific passwords', async () => {
+    const revocation = appAgent.api.com.atproto.server.revokeAppPassword({
+      name: 'test-pass',
+    })
+
+    expect(revocation).rejects.toThrow('Token could not be verified')
+  })
+
   it('allows actions to be performed from app', async () => {
     await appAgent.api.app.bsky.feed.post.create(
       {
@@ -112,8 +120,8 @@ describe('app_passwords', () => {
     expect(res.data.passwords[0].name).toEqual('test-pass')
   })
 
-  it('revokes an app-specific password', async () => {
-    await appAgent.api.com.atproto.server.revokeAppPassword({
+  it('revokes the app-specific password only with the account login', async () => {
+    await accntAgent.api.com.atproto.server.revokeAppPassword({
       name: 'test-pass',
     })
   })


### PR DESCRIPTION
This fixes that sessions created with an app password can delete itself and other app passwords. Now only `Access` sessions (i.e. those authenticated with a user password) can delete them.

@dholms, this was one of the issues I reported via email but I saw it already [discussed on bsky](https://staging.bsky.app/profile/mattn.bsky.social/post/3jubuwn3kba2i), so yeah here’s a fix.