### PR TITLE
Disallow scheduling repeated view refreshes

### DIFF
--- a/packages/pds/src/db/index.ts
+++ b/packages/pds/src/db/index.ts
@@ -264,6 +264,13 @@ export class Database {
     )
     const { views, intervalSec, signal } = opts
     while (!signal.aborted) {
+      // super basic synchronization by agreeing when the intervals land relative to unix timestamp
+      const now = Date.now()
+      const intervalMs = 1000 * intervalSec
+      const nextIteration = Math.ceil(now / intervalMs)
+      const nextInMs = nextIteration * intervalMs - now
+      await wait(nextInMs)
+      if (signal.aborted) break
       await Promise.all(
         views.map(async (view) => {
           try {
@@ -280,12 +287,6 @@ export class Database {
           }
         }),
       )
-      // super basic synchronization by agreeing when the intervals land relative to unix timestamp
-      const now = Date.now()
-      const intervalMs = 1000 * intervalSec
-      const nextIteration = Math.ceil(now / intervalMs)
-      const nextInMs = nextIteration * intervalMs - now
-      await wait(nextInMs)
     }
   }
 


### PR DESCRIPTION
We haven't seen this issue actually occur, but in theory if PDSes are spinning then the view refreshes could happen many times in a row.  This avoids that by scheduling the first refresh rather than running it immediately.