### PR TITLE
[WIP] Muted keywords init

### DIFF
--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -10,7 +10,11 @@
         "properties": {
           "algorithm": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
-          "cursor": {"type": "string"}
+          "cursor": {"type": "string"},
+          "mutedKeywords": {
+            "type": "array", 
+            "items": { "type": "string" }
+          }
         }
       },
       "output": {

--- a/packages/bsky/src/db/pagination.ts
+++ b/packages/bsky/src/db/pagination.ts
@@ -105,13 +105,18 @@ export const paginate = <
     cursor?: string
     direction?: 'asc' | 'desc'
     keyset: K
+    mutedKeywords?: string[]
   },
 ): QB => {
-  const { limit, cursor, keyset, direction = 'desc' } = opts
+  const { limit, cursor, keyset, mutedKeywords, direction = 'desc' } = opts
   const keysetSql = keyset.getSql(keyset.unpack(cursor), direction)
-  return qb
-    .if(!!limit, (q) => q.limit(limit as number))
-    .orderBy(keyset.primary, direction)
-    .orderBy(keyset.secondary, direction)
-    .if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb)) as QB
+  console.log(mutedKeywords)
+  return (
+    qb
+      .if(!!limit, (q) => q.limit(limit as number))
+      // .if(!!mutedKeywords && mutedKeywords.length > 0, (q) => q.where())
+      .orderBy(keyset.primary, direction)
+      .orderBy(keyset.secondary, direction)
+      .if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb)) as QB
+  )
 }

--- a/packages/bsky/src/db/pagination.ts
+++ b/packages/bsky/src/db/pagination.ts
@@ -105,18 +105,13 @@ export const paginate = <
     cursor?: string
     direction?: 'asc' | 'desc'
     keyset: K
