### PR TITLE
chore: update docker/setup-buildx-action github action to v2

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2

--- a/.github/workflows/build-and-push-bsky-ghcr.yaml
+++ b/.github/workflows/build-and-push-bsky-ghcr.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2

--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2


### PR DESCRIPTION
Updates github action docker/setup-buildx-action from v1 to v2 which
 - [moves Node 12 to Node 16](https://github.com/docker/setup-buildx-action/pull/131)
 - [stops using the setOutput workaround](https://github.com/docker/setup-buildx-action/pull/170)
 
 which gets rid of some of these annoying annotation warnings during the build pipeline:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: docker/setup-buildx-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
```

&

```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```