### PR TITLE
Do not filter on negative labels on getPopular

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -41,6 +41,7 @@ export default function (server: Server, ctx: AppContext) {
             .selectFrom('label')
             .selectAll()
             .where('val', 'in', labelsToFilter)
+            .where('neg', '=', 0)
             .where((clause) =>
               clause
                 .whereRef('label.uri', '=', ref('post.creator'))


### PR DESCRIPTION
These are redacted labels that still have a row in the DB