### PR TITLE
Fix definitions in bsky

### DIFF
--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5202,7 +5202,7 @@ export const schemaDict = {
     defs: {
       listViewBasic: {
         type: 'object',
-        required: ['uri', 'creator', 'name', 'purpose'],
+        required: ['uri', 'name', 'purpose'],
         properties: {
           uri: {
             type: 'string',


### PR DESCRIPTION
Lexicon required properties check wasn't rebased onto main before merge which introduced invalid lexicon(creator field was not defined despite being in the required fields list)