### PR TITLE
Revert feed date threshold for with-friends

### DIFF
--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -2,10 +2,7 @@ import AppContext from '../context'
 import { QueryParams as SkeletonParams } from '../lexicon/types/app/bsky/feed/getFeedSkeleton'
 import { paginate } from '../db/pagination'
 import { AlgoHandler, AlgoResponse } from './types'
-import {
-  FeedKeyset,
-  getFeedDateThreshold,
-} from '../app-view/api/app/bsky/util/feed'
+import { FeedKeyset } from '../app-view/api/app/bsky/util/feed'
 
 const handler: AlgoHandler = async (
   ctx: AppContext,
@@ -19,8 +16,8 @@ const handler: AlgoHandler = async (
 
   const { ref } = ctx.db.db.dynamic
 
+  // @NOTE use of getFeedDateThreshold() not currently beneficial to this feed
   const keyset = new FeedKeyset(ref('feed_item.sortAt'), ref('feed_item.cid'))
-  const sortFrom = keyset.unpack(cursor)?.primary
 
   let postsQb = feedService
     .selectFeedItemQb()
@@ -37,7 +34,6 @@ const handler: AlgoHandler = async (
       accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
     )
     .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
-    .where('feed_item.sortAt', '>', getFeedDateThreshold(sortFrom))
 
   postsQb = paginate(postsQb, { limit, cursor, keyset })
 


### PR DESCRIPTION
This optimization didn't turn out to be beneficial for the with-friends algo, so reverting.