### PR TITLE
Add indexes to support account deletion

### DIFF
--- a/packages/pds/src/app-view/services/indexing/index.ts
+++ b/packages/pds/src/app-view/services/indexing/index.ts
@@ -110,9 +110,5 @@ export class IndexingService {
     await this.db.db.deleteFrom('profile').where('creator', '=', did).execute()
     await this.db.db.deleteFrom('repost').where('creator', '=', did).execute()
     await this.db.db.deleteFrom('like').where('creator', '=', did).execute()
-    await this.db.db
-      .deleteFrom('actor_block')
-      .where('creator', '=', did)
-      .execute()
   }
 }

--- a/packages/pds/src/db/migrations/20230508T193807762Z-acct-deletion-indexes.ts
+++ b/packages/pds/src/db/migrations/20230508T193807762Z-acct-deletion-indexes.ts
@@ -1,0 +1,49 @@
+import { Kysely } from 'kysely'
+import { Dialect } from '..'
+
+// Indexes to support efficient account deletion
+
+export async function up(db: Kysely<unknown>, dialect: Dialect): Promise<void> {
+  await db.schema // Also supports record deletes
+    .createIndex('duplicate_record_duplicate_of_idx')
+    .on('duplicate_record')
+    .column('duplicateOf')
+    .execute()
+  await db.schema
+    .createIndex('like_creator_idx')
+    .on('like')
+    .column('creator')
+    .execute()
+  await db.schema
+    .createIndex('user_notification_author_idx')
+    .on('user_notification')
+    .column('author')
+    .execute()
+  if (dialect !== 'sqlite') {
+    // We want to keep record of the moderations actions even when deleting the underlying repo_blob record.
+    await db.schema
+      .alterTable('moderation_action_subject_blob')
+      .dropConstraint('moderation_action_subject_blob_repo_blob_fkey')
+      .execute()
+  }
+}
+
+export async function down(
+  db: Kysely<unknown>,
+  dialect: Dialect,
+): Promise<void> {
+  if (dialect !== 'sqlite') {
+    await db.schema
+      .alterTable('moderation_action_subject_blob')
+      .addForeignKeyConstraint(
+        'moderation_action_subject_blob_repo_blob_fkey',
+        ['cid', 'recordUri'],
+        'repo_blob',
+        ['cid', 'recordUri'],
+      )
+      .execute()
+  }
+  await db.schema.dropIndex('user_notification_author_idx').execute()
+  await db.schema.dropIndex('like_creator_idx').execute()
+  await db.schema.dropIndex('duplicate_record_duplicate_of_idx').execute()
+}

--- a/packages/pds/src/db/migrations/20230508T193807762Z-acct-deletion-indexes.ts
+++ b/packages/pds/src/db/migrations/20230508T193807762Z-acct-deletion-indexes.ts
@@ -4,6 +4,7 @@ import { Dialect } from '..'
 // Indexes to support efficient account deletion
 
 export async function up(db: Kysely<unknown>, dialect: Dialect): Promise<void> {
+  /* Temporarily skipping index creation, will re-enable asap
   await db.schema // Also supports record deletes
     .createIndex('duplicate_record_duplicate_of_idx')
     .on('duplicate_record')
@@ -19,6 +20,7 @@ export async function up(db: Kysely<unknown>, dialect: Dialect): Promise<void> {
     .on('user_notification')
     .column('author')
     .execute()
+  */
   if (dialect !== 'sqlite') {
     // We want to keep record of the moderations actions even when deleting the underlying repo_blob record.
     await db.schema
@@ -43,7 +45,9 @@ export async function down(
       )
       .execute()
   }
+  /* Temporarily skipping index creation, will re-enable asap
   await db.schema.dropIndex('user_notification_author_idx').execute()
   await db.schema.dropIndex('like_creator_idx').execute()
   await db.schema.dropIndex('duplicate_record_duplicate_of_idx').execute()
+  */
 }

--- a/packages/pds/src/db/migrations/index.ts
+++ b/packages/pds/src/db/migrations/index.ts
@@ -43,3 +43,4 @@ export * as _20230416T221236745Z from './20230416T221236745Z-app-specific-passwo
 export * as _20230420T143821201Z from './20230420T143821201Z-post-profile-aggs'
 export * as _20230427T194652255Z from './20230427T194652255Z-notif-record-index'
 export * as _20230428T195614638Z from './20230428T195614638Z-actor-block-init'
+export * as _20230508T193807762Z from './20230508T193807762Z-acct-deletion-indexes'


### PR DESCRIPTION
Just a headsup—going to land this temporarily skipping the index creation for _reasons_, then will re-enable it.

Here's the sql for the index creation:
```
    create index "duplicate_record_duplicate_of_idx" on "duplicate_record" ("duplicateOf")
    create index "like_creator_idx" on "like" ("creator")
    create index "user_notification_author_idx" on "user_notification" ("author")
```