### PR TITLE
Allow optional auth for reporting on bsky appview

### DIFF
--- a/packages/bsky/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/bsky/src/api/com/atproto/moderation/createReport.ts
@@ -6,16 +6,19 @@ import { softDeleted } from '../../../../db/util'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.moderation.createReport({
-    auth: ctx.authVerifier,
+    // @TODO anonymous reports w/ optional auth are a temporary measure
+    auth: ctx.authOptionalVerifier,
     handler: async ({ input, auth }) => {
       const { db, services } = ctx
       const { reasonType, reason, subject } = input.body
       const requester = auth.credentials.did
 
-      // Don't accept reports from users that are fully taken-down
-      const actor = await services.actor(db).getActor(requester, true)
-      if (actor && softDeleted(actor)) {
-        throw new AuthRequiredError()
+      if (requester) {
+        // Don't accept reports from users that are fully taken-down
+        const actor = await services.actor(db).getActor(requester, true)
+        if (actor && softDeleted(actor)) {
+          throw new AuthRequiredError()
+        }
       }
 
       const moderationService = services.moderation(db)
@@ -24,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
         reasonType: getReasonType(reasonType),
         reason,
         subject: getSubject(subject),
-        reportedBy: requester,
+        reportedBy: requester || ctx.cfg.serverDid,
       })
 
       return {


### PR DESCRIPTION
The bsky appview will temporarily allow anonymous reports to support early usage in sandbox.