### PR TITLE
lexicon: remove 'enum' from string and integer validators

### DIFF
--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -22,7 +22,6 @@ export const lexInteger = z
     default: z.number().int().optional(),
     minimum: z.number().int().optional(),
     maximum: z.number().int().optional(),
-    enum: z.number().int().array().optional(),
     const: z.number().int().optional(),
   })
   .strict()
@@ -50,7 +49,6 @@ export const lexString = z
     maxLength: z.number().int().optional(),
     minGraphemes: z.number().int().optional(),
     maxGraphemes: z.number().int().optional(),
-    enum: z.string().array().optional(),
     const: z.string().optional(),
     knownValues: z.string().array().optional(),
   })

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -112,18 +112,6 @@ export function integer(
     }
   }
 
-  // enum
-  if (Array.isArray(def.enum)) {
-    if (!def.enum.includes(value as number)) {
-      return {
-        success: false,
-        error: new ValidationError(
-          `${path} must be one of (${def.enum.join('|')})`,
-        ),
-      }
-    }
-  }
-
   // maximum
   if (typeof def.maximum === 'number') {
     if ((value as number) > def.maximum) {
@@ -181,18 +169,6 @@ export function string(
       return {
         success: false,
         error: new ValidationError(`${path} must be ${def.const}`),
-      }
-    }
-  }
-
-  // enum
-  if (Array.isArray(def.enum)) {
-    if (!def.enum.includes(value as string)) {
-      return {
-        success: false,
-        error: new ValidationError(
-          `${path} must be one of (${def.enum.join('|')})`,
-        ),
       }
     }
   }

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -258,24 +258,6 @@ export default [
   },
   {
     lexicon: 1,
-    id: 'com.example.integerEnum',
-    defs: {
-      main: {
-        type: 'record',
-        record: {
-          type: 'object',
-          properties: {
-            integer: {
-              type: 'integer',
-              enum: [1, 2],
-            },
-          },
-        },
-      },
-    },
-  },
-  {
-    lexicon: 1,
     id: 'com.example.integerConst',
     defs: {
       main: {
@@ -332,7 +314,7 @@ export default [
   },
   {
     lexicon: 1,
-    id: 'com.example.stringEnum',
+    id: 'com.example.stringKnownValues',
     defs: {
       main: {
         type: 'record',
@@ -341,7 +323,7 @@ export default [
           properties: {
             string: {
               type: 'string',
-              enum: ['a', 'b'],
+              knownValues: ['a', 'b'],
             },
           },
         },

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -532,19 +532,6 @@ describe('Record validation', () => {
     ).toThrow('Record/integer can not be greater than 4')
   })
 
-  it('Applies integer enum constraint', () => {
-    lex.assertValidRecord('com.example.integerEnum', {
-      $type: 'com.example.integerEnum',
-      integer: 2,
-    })
-    expect(() =>
-      lex.assertValidRecord('com.example.integerEnum', {
-        $type: 'com.example.integerEnum',
-        integer: 0,
-      }),
-    ).toThrow('Record/integer must be one of (1|2)')
-  })
-
   it('Applies integer const constraint', () => {
     lex.assertValidRecord('com.example.integerConst', {
       $type: 'com.example.integerConst',
@@ -611,14 +598,14 @@ describe('Record validation', () => {
     ).toThrow('Record/string must not be longer than 4 graphemes')
   })
 
-  it('Applies string enum constraint', () => {
-    lex.assertValidRecord('com.example.stringEnum', {
-      $type: 'com.example.stringEnum',
+  it('Applies string knownValues constraint', () => {
+    lex.assertValidRecord('com.example.stringKnownValues', {
+      $type: 'com.example.stringKnownValues',
       string: 'a',
     })
     expect(() =>
-      lex.assertValidRecord('com.example.stringEnum', {
-        $type: 'com.example.stringEnum',
+      lex.assertValidRecord('com.example.stringKnownValues', {
+        $type: 'com.example.stringKnownValues',
         string: 'c',
       }),
     ).toThrow('Record/string must be one of (a|b)')


### PR DESCRIPTION
DO NOT MERGE

This PR is an elaborate way of asking the question: why do we have both 'enum' and 'knownValues' constraints on strings in Lexicon? And should we remove 'enum' in integers, given that we don't support it.

There doesn't seem to be test coverage for 'knownValues'? Though maybe i'm misunderstanding what 'knownValues' actually means.