### PR TITLE
moderation action 'escalate' type

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -70,7 +70,8 @@
       "knownValues": [
         "#takedown",
         "#flag",
-        "#acknowledge"
+        "#acknowledge",
+        "#escalate"
       ]
     },
     "takedown": {
@@ -84,6 +85,10 @@
     "acknowledge": {
       "type": "token",
       "description": "Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules."
+    },
+    "escalate": {
+      "type": "token",
+      "description": "Moderation action type: Escalate. Indicates that the content has been flagged for additional review."
     },
     "reportView": {
       "type": "object",

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -201,6 +201,7 @@ export const COM_ATPROTO_ADMIN = {
   DefsTakedown: 'com.atproto.admin.defs#takedown',
   DefsFlag: 'com.atproto.admin.defs#flag',
   DefsAcknowledge: 'com.atproto.admin.defs#acknowledge',
+  DefsEscalate: 'com.atproto.admin.defs#escalate',
 }
 export const COM_ATPROTO_MODERATION = {
   DefsReasonSpam: 'com.atproto.moderation.defs#reasonSpam',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -182,6 +182,7 @@ export const schemaDict = {
           'lex:com.atproto.admin.defs#takedown',
           'lex:com.atproto.admin.defs#flag',
           'lex:com.atproto.admin.defs#acknowledge',
+          'lex:com.atproto.admin.defs#escalate',
         ],
       },
       takedown: {
@@ -198,6 +199,11 @@ export const schemaDict = {
         type: 'token',
         description:
           'Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules.',
+      },
+      escalate: {
+        type: 'token',
+        description:
+          'Moderation action type: Escalate. Indicates that the content has been flagged for additional review.',
       },
       reportView: {
         type: 'object',

--- a/packages/api/src/client/types/com/atproto/admin/defs.ts
+++ b/packages/api/src/client/types/com/atproto/admin/defs.ts
@@ -108,6 +108,7 @@ export type ActionType =
   | 'lex:com.atproto.admin.defs#takedown'
   | 'lex:com.atproto.admin.defs#flag'
   | 'lex:com.atproto.admin.defs#acknowledge'
+  | 'lex:com.atproto.admin.defs#escalate'
   | (string & {})
 
 /** Moderation action type: Takedown. Indicates that content should not be served by the PDS. */
@@ -116,6 +117,8 @@ export const TAKEDOWN = 'com.atproto.admin.defs#takedown'
 export const FLAG = 'com.atproto.admin.defs#flag'
 /** Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules. */
 export const ACKNOWLEDGE = 'com.atproto.admin.defs#acknowledge'
+/** Moderation action type: Escalate. Indicates that the content has been flagged for additional review. */
+export const ESCALATE = 'com.atproto.admin.defs#escalate'
 
 export interface ReportView {
   id: number

--- a/packages/bsky/src/api/com/atproto/moderation/util.ts
+++ b/packages/bsky/src/api/com/atproto/moderation/util.ts
@@ -9,6 +9,7 @@ import {
   ACKNOWLEDGE,
   FLAG,
   TAKEDOWN,
+  ESCALATE,
 } from '../../../../lexicon/types/com/atproto/admin/defs'
 import {
   REASONOTHER,
@@ -49,7 +50,7 @@ export const getReasonType = (reasonType: ReportInput['reasonType']) => {
 }
 
 export const getAction = (action: ActionInput['action']) => {
-  if (action === TAKEDOWN || action === FLAG || action === ACKNOWLEDGE) {
+  if (action === TAKEDOWN || action === FLAG || action === ACKNOWLEDGE || action === ESCALATE) { 
     return action as ModerationAction['action']
   }
   throw new InvalidRequestError('Invalid action')

--- a/packages/bsky/src/db/tables/moderation.ts
+++ b/packages/bsky/src/db/tables/moderation.ts
@@ -3,6 +3,7 @@ import {
   ACKNOWLEDGE,
   FLAG,
   TAKEDOWN,
+  ESCALATE,
 } from '../../lexicon/types/com/atproto/admin/defs'
 import {
   REASONOTHER,
@@ -20,7 +21,7 @@ export const reportResolutionTableName = 'moderation_report_resolution'
 
 export interface ModerationAction {
   id: Generated<number>
-  action: typeof TAKEDOWN | typeof FLAG | typeof ACKNOWLEDGE
+  action: typeof TAKEDOWN | typeof FLAG | typeof ACKNOWLEDGE | typeof ESCALATE
   subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.strongRef'
   subjectDid: string
   subjectUri: string | null

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -90,6 +90,7 @@ export const COM_ATPROTO_ADMIN = {
   DefsTakedown: 'com.atproto.admin.defs#takedown',
   DefsFlag: 'com.atproto.admin.defs#flag',
   DefsAcknowledge: 'com.atproto.admin.defs#acknowledge',
+  DefsEscalate: 'com.atproto.admin.defs#escalate',
 }
 export const COM_ATPROTO_MODERATION = {
   DefsReasonSpam: 'com.atproto.moderation.defs#reasonSpam',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -182,6 +182,7 @@ export const schemaDict = {
           'lex:com.atproto.admin.defs#takedown',
           'lex:com.atproto.admin.defs#flag',
           'lex:com.atproto.admin.defs#acknowledge',
+          'lex:com.atproto.admin.defs#escalate',
         ],
       },
       takedown: {
@@ -198,6 +199,11 @@ export const schemaDict = {
         type: 'token',
         description:
           'Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules.',
+      },
+      escalate: {
+        type: 'token',
+        description:
+          'Moderation action type: Escalate. Indicates that the content has been flagged for additional review.',
       },
       reportView: {
         type: 'object',
@@ -5076,6 +5082,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            includeNsfw: {
+              type: 'boolean',
+              default: false,
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopular.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopular.ts
@@ -10,6 +10,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  includeNsfw: boolean
   limit: number
   cursor?: string
 }

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
@@ -108,6 +108,7 @@ export type ActionType =
   | 'lex:com.atproto.admin.defs#takedown'
   | 'lex:com.atproto.admin.defs#flag'
   | 'lex:com.atproto.admin.defs#acknowledge'
+  | 'lex:com.atproto.admin.defs#escalate'
   | (string & {})
 
 /** Moderation action type: Takedown. Indicates that content should not be served by the PDS. */
@@ -116,6 +117,8 @@ export const TAKEDOWN = 'com.atproto.admin.defs#takedown'
 export const FLAG = 'com.atproto.admin.defs#flag'
 /** Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules. */
 export const ACKNOWLEDGE = 'com.atproto.admin.defs#acknowledge'
+/** Moderation action type: Escalate. Indicates that the content has been flagged for additional review. */
+export const ESCALATE = 'com.atproto.admin.defs#escalate'
 
 export interface ReportView {
   id: number

--- a/packages/pds/src/api/com/atproto/moderation/util.ts
+++ b/packages/pds/src/api/com/atproto/moderation/util.ts
@@ -8,6 +8,7 @@ import {
   ACKNOWLEDGE,
   FLAG,
   TAKEDOWN,
+  ESCALATE,
 } from '../../../../lexicon/types/com/atproto/admin/defs'
 import {
   REASONOTHER,
@@ -49,7 +50,7 @@ export const getReasonType = (reasonType: ReportInput['reasonType']) => {
 }
 
 export const getAction = (action: ActionInput['action']) => {
-  if (action === TAKEDOWN || action === FLAG || action === ACKNOWLEDGE) {
+  if (action === TAKEDOWN || action === FLAG || action === ACKNOWLEDGE || action === ESCALATE) {
     return action as ModerationAction['action']
   }
   throw new InvalidRequestError('Invalid action')

--- a/packages/pds/src/db/tables/moderation.ts
+++ b/packages/pds/src/db/tables/moderation.ts
@@ -3,6 +3,7 @@ import {
   ACKNOWLEDGE,
   FLAG,
   TAKEDOWN,
+  ESCALATE,
 } from '../../lexicon/types/com/atproto/admin/defs'
 import {
   REASONOTHER,
@@ -20,7 +21,7 @@ export const reportResolutionTableName = 'moderation_report_resolution'
 
 export interface ModerationAction {
   id: Generated<number>
-  action: typeof TAKEDOWN | typeof FLAG | typeof ACKNOWLEDGE
+  action: typeof TAKEDOWN | typeof FLAG | typeof ACKNOWLEDGE | typeof ESCALATE
   subjectType: 'com.atproto.admin.defs#repoRef' | 'com.atproto.repo.strongRef'
   subjectDid: string
   subjectUri: string | null

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -90,6 +90,7 @@ export const COM_ATPROTO_ADMIN = {
   DefsTakedown: 'com.atproto.admin.defs#takedown',
   DefsFlag: 'com.atproto.admin.defs#flag',
   DefsAcknowledge: 'com.atproto.admin.defs#acknowledge',
+  DefsEscalate: 'com.atproto.admin.defs#escalate',
 }
 export const COM_ATPROTO_MODERATION = {
   DefsReasonSpam: 'com.atproto.moderation.defs#reasonSpam',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -182,6 +182,7 @@ export const schemaDict = {
           'lex:com.atproto.admin.defs#takedown',
           'lex:com.atproto.admin.defs#flag',
           'lex:com.atproto.admin.defs#acknowledge',
+          'lex:com.atproto.admin.defs#escalate',
         ],
       },
       takedown: {
@@ -198,6 +199,11 @@ export const schemaDict = {
         type: 'token',
         description:
           'Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules.',
+      },
+      escalate: {
+        type: 'token',
+        description:
+          'Moderation action type: Escalate. Indicates that the content has been flagged for additional review.',
       },
       reportView: {
         type: 'object',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
@@ -108,6 +108,7 @@ export type ActionType =
   | 'lex:com.atproto.admin.defs#takedown'
   | 'lex:com.atproto.admin.defs#flag'
   | 'lex:com.atproto.admin.defs#acknowledge'
+  | 'lex:com.atproto.admin.defs#escalate'
   | (string & {})
 
 /** Moderation action type: Takedown. Indicates that content should not be served by the PDS. */
@@ -116,6 +117,8 @@ export const TAKEDOWN = 'com.atproto.admin.defs#takedown'
 export const FLAG = 'com.atproto.admin.defs#flag'
 /** Moderation action type: Acknowledge. Indicates that the content was reviewed and not considered to violate PDS rules. */
 export const ACKNOWLEDGE = 'com.atproto.admin.defs#acknowledge'
+/** Moderation action type: Escalate. Indicates that the content has been flagged for additional review. */
+export const ESCALATE = 'com.atproto.admin.defs#escalate'
 
 export interface ReportView {
   id: number


### PR DESCRIPTION
Motivation is to enable smoother moderation escalation workflow entirely within redsky (without using an external spreadsheet for escalations).

This is the first time I have tried to do codegen in typescript. I ran `yarn codegen` in the pds, api, and bsky packages, and then basically just grep'd for other action types and updated code to match. I may have missed some files, and haven't added any specific tests.