### PR TITLE
pds: place-holder robots.txt, and a text base-level route (/)

### DIFF
--- a/packages/pds/src/api/index.ts
+++ b/packages/pds/src/api/index.ts
@@ -3,8 +3,6 @@ import comAtproto from './com/atproto'
 import appBsky from './app/bsky'
 import AppContext from '../context'
 
-export * as health from './health'
-
 export default function (server: Server, ctx: AppContext) {
   comAtproto(server, ctx)
   appBsky(server, ctx)

--- a/packages/pds/src/basic-routes.ts
+++ b/packages/pds/src/basic-routes.ts
@@ -1,9 +1,23 @@
 import express from 'express'
 import { sql } from 'kysely'
-import AppContext from '../context'
+import AppContext from './context'
 
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
+
+  router.get('/', function (req, res) {
+    res.type('text/plain')
+    res.send(
+      'This is an AT Protocol Personal Data Server (PDS): https://github.com/bluesky-social/atproto\n\nMost API routes are under /xrpc/',
+    )
+  })
+
+  router.get('/robots.txt', function (req, res) {
+    res.type('text/plain')
+    res.send(
+      '# Hello!\n\n# Crawling the public API is allowed\nUser-agent: *\nAllow: /',
+    )
+  })
 
   router.get('/xrpc/_health', async function (req, res) {
     const { version } = ctx.cfg

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -186,6 +186,18 @@ export class PDS {
     }
 
     app.use(health.createRouter(ctx))
+    app.get('/', function (req, res) {
+      res.type('text/plain')
+      res.send(
+        'This is an AT Protocol Personal Data Server (PDS): https://github.com/bluesky-social/atproto\n\nMost API routes are under /xrpc/',
+      )
+    })
+    app.get('/robots.txt', function (req, res) {
+      res.type('text/plain')
+      res.send(
+        '# Hello!\n\n# Crawling the public API is allowed\nUser-agent: *\nAllow: /',
+      )
+    })
     app.use(server.xrpc.router)
     app.use(error.handler)
 

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -14,7 +14,8 @@ import { BlobStore } from '@atproto/repo'
 import { AppViewIndexer } from './app-view/indexer'
 import inProcessAppView from './app-view/api'
 import proxiedAppView from './app-view/proxied'
-import API, { health } from './api'
+import API from './api'
+import * as basicRoutes from './basic-routes'
 import Database from './db'
 import { ServerAuth } from './auth'
 import * as error from './error'
@@ -185,19 +186,7 @@ export class PDS {
       server = inProcessAppView(server, ctx)
     }
 
-    app.use(health.createRouter(ctx))
-    app.get('/', function (req, res) {
-      res.type('text/plain')
-      res.send(
-        'This is an AT Protocol Personal Data Server (PDS): https://github.com/bluesky-social/atproto\n\nMost API routes are under /xrpc/',
-      )
-    })
-    app.get('/robots.txt', function (req, res) {
-      res.type('text/plain')
-      res.send(
-        '# Hello!\n\n# Crawling the public API is allowed\nUser-agent: *\nAllow: /',
-      )
-    })
+    app.use(basicRoutes.createRouter(ctx))
     app.use(server.xrpc.router)
     app.use(error.handler)
 


### PR DESCRIPTION
robots.txt: want to be explicit about allowing public crawling

/: a bit of dev-experience polish. in prod we already redirect this route, but may be helpful for self-hosting folks and people just exploring