### PR TITLE
Feed publishing tweaks

### DIFF
--- a/packages/dev-env/src/pds.ts
+++ b/packages/dev-env/src/pds.ts
@@ -59,6 +59,7 @@ export class TestPds {
       repoBackfillLimitMs: 1000 * 60 * 60, // 1hr
       labelerDid: 'did:example:labeler',
       labelerKeywords: { label_me: 'test-label', label_me_2: 'test-label-2' },
+      feedGenDid: 'did:example:feedGen',
       ...cfg,
     })
 

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -14,7 +14,11 @@ import {
 } from '../../../../repo'
 import { ConcurrentWriteError } from '../../../../services/repo'
 
-const ALLOWED_PUTS = [ids.AppBskyActorProfile, ids.AppBskyGraphList]
+const ALLOWED_PUTS = [
+  ids.AppBskyActorProfile,
+  ids.AppBskyGraphList,
+  ids.AppBskyFeedGenerator,
+]
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.putRecord({

--- a/packages/pds/src/app-view/api/app/bsky/feed/describeFeedGenerator.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/describeFeedGenerator.ts
@@ -1,14 +1,19 @@
 import { Server } from '../../../../../lexicon'
 import AppContext from '../../../../../context'
+import { MethodNotImplementedError } from '@atproto/xrpc-server'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.describeFeedGenerator(async () => {
+    if (!ctx.cfg.feedGenDid) {
+      throw new MethodNotImplementedError()
+    }
+
     const feeds = Object.keys(ctx.algos).map((uri) => ({ uri }))
 
     return {
       encoding: 'application/json',
       body: {
-        did: ctx.cfg.serverDid,
+        did: ctx.cfg.feedGenDid,
         feeds,
       },
     }

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -48,6 +48,8 @@ export interface ServerConfigValues {
   labelerDid: string
   labelerKeywords: Record<string, string>
 
+  feedGenDid?: string
+
   maxSubscriptionBuffer: number
   repoBackfillLimitMs: number
 
@@ -143,6 +145,8 @@ export class ServerConfig {
     const labelerDid = process.env.LABELER_DID || 'did:example:labeler'
     const labelerKeywords = {}
 
+    const feedGenDid = process.env.FEED_GEN_DID
+
     const dbPostgresUrl = process.env.DB_POSTGRES_URL
     const dbPostgresSchema = process.env.DB_POSTGRES_SCHEMA
 
@@ -200,6 +204,7 @@ export class ServerConfig {
       hiveApiKey,
       labelerDid,
       labelerKeywords,
+      feedGenDid,
       maxSubscriptionBuffer,
       repoBackfillLimitMs,
       appViewRepoProvider,
@@ -373,6 +378,10 @@ export class ServerConfig {
 
   get labelerKeywords() {
     return this.cfg.labelerKeywords
+  }
+
+  get feedGenDid() {
+    return this.cfg.feedGenDid
   }
 
   get maxSubscriptionBuffer() {

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -99,6 +99,7 @@ export const runTestServer = async (
     blobstoreTmp: `${blobstoreLoc}/tmp`,
     labelerDid: 'did:example:labeler',
     labelerKeywords: { label_me: 'test-label', label_me_2: 'test-label-2' },
+    feedGenDid: 'did:example:feedGen',
     maxSubscriptionBuffer: 200,
     repoBackfillLimitMs: HOUR,
     ...params,

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -47,6 +47,11 @@ describe('feed generation', () => {
     await network.close()
   })
 
+  it('describes the feed generator', async () => {
+    const res = await agent.api.app.bsky.feed.describeFeedGenerator()
+    expect(res.data.did).toBe(network.pds.ctx.cfg.feedGenDid)
+  })
+
   it('feed gen records can be created.', async () => {
     const all = await agent.api.app.bsky.feed.generator.create(
       { repo: alice, rkey: 'all' },

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -64,13 +64,12 @@ describe('feed generation', () => {
       },
       sc.getHeaders(alice),
     )
-    // updated in next test
     const even = await agent.api.app.bsky.feed.generator.create(
       { repo: alice, rkey: 'even' },
       {
         did: gen.did,
-        displayName: 'Temp',
-        description: 'Temp',
+        displayName: 'Even',
+        description: 'Provides even-indexed feed candidates',
         createdAt: new Date().toISOString(),
       },
       sc.getHeaders(alice),
@@ -80,8 +79,8 @@ describe('feed generation', () => {
       { repo: alice, rkey: 'odd' },
       {
         did: gen.did,
-        displayName: 'Odd',
-        description: 'Provides odd-indexed feed candidates',
+        displayName: 'Temp', // updated in next test
+        description: 'Temp', // updated in next test
         createdAt: new Date().toISOString(),
       },
       sc.getHeaders(alice),
@@ -97,11 +96,11 @@ describe('feed generation', () => {
       {
         repo: alice,
         collection: ids.AppBskyFeedGenerator,
-        rkey: 'even',
+        rkey: 'odd',
         record: {
           did: gen.did,
-          displayName: 'Even',
-          description: 'Provides even-indexed feed candidates',
+          displayName: 'Odd',
+          description: 'Provides odd-indexed feed candidates',
           createdAt: new Date().toISOString(),
         },
       },

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@atproto/api/src/client/types/app/bsky/feed/defs'
 import { SkeletonFeedPost } from '../src/lexicon/types/app/bsky/feed/defs'
 import { RecordRef } from './seeds/client'
+import { ids } from '../src/lexicon/lexicons'
 
 describe('feed generation', () => {
   let network: TestNetworkNoAppView
@@ -63,12 +64,13 @@ describe('feed generation', () => {
       },
       sc.getHeaders(alice),
     )
+    // updated in next test
     const even = await agent.api.app.bsky.feed.generator.create(
       { repo: alice, rkey: 'even' },
       {
         did: gen.did,
-        displayName: 'Even',
-        description: 'Provides even-indexed feed candidates',
+        displayName: 'Temp',
+        description: 'Temp',
         createdAt: new Date().toISOString(),
       },
       sc.getHeaders(alice),
@@ -88,6 +90,23 @@ describe('feed generation', () => {
     feedUriAllRef = new RecordRef(all.uri, all.cid)
     feedUriEven = even.uri
     feedUriOdd = odd.uri
+  })
+
+  it('feed gen records can be updated', async () => {
+    await agent.api.com.atproto.repo.putRecord(
+      {
+        repo: alice,
+        collection: ids.AppBskyFeedGenerator,
+        rkey: 'even',
+        record: {
+          did: gen.did,
+          displayName: 'Even',
+          description: 'Provides even-indexed feed candidates',
+          createdAt: new Date().toISOString(),
+        },
+      },
+      { headers: sc.getHeaders(alice), encoding: 'application/json' },
+    )
   })
 
   it('getActorFeeds fetches feed generators by actor.', async () => {


### PR DESCRIPTION
Two things here:
- We need a feed generator did provided to the server so that it can properly respond to `describeFeedGenerator`
- We allow `putRecord` for generator records

Note: before, deploy we should add the following DIDs to our service configs:
```
staging: did:plc:go3w5oz6pk4a56zaaprn3lyr
production: did:plc:5fllqkujj6kqp5izd5jg7gox
```