### PR TITLE
Disable resolution of handles through xrpc

### DIFF
--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -17,24 +17,13 @@ export class HandleResolver {
     const httpPromise = this.resolveHttp(handle, httpAbort.signal).catch(
       () => undefined,
     )
-    const httpLegacyAbort = new AbortController()
-    const httpPromiseLegacy = this.resolveHttpLegacy(
-      handle,
-      httpLegacyAbort.signal,
-    ).catch(() => undefined)
 
     const dnsRes = await dnsPromise
     if (dnsRes) {
       httpAbort.abort()
-      httpLegacyAbort.abort()
       return dnsRes
     }
-    const httpRes = await httpPromise
-    if (httpRes) {
-      httpLegacyAbort.abort()
-      return httpRes
-    }
-    return httpPromiseLegacy
+    return httpPromise
   }
 
   async resolveDns(handle: string): Promise<string | undefined> {
@@ -64,25 +53,6 @@ export class HandleResolver {
         return did
       }
       return undefined
-    } catch (err) {
-      return undefined
-    }
-  }
-
-  // DEPRECATED
-  // @TODO remove
-  async resolveHttpLegacy(
-    handle: string,
-    signal?: AbortSignal,
-  ): Promise<string | undefined> {
-    const url = new URL(
-      `/xrpc/com.atproto.identity.resolveHandle?handle=${handle}`,
-      `https://${handle}`,
-    )
-    try {
-      const res = await fetch(url, { signal })
-      const data = await res.json()
-      return typeof data?.did === 'string' ? data.did : undefined
     } catch (err) {
       return undefined
     }

--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -44,14 +44,6 @@ export default function (server: Server, ctx: AppContext) {
       if (!existingAccnt) {
         throw new InvalidRequestError(`Account not found: ${did}`)
       }
-      const isServiceDomain = ctx.cfg.availableUserDomains.find((domain) =>
-        existingAccnt.handle.endsWith(domain),
-      )
-      if (!isServiceDomain) {
-        throw new InvalidRequestError(
-          `Account not on an available service domain: ${existingAccnt.handle}`,
-        )
-      }
 
       await ctx.db.transaction(async (dbTxn) => {
         try {

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -264,22 +264,6 @@ describe('handles', () => {
     expect(profile.data.handle).toBe('dril.test')
   })
 
-  it('disallows admin overrules of off-service domains', async () => {
-    const attempt = agent.api.com.atproto.admin.updateAccountHandle(
-      {
-        did: alice,
-        handle: 'alice-alt.test',
-      },
-      {
-        headers: { authorization: util.adminAuth() },
-        encoding: 'application/json',
-      },
-    )
-    await expect(attempt).rejects.toThrow(
-      'Account not on an available service domain: alice.external',
-    )
-  })
-
   it('disallows setting handle to an off-service domain', async () => {
     const attempt = agent.api.com.atproto.admin.updateAccountHandle(
       {


### PR DESCRIPTION
Disables legacy allowance of xrpc handles.

We only allow registering a handle through DNS or .well-known now.

Also tweaks admin updates of handles so that we can deprecate handle violations