### PR TITLE
Bsky appview: resolve long transactions, tombstone behavior

### DIFF
--- a/lexicons/com/atproto/sync/getHead.json
+++ b/lexicons/com/atproto/sync/getHead.json
@@ -25,7 +25,10 @@
             "root": {"type": "string", "format": "cid"}
           }
         }
-      }
+      },
+      "errors": [
+        {"name": "HeadNotFound"}
+      ]
     }
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3059,6 +3059,11 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'HeadNotFound',
+          },
+        ],
       },
     },
   },

--- a/packages/api/src/client/types/com/atproto/sync/getHead.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getHead.ts
@@ -29,8 +29,15 @@ export interface Response {
   data: OutputSchema
 }
 
+export class HeadNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
+    if (e.error === 'HeadNotFound') return new HeadNotFoundError(e)
   }
   return e
 }

--- a/packages/bsky/src/db/index.ts
+++ b/packages/bsky/src/db/index.ts
@@ -106,6 +106,10 @@ export class Database {
     assert(this.isTransaction, 'Transaction required')
   }
 
+  assertNotTransaction() {
+    assert(!this.isTransaction, 'Cannot be in a transaction')
+  }
+
   async close(): Promise<void> {
     if (this.destroyed) return
     await this.db.destroy()

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3059,6 +3059,11 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'HeadNotFound',
+          },
+        ],
       },
     },
   },

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getHead.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getHead.ts
@@ -31,6 +31,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'HeadNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/tests/duplicate-records.test.ts
+++ b/packages/bsky/tests/duplicate-records.test.ts
@@ -39,38 +39,32 @@ describe('duplicate record', () => {
     const subjectCid = await cidForCbor({ test: 'blah' })
     const coll = lex.ids.AppBskyFeedRepost
     const uris: AtUri[] = []
-    await db.transaction(async (tx) => {
-      for (let i = 0; i < 5; i++) {
-        const repost = {
-          $type: coll,
-          subject: {
-            uri: subject.toString(),
-            cid: subjectCid.toString(),
-          },
-          createdAt: new Date().toISOString(),
-        }
-        const uri = AtUri.make(did, coll, TID.nextStr())
-        const cid = await cidForCbor(repost)
-        await services
-          .indexing(tx)
-          .indexRecord(uri, cid, repost, WriteOpAction.Create, repost.createdAt)
-        uris.push(uri)
+    for (let i = 0; i < 5; i++) {
+      const repost = {
+        $type: coll,
+        subject: {
+          uri: subject.toString(),
+          cid: subjectCid.toString(),
+        },
+        createdAt: new Date().toISOString(),
       }
-    })
+      const uri = AtUri.make(did, coll, TID.nextStr())
+      const cid = await cidForCbor(repost)
+      await services
+        .indexing(db)
+        .indexRecord(uri, cid, repost, WriteOpAction.Create, repost.createdAt)
+      uris.push(uri)
+    }
 
     let count = await countRecords(db, 'repost')
     expect(count).toBe(1)
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[0], false)
-    })
+    await services.indexing(db).deleteRecord(uris[0], false)
 
     count = await countRecords(db, 'repost')
     expect(count).toBe(1)
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[1], true)
-    })
+    await services.indexing(db).deleteRecord(uris[1], true)
 
     count = await countRecords(db, 'repost')
     expect(count).toBe(0)
@@ -81,31 +75,27 @@ describe('duplicate record', () => {
     const subjectCid = await cidForCbor({ test: 'blah' })
     const coll = lex.ids.AppBskyFeedLike
     const uris: AtUri[] = []
-    await db.transaction(async (tx) => {
-      for (let i = 0; i < 5; i++) {
-        const like = {
-          $type: coll,
-          subject: {
-            uri: subject.toString(),
-            cid: subjectCid.toString(),
-          },
-          createdAt: new Date().toISOString(),
-        }
-        const uri = AtUri.make(did, coll, TID.nextStr())
-        const cid = await cidForCbor(like)
-        await services
-          .indexing(tx)
-          .indexRecord(uri, cid, like, WriteOpAction.Create, like.createdAt)
-        uris.push(uri)
+    for (let i = 0; i < 5; i++) {
+      const like = {
+        $type: coll,
+        subject: {
+          uri: subject.toString(),
+          cid: subjectCid.toString(),
+        },
+        createdAt: new Date().toISOString(),
       }
-    })
+      const uri = AtUri.make(did, coll, TID.nextStr())
+      const cid = await cidForCbor(like)
+      await services
+        .indexing(db)
+        .indexRecord(uri, cid, like, WriteOpAction.Create, like.createdAt)
+      uris.push(uri)
+    }
 
     let count = await countRecords(db, 'like')
     expect(count).toBe(1)
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[0], false)
-    })
+    await services.indexing(db).deleteRecord(uris[0], false)
 
     count = await countRecords(db, 'like')
     expect(count).toBe(1)
