### PR TITLE
Add lily to contributors for sec disclosure

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,5 +4,8 @@ ATProto receives so many contributions that we could never list everyone who des
 
 ### The AT Protocol maintainers give their thanks to:
 
-#### [rmcan](https://github.com/rmcan) Security disclosure, April 2023
-#### [ianklatzco](https://github.com/ianklatzco) Security disclosure, April 2023
+#### [rmcan](https://github.com/rmcan), Security disclosure, April 2023
+
+#### [ianklatzco](https://github.com/ianklatzco), Security disclosure, April 2023
+
+#### lily, Security disclosure, May 2023


### PR DESCRIPTION
Adding lily to contrib for a security disclosure.  I added a small amount of extra formatting (a comma) to help distinguish names of folks that aren't linked anywhere.