### PR TITLE
service <> service auth

### DIFF
--- a/packages/bsky/src/auth.ts
+++ b/packages/bsky/src/auth.ts
@@ -3,13 +3,13 @@ import { AuthRequiredError, verifyJwt } from '@atproto/xrpc-server'
 import { DidResolver } from '@atproto/did-resolver'
 
 export const authVerifier =
-  (didResolver: DidResolver) =>
+  (serverDid: string, didResolver: DidResolver) =>
   async (reqCtx: { req: express.Request; res: express.Response }) => {
     const jwtStr = getJwtStrFromReq(reqCtx.req)
     if (!jwtStr) {
       throw new AuthRequiredError('missing jwt', 'MissingJwt')
     }
-    const did = await verifyJwt(jwtStr, async (did: string) => {
+    const did = await verifyJwt(jwtStr, serverDid, async (did: string) => {
       const atprotoData = await didResolver.resolveAtprotoData(did)
       return atprotoData.signingKey
     })
@@ -17,12 +17,12 @@ export const authVerifier =
   }
 
 export const authOptionalVerifier =
-  (didResolver: DidResolver) =>
+  (serverDid: string, didResolver: DidResolver) =>
   async (reqCtx: { req: express.Request; res: express.Response }) => {
     if (!reqCtx.req.headers.authorization) {
       return { credentials: { did: null } }
     }
-    return authVerifier(didResolver)(reqCtx)
+    return authVerifier(serverDid, didResolver)(reqCtx)
   }
 
 export const getJwtStrFromReq = (req: express.Request): string | null => {

--- a/packages/bsky/src/auth.ts
+++ b/packages/bsky/src/auth.ts
@@ -1,8 +1,5 @@
 import express from 'express'
-import * as ui8 from 'uint8arrays'
-import * as crypto from '@atproto/crypto'
-import * as common from '@atproto/common'
-import { AuthRequiredError } from '@atproto/xrpc-server'
+import { AuthRequiredError, verifyJwt } from '@atproto/xrpc-server'
 import { DidResolver } from '@atproto/did-resolver'
 
 export const authVerifier =
@@ -12,7 +9,10 @@ export const authVerifier =
     if (!jwtStr) {
       throw new AuthRequiredError('missing jwt', 'MissingJwt')
     }
-    const did = await verifyJwt(didResolver, jwtStr)
+    const did = await verifyJwt(jwtStr, async (did: string) => {
+      const atprotoData = await didResolver.resolveAtprotoData(did)
+      return atprotoData.signingKey
+    })
     return { credentials: { did } }
   }
 
@@ -25,73 +25,10 @@ export const authOptionalVerifier =
     return authVerifier(didResolver)(reqCtx)
   }
 
-const verifyJwt = async (
-  didResolver: DidResolver,
-  jwtStr: string,
-): Promise<string> => {
-  const parts = jwtStr.split('.')
-  if (parts.length !== 3) {
-    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
-  }
-  const payload = parsePayload(parts[1])
-  const sig = parts[2]
-
-  if (Date.now() / 1000 > payload.exp) {
-    throw new AuthRequiredError('jwt expired', 'JwtExpired')
-  }
-
-  const msgBytes = ui8.fromString(parts.slice(0, 2).join('.'), 'utf8')
-  const sigBytes = ui8.fromString(sig, 'base64url')
-
-  const atpData = await didResolver.resolveAtprotoData(payload.iss)
-  let validSig: boolean
-  try {
-    validSig = await crypto.verifySignature(
-      atpData.signingKey,
-      msgBytes,
-      sigBytes,
-    )
-  } catch (err) {
-    throw new AuthRequiredError(
-      'could not verify jwt signature',
-      'BadJwtSignature',
-    )
-  }
-  if (!validSig) {
-    throw new AuthRequiredError(
-      'jwt signature does not match jwt issuer',
-      'BadJwtSignature',
-    )
-  }
-
-  return payload.iss
-}
-
 export const getJwtStrFromReq = (req: express.Request): string | null => {
   const { authorization = '' } = req.headers
   if (!authorization.startsWith('Bearer ')) {
     return null
   }
   return authorization.replace('Bearer ', '').trim()
-}
-
-const parseB64UrlToJson = (b64: string) => {
-  return JSON.parse(common.b64UrlToUtf8(b64))
-}
-
-const parsePayload = (b64: string): JwtPayload => {
-  const payload = parseB64UrlToJson(b64)
-  if (!payload || typeof payload !== 'object') {
-    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
-  } else if (typeof payload.exp !== 'number') {
-    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
-  } else if (typeof payload.iss !== 'string') {
-    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
-  }
-  return payload
-}
-
-type JwtPayload = {
-  iss: string
-  exp: number
 }

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -6,6 +6,7 @@ export interface ServerConfigValues {
   debugMode?: boolean
   port?: number
   publicUrl?: string
+  serverDid: string
   dbPostgresUrl: string
   dbPostgresSchema?: string
   didPlcUrl: string
@@ -31,6 +32,7 @@ export class ServerConfig {
     const version = process.env.BSKY_VERSION || '0.0.0'
     const debugMode = process.env.NODE_ENV !== 'production'
     const publicUrl = process.env.PUBLIC_URL || undefined
+    const serverDid = process.env.SERVER_DID || 'did:example:test'
     const envPort = parseInt(process.env.PORT || '', 10)
     const port = isNaN(envPort) ? 2584 : envPort
     const didPlcUrl = process.env.DID_PLC_URL || 'http://localhost:2582'
@@ -63,6 +65,7 @@ export class ServerConfig {
       debugMode,
       port,
       publicUrl,
+      serverDid,
       dbPostgresUrl,
       dbPostgresSchema,
       didPlcUrl,
@@ -108,6 +111,10 @@ export class ServerConfig {
 
   get publicUrl() {
     return this.cfg.publicUrl
+  }
+
+  get serverDid() {
+    return this.cfg.serverDid
   }
 
   get dbPostgresUrl() {

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -50,11 +50,11 @@ export class AppContext {
   }
 
   get authVerifier() {
-    return auth.authVerifier(this.didResolver)
+    return auth.authVerifier(this.cfg.serverDid, this.didResolver)
   }
 
   get authOptionalVerifier() {
-    return auth.authOptionalVerifier(this.didResolver)
+    return auth.authOptionalVerifier(this.cfg.serverDid, this.didResolver)
   }
 
   get labeler(): Labeler {

--- a/packages/bsky/tests/_util.ts
+++ b/packages/bsky/tests/_util.ts
@@ -10,7 +10,7 @@ import {
   isThreadViewPost,
 } from '../src/lexicon/types/app/bsky/feed/defs'
 import { isViewRecord } from '../src/lexicon/types/app/bsky/embed/record'
-import { createServiceJwt } from '@atproto/pds/src/auth'
+import { createServiceJwt } from '@atproto/xrpc-server'
 
 // for pds
 export const adminAuth = () => {
@@ -24,7 +24,11 @@ export const adminAuth = () => {
 }
 
 export const appViewHeaders = async (did: string, env: TestEnvInfo) => {
-  const jwt = await createServiceJwt(did, env.pds.ctx.repoSigningKey)
+  const jwt = await createServiceJwt({
+    iss: did,
+    aud: env.bsky.ctx.cfg.serverDid,
+    keypair: env.pds.ctx.repoSigningKey,
+  })
   return { authorization: `Bearer ${jwt}` }
 }
 

--- a/packages/dev-env/src/index.ts
+++ b/packages/dev-env/src/index.ts
@@ -144,8 +144,19 @@ export class DevEnvServer {
           )
         }
 
+        const keypair = await crypto.Secp256k1Keypair.create()
+        const plcClient = new plc.Client(this.env.plcUrl)
+        const serverDid = await plcClient.createDid({
+          signingKey: keypair.did(),
+          rotationKeys: [keypair.did()],
+          handle: 'localhost',
+          pds: `http://localhost:${this.port}`,
+          signer: keypair,
+        })
+
         const config = new bsky.ServerConfig({
           version: '0.0.0',
+          serverDid,
           didPlcUrl: this.env.plcUrl,
           publicUrl: 'https://bsky.public.url',
           imgUriSalt: '9dd04221f5755bce5f55f47464c27e1e',

--- a/packages/pds/src/app-view/proxied/index.ts
+++ b/packages/pds/src/app-view/proxied/index.ts
@@ -1,6 +1,6 @@
 import { AtpAgent } from '@atproto/api'
 import { dedupeStrs } from '@atproto/common'
-import { createServiceJwt } from '@atproto/xrpc-server'
+import { createServiceAuthHeaders } from '@atproto/xrpc-server'
 import { Server } from '../../lexicon'
 import AppContext from '../../context'
 import {
@@ -11,16 +11,23 @@ import {
 } from '../../lexicon/types/app/bsky/feed/defs'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.cfg.bskyAppViewEndpoint) {
+  const appviewEndpoint = ctx.cfg.bskyAppViewEndpoint
+  const appviewDid = ctx.cfg.bskyAppViewDid
+  if (!appviewEndpoint) {
     throw new Error('Could not find bsky appview endpoint')
   }
-  const agent = new AtpAgent({ service: ctx.cfg.bskyAppViewEndpoint })
+  if (!appviewDid) {
+    throw new Error('Could not find bsky appview did')
+  }
+
+  const agent = new AtpAgent({ service: appviewEndpoint })
 
   const headers = async (did: string) => {
-    const jwt = await createServiceJwt(did, ctx.repoSigningKey)
-    return {
-      headers: { authorization: `Bearer ${jwt}` },
-    }
+    return createServiceAuthHeaders({
+      iss: did,
+      aud: appviewDid,
+      keypair: ctx.repoSigningKey,
+    })
   }
 
   server.app.bsky.actor.getProfile({

--- a/packages/pds/src/app-view/proxied/index.ts
+++ b/packages/pds/src/app-view/proxied/index.ts
@@ -1,5 +1,6 @@
 import { AtpAgent } from '@atproto/api'
 import { dedupeStrs } from '@atproto/common'
+import { createServiceJwt } from '@atproto/xrpc-server'
 import { Server } from '../../lexicon'
 import AppContext from '../../context'
 import {
@@ -8,7 +9,6 @@ import {
   isReasonRepost,
   isThreadViewPost,
 } from '../../lexicon/types/app/bsky/feed/defs'
-import { createServiceJwt } from '../../auth'
 
 export default function (server: Server, ctx: AppContext) {
   if (!ctx.cfg.bskyAppViewEndpoint) {

--- a/packages/pds/src/auth.ts
+++ b/packages/pds/src/auth.ts
@@ -1,12 +1,10 @@
 import * as crypto from '@atproto/crypto'
-import * as common from '@atproto/common'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import * as ui8 from 'uint8arrays'
 import express from 'express'
 import * as jwt from 'jsonwebtoken'
 import AppContext from './context'
 import { softDeleted } from './db/util'
-import { MINUTE } from '@atproto/common'
 
 const BEARER = 'Bearer '
 const BASIC = 'Basic '
@@ -253,27 +251,4 @@ export const moderatorVerifier =
 
 export const getRefreshTokenId = () => {
   return ui8.toString(crypto.randomBytes(32), 'base64')
-}
-
-export const createServiceJwt = async (
-  accountDid: string,
-  keypair: crypto.Keypair,
-): Promise<string> => {
-  const header = {
-    typ: 'JWT',
-    alg: keypair.jwtAlg,
-  }
-  const exp = Math.floor((Date.now() + MINUTE) / 1000)
-  const payload = {
-    iss: accountDid,
-    exp,
-  }
-  const toSignStr = `${jsonToB64Url(header)}.${jsonToB64Url(payload)}`
-  const toSign = ui8.fromString(toSignStr, 'utf8')
-  const sig = await keypair.sign(toSign)
-  return `${toSignStr}.${ui8.toString(sig, 'base64url')}`
-}
-
-const jsonToB64Url = (json: Record<string, unknown>): string => {
-  return common.utf8ToB64Url(JSON.stringify(json))
 }

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -52,6 +52,7 @@ export interface ServerConfigValues {
   appViewRepoProvider?: string
 
   bskyAppViewEndpoint?: string
+  bskyAppViewDid?: string
 }
 
 export class ServerConfig {
@@ -152,6 +153,7 @@ export class ServerConfig {
     const bskyAppViewEndpoint = nonemptyString(
       process.env.BSKY_APP_VIEW_ENDPOINT,
     )
+    const bskyAppViewDid = nonemptyString(process.env.BSKY_APP_VIEW_DID)
 
     return new ServerConfig({
       debugMode,
@@ -190,6 +192,7 @@ export class ServerConfig {
       repoBackfillLimitMs,
       appViewRepoProvider,
       bskyAppViewEndpoint,
+      bskyAppViewDid,
       ...overrides,
     })
   }
@@ -366,6 +369,10 @@ export class ServerConfig {
 
   get bskyAppViewEndpoint() {
     return this.cfg.bskyAppViewEndpoint
+  }
+
+  get bskyAppViewDid() {
+    return this.cfg.bskyAppViewDid
   }
 }
 

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -179,7 +179,7 @@ export class PDS {
     })
 
     server = API(server, ctx)
-    if (ctx.cfg.bskyAppViewEndpoint) {
+    if (ctx.cfg.bskyAppViewEndpoint && ctx.cfg.bskyAppViewDid) {
       server = proxiedAppView(server, ctx)
     } else {
       server = inProcessAppView(server, ctx)

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -179,7 +179,7 @@ export class PDS {
     })
 
     server = API(server, ctx)
-    if (ctx.cfg.bskyAppViewEndpoint && ctx.cfg.bskyAppViewDid) {
+    if (ctx.cfg.bskyAppViewEndpoint) {
       server = proxiedAppView(server, ctx)
     } else {
       server = inProcessAppView(server, ctx)

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/xrpc-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "scripts": {
     "test": "jest",

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@atproto/common": "*",
+    "@atproto/crypto": "*",
     "@atproto/lexicon": "*",
     "cbor-x": "^1.5.1",
     "express": "^4.17.2",

--- a/packages/xrpc-server/src/auth.ts
+++ b/packages/xrpc-server/src/auth.ts
@@ -44,6 +44,7 @@ const jsonToB64Url = (json: Record<string, unknown>): string => {
 
 export const verifyJwt = async (
   jwtStr: string,
+  ownDid: string,
   getSigningKey: (did: string) => Promise<string>,
 ): Promise<string> => {
   const parts = jwtStr.split('.')
@@ -55,6 +56,12 @@ export const verifyJwt = async (
 
   if (Date.now() / 1000 > payload.exp) {
     throw new AuthRequiredError('jwt expired', 'JwtExpired')
+  }
+  if (payload.aud !== ownDid) {
+    throw new AuthRequiredError(
+      'jwt audience does not match service did',
+      'BadJwtAudience',
+    )
   }
 
   const msgBytes = ui8.fromString(parts.slice(0, 2).join('.'), 'utf8')

--- a/packages/xrpc-server/src/auth.ts
+++ b/packages/xrpc-server/src/auth.ts
@@ -1,0 +1,104 @@
+import * as common from '@atproto/common'
+import { MINUTE } from '@atproto/common'
+import * as crypto from '@atproto/crypto'
+import * as ui8 from 'uint8arrays'
+import { AuthRequiredError } from './types'
+
+type ServiceJwtParams = {
+  iss: string
+  aud: string
+  exp?: number
+  keypair: crypto.Keypair
+}
+
+export const createServiceJwt = async (
+  params: ServiceJwtParams,
+): Promise<string> => {
+  const { iss, aud, keypair } = params
+  const exp = params.exp ?? Math.floor((Date.now() + MINUTE) / 1000)
+  const header = {
+    typ: 'JWT',
+    alg: keypair.jwtAlg,
+  }
+  const payload = {
+    iss,
+    aud,
+    exp,
+  }
+  const toSignStr = `${jsonToB64Url(header)}.${jsonToB64Url(payload)}`
+  const toSign = ui8.fromString(toSignStr, 'utf8')
+  const sig = await keypair.sign(toSign)
+  return `${toSignStr}.${ui8.toString(sig, 'base64url')}`
+}
+
+export const createServiceAuthHeaders = async (params: ServiceJwtParams) => {
+  const jwt = await createServiceJwt(params)
+  return {
+    headers: { authorization: `Bearer ${jwt}` },
+  }
+}
+
+const jsonToB64Url = (json: Record<string, unknown>): string => {
+  return common.utf8ToB64Url(JSON.stringify(json))
+}
+
+export const verifyJwt = async (
+  jwtStr: string,
+  getSigningKey: (did: string) => Promise<string>,
+): Promise<string> => {
+  const parts = jwtStr.split('.')
+  if (parts.length !== 3) {
+    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
+  }
+  const payload = parsePayload(parts[1])
+  const sig = parts[2]
+
+  if (Date.now() / 1000 > payload.exp) {
+    throw new AuthRequiredError('jwt expired', 'JwtExpired')
+  }
+
+  const msgBytes = ui8.fromString(parts.slice(0, 2).join('.'), 'utf8')
+  const sigBytes = ui8.fromString(sig, 'base64url')
+
+  const signingKey = await getSigningKey(payload.iss)
+
+  let validSig: boolean
+  try {
+    validSig = await crypto.verifySignature(signingKey, msgBytes, sigBytes)
+  } catch (err) {
+    throw new AuthRequiredError(
+      'could not verify jwt signature',
+      'BadJwtSignature',
+    )
+  }
+  if (!validSig) {
+    throw new AuthRequiredError(
+      'jwt signature does not match jwt issuer',
+      'BadJwtSignature',
+    )
+  }
+
+  return payload.iss
+}
+
+const parseB64UrlToJson = (b64: string) => {
+  return JSON.parse(common.b64UrlToUtf8(b64))
+}
+
+const parsePayload = (b64: string): JwtPayload => {
+  const payload = parseB64UrlToJson(b64)
+  if (!payload || typeof payload !== 'object') {
+    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
+  } else if (typeof payload.exp !== 'number') {
+    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
+  } else if (typeof payload.iss !== 'string') {
+    throw new AuthRequiredError('poorly formatted jwt', 'BadJwt')
+  }
+  return payload
+}
+
+type JwtPayload = {
+  iss: string
+  aud: string
+  exp: number
+}

--- a/packages/xrpc-server/src/index.ts
+++ b/packages/xrpc-server/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
+export * from './auth'
 export * from './server'
 export * from './stream'

--- a/packages/xrpc-server/tsconfig.json
+++ b/packages/xrpc-server/tsconfig.json
@@ -8,6 +8,7 @@
   "include": ["./src","__tests__/**/**.ts"],
   "references": [
     { "path": "../common/tsconfig.build.json" },
+    { "path": "../crypto/tsconfig.build.json" },
     { "path": "../lexicon/tsconfig.build.json" },
     { "path": "../xrpc/tsconfig.build.json" },
   ]


### PR DESCRIPTION
This tidies & formalizes service <> service auth.

Three primary changes:
- moves creation & validation of service jwts to `@atproto/xrpc-server` for easier reuse
- adds `aud` to service jwt. this is security consideration to prevent MITM attacks
- formalizes the concept that services should have DIDs & gives both the appview & PDS real DIDs (in their cfg & in test envs)