### PR TITLE
Minor perf tweaks for getTimeline and getRepo

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -34,6 +34,7 @@ export default function (server: Server, ctx: AppContext) {
             .where('originatorDid', '=', requester)
             .orWhere('originatorDid', 'in', followingIdsSubquery),
         )
+        .where('feed_item.sortAt', '>', getTimelineDateThreshold())
 
       const keyset = new FeedKeyset(
         ref('feed_item.sortAt'),
@@ -62,4 +63,11 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+// For users with sparse feeds, avoid scanning back further than two weeks
+const getTimelineDateThreshold = () => {
+  const timelineDateThreshold = new Date()
+  timelineDateThreshold.setDate(timelineDateThreshold.getDate() - 14)
+  return timelineDateThreshold.toISOString()
 }

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
       throw new InvalidRequestError(`Could not find shared history`)
     }
 
-    const commitChunks = chunkArray(commitPath, 25)
+    const commitChunks = chunkArray(commitPath, 50)
     const carStream = repo.writeCar(latest, async (car) => {
       for (const chunk of commitChunks) {
         const blocks = await storage.getAllBlocksForCommits(chunk)

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -48,6 +48,7 @@ export default function (server: Server, ctx: AppContext) {
             ref('originatorDid'),
           ]),
         )
+        .where('feed_item.sortAt', '>', getTimelineDateThreshold())
 
       const keyset = new FeedKeyset(
         ref('feed_item.sortAt'),
@@ -71,4 +72,11 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+// For users with sparse feeds, avoid scanning back further than two weeks
+const getTimelineDateThreshold = () => {
+  const timelineDateThreshold = new Date()
+  timelineDateThreshold.setDate(timelineDateThreshold.getDate() - 14)
+  return timelineDateThreshold.toISOString()
 }


### PR DESCRIPTION
 - Avoid scanning back further than two weeks on timeline, to avoid worst-case degenerate cases for building feeds.
 - Increase commit chunk size when pulling blocks in `getRepo`, hoping for a positive tradeoff when halving the number of total queries.