### PR TITLE
Make requestCrawl & notifyOfUpdate procedures

### DIFF
--- a/lexicons/com/atproto/sync/notifyOfUpdate.json
+++ b/lexicons/com/atproto/sync/notifyOfUpdate.json
@@ -3,13 +3,16 @@
   "id": "com.atproto.sync.notifyOfUpdate",
   "defs": {
     "main": {
-      "type": "query",
+      "type": "procedure",
       "description": "Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.",
-      "parameters": {
-        "type": "params",
-        "required": ["hostname"],
-        "properties": {
-          "hostname": {"type": "string", "description": "Hostname of the service that is notifying of update."}
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["hostname"],
+          "properties": {
+            "hostname": {"type": "string", "description": "Hostname of the service that is notifying of update."}
+          }
         }
       }
     }

--- a/lexicons/com/atproto/sync/requestCrawl.json
+++ b/lexicons/com/atproto/sync/requestCrawl.json
@@ -3,13 +3,16 @@
   "id": "com.atproto.sync.requestCrawl",
   "defs": {
     "main": {
-      "type": "query",
+      "type": "procedure",
       "description": "Request a service to persistently crawl hosted repos.",
-      "parameters": {
-        "type": "params",
-        "required": ["hostname"],
-        "properties": {
-          "hostname": {"type": "string", "description": "Hostname of the service that is requesting to be crawled."}
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["hostname"],
+          "properties": {
+            "hostname": {"type": "string", "description": "Hostname of the service that is requesting to be crawled."}
+          }
         }
       }
     }

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -982,22 +982,22 @@ export class SyncNS {
   }
 
   notifyOfUpdate(
-    params?: ComAtprotoSyncNotifyOfUpdate.QueryParams,
+    data?: ComAtprotoSyncNotifyOfUpdate.InputSchema,
     opts?: ComAtprotoSyncNotifyOfUpdate.CallOptions,
   ): Promise<ComAtprotoSyncNotifyOfUpdate.Response> {
     return this._service.xrpc
-      .call('com.atproto.sync.notifyOfUpdate', params, undefined, opts)
+      .call('com.atproto.sync.notifyOfUpdate', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoSyncNotifyOfUpdate.toKnownErr(e)
       })
   }
 
   requestCrawl(
-    params?: ComAtprotoSyncRequestCrawl.QueryParams,
+    data?: ComAtprotoSyncRequestCrawl.InputSchema,
     opts?: ComAtprotoSyncRequestCrawl.CallOptions,
   ): Promise<ComAtprotoSyncRequestCrawl.Response> {
     return this._service.xrpc
-      .call('com.atproto.sync.requestCrawl', params, undefined, opts)
+      .call('com.atproto.sync.requestCrawl', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoSyncRequestCrawl.toKnownErr(e)
       })

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3248,17 +3248,20 @@ export const schemaDict = {
     id: 'com.atproto.sync.notifyOfUpdate',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description:
           'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is notifying of update.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is notifying of update.',
+              },
             },
           },
         },
@@ -3270,16 +3273,19 @@ export const schemaDict = {
     id: 'com.atproto.sync.requestCrawl',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description: 'Request a service to persistently crawl hosted repos.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is requesting to be crawled.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is requesting to be crawled.',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
@@ -7,15 +7,18 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is notifying of update. */
   hostname: string
+  [k: string]: unknown
 }
-
-export type InputSchema = undefined
 
 export interface CallOptions {
   headers?: Headers
+  qp?: QueryParams
+  encoding: 'application/json'
 }
 
 export interface Response {

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -7,15 +7,18 @@ import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is requesting to be crawled. */
   hostname: string
+  [k: string]: unknown
 }
-
-export type InputSchema = undefined
 
 export interface CallOptions {
   headers?: Headers
+  qp?: QueryParams
+  encoding: 'application/json'
 }
 
 export interface Response {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3248,17 +3248,20 @@ export const schemaDict = {
     id: 'com.atproto.sync.notifyOfUpdate',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description:
           'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is notifying of update.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is notifying of update.',
+              },
             },
           },
         },
@@ -3270,16 +3273,19 @@ export const schemaDict = {
     id: 'com.atproto.sync.requestCrawl',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description: 'Request a service to persistently crawl hosted repos.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is requesting to be crawled.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is requesting to be crawled.',
+              },
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -8,13 +8,18 @@ import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is notifying of update. */
   hostname: string
+  [k: string]: unknown
 }
 
-export type InputSchema = undefined
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerError {
   status: number

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -8,13 +8,18 @@ import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is requesting to be crawled. */
   hostname: string
+  [k: string]: unknown
 }
 
-export type InputSchema = undefined
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerError {
   status: number

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3248,17 +3248,20 @@ export const schemaDict = {
     id: 'com.atproto.sync.notifyOfUpdate',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description:
           'Notify a crawling service of a recent update. Often when a long break between updates causes the connection with the crawling service to break.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is notifying of update.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is notifying of update.',
+              },
             },
           },
         },
@@ -3270,16 +3273,19 @@ export const schemaDict = {
     id: 'com.atproto.sync.requestCrawl',
     defs: {
       main: {
-        type: 'query',
+        type: 'procedure',
         description: 'Request a service to persistently crawl hosted repos.',
-        parameters: {
-          type: 'params',
-          required: ['hostname'],
-          properties: {
-            hostname: {
-              type: 'string',
-              description:
-                'Hostname of the service that is requesting to be crawled.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['hostname'],
+            properties: {
+              hostname: {
+                type: 'string',
+                description:
+                  'Hostname of the service that is requesting to be crawled.',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -8,13 +8,18 @@ import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is notifying of update. */
   hostname: string
+  [k: string]: unknown
 }
 
-export type InputSchema = undefined
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerError {
   status: number

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -8,13 +8,18 @@ import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth } from '@atproto/xrpc-server'
 
-export interface QueryParams {
+export interface QueryParams {}
+
+export interface InputSchema {
   /** Hostname of the service that is requesting to be crawled. */
   hostname: string
+  [k: string]: unknown
 }
 
-export type InputSchema = undefined
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerError {
   status: number


### PR DESCRIPTION
re: https://github.com/bluesky-social/atproto/discussions/1214

Because these are intended to have side effects they really should be POSTs instead of GETs.

Rollout plan: we're intending to support both POSTs & GETs on BGS for some period - likely a week - as this change goes out, then we will be deprecating GETs