### PR TITLE
Update zod version, some perf improvements

### DIFF
--- a/packages/common-web/package.json
+++ b/packages/common-web/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "multiformats": "^9.6.4",
     "uint8arrays": "3.0.0",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   }
 }

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -28,7 +28,7 @@
     "@atproto/common-web": "*",
     "@atproto/crypto": "*",
     "axios": "^0.27.2",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@did-plc/lib": "^0.0.1",

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -30,6 +30,6 @@
     "@atproto/uri": "*",
     "iso-datestring-validator": "^2.2.2",
     "multiformats": "^9.6.4",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   }
 }

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -36,6 +36,6 @@
     "@ipld/dag-cbor": "^7.0.0",
     "multiformats": "^9.6.4",
     "uint8arrays": "3.0.0",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   }
 }

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -32,7 +32,7 @@
     "mime-types": "^2.1.35",
     "uint8arrays": "3.0.0",
     "ws": "^8.12.0",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@atproto/crypto": "*",

--- a/packages/xrpc/package.json
+++ b/packages/xrpc/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "@atproto/lexicon": "*",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12074,3 +12074,8 @@ zod@^3.14.2:
   version "3.19.1"
   resolved "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz"
   integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
+
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
Zod has had a handful of improvements since we last bumped it, in particular a. it put `ZodError` creation behind a getter and b. compiler perf improvements in https://github.com/colinhacks/zod/pull/2107.

Ref: #915 #1018