### PR TITLE
fix: updated repository field for packages

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,11 @@
     "test": "jest"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/api"
+  },
   "dependencies": {
     "@atproto/common-web": "*",
     "@atproto/uri": "*",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.1",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/aws"
+  },
   "scripts": {
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -2,7 +2,11 @@
   "name": "@atproto/bsky",
   "version": "0.0.0",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/bsky"
+  },
   "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {

--- a/packages/common-web/package.json
+++ b/packages/common-web/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/common-web"
+  },
   "scripts": {
     "test": "jest",
     "prettier": "prettier --check src/",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,11 @@
   "version": "0.2.0",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/common"
+  },
   "scripts": {
     "test": "jest",
     "prettier": "prettier --check src/",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.1",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/crypto"
+  },
   "scripts": {
     "test": "jest ",
     "prettier": "prettier --check src/",

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -4,7 +4,11 @@
   "main": "src/test-env.ts",
   "bin": "dist/cli.js",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/dev-env"
+  },
   "scripts": {
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.1",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/did-resolver"
+  },
   "scripts": {
     "test": "jest",
     "test:log": "cat test.log | pino-pretty",

--- a/packages/identifier/package.json
+++ b/packages/identifier/package.json
@@ -18,7 +18,11 @@
     "postpublish": "npm run update-main-to-src"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/identifier"
+  },
   "dependencies": {
     "@atproto/common-web": "*"
   },

--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -16,7 +16,11 @@
     "postbuild": "tsc --build tsconfig.build.json"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/lex-cli"
+  },
   "dependencies": {
     "@atproto/lexicon": "*",
     "@atproto/nsid": "*",

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -18,7 +18,11 @@
     "postpublish": "npm run update-main-to-src"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/lexicon"
+  },
   "dependencies": {
     "@atproto/common-web": "*",
     "@atproto/identifier": "*",

--- a/packages/nsid/package.json
+++ b/packages/nsid/package.json
@@ -14,6 +14,10 @@
     "postbuild": "tsc --build tsconfig.build.json"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/nsid"
+  },
   "dependencies": {}
 }

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -2,7 +2,11 @@
   "name": "@atproto/pds",
   "version": "0.1.5",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/pds"
+  },
   "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "main": "src/index.ts",
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/repo"
+  },
   "scripts": {
     "test": "jest",
     "test:profile": "node --inspect ../../node_modules/.bin/jest",

--- a/packages/uri/package.json
+++ b/packages/uri/package.json
@@ -18,7 +18,11 @@
     "postpublish": "npm run update-main-to-src"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/uri"
+  },
   "dependencies": {
     "@atproto/identifier": "*",
     "@atproto/nsid": "*"

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -18,7 +18,11 @@
     "postpublish": "npm run update-main-to-src"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/xrpc-server"
+  },
   "dependencies": {
     "@atproto/common": "*",
     "@atproto/lexicon": "*",

--- a/packages/xrpc/package.json
+++ b/packages/xrpc/package.json
@@ -17,7 +17,11 @@
     "postpublish": "npm run update-main-to-src"
   },
   "license": "MIT",
-  "repository": "git@github.com:bluesky-social/atproto.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto.git",
+    "directory": "packages/xrpc"
+  },
   "dependencies": {
     "@atproto/lexicon": "*",
     "zod": "^3.14.2"


### PR DESCRIPTION
Swapped in the format which allows for specifying a subdirectory in a monorepo. This should help the npm website link to the right place.