### PR TITLE
Bugfix for well-known handle resolution

### DIFF
--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -63,7 +63,11 @@ export class HandleResolver {
     const url = new URL('/.well-known/atproto-did', `https://${handle}`)
     try {
       const res = await fetch(url, { signal })
-      return await res.text()
+      const did = await res.text()
+      if (typeof did === 'string' && did.startsWith('did:')) {
+        return did
+      }
+      return undefined
     } catch (err) {
       return undefined
     }


### PR DESCRIPTION
Small bugfix. It was returning error content as a string instead of interpreting as an error