### PR TITLE
Handling deleted content on admin/moderation methods

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -35,7 +35,9 @@
           "type": "union",
           "refs": [
             "#repoView",
-            "#recordView"
+            "#repoViewNotFound",
+            "#recordView",
+            "#recordViewNotFound"
           ]
         },
         "subjectBlobs": {"type": "array", "items": {"type": "ref", "ref": "#blobView"}},
@@ -120,7 +122,9 @@
           "type": "union",
           "refs": [
             "#repoView",
-            "#recordView"
+            "#repoViewNotFound",
+            "#recordView",
+            "#recordViewNotFound"
           ]
         },
         "reportedBy": {"type": "string", "format": "did"},
@@ -164,6 +168,13 @@
         "invitesDisabled": {"type": "boolean"}
       }
     },
+    "repoViewNotFound": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": {"type": "string", "format": "did"}
+      }
+    },
     "repoRef": {
       "type": "object",
       "required": ["did"],
@@ -199,6 +210,13 @@
         "indexedAt": {"type": "string", "format": "datetime"},
         "moderation": {"type": "ref", "ref": "#moderationDetail"},
         "repo": {"type": "ref", "ref": "#repoView"}
+      }
+    },
+    "recordViewNotFound": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "uri": {"type": "string", "format": "at-uri"}
       }
     },
     "moderation": {

--- a/lexicons/com/atproto/admin/getRecord.json
+++ b/lexicons/com/atproto/admin/getRecord.json
@@ -16,7 +16,10 @@
       "output": {
         "encoding": "application/json",
         "schema": {"type": "ref", "ref": "com.atproto.admin.defs#recordViewDetail"}
-      }
+      },
+      "errors": [
+        {"name": "RecordNotFound"}
+      ]
     }
   }
 }

--- a/lexicons/com/atproto/admin/getRepo.json
+++ b/lexicons/com/atproto/admin/getRepo.json
@@ -15,7 +15,10 @@
       "output": {
         "encoding": "application/json",
         "schema": {"type": "ref", "ref": "com.atproto.admin.defs#repoViewDetail"}
-      }
+      },
+      "errors": [
+        {"name": "RepoNotFound"}
+      ]
     }
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -100,7 +100,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           subjectBlobs: {
@@ -274,7 +276,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           reportedBy: {
@@ -396,6 +400,16 @@ export const schemaDict = {
           },
         },
       },
+      repoViewNotFound: {
+        type: 'object',
+        required: ['did'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       repoRef: {
         type: 'object',
         required: ['did'],
@@ -498,6 +512,16 @@ export const schemaDict = {
           repo: {
             type: 'ref',
             ref: 'lex:com.atproto.admin.defs#repoView',
+          },
+        },
+      },
+      recordViewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },
@@ -905,6 +929,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#recordViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RecordNotFound',
+          },
+        ],
       },
     },
   },
@@ -932,6 +961,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#repoViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RepoNotFound',
+          },
+        ],
       },
     },
   },

--- a/packages/api/src/client/types/com/atproto/admin/defs.ts
+++ b/packages/api/src/client/types/com/atproto/admin/defs.ts
@@ -43,7 +43,12 @@ export function validateActionView(v: unknown): ValidationResult {
 export interface ActionViewDetail {
   id: number
   action: ActionType
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   subjectBlobs: BlobView[]
   createLabelVals?: string[]
   negateLabelVals?: string[]
@@ -150,7 +155,12 @@ export interface ReportViewDetail {
   id: number
   reasonType: ComAtprotoModerationDefs.ReasonType
   reason?: string
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   reportedBy: string
   createdAt: string
   resolvedByActions: ActionView[]
@@ -219,6 +229,23 @@ export function validateRepoViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoViewDetail', v)
 }
 
+export interface RepoViewNotFound {
+  did: string
+  [k: string]: unknown
+}
+
+export function isRepoViewNotFound(v: unknown): v is RepoViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#repoViewNotFound'
+  )
+}
+
+export function validateRepoViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#repoViewNotFound', v)
+}
+
 export interface RepoRef {
   did: string
   [k: string]: unknown
@@ -281,6 +308,23 @@ export function isRecordViewDetail(v: unknown): v is RecordViewDetail {
 
 export function validateRecordViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#recordViewDetail', v)
+}
+
+export interface RecordViewNotFound {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isRecordViewNotFound(v: unknown): v is RecordViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#recordViewNotFound'
+  )
+}
+
+export function validateRecordViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#recordViewNotFound', v)
 }
 
 export interface Moderation {

--- a/packages/api/src/client/types/com/atproto/admin/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRecord.ts
@@ -26,8 +26,15 @@ export interface Response {
   data: OutputSchema
 }
 
+export class RecordNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'RecordNotFound') return new RecordNotFoundError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRepo.ts
@@ -25,8 +25,15 @@ export interface Response {
   data: OutputSchema
 }
 
+export class RepoNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'RepoNotFound') return new RepoNotFoundError(e)
   }
   return e
 }

