### PR TITLE
Include nsfw flag for getPopular

### DIFF
--- a/lexicons/app/bsky/unspecced/getPopular.json
+++ b/lexicons/app/bsky/unspecced/getPopular.json
@@ -8,6 +8,7 @@
       "parameters": {
         "type": "params",
         "properties": {
+          "includeNsfw": {"type": "boolean", "default": false},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"}
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5076,6 +5076,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            includeNsfw: {
+              type: 'boolean',
+              default: false,
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/api/src/client/types/app/bsky/unspecced/getPopular.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPopular.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  includeNsfw?: boolean
   limit?: number
   cursor?: string
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5076,6 +5076,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            includeNsfw: {
+              type: 'boolean',
+              default: false,
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopular.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopular.ts
@@ -10,6 +10,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  includeNsfw: boolean
   limit: number
   cursor?: string
 }


### PR DESCRIPTION
Adds an optional (default false) flag to include nsfw in getPopular. Intended for use in alt clients