### PR TITLE
Normalize creation times on list, list item, feedgen records

### DIFF
--- a/packages/pds/src/app-view/services/indexing/plugins/feed-generator.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/feed-generator.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../db/database-schema'
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyFeedGenerator
 type IndexedFeedGenerator = DatabaseSchemaType['feed_generator']
@@ -33,7 +34,7 @@ const insertFn = async (
         ? JSON.stringify(obj.descriptionFacets)
         : undefined,
       avatarCid: obj.avatar?.ref.toString(),
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/pds/src/app-view/services/indexing/plugins/list-item.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/list-item.ts
@@ -10,6 +10,7 @@ import {
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
 import { InvalidRequestError } from '@atproto/xrpc-server'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyGraphListitem
 type IndexedListItem = DatabaseSchemaType['list_item']
@@ -35,7 +36,7 @@ const insertFn = async (
       creator: uri.host,
       subjectDid: obj.subject,
       listUri: obj.list,
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())

--- a/packages/pds/src/app-view/services/indexing/plugins/list.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/list.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../db/database-schema'
 import { BackgroundQueue } from '../../../../event-stream/background-queue'
 import RecordProcessor from '../processor'
+import { toSimplifiedISOSafe } from '../util'
 
 const lexId = lex.ids.AppBskyGraphList
 type IndexedList = DatabaseSchemaType['list']
@@ -33,7 +34,7 @@ const insertFn = async (
         ? JSON.stringify(obj.descriptionFacets)
         : undefined,
       avatarCid: obj.avatar?.ref.toString(),
-      createdAt: obj.createdAt,
+      createdAt: toSimplifiedISOSafe(obj.createdAt),
       indexedAt: timestamp,
     })
     .onConflict((oc) => oc.doNothing())


### PR DESCRIPTION
Some records being indexed—lists, list items, and feedgens—weren't having their `createdAt` times normalized.  This sometimes threw-off pagination as in #1176.

Resolves #1176.