### PR TITLE
Clean up what's hot

### DIFF
--- a/packages/bsky/src/services/label/index.ts
+++ b/packages/bsky/src/services/label/index.ts
@@ -3,13 +3,8 @@ import Database from '../../db'
 import { Label } from '../../lexicon/types/com/atproto/label/defs'
 import { ids } from '../../lexicon/lexicons'
 import { sql } from 'kysely'
-import { NotEmptyArray } from '@atproto/common'
 
 export type Labels = Record<string, Label[]>
-
-// @TODO forward these labels to client
-// these are labels are currently only used server side & not sent to client since it does not handle them correctly
-const SERVER_SIDE_LABELS: NotEmptyArray<string> = ['!no-promote']
 
 export class LabelService {
   constructor(public db: Database) {}
@@ -73,7 +68,6 @@ export class LabelService {
     const res = await this.db.db
       .selectFrom('label')
       .where('label.uri', 'in', subjects)
-      .where('label.val', 'not in', SERVER_SIDE_LABELS)
       .if(!includeNeg, (qb) => qb.where('neg', '=', false))
       .selectAll()
       .execute()

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -65,7 +65,6 @@ export default function (server: Server, ctx: AppContext) {
       feedQb = paginate(feedQb, { limit, cursor, keyset })
 
       const feedItems: FeedRow[] = await feedQb.execute()
-      // console.log(feedItems)
       const feed: FeedViewPost[] = await composeFeed(
         feedService,
         labelService,

--- a/packages/pds/src/app-view/services/label/index.ts
+++ b/packages/pds/src/app-view/services/label/index.ts
@@ -3,13 +3,8 @@ import Database from '../../../db'
 import { Label } from '../../../lexicon/types/com/atproto/label/defs'
 import { ids } from '../../../lexicon/lexicons'
 import { sql } from 'kysely'
-import { NotEmptyArray } from '@atproto/common'
 
 export type Labels = Record<string, Label[]>
-
-// @TODO forward these labels to client
-// these are labels are currently only used server side & not sent to client since it does not handle them correctly
-const SERVER_SIDE_LABELS: NotEmptyArray<string> = ['!no-promote']
 
 export class LabelService {
   constructor(public db: Database) {}
@@ -73,7 +68,6 @@ export class LabelService {
     const res = await this.db.db
       .selectFrom('label')
       .where('label.uri', 'in', subjects)
-      .where('label.val', 'not in', SERVER_SIDE_LABELS)
       .if(!includeNeg, (qb) => qb.where('neg', '=', 0))
       .selectAll()
       .execute()

--- a/packages/pds/src/labeler/hive.ts
+++ b/packages/pds/src/labeler/hive.ts
@@ -129,6 +129,14 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
       return ['nudity']
     }
   }
+
+  // as a stop gap, we label underwear posts as !no-promote to keep them out of what's hot
+  for (const nudityClass of ['yes_male_underwear', 'yes_female_underwear']) {
+    if (scores[nudityClass] >= 0.9) {
+      return ['!no-promote']
+    }
+  }
+
   return []
 }
 

--- a/packages/pds/src/labeler/hive.ts
+++ b/packages/pds/src/labeler/hive.ts
@@ -133,7 +133,7 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
   // as a stop gap, we label underwear posts as !no-promote to keep them out of what's hot
   for (const nudityClass of ['yes_male_underwear', 'yes_female_underwear']) {
     if (scores[nudityClass] >= 0.9) {
-      return ['!no-promote']
+      return ['underwear']
     }
   }
 

--- a/packages/pds/tests/views/popular.test.ts
+++ b/packages/pds/tests/views/popular.test.ts
@@ -89,7 +89,7 @@ describe('popular views', () => {
       { headers: sc.getHeaders(alice) },
     )
     const feedUris = res.data.feed.map((i) => i.post.uri).sort()
-    const expected = [one.ref.uriStr, two.ref.uriStr, three.ref.uriStr].sort()
+    const expected = [one.ref.uriStr, two.ref.uriStr].sort()
     expect(feedUris).toEqual(expected)
   })
 


### PR DESCRIPTION
Generally trying to reduce nsfw & raunchy material in what's hot, we apply 3 fixes:
- no longer serve replies
- ensure we filter quote posts that don't pass our filters
- label underwear photos & strip underwear & nudity from what's hot

I also updated our labeling service to accurately return `!no-promote` labels