### PR TITLE
Rebase rework

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/rebaseRepo.ts
+++ b/packages/pds/src/api/com/atproto/repo/rebaseRepo.ts
@@ -21,9 +21,7 @@ export default function (server: Server, ctx: AppContext) {
       const swapCommitCid = swapCommit ? CID.parse(swapCommit) : undefined
 
       try {
-        await ctx.db.transaction((dbTxn) =>
-          ctx.services.repo(dbTxn).rebaseRepo(repo, swapCommitCid),
-        )
+        await ctx.services.repo(ctx.db).rebaseRepo(repo, swapCommitCid)
       } catch (err) {
         if (err instanceof BadCommitSwapError) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')

--- a/packages/pds/src/api/com/atproto/repo/rebaseRepo.ts
+++ b/packages/pds/src/api/com/atproto/repo/rebaseRepo.ts
@@ -21,7 +21,9 @@ export default function (server: Server, ctx: AppContext) {
       const swapCommitCid = swapCommit ? CID.parse(swapCommit) : undefined
 
       try {
-        await ctx.services.repo(ctx.db).rebaseRepo(repo, swapCommitCid)
+        await ctx.db.transaction((dbTxn) =>
+          ctx.services.repo(dbTxn).rebaseRepo(repo, swapCommitCid),
+        )
       } catch (err) {
         if (err instanceof BadCommitSwapError) {
           throw new InvalidRequestError(err.message, 'InvalidSwap')

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -251,7 +251,9 @@ export class RepoService {
     const recordCountAfter = await this.countRecordBlocks(did)
     // This is purely a dummy check on a very sensitive operation
     if (recordCountBefore !== recordCountAfter) {
-      throw new Error('Record blocks deleted during rebase. Rolling back')
+      throw new Error(
+        `Record blocks deleted during rebase. Rolling back: ${did}`,
+      )
     }
 
     await this.afterRebaseProcessing(did, rebaseData)

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -2,11 +2,15 @@ import { CID } from 'multiformats/cid'
 import * as crypto from '@atproto/crypto'
 import {
   BlobStore,
+  MemoryBlockstore,
+  BlockMap,
   CommitData,
   RebaseData,
   Repo,
   WriteOpAction,
 } from '@atproto/repo'
+import * as repo from '@atproto/repo'
+import { AtUri } from '@atproto/uri'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import Database from '../../db'
 import { MessageQueue } from '../../event-stream/types'
@@ -24,6 +28,7 @@ import * as sequencer from '../../sequencer'
 import { Labeler } from '../../labeler'
 import { wait } from '@atproto/common'
 import { BackgroundQueue } from '../../event-stream/background-queue'
+import { countAll } from '../../db/util'
 
 export class RepoService {
   blobs: RepoBlobs
@@ -229,32 +234,10 @@ export class RepoService {
     await sequencer.sequenceEvt(this.db, seqEvt)
   }
 
+  // rebases are expensive & should be done rarely, we don't try to re-process on concurrent writes
   async rebaseRepo(did: string, swapCommit?: CID) {
-    this.db.assertNotTransaction()
-    const storage = new SqlRepoStorage(this.db, did)
-    const currRoot = await storage.getHead()
-    if (!currRoot) {
-      throw new InvalidRequestError(
-        `${did} is not a registered repo on this server`,
-      )
-    }
-    const repo = await Repo.load(storage, currRoot)
-    const rebaseData = await repo.formatRebase(this.repoSigningKey)
-
-    // rebases are expensive & should be done rarely, we don't try to re-process on concurrent writes
-    await this.serviceTx(async (srvcTx) =>
-      srvcTx.processRebase(did, rebaseData, swapCommit),
-    )
-  }
-
-  async processRebase(
-    did: string,
-    rebaseData: RebaseData,
-    swapCommit?: CID,
-    now?: string,
-  ) {
     this.db.assertTransaction()
-    const storage = new SqlRepoStorage(this.db, did, now)
+    const storage = new SqlRepoStorage(this.db, did, new Date().toISOString())
     const currRoot = await storage.lockHead()
     if (!currRoot) {
       throw new ConcurrentWriteError()
@@ -262,10 +245,65 @@ export class RepoService {
     if (swapCommit && !currRoot.equals(swapCommit)) {
       throw new BadCommitSwapError(currRoot)
     }
-    await Promise.all([
-      storage.applyRebase(rebaseData),
-      this.afterRebaseProcessing(did, rebaseData),
-    ])
+    const rebaseData = await this.formatRebase(did, currRoot)
+    const recordCountBefore = await this.countRecordBlocks(did)
+    await storage.applyRebase(rebaseData)
+    const recordCountAfter = await this.countRecordBlocks(did)
+    // This is purely a dummy check on a very sensitive operation
+    if (recordCountBefore !== recordCountAfter) {
+      throw new Error('Record blocks deleted during rebase. Rolling back')
+    }
+
+    await this.afterRebaseProcessing(did, rebaseData)
+  }
+
+  async formatRebase(did: string, currRoot: CID): Promise<RebaseData> {
+    const records = await this.db.db
+      .selectFrom('record')
+      .where('did', '=', did)
+      .select(['uri', 'cid'])
+      .execute()
+    const memoryStore = new MemoryBlockstore()
+    let data = await repo.MST.create(memoryStore)
+    for (const record of records) {
+      const uri = new AtUri(record.uri)
+      const cid = CID.parse(record.cid)
+      const dataKey = repo.formatDataKey(uri.collection, uri.rkey)
+      data = await data.add(dataKey, cid)
+    }
+    const commit = await repo.signCommit(
+      {
+        did,
+        version: 2,
+        prev: null,
+        data: await data.getPointer(),
+      },
+      this.repoSigningKey,
+    )
+    const currCids = await data.allCids()
+    const newBlocks = new BlockMap()
+    const commitCid = await newBlocks.add(commit)
+    return {
+      commit: commitCid,
+      rebased: currRoot,
+      blocks: newBlocks,
+      preservedCids: currCids.toList(),
+    }
+  }
+
+  // used for integrity check
+  private async countRecordBlocks(did: string): Promise<number> {
+    const res = await this.db.db
+      .selectFrom('record')
+      .where('record.did', '=', did)
+      .innerJoin('ipld_block', (join) =>
+        join
+          .onRef('ipld_block.creator', '=', 'record.did')
+          .onRef('ipld_block.cid', '=', 'record.cid'),
+      )
+      .select(countAll.as('count'))
+      .executeTakeFirst()
+    return res?.count ?? 0
   }
 
   async afterRebaseProcessing(did: string, rebaseData: RebaseData) {

--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -150,16 +150,15 @@ export class SqlRepoStorage extends RepoStorage {
     await this.indexCommitCids([
       { commit: rebase.commit, prev: null, cids: allCids },
     ])
-    const { ref } = this.db.db.dynamic
     await this.db.db
       .deleteFrom('ipld_block')
       .where('ipld_block.creator', '=', this.did)
-      .whereNotExists(
-        this.db.db
+      .whereNotExists((qb) =>
+        qb
           .selectFrom('repo_commit_block')
           .selectAll()
           .where('repo_commit_block.creator', '=', this.did)
-          .whereRef('repo_commit_block.block', '=', ref('ipld_block.cid')),
+          .whereRef('repo_commit_block.block', '=', 'ipld_block.cid'),
       )
       .execute()
     await this.updateHead(rebase.commit, rebase.rebased)


### PR DESCRIPTION
This is a small rework to rebases

The primary change is that instead of walking the repo from the top, we reconstruct it from the records at the bottom.

This does a couple things:
- reduces likelihood of a bug that deletes records
- allows recoverability from an unwalkable repo (ie, in a bad state) 
- prevents records from becoming orphaned if there was bad bookkeeping

This should also entail less back and forth with the database so should be more efficient as well

This also includes a dummy check that counts the number of record blocks before & after the tx and rolls the tx back if the numbers are not the same. This check may be deleted eventually, but is useful now because this is a potentially destructive operation. As long as record blocks are not deleted, we can always reconstruct a repository 