### PR TITLE
Delete dereferenced blobs

### DIFF
--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -42,6 +42,8 @@ export function createServices(resources: {
       repoSigningKey,
       messageDispatcher,
       blobstore,
+      imgUriBuilder,
+      imgInvalidator,
       labeler,
     ),
     moderation: ModerationService.creator(

--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -42,6 +42,7 @@ export function createServices(resources: {
       repoSigningKey,
       messageDispatcher,
       blobstore,
+      backgroundQueue,
       imgUriBuilder,
       imgInvalidator,
       labeler,

--- a/packages/pds/src/services/repo/blobs.ts
+++ b/packages/pds/src/services/repo/blobs.ts
@@ -203,47 +203,11 @@ export class RepoBlobs {
   }
 
   async processRebaseBlobs(did: string, newRoot: CID) {
-    const deleteUnreferenced = this.db.db
-      .deleteFrom('repo_blob')
-      .where('did', '=', did)
-      .whereNotExists(
-        this.db.db.selectFrom('record').where('did', '=', did).select('uri'),
-      )
-      .returningAll()
-      .execute()
-
-    const updateReferenced = this.db.db
+    await this.db.db
       .updateTable('repo_blob')
       .set({ commit: newRoot.toString() })
       .where('did', '=', did)
-      .whereExists(
-        this.db.db.selectFrom('record').where('did', '=', did).select('uri'),
-      )
       .execute()
-
-    // delete blobs that have been rebased away & only belong to the repo in question
-    const [deleted] = await Promise.all([deleteUnreferenced, updateReferenced])
-    const deletedCids = deleted.map((row) => row.cid)
-    if (deleted.length > 0) {
-      const [duplicates] = await Promise.all([
-        this.db.db
-          .selectFrom('repo_blob')
-          .where('cid', 'in', deletedCids)
-          .selectAll()
-          .execute(),
-        this.db.db
-          .deleteFrom('blob')
-          .where('creator', '=', did)
-          .where('cid', 'in', deletedCids)
-          .returningAll()
-          .execute(),
-      ])
-      const duplicateCids = duplicates.map((row) => row.cid)
-      const toDelete = deletedCids.filter((cid) => !duplicateCids.includes(cid))
-      await Promise.all(
-        toDelete.map((cid) => this.blobstore.delete(CID.parse(cid))),
-      )
-    }
   }
 
   async listForCommits(did: string, commits: CID[]): Promise<CID[]> {

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -23,6 +23,8 @@ import { RecordService } from '../record'
 import * as sequencer from '../../sequencer'
 import { Labeler } from '../../labeler'
 import { wait } from '@atproto/common'
+import { ImageInvalidator } from '../../image/invalidator'
+import { ImageUriBuilder } from '../../image/uri'
 
 export class RepoService {
   blobs: RepoBlobs
@@ -32,19 +34,31 @@ export class RepoService {
     public repoSigningKey: crypto.Keypair,
     public messageDispatcher: MessageQueue,
     public blobstore: BlobStore,
+    public imgUriBuilder: ImageUriBuilder,
+    public imgInvalidator: ImageInvalidator,
     public labeler: Labeler,
   ) {
-    this.blobs = new RepoBlobs(db, blobstore)
+    this.blobs = new RepoBlobs(db, blobstore, imgUriBuilder, imgInvalidator)
   }
 
   static creator(
     keypair: crypto.Keypair,
     messageDispatcher: MessageQueue,
     blobstore: BlobStore,
+    imgUriBuilder: ImageUriBuilder,
+    imgInvalidator: ImageInvalidator,
     labeler: Labeler,
   ) {
     return (db: Database) =>
-      new RepoService(db, keypair, messageDispatcher, blobstore, labeler)
+      new RepoService(
+        db,
+        keypair,
+        messageDispatcher,
+        blobstore,
+        imgUriBuilder,
+        imgInvalidator,
+        labeler,
+      )
   }
 
   services = {
@@ -61,6 +75,8 @@ export class RepoService {
         this.repoSigningKey,
         this.messageDispatcher,
         this.blobstore,
+        this.imgUriBuilder,
+        this.imgInvalidator,
         this.labeler,
       )
       return fn(srvc)

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -25,6 +25,7 @@ import { Labeler } from '../../labeler'
 import { wait } from '@atproto/common'
 import { ImageInvalidator } from '../../image/invalidator'
 import { ImageUriBuilder } from '../../image/uri'
+import { BackgroundQueue } from '../../event-stream/background-queue'
 
 export class RepoService {
   blobs: RepoBlobs
@@ -34,17 +35,25 @@ export class RepoService {
     public repoSigningKey: crypto.Keypair,
     public messageDispatcher: MessageQueue,
     public blobstore: BlobStore,
+    public backgroundQueue: BackgroundQueue,
     public imgUriBuilder: ImageUriBuilder,
     public imgInvalidator: ImageInvalidator,
     public labeler: Labeler,
   ) {
-    this.blobs = new RepoBlobs(db, blobstore, imgUriBuilder, imgInvalidator)
+    this.blobs = new RepoBlobs(
+      db,
+      blobstore,
+      backgroundQueue,
+      imgUriBuilder,
+      imgInvalidator,
+    )
   }
 
   static creator(
     keypair: crypto.Keypair,
     messageDispatcher: MessageQueue,
     blobstore: BlobStore,
+    backgroundQueue: BackgroundQueue,
     imgUriBuilder: ImageUriBuilder,
     imgInvalidator: ImageInvalidator,
     labeler: Labeler,
@@ -55,6 +64,7 @@ export class RepoService {
         keypair,
         messageDispatcher,
         blobstore,
+        backgroundQueue,
         imgUriBuilder,
         imgInvalidator,
         labeler,
@@ -75,6 +85,7 @@ export class RepoService {
         this.repoSigningKey,
         this.messageDispatcher,
         this.blobstore,
+        this.backgroundQueue,
         this.imgUriBuilder,
         this.imgInvalidator,
         this.labeler,

--- a/packages/pds/src/storage/disk-blobstore.ts
+++ b/packages/pds/src/storage/disk-blobstore.ts
@@ -121,7 +121,15 @@ export class DiskBlobStore implements BlobStore {
   }
 
   async delete(cid: CID): Promise<void> {
-    await fs.rm(this.getStoredPath(cid))
+    try {
+      await fs.rm(this.getStoredPath(cid))
+    } catch (err) {
+      if (isErrnoException(err) && err.code === 'ENOENT') {
+        // if blob not found, then it's already been deleted & we can just return
+        return
+      }
+      throw err
+    }
   }
 }
 

--- a/packages/pds/tests/blob-deletes.test.ts
+++ b/packages/pds/tests/blob-deletes.test.ts
@@ -58,6 +58,7 @@ describe('blob deletes', () => {
     )
     const post = await sc.post(alice, 'test', undefined, [img])
     await sc.deletePost(alice, post.ref.uri)
+    await server.ctx.backgroundQueue.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(0)
@@ -79,6 +80,7 @@ describe('blob deletes', () => {
     )
     await updateProfile(sc, alice, img.image, img.image)
     await updateProfile(sc, alice, img2.image, img2.image)
+    await server.ctx.backgroundQueue.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(1)
@@ -107,6 +109,7 @@ describe('blob deletes', () => {
     )
     await updateProfile(sc, alice, img.image, img.image)
     await updateProfile(sc, alice, img.image, img2.image)
+    await server.ctx.backgroundQueue.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(2)
@@ -157,6 +160,7 @@ describe('blob deletes', () => {
       },
       { encoding: 'application/json', headers: sc.getHeaders(alice) },
     )
+    await server.ctx.backgroundQueue.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(1)

--- a/packages/pds/tests/blob-deletes.test.ts
+++ b/packages/pds/tests/blob-deletes.test.ts
@@ -1,0 +1,282 @@
+import fs from 'fs/promises'
+import { gzipSync } from 'zlib'
+import AtpAgent from '@atproto/api'
+import { CloseFn, runTestServer, TestServerInfo } from './_util'
+import { Database, ServerConfig } from '../src'
+import DiskBlobStore from '../src/storage/disk-blobstore'
+import * as uint8arrays from 'uint8arrays'
+import * as image from '../src/image'
+import axios from 'axios'
+import { randomBytes } from '@atproto/crypto'
+import { BlobRef } from '@atproto/lexicon'
+import { ids } from '../src/lexicon/lexicons'
+import { SeedClient } from './seeds/client'
+import userSeed from './seeds/users'
+
+describe('blob deletes', () => {
+  let server: TestServerInfo
+  let agent: AtpAgent
+  let sc: SeedClient
+
+  let bobAgent: AtpAgent
+  let blobstore: DiskBlobStore
+  let db: Database
+  let cfg: ServerConfig
+  let serverUrl: string
+
+  let alice: string
+  let bob: string
+
+  beforeAll(async () => {
+    server = await runTestServer({
+      dbPostgresSchema: 'blob_deletes',
+    })
+    blobstore = server.ctx.blobstore as DiskBlobStore
+    db = server.ctx.db
+    agent = new AtpAgent({ service: server.url })
+    sc = new SeedClient(agent)
+    await userSeed(sc)
+    alice = sc.dids.alice
+    bob = sc.dids.bob
+    cfg = server.ctx.cfg
+    serverUrl = server.url
+  })
+
+  afterAll(async () => {
+    await server.close()
+  })
+
+  const getDbBlobsForDid = (did: string) => {
+    return db.db
+      .selectFrom('blob')
+      .selectAll()
+      .where('creator', '=', did)
+      .execute()
+  }
+
+  it('deletes blob when record is deleted', async () => {
+    const img = await sc.uploadFile(
+      alice,
+      'tests/image/fixtures/key-portrait-small.jpg',
+      'image/jpeg',
+    )
+    const post = await sc.post(alice, 'test', undefined, [img])
+    await sc.deletePost(alice, post.ref.uri)
+
+    const thing = await db.db
+      .selectFrom('repo_blob')
+      .selectAll()
+      .where('did', '=', alice)
+      .execute()
+
+    console.log(thing)
+
+    const dbBlobs = await getDbBlobsForDid(alice)
+    expect(dbBlobs.length).toBe(0)
+
+    const hasImg = await blobstore.hasStored(img.image.ref)
+    expect(hasImg).toBeFalsy()
+  })
+
+  // it('can reference the file', async () => {
+  //   await updateProfile(aliceAgent, {
+  //     displayName: 'Alice',
+  //     avatar: smallBlob,
+  //   })
+  // })
+
+  // it('after being referenced, the file is moved to permanent storage', async () => {
+  //   const found = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', smallBlob.ref.toString())
+  //     .executeTakeFirst()
+
+  //   expect(found?.tempKey).toBeNull()
+  //   expect(await blobstore.hasStored(smallBlob.ref)).toBeTruthy()
+  //   const storedBytes = await blobstore.getBytes(smallBlob.ref)
+  //   expect(uint8arrays.equals(smallFile, storedBytes)).toBeTruthy()
+  // })
+
+  // it('can fetch the file after being referenced', async () => {
+  //   const { headers, data } = await aliceAgent.api.com.atproto.sync.getBlob({
+  //     did: alice.did,
+  //     cid: smallBlob.ref.toString(),
+  //   })
+  //   expect(headers['content-type']).toEqual('image/jpeg')
+  //   expect(headers['content-security-policy']).toEqual(
+  //     `default-src 'none'; sandbox`,
+  //   )
+  //   expect(headers['x-content-type-options']).toEqual('nosniff')
+  //   expect(uint8arrays.equals(smallFile, new Uint8Array(data))).toBeTruthy()
+  // })
+
+  // it('serves the referenced blob', async () => {
+  //   const profile = await aliceAgent.api.app.bsky.actor.getProfile({
+  //     actor: 'alice.test',
+  //   })
+  //   const avatar = profile.data.avatar as string
+  //   expect(typeof avatar).toBe('string')
+  //   const url = avatar.replace(cfg.publicUrl, serverUrl)
+  //   const res = await axios.get(url, { responseType: 'stream' })
+  //   expect(res.headers['content-type']).toBe('image/jpeg')
+  //   const info = await image.getInfo(res.data)
+  //   expect(info).toEqual(
+  //     expect.objectContaining({
+  //       height: 1000,
+  //       width: 1000,
+  //     }),
+  //   )
+  // })
+
+  // let largeBlob: BlobRef
+  // let largeFile: Uint8Array
+
+  // it('does not allow referencing a file that is outside blob constraints', async () => {
+  //   largeFile = await fs.readFile('tests/image/fixtures/hd-key.jpg')
+  //   const res = await aliceAgent.api.com.atproto.repo.uploadBlob(largeFile, {
+  //     encoding: 'image/jpeg',
+  //   })
+  //   largeBlob = res.data.blob
+
+  //   const profilePromise = updateProfile(aliceAgent, {
+  //     avatar: largeBlob,
+  //   })
+
+  //   await expect(profilePromise).rejects.toThrow()
+  // })
+
+  // it('does not make a blob permanent if referencing failed', async () => {
+  //   const found = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', largeBlob.ref.toString())
+  //     .executeTakeFirst()
+
+  //   expect(found?.tempKey).toBeDefined()
+  //   expect(await blobstore.hasTemp(found?.tempKey as string)).toBeTruthy()
+  //   expect(await blobstore.hasStored(largeBlob.ref)).toBeFalsy()
+  // })
+
+  // it('permits duplicate uploads of the same file', async () => {
+  //   const file = await fs.readFile(
+  //     'tests/image/fixtures/key-landscape-small.jpg',
+  //   )
+  //   const { data: uploadA } = await aliceAgent.api.com.atproto.repo.uploadBlob(
+  //     file,
+  //     {
+  //       encoding: 'image/jpeg',
+  //     } as any,
+  //   )
+  //   const { data: uploadB } = await bobAgent.api.com.atproto.repo.uploadBlob(
+  //     file,
+  //     {
+  //       encoding: 'image/jpeg',
+  //     } as any,
+  //   )
+  //   expect(uploadA).toEqual(uploadB)
+
+  //   await updateProfile(aliceAgent, {
+  //     displayName: 'Alice',
+  //     avatar: uploadA.blob,
+  //   })
+  //   const profileA = await aliceAgent.api.app.bsky.actor.profile.get({
+  //     repo: alice.did,
+  //     rkey: 'self',
+  //   })
+  //   expect((profileA.value as any).avatar.cid).toEqual(uploadA.cid)
+  //   await updateProfile(bobAgent, {
+  //     displayName: 'Bob',
+  //     avatar: uploadB.blob,
+  //   })
+  //   const profileB = await bobAgent.api.app.bsky.actor.profile.get({
+  //     repo: bob.did,
+  //     rkey: 'self',
+  //   })
+  //   expect((profileB.value as any).avatar.cid).toEqual(uploadA.cid)
+  //   const { data: uploadAfterPermanent } =
+  //     await aliceAgent.api.com.atproto.repo.uploadBlob(file, {
+  //       encoding: 'image/jpeg',
+  //     } as any)
+  //   expect(uploadAfterPermanent).toEqual(uploadA)
+  //   const blob = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', uploadAfterPermanent.blob.ref.toString())
+  //     .executeTakeFirstOrThrow()
+  //   expect(blob.tempKey).toEqual(null)
+  // })
+
+  // it('supports compression during upload', async () => {
+  //   const { data: uploaded } = await aliceAgent.api.com.atproto.repo.uploadBlob(
+  //     gzipSync(smallFile),
+  //     {
+  //       encoding: 'image/jpeg',
+  //       headers: {
+  //         'content-encoding': 'gzip',
+  //       },
+  //     } as any,
+  //   )
+  //   expect(uploaded.blob.ref.equals(smallBlob.ref)).toBeTruthy()
+  // })
+
+  // it('corrects a bad mimetype', async () => {
+  //   const file = await fs.readFile(
+  //     'tests/image/fixtures/key-landscape-large.jpg',
+  //   )
+  //   const res = await aliceAgent.api.com.atproto.repo.uploadBlob(file, {
+  //     encoding: 'video/mp4',
+  //   } as any)
+
+  //   const found = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', res.data.blob.ref.toString())
+  //     .executeTakeFirst()
+
+  //   expect(found?.mimeType).toBe('image/jpeg')
+  //   expect(found?.width).toBe(1280)
+  //   expect(found?.height).toBe(742)
+  // })
+
+  // it('handles pngs', async () => {
+  //   const file = await fs.readFile('tests/image/fixtures/at.png')
+  //   const res = await aliceAgent.api.com.atproto.repo.uploadBlob(file, {
+  //     encoding: 'image/png',
+  //   })
+
+  //   const found = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', res.data.blob.ref.toString())
+  //     .executeTakeFirst()
+
+  //   expect(found?.mimeType).toBe('image/png')
+  //   expect(found?.width).toBe(554)
+  //   expect(found?.height).toBe(532)
+  // })
+
+  // it('handles unknown mimetypes', async () => {
+  //   const file = await randomBytes(20000)
+  //   const res = await aliceAgent.api.com.atproto.repo.uploadBlob(file, {
+  //     encoding: 'test/fake',
+  //   } as any)
+
+  //   const found = await db.db
+  //     .selectFrom('blob')
+  //     .selectAll()
+  //     .where('cid', '=', res.data.blob.ref.toString())
+  //     .executeTakeFirst()
+
+  //   expect(found?.mimeType).toBe('test/fake')
+  // })
+})
+
+async function updateProfile(agent: AtpAgent, record: Record<string, unknown>) {
+  return await agent.api.com.atproto.repo.putRecord({
+    repo: agent.session?.did ?? '',
+    collection: ids.AppBskyActorProfile,
+    rkey: 'self',
+    record,
+  })
+}

--- a/packages/pds/tests/rebase.test.ts
+++ b/packages/pds/tests/rebase.test.ts
@@ -9,7 +9,6 @@ describe('repo rebases', () => {
   let agent: AtpAgent
   let sc: SeedClient
   let alice: string
-  let bob: string
 
   let ctx: AppContext
 
@@ -28,13 +27,7 @@ describe('repo rebases', () => {
       handle: 'alice.test',
       password: 'alice-pass',
     })
-    await sc.createAccount('bob', {
-      email: 'bob@test.com',
-      handle: 'bob.test',
-      password: 'bob-pass',
-    })
     alice = sc.dids.alice
-    bob = sc.dids.bob
   })
 
   afterAll(async () => {
@@ -72,61 +65,14 @@ describe('repo rebases', () => {
     const contentsAfter = await after.repo.getContents()
     expect(contentsAfter).toEqual(contentsBefore)
     expect(after.repo.commit.prev).toBe(null)
-  })
-
-  it('handles blobs that have been rebased away', async () => {
-    const file1 = await sc.uploadFile(
-      alice,
-      'tests/image/fixtures/key-landscape-small.jpg',
-      'image/jpeg',
-    )
-    const file2 = await sc.uploadFile(
-      alice,
-      'tests/image/fixtures/key-portrait-small.jpg',
-      'image/jpeg',
-    )
-    const file3Alice = await sc.uploadFile(
-      alice,
-      'tests/image/fixtures/key-alt.jpg',
-      'image/jpeg',
-    )
-    const file3Bob = await sc.uploadFile(
-      bob,
-      'tests/image/fixtures/key-alt.jpg',
-      'image/jpeg',
-    )
-
-    const post1 = await sc.post(alice, 'first post', undefined, [file1])
-    await sc.post(alice, 'second post', undefined, [file2])
-    const post3 = await sc.post(alice, 'third post', undefined, [file3Alice])
-    await sc.post(bob, 'bob post', undefined, [file3Bob])
-    await sc.deletePost(alice, post1.ref.uri)
-    await sc.deletePost(alice, post3.ref.uri)
-
-    await ctx.db.transaction((dbTxn) =>
-      ctx.services.repo(dbTxn).rebaseRepo(alice, new Date().toISOString()),
-    )
 
     const repoBlobs = await ctx.db.db
       .selectFrom('repo_blob')
       .where('did', '=', alice)
       .selectAll()
       .execute()
-    const repoBlobCids = repoBlobs.map((row) => row.cid)
-    expect(repoBlobCids).toEqual([file2.image.ref.toString()])
-    const blobs = await ctx.db.db
-      .selectFrom('blob')
-      .where('creator', '=', alice)
-      .selectAll()
-      .execute()
-    const blobCids = blobs.map((row) => row.cid)
-
-    expect(blobCids).toEqual([file2.image.ref.toString()])
-    const has1 = await ctx.blobstore.hasStored(file1.image.ref)
-    expect(has1).toBe(false)
-    const has2 = await ctx.blobstore.hasStored(file2.image.ref)
-    expect(has2).toBe(true)
-    const has3 = await ctx.blobstore.hasStored(file3Bob.image.ref)
-    expect(has3).toBe(true)
+    expect(
+      repoBlobs.every((row) => row.commit === commitPath[0].tostring()),
+    ).toBeTruthy()
   })
 })


### PR DESCRIPTION
When a blob is dereferenced (no more records from that user pointing to it) during a commit, we remove the blob, delete it from the blobstore (if not shared with another user) & invalidate the blob in the cache.

You'll note that the rebase code as changed - we no longer need to do blob deletes in rebases because we do them proactively in deletes now.

This PR should be coupled with an app migration that deletes all existing dereferenced blobs