### PR TITLE
test (api, common, common-web): add further tests

### DIFF
--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -137,4 +137,67 @@ describe('agent', () => {
     })
     await expect(p).rejects.toThrow('Record/displayName must be a string')
   })
+
+  describe('app', () => {
+    it('should retrieve the api app', () => {
+      const agent = new BskyAgent({ service: server.url })
+      expect(agent.app).toBe(agent.api.app)
+    })
+  })
+
+  describe('post', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.post({ text: 'foo' })).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('deletePost', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.deletePost('foo')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('like', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.like('foo', 'bar')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('deleteLike', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.deleteLike('foo')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('repost', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.repost('foo', 'bar')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('deleteRepost', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.deleteRepost('foo')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('follow', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.follow('foo')).rejects.toThrow('Not logged in')
+    })
+  })
+
+  describe('deleteFollow', () => {
+    it('should throw if no session', async () => {
+      const agent = new BskyAgent({ service: server.url })
+      await expect(agent.deleteFollow('foo')).rejects.toThrow('Not logged in')
+    })
+  })
 })

--- a/packages/common-web/tests/check.test.ts
+++ b/packages/common-web/tests/check.test.ts
@@ -1,0 +1,89 @@
+import { check } from '../src/index'
+import { ZodError } from 'zod'
+
+describe('check', () => {
+  describe('is', () => {
+    it('checks object against definition', () => {
+      const checkable: check.Checkable<boolean> = {
+        parse(obj) {
+          return Boolean(obj)
+        },
+        safeParse(obj) {
+          return {
+            success: true,
+            data: Boolean(obj),
+          }
+        },
+      }
+
+      expect(check.is(true, checkable)).toBe(true)
+    })
+
+    it('handles failed checks', () => {
+      const checkable: check.Checkable<boolean> = {
+        parse(obj) {
+          return Boolean(obj)
+        },
+        safeParse() {
+          return {
+            success: false,
+            error: new ZodError([]),
+          }
+        },
+      }
+
+      expect(check.is(true, checkable)).toBe(false)
+    })
+  })
+
+  describe('assure', () => {
+    it('returns value on success', () => {
+      const checkable: check.Checkable<boolean> = {
+        parse(obj) {
+          return Boolean(obj)
+        },
+        safeParse(obj) {
+          return {
+            success: true,
+            data: Boolean(obj),
+          }
+        },
+      }
+
+      expect(check.assure(checkable, true)).toEqual(true)
+    })
+
+    it('throws on failure', () => {
+      const err = new Error('foo')
+      const checkable: check.Checkable<boolean> = {
+        parse() {
+          throw err
+        },
+        safeParse() {
+          throw err
+        },
+      }
+
+      expect(() => check.assure(checkable, true)).toThrow(err)
+    })
+  })
+
+  describe('isObject', () => {
+    const falseTestValues: unknown[] = [null, undefined, 'foo', 123, true]
+
+    for (const obj of falseTestValues) {
+      it(`returns false for ${obj}`, () => {
+        expect(check.isObject(obj)).toBe(false)
+      })
+    }
+
+    it('returns true for objects', () => {
+      expect(check.isObject({})).toBe(true)
+    })
+
+    it('returns true for instances of classes', () => {
+      const obj = new (class {})()
+      expect(check.isObject(obj)).toBe(true)
+    })
+  })
+})

--- a/packages/common-web/tests/tid.test.ts
+++ b/packages/common-web/tests/tid.test.ts
@@ -15,4 +15,122 @@ describe('TIDs', () => {
     expect(parsed.timestamp()).toEqual(tid.timestamp())
     expect(parsed.clockid()).toEqual(tid.clockid())
   })