-    mutedKeywords?: string[]
   },
 ): QB => {
-  const { limit, cursor, keyset, mutedKeywords, direction = 'desc' } = opts
+  const { limit, cursor, keyset, direction = 'desc' } = opts
   const keysetSql = keyset.getSql(keyset.unpack(cursor), direction)
-  console.log(mutedKeywords)
-  return (
-    qb
-      .if(!!limit, (q) => q.limit(limit as number))
-      // .if(!!mutedKeywords && mutedKeywords.length > 0, (q) => q.where())
-      .orderBy(keyset.primary, direction)
-      .orderBy(keyset.secondary, direction)
-      .if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb)) as QB
-  )
+  return qb
+    .if(!!limit, (q) => q.limit(limit as number))
+    .orderBy(keyset.primary, direction)
+    .orderBy(keyset.secondary, direction)
+    .if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb)) as QB
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4618,6 +4618,12 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            mutedKeywords: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
           },
         },
         output: {

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -13,6 +13,7 @@ export interface QueryParams {
   algorithm?: string
   limit: number
   cursor?: string
+  mutedKeywords?: string[]
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -10,7 +10,7 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getTimeline({
     auth: ctx.accessVerifier,
     handler: async ({ params, auth }) => {
-      const { algorithm, limit, cursor } = params
+      const { algorithm, limit, cursor, mutedKeywords } = params
       const db = ctx.db.db
       const { ref } = db.dynamic
       const requester = auth.credentials.did
@@ -66,6 +66,7 @@ export default function (server: Server, ctx: AppContext) {
         labelService,
         feedItems,
         requester,
+        mutedKeywords,
       )
 
       return {

--- a/packages/pds/src/app-view/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/util/feed.ts
@@ -11,6 +11,7 @@ export const composeFeed = async (
   labelService: LabelService,
   rows: FeedRow[],
   requester: string,
+  mutedKeywords?: string[],
 ): Promise<FeedViewPost[]> => {
   const actorDids = new Set<string>()
   const postUris = new Set<string>()
@@ -68,23 +69,29 @@ export const composeFeed = async (
           )
         : undefined
 
-      feed.push({
-        post,
-        reason: reasonType
-          ? {
-              $type: reasonType,
-              by: actors[row.originatorDid],
-              indexedAt: row.sortAt,
-            }
-          : undefined,
-        reply:
-          replyRoot && replyParent // @TODO consider supporting #postNotFound here
+      if (
+        mutedKeywords?.every(
+          (r) => !post.record.text.toLowerCase().includes(r.toLowerCase()),
+        )
+      ) {
+        feed.push({
+          post,
+          reason: reasonType
             ? {
-                root: replyRoot,
-                parent: replyParent,
+                $type: reasonType,
+                by: actors[row.originatorDid],
+                indexedAt: row.sortAt,
               }
             : undefined,
-      })
+          reply:
+            replyRoot && replyParent // @TODO consider supporting #postNotFound here
+              ? {
+                  root: replyRoot,
+                  parent: replyParent,
+                }
+              : undefined,
+        })
+      }
     }
   }
   return feed

--- a/packages/pds/src/app-view/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/util/feed.ts
@@ -4,6 +4,7 @@ import { FeedViewPost } from '../../../../../lexicon/types/app/bsky/feed/defs'
 import { FeedRow, FeedService } from '../../../../services/feed'
 import { LabelService } from '../../../../services/label'
 import { AppBskyFeedPost } from '@atproto/api'
+import { PostView } from '@atproto/api/src/client/types/app/bsky/feed/defs'
 
 // Present post and repost results into FeedViewPosts
 // Including links to embedded media
@@ -70,14 +71,8 @@ export const composeFeed = async (
           )
         : undefined
 
-      if (AppBskyFeedPost.isRecord(post)) {
-        const res = AppBskyFeedPost.validateRecord(post)
-        if (
-          res.success &&
-          mutedKeywords?.every(
-            (r) => !post.text.toLowerCase().includes(r.toLowerCase()),
-          )
-        ) {
+      if (excludesMutedKeywords(post.record, mutedKeywords)) {
+        {
           feed.push({
             post,
             reason: reasonType
@@ -104,6 +99,28 @@ export const composeFeed = async (
 
 export enum FeedAlgorithm {
   ReverseChronological = 'reverse-chronological',
+}
+
+function excludesMutedKeywords(
+  post: unknown,
+  mutedKeywords?: string[],
+): boolean {
+  if (AppBskyFeedPost.isRecord(post)) {
+    console.log('It is a record')
+    const res = AppBskyFeedPost.validateRecord(post)
+    if (!mutedKeywords) return true
+    return (
+      res.success &&
+      mutedKeywords.every(
+        (r) => !post.text.toLowerCase().includes(r.toLowerCase()),
+      )
+    )
+  }
+  if (AppBskyFeedPost.isRecord(post)) {
+    console.log('interesting...')
+  }
+  console.log('nahhhh...')
+  return true
 }
 
 export class FeedKeyset extends TimeCidKeyset<FeedRow> {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4618,6 +4618,12 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            mutedKeywords: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
           },
         },
         output: {

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -13,6 +13,7 @@ export interface QueryParams {
   algorithm?: string
   limit: number
   cursor?: string
+  mutedKeywords?: string[]
 }
 
 export type InputSchema = undefined


### PR DESCRIPTION
This is a server side solution addressing [issue #670](https://github.com/bluesky-social/social-app/issues/670) in the blue-sky repo. Still very much a WIP.
The purpose of this PR is to propose functionality to add keyword muting functionality to AT. A query parameter array `mutedKeywords` is added to `app.bsky.feed.getTimeline`, allowing multiple words to be muted. From there, `composeFeed()` will check the record's text against every muted keyword, foregoing a push if a subtext match is found.

TODO:
- [ ] Exclude replies if they too include muted words
- [ ] Exclude parents elegantly if they include muted words (wondering if this will prove difficult)
- [x] Find a way to allow a `text` property to be retrieved from an unknown record type without the TS yelling at me
- [ ] Implement for `packages/bsky`
- [ ] Unit tests