### PR TITLE
Fix lexicon. "format" instead of "ref" in type "string"

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -128,7 +128,7 @@
       "type": "object",
       "required": ["repost"],
       "properties": {
-        "repost": {"type": "string", "ref": "at-uri"}
+        "repost": {"type": "string", "format": "at-uri"}
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4432,7 +4432,7 @@ export const schemaDict = {
         properties: {
           repost: {
             type: 'string',
-            ref: 'at-uri',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4432,7 +4432,7 @@ export const schemaDict = {
         properties: {
           repost: {
             type: 'string',
-            ref: 'at-uri',
+            format: 'at-uri',
           },
         },
       },


### PR DESCRIPTION
my Python codegen failed on it. let me know pls if the lexicon has been changed and it's not a typo 