### PR TITLE
Fix incorrect union validation

### DIFF
--- a/packages/lexicon/src/util.ts
+++ b/packages/lexicon/src/util.ts
@@ -10,6 +10,10 @@ import {
 import { z } from 'zod'
 
 export function toLexUri(str: string, baseUri?: string): string {
+  if (str.split('#').length > 2) {
+    throw new Error('Uri can only have one hash segment')
+  }
+
   if (str.startsWith('lex:')) {
     return str
   }

--- a/packages/lexicon/src/util.ts
+++ b/packages/lexicon/src/util.ts
@@ -41,7 +41,7 @@ export function validateOneOf(
         ),
       }
     }
-    if (!def.refs.includes(toLexUri(value.$type))) {
+    if (!refsContainType(def.refs, value.$type)) {
       if (def.closed) {
         return {
           success: false,
@@ -143,5 +143,20 @@ export function requiredPropertiesRefinement<
         message: `Required field "${field}" not defined`,
       })
     }
+  }
+}
+
+// to avoid bugs like #0189 this needs to handle both
+// explicit and implicit #main
+const refsContainType = (refs: string[], type: string) => {
+  const lexUri = toLexUri(type)
+  if (refs.includes(lexUri)) {
+    return true
+  }
+
+  if (lexUri.endsWith('#main')) {
+    return refs.includes(lexUri.replace('#main', ''))
+  } else {
+    return refs.includes(lexUri + '#main')
   }
 }

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -101,6 +101,57 @@ describe('General validation', () => {
       lexiconDoc.parse(schema)
     }).toThrow('Required field \\"foo\\" not defined')
   })
+  it('fails lexicon parsing when uri is invalid', () => {
+    const schema = {
+      lexicon: 1,
+      id: 'com.example.invalidUri',
+      defs: {
+        main: {
+          type: 'object',
+          properties: {
+            test: { type: 'ref', ref: 'com.example.invalid#test#test' },
+          },
+        },
+      },
+    }
+
+    expect(() => {
+      new Lexicons([schema])
+    }).toThrow('Uri can only have one hash segment')
+  })
+  it('fails validation when ref uri has multiple hash segments', () => {
+    const schema = {
+      lexicon: 1,
+      id: 'com.example.invalidUri',
+      defs: {
+        main: {
+          type: 'object',
+          properties: {
+            test: { type: 'integer' },
+          },
+        },
+        object: {
+          type: 'object',
+          required: ['test'],
+          properties: {
+            test: {
+              type: 'union',
+              refs: ['com.example.invalidUri'],
+            },
+          },
+        },
+      },
+    }
+    const lexicons = new Lexicons([schema])
+    expect(() => {
+      lexicons.validate('com.example.invalidUri#object', {
+        test: {
+          $type: 'com.example.invalidUri#main#main',
+          test: 123,
+        },
+      })
+    }).toThrow('Uri can only have one hash segment')
+  })
   it('union handles both implicit and explicit #main', () => {
     const schemas = [
       {

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -101,6 +101,93 @@ describe('General validation', () => {
       lexiconDoc.parse(schema)
     }).toThrow('Required field \\"foo\\" not defined')
   })
+  it('union handles both implicit and explicit #main', () => {
+    const schemas = [
+      {
+        lexicon: 1,
+        id: 'com.example.implicitMain',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['test'],
+            properties: {
+              test: { type: 'string' },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.testImplicitMain',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['union'],
+            properties: {
+              union: {
+                type: 'union',
+                refs: ['com.example.implicitMain'],
+              },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.testExplicitMain',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['union'],
+            properties: {
+              union: {
+                type: 'union',
+                refs: ['com.example.implicitMain#main'],
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const lexicon = new Lexicons(schemas)
+
+    let result = lexicon.validate('com.example.testImplicitMain', {
+      union: {
+        $type: 'com.example.implicitMain',
+        test: 123,
+      },
+    })
+    expect(result.success).toBeFalsy()
+    expect(result['error']?.message).toBe('Object/union/test must be a string')
+
+    result = lexicon.validate('com.example.testImplicitMain', {
+      union: {
+        $type: 'com.example.implicitMain#main',
+        test: 123,
+      },
+    })
+    expect(result.success).toBeFalsy()
+    expect(result['error']?.message).toBe('Object/union/test must be a string')
+
+    result = lexicon.validate('com.example.testExplicitMain', {
+      union: {
+        $type: 'com.example.implicitMain',
+        test: 123,
+      },
+    })
+    expect(result.success).toBeFalsy()
+    expect(result['error']?.message).toBe('Object/union/test must be a string')
+
+    result = lexicon.validate('com.example.testExplicitMain', {
+      union: {
+        $type: 'com.example.implicitMain#main',
+        test: 123,
+      },
+    })
+    expect(result.success).toBeFalsy()
+    expect(result['error']?.message).toBe('Object/union/test must be a string')
+  })
 })
 
 describe('Record validation', () => {


### PR DESCRIPTION
Fixes lexicon validation so incorrect types like in #1089 don't validate.
Now when a request like in #1089 is sent a proper 400 is returned :) 