### PR TITLE
Implement quicker mute checks on pds

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -50,8 +50,10 @@ export default function (server: Server, ctx: AppContext) {
           // Hide reposts of muted content
           qb
             .where('type', '=', 'post')
-            .orWhereNotExists(
-              accountService.mutedQb(requester, [ref('post.creator')]),
+            .orWhere((qb) =>
+              accountService.whereNotMuted(qb, requester, [
+                ref('post.creator'),
+              ]),
             ),
         )
         .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))

--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
@@ -103,9 +103,9 @@ async function skeletonFromFeedGen(
     ? await feedService
         .selectFeedItemQb()
         .where('feed_item.uri', 'in', feedItemUris)
-        .whereNotExists(
+        .where((qb) =>
           // Hide posts and reposts of or by muted actors
-          accountService.mutedQb(requester, [
+          accountService.whereNotMuted(qb, requester, [
             ref('post.creator'),
             ref('originatorDid'),
           ]),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -35,9 +35,9 @@ export default function (server: Server, ctx: AppContext) {
             .where('originatorDid', '=', requester)
             .orWhere('originatorDid', 'in', followingIdsSubquery),
         )
-        .whereNotExists(
+        .where((qb) =>
           // Hide posts and reposts of or by muted actors
-          accountService.mutedQb(requester, [
+          accountService.whereNotMuted(qb, requester, [
             ref('post.creator'),
             ref('originatorDid'),
           ]),

--- a/packages/pds/src/app-view/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/getUnreadCount.ts
@@ -30,8 +30,8 @@ export default function (server: Server, ctx: AppContext) {
         .where(notSoftDeletedClause(ref('author_repo')))
         .where(notSoftDeletedClause(ref('record')))
         .where('notif.userDid', '=', requester)
-        .whereNotExists(
-          accountService.mutedQb(requester, [ref('notif.author')]),
+        .where((qb) =>
+          accountService.whereNotMuted(qb, requester, [ref('notif.author')]),
         )
         .whereRef('notif.indexedAt', '>', 'user_state.lastSeenNotifs')
         .executeTakeFirst()

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -32,8 +32,8 @@ export default function (server: Server, ctx: AppContext) {
         .where(notSoftDeletedClause(ref('author_repo')))
         .where(notSoftDeletedClause(ref('record')))
         .where('notif.userDid', '=', requester)
-        .whereNotExists(
-          accountService.mutedQb(requester, [ref('notif.author')]),
+        .where((qb) =>
+          accountService.whereNotMuted(qb, requester, [ref('notif.author')]),
         )
         .whereNotExists(graphService.blockQb(requester, [ref('notif.author')]))
         .where((clause) =>

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -51,8 +51,8 @@ export default function (server: Server, ctx: AppContext) {
                 .orWhereRef('label.uri', '=', ref('post.uri')),
             ),
         )
-        .whereNotExists(
-          accountService.mutedQb(requester, [ref('post.creator')]),
+        .where((qb) =>
+          accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
         )
         .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
 

--- a/packages/pds/src/feed-gen/bsky-team.ts
+++ b/packages/pds/src/feed-gen/bsky-team.ts
@@ -35,7 +35,9 @@ const handler: AlgoHandler = async (
   const postsQb = feedService
     .selectPostQb()
     .where('post.creator', 'in', BSKY_TEAM)
-    .whereNotExists(accountService.mutedQb(requester, [ref('post.creator')]))
+    .where((qb) =>
+      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+    )
     .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
 
   const keyset = new FeedKeyset(ref('sortAt'), ref('cid'))

--- a/packages/pds/src/feed-gen/hot-classic.ts
+++ b/packages/pds/src/feed-gen/hot-classic.ts
@@ -46,7 +46,9 @@ const handler: AlgoHandler = async (
             .orWhereRef('label.uri', '=', ref('post_embed_record.embedUri')),
         ),
     )
-    .whereNotExists(accountService.mutedQb(requester, [ref('post.creator')]))
+    .where((qb) =>
+      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+    )
     .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
 
   const keyset = new FeedKeyset(ref('sortAt'), ref('cid'))

--- a/packages/pds/src/feed-gen/whats-hot.ts
+++ b/packages/pds/src/feed-gen/whats-hot.ts
@@ -77,7 +77,9 @@ const handler: AlgoHandler = async (
             .orWhereRef('label.uri', '=', ref('post_embed_record.embedUri')),
         ),
     )
-    .whereNotExists(accountService.mutedQb(requester, [ref('post.creator')]))
+    .where((qb) =>
+      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+    )
     .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
     .orderBy('candidate.score', 'desc')
     .limit(limit)

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -58,7 +58,9 @@ const handler: AlgoHandler = async (
           valuesList(mostActiveMutuals.map((follow) => follow.did)),
         )
     })
-    .whereNotExists(accountService.mutedQb(requester, [ref('post.creator')]))
+    .where((qb) =>
+      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+    )
     .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
 
   const keyset = new FeedKeyset(ref('feed_item.sortAt'), ref('feed_item.cid'))


### PR DESCRIPTION
Previously the query snippet we'd use for excluding a user's mutes was roughly:
```
where not exists ((direct mutes) union all (mutes from lists))
```

Breaking-up the checks for direct mutes and list mutes turns out to be more flexible for the query planner, allowing it to speed some queries up.  So now we roughly do this:
```
where (not exists (direct mutes) and not exists (mutes from lists))
```