### PR TITLE
Catch missed txn rollbacks

### DIFF
--- a/packages/bsky/tests/db.test.ts
+++ b/packages/bsky/tests/db.test.ts
@@ -125,6 +125,37 @@ describe('db', () => {
 
       expect(res.length).toBe(0)
     })
+
+    it('ensures all inflight querys are rolled back', async () => {
+      let promise: Promise<unknown> | undefined = undefined
+      try {
+        await db.transaction(async (dbTxn) => {
+          const queryA = dbTxn.db
+            .insertInto('actor')
+            .values({ handle: 'a', did: 'a', indexedAt: 'bad-date' })
+            .execute()
+          const queryB = dbTxn.db
+            .insertInto('actor')
+            .values({ handle: 'b', did: 'b', indexedAt: 'bad-date' })
+            .execute()
+
+          promise = Promise.allSettled([queryA, queryB])
+          throw new Error()
+        })
+      } catch (err) {
+        expect(err).toBeDefined()
+      }
+      if (promise) {
+        await promise
+      }
+
+      const res = await db.db
+        .selectFrom('actor')
+        .selectAll()
+        .where('did', 'in', ['a', 'b'])
+        .execute()
+      expect(res.length).toBe(0)
+    })
   })
 
   describe('Leader', () => {

--- a/packages/pds/tests/db.test.ts
+++ b/packages/pds/tests/db.test.ts
@@ -132,18 +132,24 @@ describe('db', () => {
 
     it('ensures all inflight querys are rolled back', async () => {
       let promise: Promise<unknown> | undefined = undefined
+      const names: string[] = []
       try {
         await db.transaction(async (dbTxn) => {
-          const queryA = dbTxn.db
-            .insertInto('repo_root')
-            .values({ root: 'a', did: 'a', indexedAt: 'bad-date' })
-            .execute()
-          const queryB = dbTxn.db
-            .insertInto('repo_root')
-            .values({ root: 'b', did: 'b', indexedAt: 'bad-date' })
-            .execute()
-
-          promise = Promise.allSettled([queryA, queryB])
+          const queries: Promise<unknown>[] = []
+          for (let i = 0; i < 20; i++) {
+            const name = `user${i}`
+            const query = dbTxn.db
+              .insertInto('repo_root')
+              .values({
+                root: name,
+                did: name,
+                indexedAt: 'bad-date',
+              })
+              .execute()
+            names.push(name)
+            queries.push(query)
+          }
+          promise = Promise.allSettled(queries)
           throw new Error()
         })
       } catch (err) {
@@ -156,7 +162,7 @@ describe('db', () => {
       const res = await db.db
         .selectFrom('repo_root')
         .selectAll()
-        .where('did', 'in', ['a', 'b'])
+        .where('did', 'in', names)
         .execute()
       expect(res.length).toBe(0)
     })


### PR DESCRIPTION
There is a race condition on transaction execution that looks something like:
- transaction is begun
- query is formatted, passed to executor & through plugins
- error is thrown
- transaction is rolled back
- query is processed by postgres _outside of_ txn

The LeakyTx plugin was meant to catch these, but apparently that plugin is not the absolute last thing done before sending the query.

The fix I applied here feels just a lil bit hacky but I can't see a better approach. We wait for 10ms after receiving an error for any queries to get sent off before throwing the error which will all it to rollback. During that 10ms, we stop any new queries from being sent.

You can see another approach I tried in the commit log where I tracked in-flight queries, but this was failing on queries that would throw (as they don't get passed back through the kysely plugin system)

Closes https://github.com/bluesky-social/atproto/issues/1089