### PR TITLE
Some improvements for tid.ts

### DIFF
--- a/packages/common-web/src/tid.ts
+++ b/packages/common-web/src/tid.ts
@@ -6,7 +6,9 @@ let lastTimestamp = 0
 let timestampCount = 0
 let clockid: number | null = null
 
-const dedash = str => str.replaceAll('-', '')
+function dedash(str: string): string {
+  return str.replaceAll('-', '')
+}
 
 export class TID {
   str: string

--- a/packages/common-web/src/tid.ts
+++ b/packages/common-web/src/tid.ts
@@ -56,7 +56,7 @@ export class TID {
   static oldestFirst(a: TID, b: TID): number {
     return a.compareTo(b)
   }
-  
+
   static newestFirst(a: TID, b: TID): number {
     return b.compareTo(a)
   }

--- a/packages/common-web/src/tid.ts
+++ b/packages/common-web/src/tid.ts
@@ -93,7 +93,7 @@ export class TID {
   }
 
   equals(other: TID): boolean {
-    return this.str == other.str
+    return this.str === other.str
   }
 
   newerThan(other: TID): boolean {

--- a/packages/common-web/src/tid.ts
+++ b/packages/common-web/src/tid.ts
@@ -1,14 +1,19 @@
 import { s32encode, s32decode } from './util'
+
+const TID_LEN = 13
+
 let lastTimestamp = 0
 let timestampCount = 0
 let clockid: number | null = null
+
+const dedash = str => str.replaceAll('-', '')
 
 export class TID {
   str: string
 
   constructor(str: string) {
-    const noDashes = str.replace(/-/g, '')
-    if (noDashes.length !== 13) {
+    const noDashes = dedash(str)
+    if (noDashes.length !== TID_LEN) {
       throw new Error(`Poorly formatted TID: ${noDashes.length} length`)
     }
     this.str = noDashes
@@ -46,31 +51,24 @@ export class TID {
     return new TID(str)
   }
 
-  static newestFirst(a: TID, b: TID): number {
-    return a.compareTo(b) * -1
-  }
-
   static oldestFirst(a: TID, b: TID): number {
     return a.compareTo(b)
   }
+  
+  static newestFirst(a: TID, b: TID): number {
+    return b.compareTo(a)
+  }
 
   static is(str: string): boolean {
-    try {
-      TID.fromStr(str)
-      return true
-    } catch (err) {
-      return false
-    }
+    return dedash(str).length === TID_LEN
   }
 
   timestamp(): number {
-    const substr = this.str.slice(0, 11)
-    return s32decode(substr)
+    return s32decode(this.str.slice(0, 11))
   }
 
   clockid(): number {
-    const substr = this.str.slice(11, 13)
-    return s32decode(substr)
+    return s32decode(this.str.slice(11, 13))
   }
 
   formatted(): string {
@@ -93,7 +91,7 @@ export class TID {
   }
 
   equals(other: TID): boolean {
-    return this.compareTo(other) === 0
+    return this.str == other.str
   }
 
   newerThan(other: TID): boolean {


### PR DESCRIPTION
Changes:

- Use `String.p.replaceAll` (available since `node.js >= 15`) instead `String.p.replace + regexp`
- Globalize validation constant to `TID_LEN`
- Simplify `TID.is` by avoiding try / catch and allocation
- Simplify `TID.p.equals` by using direct comparison