### PR TITLE
lexicon: maximum report "reason" length of 500 chars (graphemes)

### DIFF
--- a/lexicons/com/atproto/moderation/createReport.json
+++ b/lexicons/com/atproto/moderation/createReport.json
@@ -31,7 +31,7 @@
           "properties": {
             "id": {"type": "integer"},
             "reasonType": {"type": "ref", "ref": "com.atproto.moderation.defs#reasonType"},
-            "reason": {"type": "string"},
+            "reason": {"type": "string", "maxGraphemes": 500, "maxLength": 5000},
             "subject": {
               "type": "union",
               "refs": [


### PR DESCRIPTION
Discussed integrating a reason text field in the client with Jay and Ansh, we settled on 500 chars, bit longer than a post. Presumably easier to extend to longer in the future.

I could somewhat go either way on this. From a mod team standpoint, we don't want folks writing a huge story in the report reason box. If they need a long conversation or a lot of context, that needs to be some out-of-band thing like an email or google doc or something like that.

On the other hand, any particular max feels kind of arbitrary and restrictive, and third party folks will probably want a different limit/behavior. This is also an atproto-wide mechanism, not restricted to app.bsky content.

So, basically, sending for review, but not sure this is urgent or even the correct values.