--- a/packages/bsky/src/api/com/atproto/admin/getRecord.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getRecord.ts
@@ -15,7 +15,9 @@ export default function (server: Server, ctx: AppContext) {
         .where('uri', '=', uri)
         .if(!!cid, (qb) => qb.where('cid', '=', cid ?? ''))
         .executeTakeFirst()
-      if (!result) throw new InvalidRequestError('Record not found')
+      if (!result) {
+        throw new InvalidRequestError('Record not found', 'RecordNotFound')
+      }
       return {
         encoding: 'application/json',
         body: await services.moderation(db).views.recordDetail(result),

--- a/packages/bsky/src/api/com/atproto/admin/getRepo.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getRepo.ts
@@ -10,7 +10,9 @@ export default function (server: Server, ctx: AppContext) {
       const { db, services } = ctx
       const { did } = params
       const result = await services.actor(db).getActor(did, true)
-      if (!result) throw new InvalidRequestError('Repo not found')
+      if (!result) {
+        throw new InvalidRequestError('Repo not found', 'RepoNotFound')
+      }
       return {
         encoding: 'application/json',
         body: await services.moderation(db).views.repoDetail(result),

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -83,9 +83,14 @@ import * as AppBskyFeedGetTimeline from './types/app/bsky/feed/getTimeline'
 import * as AppBskyGraphGetBlocks from './types/app/bsky/graph/getBlocks'
 import * as AppBskyGraphGetFollowers from './types/app/bsky/graph/getFollowers'
 import * as AppBskyGraphGetFollows from './types/app/bsky/graph/getFollows'
+import * as AppBskyGraphGetList from './types/app/bsky/graph/getList'
+import * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes'
+import * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes'
 import * as AppBskyGraphMuteActor from './types/app/bsky/graph/muteActor'
+import * as AppBskyGraphMuteActorList from './types/app/bsky/graph/muteActorList'
 import * as AppBskyGraphUnmuteActor from './types/app/bsky/graph/unmuteActor'
+import * as AppBskyGraphUnmuteActorList from './types/app/bsky/graph/unmuteActorList'
 import * as AppBskyNotificationGetUnreadCount from './types/app/bsky/notification/getUnreadCount'
 import * as AppBskyNotificationListNotifications from './types/app/bsky/notification/listNotifications'
 import * as AppBskyNotificationUpdateSeen from './types/app/bsky/notification/updateSeen'
@@ -104,6 +109,9 @@ export const COM_ATPROTO_MODERATION = {
   DefsReasonSexual: 'com.atproto.moderation.defs#reasonSexual',
   DefsReasonRude: 'com.atproto.moderation.defs#reasonRude',
   DefsReasonOther: 'com.atproto.moderation.defs#reasonOther',
+}
+export const APP_BSKY_GRAPH = {
+  DefsModlist: 'app.bsky.graph.defs#modlist',
 }
 
 export function createServer(options?: XrpcOptions): Server {
@@ -857,6 +865,27 @@ export class GraphNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
+  getList<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphGetList.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.getList' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getListMutes<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphGetListMutes.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.getListMutes' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getLists<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphGetLists.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.getLists' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   getMutes<AV extends AuthVerifier>(
     cfg: ConfigOf<AV, AppBskyGraphGetMutes.Handler<ExtractAuth<AV>>>,
   ) {
@@ -871,10 +900,24 @@ export class GraphNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
+  muteActorList<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphMuteActorList.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.muteActorList' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   unmuteActor<AV extends AuthVerifier>(
     cfg: ConfigOf<AV, AppBskyGraphUnmuteActor.Handler<ExtractAuth<AV>>>,
   ) {
     const nsid = 'app.bsky.graph.unmuteActor' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  unmuteActorList<AV extends AuthVerifier>(
+    cfg: ConfigOf<AV, AppBskyGraphUnmuteActorList.Handler<ExtractAuth<AV>>>,
+  ) {
+    const nsid = 'app.bsky.graph.unmuteActorList' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -100,7 +100,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           subjectBlobs: {
@@ -274,7 +276,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           reportedBy: {
@@ -396,6 +400,16 @@ export const schemaDict = {
           },
         },
       },
+      repoViewNotFound: {
+        type: 'object',
+        required: ['did'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       repoRef: {
         type: 'object',
         required: ['did'],
@@ -498,6 +512,16 @@ export const schemaDict = {
           repo: {
             type: 'ref',
             ref: 'lex:com.atproto.admin.defs#repoView',
+          },
+        },
+      },
+      recordViewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },
@@ -905,6 +929,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#recordViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RecordNotFound',
+          },
+        ],
       },
     },
   },
@@ -932,6 +961,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#repoViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RepoNotFound',
+          },
+        ],
       },
     },
   },
@@ -2123,6 +2157,10 @@ export const schemaDict = {
                 type: 'string',
                 format: 'handle',
               },
+              did: {
+                type: 'string',
+                format: 'did',
+              },
               inviteCode: {
                 type: 'string',
               },
@@ -2173,6 +2211,12 @@ export const schemaDict = {
           },
           {
             name: 'UnsupportedDomain',
+          },
+          {
+            name: 'UnresolvableDid',
+          },
+          {
+            name: 'IncompatibleDidDoc',
           },
         ],
       },