@@ -116,9 +106,7 @@ describe('duplicate record', () => {
       .executeTakeFirst()
     expect(got?.uri).toEqual(uris[1].toString())
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[1], true)
-    })
+    await services.indexing(db).deleteRecord(uris[1], true)
 
     count = await countRecords(db, 'like')
     expect(count).toBe(0)
@@ -127,35 +115,29 @@ describe('duplicate record', () => {
   it('dedupes follows', async () => {
     const coll = lex.ids.AppBskyGraphFollow
     const uris: AtUri[] = []
-    await db.transaction(async (tx) => {
-      for (let i = 0; i < 5; i++) {
-        const follow = {
-          $type: coll,
-          subject: 'did:example:bob',
-          createdAt: new Date().toISOString(),
-        }
-        const uri = AtUri.make(did, coll, TID.nextStr())
-        const cid = await cidForCbor(follow)
-        await services
-          .indexing(tx)
-          .indexRecord(uri, cid, follow, WriteOpAction.Create, follow.createdAt)
-        uris.push(uri)
+    for (let i = 0; i < 5; i++) {
+      const follow = {
+        $type: coll,
+        subject: 'did:example:bob',
+        createdAt: new Date().toISOString(),
       }
-    })
+      const uri = AtUri.make(did, coll, TID.nextStr())
+      const cid = await cidForCbor(follow)
+      await services
+        .indexing(db)
+        .indexRecord(uri, cid, follow, WriteOpAction.Create, follow.createdAt)
+      uris.push(uri)
+    }
 
     let count = await countRecords(db, 'follow')
     expect(count).toBe(1)
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[0], false)
-    })
+    await services.indexing(db).deleteRecord(uris[0], false)
 
     count = await countRecords(db, 'follow')
     expect(count).toBe(1)
 
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).deleteRecord(uris[1], true)
-    })
+    await services.indexing(db).deleteRecord(uris[1], true)
 
     count = await countRecords(db, 'follow')
     expect(count).toBe(0)

