### PR TITLE
identifier tweaks

### DIFF
--- a/packages/identifier/src/did.ts
+++ b/packages/identifier/src/did.ts
@@ -39,7 +39,7 @@ export const ensureValidDid = (did: string): void => {
   }
 
   if (did.length > 2 * 1024) {
-    throw new InvalidDidError('DID is far too long')
+    throw new InvalidDidError('DID is too long (2048 chars max)')
   }
 }
 
@@ -51,7 +51,7 @@ export const ensureValidDidRegex = (did: string): void => {
   }
 
   if (did.length > 2 * 1024) {
-    throw new InvalidDidError('DID is far too long')
+    throw new InvalidDidError('DID is too long (2048 chars max)')
   }
 }
 

--- a/packages/identifier/src/did.ts
+++ b/packages/identifier/src/did.ts
@@ -38,7 +38,7 @@ export const ensureValidDid = (did: string): void => {
     throw new InvalidDidError('DID can not end with ":" or "%"')
   }
 
-  if (did.length > 8 * 1024) {
+  if (did.length > 2 * 1024) {
     throw new InvalidDidError('DID is far too long')
   }
 }
@@ -50,7 +50,7 @@ export const ensureValidDidRegex = (did: string): void => {
     throw new InvalidDidError("DID didn't validate via regex")
   }
 
-  if (did.length > 8 * 1024) {
+  if (did.length > 2 * 1024) {
     throw new InvalidDidError('DID is far too long')
   }
 }

--- a/packages/identifier/tests/did.test.ts
+++ b/packages/identifier/tests/did.test.ts
@@ -60,6 +60,7 @@ describe('DID permissive validation', () => {
     expectValid('did:example:123456789abcdefghi')
     expectValid('did:plc:7iza6de2dwap2sbkpav7c6c6')
     expectValid('did:web:example.com')
+    expectValid('did:web:localhost%3A1234')
     expectValid('did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N')
     expectValid('did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a')
   })

