### PR TITLE
Limit getPostThread recursion into parents

### DIFF
--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -9,8 +9,18 @@
         "required": ["uri"],
         "properties": {
           "uri": {"type": "string", "format": "at-uri"},
-          "depth": {"type": "integer"},
-          "parentHeight": {"type": "integer"}
+          "depth": {
+            "type": "integer",
+            "default": 6,
+            "minimum": 0,
+            "maximum": 1000
+          },
+          "parentHeight": {
+            "type": "integer",
+            "default": 80,
+            "minimum": 0,
+            "maximum": 1000
+          }
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -9,7 +9,8 @@
         "required": ["uri"],
         "properties": {
           "uri": {"type": "string", "format": "at-uri"},
-          "depth": {"type": "integer"}
+          "depth": {"type": "integer"},
+          "parentHeight": {"type": "integer"}
         }
       },
       "output": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4469,6 +4469,15 @@ export const schemaDict = {
             },
             depth: {
               type: 'integer',
+              default: 6,
+              minimum: 0,
+              maximum: 1000,
+            },
+            parentHeight: {
+              type: 'integer',
+              default: 80,
+              minimum: 0,
+              maximum: 1000,
             },
           },
         },

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -11,6 +11,7 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   uri: string
   depth?: number
+  parentHeight?: number
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4469,6 +4469,15 @@ export const schemaDict = {
             },
             depth: {
               type: 'integer',
+              default: 6,
+              minimum: 0,
+              maximum: 1000,
+            },
+            parentHeight: {
+              type: 'integer',
+              default: 80,
+              minimum: 0,
+              maximum: 1000,
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -11,7 +11,8 @@ import * as AppBskyFeedDefs from './defs'
 
 export interface QueryParams {
   uri: string
-  depth?: number
+  depth: number
+  parentHeight: number
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getPostThread({
     auth: ctx.accessVerifier,
     handler: async ({ params, auth }) => {
-      const { uri, depth = 6, parentHeight = 80 } = params
+      const { uri, depth, parentHeight } = params
       const requester = auth.credentials.did
 
       const feedService = ctx.services.appView.feed(ctx.db)

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -189,7 +189,7 @@ const getThreadData = async (
   return {
     post,
     parent: post.replyParent
-      ? getParentData(parentsByUri, post.replyParent)
+      ? getParentData(parentsByUri, post.replyParent, depth)
       : undefined,
     replies: getChildrenData(childrenByParentUri, uri, depth),
   }
@@ -198,13 +198,15 @@ const getThreadData = async (
 const getParentData = (
   postsByUri: Record<string, FeedRow>,
   uri: string,
-): PostThread | ParentNotFoundError => {
+  depth: number,
+): PostThread | ParentNotFoundError | undefined => {
+  if (depth === 0) return undefined
   const post = postsByUri[uri]
   if (!post) return new ParentNotFoundError(uri)
   return {
     post,
     parent: post.replyParent
-      ? getParentData(postsByUri, post.replyParent)
+      ? getParentData(postsByUri, post.replyParent, depth - 1)
       : undefined,
     replies: [],
   }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -32,7 +32,12 @@ export default function (server: Server, ctx: AppContext) {
       const feedService = ctx.services.appView.feed(ctx.db)
       const labelService = ctx.services.appView.label(ctx.db)
 
-      const threadData = await getThreadData(feedService, uri, depth, parentHeight)
+      const threadData = await getThreadData(
+        feedService,
+        uri,
+        depth,
+        parentHeight,
+      )
       if (!threadData) {
         throw new InvalidRequestError(`Post not found: ${uri}`, 'NotFound')
       }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -26,13 +26,13 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getPostThread({
     auth: ctx.accessVerifier,
     handler: async ({ params, auth }) => {
-      const { uri, depth = 6 } = params
+      const { uri, depth = 6, parentHeight = 80 } = params
       const requester = auth.credentials.did
 
       const feedService = ctx.services.appView.feed(ctx.db)
       const labelService = ctx.services.appView.label(ctx.db)
 
-      const threadData = await getThreadData(feedService, uri, depth)
+      const threadData = await getThreadData(feedService, uri, depth, parentHeight)
       if (!threadData) {
         throw new InvalidRequestError(`Post not found: ${uri}`, 'NotFound')
       }
@@ -159,6 +159,7 @@ const getThreadData = async (
   feedService: FeedService,
   uri: string,
   depth: number,
+  parentHeight: number,
 ): Promise<PostThread | null> => {
   const [parents, children] = await Promise.all([
     feedService
@@ -189,7 +190,7 @@ const getThreadData = async (
   return {
     post,
     parent: post.replyParent
-      ? getParentData(parentsByUri, post.replyParent, depth)
+      ? getParentData(parentsByUri, post.replyParent, parentHeight)
       : undefined,
     replies: getChildrenData(childrenByParentUri, uri, depth),
   }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4469,6 +4469,15 @@ export const schemaDict = {
             },
             depth: {
               type: 'integer',
+              default: 6,
+              minimum: 0,
+              maximum: 1000,
+            },
+            parentHeight: {
+              type: 'integer',
+              default: 80,
+              minimum: 0,
+              maximum: 1000,
             },
           },
         },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -11,8 +11,8 @@ import * as AppBskyFeedDefs from './defs'
 
 export interface QueryParams {
   uri: string
-  depth?: number
-  parentHeight?: number
+  depth: number
+  parentHeight: number
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -12,6 +12,7 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   uri: string
   depth?: number
+  parentHeight?: number
 }
 
 export type InputSchema = undefined

--- a/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/pds/tests/views/__snapshots__/thread.test.ts.snap
@@ -760,6 +760,136 @@ Object {
 }
 `;
 
+exports[`pds thread views fetches shallow ancestors 1`] = `
+Object {
+  "$type": "app.bsky.feed.defs#threadViewPost",
+  "parent": Object {
+    "$type": "app.bsky.feed.defs#threadViewPost",
+    "post": Object {
+      "author": Object {
+        "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+        "did": "user(1)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+        "labels": Array [],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
+      "cid": "cids(2)",
+      "embed": Object {
+        "$type": "app.bsky.embed.images#view",
+        "images": Array [
+          Object {
+            "alt": "tests/image/fixtures/key-landscape-small.jpg",
+            "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+            "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+          },
+        ],
+      },
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "did:example:labeler",
+          "uri": "record(4)",
+          "val": "test-label",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "did:example:labeler",
+          "uri": "record(4)",
+          "val": "test-label-2",
+        },
+      ],
+      "likeCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.images",
+          "images": Array [
+            Object {
+              "alt": "tests/image/fixtures/key-landscape-small.jpg",
+              "image": Object {
+                "$type": "blob",
+                "mimeType": "image/jpeg",
+                "ref": Object {
+                  "$link": "cids(3)",
+                },
+                "size": 4114,
+              },
+            },
+          ],
+        },
+        "reply": Object {
+          "parent": Object {
+            "cid": "cids(1)",
+            "uri": "record(3)",
+          },
+          "root": Object {
+            "cid": "cids(1)",
+            "uri": "record(3)",
+          },
+        },
+        "text": "hear that label_me label_me_2",
+      },
+      "replyCount": 1,
+      "repostCount": 0,
+      "uri": "record(4)",
+      "viewer": Object {},
+    },
+    "replies": Array [],
+  },
+  "post": Object {
+    "author": Object {
+      "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [],
+      "viewer": Object {
+        "blockedBy": false,
+        "followedBy": "record(2)",
+        "following": "record(1)",
+        "muted": false,
+      },
+    },
+    "cid": "cids(0)",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "likeCount": 0,
+    "record": Object {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "reply": Object {
+        "parent": Object {
+          "cid": "cids(2)",
+          "uri": "record(4)",
+        },
+        "root": Object {
+          "cid": "cids(1)",
+          "uri": "record(3)",
+        },
+      },
+      "text": "thanks bob",
+    },
+    "replyCount": 0,
+    "repostCount": 1,
+    "uri": "record(0)",
+    "viewer": Object {
+      "repost": "record(5)",
+    },
+  },
+  "replies": Array [],
+}
+`;
+
 exports[`pds thread views fetches shallow post thread 1`] = `
 Object {
   "$type": "app.bsky.feed.defs#threadViewPost",

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -75,6 +75,15 @@ describe('pds thread views', () => {
     expect(forSnapshot(thread.data.thread)).toMatchSnapshot()
   })
 
+  it('fetches shallow ancestors', async () => {
+    const thread = await agent.api.app.bsky.feed.getPostThread(
+      { depth: 1, parentHeight: 1, uri: sc.replies[alice][0].ref.uriStr },
+      { headers: sc.getHeaders(bob) },
+    )
+
+    expect(forSnapshot(thread.data.thread)).toMatchSnapshot()
+  })
+
   it('fails for an unknown post', async () => {
     const promise = agent.api.app.bsky.feed.getPostThread(
       { uri: 'at://did:example:fake/does.not.exist/self' },


### PR DESCRIPTION
This PR implements the changes required for https://github.com/bluesky-social/social-app/pull/723

It limits recursion into parent posts, in exactly the same way as recursion into child posts was previously limited.

Right now it uses the same depth limit value, perhaps there should be a secondary limit if you want to configure a different maximum parent depth vs child depth.

If it's going to be merged, https://github.com/bluesky-social/social-app/pull/723 should be merged first.