### PR TITLE
disallow new registration of .arpa, .local, etc handles

### DIFF
--- a/packages/identifier/tests/handle.test.ts
+++ b/packages/identifier/tests/handle.test.ts
@@ -199,6 +199,13 @@ describe('service constraints & normalization', () => {
     expectThrow('about.test', 'Reserved handle')
     expectThrow('atp.test', 'Reserved handle')
     expectThrow('barackobama.test', 'Reserved handle')
+
+    expectThrow('atproto.local', 'Handle TLD is invalid or disallowed')
+    expectThrow('atproto.arpa', 'Handle TLD is invalid or disallowed')
+    expectThrow('atproto.invalid', 'Handle TLD is invalid or disallowed')
+    expectThrow('atproto.localhost', 'Handle TLD is invalid or disallowed')
+    expectThrow('atproto.onion', 'Handle TLD is invalid or disallowed')
+    expectThrow('atproto.internal', 'Handle TLD is invalid or disallowed')
   })
 
   it('normalizes handles', () => {

--- a/packages/identifier/tests/handle.test.ts
+++ b/packages/identifier/tests/handle.test.ts
@@ -39,12 +39,17 @@ describe('handle validation', () => {
     expectValid('jaymome-johnber123456.test')
     expectValid('jay.mome-johnber123456.test')
     expectValid('john.test.bsky.app')
-    expectValid('laptop.local')
-    expectValid('laptop.arpa')
 
     // NOTE: this probably isn't ever going to be a real domain, but my read of
     // the RFC is that it would be possible
     expectValid('john.t')
+  })
+
+  // NOTE: we may change this at the proto level; currently only disallowed at
+  // the registration level
+  it('allows .local and .arpa handles (proto-level)', () => {
+    expectValid('laptop.local')
+    expectValid('laptop.arpa')
   })
 
   it('allows punycode handles', () => {
@@ -111,6 +116,13 @@ describe('handle validation', () => {
     expectInvalid('joh-.test')
     expectInvalid('john.-est')
     expectInvalid('john.tes-')
+  })
+
+  it('throws on "dotless" TLD handles', () => {
+    expectInvalid('org')
+    expectInvalid('ai')
+    expectInvalid('gg')
+    expectInvalid('io')
   })
 
   it('correctly validates corner cases (modern vs. old RFCs)', () => {


### PR DESCRIPTION
This is a "stop the bleeding" PR to halt creation and migration of new handles with `.arpa`, `.local`, and a couple other special "infrastructure" and "reserved" TLDs.

Rough plan would be to get this in, then ask existing `.arpa` tricksters to change handle (or better yet just delete those accounts), and then soon disallow at the protocol level (aka, even referencing such a domain would be invalid).

Also adds test coverage to ensure we don't allow "dotless" top-level handles, like "io". These are controversial and seem to be considered an anti-pattern by many IETF folk. I think they would be super duper cool but also super confusing for users, so we should continue to disallow at the protocol level.

cc: @devinivy @dholms for visibility