### PR TITLE
use blob as fetch fallback

### DIFF
--- a/packages/api/docs/rn-fetch-handler.ts
+++ b/packages/api/docs/rn-fetch-handler.ts
@@ -74,7 +74,7 @@ async function fetchHandler(
     } else if (resMimeType.startsWith('text/')) {
       resBody = await res.text()
     } else {
-      throw new Error('TODO: non-textual response body')
+      resBody = await res.blob()
     }
   }
 


### PR DESCRIPTION
for non-textual response bodies, blob is the safest fallback that should work for everything