+
+  it('throws if invalid tid passed', () => {
+    expect(() => new TID('')).toThrow('Poorly formatted TID: 0 length')
+  })
+
+  describe('nextStr', () => {
+    it('returns next tid as a string', () => {
+      const str = TID.nextStr()
+      expect(typeof str).toEqual('string')
+      expect(str.length).toEqual(13)
+    })
+  })
+
+  describe('newestFirst', () => {
+    it('sorts tids newest first', () => {
+      const oldest = TID.next()
+      const newest = TID.next()
+
+      const tids = [oldest, newest]
+
+      tids.sort(TID.newestFirst)
+
+      expect(tids).toEqual([newest, oldest])
+    })
+  })
+
+  describe('oldestFirst', () => {
+    it('sorts tids oldest first', () => {
+      const oldest = TID.next()
+      const newest = TID.next()
+
+      const tids = [newest, oldest]
+
+      tids.sort(TID.oldestFirst)
+
+      expect(tids).toEqual([oldest, newest])
+    })
+  })
+
+  describe('is', () => {
+    it('true for valid tids', () => {
+      const tid = TID.next()
+      const asStr = tid.toString()
+
+      expect(TID.is(asStr)).toBe(true)
+    })
+
+    it('false for invalid tids', () => {
+      expect(TID.is('')).toBe(false)
+    })
+  })
+
+  describe('equals', () => {
+    it('true when same tid', () => {
+      const tid = TID.next()
+      expect(tid.equals(tid)).toBe(true)
+    })
+
+    it('true when different instance, same tid', () => {
+      const tid0 = TID.next()
+      const tid1 = new TID(tid0.toString())
+
+      expect(tid0.equals(tid1)).toBe(true)
+    })
+
+    it('false when different tid', () => {
+      const tid0 = TID.next()
+      const tid1 = TID.next()
+
+      expect(tid0.equals(tid1)).toBe(false)
+    })
+  })
+
+  describe('newerThan', () => {
+    it('true for newer tid', () => {
+      const tid0 = TID.next()
+      const tid1 = TID.next()
+
+      expect(tid1.newerThan(tid0)).toBe(true)
+    })
+
+    it('false for older tid', () => {
+      const tid0 = TID.next()
+      const tid1 = TID.next()
+
+      expect(tid0.newerThan(tid1)).toBe(false)
+    })
+
+    it('false for identical tids', () => {
+      const tid0 = TID.next()
+      const tid1 = new TID(tid0.toString())
+
+      expect(tid0.newerThan(tid1)).toBe(false)
+    })
+  })
+
+  describe('olderThan', () => {
+    it('true for older tid', () => {
+      const tid0 = TID.next()
+      const tid1 = TID.next()
+
+      expect(tid0.olderThan(tid1)).toBe(true)
+    })
+
+    it('false for newer tid', () => {
+      const tid0 = TID.next()
+      const tid1 = TID.next()
+
+      expect(tid1.olderThan(tid0)).toBe(false)
+    })
+
+    it('false for identical tids', () => {
+      const tid0 = TID.next()
+      const tid1 = new TID(tid0.toString())
+
+      expect(tid0.olderThan(tid1)).toBe(false)
+    })
+  })
 })

