### PR TITLE
Notify crawlers on write

### DIFF
--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -58,6 +58,8 @@ export interface ServerConfigValues {
 
   bskyAppViewEndpoint?: string
   bskyAppViewDid?: string
+
+  crawlersToNotify?: string[]
 }
 
 export class ServerConfig {
@@ -175,6 +177,10 @@ export class ServerConfig {
     )
     const bskyAppViewDid = nonemptyString(process.env.BSKY_APP_VIEW_DID)
 
+    const crawlersToNotify = process.env.CRAWLERS_TO_NOTIFY
+      ? process.env.CRAWLERS_TO_NOTIFY.split(',')
+      : []
+
     return new ServerConfig({
       debugMode,
       version,
@@ -217,6 +223,7 @@ export class ServerConfig {
       appViewRepoProvider,
       bskyAppViewEndpoint,
       bskyAppViewDid,
+      crawlersToNotify,
       ...overrides,
     })
   }
@@ -413,6 +420,10 @@ export class ServerConfig {
 
   get bskyAppViewDid() {
     return this.cfg.bskyAppViewDid
+  }
+
+  get crawlersToNotify() {
+    return this.cfg.crawlersToNotify
   }
 }
 

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -177,9 +177,9 @@ export class ServerConfig {
     )
     const bskyAppViewDid = nonemptyString(process.env.BSKY_APP_VIEW_DID)
 
-    const crawlersToNotify = process.env.CRAWLERS_TO_NOTIFY
-      ? process.env.CRAWLERS_TO_NOTIFY.split(',')
-      : []
+    const crawlersEnv = process.env.CRAWLERS_TO_NOTIFY
+    const crawlersToNotify =
+      crawlersEnv && crawlersEnv.length > 0 ? crawlersEnv.split(',') : []
 
     return new ServerConfig({
       debugMode,

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -14,6 +14,7 @@ import { Labeler } from './labeler'
 import { BackgroundQueue } from './event-stream/background-queue'
 import DidSqlCache from './did-cache'
 import { MountedAlgos } from './feed-gen/types'
+import { Crawlers } from './crawlers'
 
 export class AppContext {
   constructor(
@@ -34,6 +35,7 @@ export class AppContext {
       sequencerLeader: SequencerLeader
       labeler: Labeler
       backgroundQueue: BackgroundQueue
+      crawlers: Crawlers
       algos: MountedAlgos
     },
   ) {}
@@ -116,6 +118,10 @@ export class AppContext {
 
   get backgroundQueue(): BackgroundQueue {
     return this.opts.backgroundQueue
+  }
+
+  get crawlers(): Crawlers {
+    return this.opts.crawlers
   }
 
   get plcClient(): plc.Client {

--- a/packages/pds/src/crawlers.ts
+++ b/packages/pds/src/crawlers.ts
@@ -26,7 +26,7 @@ export class Crawlers {
           })
         } catch (err) {
           log.warn(
-            { err, service: agent.service.toString() },
+            { err, cralwer: agent.service.toString() },
             'failed to request crawl',
           )
         }

--- a/packages/pds/src/crawlers.ts
+++ b/packages/pds/src/crawlers.ts
@@ -1,0 +1,37 @@
+import { AtpAgent } from '@atproto/api'
+import { crawlerLogger as log } from './logger'
+import { MINUTE } from '@atproto/common'
+
+const NOTIFY_THRESHOLD = 20 * MINUTE
+
+export class Crawlers {
+  public agents: AtpAgent[]
+  public lastNotified = 0
+
+  constructor(public hostname: string, public crawlers: string[]) {
+    this.agents = crawlers.map((service) => new AtpAgent({ service }))
+  }
+
+  async notifyOfUpdate() {
+    const now = Date.now()
+    if (now - this.lastNotified < NOTIFY_THRESHOLD) {
+      return
+    }
+
+    await Promise.all(
+      this.agents.map(async (agent) => {
+        try {
+          await agent.api.com.atproto.sync.notifyOfUpdate({
+            hostname: this.hostname,
+          })
+        } catch (err) {
+          log.warn(
+            { err, service: agent.service.toString() },
+            'failed to request crawl',
+          )
+        }
+      }),
+    )
+    this.lastNotified = now
+  }
+}

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -40,6 +40,7 @@ import { BackgroundQueue } from './event-stream/background-queue'
 import DidSqlCache from './did-cache'
 import { IdResolver } from '@atproto/identity'
 import { MountedAlgos } from './feed-gen/types'
+import { Crawlers } from './crawlers'
 
 export type { ServerConfigValues } from './config'
 export { ServerConfig } from './config'
@@ -147,6 +148,10 @@ export class PDS {
     )
 
     const backgroundQueue = new BackgroundQueue(db)
+    const crawlers = new Crawlers(
+      config.hostname,
+      config.crawlersToNotify ?? [],
+    )
 
     let labeler: Labeler
     if (config.hiveApiKey) {
@@ -176,6 +181,7 @@ export class PDS {
       imgInvalidator,
       labeler,
       backgroundQueue,
+      crawlers,
     })
 
     const ctx = new AppContext({
@@ -195,6 +201,7 @@ export class PDS {
       mailer,
       imgUriBuilder,
       backgroundQueue,
+      crawlers,
       algos,
     })
 

--- a/packages/pds/src/logger.ts
+++ b/packages/pds/src/logger.ts
@@ -8,6 +8,7 @@ export const dbLogger = subsystemLogger('pds:db')
 export const seqLogger = subsystemLogger('pds:sequencer')
 export const mailerLogger = subsystemLogger('pds:mailer')
 export const labelerLogger = subsystemLogger('pds:labler')
+export const crawlerLogger = subsystemLogger('pds:crawler')
 export const httpLogger = subsystemLogger('pds')
 
 export const loggerMiddleware = pinoHttp({

--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -16,6 +16,7 @@ import { IndexingService } from '../app-view/services/indexing'
 import { Labeler } from '../labeler'
 import { LabelService } from '../app-view/services/label'
 import { BackgroundQueue } from '../event-stream/background-queue'
+import { Crawlers } from '../crawlers'
 
 export function createServices(resources: {
   repoSigningKey: crypto.Keypair
@@ -25,6 +26,7 @@ export function createServices(resources: {
   imgInvalidator: ImageInvalidator
   labeler: Labeler
   backgroundQueue: BackgroundQueue
+  crawlers: Crawlers
 }): Services {
   const {
     repoSigningKey,
@@ -34,6 +36,7 @@ export function createServices(resources: {
     imgInvalidator,
     labeler,
     backgroundQueue,
+    crawlers,
   } = resources
   return {
     account: AccountService.creator(),
@@ -44,6 +47,7 @@ export function createServices(resources: {
       messageDispatcher,
       blobstore,
       backgroundQueue,
+      crawlers,
       labeler,
     ),
     moderation: ModerationService.creator(

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -29,6 +29,7 @@ import { Labeler } from '../../labeler'
 import { wait } from '@atproto/common'
 import { BackgroundQueue } from '../../event-stream/background-queue'
 import { countAll } from '../../db/util'
+import { Crawlers } from '../../crawlers'
 
 export class RepoService {
   blobs: RepoBlobs
@@ -39,6 +40,7 @@ export class RepoService {
     public messageDispatcher: MessageQueue,
     public blobstore: BlobStore,
     public backgroundQueue: BackgroundQueue,
+    public crawlers: Crawlers,
     public labeler: Labeler,
   ) {
     this.blobs = new RepoBlobs(db, blobstore, backgroundQueue)
@@ -49,6 +51,7 @@ export class RepoService {
     messageDispatcher: MessageQueue,
     blobstore: BlobStore,
     backgroundQueue: BackgroundQueue,
+    crawlers: Crawlers,
     labeler: Labeler,
   ) {
     return (db: Database) =>
@@ -58,6 +61,7 @@ export class RepoService {
         messageDispatcher,
         blobstore,
         backgroundQueue,
+        crawlers,
         labeler,
       )
   }
@@ -77,6 +81,7 @@ export class RepoService {
         this.messageDispatcher,
         this.blobstore,
         this.backgroundQueue,
+        this.crawlers,
         this.labeler,
       )
       return fn(srvc)
@@ -220,6 +225,10 @@ export class RepoService {
     commitData: CommitData,
     writes: PreparedWrite[],
   ) {
+    this.db.onCommit(() => {
+      this.crawlers.notifyOfUpdate()
+    })
+
     const seqEvt = await sequencer.formatSeqCommit(did, commitData, writes)
     await sequencer.sequenceEvt(this.db, seqEvt)
 

--- a/packages/pds/src/services/repo/index.ts
+++ b/packages/pds/src/services/repo/index.ts
@@ -226,7 +226,9 @@ export class RepoService {
     writes: PreparedWrite[],
   ) {
     this.db.onCommit(() => {
-      this.crawlers.notifyOfUpdate()
+      this.backgroundQueue.add(async () => {
+        await this.crawlers.notifyOfUpdate()
+      })
     })
 
     const seqEvt = await sequencer.formatSeqCommit(did, commitData, writes)


### PR DESCRIPTION
Notify crawlers on write.

On write, ping all configured crawlers that a new write is available.

Only do this maximum once every 20 minutes.