### PR TITLE
Improve handle indexing on appview

### DIFF
--- a/packages/bsky/src/services/indexing/index.ts
+++ b/packages/bsky/src/services/indexing/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@atproto/repo'
 import { AtUri } from '@atproto/uri'
 import { IdResolver, getPds } from '@atproto/identity'
-import { chunkArray } from '@atproto/common'
+import { DAY, chunkArray } from '@atproto/common'
 import { ValidationError } from '@atproto/lexicon'
 import Database from '../../db'
 import * as Post from './plugins/post'
@@ -118,7 +118,13 @@ export class IndexingService {
       .where('did', '=', did)
       .selectAll()
       .executeTakeFirst()
-    if (actor && !force) {
+    const timestampAt = new Date(timestamp)
+    const lastIndexedAt = actor && new Date(actor.indexedAt)
+    const needsReindex =
+      force ||
+      !lastIndexedAt ||
+      timestampAt.getTime() - lastIndexedAt.getTime() > DAY
+    if (!needsReindex) {
       return
     }
     const { handle } = await this.idResolver.did.resolveAtprotoData(did, true)


### PR DESCRIPTION
A couple improvements to indexing handles on the appview:
 - On an unprocessable commit event, still attempt to index the handle.
 - Attempt to revalidate each handle daily (i.e. in the absence of a handle update event).
 - Improve error handling/reporting on commit events.