--- a/packages/identifier/tests/handle.test.ts
+++ b/packages/identifier/tests/handle.test.ts
@@ -55,6 +55,15 @@ describe('handle validation', () => {
   it('allows punycode handles', () => {
     expectValid('xn--ls8h.test') // 💩.test
     expectValid('xn--bcher-kva.tld') // bücher.tld
+    expectValid('xn--3jk.com')
+    expectValid('xn--w3d.com')
+    expectValid('xn--vqb.com')
+    expectValid('xn--ppd.com')
+    expectValid('xn--cs9a.com')
+    expectValid('xn--8r9a.com')
+    expectValid('xn--cfd.com')
+    expectValid('xn--5jk.com')
+    expectValid('xn--2lb.com')
   })
 
   it('allows onion (Tor) handles', () => {

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "test": "jest",
     "test:log": "cat test.log | pino-pretty",
-    "prettier": "prettier --check src/",
-    "prettier:fix": "prettier --write src/",
+    "prettier": "prettier --check src/ tests/",
+    "prettier:fix": "prettier --write src/ tests/",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "yarn lint --fix",
     "verify": "run-p prettier lint",

--- a/packages/identity/src/did/web-resolver.ts
+++ b/packages/identity/src/did/web-resolver.ts
@@ -19,7 +19,7 @@ export class DidWebResolver extends BaseResolver {
     } else if (parts.length === 1) {
       path = parts[0] + DOC_PATH
     } else {
-      // how we *would* resolve a did:web with path, atproto supported it
+      // how we *would* resolve a did:web with path, if atproto supported it
       //path = parts.join('/') + '/did.json'
       throw new UnsupportedDidWebPathError(did)
     }

--- a/packages/identity/src/did/web-resolver.ts
+++ b/packages/identity/src/did/web-resolver.ts
@@ -19,7 +19,9 @@ export class DidWebResolver extends BaseResolver {
     } else if (parts.length === 1) {
       path = parts[0] + DOC_PATH
     } else {
-      path = parts.join('/') + '/did.json'
+      // how we *would* resolve a did:web with path, atproto supported it
+      //path = parts.join('/') + '/did.json'
+      throw new UnsupportedDidWebPathError(did)
     }
 
     const url = new URL(`https://${path}`)

--- a/packages/identity/src/did/web-resolver.ts
+++ b/packages/identity/src/did/web-resolver.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios'
 import BaseResolver from './base-resolver'
 import { DidCache } from '../types'
-import { PoorlyFormattedDidError } from '../errors'
+import { PoorlyFormattedDidError, UnsupportedDidWebPathError } from '../errors'
 
 export const DOC_PATH = '/.well-known/did.json'
 

--- a/packages/identity/src/errors.ts
+++ b/packages/identity/src/errors.ts
@@ -21,3 +21,9 @@ export class PoorlyFormattedDidDocumentError extends Error {
     super(`Poorly formatted DID Document: ${doc}`)
   }
 }
+
+export class UnsupportedDidWebPathError extends Error {
+  constructor(public did: string) {
+    super(`Unsupported did:web paths: ${did}`)
+  }
+}

--- a/packages/identity/tests/did-resolver.test.ts
+++ b/packages/identity/tests/did-resolver.test.ts
@@ -89,6 +89,12 @@ describe('did resolver', () => {
     await expect(resolver.ensureResolve(``)).rejects.toThrow()
   })
 
+  it('throws on did:web with path components', async () => {
+    await expect(
+      resolver.ensureResolveDid(`did:web:example.com:u:bob`),
+    ).rejects.toThrow()
+  })
+
   it('resolve valid did:plc', async () => {
     const didRes = await resolver.ensureResolve(plcDid)
     expect(didRes).toEqual(didPlcDoc)

--- a/packages/identity/tests/did-resolver.test.ts
+++ b/packages/identity/tests/did-resolver.test.ts
@@ -91,7 +91,7 @@ describe('did resolver', () => {
 
   it('throws on did:web with path components', async () => {
     await expect(
-      resolver.ensureResolveDid(`did:web:example.com:u:bob`),
+      resolver.ensureResolve(`did:web:example.com:u:bob`),
     ).rejects.toThrow()
   })
 

--- a/packages/nsid/src/index.ts
+++ b/packages/nsid/src/index.ts
@@ -69,8 +69,8 @@ export const ensureValidNsid = (nsid: string): void => {
     )
   }
 
-  if (toCheck.length > 253 + 1 + 128) {
-    throw new InvalidNsidError('NSID is too long (382 chars max)')
+  if (toCheck.length > 253 + 1 + 63) {
+    throw new InvalidNsidError('NSID is too long (317 chars max)')
   }
   const labels = toCheck.split('.')
   if (split.length < 3) {
@@ -81,8 +81,8 @@ export const ensureValidNsid = (nsid: string): void => {
     if (l.length < 1) {
       throw new InvalidNsidError('NSID parts can not be empty')
     }
-    if (l.length > 63 && i + 1 < labels.length) {
-      throw new InvalidNsidError('NSID domain part too long (max 63 chars)')
+    if (l.length > 63) {
+      throw new InvalidNsidError('NSID part too long (max 63 chars)')
     }
     if (l.length > 128 && i + 1 == labels.length) {
       throw new InvalidNsidError('NSID name part too long (max 128 chars)')
@@ -107,8 +107,8 @@ export const ensureValidNsidRegex = (nsid: string): void => {
   ) {
     throw new InvalidNsidError("NSID didn't validate via regex")
   }
-  if (nsid.length > 253 + 1 + 128) {
-    throw new InvalidNsidError('NSID is too long (382 chars max)')
+  if (nsid.length > 253 + 1 + 63) {
+    throw new InvalidNsidError('NSID is too long (317 chars max)')
   }
 }
 

--- a/packages/nsid/src/index.ts
+++ b/packages/nsid/src/index.ts
@@ -8,7 +8,6 @@ segment   = alpha *( alpha / number / "-" )
 authority = segment *( delim segment )
 name      = segment
 nsid      = authority delim name
-nsid-ns   = authority delim "*"
 
 */
 
@@ -55,12 +54,10 @@ export class NSID {
 }
 
 // Human readable constraints on NSID:
-// - a valid domain in reversed notation. which means the same as a loose domain!
+// - a valid domain in reversed notation
+// - followed by an additional period-separated name, which is camel-case letters
 export const ensureValidNsid = (nsid: string): void => {
-  // to handle nsid-ns
-  const split = nsid.split('.')
-  const toCheck =
-    split.at(-1) === '*' ? split.slice(0, -1).join('.') : split.join('.')
+  const toCheck = nsid
 
   // check that all chars are boring ASCII
   if (!/^[a-zA-Z0-9.-]*$/.test(toCheck)) {
@@ -73,7 +70,7 @@ export const ensureValidNsid = (nsid: string): void => {
     throw new InvalidNsidError('NSID is too long (317 chars max)')
   }
   const labels = toCheck.split('.')
-  if (split.length < 3) {
+  if (labels.length < 3) {
     throw new InvalidNsidError('NSID needs at least three parts')
   }
   for (let i = 0; i < labels.length; i++) {
@@ -96,7 +93,6 @@ export const ensureValidNsid = (nsid: string): void => {
   }
 }
 
-// nsid-ns is not handled in regex yet
 export const ensureValidNsidRegex = (nsid: string): void => {
   // simple regex to enforce most constraints via just regex and length.
   // hand wrote this regex based on above constraints

--- a/packages/nsid/src/index.ts
+++ b/packages/nsid/src/index.ts
@@ -6,7 +6,7 @@ number    = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" / "0"
 delim     = "."
 segment   = alpha *( alpha / number / "-" )
 authority = segment *( delim segment )
-name      = segment
+name      = alpha *( alpha )
 nsid      = authority delim name
 
 */
@@ -81,14 +81,14 @@ export const ensureValidNsid = (nsid: string): void => {
     if (l.length > 63) {
       throw new InvalidNsidError('NSID part too long (max 63 chars)')
     }
-    if (l.length > 128 && i + 1 == labels.length) {
-      throw new InvalidNsidError('NSID name part too long (max 128 chars)')
+    if (l.endsWith('-') || l.startsWith('-')) {
+      throw new InvalidNsidError('NSID parts can not start or end with hyphen')
     }
-    if (l.endsWith('-')) {
-      throw new InvalidNsidError('NSID parts can not end with hyphen')
+    if (/^[0-9]/.test(l) && i == 0) {
+      throw new InvalidNsidError('NSID first part may not start with a digit')
     }
-    if (!/^[a-zA-Z]/.test(l)) {
-      throw new InvalidNsidError('NSID parts must start with ASCII letter')
+    if (!/^[a-zA-Z]+$/.test(l) && i + 1 == labels.length) {
+      throw new InvalidNsidError('NSID name part must be only letters')
     }
   }
 }
@@ -97,7 +97,7 @@ export const ensureValidNsidRegex = (nsid: string): void => {
   // simple regex to enforce most constraints via just regex and length.
   // hand wrote this regex based on above constraints
   if (
-    !/^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z0-9-]{0,126}[a-zA-Z0-9])?)$/.test(
+    !/^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z]{0,61}[a-zA-Z])?)$/.test(
       nsid,
     )
   ) {

--- a/packages/nsid/tests/nsid.test.ts
+++ b/packages/nsid/tests/nsid.test.ts
@@ -10,9 +10,6 @@ describe('NSID parsing & creation', () => {
     expect(NSID.parse('com.example.foo').authority).toBe('example.com')
     expect(NSID.parse('com.example.foo').name).toBe('foo')
     expect(NSID.parse('com.example.foo').toString()).toBe('com.example.foo')
-    expect(NSID.parse('com.example.*').authority).toBe('example.com')
-    expect(NSID.parse('com.example.*').name).toBe('*')
-    expect(NSID.parse('com.example.*').toString()).toBe('com.example.*')
     expect(NSID.parse('com.long-thing1.cool.fooBarBaz').authority).toBe(
       'cool.long-thing1.com',
     )
@@ -26,9 +23,6 @@ describe('NSID parsing & creation', () => {
     expect(NSID.create('example.com', 'foo').authority).toBe('example.com')
     expect(NSID.create('example.com', 'foo').name).toBe('foo')
     expect(NSID.create('example.com', 'foo').toString()).toBe('com.example.foo')
-    expect(NSID.create('example.com', '*').authority).toBe('example.com')
-    expect(NSID.create('example.com', '*').name).toBe('*')
-    expect(NSID.create('example.com', '*').toString()).toBe('com.example.*')
     expect(NSID.create('cool.long-thing1.com', 'fooBarBaz').authority).toBe(
       'cool.long-thing1.com',
     )

--- a/packages/nsid/tests/nsid.test.ts
+++ b/packages/nsid/tests/nsid.test.ts
@@ -67,15 +67,33 @@ describe('NSID validation', () => {
     expect(tooLongOverall.length).toBe(357)
     expectInvalid(tooLongOverall)
 
+    expectValid('com.example.fooBar')
+    expectValid('net.users.bob.ping')
     expectValid('a.b.c')
-    expectValid('a0.b1.c3')
-    expectValid('a-0.b-1.c-3')
     expectValid('m.xn--masekowski-d0b.pl')
     expectValid('one.two.three')
+    expectValid('one.two.three.four-and.FiVe')
+    expectValid('one.2.three')
+    expectValid('a-0.b-1.c')
+    expectValid('a0.b1.cc')
+    expectValid('cn.8.lex.stuff')
+    expectValid('test.12345.record')
+    expectValid('a01.thing.record')
+    expectValid('a.0.c')
+    expectValid('xn--fiqs8s.xn--fiqa61au8b7zsevnm8ak20mc4a87e.record.two')
 
+    expectInvalid('com.example.foo.*')
+    expectInvalid('com.example.foo.blah*')
+    expectInvalid('com.example.foo.*blah')
+    expectInvalid('com.example.f00')
+    expectInvalid('com.exa💩ple.thing')
+    expectInvalid('a-0.b-1.c-3')
+    expectInvalid('a-0.b-1.c-o')
+    expectInvalid('a0.b1.c3')
+    expectInvalid('1.0.0.127.record')
+    expectInvalid('0two.example.foo')
     expectInvalid('example.com')
     expectInvalid('com.example')
-    expectInvalid('a.0.c')
     expectInvalid('a.')
     expectInvalid('.one.two.three')
     expectInvalid('one.two.three ')
@@ -98,10 +116,10 @@ describe('NSID validation', () => {
     )
   })
 
-  it('blocks starting-with-numeric segments (differently from domains)', () => {
-    expectInvalid('org.4chan.lex.getThing')
-    expectInvalid('cn.8.lex.stuff')
-    expectInvalid(
+  it('allows starting-with-numeric segments (same as domains)', () => {
+    expectValid('org.4chan.lex.getThing')
+    expectValid('cn.8.lex.stuff')
+    expectValid(
       'onion.2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.lex.deleteThing',
     )
   })

--- a/packages/nsid/tests/nsid.test.ts
+++ b/packages/nsid/tests/nsid.test.ts
@@ -59,18 +59,18 @@ describe('NSID validation', () => {
     const tooLongNsid = 'com.' + 'o'.repeat(64) + '.foo'
     expectInvalid(tooLongNsid)
 
-    const longEnd = 'com.example.' + 'o'.repeat(128)
+    const longEnd = 'com.example.' + 'o'.repeat(63)
     expectValid(longEnd)
 
-    const tooLongEnd = 'com.example.' + 'o'.repeat(129)
+    const tooLongEnd = 'com.example.' + 'o'.repeat(64)
     expectInvalid(tooLongEnd)
 
-    const longOverall = 'com.' + 'middle.'.repeat(50) + 'foo'
-    expect(longOverall.length).toBe(357)
+    const longOverall = 'com.' + 'middle.'.repeat(40) + 'foo'
+    expect(longOverall.length).toBe(287)
     expectValid(longOverall)
 
-    const tooLongOverall = 'com.' + 'middle.'.repeat(100) + 'foo'
-    expect(tooLongOverall.length).toBe(707)
+    const tooLongOverall = 'com.' + 'middle.'.repeat(50) + 'foo'
+    expect(tooLongOverall.length).toBe(357)
     expectInvalid(tooLongOverall)
 
     expectValid('a.b.c')

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -4,8 +4,8 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "jest",
-    "prettier": "prettier --check src/",
-    "prettier:fix": "prettier --write src/",
+    "prettier": "prettier --check src/ tests/",
+    "prettier:fix": "prettier --write src/ tests/",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "yarn lint --fix",
     "verify": "run-p prettier lint",

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -43,7 +43,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.validationTest2',
+    id: 'io.example.validationTestTwo',
     defs: {
       main: {
         type: 'query',
@@ -101,7 +101,7 @@ describe('Bodies', () => {
       body: ctx.input?.body,
     }),
   )
-  server.method('io.example.validationTest2', () => ({
+  server.method('io.example.validationTestTwo', () => ({
     encoding: 'json',
     body: { wrong: 'data' },
   }))
@@ -175,7 +175,7 @@ describe('Bodies', () => {
       return logger.error(obj, ...args)
     }
 
-    await expect(client.call('io.example.validationTest2')).rejects.toThrow(
+    await expect(client.call('io.example.validationTestTwo')).rejects.toThrow(
       'Internal Server Error',
     )
     expect(error).toEqual(`Output must have the property "foo"`)

--- a/packages/xrpc-server/tests/procedures.test.ts
+++ b/packages/xrpc-server/tests/procedures.test.ts
@@ -8,7 +8,7 @@ import * as xrpcServer from '../src'
 const LEXICONS = [
   {
     lexicon: 1,
-    id: 'io.example.ping1',
+    id: 'io.example.pingOne',
     defs: {
       main: {
         type: 'procedure',
@@ -26,7 +26,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.ping2',
+    id: 'io.example.pingTwo',
     defs: {
       main: {
         type: 'procedure',
@@ -41,7 +41,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.ping3',
+    id: 'io.example.pingThree',
     defs: {
       main: {
         type: 'procedure',
@@ -56,7 +56,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.ping4',
+    id: 'io.example.pingFour',
     defs: {
       main: {
         type: 'procedure',
@@ -84,17 +84,17 @@ const LEXICONS = [
 describe('Procedures', () => {
   let s: http.Server
   const server = xrpcServer.createServer(LEXICONS)
-  server.method('io.example.ping1', (ctx: { params: xrpcServer.Params }) => {
+  server.method('io.example.pingOne', (ctx: { params: xrpcServer.Params }) => {
     return { encoding: 'text/plain', body: ctx.params.message }
   })
   server.method(
-    'io.example.ping2',
+    'io.example.pingTwo',
     (ctx: { params: xrpcServer.Params; input?: xrpcServer.HandlerInput }) => {
       return { encoding: 'text/plain', body: ctx.input?.body }
     },
   )
   server.method(
-    'io.example.ping3',
+    'io.example.pingThree',
     async (ctx: {
       params: xrpcServer.Params
       input?: xrpcServer.HandlerInput
@@ -112,7 +112,7 @@ describe('Procedures', () => {
     },
   )
   server.method(
-    'io.example.ping4',
+    'io.example.pingFour',
     (ctx: { params: xrpcServer.Params; input?: xrpcServer.HandlerInput }) => {
       return {
         encoding: 'application/json',
@@ -133,14 +133,14 @@ describe('Procedures', () => {
   })
 
   it('serves requests', async () => {
-    const res1 = await client.call('io.example.ping1', {
+    const res1 = await client.call('io.example.pingOne', {
       message: 'hello world',
     })
     expect(res1.success).toBeTruthy()
     expect(res1.headers['content-type']).toBe('text/plain; charset=utf-8')
     expect(res1.data).toBe('hello world')
 
-    const res2 = await client.call('io.example.ping2', {}, 'hello world', {
+    const res2 = await client.call('io.example.pingTwo', {}, 'hello world', {
       encoding: 'text/plain',
     })
     expect(res2.success).toBeTruthy()
@@ -148,7 +148,7 @@ describe('Procedures', () => {
     expect(res2.data).toBe('hello world')
 
     const res3 = await client.call(
-      'io.example.ping3',
+      'io.example.pingThree',
       {},
       new TextEncoder().encode('hello world'),
       { encoding: 'application/octet-stream' },
@@ -158,7 +158,7 @@ describe('Procedures', () => {
     expect(new TextDecoder().decode(res3.data)).toBe('hello world')
 
     const res4 = await client.call(
-      'io.example.ping4',
+      'io.example.pingFour',
       {},
       { message: 'hello world' },
     )

--- a/packages/xrpc-server/tests/queries.test.ts
+++ b/packages/xrpc-server/tests/queries.test.ts
@@ -7,7 +7,7 @@ import * as xrpcServer from '../src'
 const LEXICONS = [
   {
     lexicon: 1,
-    id: 'io.example.ping1',
+    id: 'io.example.pingOne',
     defs: {
       main: {
         type: 'query',
@@ -25,7 +25,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.ping2',
+    id: 'io.example.pingTwo',
     defs: {
       main: {
         type: 'query',
@@ -43,7 +43,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.ping3',
+    id: 'io.example.pingThree',
     defs: {
       main: {
         type: 'query',
@@ -69,16 +69,16 @@ const LEXICONS = [
 describe('Queries', () => {
   let s: http.Server
   const server = xrpcServer.createServer(LEXICONS)
-  server.method('io.example.ping1', (ctx: { params: xrpcServer.Params }) => {
+  server.method('io.example.pingOne', (ctx: { params: xrpcServer.Params }) => {
     return { encoding: 'text/plain', body: ctx.params.message }
   })
-  server.method('io.example.ping2', (ctx: { params: xrpcServer.Params }) => {
+  server.method('io.example.pingTwo', (ctx: { params: xrpcServer.Params }) => {
     return {
       encoding: 'application/octet-stream',
       body: new TextEncoder().encode(String(ctx.params.message)),
     }
   })
-  server.method('io.example.ping3', (ctx: { params: xrpcServer.Params }) => {
+  server.method('io.example.pingThree', (ctx: { params: xrpcServer.Params }) => {
     return {
       encoding: 'application/json',
       body: { message: ctx.params.message },
@@ -98,21 +98,21 @@ describe('Queries', () => {
   })
 
   it('serves requests', async () => {
-    const res1 = await client.call('io.example.ping1', {
+    const res1 = await client.call('io.example.pingOne', {
       message: 'hello world',
     })
     expect(res1.success).toBeTruthy()
     expect(res1.headers['content-type']).toBe('text/plain; charset=utf-8')
     expect(res1.data).toBe('hello world')
 
-    const res2 = await client.call('io.example.ping2', {
+    const res2 = await client.call('io.example.pingTwo', {
       message: 'hello world',
     })
     expect(res2.success).toBeTruthy()
     expect(res2.headers['content-type']).toBe('application/octet-stream')
     expect(new TextDecoder().decode(res2.data)).toBe('hello world')
 
-    const res3 = await client.call('io.example.ping3', {
+    const res3 = await client.call('io.example.pingThree', {
       message: 'hello world',
     })
     expect(res3.success).toBeTruthy()

--- a/packages/xrpc-server/tests/queries.test.ts
+++ b/packages/xrpc-server/tests/queries.test.ts
@@ -78,13 +78,16 @@ describe('Queries', () => {
       body: new TextEncoder().encode(String(ctx.params.message)),
     }
   })
-  server.method('io.example.pingThree', (ctx: { params: xrpcServer.Params }) => {
-    return {
-      encoding: 'application/json',
-      body: { message: ctx.params.message },
-      headers: { 'x-test-header-name': 'test-value' },
-    }
-  })
+  server.method(
+    'io.example.pingThree',
+    (ctx: { params: xrpcServer.Params }) => {
+      return {
+        encoding: 'application/json',
+        body: { message: ctx.params.message },
+        headers: { 'x-test-header-name': 'test-value' },
+      }
+    },
+  )
   xrpc.addLexicons(LEXICONS)
 
   let client: ServiceClient

--- a/packages/xrpc-server/tests/subscriptions.test.ts
+++ b/packages/xrpc-server/tests/subscriptions.test.ts
@@ -14,7 +14,7 @@ import * as xrpcServer from '../src'
 const LEXICONS = [
   {
     lexicon: 1,
-    id: 'io.example.stream1',
+    id: 'io.example.streamOne',
     defs: {
       main: {
         type: 'subscription',
@@ -37,7 +37,7 @@ const LEXICONS = [
   },
   {
     lexicon: 1,
-    id: 'io.example.stream2',
+    id: 'io.example.streamTwo',
     defs: {
       main: {
         type: 'subscription',
@@ -84,7 +84,7 @@ describe('Subscriptions', () => {
   const server = xrpcServer.createServer(LEXICONS)
   const lex = server.lex
 
-  server.streamMethod('io.example.stream1', async function* ({ params }) {
+  server.streamMethod('io.example.streamOne', async function* ({ params }) {
     const countdown = Number(params.countdown ?? 0)
     for (let i = countdown; i >= 0; i--) {
       await wait(0)
@@ -92,11 +92,11 @@ describe('Subscriptions', () => {
     }
   })
 
-  server.streamMethod('io.example.stream2', async function* ({ params }) {
+  server.streamMethod('io.example.streamTwo', async function* ({ params }) {
     const countdown = Number(params.countdown ?? 0)
     for (let i = countdown; i >= 0; i--) {
       yield {
-        $type: i % 2 === 0 ? '#even' : 'io.example.stream2#odd',
+        $type: i % 2 === 0 ? '#even' : 'io.example.streamTwo#odd',
         count: i,
       }
     }
@@ -124,7 +124,7 @@ describe('Subscriptions', () => {
 
   it('streams messages', async () => {
     const ws = new WebSocket(
-      `ws://localhost:${port}/xrpc/io.example.stream1?countdown=5`,
+      `ws://localhost:${port}/xrpc/io.example.streamOne?countdown=5`,
     )
 
     const frames: Frame[] = []
@@ -144,7 +144,7 @@ describe('Subscriptions', () => {
 
   it('streams messages in a union', async () => {
     const ws = new WebSocket(
-      `ws://localhost:${port}/xrpc/io.example.stream2?countdown=5`,
+      `ws://localhost:${port}/xrpc/io.example.streamTwo?countdown=5`,
     )
 
     const frames: Frame[] = []
@@ -192,7 +192,7 @@ describe('Subscriptions', () => {
   })
 
   it('errors immediately on bad parameter', async () => {
-    const ws = new WebSocket(`ws://localhost:${port}/xrpc/io.example.stream1`)
+    const ws = new WebSocket(`ws://localhost:${port}/xrpc/io.example.streamOne`)
 
     const frames: Frame[] = []
     for await (const frame of byFrame(ws)) {
@@ -245,11 +245,11 @@ describe('Subscriptions', () => {
     it('receives messages w/ skips', async () => {
       const sub = new Subscription({
         service: `ws://localhost:${port}`,
-        method: 'io.example.stream1',
+        method: 'io.example.streamOne',
         getParams: () => ({ countdown: 5 }),
         validate: (obj) => {
           const result = lex.assertValidXrpcMessage<{ count: number }>(
-            'io.example.stream1',
+            'io.example.streamOne',
             obj,
           )
           if (!result.count || result.count % 2) {
@@ -276,12 +276,12 @@ describe('Subscriptions', () => {
       let reconnects = 0
       const sub = new Subscription({
         service: `ws://localhost:${port}`,
-        method: 'io.example.stream1',
+        method: 'io.example.streamOne',
         onReconnectError: () => reconnects++,
         getParams: () => ({ countdown }),
         validate: (obj) => {
           return lex.assertValidXrpcMessage<{ count: number }>(
-            'io.example.stream1',
+            'io.example.streamOne',
             obj,
           )
         },
@@ -307,12 +307,12 @@ describe('Subscriptions', () => {
       const abortController = new AbortController()
       const sub = new Subscription({
         service: `ws://localhost:${port}`,
-        method: 'io.example.stream1',
+        method: 'io.example.streamOne',
         signal: abortController.signal,
         getParams: () => ({ countdown: 10 }),
         validate: (obj) => {
           const result = lex.assertValidXrpcMessage<{ count: number }>(
-            'io.example.stream1',
+            'io.example.streamOne',
             obj,
           )
           return result


### PR DESCRIPTION
The motivation was to take some of the small proposed changes from identifier specification work and put them in PR form for review here.

The NSID "name" component length change (from 128 to 63): i'm actually now kind of ambivalent after implementing this. One of the motivations was realizing huge names would bloat AT-URIs. But maybe it just doesn't matter!

NSID other restrictions: I think tracking handles to domains very closely has been a good move. I'm not sure the same needs to apply to NSIDs, but it is weird to have extra rules around NSID *domain authority* section other than "valid hostname in reverse order". I am in favor of locking down the "name" section very harshly (to just ASCII letters, either case). We can allow trailing digits or whatever later if we want, once we verify which programming languages do/don't allow that in variable names.