### PR TITLE
Add account preference APIs

### DIFF
--- a/lexicons/com/atproto/server/defs.json
+++ b/lexicons/com/atproto/server/defs.json
@@ -25,6 +25,31 @@
         "usedBy": {"type": "string", "format": "did"},
         "usedAt": {"type": "string", "format": "datetime"}
       }
+    },
+    "preferences": {
+      "type": "array",
+      "items": {
+        "type": "union",
+        "refs": [
+          "#adultContentPref",
+          "#contentLabelPref"
+        ]
+      }
+    },
+    "adultContentPref": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {"type": "boolean", "default": false}
+      }
+    },
+    "contentLabelPref": {
+      "type": "object",
+      "required": ["label", "visibility"],
+      "properties": {
+        "label": {"type": "string"},
+        "visibility": {"type": "string", "knownValues": ["show", "warn", "hide"]}
+      }
     }
   }
 }

--- a/lexicons/com/atproto/server/getAccountPreferences.json
+++ b/lexicons/com/atproto/server/getAccountPreferences.json
@@ -1,0 +1,28 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.getAccountPreferences",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get private preferences attached to the account.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "ref",
+              "ref": "com.atproto.server.defs#preferences"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/server/putAccountPreferences.json
+++ b/lexicons/com/atproto/server/putAccountPreferences.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.putAccountPreferences",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Sets the private preferences attached to the account.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "ref",
+              "ref": "com.atproto.server.defs#preferences"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is currently a proposal for adding two methods

- `com.atproto.server.getAccountPreferences`
- `com.atproto.server.putAccountPreferences`

They use an open-union array of preferences that are defined the server.defs. The settings should be stored privately under the requestor's account. The `put` should overwrite all current settings with the given input.