### PR TITLE
Tweak whats hot

### DIFF
--- a/packages/bsky/src/services/label/index.ts
+++ b/packages/bsky/src/services/label/index.ts
@@ -6,6 +6,10 @@ import { sql } from 'kysely'
 
 export type Labels = Record<string, Label[]>
 
+// @TODO forward these labels to client
+// these are labels are currently only used server side & not sent to client since it does not handle them correctly
+const SERVER_SIDE_LABELS = ['!no-promote']
+
 export class LabelService {
   constructor(public db: Database) {}
 
@@ -68,6 +72,7 @@ export class LabelService {
     const res = await this.db.db
       .selectFrom('label')
       .where('label.uri', 'in', subjects)
+      .where('label.val', 'not in', SERVER_SIDE_LABELS)
       .if(!includeNeg, (qb) => qb.where('neg', '=', false))
       .selectAll()
       .execute()

--- a/packages/bsky/src/services/label/index.ts
+++ b/packages/bsky/src/services/label/index.ts
@@ -3,12 +3,13 @@ import Database from '../../db'
 import { Label } from '../../lexicon/types/com/atproto/label/defs'
 import { ids } from '../../lexicon/lexicons'
 import { sql } from 'kysely'
+import { NotEmptyArray } from '@atproto/common'
 
 export type Labels = Record<string, Label[]>
 
 // @TODO forward these labels to client
 // these are labels are currently only used server side & not sent to client since it does not handle them correctly
-const SERVER_SIDE_LABELS = ['!no-promote']
+const SERVER_SIDE_LABELS: NotEmptyArray<string> = ['!no-promote']
 
 export class LabelService {
   constructor(public db: Database) {}

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -4,11 +4,11 @@ import { paginate } from '../../../../db/pagination'
 import AppContext from '../../../../context'
 import { FeedRow } from '../../../services/feed'
 import { FeedViewPost } from '../../../../lexicon/types/app/bsky/feed/defs'
+import { NotEmptyArray } from '@atproto/common'
 
-const NO_WHATS_HOT_LABELS = [
+const NO_WHATS_HOT_LABELS: NotEmptyArray<string> = [
   '!no-promote',
   'porn',
-  'nudity',
   'sexual',
   'corpse',
   'self-harm',

--- a/packages/pds/tests/views/popular.test.ts
+++ b/packages/pds/tests/views/popular.test.ts
@@ -12,12 +12,6 @@ describe('popular views', () => {
   // account dids, for convenience
   let alice: string
   let bob: string
-  let carol: string
-  let dan: string
-  let eve: string
-  let frank: string
-  let george: string
-  let helen: string
 
   const account = {
     email: 'blah@test.com',
@@ -32,6 +26,7 @@ describe('popular views', () => {
     agent = new AtpAgent({ service: server.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
+
     await sc.createAccount('eve', {
       ...account,
       email: 'eve@test.com',
@@ -59,12 +54,6 @@ describe('popular views', () => {
 
     alice = sc.dids.alice
     bob = sc.dids.bob
-    carol = sc.dids.carol
-    dan = sc.dids.dan
-    eve = sc.dids.eve
-    frank = sc.dids.frank
-    george = sc.dids.george
-    helen = sc.dids.helen
     await server.ctx.backgroundQueue.processAll()
   })
 
@@ -79,32 +68,20 @@ describe('popular views', () => {
       'image/jpeg',
     )
     const one = await sc.post(alice, 'first post', undefined, [img])
-    await sc.like(alice, one.ref)
-    await sc.like(bob, one.ref)
-    await sc.like(carol, one.ref)
-    await sc.like(dan, one.ref)
-    await sc.like(eve, one.ref)
-    await sc.like(frank, one.ref)
-    await sc.like(george, one.ref)
-    await sc.like(helen, one.ref)
     const two = await sc.post(bob, 'bobby boi')
-    await sc.like(alice, two.ref)
-    await sc.like(bob, two.ref)
-    await sc.like(carol, two.ref)
-    await sc.like(dan, two.ref)
-    await sc.like(eve, two.ref)
-    await sc.like(frank, two.ref)
-    await sc.like(george, two.ref)
-    await sc.like(helen, two.ref)
     const three = await sc.reply(bob, one.ref, one.ref, 'reply')
-    await sc.like(alice, three.ref)
-    await sc.like(bob, three.ref)
-    await sc.like(carol, three.ref)
-    await sc.like(dan, three.ref)
-    await sc.like(eve, three.ref)
-    await sc.like(frank, three.ref)
-    await sc.like(george, three.ref)
-    await sc.like(helen, three.ref)
+
+    for (let i = 0; i < 12; i++) {
+      const name = `user${i}`
+      await sc.createAccount(name, {
+        handle: `user${i}.test`,
+        email: `user${i}@test.com`,
+        password: 'password',
+      })
+      await sc.like(sc.dids[name], one.ref)
+      await sc.like(sc.dids[name], two.ref)
+      await sc.like(sc.dids[name], three.ref)
+    }
     await server.ctx.backgroundQueue.processAll()
 
     const res = await agent.api.app.bsky.unspecced.getPopular(


### PR DESCRIPTION
This tweaks what's hot
- formalizes a hot fix that increased like threshold to 12
- filters out content from spicier labels (mostly porn & gore)
- filters out `!no-promote` content. Does not forward `!no-promote` labels to client since client does not handle it yet