### PR TITLE
block IPs from creating accounts

### DIFF
--- a/lexicons/com/atproto/server/createAccount.json
+++ b/lexicons/com/atproto/server/createAccount.json
@@ -33,6 +33,7 @@
         }
       },
       "errors": [
+        {"name": "IpAddressBlocked"}
         {"name": "InvalidHandle"},
         {"name": "InvalidPassword"},
         {"name": "InvalidInviteCode"},

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2057,6 +2057,9 @@ export const schemaDict = {
         },
         errors: [
           {
+            name: 'IpAddressBlocked',
+          }
+          {
             name: 'InvalidHandle',
           },
           {

--- a/packages/api/src/client/types/com/atproto/server/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAccount.ts
@@ -38,6 +38,12 @@ export interface Response {
   data: OutputSchema
 }
 
+export class IpAddressBlockedError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export class InvalidHandleError extends XRPCError {
   constructor(src: XRPCError) {
     super(src.status, src.error, src.message)

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2057,6 +2057,9 @@ export const schemaDict = {
         },
         errors: [
           {
+            name: 'IpAddressBlocked',
+          }
+          {
             name: 'InvalidHandle',
           },
           {

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -41,6 +41,7 @@ export interface HandlerError {
   status: number
   message?: string
   error?:
+    | 'IpAddressBlocked'
     | 'InvalidHandle'
     | 'InvalidPassword'
     | 'InvalidInviteCode'

--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -12,6 +12,14 @@ export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.createAccount(async ({ input, req }) => {
     const { email, password, inviteCode, recoveryKey } = input.body
 
+    const blockedIps = ctx.cfg.blockedIps
+    if (blockedIps && blockedIps.includes(req.ip)) {
+      throw new InvalidRequestError(
+        'IP address is blocked',
+        'IpAddressBlocked'
+      )
+    }
+
     if (ctx.cfg.inviteRequired && !inviteCode) {
       throw new InvalidRequestError(
         'No invite code provided',

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -29,6 +29,8 @@ export interface ServerConfigValues {
   privacyPolicyUrl?: string
   termsOfServiceUrl?: string
 
+  blockedIps?: string[]
+
   databaseLocation?: string
 
   availableUserDomains: string[]
@@ -102,6 +104,10 @@ export class ServerConfig {
     )
     const privacyPolicyUrl = process.env.PRIVACY_POLICY_URL
     const termsOfServiceUrl = process.env.TERMS_OF_SERVICE_URL
+
+    const blockedIps = process.env.BLOCKED_IPS
+    ? process.env.BLOCKED_IPS.split(',')
+    : []
 
     const databaseLocation = process.env.DATABASE_LOC
 
@@ -298,6 +304,10 @@ export class ServerConfig {
       return this.publicUrl + this.cfg.termsOfServiceUrl
     }
     return this.cfg.termsOfServiceUrl
+  }
+
+  get blockedIps() {
+    return this.cfg.blockedIps
   }
 
   get databaseLocation() {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2057,6 +2057,9 @@ export const schemaDict = {
         },
         errors: [
           {
+            name: 'IpAddressBlocked'
+          }
+          {
             name: 'InvalidHandle',
           },
           {

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -41,6 +41,7 @@ export interface HandlerError {
   status: number
   message?: string
   error?:
+    | 'IpAddressBlocked'
     | 'InvalidHandle'
     | 'InvalidPassword'
     | 'InvalidInviteCode'


### PR DESCRIPTION
this pr adds a comma delimited config variable with a list of IPs blocked from creating accounts. should cut down on potential spam

no CIDR range support yet, could be an area for improvement