### PR TITLE
Tweaks to with-friends algo

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
@@ -99,7 +99,7 @@ async function skeletonFromFeedGen(
   const accountService = ctx.services.account(ctx.db)
   const feedItemUris = skeletonFeed.map(getSkeleFeedItemUri)
 
-  const feedItems = (await feedItemUris.length)
+  const feedItems = feedItemUris.length
     ? await feedService
         .selectFeedItemQb()
         .where('feed_item.uri', 'in', feedItemUris)


### PR DESCRIPTION
After testing out the with-friends algo, it felt a bit too similar to the regular following feed.  We'd also like it to be a little snappier.  The update here surfaces popular posts that have been liked by any of your most active mutuals.

This work is complete, but putting it up as a draft since the behavior itself is possibly not finalized.