### PR TITLE
Fix indexed record datetimes

### DIFF
--- a/packages/bsky/src/services/indexing/plugins/follow.ts
+++ b/packages/bsky/src/services/indexing/plugins/follow.ts
@@ -5,6 +5,7 @@ import * as Follow from '../../../lexicon/types/app/bsky/graph/follow'
 import * as lex from '../../../lexicon/lexicons'
 import { DatabaseSchema, DatabaseSchemaType } from '../../../db/database-schema'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyGraphFollow
 type IndexedFollow = Selectable<DatabaseSchemaType['follow']>
@@ -23,7 +24,7 @@ const insertFn = async (
       cid: cid.toString(),
       creator: uri.host,
       subjectDid: obj.subject,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/bsky/src/services/indexing/plugins/like.ts
+++ b/packages/bsky/src/services/indexing/plugins/like.ts
@@ -5,6 +5,7 @@ import * as Like from '../../../lexicon/types/app/bsky/feed/like'
 import * as lex from '../../../lexicon/lexicons'
 import { DatabaseSchema, DatabaseSchemaType } from '../../../db/database-schema'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyFeedLike
 type IndexedLike = Selectable<DatabaseSchemaType['like']>
@@ -24,7 +25,7 @@ const insertFn = async (
       creator: uri.host,
       subject: obj.subject.uri,
       subjectCid: obj.subject.cid,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/bsky/src/services/indexing/plugins/post.ts
+++ b/packages/bsky/src/services/indexing/plugins/post.ts
@@ -15,6 +15,7 @@ import { DatabaseSchema, DatabaseSchemaType } from '../../../db/database-schema'
 import RecordProcessor from '../processor'
 import { PostHierarchy } from '../../../db/tables/post-hierarchy'
 import { Notification } from '../../../db/tables/notification'
+import { toSimplifiedISOSafe } from '../util'
 
 type Notif = Insertable<Notification>
 type Post = Selectable<DatabaseSchemaType['post']>
@@ -43,7 +44,7 @@ const insertFn = async (
     cid: cid.toString(),
     creator: uri.host,
     text: obj.text,
-    createdAt: obj.createdAt,
+    createdAt: toSimplifiedISOSafe(obj.createdAt),
     replyRoot: obj.reply?.root?.uri || null,
     replyRootCid: obj.reply?.root?.cid || null,
     replyParent: obj.reply?.parent?.uri || null,

--- a/packages/bsky/src/services/indexing/plugins/repost.ts
+++ b/packages/bsky/src/services/indexing/plugins/repost.ts
@@ -5,6 +5,7 @@ import * as Repost from '../../../lexicon/types/app/bsky/feed/repost'
 import * as lex from '../../../lexicon/lexicons'
 import { DatabaseSchema, DatabaseSchemaType } from '../../../db/database-schema'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyFeedRepost
 type IndexedRepost = Selectable<DatabaseSchemaType['repost']>
@@ -22,7 +23,7 @@ const insertFn = async (
     creator: uri.host,
     subject: obj.subject.uri,
     subjectCid: obj.subject.cid,
-    createdAt: obj.createdAt,
+    createdAt: toSimplifiedISOSafe(obj.createdAt),
     indexedAt: timestamp,
   }
   const [inserted] = await Promise.all([

--- a/packages/bsky/src/services/indexing/util.ts
+++ b/packages/bsky/src/services/indexing/util.ts
@@ -1,0 +1,9 @@
+// Normalize date strings to simplified ISO so that the lexical sort preserves temporal sort.
+// Rather than failing on an invalid date format, returns valid unix epoch.
+export function toSimplifiedISOSafe(dateStr: string) {
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) {
+    return new Date(0).toISOString()
+  }
+  return date.toISOString() // YYYY-MM-DDTHH:mm:ss.sssZ
+}

--- a/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
@@ -164,7 +164,7 @@ Array [
             "likeCount": 3,
             "record": Object {
               "$type": "app.bsky.feed.post",
-              "createdAt": "1970-01-01T00:00:00.000Z",
+              "createdAt": "1970-01-01T00:00:00.000000Z",
               "text": "again",
             },
             "replyCount": 2,
@@ -332,7 +332,7 @@ Array [
           "likeCount": 3,
           "record": Object {
             "$type": "app.bsky.feed.post",
-            "createdAt": "1970-01-01T00:00:00.000Z",
+            "createdAt": "1970-01-01T00:00:00.000000Z",
             "text": "again",
           },
           "replyCount": 2,

--- a/packages/bsky/tests/_util.ts
+++ b/packages/bsky/tests/_util.ts
@@ -60,7 +60,13 @@ export const forSnapshot = (obj: unknown) => {
       return take(unknown, str)
     }
     if (str.match(/^\d{4}-\d{2}-\d{2}T/)) {
-      return constantDate
+      if (str.match(/\d{6}Z$/)) {
+        return constantDate.replace('Z', '000Z') // e.g. microseconds in record createdAt
+      } else if (str.endsWith('+00:00')) {
+        return constantDate.replace('Z', '+00:00') // e.g. timezone in record createdAt
+      } else {
+        return constantDate
+      }
     }
     if (str.match(/^\d+::bafy/)) {
       return constantKeysetCursor

--- a/packages/bsky/tests/seeds/basic.ts
+++ b/packages/bsky/tests/seeds/basic.ts
@@ -9,14 +9,20 @@ export default async (sc: SeedClient, users = true) => {
   const bob = sc.dids.bob
   const carol = sc.dids.carol
   const dan = sc.dids.dan
+  const createdAtMicroseconds = () => ({
+    createdAt: new Date().toISOString().replace('Z', '000Z'), // microseconds
+  })
+  const createdAtTimezone = () => ({
+    createdAt: new Date().toISOString().replace('Z', '+00:00'), // iso timezone format
+  })
 
   await sc.follow(alice, bob)
   await sc.follow(alice, carol)
   await sc.follow(alice, dan)
   await sc.follow(carol, alice)
   await sc.follow(bob, alice)
-  await sc.follow(bob, carol)
-  await sc.follow(dan, bob)
+  await sc.follow(bob, carol, createdAtMicroseconds())
+  await sc.follow(dan, bob, createdAtTimezone())
   await sc.post(alice, posts.alice[0])
   await sc.post(bob, posts.bob[0])
   const img1 = await sc.uploadFile(
@@ -54,8 +60,22 @@ export default async (sc: SeedClient, users = true) => {
     undefined,
     sc.posts[carol][0].ref, // This post contains an images embed
   )
-  await sc.post(alice, posts.alice[1])
-  await sc.post(bob, posts.bob[1])
+  await sc.post(
+    alice,
+    posts.alice[1],
+    undefined,
+    undefined,
+    undefined,
+    createdAtMicroseconds(),
+  )
+  await sc.post(
+    bob,
+    posts.bob[1],
+    undefined,
+    undefined,
+    undefined,
+    createdAtTimezone(),
+  )
   await sc.post(
     alice,
     posts.alice[2],
@@ -68,8 +88,8 @@ export default async (sc: SeedClient, users = true) => {
   await sc.like(carol, sc.posts[alice][1].ref)
   await sc.like(carol, sc.posts[alice][2].ref)
   await sc.like(dan, sc.posts[alice][1].ref)
-  await sc.like(alice, sc.posts[carol][0].ref)
-  await sc.like(bob, sc.posts[carol][0].ref)
+  await sc.like(alice, sc.posts[carol][0].ref, createdAtMicroseconds())
+  await sc.like(bob, sc.posts[carol][0].ref, createdAtTimezone())
 
   const replyImg = await sc.uploadFile(
     bob,

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -131,7 +131,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -304,7 +304,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -439,7 +439,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -467,7 +467,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -495,7 +495,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -742,7 +742,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -770,7 +770,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -907,7 +907,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1236,7 +1236,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1414,7 +1414,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
@@ -40,7 +40,7 @@ Array [
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/bsky/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/thread.test.ts.snap
@@ -25,7 +25,7 @@ Object {
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -178,7 +178,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -374,7 +374,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -818,7 +818,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -977,7 +977,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -18,7 +18,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -184,7 +184,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -317,7 +317,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -424,7 +424,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -447,7 +447,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -524,7 +524,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -549,7 +549,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -792,7 +792,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1124,7 +1124,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1185,7 +1185,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1208,7 +1208,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1314,7 +1314,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1337,7 +1337,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1522,7 +1522,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -1547,7 +1547,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -2252,7 +2252,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2317,7 +2317,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2345,7 +2345,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2453,7 +2453,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2481,7 +2481,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2669,7 +2669,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -2697,7 +2697,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3206,7 +3206,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3269,7 +3269,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3297,7 +3297,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3484,7 +3484,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3666,7 +3666,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3785,7 +3785,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3813,7 +3813,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3844,7 +3844,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,

--- a/packages/pds/src/app-view/services/indexing/plugins/block.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/block.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../db/database-schema'
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyGraphBlock
 type IndexedBlock = DatabaseSchemaType['actor_block']
@@ -27,7 +28,7 @@ const insertFn = async (
       cid: cid.toString(),
       creator: uri.host,
       subjectDid: obj.subject,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/pds/src/app-view/services/indexing/plugins/follow.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/follow.ts
@@ -10,6 +10,7 @@ import {
 import { countAll, excluded } from '../../../../db/util'
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyGraphFollow
 type IndexedFollow = DatabaseSchemaType['follow']
@@ -28,7 +29,7 @@ const insertFn = async (
       cid: cid.toString(),
       creator: uri.host,
       subjectDid: obj.subject,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/pds/src/app-view/services/indexing/plugins/like.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/like.ts
@@ -10,6 +10,7 @@ import {
 import { countAll, excluded } from '../../../../db/util'
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyFeedLike
 type IndexedLike = DatabaseSchemaType['like']
@@ -29,7 +30,7 @@ const insertFn = async (
       creator: uri.host,
       subject: obj.subject.uri,
       subjectCid: obj.subject.cid,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/pds/src/app-view/services/indexing/plugins/post.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/post.ts
@@ -21,6 +21,7 @@ import RecordProcessor from '../processor'
 import { PostHierarchy } from '../../../db/tables/post-hierarchy'
 import { UserNotification } from '../../../../db/tables/user-notification'
 import { countAll, excluded } from '../../../../db/util'
+import { toSimplifiedISOSafe } from '../util'
 
 type Post = DatabaseSchemaType['post']
 type PostEmbedImage = DatabaseSchemaType['post_embed_image']
@@ -47,7 +48,7 @@ const insertFn = async (
     cid: cid.toString(),
     creator: uri.host,
     text: obj.text,
-    createdAt: obj.createdAt,
+    createdAt: toSimplifiedISOSafe(obj.createdAt),
     replyRoot: obj.reply?.root?.uri || null,
     replyRootCid: obj.reply?.root?.cid || null,
     replyParent: obj.reply?.parent?.uri || null,

--- a/packages/pds/src/app-view/services/indexing/plugins/repost.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/repost.ts
@@ -10,6 +10,7 @@ import {
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
 import { countAll, excluded } from '../../../../db/util'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyFeedRepost
 type IndexedRepost = DatabaseSchemaType['repost']
@@ -27,7 +28,7 @@ const insertFn = async (
     creator: uri.host,
     subject: obj.subject.uri,
     subjectCid: obj.subject.cid,
-    createdAt: obj.createdAt,
+    createdAt: toSimplifiedISOSafe(obj.createdAt),
     indexedAt: timestamp,
   }
   const [inserted] = await Promise.all([

--- a/packages/pds/src/app-view/services/indexing/processor.ts
+++ b/packages/pds/src/app-view/services/indexing/processor.ts
@@ -193,6 +193,7 @@ export class RecordProcessor<T, S> {
 
   async handleNotifs(op: { deleted?: S; inserted?: S }) {
     let notifs: UserNotification[] = []
+    const runOnCommit: ((db: Database) => Promise<void>)[] = []
     if (op.deleted) {
       const forDelete = this.params.notifsForDelete(
         op.deleted,
@@ -201,13 +202,11 @@ export class RecordProcessor<T, S> {
       if (forDelete.toDelete.length > 0) {
         // Notifs can be deleted in background: they are expensive to delete and
         // listNotifications already excludes notifs with missing records.
-        this.appDb.onCommit(() => {
-          this.backgroundQueue.add(async (db) => {
-            await db.db
-              .deleteFrom('user_notification')
-              .where('recordUri', 'in', forDelete.toDelete)
-              .execute()
-          })
+        runOnCommit.push(async (db) => {
+          await db.db
+            .deleteFrom('user_notification')
+            .where('recordUri', 'in', forDelete.toDelete)
+            .execute()
         })
       }
       notifs = forDelete.notifs
@@ -215,9 +214,17 @@ export class RecordProcessor<T, S> {
       notifs = this.params.notifsForInsert(op.inserted)
     }
     if (notifs.length > 0) {
+      runOnCommit.push(async (db) => {
+        await db.db.insertInto('user_notification').values(notifs).execute()
+      })
+    }
+    if (runOnCommit.length) {
+      // Need to ensure notif deletion always happens before creation, otherwise delete may clobber in a race.
       this.appDb.onCommit(() => {
         this.backgroundQueue.add(async (db) => {
-          await db.db.insertInto('user_notification').values(notifs).execute()
+          for (const fn of runOnCommit) {
+            await fn(db)
+          }
         })
       })
     }

--- a/packages/pds/src/app-view/services/indexing/util.ts
+++ b/packages/pds/src/app-view/services/indexing/util.ts
@@ -1,0 +1,9 @@
+// Normalize date strings to simplified ISO so that the lexical sort preserves temporal sort.
+// Rather than failing on an invalid date format, returns valid unix epoch.
+export function toSimplifiedISOSafe(dateStr: string) {
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) {
+    return new Date(0).toISOString()
+  }
+  return date.toISOString() // YYYY-MM-DDTHH:mm:ss.sssZ
+}

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -201,7 +201,13 @@ export const forSnapshot = (obj: unknown) => {
       return take(unknown, str)
     }
     if (str.match(/^\d{4}-\d{2}-\d{2}T/)) {
-      return constantDate
+      if (str.match(/\d{6}Z$/)) {
+        return constantDate.replace('Z', '000Z') // e.g. microseconds in record createdAt
+      } else if (str.endsWith('+00:00')) {
+        return constantDate.replace('Z', '+00:00') // e.g. timezone in record createdAt
+      } else {
+        return constantDate
+      }
     }
     if (str.match(/^\d+::bafy/)) {
       return constantKeysetCursor

--- a/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
+++ b/packages/pds/tests/event-stream/__snapshots__/sync.test.ts.snap
@@ -21,7 +21,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -369,7 +369,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -435,7 +435,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -461,7 +461,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -572,7 +572,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -598,7 +598,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -791,7 +791,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -819,7 +819,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/proxied/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/author-feed.test.ts.snap
@@ -145,7 +145,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -322,7 +322,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -471,7 +471,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -500,7 +500,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -539,7 +539,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -813,7 +813,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -842,7 +842,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -991,7 +991,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1535,7 +1535,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1715,7 +1715,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/posts.test.ts.snap
@@ -44,7 +44,7 @@ Array [
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/pds/tests/proxied/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/thread.test.ts.snap
@@ -26,7 +26,7 @@ Object {
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -192,7 +192,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -402,7 +402,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -774,7 +774,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/pds/tests/proxied/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/timeline.test.ts.snap
@@ -20,7 +20,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -360,7 +360,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -424,7 +424,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -449,7 +449,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -567,7 +567,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -592,7 +592,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -780,7 +780,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -807,7 +807,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1506,7 +1506,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1573,7 +1573,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1602,7 +1602,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1722,7 +1722,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1751,7 +1751,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1942,7 +1942,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -1971,7 +1971,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -2482,7 +2482,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2548,7 +2548,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2577,7 +2577,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2757,7 +2757,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -2934,7 +2934,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3066,7 +3066,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3095,7 +3095,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3136,7 +3136,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -3386,7 +3386,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3551,7 +3551,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3728,7 +3728,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/seeds/basic.ts
+++ b/packages/pds/tests/seeds/basic.ts
@@ -11,14 +11,20 @@ export default async (sc: SeedClient) => {
   const bob = sc.dids.bob
   const carol = sc.dids.carol
   const dan = sc.dids.dan
+  const createdAtMicroseconds = () => ({
+    createdAt: new Date().toISOString().replace('Z', '000Z'), // microseconds
+  })
+  const createdAtTimezone = () => ({
+    createdAt: new Date().toISOString().replace('Z', '+00:00'), // iso timezone format
+  })
 
   await sc.follow(alice, bob)
   await sc.follow(alice, carol)
   await sc.follow(alice, dan)
   await sc.follow(carol, alice)
   await sc.follow(bob, alice)
-  await sc.follow(bob, carol)
-  await sc.follow(dan, bob)
+  await sc.follow(bob, carol, createdAtMicroseconds())
+  await sc.follow(dan, bob, createdAtTimezone())
   await sc.post(alice, posts.alice[0])
   await sc.post(bob, posts.bob[0])
   const img1 = await sc.uploadFile(
@@ -56,8 +62,22 @@ export default async (sc: SeedClient) => {
     undefined,
     sc.posts[carol][0].ref, // This post contains an images embed
   )
-  await sc.post(alice, posts.alice[1])
-  await sc.post(bob, posts.bob[1])
+  await sc.post(
+    alice,
+    posts.alice[1],
+    undefined,
+    undefined,
+    undefined,
+    createdAtMicroseconds(),
+  )
+  await sc.post(
+    bob,
+    posts.bob[1],
+    undefined,
+    undefined,
+    undefined,
+    createdAtTimezone(),
+  )
   await sc.post(
     alice,
     posts.alice[2],
@@ -70,8 +90,8 @@ export default async (sc: SeedClient) => {
   await sc.like(carol, sc.posts[alice][1].ref)
   await sc.like(carol, sc.posts[alice][2].ref)
   await sc.like(dan, sc.posts[alice][1].ref)
-  await sc.like(alice, sc.posts[carol][0].ref)
-  await sc.like(bob, sc.posts[carol][0].ref)
+  await sc.like(alice, sc.posts[carol][0].ref, createdAtMicroseconds())
+  await sc.like(bob, sc.posts[carol][0].ref, createdAtTimezone())
 
   const replyImg = await sc.uploadFile(
     bob,

--- a/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -139,7 +139,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -330,7 +330,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -473,7 +473,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -503,7 +503,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -534,7 +534,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -808,7 +808,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -838,7 +838,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -982,7 +982,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1557,7 +1557,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1753,7 +1753,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/blocks.test.ts.snap
@@ -188,7 +188,7 @@ Object {
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/posts.test.ts.snap
@@ -46,7 +46,7 @@ Array [
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -127,7 +127,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -293,7 +293,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -418,7 +418,7 @@ Object {
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -578,7 +578,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -783,7 +783,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,
@@ -1145,7 +1145,7 @@ Object {
     "likeCount": 3,
     "record": Object {
       "$type": "app.bsky.feed.post",
-      "createdAt": "1970-01-01T00:00:00.000Z",
+      "createdAt": "1970-01-01T00:00:00.000000Z",
       "text": "again",
     },
     "replyCount": 2,

--- a/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/timeline.test.ts.snap
@@ -21,7 +21,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -216,7 +216,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -375,7 +375,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -500,7 +500,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -526,7 +526,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -608,7 +608,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -636,7 +636,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -901,7 +901,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -1267,7 +1267,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1333,7 +1333,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1359,7 +1359,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1470,7 +1470,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1496,7 +1496,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -1698,7 +1698,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -1726,7 +1726,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -2488,7 +2488,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2557,7 +2557,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2587,7 +2587,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2700,7 +2700,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2730,7 +2730,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -2935,7 +2935,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -2965,7 +2965,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -3509,7 +3509,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3577,7 +3577,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3607,7 +3607,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -3812,7 +3812,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -4003,7 +4003,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -4137,7 +4137,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -4167,7 +4167,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -4200,7 +4200,7 @@ Array [
       "likeCount": 0,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000+00:00",
         "text": "bobby boy here",
       },
       "replyCount": 0,
@@ -4484,7 +4484,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,
@@ -4652,7 +4652,7 @@ Array [
         "likeCount": 3,
         "record": Object {
           "$type": "app.bsky.feed.post",
-          "createdAt": "1970-01-01T00:00:00.000Z",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
           "text": "again",
         },
         "replyCount": 2,
@@ -4852,7 +4852,7 @@ Array [
       "likeCount": 3,
       "record": Object {
         "$type": "app.bsky.feed.post",
-        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdAt": "1970-01-01T00:00:00.000000Z",
         "text": "again",
       },
       "replyCount": 2,

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -306,6 +306,7 @@ Array [
     "did": "user(0)",
     "handle": "aliya-hodkiewicz.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {},
     "relatedRecords": Array [
       Object {
@@ -330,6 +331,7 @@ Array [
     "did": "user(1)",
     "handle": "cara-wiegand69.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {
       "currentAction": Object {
         "action": "com.atproto.admin.defs#takedown",
@@ -345,6 +347,7 @@ Array [
     "did": "user(2)",
     "handle": "carlos6.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {},
     "relatedRecords": Array [],
   },
@@ -355,6 +358,7 @@ Array [
     "did": "user(3)",
     "handle": "carolina-mcdermott77.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {},
     "relatedRecords": Array [
       Object {
@@ -379,6 +383,7 @@ Array [
     "did": "user(4)",
     "handle": "eudora-dietrich4.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {},
     "relatedRecords": Array [
       Object {
@@ -403,6 +408,7 @@ Array [
     "did": "user(5)",
     "handle": "shane-torphy52.test",
     "indexedAt": "1970-01-01T00:00:00.000Z",
+    "invitesDisabled": false,
     "moderation": Object {},
     "relatedRecords": Array [
       Object {

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -75,6 +75,7 @@ describe('pds notification views', () => {
       sc.replies[alice][0].ref,
       'indeed',
     )
+    await server.ctx.backgroundQueue.processAll()
 
     const notifCountAlice =
       await agent.api.app.bsky.notification.getUnreadCount(


### PR DESCRIPTION
Datetimes in records are validated as ISO.  When we index these dates with the intent of lexically sorting them, we need to ensure that the dates are normalized to the same format in order to preserve temporal sorting.

Please approach with care and test this yourself if you go for it, but an approach such as this could be used to fix datetimes in the db retroactively.  Would need to be run on post, repost, like, follow, and block tables.
```sql
# dry run
select
  "createdAt" as before,
  to_char("createdAt"::timestamptz at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as after
from post
  where length("createdAt") != 24 or right("createdAt", 1) != 'Z';

# live run
update post
  set "createdAt" = to_char("createdAt"::timestamptz at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') 
  where length("createdAt") != 24 or right("createdAt", 1) != 'Z';
```