### PR TITLE
more labeling tweaks

### DIFF
--- a/packages/pds/src/labeler/hive.ts
+++ b/packages/pds/src/labeler/hive.ts
@@ -121,7 +121,7 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
     }
   }
 
-  // then finally non-sexual nudity...
+  // then non-sexual nudity...
   for (const nudityClass of [
     'yes_male_nudity',
     'yes_female_nudity',
@@ -132,10 +132,14 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
     }
   }
 
-  // as a stop gap, we label underwear posts as !no-promote to keep them out of what's hot
+  // then finally flag remaining "underwear" images in to sexually suggestive
+  // (after non-sexual content already labeled above)
   for (const nudityClass of ['yes_male_underwear', 'yes_female_underwear']) {
     if (scores[nudityClass] >= 0.9) {
-      return ['underwear']
+      // TODO: retaining 'underwear' label for a short time to help understand
+      // the impact of labeling all "underwear" as "sexual". This *will* be
+      // pulling in somewhat non-sexual content in to "sexual" label.
+      return ['sexual', 'underwear']
     }
   }
 

--- a/packages/pds/src/labeler/hive.ts
+++ b/packages/pds/src/labeler/hive.ts
@@ -109,8 +109,10 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
   }
 
   // then check for sexual suggestive (which may include nudity)...
-  if (scores['yes_sexual_intent'] >= 0.9) {
-    return ['sexual']
+  for (const sexualClass of ['yes_sexual_intent', 'yes_sex_toy']) {
+    if (scores[sexualClass] >= 0.9) {
+      return ['sexual']
+    }
   }
   if (scores['yes_undressed'] >= 0.9) {
     // special case for bondage examples

--- a/packages/pds/src/labeler/hive.ts
+++ b/packages/pds/src/labeler/hive.ts
@@ -146,6 +146,7 @@ export const sexualLabels = (classes: HiveRespClass[]): string[] => {
 const labelForClass = {
   very_bloody: 'gore',
   human_corpse: 'corpse',
+  hanging: 'corpse',
   yes_self_harm: 'self-harm',
 }
 


### PR DESCRIPTION
The "sex toy" and "hanging" changes are pretty simple.

Flagging all "underwear" in to "sexually suggestive" is more disruptive. I did some spot checks and posted examples in slack if you want to review. The motivation is to improve overall "NSFW" filtering using the existing toggles/config, weighed against over-sexualizing simple/neutral photos.