### PR TITLE
Backport: fallback to getRecord on appview, misc fixes

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - bsky-app-view
+      - simplify-pds
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - simplify-pds
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-bsky-ghcr.yaml
+++ b/.github/workflows/build-and-push-bsky-ghcr.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - simplify-pds
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-and-push-bsky-ghcr.yaml
+++ b/.github/workflows/build-and-push-bsky-ghcr.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - simplify-pds
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/packages/bsky/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/bsky/src/api/com/atproto/repo/getRecord.ts
@@ -1,0 +1,38 @@
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { AtUri } from '@atproto/uri'
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+import { jsonStringToLex } from '@atproto/lexicon'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.repo.getRecord(async ({ params }) => {
+    const { repo, collection, rkey, cid } = params
+    const did = await ctx.services.actor(ctx.db).getActorDid(repo)
+    if (!did) {
+      throw new InvalidRequestError(`Could not find repo: ${repo}`)
+    }
+
+    const uri = AtUri.make(did, collection, rkey)
+
+    let builder = ctx.db.db
+      .selectFrom('record')
+      .selectAll()
+      .where('uri', '=', uri.toString())
+    if (cid) {
+      builder = builder.where('cid', '=', cid)
+    }
+
+    const record = await builder.executeTakeFirst()
+    if (!record) {
+      throw new InvalidRequestError(`Could not locate record: ${uri}`)
+    }
+    return {
+      encoding: 'application/json',
+      body: {
+        uri: record.uri,
+        cid: record.cid,
+        value: jsonStringToLex(record.json) as Record<string, unknown>,
+      },
+    }
+  })
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -36,13 +36,14 @@ import resolveModerationReports from './com/atproto/admin/resolveModerationRepor
 import reverseModerationAction from './com/atproto/admin/reverseModerationAction'
 import takeModerationAction from './com/atproto/admin/takeModerationAction'
 import searchRepos from './com/atproto/admin/searchRepos'
-import getRecord from './com/atproto/admin/getRecord'
+import adminGetRecord from './com/atproto/admin/getRecord'
 import getRepo from './com/atproto/admin/getRepo'
 import getModerationAction from './com/atproto/admin/getModerationAction'
 import getModerationActions from './com/atproto/admin/getModerationActions'
 import getModerationReport from './com/atproto/admin/getModerationReport'
 import getModerationReports from './com/atproto/admin/getModerationReports'
 import resolveHandle from './com/atproto/identity/resolveHandle'
+import getRecord from './com/atproto/repo/getRecord'
 
 export * as health from './health'
 
@@ -87,12 +88,13 @@ export default function (server: Server, ctx: AppContext) {
   reverseModerationAction(server, ctx)
   takeModerationAction(server, ctx)
   searchRepos(server, ctx)
-  getRecord(server, ctx)
+  adminGetRecord(server, ctx)
   getRepo(server, ctx)
   getModerationAction(server, ctx)
   getModerationActions(server, ctx)
   getModerationReport(server, ctx)
   getModerationReports(server, ctx)
   resolveHandle(server, ctx)
+  getRecord(server, ctx)
   return server
 }

--- a/packages/pds/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/getRecord.ts
@@ -1,4 +1,5 @@
 import { AtUri } from '@atproto/uri'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
@@ -25,10 +26,17 @@ export default function (server: Server, ctx: AppContext) {
       }
     }
 
-    const res = await ctx.appViewAgent.api.com.atproto.repo.getRecord(params)
-    return {
-      encoding: 'application/json',
-      body: res.data,
+    if (ctx.cfg.bskyAppViewEndpoint) {
+      const res = await ctx.appviewAgent.api.com.atproto.repo.getRecord(params)
+      return {
+        encoding: 'application/json',
+        body: res.data,
+      }
+    } else {
+      const uri = AtUri.make(did || repo, collection, rkey)
+      throw new InvalidRequestError(
+        `Could not locate record: ${uri.toString()}`,
+      )
     }
   })
 }

--- a/packages/pds/src/crawlers.ts
+++ b/packages/pds/src/crawlers.ts
@@ -21,7 +21,7 @@ export class Crawlers {
     await Promise.all(
       this.agents.map(async (agent) => {
         try {
-          await agent.api.com.atproto.sync.notifyOfUpdate({
+          await agent.api.com.atproto.sync.requestCrawl({
             hostname: this.hostname,
           })
         } catch (err) {


### PR DESCRIPTION
Porting some changes from https://github.com/bluesky-social/atproto/pull/1198/commits/a109e140134ac416cc7dd2f5e62b96c7c185df0f

 - Implement `getRecord` on appview to support some usage by the client via @atproto/api.
 - Fallback to appview in `getRecord` on the pds when applicable.
 - Temporarily use `requestCrawl` rather than `notifyOfUpdate` for notifying crawlers.
 - Misc tidying.