### PR TITLE
fix: removed `action` from required (#1037)

### DIFF
--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -39,7 +39,7 @@
     "create": {
       "type": "object",
       "description": "Create a new record.",
-      "required": ["action", "collection", "value"],
+      "required": ["collection", "value"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"},
@@ -49,7 +49,7 @@
     "update": {
       "type": "object",
       "description": "Update an existing record.",
-      "required": ["action", "collection", "rkey", "value"],
+      "required": ["collection", "rkey", "value"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"},
@@ -59,7 +59,7 @@
     "delete": {
       "type": "object",
       "description": "Delete an existing record.",
-      "required": ["action", "collection", "rkey"],
+      "required": ["collection", "rkey"],
       "properties": {
         "collection": {"type": "string", "format": "nsid"},
         "rkey": {"type": "string"}


### PR DESCRIPTION
Hi,

As I wrote recently in #1037, there is no longer `action` parameter in `com.atproto.repo.applyWrites` for `create`, `update` and `dalete`. But there was still an `action` in required, so I simply removed it.