@@ -3497,6 +3541,10 @@ export const schemaDict = {
           muted: {
             type: 'boolean',
           },
+          mutedByList: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listViewBasic',
+          },
           blockedBy: {
             type: 'boolean',
           },
@@ -4768,6 +4816,115 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphDefs: {
+    lexicon: 1,
+    id: 'app.bsky.graph.defs',
+    defs: {
+      listViewBasic: {
+        type: 'object',
+        required: ['uri', 'creator', 'name', 'purpose'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          name: {
+            type: 'string',
+            maxLength: 64,
+            minLength: 1,
+          },
+          purpose: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listPurpose',
+          },
+          avatar: {
+            type: 'string',
+          },
+          viewer: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listViewerState',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+        },
+      },
+      listView: {
+        type: 'object',
+        required: ['uri', 'creator', 'name', 'purpose', 'indexedAt'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          creator: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+          name: {
+            type: 'string',
+            maxLength: 64,
+            minLength: 1,
+          },
+          purpose: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listPurpose',
+          },
+          description: {
+            type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          descriptionFacets: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.richtext.facet',
+            },
+          },
+          avatar: {
+            type: 'string',
+          },
+          viewer: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listViewerState',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+        },
+      },
+      listItemView: {
+        type: 'object',
+        required: ['subject'],
+        properties: {
+          subject: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+        },
+      },
+      listPurpose: {
+        type: 'string',
+        knownValues: ['app.bsky.graph.defs#modlist'],
+      },
+      modlist: {
+        type: 'token',
+        description:
+          'A list of actors to apply an aggregate moderation action (mute/block) on',
+      },
+      listViewerState: {
+        type: 'object',
+        properties: {
+          muted: {
+            type: 'boolean',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphFollow: {
     lexicon: 1,
     id: 'app.bsky.graph.follow',
@@ -4940,6 +5097,149 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetList: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getList',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Fetch a list of actors',
+        parameters: {
+          type: 'params',
+          required: ['list'],
+          properties: {
+            list: {
+              type: 'string',
+              format: 'at-uri',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['list', 'items'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              list: {
+                type: 'ref',
+                ref: 'lex:app.bsky.graph.defs#listView',
+              },
+              items: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.defs#listItemView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphGetListMutes: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getListMutes',
+    defs: {
+      main: {
+        type: 'query',
+        description: "Which lists is the requester's account muting?",
+        parameters: {
+          type: 'params',
+          properties: {
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['lists'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              lists: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.defs#listView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphGetLists: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getLists',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Fetch a list of lists that belong to an actor',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['lists'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              lists: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.defs#listView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetMutes: {
     lexicon: 1,
     id: 'app.bsky.graph.getMutes',
@@ -4983,6 +5283,82 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphList: {
+    lexicon: 1,
+    id: 'app.bsky.graph.list',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'A declaration of a list of actors.',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['name', 'purpose', 'createdAt'],
+          properties: {
+            purpose: {
+              type: 'ref',
+              ref: 'lex:app.bsky.graph.defs#listPurpose',
+            },
+            name: {
+              type: 'string',
+              maxLength: 64,
+              minLength: 1,
+            },
+            description: {
+              type: 'string',
+              maxGraphemes: 300,
+              maxLength: 3000,
+            },
+            descriptionFacets: {
+              type: 'array',
+              items: {
+                type: 'ref',
+                ref: 'lex:app.bsky.richtext.facet',
+              },
+            },
+            avatar: {
+              type: 'blob',
+              accept: ['image/png', 'image/jpeg'],
+              maxSize: 1000000,
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphListitem: {
+    lexicon: 1,
+    id: 'app.bsky.graph.listitem',
+    defs: {
+      main: {
+        type: 'record',
+        description: 'An item under a declared list of actors',
+        key: 'tid',
+        record: {
+          type: 'object',
+          required: ['subject', 'list', 'createdAt'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'did',
+            },
+            list: {
+              type: 'string',
+              format: 'at-uri',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'datetime',
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphMuteActor: {
     lexicon: 1,
     id: 'app.bsky.graph.muteActor',
@@ -5006,6 +5382,29 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphMuteActorList: {
+    lexicon: 1,
+    id: 'app.bsky.graph.muteActorList',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Mute a list of actors.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['list'],
+            properties: {
+              list: {
+                type: 'string',
+                format: 'at-uri',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphUnmuteActor: {
     lexicon: 1,
     id: 'app.bsky.graph.unmuteActor',
@@ -5022,6 +5421,29 @@ export const schemaDict = {
               actor: {
                 type: 'string',
                 format: 'at-identifier',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyGraphUnmuteActorList: {
+    lexicon: 1,
+    id: 'app.bsky.graph.unmuteActorList',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Unmute a list of actors.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['list'],
+            properties: {
+              list: {
+                type: 'string',
+                format: 'at-uri',
               },
             },
           },
@@ -5396,13 +5818,21 @@ export const ids = {
   AppBskyFeedPost: 'app.bsky.feed.post',
   AppBskyFeedRepost: 'app.bsky.feed.repost',
   AppBskyGraphBlock: 'app.bsky.graph.block',
+  AppBskyGraphDefs: 'app.bsky.graph.defs',
   AppBskyGraphFollow: 'app.bsky.graph.follow',
   AppBskyGraphGetBlocks: 'app.bsky.graph.getBlocks',
   AppBskyGraphGetFollowers: 'app.bsky.graph.getFollowers',
   AppBskyGraphGetFollows: 'app.bsky.graph.getFollows',
+  AppBskyGraphGetList: 'app.bsky.graph.getList',
+  AppBskyGraphGetListMutes: 'app.bsky.graph.getListMutes',
+  AppBskyGraphGetLists: 'app.bsky.graph.getLists',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',
+  AppBskyGraphList: 'app.bsky.graph.list',
+  AppBskyGraphListitem: 'app.bsky.graph.listitem',
   AppBskyGraphMuteActor: 'app.bsky.graph.muteActor',
+  AppBskyGraphMuteActorList: 'app.bsky.graph.muteActorList',
   AppBskyGraphUnmuteActor: 'app.bsky.graph.unmuteActor',
+  AppBskyGraphUnmuteActorList: 'app.bsky.graph.unmuteActorList',
   AppBskyNotificationGetUnreadCount: 'app.bsky.notification.getUnreadCount',
   AppBskyNotificationListNotifications:
     'app.bsky.notification.listNotifications',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -6,6 +6,7 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
+import * as AppBskyGraphDefs from '../graph/defs'
 
 export interface ProfileViewBasic {
   did: string
@@ -83,6 +84,7 @@ export function validateProfileViewDetailed(v: unknown): ValidationResult {
 
 export interface ViewerState {
   muted?: boolean
+  mutedByList?: AppBskyGraphDefs.ListViewBasic
   blockedBy?: boolean
   blocking?: string
   following?: string

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/defs.ts
@@ -1,0 +1,95 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyRichtextFacet from '../richtext/facet'
+
+export interface ListViewBasic {
+  uri: string
+  name: string
+  purpose: ListPurpose
+  avatar?: string
+  viewer?: ListViewerState
+  indexedAt?: string
+  [k: string]: unknown
+}
+
+export function isListViewBasic(v: unknown): v is ListViewBasic {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.defs#listViewBasic'
+  )
+}
+
+export function validateListViewBasic(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.defs#listViewBasic', v)
+}
+
+export interface ListView {
+  uri: string
+  creator: AppBskyActorDefs.ProfileView
+  name: string
+  purpose: ListPurpose
+  description?: string
+  descriptionFacets?: AppBskyRichtextFacet.Main[]
+  avatar?: string
+  viewer?: ListViewerState
+  indexedAt: string
+  [k: string]: unknown
+}
+
+export function isListView(v: unknown): v is ListView {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.defs#listView'
+  )
+}
+
+export function validateListView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.defs#listView', v)
+}
+
+export interface ListItemView {
+  subject: AppBskyActorDefs.ProfileView
+  [k: string]: unknown
+}
+
+export function isListItemView(v: unknown): v is ListItemView {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.defs#listItemView'
+  )
+}
+
+export function validateListItemView(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.defs#listItemView', v)
+}
+
+export type ListPurpose = 'app.bsky.graph.defs#modlist' | (string & {})
+
+/** A list of actors to apply an aggregate moderation action (mute/block) on */
+export const MODLIST = 'app.bsky.graph.defs#modlist'
+
+export interface ListViewerState {
+  muted?: boolean
+  [k: string]: unknown
+}
+
+export function isListViewerState(v: unknown): v is ListViewerState {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.graph.defs#listViewerState'
+  )
+}
+
+export function validateListViewerState(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.defs#listViewerState', v)
+}

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getList.ts
@@ -7,31 +7,24 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
+import * as AppBskyGraphDefs from './defs'
 
-export interface QueryParams {}
-
-export interface InputSchema {
-  email: string
-  handle: string
-  did?: string
-  inviteCode?: string
-  password: string
-  recoveryKey?: string
-  [k: string]: unknown
+export interface QueryParams {
+  list: string
+  limit: number
+  cursor?: string
 }
+
+export type InputSchema = undefined
 
 export interface OutputSchema {
-  accessJwt: string
-  refreshJwt: string
-  handle: string
-  did: string
+  cursor?: string
+  list: AppBskyGraphDefs.ListView
+  items: AppBskyGraphDefs.ListItemView[]
   [k: string]: unknown
 }
 
-export interface HandlerInput {
-  encoding: 'application/json'
-  body: InputSchema
-}
+export type HandlerInput = undefined
 
 export interface HandlerSuccess {
   encoding: 'application/json'
@@ -41,14 +34,6 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'InvalidHandle'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'HandleNotAvailable'
-    | 'UnsupportedDomain'
-    | 'UnresolvableDid'
-    | 'IncompatibleDidDoc'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getListMutes.ts
@@ -7,31 +7,22 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
+import * as AppBskyGraphDefs from './defs'
 
-export interface QueryParams {}
-
-export interface InputSchema {
-  email: string
-  handle: string
-  did?: string
-  inviteCode?: string
-  password: string
-  recoveryKey?: string
-  [k: string]: unknown
+export interface QueryParams {
+  limit: number
+  cursor?: string
 }
+
+export type InputSchema = undefined
 
 export interface OutputSchema {
-  accessJwt: string
-  refreshJwt: string
-  handle: string
-  did: string
+  cursor?: string
+  lists: AppBskyGraphDefs.ListView[]
   [k: string]: unknown
 }
 
-export interface HandlerInput {
-  encoding: 'application/json'
-  body: InputSchema
-}
+export type HandlerInput = undefined
 
 export interface HandlerSuccess {
   encoding: 'application/json'
@@ -41,14 +32,6 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'InvalidHandle'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'HandleNotAvailable'
-    | 'UnsupportedDomain'
-    | 'UnresolvableDid'
-    | 'IncompatibleDidDoc'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -7,31 +7,23 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
+import * as AppBskyGraphDefs from './defs'
 
-export interface QueryParams {}
-
-export interface InputSchema {
-  email: string
-  handle: string
-  did?: string
-  inviteCode?: string
-  password: string
-  recoveryKey?: string
-  [k: string]: unknown
+export interface QueryParams {
+  actor: string
+  limit: number
+  cursor?: string
 }
+
+export type InputSchema = undefined
 
 export interface OutputSchema {
-  accessJwt: string
-  refreshJwt: string
-  handle: string
-  did: string
+  cursor?: string
+  lists: AppBskyGraphDefs.ListView[]
   [k: string]: unknown
 }
 
-export interface HandlerInput {
-  encoding: 'application/json'
-  body: InputSchema
-}
+export type HandlerInput = undefined
 
 export interface HandlerSuccess {
   encoding: 'application/json'
@@ -41,14 +33,6 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'InvalidHandle'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'HandleNotAvailable'
-    | 'UnsupportedDomain'
-    | 'UnresolvableDid'
-    | 'IncompatibleDidDoc'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/list.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/list.ts
@@ -1,0 +1,32 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import * as AppBskyGraphDefs from './defs'
+import * as AppBskyRichtextFacet from '../richtext/facet'
+
+export interface Record {
+  purpose: AppBskyGraphDefs.ListPurpose
+  name: string
+  description?: string
+  descriptionFacets?: AppBskyRichtextFacet.Main[]
+  avatar?: BlobRef
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.list#main' ||
+      v.$type === 'app.bsky.graph.list')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.list#main', v)
+}

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/listitem.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/listitem.ts
@@ -1,0 +1,27 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+
+export interface Record {
+  subject: string
+  list: string
+  createdAt: string
+  [k: string]: unknown
+}
+
+export function isRecord(v: unknown): v is Record {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    (v.$type === 'app.bsky.graph.listitem#main' ||
+      v.$type === 'app.bsky.graph.listitem')
+  )
+}
+
+export function validateRecord(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.graph.listitem#main', v)
+}

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/muteActorList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/muteActorList.ts
@@ -11,20 +11,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  email: string
-  handle: string
-  did?: string
-  inviteCode?: string
-  password: string
-  recoveryKey?: string
-  [k: string]: unknown
-}
-
-export interface OutputSchema {
-  accessJwt: string
-  refreshJwt: string
-  handle: string
-  did: string
+  list: string
   [k: string]: unknown
 }
 
@@ -33,25 +20,12 @@ export interface HandlerInput {
   body: InputSchema
 }
 
-export interface HandlerSuccess {
-  encoding: 'application/json'
-  body: OutputSchema
-}
-
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'InvalidHandle'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'HandleNotAvailable'
-    | 'UnsupportedDomain'
-    | 'UnresolvableDid'
-    | 'IncompatibleDidDoc'
 }
 
-export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerOutput = HandlerError | void
 export type Handler<HA extends HandlerAuth = never> = (ctx: {
   auth: HA
   params: QueryParams

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
@@ -11,20 +11,7 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  email: string
-  handle: string
-  did?: string
-  inviteCode?: string
-  password: string
-  recoveryKey?: string
-  [k: string]: unknown
-}
-
-export interface OutputSchema {
-  accessJwt: string
-  refreshJwt: string
-  handle: string
-  did: string
+  list: string
   [k: string]: unknown
 }
 
@@ -33,25 +20,12 @@ export interface HandlerInput {
   body: InputSchema
 }
 
-export interface HandlerSuccess {
-  encoding: 'application/json'
-  body: OutputSchema
-}
-
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'InvalidHandle'
-    | 'InvalidPassword'
-    | 'InvalidInviteCode'
-    | 'HandleNotAvailable'
-    | 'UnsupportedDomain'
-    | 'UnresolvableDid'
-    | 'IncompatibleDidDoc'
 }
 
-export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerOutput = HandlerError | void
 export type Handler<HA extends HandlerAuth = never> = (ctx: {
   auth: HA
   params: QueryParams

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
@@ -43,7 +43,12 @@ export function validateActionView(v: unknown): ValidationResult {
 export interface ActionViewDetail {
   id: number
   action: ActionType
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   subjectBlobs: BlobView[]
   createLabelVals?: string[]
   negateLabelVals?: string[]
@@ -150,7 +155,12 @@ export interface ReportViewDetail {
   id: number
   reasonType: ComAtprotoModerationDefs.ReasonType
   reason?: string
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   reportedBy: string
   createdAt: string
   resolvedByActions: ActionView[]
@@ -219,6 +229,23 @@ export function validateRepoViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoViewDetail', v)
 }
 
+export interface RepoViewNotFound {
+  did: string
+  [k: string]: unknown
+}
+
+export function isRepoViewNotFound(v: unknown): v is RepoViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#repoViewNotFound'
+  )
+}
+
+export function validateRepoViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#repoViewNotFound', v)
+}
+
 export interface RepoRef {
   did: string
   [k: string]: unknown
@@ -281,6 +308,23 @@ export function isRecordViewDetail(v: unknown): v is RecordViewDetail {
 
 export function validateRecordViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#recordViewDetail', v)
+}
+
+export interface RecordViewNotFound {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isRecordViewNotFound(v: unknown): v is RecordViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#recordViewNotFound'
+  )
+}
+
+export function validateRecordViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#recordViewNotFound', v)
 }
 
 export interface Moderation {

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getRecord.ts
@@ -26,6 +26,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'RecordNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getRepo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getRepo.ts
@@ -25,6 +25,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'RepoNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/services/moderation/views.ts
+++ b/packages/bsky/src/services/moderation/views.ts
@@ -451,13 +451,13 @@ export class ModerationViews {
         .selectAll()
         .where('did', '=', result.subjectDid)
         .executeTakeFirst()
-      if (!repoResult) {
-        throw new Error(
-          `Subject is missing: (${result.id}) ${result.subjectDid}`,
-        )
+      if (repoResult) {
+        subject = await this.repo(repoResult)
+        subject.$type = 'com.atproto.admin.defs#repoView'
+      } else {
+        subject = { did: result.subjectDid }
+        subject.$type = 'com.atproto.admin.defs#repoViewNotFound'
       }
-      subject = await this.repo(repoResult)
-      subject.$type = 'com.atproto.admin.defs#repoView'
     } else if (
       result.subjectType === 'com.atproto.repo.strongRef' &&
       result.subjectUri !== null
@@ -467,13 +467,13 @@ export class ModerationViews {
         .selectAll()
         .where('uri', '=', result.subjectUri)
         .executeTakeFirst()
-      if (!recordResult) {
-        throw new Error(
-          `Subject is missing: (${result.id}) ${result.subjectUri}`,
-        )
+      if (recordResult) {
+        subject = await this.record(recordResult)
+        subject.$type = 'com.atproto.admin.defs#recordView'
+      } else {
+        subject = { uri: result.subjectUri }
+        subject.$type = 'com.atproto.admin.defs#recordViewNotFound'
       }
-      subject = await this.record(recordResult)
-      subject.$type = 'com.atproto.admin.defs#recordView'
     } else {
       throw new Error(`Bad subject data: (${result.id}) ${result.subjectType}`)
     }

--- a/packages/bsky/tests/__snapshots__/moderation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/moderation.test.ts.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`moderation actioning resolves reports on missing repos and records. 1`] = `
+Object {
+  "recordActionDetail": Object {
+    "action": "com.atproto.admin.defs#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "did:example:admin",
+    "id": 2,
+    "reason": "Y",
+    "resolvedReports": Array [
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 11,
+        "reason": "defamation",
+        "reasonType": "com.atproto.moderation.defs#reasonOther",
+        "reportedBy": "user(0)",
+        "resolvedByActionIds": Array [
+          2,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 10,
+        "reasonType": "com.atproto.moderation.defs#reasonSpam",
+        "reportedBy": "user(1)",
+        "resolvedByActionIds": Array [
+          2,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.admin.defs#repoRef",
+          "did": "user(2)",
+        },
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#recordViewNotFound",
+      "uri": "record(0)",
+    },
+    "subjectBlobs": Array [],
+  },
+  "reportADetail": Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 10,
+    "reasonType": "com.atproto.moderation.defs#reasonSpam",
+    "reportedBy": "user(1)",
+    "resolvedByActions": Array [
+      Object {
+        "action": "com.atproto.admin.defs#flag",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "did:example:admin",
+        "id": 2,
+        "reason": "Y",
+        "resolvedReportIds": Array [
+          11,
+          10,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+        "subjectBlobCids": Array [],
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoViewNotFound",
+      "did": "user(2)",
+    },
+  },
+  "reportBDetail": Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 11,
+    "reason": "defamation",
+    "reasonType": "com.atproto.moderation.defs#reasonOther",
+    "reportedBy": "user(0)",
+    "resolvedByActions": Array [
+      Object {
+        "action": "com.atproto.admin.defs#flag",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "did:example:admin",
+        "id": 2,
+        "reason": "Y",
+        "resolvedReportIds": Array [
+          11,
+          10,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+        "subjectBlobCids": Array [],
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#recordViewNotFound",
+      "uri": "record(0)",
+    },
+  },
+}
+`;
+
 exports[`moderation actioning resolves reports on repos and records. 1`] = `
 Object {
   "action": "com.atproto.admin.defs#takedown",

--- a/packages/pds/src/api/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRecord.ts
@@ -12,7 +12,9 @@ export default function (server: Server, ctx: AppContext) {
       const result = await services
         .record(db)
         .getRecord(new AtUri(uri), cid ?? null, true)
-      if (!result) throw new InvalidRequestError('Record not found')
+      if (!result) {
+        throw new InvalidRequestError('Record not found', 'RecordNotFound')
+      }
       return {
         encoding: 'application/json',
         body: await services.moderation(db).views.recordDetail(result),

--- a/packages/pds/src/api/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRepo.ts
@@ -9,7 +9,9 @@ export default function (server: Server, ctx: AppContext) {
       const { db, services } = ctx
       const { did } = params
       const result = await services.account(db).getAccount(did, true)
-      if (!result) throw new InvalidRequestError('Repo not found')
+      if (!result) {
+        throw new InvalidRequestError('Repo not found', 'RepoNotFound')
+      }
       return {
         encoding: 'application/json',
         body: await services.moderation(db).views.repoDetail(result),

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -100,7 +100,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           subjectBlobs: {
@@ -274,7 +276,9 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.admin.defs#repoView',
+              'lex:com.atproto.admin.defs#repoViewNotFound',
               'lex:com.atproto.admin.defs#recordView',
+              'lex:com.atproto.admin.defs#recordViewNotFound',
             ],
           },
           reportedBy: {
@@ -396,6 +400,16 @@ export const schemaDict = {
           },
         },
       },
+      repoViewNotFound: {
+        type: 'object',
+        required: ['did'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       repoRef: {
         type: 'object',
         required: ['did'],
@@ -498,6 +512,16 @@ export const schemaDict = {
           repo: {
             type: 'ref',
             ref: 'lex:com.atproto.admin.defs#repoView',
+          },
+        },
+      },
+      recordViewNotFound: {
+        type: 'object',
+        required: ['uri'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },
@@ -905,6 +929,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#recordViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RecordNotFound',
+          },
+        ],
       },
     },
   },
@@ -932,6 +961,11 @@ export const schemaDict = {
             ref: 'lex:com.atproto.admin.defs#repoViewDetail',
           },
         },
+        errors: [
+          {
+            name: 'RepoNotFound',
+          },
+        ],
       },
     },
   },

--- a/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
@@ -43,7 +43,12 @@ export function validateActionView(v: unknown): ValidationResult {
 export interface ActionViewDetail {
   id: number
   action: ActionType
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   subjectBlobs: BlobView[]
   createLabelVals?: string[]
   negateLabelVals?: string[]
@@ -150,7 +155,12 @@ export interface ReportViewDetail {
   id: number
   reasonType: ComAtprotoModerationDefs.ReasonType
   reason?: string
-  subject: RepoView | RecordView | { $type: string; [k: string]: unknown }
+  subject:
+    | RepoView
+    | RepoViewNotFound
+    | RecordView
+    | RecordViewNotFound
+    | { $type: string; [k: string]: unknown }
   reportedBy: string
   createdAt: string
   resolvedByActions: ActionView[]
@@ -219,6 +229,23 @@ export function validateRepoViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoViewDetail', v)
 }
 
+export interface RepoViewNotFound {
+  did: string
+  [k: string]: unknown
+}
+
+export function isRepoViewNotFound(v: unknown): v is RepoViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#repoViewNotFound'
+  )
+}
+
+export function validateRepoViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#repoViewNotFound', v)
+}
+
 export interface RepoRef {
   did: string
   [k: string]: unknown
@@ -281,6 +308,23 @@ export function isRecordViewDetail(v: unknown): v is RecordViewDetail {
 
 export function validateRecordViewDetail(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#recordViewDetail', v)
+}
+
+export interface RecordViewNotFound {
+  uri: string
+  [k: string]: unknown
+}
+
+export function isRecordViewNotFound(v: unknown): v is RecordViewNotFound {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#recordViewNotFound'
+  )
+}
+
+export function validateRecordViewNotFound(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#recordViewNotFound', v)
 }
 
 export interface Moderation {

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getRecord.ts
@@ -26,6 +26,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'RecordNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getRepo.ts
@@ -25,6 +25,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'RepoNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/services/moderation/index.ts
+++ b/packages/pds/src/services/moderation/index.ts
@@ -223,8 +223,7 @@ export class ModerationService {
     // Resolve subject info
     let subjectInfo: SubjectInfo
     if ('did' in subject) {
-      const repo = await new SqlRepoStorage(this.db, subject.did).getHead()
-      if (!repo) throw new InvalidRequestError('Repo not found')
+      // Allowing dids that may not exist: may have been deleted but needs to remain actionable.
       subjectInfo = {
         subjectType: 'com.atproto.admin.defs#repoRef',
         subjectDid: subject.did,
@@ -235,15 +234,12 @@ export class ModerationService {
         throw new InvalidRequestError('Blobs do not apply to repo subjects')
       }
     } else {
-      const record = await this.services
-        .record(this.db)
-        .getRecord(subject.uri, subject.cid.toString() ?? null, true)
-      if (!record) throw new InvalidRequestError('Record not found')
+      // Allowing records/blobs that may not exist: may have been deleted but needs to remain actionable.
       subjectInfo = {
         subjectType: 'com.atproto.repo.strongRef',
         subjectDid: subject.uri.host,
         subjectUri: subject.uri.toString(),
-        subjectCid: record.cid,
+        subjectCid: subject.cid.toString(),
       }
       if (subjectBlobCids?.length) {
         const cidsFromSubject = await this.db.db

--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -477,13 +477,13 @@ export class ModerationViews {
       const repoResult = await this.services
         .account(this.db)
         .getAccount(result.subjectDid, true)
-      if (!repoResult) {
-        throw new Error(
-          `Subject is missing: (${result.id}) ${result.subjectDid}`,
-        )
+      if (repoResult) {
+        subject = await this.repo(repoResult)
+        subject.$type = 'com.atproto.admin.defs#repoView'
+      } else {
+        subject = { did: result.subjectDid }
+        subject.$type = 'com.atproto.admin.defs#repoViewNotFound'
       }
-      subject = await this.repo(repoResult)
-      subject.$type = 'com.atproto.admin.defs#repoView'
     } else if (
       result.subjectType === 'com.atproto.repo.strongRef' &&
       result.subjectUri !== null
@@ -491,13 +491,13 @@ export class ModerationViews {
       const recordResult = await this.services
         .record(this.db)
         .getRecord(new AtUri(result.subjectUri), null, true)
-      if (!recordResult) {
-        throw new Error(
-          `Subject is missing: (${result.id}) ${result.subjectUri}`,
-        )
+      if (recordResult) {
+        subject = await this.record(recordResult)
+        subject.$type = 'com.atproto.admin.defs#recordView'
+      } else {
+        subject = { uri: result.subjectUri }
+        subject.$type = 'com.atproto.admin.defs#recordViewNotFound'
       }
-      subject = await this.record(recordResult)
-      subject.$type = 'com.atproto.admin.defs#recordView'
     } else {
       throw new Error(`Bad subject data: (${result.id}) ${result.subjectType}`)
     }

--- a/packages/pds/tests/__snapshots__/moderation.test.ts.snap
+++ b/packages/pds/tests/__snapshots__/moderation.test.ts.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`moderation actioning resolves reports on missing repos and records. 1`] = `
+Object {
+  "recordActionDetail": Object {
+    "action": "com.atproto.admin.defs#flag",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "did:example:admin",
+    "id": 4,
+    "reason": "Y",
+    "resolvedReports": Array [
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 8,
+        "reason": "defamation",
+        "reasonType": "com.atproto.moderation.defs#reasonOther",
+        "reportedBy": "user(1)",
+        "resolvedByActionIds": Array [
+          4,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+      },
+      Object {
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "id": 7,
+        "reasonType": "com.atproto.moderation.defs#reasonSpam",
+        "reportedBy": "user(2)",
+        "resolvedByActionIds": Array [
+          4,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.admin.defs#repoRef",
+          "did": "user(0)",
+        },
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#recordViewNotFound",
+      "uri": "record(0)",
+    },
+    "subjectBlobs": Array [],
+  },
+  "repoDeletionActionDetail": Object {
+    "action": "com.atproto.admin.defs#takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(0)",
+    "id": 3,
+    "reason": "ACCOUNT DELETION",
+    "resolvedReports": Array [],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoViewNotFound",
+      "did": "user(0)",
+    },
+    "subjectBlobs": Array [],
+  },
+  "reportADetail": Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 7,
+    "reasonType": "com.atproto.moderation.defs#reasonSpam",
+    "reportedBy": "user(2)",
+    "resolvedByActions": Array [
+      Object {
+        "action": "com.atproto.admin.defs#flag",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "did:example:admin",
+        "id": 4,
+        "reason": "Y",
+        "resolvedReportIds": Array [
+          8,
+          7,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+        "subjectBlobCids": Array [],
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoViewNotFound",
+      "did": "user(0)",
+    },
+  },
+  "reportBDetail": Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "id": 8,
+    "reason": "defamation",
+    "reasonType": "com.atproto.moderation.defs#reasonOther",
+    "reportedBy": "user(1)",
+    "resolvedByActions": Array [
+      Object {
+        "action": "com.atproto.admin.defs#flag",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "createdBy": "did:example:admin",
+        "id": 4,
+        "reason": "Y",
+        "resolvedReportIds": Array [
+          8,
+          7,
+        ],
+        "subject": Object {
+          "$type": "com.atproto.repo.strongRef",
+          "cid": "cids(0)",
+          "uri": "record(0)",
+        },
+        "subjectBlobCids": Array [],
+      },
+    ],
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#recordViewNotFound",
+      "uri": "record(0)",
+    },
+  },
+}
+`;
+
 exports[`moderation actioning resolves reports on repos and records. 1`] = `
 Object {
   "action": "com.atproto.admin.defs#takedown",


### PR DESCRIPTION
The admin views for moderation actions and reports were not adequately handling deleted repos and records.  This work ensures that deleted repos/records remain actionable, and that report and action detail views have a way to represent a missing repo/record.  The appview already had this covered in both cases, but tests have been added to back-up that behavior.