### PR TITLE
Reports by active action type

### DIFF
--- a/lexicons/com/atproto/admin/getModerationReports.json
+++ b/lexicons/com/atproto/admin/getModerationReports.json
@@ -10,6 +10,15 @@
         "properties": {
           "subject": {"type": "string"},
           "resolved": {"type": "boolean"},
+          "actionType": {
+            "type": "string",
+            "knownValues": [
+              "com.atproto.admin.defs#takedown",
+              "com.atproto.admin.defs#flag",
+              "com.atproto.admin.defs#acknowledge",
+              "com.atproto.admin.defs#escalate"
+            ]
+          },
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"}
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -835,6 +835,15 @@ export const schemaDict = {
             resolved: {
               type: 'boolean',
             },
+            actionType: {
+              type: 'string',
+              knownValues: [
+                'com.atproto.admin.defs#takedown',
+                'com.atproto.admin.defs#flag',
+                'com.atproto.admin.defs#acknowledge',
+                'com.atproto.admin.defs#escalate',
+              ],
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
@@ -11,6 +11,12 @@ import * as ComAtprotoAdminDefs from './defs'
 export interface QueryParams {
   subject?: string
   resolved?: boolean
+  actionType?:
+    | 'com.atproto.admin.defs#takedown'
+    | 'com.atproto.admin.defs#flag'
+    | 'com.atproto.admin.defs#acknowledge'
+    | 'com.atproto.admin.defs#escalate'
+    | (string & {})
   limit?: number
   cursor?: string
 }

--- a/packages/bsky/src/api/com/atproto/admin/getModerationReports.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getModerationReports.ts
@@ -7,11 +7,12 @@ export default function (server: Server, ctx: AppContext) {
     auth: adminVerifier(ctx.cfg.adminPassword),
     handler: async ({ params }) => {
       const { db, services } = ctx
-      const { subject, resolved, limit = 50, cursor } = params
+      const { subject, resolved, actionType, limit = 50, cursor } = params
       const moderationService = services.moderation(db)
       const results = await moderationService.getReports({
         subject,
         resolved,
+        actionType,
         limit,
         cursor,
       })

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -9,7 +9,9 @@ import {
   StreamAuthVerifier,
 } from '@atproto/xrpc-server'
 import { schemas } from './lexicons'
+import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
+import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
 import * as ComAtprotoAdminGetInviteCodes from './types/com/atproto/admin/getInviteCodes'
 import * as ComAtprotoAdminGetModerationAction from './types/com/atproto/admin/getModerationAction'
 import * as ComAtprotoAdminGetModerationActions from './types/com/atproto/admin/getModerationActions'
@@ -35,6 +37,7 @@ import * as ComAtprotoRepoDescribeRepo from './types/com/atproto/repo/describeRe
 import * as ComAtprotoRepoGetRecord from './types/com/atproto/repo/getRecord'
 import * as ComAtprotoRepoListRecords from './types/com/atproto/repo/listRecords'
 import * as ComAtprotoRepoPutRecord from './types/com/atproto/repo/putRecord'
+import * as ComAtprotoRepoRebaseRepo from './types/com/atproto/repo/rebaseRepo'
 import * as ComAtprotoRepoUploadBlob from './types/com/atproto/repo/uploadBlob'
 import * as ComAtprotoServerCreateAccount from './types/com/atproto/server/createAccount'
 import * as ComAtprotoServerCreateAppPassword from './types/com/atproto/server/createAppPassword'
@@ -156,6 +159,16 @@ export class AdminNS {
     this._server = server
   }
 
+  disableAccountInvites<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminDisableAccountInvites.Handler<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.disableAccountInvites' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   disableInviteCodes<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -163,6 +176,16 @@ export class AdminNS {
     >,
   ) {
     const nsid = 'com.atproto.admin.disableInviteCodes' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  enableAccountInvites<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminEnableAccountInvites.Handler<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.enableAccountInvites' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 
@@ -400,6 +423,13 @@ export class RepoNS {
     cfg: ConfigOf<AV, ComAtprotoRepoPutRecord.Handler<ExtractAuth<AV>>>,
   ) {
     const nsid = 'com.atproto.repo.putRecord' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  rebaseRepo<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, ComAtprotoRepoRebaseRepo.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'com.atproto.repo.rebaseRepo' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -333,6 +333,9 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:com.atproto.server.defs#inviteCode',
           },
+          invitesDisabled: {
+            type: 'boolean',
+          },
         },
       },
       repoViewDetail: {
@@ -387,6 +390,9 @@ export const schemaDict = {
               type: 'ref',
               ref: 'lex:com.atproto.server.defs#inviteCode',
             },
+          },
+          invitesDisabled: {
+            type: 'boolean',
           },
         },
       },
@@ -589,6 +595,30 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDisableAccountInvites: {
+    lexicon: 1,
+    id: 'com.atproto.admin.disableAccountInvites',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Disable an account from receiving new invite codes, but does not invalidate existing codes',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['account'],
+            properties: {
+              account: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableInviteCodes: {
     lexicon: 1,
     id: 'com.atproto.admin.disableInviteCodes',
@@ -613,6 +643,29 @@ export const schemaDict = {
                 items: {
                   type: 'string',
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ComAtprotoAdminEnableAccountInvites: {
+    lexicon: 1,
+    id: 'com.atproto.admin.enableAccountInvites',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Re-enable an accounts ability to receive invite codes',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['account'],
+            properties: {
+              account: {
+                type: 'string',
+                format: 'did',
               },
             },
           },
@@ -781,6 +834,15 @@ export const schemaDict = {
             },
             resolved: {
               type: 'boolean',
+            },
+            actionType: {
+              type: 'string',
+              knownValues: [
+                'com.atproto.admin.defs#takedown',
+                'com.atproto.admin.defs#flag',
+                'com.atproto.admin.defs#acknowledge',
+                'com.atproto.admin.defs#escalate',
+              ],
             },
             limit: {
               type: 'integer',
@@ -1947,6 +2009,41 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+            },
+          },
+        },
+        errors: [
+          {
+            name: 'InvalidSwap',
+          },
+        ],
+      },
+    },
+  },
+  ComAtprotoRepoRebaseRepo: {
+    lexicon: 1,
+    id: 'com.atproto.repo.rebaseRepo',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Simple rebase of repo that deletes history',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['repo'],
+            properties: {
+              repo: {
+                type: 'string',
+                format: 'at-identifier',
+                description: 'The handle or DID of the repo.',
+              },
+              swapCommit: {
+                type: 'string',
+                format: 'cid',
+                description:
+                  'Compare and swap with the previous commit by cid.',
               },
             },
           },
@@ -5124,7 +5221,10 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDisableAccountInvites:
+    'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',
+  ComAtprotoAdminEnableAccountInvites: 'com.atproto.admin.enableAccountInvites',
   ComAtprotoAdminGetInviteCodes: 'com.atproto.admin.getInviteCodes',
   ComAtprotoAdminGetModerationAction: 'com.atproto.admin.getModerationAction',
   ComAtprotoAdminGetModerationActions: 'com.atproto.admin.getModerationActions',
@@ -5154,6 +5254,7 @@ export const ids = {
   ComAtprotoRepoGetRecord: 'com.atproto.repo.getRecord',
   ComAtprotoRepoListRecords: 'com.atproto.repo.listRecords',
   ComAtprotoRepoPutRecord: 'com.atproto.repo.putRecord',
+  ComAtprotoRepoRebaseRepo: 'com.atproto.repo.rebaseRepo',
   ComAtprotoRepoStrongRef: 'com.atproto.repo.strongRef',
   ComAtprotoRepoUploadBlob: 'com.atproto.repo.uploadBlob',
   ComAtprotoServerCreateAccount: 'com.atproto.server.createAccount',

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
@@ -177,6 +177,7 @@ export interface RepoView {
   indexedAt: string
   moderation: Moderation
   invitedBy?: ComAtprotoServerDefs.InviteCode
+  invitesDisabled?: boolean
   [k: string]: unknown
 }
 
@@ -202,6 +203,7 @@ export interface RepoViewDetail {
   labels?: ComAtprotoLabelDefs.Label[]
   invitedBy?: ComAtprotoServerDefs.InviteCode
   invites?: ComAtprotoServerDefs.InviteCode[]
+  invitesDisabled?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
@@ -7,34 +7,17 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
-import * as ComAtprotoAdminDefs from './defs'
 
-export interface QueryParams {
-  subject?: string
-  resolved?: boolean
-  actionType?:
-    | 'com.atproto.admin.defs#takedown'
-    | 'com.atproto.admin.defs#flag'
-    | 'com.atproto.admin.defs#acknowledge'
-    | 'com.atproto.admin.defs#escalate'
-    | (string & {})
-  limit: number
-  cursor?: string
-}
+export interface QueryParams {}
 
-export type InputSchema = undefined
-
-export interface OutputSchema {
-  cursor?: string
-  reports: ComAtprotoAdminDefs.ReportView[]
+export interface InputSchema {
+  account: string
   [k: string]: unknown
 }
 
-export type HandlerInput = undefined
-
-export interface HandlerSuccess {
+export interface HandlerInput {
   encoding: 'application/json'
-  body: OutputSchema
+  body: InputSchema
 }
 
 export interface HandlerError {
@@ -42,7 +25,7 @@ export interface HandlerError {
   message?: string
 }
 
-export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerOutput = HandlerError | void
 export type Handler<HA extends HandlerAuth = never> = (ctx: {
   auth: HA
   params: QueryParams

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
@@ -7,34 +7,17 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
-import * as ComAtprotoAdminDefs from './defs'
 
-export interface QueryParams {
-  subject?: string
-  resolved?: boolean
-  actionType?:
-    | 'com.atproto.admin.defs#takedown'
-    | 'com.atproto.admin.defs#flag'
-    | 'com.atproto.admin.defs#acknowledge'
-    | 'com.atproto.admin.defs#escalate'
-    | (string & {})
-  limit: number
-  cursor?: string
-}
+export interface QueryParams {}
 
-export type InputSchema = undefined
-
-export interface OutputSchema {
-  cursor?: string
-  reports: ComAtprotoAdminDefs.ReportView[]
+export interface InputSchema {
+  account: string
   [k: string]: unknown
 }
 
-export type HandlerInput = undefined
-
-export interface HandlerSuccess {
+export interface HandlerInput {
   encoding: 'application/json'
-  body: OutputSchema
+  body: InputSchema
 }
 
 export interface HandlerError {
@@ -42,7 +25,7 @@ export interface HandlerError {
   message?: string
 }
 
-export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerOutput = HandlerError | void
 export type Handler<HA extends HandlerAuth = never> = (ctx: {
   auth: HA
   params: QueryParams

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/rebaseRepo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/rebaseRepo.ts
@@ -7,42 +7,29 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
-import * as ComAtprotoAdminDefs from './defs'
 
-export interface QueryParams {
-  subject?: string
-  resolved?: boolean
-  actionType?:
-    | 'com.atproto.admin.defs#takedown'
-    | 'com.atproto.admin.defs#flag'
-    | 'com.atproto.admin.defs#acknowledge'
-    | 'com.atproto.admin.defs#escalate'
-    | (string & {})
-  limit: number
-  cursor?: string
-}
+export interface QueryParams {}
 
-export type InputSchema = undefined
-
-export interface OutputSchema {
-  cursor?: string
-  reports: ComAtprotoAdminDefs.ReportView[]
+export interface InputSchema {
+  /** The handle or DID of the repo. */
+  repo: string
+  /** Compare and swap with the previous commit by cid. */
+  swapCommit?: string
   [k: string]: unknown
 }
 
-export type HandlerInput = undefined
-
-export interface HandlerSuccess {
+export interface HandlerInput {
   encoding: 'application/json'
-  body: OutputSchema
+  body: InputSchema
 }
 
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'InvalidSwap'
 }
 
-export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerOutput = HandlerError | void
 export type Handler<HA extends HandlerAuth = never> = (ctx: {
   auth: HA
   params: QueryParams

--- a/packages/bsky/src/services/moderation/index.ts
+++ b/packages/bsky/src/services/moderation/index.ts
@@ -1,4 +1,4 @@
-import { Selectable } from 'kysely'
+import { Selectable, sql } from 'kysely'
 import { CID } from 'multiformats/cid'
 import { AtUri } from '@atproto/uri'
 import { InvalidRequestError } from '@atproto/xrpc-server'
@@ -78,10 +78,11 @@ export class ModerationService {
   async getReports(opts: {
     subject?: string
     resolved?: boolean
+    actionType?: string
     limit: number
     cursor?: string
   }): Promise<ModerationReportRow[]> {
-    const { subject, resolved, limit, cursor } = opts
+    const { subject, resolved, actionType, limit, cursor } = opts
     const { ref } = this.db.db.dynamic
     let builder = this.db.db.selectFrom('moderation_report')
     if (subject) {
@@ -103,6 +104,24 @@ export class ModerationService {
       builder = resolved
         ? builder.whereExists(resolutionsQuery)
         : builder.whereNotExists(resolutionsQuery)
+    }
+    if (actionType !== undefined) {
+      const resolutionActionsQuery = this.db.db
+        .selectFrom('moderation_report_resolution')
+        .innerJoin(
+          'moderation_action',
+          'moderation_action.id',
+          'moderation_report_resolution.actionId',
+        )
+        .whereRef(
+          'moderation_report_resolution.reportId',
+          '=',
+          ref('moderation_report.id'),
+        )
+        .where('moderation_action.action', '=', sql`${actionType}`)
+        .where('moderation_action.reversedAt', 'is', null)
+        .selectAll()
+      builder = builder.whereExists(resolutionActionsQuery)
     }
     if (cursor) {
       const cursorNumeric = parseInt(cursor, 10)

--- a/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationReports.ts
@@ -6,11 +6,12 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.moderatorVerifier,
     handler: async ({ params }) => {
       const { db, services } = ctx
-      const { subject, resolved, limit = 50, cursor } = params
+      const { subject, resolved, actionType, limit = 50, cursor } = params
       const moderationService = services.moderation(db)
       const results = await moderationService.getReports({
         subject,
         resolved,
+        actionType,
         limit,
         cursor,
       })

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -835,6 +835,15 @@ export const schemaDict = {
             resolved: {
               type: 'boolean',
             },
+            actionType: {
+              type: 'string',
+              knownValues: [
+                'com.atproto.admin.defs#takedown',
+                'com.atproto.admin.defs#flag',
+                'com.atproto.admin.defs#acknowledge',
+                'com.atproto.admin.defs#escalate',
+              ],
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getModerationReports.ts
@@ -12,6 +12,12 @@ import * as ComAtprotoAdminDefs from './defs'
 export interface QueryParams {
   subject?: string
   resolved?: boolean
+  actionType?:
+    | 'com.atproto.admin.defs#takedown'
+    | 'com.atproto.admin.defs#flag'
+    | 'com.atproto.admin.defs#acknowledge'
+    | 'com.atproto.admin.defs#escalate'
+    | (string & {})
   limit: number
   cursor?: string
 }

--- a/packages/pds/tests/views/admin/__snapshots__/get-moderation-reports.test.ts.snap
+++ b/packages/pds/tests/views/admin/__snapshots__/get-moderation-reports.test.ts.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pds admin get moderation reports view gets all moderation reports by active resolution action type. 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 3,
+    "reasonType": "com.atproto.moderation.defs#reasonOther",
+    "reportedBy": "user(0)",
+    "resolvedByActionIds": Array [
+      4,
+    ],
+    "subject": Object {
+      "$type": "com.atproto.repo.strongRef",
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+]
+`;
+
 exports[`pds admin get moderation reports view gets all moderation reports for a record. 1`] = `
 Array [
   Object {

--- a/packages/pds/tests/views/admin/get-moderation-reports.test.ts
+++ b/packages/pds/tests/views/admin/get-moderation-reports.test.ts
@@ -157,6 +157,15 @@ describe('pds admin get moderation reports view', () => {
     expect(forSnapshot(unresolved.data.reports)).toMatchSnapshot()
   })
 
+  it('gets all moderation reports by active resolution action type.', async () => {
+    const reportsWithTakedown =
+      await agent.api.com.atproto.admin.getModerationReports(
+        { actionType: TAKEDOWN },
+        { headers: { authorization: adminAuth() } },
+      )
+    expect(forSnapshot(reportsWithTakedown.data.reports)).toMatchSnapshot()
+  })
+
   it('paginates.', async () => {
     const results = (results) => results.flatMap((res) => res.reports)
     const paginator = async (cursor?: string) => {


### PR DESCRIPTION
Adds support for fetching moderation reports by active action type.  For example, if you filter reports by the action type "flag" then you will find all reports that were resolved with a flag action that hasn't been reversed.