--- a/packages/common-web/tests/util.test.ts
+++ b/packages/common-web/tests/util.test.ts
@@ -1,0 +1,107 @@
+import { util } from '../src/index'
+
+describe('util', () => {
+  describe('noUndefinedVals', () => {
+    it('removes undefined top-level keys', () => {
+      const obj: Record<string, unknown> = {
+        foo: 123,
+        bar: undefined,
+      }
+
+      const result = util.noUndefinedVals(obj)
+
+      expect(result).toBe(obj)
+      expect(result).toEqual({
+        foo: 123,
+      })
+    })
+
+    it('handles empty objects', () => {
+      expect(util.noUndefinedVals({})).toEqual({})
+    })
+
+    it('leaves deep values intact', () => {
+      const obj: Record<string, unknown> = {
+        foo: 123,
+        bar: {
+          baz: undefined,
+        },
+      }
+      const result = util.noUndefinedVals(obj)
+
+      expect(result).toEqual({
+        foo: 123,
+        bar: {
+          baz: undefined,
+        },
+      })
+    })
+  })
+
+  describe('flattenUint8Arrays', () => {
+    it('flattens to single array of values', () => {
+      const arr = [new Uint8Array([0xa, 0xb]), new Uint8Array([0xc, 0xd])]
+
+      const flat = util.flattenUint8Arrays(arr)
+
+      expect([...flat]).toEqual([0xa, 0xb, 0xc, 0xd])
+    })
+
+    it('flattens empty arrays', () => {
+      const arr = [new Uint8Array(0), new Uint8Array(0)]
+      const flat = util.flattenUint8Arrays(arr)
+
+      expect(flat.length).toBe(0)
+    })
+  })
+
+  describe('streamToBuffer', () => {
+    it('reads iterable into array', async () => {
+      const iterable: AsyncIterable<Uint8Array> = {
+        async *[Symbol.asyncIterator]() {
+          yield new Uint8Array([0xa, 0xb])
+          yield new Uint8Array([0xc, 0xd])
+        },
+      }
+      const buffer = await util.streamToBuffer(iterable)
+
+      expect([...buffer]).toEqual([0xa, 0xb, 0xc, 0xd])
+    })
+  })
+
+  describe('asyncFilter', () => {
+    it('filters array values', async () => {
+      const result = await util.asyncFilter([0, 1, 2], (n) =>
+        Promise.resolve(n === 0),
+      )
+
+      expect(result).toEqual([0])
+    })
+  })
+
+  describe('range', () => {
+    it('generates numeric range', () => {
+      expect(util.range(4)).toEqual([0, 1, 2, 3])
+    })
+  })
+
+  describe('dedupeStrs', () => {
+    it('removes duplicates', () => {
+      expect(util.dedupeStrs(['a', 'a', 'b'])).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('parseIntWithFallback', () => {
+    it('accepts undefined', () => {
+      expect(util.parseIntWithFallback(undefined, -10)).toBe(-10)
+    })
+
+    it('parses numbers', () => {
+      expect(util.parseIntWithFallback('100', -10)).toBe(100)
+    })
+
+    it('supports non-numeric fallbacks', () => {
+      expect(util.parseIntWithFallback(undefined, 'foo')).toBe('foo')
+    })
+  })
+})

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -1,0 +1,136 @@
+import * as streams from '../src/streams'
+import { PassThrough, Readable, pipeline } from 'node:stream'
+
+describe('streams', () => {
+  describe('forwardStreamErrors', () => {
+    it('forwards errors through a set of streams', () => {
+      const streamA = new PassThrough()
+      const streamB = new PassThrough()
+      let streamBError: Error | null = null
+      const err = new Error('foo')
+
+      streamB.on('error', (err) => {
+        streamBError = err
+      })
+
+      streams.forwardStreamErrors(streamA, streamB)
+
+      streamA.emit('error', err)
+
+      expect(streamBError).toBe(err)
+    })
+  })
+
+  describe('cloneStream', () => {
+    it('should clone stream', () => {
+      const stream = new PassThrough()
+      let clonedError: Error | undefined
+      let clonedData: string | undefined
+
+      const cloned = streams.cloneStream(stream)
+
+      cloned.on('data', (data) => {
+        clonedData = String(data)
+      })
+      cloned.on('error', (err) => {
+        clonedError = err
+      })
+
+      stream.emit('data', 'foo')
+      stream.emit('error', new Error('foo error'))
+
+      expect(clonedData).toEqual('foo')
+      expect(clonedError?.message).toEqual('foo error')
+    })
+  })
+
+  describe('streamSize', () => {
+    it('reads entire stream and computes size', async () => {
+      const stream = Readable.from(['f', 'o', 'o'])
+
+      const size = await streams.streamSize(stream)
+
+      expect(size).toBe(3)
+    })
+
+    it('returns 0 for empty streams', async () => {
+      const stream = Readable.from([])
+      const size = await streams.streamSize(stream)
+
+      expect(size).toBe(0)
+    })
+  })
+
+  describe('streamToBytes', () => {
+    it('converts stream to byte array', async () => {
+      const stream = Readable.from(Buffer.from('foo'))
+      const bytes = await streams.streamToBytes(stream)
+
+      expect(bytes[0]).toBe('f'.charCodeAt(0))
+      expect(bytes[1]).toBe('o'.charCodeAt(0))
+      expect(bytes[2]).toBe('o'.charCodeAt(0))
+    })
+  })
+
+  describe('byteIterableToStream', () => {
+    it('converts byte iterable to stream', async () => {
+      const iterable: AsyncIterable<Uint8Array> = {
+        async *[Symbol.asyncIterator]() {
+          yield new Uint8Array([0xa, 0xb])
+        },
+      }
+
+      const stream = streams.byteIterableToStream(iterable)
+
+      for await (const chunk of stream) {
+        expect(chunk[0]).toBe(0xa)
+        expect(chunk[1]).toBe(0xb)
+      }
+    })
+  })
+
+  describe('bytesToStream', () => {
+    it('converts byte array to readable stream', async () => {
+      const bytes = new Uint8Array([0xa, 0xb])
+      const stream = streams.bytesToStream(bytes)
+
+      for await (const chunk of stream) {
+        expect(chunk[0]).toBe(0xa)
+        expect(chunk[1]).toBe(0xb)
+      }
+    })
+  })
+
+  describe('MaxSizeChecker', () => {
+    it('destroys once max size is met', async () => {
+      const stream = new Readable()
+      const err = new Error('foo')
+      const checker = new streams.MaxSizeChecker(1, () => err)
+      let lastError: Error | undefined
+
+      const outStream = stream.pipe(checker)
+
+      outStream.on('error', (err) => {
+        lastError = err
+      })
+
+      const waitForStream = new Promise<void>((resolve) => {
+        stream.on('end', () => {
+          resolve()
+        })
+      })
+
+      expect(checker.totalSize).toBe(0)
+
+      stream.push(new Uint8Array([0xa]))
+      stream.push(new Uint8Array([0xb]))
+      stream.push(null)
+
+      await waitForStream
+
+      expect(checker.totalSize).toBe(2)
+      expect(checker.destroyed).toBe(true)
+      expect(lastError).toBe(err)
+    })
+  })
+})


### PR DESCRIPTION
just getting my head around the repo out of curiosity, so i filled in some test gaps while i was there

let me know if there's anything you want changing, and if you want this

fwiw too the agent tests could be better to purge the in-memory db between tests. you spin up a single db before the entire suite presumably to save time/resources. however, it means tests can pollute each others' state, and you end up with these ever-incrementing user IDs in your test cases to avoid conflicts.

would be much better if you could `afterEach(() => server.ctx.db.clear())` somehow