### PR TITLE
Batch fetching of labels across posts and actors

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -35,7 +35,7 @@ export default function (server: Server, ctx: AppContext) {
         feedService.getActorViews(Array.from(relevant.dids), requester),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
-        labelService.getLabelsForSubjects(Array.from(relevant.uris)),
+        labelService.getLabelsForUris(Array.from(relevant.uris)),
       ])
 
       const thread = composeThread(

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -32,10 +32,10 @@ export default function (server: Server, ctx: AppContext) {
       }
       const relevant = getRelevantIds(threadData)
       const [actors, posts, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(relevant.dids), requester),
+        feedService.getActorViews(Array.from(relevant.dids), requester, true),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
-        labelService.getLabelsForUris(Array.from(relevant.uris)),
+        labelService.getLabelsForSubjects([...relevant.uris, ...relevant.dids]),
       ])
 
       const thread = composeThread(

--- a/packages/bsky/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPosts.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
         feedService.getActorViews(Array.from(dids), requester),
         feedService.getPostViews(Array.from(uris), requester),
         feedService.embedsForPosts(Array.from(uris), requester),
-        labelService.getLabelsForSubjects(Array.from(uris)),
+        labelService.getLabelsForUris(Array.from(uris)),
       ])
 
       const posts: PostView[] = []

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -68,7 +68,7 @@ export default function (server: Server, ctx: AppContext) {
           })),
           requester,
         ),
