### PR TITLE
Add post options

### DIFF
--- a/lexicons/app/bsky/feed/addPostOption
+++ b/lexicons/app/bsky/feed/addPostOption
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.addPostOption",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Add a webhook to a list of post options.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["postOption"],
+          "properties": {
+            "postOption": { "type": "object", "ref": "app.bsky.feed.defs#feedViewPostOption" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -130,6 +130,27 @@
       "properties": {
         "repost": {"type": "string", "format": "at-uri"}
       }
+    },
+    "feedViewPostOption": {
+      "type": "object",
+      "required": ["title", "callbackUri"],
+      "properties": {
+        "title": {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "text": {"type": "string", "format": "uri"}
+          }
+        },
+        "callbackUri": {
+          "type": "object",
+          "description": "A URI used as a callback for this option.",
+          "required": ["uri"],
+          "properties": {
+            "uri": {"type": "string", "format": "uri"}
+          }
+        }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/feed/getPostOptions.json
+++ b/lexicons/app/bsky/feed/getPostOptions.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.getPostOptions",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "A view of options for a post in an actor's feed.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "cursor": {"type": "string"}
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["options"],
+          "properties": {
+            "cursor": {"type": "string"},
+            "options": {"type": "ref", "ref": "app.bsky.feed.defs#feedViewPostOption"}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This idea came up as a result of a conversation on Bluesky with @jackmcasey - allowing the `…` menu of a Post View in the Feed to be populated by Post Options provided by 3rd Parties – https://bsky.app/profile/jik.wtf/post/3jwzzhwrsbc27

The screenshot below includes the image from the original post above:

<img src="https://cdn.bsky.social/imgproxy/wJ5GXC3Rt_G82o5G9AQ8uLeTlZVEC9q0-23oxrM70BA/rs:fit:2000:2000:1:0/plain/bafkreigmihafi26drk3e7makj3epdf2sjxlww6r6ipt5umesgrfrwrcvlu@jpeg" alt="Screenshot of the Bluesky app on iOS, showing a post by Paul Frazee, with the ellipsis highlighted">

On a technical level, Post Options would be a simple webhook. This would allow a third party to provide a webhook that can be stored in an actor's repo as a reachable Post Option under the `…` on a Post.

When an actor selects the Post Option from the `…` menu of the Post View, the `callbackUri` of the Post Option would receive the payload, which should include at least the URI of the Post that the Post Option was executed on.

An example – a Zapier action that receives the URI to a Post, and after a certain time, forwards the URI of that Post by email.

To add a Post Option to the `…` menu of the Post View, a 3rd Party would provide a method to run a procedure (i.e. POST the payload of that Post Option (see the defs.json diff) to the actor's Bluesky account)

* The procedure to add a Post Option is defined in `addPostOption.json`
* The query to retrieve Post Options is defined in `getPostOptions.json`
* The definition of a `feedViewPostOption` is added to `defs.json`