### PR TITLE
Normalize http headers before sending xrpc requests

### DIFF
--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -6,6 +6,7 @@ import {
   encodeMethodCallBody,
   httpResponseCodeToEnum,
   httpResponseBodyParse,
+  normalizeHeaders,
 } from './util'
 import {
   FetchHandler,
@@ -139,10 +140,11 @@ export async function defaultFetchHandler(
   try {
     // The duplex field is now required for streaming bodies, but not yet reflected
     // anywhere in docs or types. See whatwg/fetch#1438, nodejs/node#46221.
+    const headers = normalizeHeaders(httpHeaders)
     const reqInit: RequestInit & { duplex: string } = {
       method: httpMethod,
-      headers: httpHeaders,
-      body: encodeMethodCallBody(httpHeaders, httpReqBody),
+      headers,
+      body: encodeMethodCallBody(headers, httpReqBody),
       duplex: 'half',
     }
     const res = await fetch(httpUri, reqInit)

--- a/packages/xrpc/src/util.ts
+++ b/packages/xrpc/src/util.ts
@@ -85,6 +85,15 @@ export function encodeQueryParam(
   throw new Error(`Unsupported query param type: ${type}`)
 }
 
+export function normalizeHeaders(headers: Headers): Headers {
+  const normalized: Headers = {}
+  for (const [header, value] of Object.entries(headers)) {
+    normalized[header.toLowerCase()] = value
+  }
+
+  return normalized
+}
+
 export function constructMethodCallHeaders(
   schema: LexXrpcProcedure | LexXrpcQuery,
   data?: any,
@@ -108,16 +117,17 @@ export function encodeMethodCallBody(
   headers: Headers,
   data?: any,
 ): ArrayBuffer | undefined {
-  if (!headers['Content-Type'] || typeof data === 'undefined') {
+  const normalizedHeaders = normalizeHeaders(headers)
+  if (!normalizedHeaders['content-type'] || typeof data === 'undefined') {
     return undefined
   }
   if (data instanceof ArrayBuffer) {
     return data
   }
-  if (headers['Content-Type'].startsWith('text/')) {
+  if (normalizedHeaders['content-type'].startsWith('text/')) {
     return new TextEncoder().encode(data.toString())
   }
-  if (headers['Content-Type'].startsWith('application/json')) {
+  if (normalizedHeaders['content-type'].startsWith('application/json')) {
     return new TextEncoder().encode(stringifyLex(data))
   }
   return data

--- a/packages/xrpc/src/util.ts
+++ b/packages/xrpc/src/util.ts
@@ -117,17 +117,16 @@ export function encodeMethodCallBody(
   headers: Headers,
   data?: any,
 ): ArrayBuffer | undefined {
-  const normalizedHeaders = normalizeHeaders(headers)
-  if (!normalizedHeaders['content-type'] || typeof data === 'undefined') {
+  if (!headers['content-type'] || typeof data === 'undefined') {
     return undefined
   }
   if (data instanceof ArrayBuffer) {
     return data
   }
-  if (normalizedHeaders['content-type'].startsWith('text/')) {
+  if (headers['content-type'].startsWith('text/')) {
     return new TextEncoder().encode(data.toString())
   }
-  if (normalizedHeaders['content-type'].startsWith('application/json')) {
+  if (headers['content-type'].startsWith('application/json')) {
     return new TextEncoder().encode(stringifyLex(data))
   }
   return data


### PR DESCRIPTION
This isn't fully upto HTTP Spec, but it solves #1029. The `normalizeHeaders` function deduplicates HTTP headers, but it doesn't take into account the rules from [RFC9110 appendix A](https://www.rfc-editor.org/rfc/rfc9110#appendix-A)

When using `AtpAgent` the `authorization` header supplied to the xrpc call will take precedence over the internal one