--- a/packages/bsky/tests/indexing.test.ts
+++ b/packages/bsky/tests/indexing.test.ts
@@ -96,9 +96,7 @@ describe('indexing', () => {
     })
 
     // Create
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).indexRecord(...createRecord)
-    })
+    await services.indexing(db).indexRecord(...createRecord)
 
     const getAfterCreate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -108,9 +106,7 @@ describe('indexing', () => {
     const createNotifications = await getNotifications(db, uri)
 
     // Update
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).indexRecord(...updateRecord)
-    })
+    await services.indexing(db).indexRecord(...updateRecord)
 
     const getAfterUpdate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -120,9 +116,7 @@ describe('indexing', () => {
     const updateNotifications = await getNotifications(db, uri)
 
     // Delete
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).deleteRecord(...deleteRecord)
-    })
+    await services.indexing(db).deleteRecord(...deleteRecord)
 
     const getAfterDelete = agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -168,9 +162,7 @@ describe('indexing', () => {
     })
 
     // Create
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).indexRecord(...createRecord)
-    })
+    await services.indexing(db).indexRecord(...createRecord)
 
     const getAfterCreate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -179,9 +171,7 @@ describe('indexing', () => {
     expect(forSnapshot(getAfterCreate.data)).toMatchSnapshot()
 
     // Update
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).indexRecord(...updateRecord)
-    })
+    await services.indexing(db).indexRecord(...updateRecord)
 
     const getAfterUpdate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -190,9 +180,7 @@ describe('indexing', () => {
     expect(forSnapshot(getAfterUpdate.data)).toMatchSnapshot()
 
     // Delete
-    await db.transaction(async (tx) => {
-      return await services.indexing(tx).deleteRecord(...deleteRecord)
-    })
+    await services.indexing(db).deleteRecord(...deleteRecord)
 
     const getAfterDelete = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -248,13 +236,11 @@ describe('indexing', () => {
         createdAt,
       } as AppBskyFeedRepost.Record,
     })
-    await db.transaction(async (tx) => {
-      // reply, like, and repost indexed orior to the original post
-      await services.indexing(tx).indexRecord(...reply)
-      await services.indexing(tx).indexRecord(...like)
-      await services.indexing(tx).indexRecord(...repost)
-      await services.indexing(tx).indexRecord(...originalPost)
-    })
+    // reply, like, and repost indexed orior to the original post
+    await services.indexing(db).indexRecord(...reply)
+    await services.indexing(db).indexRecord(...like)
+    await services.indexing(db).indexRecord(...repost)
+    await services.indexing(db).indexRecord(...originalPost)
     await network.bsky.ctx.backgroundQueue.processAll()
     const agg = await db.db
       .selectFrom('post_agg')
@@ -268,19 +254,17 @@ describe('indexing', () => {
       likeCount: 1,
     })
     // Cleanup
-    await db.transaction(async (tx) => {
-      const del = (uri: AtUri) => {
-        return prepareDelete({
-          did: uri.host,
-          collection: uri.collection,
-          rkey: uri.rkey,
-        })
-      }
-      await services.indexing(tx).deleteRecord(...del(reply[0]))
-      await services.indexing(tx).deleteRecord(...del(like[0]))
-      await services.indexing(tx).deleteRecord(...del(repost[0]))
-      await services.indexing(tx).deleteRecord(...del(originalPost[0]))
-    })
+    const del = (uri: AtUri) => {
+      return prepareDelete({
+        did: uri.host,
+        collection: uri.collection,
+        rkey: uri.rkey,
+      })
+    }
+    await services.indexing(db).deleteRecord(...del(reply[0]))
+    await services.indexing(db).deleteRecord(...del(like[0]))
+    await services.indexing(db).deleteRecord(...del(repost[0]))
+    await services.indexing(db).deleteRecord(...del(originalPost[0]))
   })
 
   it('handles profile aggregations out of order.', async () => {
@@ -296,9 +280,7 @@ describe('indexing', () => {
         createdAt,
       } as AppBskyGraphFollow.Record,
     })
-    await db.transaction(async (tx) => {
-      await services.indexing(tx).indexRecord(...follow)
-    })
+    await services.indexing(db).indexRecord(...follow)
     await network.bsky.ctx.backgroundQueue.processAll()
     const agg = await db.db
       .selectFrom('profile_agg')
@@ -310,16 +292,14 @@ describe('indexing', () => {
       followersCount: 1,
     })
     // Cleanup
-    await db.transaction(async (tx) => {
-      const del = (uri: AtUri) => {
-        return prepareDelete({
-          did: uri.host,
-          collection: uri.collection,
-          rkey: uri.rkey,
-        })
-      }
-      await services.indexing(tx).deleteRecord(...del(follow[0]))
-    })
+    const del = (uri: AtUri) => {
+      return prepareDelete({
+        did: uri.host,
+        collection: uri.collection,
+        rkey: uri.rkey,
+      })
+    }
+    await services.indexing(db).deleteRecord(...del(follow[0]))
   })
 
   describe('indexRepo', () => {
@@ -350,9 +330,7 @@ describe('indexing', () => {
       const { data: head } = await pdsAgent.api.com.atproto.sync.getHead({
         did: sc.dids.alice,
       })
-      await db.transaction((tx) =>
-        services.indexing(tx).indexRepo(sc.dids.alice, head.root),
-      )
+      await services.indexing(db).indexRepo(sc.dids.alice, head.root)
       // Check
       const { data: profile } = await agent.api.app.bsky.actor.getProfile(
         { actor: sc.dids.alice },
@@ -395,9 +373,7 @@ describe('indexing', () => {
       const { data: head } = await pdsAgent.api.com.atproto.sync.getHead({
         did: sc.dids.alice,
       })
-      await db.transaction((tx) =>
-        services.indexing(tx).indexRepo(sc.dids.alice, head.root),
-      )
+      await services.indexing(db).indexRepo(sc.dids.alice, head.root)
       // Check
       const { data: profile } = await agent.api.app.bsky.actor.getProfile(
         { actor: sc.dids.alice },
@@ -442,9 +418,7 @@ describe('indexing', () => {
       const { data: head } = await pdsAgent.api.com.atproto.sync.getHead({
         did: sc.dids.alice,
       })
-      await db.transaction((tx) =>
-        services.indexing(tx).indexRepo(sc.dids.alice, head.root),
-      )
+      await services.indexing(db).indexRepo(sc.dids.alice, head.root)
       // Check
       const getGoodPost = agent.api.app.bsky.feed.getPostThread(
         { uri: writes[0].uri.toString(), depth: 0 },
@@ -480,7 +454,7 @@ describe('indexing', () => {
         password: 'password',
       })
       await expect(getIndexedHandle(did)).rejects.toThrow('Profile not found')
-      await db.transaction((tx) => services.indexing(tx).indexHandle(did, now))
+      await services.indexing(db).indexHandle(did, now)
       await expect(getIndexedHandle(did)).resolves.toEqual('did1.test')
     })
 
@@ -495,16 +469,14 @@ describe('indexing', () => {
         handle: 'did2.test',
         password: 'password',
       })
-      await db.transaction((tx) => services.indexing(tx).indexHandle(did, now))
+      await services.indexing(db).indexHandle(did, now)
       await expect(getIndexedHandle(did)).resolves.toEqual('did2.test')
       await sessionAgent.com.atproto.identity.updateHandle({
         handle: 'did2-updated.test',
       })
-      await db.transaction((tx) => services.indexing(tx).indexHandle(did, now))
+      await services.indexing(db).indexHandle(did, now)
       await expect(getIndexedHandle(did)).resolves.toEqual('did2.test') // Didn't update, not forced
-      await db.transaction((tx) =>
-        services.indexing(tx).indexHandle(did, now, true),
-      )
+      await services.indexing(db).indexHandle(did, now, true)
       await expect(getIndexedHandle(did)).resolves.toEqual('did2-updated.test')
     })
 
@@ -528,10 +500,8 @@ describe('indexing', () => {
           createdAt: now,
         } as AppBskyGraphFollow.Record,
       })
-      await db.transaction(async (tx) => {
-        await services.indexing(tx).indexRecord(...follow)
-        await services.indexing(tx).indexHandle(did, now)
-      })
+      await services.indexing(db).indexRecord(...follow)
+      await services.indexing(db).indexHandle(did, now)
       await network.bsky.ctx.backgroundQueue.processAll()
       const agg = await db.db
         .selectFrom('profile_agg')
@@ -553,9 +523,7 @@ describe('indexing', () => {
         { headers: await network.serviceHeaders(sc.dids.bob) },
       )
       // Attempt indexing tombstone
-      await db.transaction((tx) =>
-        services.indexing(tx).tombstoneActor(sc.dids.alice),
-      )
+      await services.indexing(db).tombstoneActor(sc.dids.alice)
       const { data: profileAfter } = await agent.api.app.bsky.actor.getProfile(
         { actor: sc.dids.alice },
         { headers: await network.serviceHeaders(sc.dids.bob) },
@@ -574,9 +542,7 @@ describe('indexing', () => {
       const plcClient = new Client(network.plc.url)
       await plcClient.tombstone(sc.dids.alice, network.pds.ctx.plcRotationKey)
       // Index tombstone
-      await db.transaction((tx) =>
-        services.indexing(tx).tombstoneActor(sc.dids.alice),
-      )
+      await services.indexing(db).tombstoneActor(sc.dids.alice)
       const getProfileAfter = agent.api.app.bsky.actor.getProfile(
         { actor: sc.dids.alice },
         { headers: await network.serviceHeaders(sc.dids.bob) },

--- a/packages/pds/src/api/com/atproto/sync/getHead.ts
+++ b/packages/pds/src/api/com/atproto/sync/getHead.ts
@@ -9,7 +9,10 @@ export default function (server: Server, ctx: AppContext) {
     const storage = new SqlRepoStorage(ctx.db, did)
     const root = await storage.getHead()
     if (root === null) {
-      throw new InvalidRequestError(`Could not find root for DID: ${did}`)
+      throw new InvalidRequestError(
+        `Could not find root for DID: ${did}`,
+        'HeadNotFound',
+      )
     }
     return {
       encoding: 'application/json',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3059,6 +3059,11 @@ export const schemaDict = {
             },
           },
         },
+        errors: [
+          {
+            name: 'HeadNotFound',
+          },
+        ],
       },
     },
   },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getHead.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getHead.ts
@@ -31,6 +31,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
+  error?: 'HeadNotFound'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess


### PR DESCRIPTION
Some more cleanup in the bsky appview:
 - Now we process each record indexing transactionally, but other indexing operations are not necessarily transactional.  The goal here is to avoid prohibitively long transactions that could affect indexing of other repositories.  A handful of http requests that previously held-up a transaction now occur outside of one.
 - The behavior for indexing tombstones is now loosened from "did doc no longer resolves" to "there is no pds hosting this user's content".
 - The `sync.getHead` endpoint now has an error type to explicitly indicate that the head cannot be found.

I expect it will be easiest to review this [ignoring whitespace](https://github.com/bluesky-social/atproto/pull/1192/files?w=1).