### PR TITLE
Ensure keyset pagination makes use of indexes on timeline

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -51,7 +51,9 @@ export default function (server: Server, ctx: AppContext) {
         limit,
         cursor,
         keyset,
+        tryIndex: true,
       })
+
       const feedItems = await feedItemsQb.execute()
       const feed = await composeFeed(
         feedService,

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -60,7 +60,9 @@ export default function (server: Server, ctx: AppContext) {
         limit,
         cursor,
         keyset,
+        tryIndex: true,
       })
+
       const feedItems: FeedRow[] = await feedItemsQb.execute()
       const feed = await feedService.hydrateFeed(feedItems, requester)
 


### PR DESCRIPTION
The query snippet we use for keyset pagination wouldn't get picked-up by an index on `(primary-column, secondary-column)` due to its form using `or`.  We now use a "row value" comparison which is simpler to write and indexes know how to use it.  Currently just rolling out on `getTimeline`:  will eventually enable this other places once it's proven to work as intended, and hopefully remove the original implementation.