-        labelService.getLabelsForSubjects(recordUris),
+        labelService.getLabelsForUris(recordUris),
       ])
 
       const notifications = notifs.map((notif, i) => ({

--- a/packages/bsky/src/api/app/bsky/util/feed.ts
+++ b/packages/bsky/src/api/app/bsky/util/feed.ts
@@ -29,10 +29,10 @@ export const composeFeed = async (
     }
   }
   const [actors, posts, embeds, labels] = await Promise.all([
-    feedService.getActorViews(Array.from(actorDids), viewer),
+    feedService.getActorViews(Array.from(actorDids), viewer, true),
     feedService.getPostViews(Array.from(postUris), viewer),
     feedService.embedsForPosts(Array.from(postUris), viewer),
-    labelService.getLabelsForUris(Array.from(postUris)),
+    labelService.getLabelsForSubjects([...postUris, ...actorDids]),
   ])
 
   const feed: FeedViewPost[] = []

--- a/packages/bsky/src/api/app/bsky/util/feed.ts
+++ b/packages/bsky/src/api/app/bsky/util/feed.ts
@@ -32,7 +32,7 @@ export const composeFeed = async (
     feedService.getActorViews(Array.from(actorDids), viewer),
     feedService.getPostViews(Array.from(postUris), viewer),
     feedService.embedsForPosts(Array.from(postUris), viewer),
-    labelService.getLabelsForSubjects(Array.from(postUris)),
+    labelService.getLabelsForUris(Array.from(postUris)),
   ])
 
   const feed: FeedViewPost[] = []

--- a/packages/bsky/src/services/actor/views.ts
+++ b/packages/bsky/src/services/actor/views.ts
@@ -80,7 +80,7 @@ export class ActorViews {
 
     const [profileInfos, labels] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForProfiles(dids),
+      this.services.label(this.db).getLabelsForSubjects(dids),
     ])
 
     const profileInfoByDid = profileInfos.reduce((acc, info) => {
@@ -169,7 +169,7 @@ export class ActorViews {
 
     const [profileInfos, labels] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForProfiles(dids),
+      this.services.label(this.db).getLabelsForSubjects(dids),
     ])
 
     const profileInfoByDid = profileInfos.reduce((acc, info) => {

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -343,7 +343,8 @@ export class FeedService {
     const post = posts[uri]
     const author = actors[post?.creator]
     if (!post || !author) return undefined
-    // If the author labels are not hydrated yet, attempt to pull them from labels
+    // If the author labels are not hydrated yet, attempt to pull them
+    // from labels: e.g. compatible with composeFeed() batching label hydration.
     author.labels ??= labels[author.did] ?? []
     return {
       $type: 'app.bsky.feed.defs#postView',

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -101,7 +101,7 @@ export class FeedService {
             .as('requesterFollowedBy'),
         ])
         .execute(),
-      this.services.label(this.db).getLabelsForProfiles(dids),
+      this.services.label(this.db).getLabelsForSubjects(dids),
     ])
     return actors.reduce((acc, cur) => {
       return {

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -234,7 +234,7 @@ export class FeedService {
           viewer,
         ),
         this.embedsForPosts(nestedUris, viewer, _depth + 1),
-        this.services.label(this.db).getLabelsForSubjects(nestedUris),
+        this.services.label(this.db).getLabelsForUris(nestedUris),
       ])
     let embeds = images.reduce((acc, cur) => {
       const embed = (acc[cur.postUri] ??= {

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -70,6 +70,7 @@ export class FeedService {
   async getActorViews(
     dids: string[],
     viewer: string | null,
+    skipLabels?: boolean, // @NOTE used by composeFeed() to batch label hydration
   ): Promise<ActorViewMap> {
     if (dids.length < 1) return {}
     const { ref } = this.db.db.dynamic
@@ -101,9 +102,10 @@ export class FeedService {
             .as('requesterFollowedBy'),
         ])
         .execute(),
-      this.services.label(this.db).getLabelsForSubjects(dids),
+      this.services.label(this.db).getLabelsForSubjects(skipLabels ? [] : dids),
     ])
     return actors.reduce((acc, cur) => {
+      const actorLabels = labels[cur.did] ?? []
       return {
         ...acc,
         [cur.did]: {
@@ -124,7 +126,7 @@ export class FeedService {
                 // muted field hydrated on pds
               }
             : undefined,
-          labels: labels[cur.did] ?? [],
+          labels: skipLabels ? undefined : actorLabels,
         },
       }
     }, {} as ActorViewMap)
@@ -341,6 +343,8 @@ export class FeedService {
     const post = posts[uri]
     const author = actors[post?.creator]
     if (!post || !author) return undefined
+    // If the author labels are not hydrated yet, attempt to pull them from labels
+    author.labels ??= labels[author.did] ?? []
     return {
       $type: 'app.bsky.feed.defs#postView',
       uri: post.uri,

--- a/packages/bsky/src/services/label/index.ts
+++ b/packages/bsky/src/services/label/index.ts
@@ -60,7 +60,7 @@ export class LabelService {
       .execute()
   }
 
-  async getLabelsForSubjects(
+  async getLabelsForUris(
     subjects: string[],
     includeNeg?: boolean,
   ): Promise<Labels> {
@@ -92,7 +92,7 @@ export class LabelService {
       AtUri.make(did, ids.AppBskyActorProfile, 'self').toString(),
     )
     const subjects = [...dids, ...profileUris]
-    const labels = await this.getLabelsForSubjects(subjects, includeNeg)
+    const labels = await this.getLabelsForUris(subjects, includeNeg)
     // combine labels for profile + did
     return Object.keys(labels).reduce((acc, cur) => {
       const did = cur.startsWith('at://') ? new AtUri(cur).hostname : cur
@@ -103,7 +103,7 @@ export class LabelService {
   }
 
   async getLabels(subject: string, includeNeg?: boolean): Promise<Label[]> {
-    const labels = await this.getLabelsForSubjects([subject], includeNeg)
+    const labels = await this.getLabelsForUris([subject], includeNeg)
     return labels[subject] ?? []
   }
 

--- a/packages/bsky/src/services/label/index.ts
+++ b/packages/bsky/src/services/label/index.ts
@@ -82,22 +82,36 @@ export class LabelService {
     }, {} as Labels)
   }
 
-  // gets labels for both did & profile record
-  async getLabelsForProfiles(
-    dids: string[],
+  // gets labels for any record. when did is present, combine labels for both did & profile record.
+  async getLabelsForSubjects(
+    subjects: string[],
     includeNeg?: boolean,
   ): Promise<Labels> {
-    if (dids.length < 1) return {}
-    const profileUris = dids.map((did) =>
-      AtUri.make(did, ids.AppBskyActorProfile, 'self').toString(),
-    )
-    const subjects = [...dids, ...profileUris]
-    const labels = await this.getLabelsForUris(subjects, includeNeg)
-    // combine labels for profile + did
+    if (subjects.length < 1) return {}
+    const expandedSubjects = subjects.flatMap((subject) => {
+      if (subject.startsWith('did:')) {
+        return [
+          subject,
+          AtUri.make(subject, ids.AppBskyActorProfile, 'self').toString(),
+        ]
+      }
+      return subject
+    })
+    const labels = await this.getLabelsForUris(expandedSubjects, includeNeg)
     return Object.keys(labels).reduce((acc, cur) => {
-      const did = cur.startsWith('at://') ? new AtUri(cur).hostname : cur
-      acc[did] ??= []
-      acc[did] = [...acc[did], ...labels[cur]]
+      const uri = cur.startsWith('at://') ? new AtUri(cur) : null
+      if (
+        uri &&
+        uri.collection === ids.AppBskyActorProfile &&
+        uri.rkey === 'self'
+      ) {
+        // combine labels for profile + did
+        const did = uri.hostname
+        acc[did] ??= []
+        acc[did].push(...labels[cur])
+      }
+      acc[cur] ??= []
+      acc[cur].push(...labels[cur])
       return acc
     }, {} as Labels)
   }
@@ -111,7 +125,7 @@ export class LabelService {
     did: string,
     includeNeg?: boolean,
   ): Promise<Label[]> {
-    const labels = await this.getLabelsForProfiles([did], includeNeg)
+    const labels = await this.getLabelsForSubjects([did], includeNeg)
     return labels[did] ?? []
   }
 }

--- a/packages/bsky/src/services/types.ts
+++ b/packages/bsky/src/services/types.ts
@@ -2,6 +2,7 @@ import { View as ViewImages } from '../lexicon/types/app/bsky/embed/images'
 import { View as ViewExternal } from '../lexicon/types/app/bsky/embed/external'
 import { View as ViewRecord } from '../lexicon/types/app/bsky/embed/record'
 import { View as ViewRecordWithMedia } from '../lexicon/types/app/bsky/embed/recordWithMedia'
+import { Label } from '../lexicon/types/com/atproto/label/defs'
 
 export type FeedEmbeds = {
   [uri: string]: ViewImages | ViewExternal | ViewRecord | ViewRecordWithMedia
@@ -29,6 +30,7 @@ export type ActorView = {
   displayName?: string
   avatar?: string
   viewer?: { muted?: boolean; following?: string; followedBy?: string }
+  labels?: Label[]
 }
 export type ActorViewMap = { [did: string]: ActorView }
 

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -43,10 +43,10 @@ export default function (server: Server, ctx: AppContext) {
       }
       const relevant = getRelevantIds(threadData)
       const [actors, posts, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(relevant.dids), requester),
+        feedService.getActorViews(Array.from(relevant.dids), requester, true),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
-        labelService.getLabelsForUris(Array.from(relevant.uris)),
+        labelService.getLabelsForSubjects([...relevant.uris, ...relevant.dids]),
       ])
 
       const thread = composeThread(

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -46,7 +46,7 @@ export default function (server: Server, ctx: AppContext) {
         feedService.getActorViews(Array.from(relevant.dids), requester),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
-        labelService.getLabelsForSubjects(Array.from(relevant.uris)),
+        labelService.getLabelsForUris(Array.from(relevant.uris)),
       ])
 
       const thread = composeThread(

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
         feedService.getActorViews(Array.from(dids), requester),
         feedService.getPostViews(Array.from(uris), requester),
         feedService.embedsForPosts(Array.from(uris), requester),
-        labelService.getLabelsForSubjects(Array.from(uris)),
+        labelService.getLabelsForUris(Array.from(uris)),
       ])
 
       const posts: PostView[] = []

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -107,7 +107,7 @@ export default function (server: Server, ctx: AppContext) {
           })),
           requester,
         ),
-        labelService.getLabelsForSubjects(recordUris),
+        labelService.getLabelsForUris(recordUris),
       ])
 
       const bytesByCid = blocks.reduce((acc, block) => {

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -86,7 +86,7 @@ export class ActorViews {
 
     const [profileInfos, labels, listMutes] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForProfiles(dids),
+      this.services.label(this.db).getLabelsForSubjects(dids),
       this.getListMutes(dids, viewer),
     ])
 
@@ -185,7 +185,7 @@ export class ActorViews {
 
     const [profileInfos, labels, listMutes] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForProfiles(dids),
+      this.services.label(this.db).getLabelsForSubjects(dids),
       this.getListMutes(dids, viewer),
     ])
 

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -117,6 +117,7 @@ export class FeedService {
   async getActorViews(
     dids: string[],
     requester: string,
+    skipLabels?: boolean, // @NOTE used by hydrateFeed() to batch label hydration
   ): Promise<ActorViewMap> {
     if (dids.length < 1) return {}
     const { ref } = this.db.db.dynamic
@@ -164,10 +165,11 @@ export class FeedService {
             .as('requesterMuted'),
         ])
         .execute(),
-      this.services.label.getLabelsForSubjects(dids),
+      this.services.label.getLabelsForSubjects(skipLabels ? [] : dids),
       this.services.actor.views.getListMutes(dids, requester),
     ])
     return actors.reduce((acc, cur) => {
+      const actorLabels = labels[cur.did] ?? []
       return {
         ...acc,
         [cur.did]: {
@@ -185,7 +187,7 @@ export class FeedService {
             following: cur?.requesterFollowing || undefined,
             followedBy: cur?.requesterFollowedBy || undefined,
           },
-          labels: labels[cur.did] ?? [],
+          labels: skipLabels ? undefined : actorLabels,
         },
       }
     }, {} as ActorViewMap)
@@ -431,10 +433,10 @@ export class FeedService {
       }
     }
     const [actors, posts, embeds, labels] = await Promise.all([
-      this.getActorViews(Array.from(actorDids), requester),
+      this.getActorViews(Array.from(actorDids), requester, true),
       this.getPostViews(Array.from(postUris), requester),
       this.embedsForPosts(Array.from(postUris), requester),
-      this.services.label.getLabelsForUris(Array.from(postUris)),
+      this.services.label.getLabelsForSubjects([...postUris, ...actorDids]),
     ])
 
     return this.views.formatFeed(

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -307,7 +307,7 @@ export class FeedService {
           requester,
         ),
         this.embedsForPosts(nestedPostUris, requester, _depth + 1),
-        this.services.label.getLabelsForSubjects(nestedPostUris),
+        this.services.label.getLabelsForUris(nestedPostUris),
         this.getFeedGeneratorViews(nestedFeedGenUris, requester),
       ])
     let embeds = images.reduce((acc, cur) => {
@@ -434,7 +434,7 @@ export class FeedService {
       this.getActorViews(Array.from(actorDids), requester),
       this.getPostViews(Array.from(postUris), requester),
       this.embedsForPosts(Array.from(postUris), requester),
-      this.services.label.getLabelsForSubjects(Array.from(postUris)),
+      this.services.label.getLabelsForUris(Array.from(postUris)),
     ])
 
     return this.views.formatFeed(

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -164,7 +164,7 @@ export class FeedService {
             .as('requesterMuted'),
         ])
         .execute(),
-      this.services.label.getLabelsForProfiles(dids),
+      this.services.label.getLabelsForSubjects(dids),
       this.services.actor.views.getListMutes(dids, requester),
     ])
     return actors.reduce((acc, cur) => {

--- a/packages/pds/src/app-view/services/feed/types.ts
+++ b/packages/pds/src/app-view/services/feed/types.ts
@@ -7,6 +7,7 @@ import {
   NotFoundPost,
   PostView,
 } from '../../../lexicon/types/app/bsky/feed/defs'
+import { Label } from '../../../lexicon/types/com/atproto/label/defs'
 import { FeedGenerator } from '../../db/tables/feed-generator'
 
 export type FeedEmbeds = {
@@ -40,6 +41,7 @@ export type ActorView = {
     following?: string
     followedBy?: string
   }
+  labels?: Label[]
 }
 export type ActorViewMap = { [did: string]: ActorView }
 

--- a/packages/pds/src/app-view/services/feed/views.ts
+++ b/packages/pds/src/app-view/services/feed/views.ts
@@ -123,7 +123,7 @@ export class FeedViews {
     const author = actors[post?.creator]
     if (!post || !author) return undefined
     // If the author labels are not hydrated yet, attempt to pull them
-    // from labels: compatible with hydrateFeed() batching label hydration.
+    // from labels: e.g. compatible with hydrateFeed() batching label hydration.
     author.labels ??= labels[author.did] ?? []
     return {
       uri: post.uri,

--- a/packages/pds/src/app-view/services/feed/views.ts
+++ b/packages/pds/src/app-view/services/feed/views.ts
@@ -122,6 +122,9 @@ export class FeedViews {
     const post = posts[uri]
     const author = actors[post?.creator]
     if (!post || !author) return undefined
+    // If the author labels are not hydrated yet, attempt to pull them
+    // from labels: compatible with hydrateFeed() batching label hydration.
+    author.labels ??= labels[author.did] ?? []
     return {
       uri: post.uri,
       cid: post.cid,

--- a/packages/pds/src/app-view/services/label/index.ts
+++ b/packages/pds/src/app-view/services/label/index.ts
@@ -60,7 +60,7 @@ export class LabelService {
       .execute()
   }
 
-  async getLabelsForSubjects(
+  async getLabelsForUris(
     subjects: string[],
     includeNeg?: boolean,
   ): Promise<Labels> {
@@ -92,7 +92,7 @@ export class LabelService {
       AtUri.make(did, ids.AppBskyActorProfile, 'self').toString(),
     )
     const subjects = [...dids, ...profileUris]
-    const labels = await this.getLabelsForSubjects(subjects, includeNeg)
+    const labels = await this.getLabelsForUris(subjects, includeNeg)
     // combine labels for profile + did
     return Object.keys(labels).reduce((acc, cur) => {
       const did = cur.startsWith('at://') ? new AtUri(cur).hostname : cur
@@ -103,7 +103,7 @@ export class LabelService {
   }
 
   async getLabels(subject: string, includeNeg?: boolean): Promise<Label[]> {
-    const labels = await this.getLabelsForSubjects([subject], includeNeg)
+    const labels = await this.getLabelsForUris([subject], includeNeg)
     return labels[subject] ?? []
   }
 

--- a/packages/pds/src/app-view/services/label/index.ts
+++ b/packages/pds/src/app-view/services/label/index.ts
@@ -82,22 +82,36 @@ export class LabelService {
     }, {} as Labels)
   }
 
-  // gets labels for both did & profile record
-  async getLabelsForProfiles(
-    dids: string[],
+  // gets labels for any record. when did is present, combine labels for both did & profile record.
+  async getLabelsForSubjects(
+    subjects: string[],
     includeNeg?: boolean,
   ): Promise<Labels> {
-    if (dids.length < 1) return {}
-    const profileUris = dids.map((did) =>
-      AtUri.make(did, ids.AppBskyActorProfile, 'self').toString(),
-    )
-    const subjects = [...dids, ...profileUris]
-    const labels = await this.getLabelsForUris(subjects, includeNeg)
-    // combine labels for profile + did
+    if (subjects.length < 1) return {}
+    const expandedSubjects = subjects.flatMap((subject) => {
+      if (subject.startsWith('did:')) {
+        return [
+          subject,
+          AtUri.make(subject, ids.AppBskyActorProfile, 'self').toString(),
+        ]
+      }
+      return subject
+    })
+    const labels = await this.getLabelsForUris(expandedSubjects, includeNeg)
     return Object.keys(labels).reduce((acc, cur) => {
-      const did = cur.startsWith('at://') ? new AtUri(cur).hostname : cur
-      acc[did] ??= []
-      acc[did] = [...acc[did], ...labels[cur]]
+      const uri = cur.startsWith('at://') ? new AtUri(cur) : null
+      if (
+        uri &&
+        uri.collection === ids.AppBskyActorProfile &&
+        uri.rkey === 'self'
+      ) {
+        // combine labels for profile + did
+        const did = uri.hostname
+        acc[did] ??= []
+        acc[did].push(...labels[cur])
+      }
+      acc[cur] ??= []
+      acc[cur].push(...labels[cur])
       return acc
     }, {} as Labels)
   }
@@ -111,7 +125,7 @@ export class LabelService {
     did: string,
     includeNeg?: boolean,
   ): Promise<Label[]> {
-    const labels = await this.getLabelsForProfiles([did], includeNeg)
+    const labels = await this.getLabelsForSubjects([did], includeNeg)
     return labels[did] ?? []
   }
 }


### PR DESCRIPTION
We don't have to land this, but this was a pretty quick/simple change I wanted to at least consider.

Since labels pervade the whole app.bsky API, the query to fetch labels is consistently the most trafficked in the entire application by around a factor of 2.  The idea here is to nearly halve the number of label queries needed to satisfy feed and thread views.

The implementation allows opting-in to this behavior.
 - `getLabelsForSubjects()` now works for both aturis and dids, aggregating profile labels for dids.  It replaces `getLabelsForProfiles()`.
 - `getLabelsForUris()` is now the lower-level method to query for labels without the special profile/did behavior.
 - When you're hydrating posts and want this behavior:
    1.  tell `getActorViews()` to skip fetching labels with the `skipLabels` arg.
    2. use `getLabelsForSubjects()` to aggregate labels for both posts and actors.
    3. allow `formatPostView()` to assign the actor labels if they are not present (i.e. if they were skipped in `getActorViews()`).