### PR TITLE
Add lexicon LexXrpcParameters, Object required properties check

### DIFF
--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -4,7 +4,7 @@
   "defs": {
     "listViewBasic": {
       "type": "object",
-      "required": ["uri", "creator", "name", "purpose"],
+      "required": ["uri", "name", "purpose"],
       "properties": {
         "uri": {"type": "string", "format": "at-uri"},
         "name": {"type": "string", "maxLength": 64, "minLength": 1},

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -39,7 +39,7 @@
     "create": {
       "type": "object",
       "description": "Create a new record.",
-      "required": ["action", "collection", "value"],
+      "required": ["collection", "value"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"},
@@ -49,7 +49,7 @@
     "update": {
       "type": "object",
       "description": "Update an existing record.",
-      "required": ["action", "collection", "rkey", "value"],
+      "required": ["collection", "rkey", "value"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"},
@@ -59,7 +59,7 @@
     "delete": {
       "type": "object",
       "description": "Delete an existing record.",
-      "required": ["action", "collection", "rkey"],
+      "required": ["collection", "rkey"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"}

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1577,7 +1577,7 @@ export const schemaDict = {
       create: {
         type: 'object',
         description: 'Create a new record.',
-        required: ['action', 'collection', 'value'],
+        required: ['collection', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1594,7 +1594,7 @@ export const schemaDict = {
       update: {
         type: 'object',
         description: 'Update an existing record.',
-        required: ['action', 'collection', 'rkey', 'value'],
+        required: ['collection', 'rkey', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1611,7 +1611,7 @@ export const schemaDict = {
       delete: {
         type: 'object',
         description: 'Delete an existing record.',
-        required: ['action', 'collection', 'rkey'],
+        required: ['collection', 'rkey'],
         properties: {
           collection: {
             type: 'string',
@@ -4788,7 +4788,7 @@ export const schemaDict = {
     defs: {
       listViewBasic: {
         type: 'object',
-        required: ['uri', 'creator', 'name', 'purpose'],
+        required: ['uri', 'name', 'purpose'],
         properties: {
           uri: {
             type: 'string',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -1577,7 +1577,7 @@ export const schemaDict = {
       create: {
         type: 'object',
         description: 'Create a new record.',
-        required: ['action', 'collection', 'value'],
+        required: ['collection', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1594,7 +1594,7 @@ export const schemaDict = {
       update: {
         type: 'object',
         description: 'Update an existing record.',
-        required: ['action', 'collection', 'rkey', 'value'],
+        required: ['collection', 'rkey', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1611,7 +1611,7 @@ export const schemaDict = {
       delete: {
         type: 'object',
         description: 'Delete an existing record.',
-        required: ['action', 'collection', 'rkey'],
+        required: ['collection', 'rkey'],
         properties: {
           collection: {
             type: 'string',

--- a/packages/lexicon/src/util.ts
+++ b/packages/lexicon/src/util.ts
@@ -7,6 +7,7 @@ import {
   ValidationResult,
   isDiscriminatedObject,
 } from './types'
+import { z } from 'zod'
 
 export function toLexUri(str: string, baseUri?: string): string {
   if (str.startsWith('lex:')) {
@@ -102,5 +103,45 @@ export function toConcreteTypes(
     return def.refs.map((ref) => lexicons.getDefOrThrow(ref)).flat()
   } else {
     return [def]
+  }
+}
+
+export function requiredPropertiesRefinement<
+  ObjectType extends {
+    required?: string[]
+    properties?: Record<string, unknown>
+  },
+>(object: ObjectType, ctx: z.RefinementCtx) {
+  // Required fields check
+  if (object.required === undefined) {
+    return
+  }
+
+  if (!Array.isArray(object.required)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.invalid_type,
+      received: typeof object.required,
+      expected: 'array',
+    })
+    return
+  }
+
+  if (object.properties === undefined) {
+    if (object.required.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Required fields defined but no properties defined`,
+      })
+    }
+    return
+  }
+
+  for (const field of object.required) {
+    if (object.properties[field] === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Required field "${field}" not defined`,
+      })
+    }
   }
 }

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -1,5 +1,6 @@
 import { CID } from 'multiformats/cid'
-import { Lexicons } from '../src/index'
+import { lexiconDoc, Lexicons } from '../src/index'
+import { object } from '../src/validators/complex'
 import LexiconDocs from './_scaffolds/lexicons'
 
 describe('Lexicons collection', () => {
@@ -83,6 +84,22 @@ describe('General validation', () => {
       if (res.success) throw new Error('Asserted')
       expect(res.error?.message).toBe('Object must have the property "object"')
     }
+  })
+  it('fails when a required property is missing', () => {
+    const schema = {
+      lexicon: 1,
+      id: 'com.example.kitchenSink',
+      defs: {
+        test: {
+          type: 'object',
+          required: ['foo'],
+          properties: {},
+        },
+      },
+    }
+    expect(() => {
+      lexiconDoc.parse(schema)
+    }).toThrow('Required field \\"foo\\" not defined')
   })
 })
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1577,7 +1577,7 @@ export const schemaDict = {
       create: {
         type: 'object',
         description: 'Create a new record.',
-        required: ['action', 'collection', 'value'],
+        required: ['collection', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1594,7 +1594,7 @@ export const schemaDict = {
       update: {
         type: 'object',
         description: 'Update an existing record.',
-        required: ['action', 'collection', 'rkey', 'value'],
+        required: ['collection', 'rkey', 'value'],
         properties: {
           collection: {
             type: 'string',
@@ -1611,7 +1611,7 @@ export const schemaDict = {
       delete: {
         type: 'object',
         description: 'Delete an existing record.',
-        required: ['action', 'collection', 'rkey'],
+        required: ['collection', 'rkey'],
         properties: {
           collection: {
             type: 'string',
@@ -4788,7 +4788,7 @@ export const schemaDict = {
     defs: {
       listViewBasic: {
         type: 'object',
-        required: ['uri', 'creator', 'name', 'purpose'],
+        required: ['uri', 'name', 'purpose'],
         properties: {
           uri: {
             type: 'string',


### PR DESCRIPTION
Opening as a draft as there are two lexicons with issues
Addresses: #1037 
Now schemas like the one below won't validate, I also had to rewrite `lexUserType` validator as `z.discriminatedUnion` can't take `ZodEffects` as an argument and using just a simple `z.union` would be quite slow on such big object.

```json
...
{

  "type": "object",
  "required": ["foo"],
  "properties": {}
}
...
````