### PR TITLE
Perform account deletion async

### DIFF
--- a/packages/pds/src/api/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteAccount.ts
@@ -1,10 +1,13 @@
 import { AuthRequiredError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
+import { TAKEDOWN } from '../../../../lexicon/types/com/atproto/admin/defs'
 import AppContext from '../../../../context'
 import Database from '../../../../db'
 
+const REASON_ACCT_DELETION = 'ACCOUNT DELETION'
+
 export default function (server: Server, ctx: AppContext) {
-  server.com.atproto.server.deleteAccount(async ({ input }) => {
+  server.com.atproto.server.deleteAccount(async ({ input, req }) => {
     const { did, password, token } = input.body
     const validPass = await ctx.services
       .account(ctx.db)
@@ -38,10 +41,41 @@ export default function (server: Server, ctx: AppContext) {
     }
 
     await ctx.db.transaction(async (dbTxn) => {
+      const moderationTxn = ctx.services.moderation(dbTxn)
+      const [currentAction] = await moderationTxn.getCurrentActions({ did })
+      if (currentAction?.action === TAKEDOWN) {
+        // Do not disturb an existing takedown, continue with account deletion
+        return await removeDeleteToken(dbTxn, did)
+      }
+      if (currentAction) {
+        // Reverse existing action to replace it with a self-takedown
+        await moderationTxn.logReverseAction({
+          id: currentAction.id,
+          reason: REASON_ACCT_DELETION,
+          createdBy: did,
+          createdAt: now,
+        })
+      }
+      const takedown = await moderationTxn.logAction({
+        action: TAKEDOWN,
+        subject: { did },
+        reason: REASON_ACCT_DELETION,
+        createdBy: did,
+        createdAt: now,
+      })
+      await moderationTxn.takedownRepo({ did, takedownId: takedown.id })
       await removeDeleteToken(dbTxn, did)
-      await ctx.services.record(dbTxn).deleteForActor(did)
-      await ctx.services.repo(dbTxn).deleteRepo(did)
-      await ctx.services.account(dbTxn).deleteAccount(did)
+    })
+
+    ctx.backgroundQueue.add(async (db) => {
+      try {
+        // In the background perform the hard account deletion work
+        await ctx.services.record(db).deleteForActor(did)
+        await ctx.services.repo(db).deleteRepo(did)
+        await ctx.services.account(db).deleteAccount(did)
+      } catch (err) {
+        req.log.error({ did, err }, 'account deletion failed')
+      }
     })
   })
 }

--- a/packages/pds/src/app-view/services/indexing/index.ts
+++ b/packages/pds/src/app-view/services/indexing/index.ts
@@ -2,8 +2,6 @@ import { CID } from 'multiformats/cid'
 import { WriteOpAction } from '@atproto/repo'
 import { AtUri } from '@atproto/uri'
 import Database from '../../../db'
-import DatabaseSchema from '../../../db/database-schema'
-import { excluded } from '../../../db/util'
 import * as Post from './plugins/post'
 import * as Like from './plugins/like'
 import * as Repost from './plugins/repost'
@@ -70,7 +68,10 @@ export class IndexingService {
   }
 
   async deleteForUser(did: string) {
-    this.db.assertTransaction()
+    // Not done in transaction because it would be too long, prone to contention.
+    // Also, this can safely be run multiple times if it fails.
+    // Omitting updates to profile_agg and post_agg since it's expensive
+    // and they'll organically update themselves over time.
 
     const postByUser = (qb) =>
       qb
@@ -78,149 +79,36 @@ export class IndexingService {
         .where('post.creator', '=', did)
         .select('post.uri as uri')
 
-    await Promise.all([
-      this.db.db
-        .deleteFrom('post_embed_image')
-        .where('post_embed_image.postUri', 'in', postByUser)
-        .execute(),
-      this.db.db
-        .deleteFrom('post_embed_external')
-        .where('post_embed_external.postUri', 'in', postByUser)
-        .execute(),
-      this.db.db
-        .deleteFrom('post_embed_record')
-        .where('post_embed_record.postUri', 'in', postByUser)
-        .execute(),
-      this.db.db
-        .deleteFrom('duplicate_record')
-        .where('duplicate_record.duplicateOf', 'in', (qb) =>
-          // @TODO remove dependency on record table from app view
-          qb
-            .selectFrom('record')
-            .where('record.did', '=', did)
-            .select('record.uri as uri'),
-        )
-        .execute(),
-    ])
-    await removeActorAggregates(this.db.db, did)
-    await Promise.all([
-      this.db.db.deleteFrom('actor_block').where('creator', '=', did).execute(),
-      this.db.db.deleteFrom('follow').where('creator', '=', did).execute(),
-      this.db.db.deleteFrom('post').where('creator', '=', did).execute(),
-      this.db.db.deleteFrom('profile').where('creator', '=', did).execute(),
-      this.db.db.deleteFrom('repost').where('creator', '=', did).execute(),
-      this.db.db.deleteFrom('like').where('creator', '=', did).execute(),
-    ])
+    await this.db.db
+      .deleteFrom('post_embed_image')
+      .where('post_embed_image.postUri', 'in', postByUser)
+      .execute()
+    await this.db.db
+      .deleteFrom('post_embed_external')
+      .where('post_embed_external.postUri', 'in', postByUser)
+      .execute()
+    await this.db.db
+      .deleteFrom('post_embed_record')
+      .where('post_embed_record.postUri', 'in', postByUser)
+      .execute()
+    await this.db.db
+      .deleteFrom('duplicate_record')
+      .where('duplicate_record.duplicateOf', 'in', (qb) =>
+        // @TODO remove dependency on record table from app view
+        qb
+          .selectFrom('record')
+          .where('record.did', '=', did)
+          .select('record.uri as uri'),
+      )
+      .execute()
+    await this.db.db
+      .deleteFrom('actor_block')
+      .where('creator', '=', did)
+      .execute()
+    await this.db.db.deleteFrom('follow').where('creator', '=', did).execute()
+    await this.db.db.deleteFrom('post').where('creator', '=', did).execute()
+    await this.db.db.deleteFrom('profile').where('creator', '=', did).execute()
+    await this.db.db.deleteFrom('repost').where('creator', '=', did).execute()
+    await this.db.db.deleteFrom('like').where('creator', '=', did).execute()
   }
-}
-
-async function removeActorAggregates(db: DatabaseSchema, did: string) {
-  const ownProfileAggQb = db.deleteFrom('profile_agg').where('did', '=', did)
-  const ownPostAggsQb = db
-    .deleteFrom('post_agg')
-    .where(
-      'uri',
-      'in',
-      db
-        .selectFrom('post')
-        .where('post.creator', '=', did)
-        .select('post.uri as uri'),
-    )
-  const replyCountQb = db
-    .insertInto('post_agg')
-    .columns(['uri', 'replyCount'])
-    .expression((exp) =>
-      exp
-        .selectFrom('post as target')
-        .leftJoin('post', (join) =>
-          join
-            .onRef('post.replyParent', '=', 'target.replyParent')
-            .on('post.creator', '!=', did),
-        )
-        .where('target.creator', '=', did)
-        .where('target.replyParent', 'is not', null)
-        .groupBy('target.replyParent')
-        .select([
-          'target.replyParent as uri',
-          db.fn.count('post.uri').as('replyCount'),
-        ]),
-    )
-    .onConflict((oc) =>
-      oc.column('uri').doUpdateSet({ replyCount: excluded(db, 'replyCount') }),
-    )
-  const followersCountQb = db
-    .insertInto('profile_agg')
-    .columns(['did', 'followersCount'])
-    .expression((exp) =>
-      exp
-        .selectFrom('follow as target')
-        .leftJoin('follow', (join) =>
-          join
-            .onRef('follow.subjectDid', '=', 'target.subjectDid')
-            .on('follow.creator', '!=', did),
-        )
-        .where('target.creator', '=', did)
-        .groupBy('target.subjectDid')
-        .select([
-          'target.subjectDid as did',
-          db.fn.count('follow.uri').as('followersCount'),
-        ]),
-    )
-    .onConflict((oc) =>
-      oc.column('did').doUpdateSet({
-        followersCount: excluded(db, 'followersCount'),
-      }),
-    )
-  const likeCountQb = db
-    .insertInto('post_agg')
-    .columns(['uri', 'likeCount'])
-    .expression((exp) =>
-      exp
-        .selectFrom('like as target')
-        .leftJoin('like', (join) =>
-          join
-            .onRef('like.subject', '=', 'target.subject')
-            .on('like.creator', '!=', did),
-        )
-        .where('target.creator', '=', did)
-        .groupBy('target.subject')
-        .select([
-          'target.subject as uri',
-          db.fn.count('like.uri').as('likeCount'),
-        ]),
-    )
-    .onConflict((oc) =>
-      oc.column('uri').doUpdateSet({ likeCount: excluded(db, 'likeCount') }),
-    )
-  const repostCountQb = db
-    .insertInto('post_agg')
-    .columns(['uri', 'repostCount'])
-    .expression((exp) =>
-      exp
-        .selectFrom('repost as target')
-        .leftJoin('repost', (join) =>
-          join
-            .onRef('repost.subject', '=', 'target.subject')
-            .on('repost.creator', '!=', did),
-        )
-        .where('target.creator', '=', did)
-        .groupBy('target.subject')
-        .select([
-          'target.subject as uri',
-          db.fn.count('repost.uri').as('repostCount'),
-        ]),
-    )
-    .onConflict((oc) =>
-      oc
-        .column('uri')
-        .doUpdateSet({ repostCount: excluded(db, 'repostCount') }),
-    )
-  await Promise.all([
-    ownProfileAggQb.execute(),
-    ownPostAggsQb.execute(),
-    replyCountQb.execute(),
-    followersCountQb.execute(),
-    likeCountQb.execute(),
-    repostCountQb.execute(),
-  ])
 }

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -344,18 +344,20 @@ export class AccountService {
   }
 
   async deleteAccount(did: string): Promise<void> {
-    this.db.assertTransaction()
-    await Promise.all([
-      this.db.db.deleteFrom('refresh_token').where('did', '=', did).execute(),
-      this.db.db
-        .deleteFrom('user_account')
-        .where('user_account.did', '=', did)
-        .execute(),
-      this.db.db
-        .deleteFrom('did_handle')
-        .where('did_handle.did', '=', did)
-        .execute(),
-    ])
+    // Not done in transaction because it would be too long, prone to contention.
+    // Also, this can safely be run multiple times if it fails.
+    await this.db.db
+      .deleteFrom('refresh_token')
+      .where('did', '=', did)
+      .execute()
+    await this.db.db
+      .deleteFrom('user_account')
+      .where('user_account.did', '=', did)
+      .execute()
+    await this.db.db
+      .deleteFrom('did_handle')
+      .where('did_handle.did', '=', did)
+      .execute()
   }
 
   selectInviteCodesQb() {

--- a/packages/pds/src/services/record/index.ts
+++ b/packages/pds/src/services/record/index.ts
@@ -227,15 +227,14 @@ export class RecordService {
   }
 
   async deleteForActor(did: string) {
-    this.db.assertTransaction()
-    await this.messageDispatcher.send(this.db, deleteRepo(did))
-    await Promise.all([
-      this.db.db.deleteFrom('record').where('did', '=', did).execute(),
-      this.db.db
-        .deleteFrom('user_notification')
-        .where('author', '=', did)
-        .execute(),
-    ])
+    // Not done in transaction because it would be too long, prone to contention.
+    // Also, this can safely be run multiple times if it fails.
+    await this.messageDispatcher.send(this.db, deleteRepo(did)) // Needs record table
+    await this.db.db.deleteFrom('record').where('did', '=', did).execute()
+    await this.db.db
+      .deleteFrom('user_notification')
+      .where('author', '=', did)
+      .execute()
   }
 
   async removeBacklinksByUri(uri: AtUri) {

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -248,22 +248,24 @@ export class RepoService {
   }
 
   async deleteRepo(did: string) {
-    this.db.assertTransaction()
+    // Not done in transaction because it would be too long, prone to contention.
+    // Also, this can safely be run multiple times if it fails.
     // delete all blocks from this did & no other did
-    await Promise.all([
-      this.db.db.deleteFrom('ipld_block').where('creator', '=', did).execute(),
-      this.db.db
-        .deleteFrom('repo_commit_block')
-        .where('creator', '=', did)
-        .execute(),
-      this.db.db
-        .deleteFrom('repo_commit_history')
-        .where('creator', '=', did)
-        .execute(),
-      this.db.db.deleteFrom('repo_root').where('did', '=', did).execute(),
-      this.db.db.deleteFrom('repo_seq').where('did', '=', did).execute(),
-      this.blobs.deleteForUser(did),
-    ])
+    await this.db.db.deleteFrom('repo_root').where('did', '=', did).execute()
+    await this.db.db.deleteFrom('repo_seq').where('did', '=', did).execute()
+    await this.db.db
+      .deleteFrom('repo_commit_block')
+      .where('creator', '=', did)
+      .execute()
+    await this.db.db
+      .deleteFrom('repo_commit_history')
+      .where('creator', '=', did)
+      .execute()
+    await this.db.db
+      .deleteFrom('ipld_block')
+      .where('creator', '=', did)
+      .execute()
+    await this.blobs.deleteForUser(did)
   }
 }
 

--- a/packages/pds/tests/account-deletion.test.ts
+++ b/packages/pds/tests/account-deletion.test.ts
@@ -1,9 +1,7 @@
-import assert from 'assert'
 import { once, EventEmitter } from 'events'
 import { Selectable } from 'kysely'
 import Mail from 'nodemailer/lib/mailer'
 import AtpAgent from '@atproto/api'
-import { isThreadViewPost } from '@atproto/api/src/client/types/app/bsky/feed/defs'
 import { SeedClient } from './seeds/client'
 import basicSeed from './seeds/basic'
 import { Database } from '../src'
@@ -28,8 +26,10 @@ import { RepoCommitHistory } from '../src/db/tables/repo-commit-history'
 import { RepoCommitBlock } from '../src/db/tables/repo-commit-block'
 import { Record } from '../src/db/tables/record'
 import { RepoSeq } from '../src/db/tables/repo-seq'
+import { ACKNOWLEDGE } from '../src/lexicon/types/com/atproto/admin/defs'
 
 describe('account deletion', () => {
+  let server: util.TestServerInfo
   let agent: AtpAgent
   let close: util.CloseFn
   let sc: SeedClient
@@ -46,7 +46,7 @@ describe('account deletion', () => {
   let carol
 
   beforeAll(async () => {
-    const server = await util.runTestServer({
+    server = await util.runTestServer({
       dbPostgresSchema: 'account_deletion',
     })
     close = server.close
@@ -120,69 +120,29 @@ describe('account deletion', () => {
     await expect(attempt).rejects.toThrow('Invalid did or password')
   })
 
-  it('deletes account with a valid token & password, updating aggregations', async () => {
-    const postAUri = sc.posts[sc.dids.alice][1].ref.uriStr
-    const postBUri = sc.posts[sc.dids.dan][1].ref.uriStr
-    const { data: profileBefore } = await agent.api.app.bsky.actor.getProfile(
-      { actor: sc.dids.alice },
-      { headers: sc.getHeaders(sc.dids.alice) },
+  it('deletes account with a valid token & password', async () => {
+    // Perform account deletion, including when there's an existing mod action on the account
+    await agent.api.com.atproto.admin.takeModerationAction(
+      {
+        action: ACKNOWLEDGE,
+        subject: {
+          $type: 'com.atproto.admin.defs#repoRef',
+          did: carol.did,
+        },
+        createdBy: 'did:example:admin',
+        reason: 'X',
+      },
+      {
+        encoding: 'application/json',
+        headers: { authorization: util.adminAuth() },
+      },
     )
-    const { data: threadBeforeA } = await agent.api.app.bsky.feed.getPostThread(
-      { uri: postAUri, depth: 0 },
-      { headers: sc.getHeaders(sc.dids.alice) },
-    )
-    const { data: threadBeforeB } = await agent.api.app.bsky.feed.getPostThread(
-      { uri: postBUri, depth: 0 },
-      { headers: sc.getHeaders(sc.dids.alice) },
-    )
-
-    // Perform account deletion
     await agent.api.com.atproto.server.deleteAccount({
       token,
       did: carol.did,
       password: carol.password,
     })
-
-    // Check aggregations: some will be decremented now that the account is deleted.
-    const { data: profileAfter } = await agent.api.app.bsky.actor.getProfile(
-      { actor: sc.dids.alice },
-      { headers: sc.getHeaders(sc.dids.alice) },
-    )
-    const { data: threadAfterA } = await agent.api.app.bsky.feed.getPostThread(
-      { uri: postAUri, depth: 0 },
-      { headers: sc.getHeaders(sc.dids.alice) },
-    )
-    const { data: threadAfterB } = await agent.api.app.bsky.feed.getPostThread(
-      { uri: postBUri, depth: 0 },
-      { headers: sc.getHeaders(sc.dids.alice) },
-    )
-    assert(isThreadViewPost(threadBeforeA.thread))
-    assert(isThreadViewPost(threadBeforeB.thread))
-    assert(isThreadViewPost(threadAfterA.thread))
-    assert(isThreadViewPost(threadAfterB.thread))
-    expect(profileAfter.followsCount).toEqual(profileBefore.followsCount)
-    expect(profileAfter.followersCount).toEqual(
-      (profileBefore.followersCount ?? 0) - 1,
-    )
-    expect(profileAfter.postsCount).toEqual(profileBefore.postsCount)
-    expect(threadAfterA.thread.post.likeCount).toEqual(
-      (threadBeforeA.thread.post.likeCount ?? 0) - 1,
-    )
-    expect(threadAfterA.thread.post.replyCount).toEqual(
-      (threadBeforeA.thread.post.replyCount ?? 0) - 1,
-    )
-    expect(threadAfterA.thread.post.repostCount).toEqual(
-      threadBeforeA.thread.post.repostCount,
-    )
-    expect(threadAfterB.thread.post.likeCount).toEqual(
-      threadBeforeB.thread.post.likeCount,
-    )
-    expect(threadAfterB.thread.post.replyCount).toEqual(
-      threadBeforeB.thread.post.replyCount,
-    )
-    expect(threadAfterB.thread.post.repostCount).toEqual(
-      (threadBeforeB.thread.post.repostCount ?? 0) - 1,
-    )
+    await server.ctx.backgroundQueue.processAll() // Finish background hard-deletions
   })
 
   it('no longer lets the user log in', async () => {


### PR DESCRIPTION
Account deletion is expensive to perform during the course of the request, so here we disable the account immediately while the hard-deletion process occurs in the background.  The deletion process has been updated to take place serially (e.g. no concurrent queries) to avoid contention, which works better now that the round-trip time is no longer in the critical path of the user's experience.