### PR TITLE
Perf tweaks to with-friends, mutuals, label batching

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -32,7 +32,9 @@ export default function (server: Server, ctx: AppContext) {
       }
       const relevant = getRelevantIds(threadData)
       const [actors, posts, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(relevant.dids), requester, true),
+        feedService.getActorViews(Array.from(relevant.dids), requester, {
+          skipLabels: true,
+        }),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
         labelService.getLabelsForSubjects([...relevant.uris, ...relevant.dids]),

--- a/packages/bsky/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPosts.ts
@@ -19,10 +19,12 @@ export default function (server: Server, ctx: AppContext) {
       )
 
       const [actors, postViews, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(dids), requester),
+        feedService.getActorViews(Array.from(dids), requester, {
+          skipLabels: true,
+        }),
         feedService.getPostViews(Array.from(uris), requester),
         feedService.embedsForPosts(Array.from(uris), requester),
-        labelService.getLabelsForUris(Array.from(uris)),
+        labelService.getLabelsForSubjects([...uris, ...dids]),
       ])
 
       const posts: PostView[] = []

--- a/packages/bsky/src/api/app/bsky/util/feed.ts
+++ b/packages/bsky/src/api/app/bsky/util/feed.ts
@@ -29,7 +29,9 @@ export const composeFeed = async (
     }
   }
   const [actors, posts, embeds, labels] = await Promise.all([
-    feedService.getActorViews(Array.from(actorDids), viewer, true),
+    feedService.getActorViews(Array.from(actorDids), viewer, {
+      skipLabels: true,
+    }),
     feedService.getPostViews(Array.from(postUris), viewer),
     feedService.embedsForPosts(Array.from(postUris), viewer),
     labelService.getLabelsForSubjects([...postUris, ...actorDids]),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -43,7 +43,9 @@ export default function (server: Server, ctx: AppContext) {
       }
       const relevant = getRelevantIds(threadData)
       const [actors, posts, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(relevant.dids), requester, true),
+        feedService.getActorViews(Array.from(relevant.dids), requester, {
+          skipLabels: true,
+        }),
         feedService.getPostViews(Array.from(relevant.uris), requester),
         feedService.embedsForPosts(Array.from(relevant.uris), requester),
         labelService.getLabelsForSubjects([...relevant.uris, ...relevant.dids]),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
@@ -19,10 +19,10 @@ export default function (server: Server, ctx: AppContext) {
       )
 
       const [actors, postViews, embeds, labels] = await Promise.all([
-        feedService.getActorViews(Array.from(dids), requester),
-        feedService.getPostViews(Array.from(uris), requester),
-        feedService.embedsForPosts(Array.from(uris), requester),
-        labelService.getLabelsForUris(Array.from(uris)),
+        feedService.getActorViews(dids, requester, { skipLabels: true }),
+        feedService.getPostViews(uris, requester),
+        feedService.embedsForPosts(uris, requester),
+        labelService.getLabelsForSubjects([...uris, ...dids]),
       ])
 
       const posts: PostView[] = []

--- a/packages/pds/src/app-view/services/feed/views.ts
+++ b/packages/pds/src/app-view/services/feed/views.ts
@@ -29,12 +29,19 @@ export class FeedViews {
   formatFeedGeneratorView(
     info: FeedGenInfo,
     profiles: Record<string, ProfileView>,
+    labels?: Labels,
   ): GeneratorView {
+    const profile = profiles[info.creator]
+    if (profile) {
+      // If the creator labels are not hydrated yet, attempt to pull them
+      // from labels: e.g. compatible with embedsForPosts() batching label hydration.
+      profile.labels ??= labels?.[info.creator] ?? []
+    }
     return {
       uri: info.uri,
       cid: info.cid,
       did: info.feedDid,
-      creator: profiles[info.creator],
+      creator: profile,
       displayName: info.displayName ?? undefined,
       description: info.description ?? undefined,
       descriptionFacets: info.descriptionFacets

--- a/packages/pds/src/feed-gen/mutuals.ts
+++ b/packages/pds/src/feed-gen/mutuals.ts
@@ -36,15 +36,16 @@ const handler: AlgoHandler = async (
 
   let feedQb = feedService
     .selectFeedItemQb()
+    .where('feed_item.type', '=', 'post') // ensures originatorDid is post.creator
     .where((qb) =>
       qb
-        .where('post.creator', '=', requester)
-        .orWhere('post.creator', 'in', mutualsSubquery),
+        .where('originatorDid', '=', requester)
+        .orWhere('originatorDid', 'in', mutualsSubquery),
     )
     .where((qb) =>
-      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+      accountService.whereNotMuted(qb, requester, [ref('originatorDid')]),
     )
-    .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
+    .whereNotExists(graphService.blockQb(requester, [ref('originatorDid')]))
     .where('feed_item.sortAt', '>', getFeedDateThreshold(sortFrom))
 
   feedQb = paginate(feedQb, { limit, cursor, keyset })


### PR DESCRIPTION
A few changes here:
 - On with-friends algo I switched the filtering to use `originatorDid` rather than `post.creator`.  These are the same value, but the former comes from the base table rather than a joined table.  This seems to open up some options for the query planner, and based on my testing it lands in a much better place.
   - With that change I figured it made sense to reintroduce the date threshold.
 - Same with the mutuals algo.  Also constrained it only to posts, since it was including _all_ reposts of mutuals' posts.
 - Applied more label batching to other places it could easily fit-in.