### PR TITLE
:sparkles: Allow searching repo by DID

### DIFF
--- a/packages/bsky/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/searchRepos.ts
@@ -4,7 +4,6 @@ import AppContext from '../../../../context'
 import { adminVerifier } from '../../../auth'
 import { paginate } from '../../../../db/pagination'
 import { ListKeyset } from '../../../../services/actor'
-import { ensureValidDid } from '@atproto/identifier'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.searchRepos({
@@ -17,13 +16,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError('The invitedBy parameter is unsupported')
       }
 
-      let searchField: 'did' | 'handle'
-      try {
-        ensureValidDid(term)
-        searchField = 'did'
-      } catch (err) {
-        searchField = 'handle'
-      }
+      const searchField = term.startsWith('did:') ? 'did' : 'handle'
 
       const { ref } = db.db.dynamic
       const keyset = new ListKeyset(ref('indexedAt'), ref('handle'))

--- a/packages/bsky/src/services/actor/index.ts
+++ b/packages/bsky/src/services/actor/index.ts
@@ -64,9 +64,16 @@ export class ActorService {
     })
   }
 
-  searchQb(term?: string) {
+  searchQb(searchField: 'did' | 'handle' = 'handle', term?: string) {
     const { ref } = this.db.db.dynamic
     let builder = this.db.db.selectFrom('actor')
+
+    // When searchField === 'did', the term will always be a valid string because
+    // searchField is set to 'did' after checking that the term is a valid did
+    if (searchField === 'did' && term) {
+      return builder.where('actor.did', '=', term)
+    }
+
     if (term) {
       builder = builder.where((qb) => {
         // Performing matching by word using "strict word similarity" operator.

--- a/packages/bsky/tests/views/admin/repo-search.test.ts
+++ b/packages/bsky/tests/views/admin/repo-search.test.ts
@@ -1,0 +1,80 @@
+import AtpAgent from '@atproto/api'
+import { wait } from '@atproto/common'
+import { TestNetwork } from '@atproto/dev-env'
+import { SeedClient } from '../../seeds/client'
+import usersBulkSeed from '../../seeds/users-bulk'
+
+describe('pds admin repo search views', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let sc: SeedClient
+  let headers: { [s: string]: string }
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_repo_search',
+    })
+    agent = network.bsky.getClient()
+    const pdsAgent = network.pds.getClient()
+    sc = new SeedClient(pdsAgent)
+
+    await wait(50) // allow pending sub to be established
+    await network.bsky.sub?.destroy()
+    await usersBulkSeed(sc)
+
+    // Skip did/handle resolution for expediency
+    const { db } = network.bsky.ctx
+    const now = new Date().toISOString()
+    await db.db
+      .insertInto('actor')
+      .values(
+        Object.entries(sc.dids).map(([handle, did]) => ({
+          did,
+          handle,
+          indexedAt: now,
+        })),
+      )
+      .onConflict((oc) => oc.doNothing())
+      .execute()
+
+    // Process remaining profiles
+    network.bsky.sub?.resume()
+    await network.processAll(50000)
+    headers = await network.adminHeaders({})
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('gives relevant results when searched by handle', async () => {
+    const result = await agent.api.com.atproto.admin.searchRepos(
+      { term: 'car' },
+      { headers },
+    )
+
+    const shouldContain = [
+      'cara-wiegand69.test', // Present despite repo takedown
+      'eudora-dietrich4.test', // Carol Littel
+      'shane-torphy52.test', //Sadie Carter
+      'aliya-hodkiewicz.test', // Carlton Abernathy IV
+      'carlos6.test',
+      'carolina-mcdermott77.test',
+    ]
+
+    const handles = result.data.repos.map((u) => u.handle)
+
+    shouldContain.forEach((handle) => expect(handles).toContain(handle))
+  })
+
+  it('gives relevant results when searched by did', async () => {
+    const term = sc.dids['cara-wiegand69.test']
+    const res = await agent.api.com.atproto.admin.searchRepos(
+      { term },
+      { headers },
+    )
+
+    expect(res.data.repos.length).toEqual(1)
+    expect(res.data.repos[0].did).toEqual(term)
+  })
+})

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import * as uint8arrays from 'uint8arrays'
 import getPort from 'get-port'
 import { wait } from '@atproto/common-web'
 import { createServiceJwt } from '@atproto/xrpc-server'
@@ -8,6 +9,9 @@ import { TestPds } from './pds'
 import { TestBsky } from './bsky'
 import { mockNetworkUtilities } from './util'
 import { TestNetworkNoAppView } from './network-no-appview'
+
+const ADMIN_USERNAME = 'admin'
+const ADMIN_PASSWORD = 'admin-pass'
 
 export class TestNetwork extends TestNetworkNoAppView {
   constructor(public plc: TestPlc, public pds: TestPds, public bsky: TestBsky) {
@@ -75,6 +79,23 @@ export class TestNetwork extends TestNetworkNoAppView {
       keypair: this.pds.ctx.repoSigningKey,
     })
     return { authorization: `Bearer ${jwt}` }
+  }
+
+  async adminHeaders({
+    username = ADMIN_USERNAME,
+    password = ADMIN_PASSWORD,
+  }: {
+    username?: string
+    password?: string
+  }) {
+    return {
+      authorization:
+        'Basic ' +
+        uint8arrays.toString(
+          uint8arrays.fromString(`${username}:${password}`, 'utf8'),
+          'base64pad',
+        ),
+    }
   }
 
   async close() {

--- a/packages/pds/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchRepos.ts
@@ -3,6 +3,7 @@ import AppContext from '../../../../context'
 import { SearchKeyset } from '../../../../services/util/search'
 import { sql } from 'kysely'
 import { ListKeyset } from '../../../../services/account'
+import { ensureValidDid } from '@atproto/identifier'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.searchRepos({
@@ -27,15 +28,25 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
+      let searchField: 'did' | 'handle'
+      try {
+        ensureValidDid(term)
+        searchField = 'did'
+      } catch (err) {
+        searchField = 'handle'
+      }
+
       const results = await services
         .account(db)
-        .search({ term, limit, cursor, includeSoftDeleted: true })
+        .search({ searchField, term, limit, cursor, includeSoftDeleted: true })
       const keyset = new SearchKeyset(sql``, sql``)
 
       return {
         encoding: 'application/json',
         body: {
-          cursor: keyset.packFromResult(results),
+          // For did search, we can only find 1 or no match, cursors can be ignored entirely
+          cursor:
+            searchField === 'did' ? undefined : keyset.packFromResult(results),
           repos: await moderationService.views.repo(results),
         },
       }

--- a/packages/pds/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchRepos.ts
@@ -3,7 +3,6 @@ import AppContext from '../../../../context'
 import { SearchKeyset } from '../../../../services/util/search'
 import { sql } from 'kysely'
 import { ListKeyset } from '../../../../services/account'
-import { ensureValidDid } from '@atproto/identifier'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.searchRepos({
@@ -28,13 +27,7 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
-      let searchField: 'did' | 'handle'
-      try {
-        ensureValidDid(term)
-        searchField = 'did'
-      } catch (err) {
-        searchField = 'handle'
-      }
+      const searchField = term.startsWith('did:') ? 'did' : 'handle'
 
       const results = await services
         .account(db)

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -333,11 +333,25 @@ export class AccountService {
   }
 
   async search(opts: {
+    searchField?: 'did' | 'handle'
     term: string
     limit: number
     cursor?: string
     includeSoftDeleted?: boolean
   }): Promise<(RepoRoot & DidHandle & { distance: number })[]> {
+    // TODO: Implement sqlite specific version?
+    // There are some common calls to join and select, should we refactor instead of early exit approach?
+    if (opts.searchField === 'did') {
+      const didSearchBuilder = this.db.db
+        .selectFrom('did_handle')
+        .where('did_handle.did', '=', opts.term)
+        .innerJoin('repo_root', 'repo_root.did', 'did_handle.did')
+        .selectAll(['did_handle', 'repo_root'])
+        .select(sql<number>`0`.as('distance'))
+
+      return await didSearchBuilder.execute()
+    }
+
     const builder =
       this.db.dialect === 'pg'
         ? getUserSearchQueryPg(this.db, opts)
@@ -351,6 +365,7 @@ export class AccountService {
             .selectAll('did_handle')
             .selectAll('repo_root')
             .select(sql<number>`0`.as('distance'))
+
     return await builder.execute()
   }
 

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -339,8 +339,6 @@ export class AccountService {
     cursor?: string
     includeSoftDeleted?: boolean
   }): Promise<(RepoRoot & DidHandle & { distance: number })[]> {
-    // TODO: Implement sqlite specific version?
-    // There are some common calls to join and select, should we refactor instead of early exit approach?
     if (opts.searchField === 'did') {
       const didSearchBuilder = this.db.db
         .selectFrom('did_handle')

--- a/packages/pds/tests/views/admin/repo-search.test.ts
+++ b/packages/pds/tests/views/admin/repo-search.test.ts
@@ -88,6 +88,17 @@ describe('pds admin repo search view', () => {
     }
   })
 
+  it('finds repo by did', async () => {
+    const term = sc.dids['cara-wiegand69.test']
+    const res = await agent.api.com.atproto.admin.searchRepos(
+      { term, limit: 1 },
+      { headers },
+    )
+
+    expect(res.data.repos.length).toEqual(1)
+    expect(res.data.repos[0].did).toEqual(term)
+  })
+
   it('paginates with term', async () => {
     const results = (results) => results.flatMap((res) => res.users)
     const paginator = async (cursor?: string) => {


### PR DESCRIPTION
This PR allows `admin.searchRepos` to take `did` as a search term along with handles.