### PR TITLE
Run test DB for full monorepo tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "verify": "lerna run verify --stream",
     "prettier": "lerna run prettier",
     "build": "lerna run build",
-    "test": "NODE_ENV=development lerna run test --stream",
-    "test:withFlags": "NODE_ENV=development lerna run test --stream --"
+    "test": "LOG_ENABLED=false NODE_ENV=development ./packages/pg/with-test-db.sh lerna run test --stream",
+    "test:withFlags": "LOG_ENABLED=false NODE_ENV=development ./packages/pg/with-test-db.sh lerna run test --stream --"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/packages/bsky/tests/algos/hot-classic.test.ts
+++ b/packages/bsky/tests/algos/hot-classic.test.ts
@@ -22,7 +22,7 @@ describe('algo hot-classic', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'algo_hot_classic',
+      dbPostgresSchema: 'bsky_algo_hot_classic',
       bsky: { algos: makeAlgos(feedPublisherDid) },
     })
     agent = new AtpAgent({ service: network.bsky.url })

--- a/packages/bsky/tests/algos/whats-hot.test.ts
+++ b/packages/bsky/tests/algos/whats-hot.test.ts
@@ -24,7 +24,7 @@ describe('algo whats-hot', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'algo_whats_hot',
+      dbPostgresSchema: 'bsky_algo_whats_hot',
       bsky: { algos: makeAlgos(feedPublisherDid) },
     })
     agent = new AtpAgent({ service: network.bsky.url })

--- a/packages/bsky/tests/algos/with-friends.test.ts
+++ b/packages/bsky/tests/algos/with-friends.test.ts
@@ -24,7 +24,7 @@ describe.skip('algo with friends', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'algo_with_friends',
+      dbPostgresSchema: 'bsky_algo_with_friends',
       bsky: { algos: makeAlgos(feedPublisherDid) },
     })
     agent = new AtpAgent({ service: network.bsky.url })

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -34,7 +34,7 @@ describe('feed generation', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'feed_generation',
+      dbPostgresSchema: 'bsky_feed_generation',
     })
     agent = network.bsky.getClient()
     pdsAgent = network.pds.getClient()

--- a/packages/bsky/tests/labeler/labeler.test.ts
+++ b/packages/bsky/tests/labeler/labeler.test.ts
@@ -28,7 +28,7 @@ describe('labeler', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'labeler',
+      dbPostgresSchema: 'bsky_labeler',
     })
     ctx = network.bsky.ctx
     const pdsCtx = network.pds.ctx

--- a/packages/bsky/tests/moderation.test.ts
+++ b/packages/bsky/tests/moderation.test.ts
@@ -22,7 +22,7 @@ describe('moderation', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'moderation',
+      dbPostgresSchema: 'bsky_moderation',
     })
     agent = network.bsky.getClient()
     const pdsAgent = network.pds.getClient()

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -6,6 +6,7 @@ import * as plc from '@did-plc/lib'
 import { PlcServer, Database as PlcDatabase } from '@did-plc/server'
 import { AtUri } from '@atproto/uri'
 import { randomStr } from '@atproto/crypto'
+import { uniqueLockId } from '@atproto/dev-env'
 import { CID } from 'multiformats/cid'
 import * as uint8arrays from 'uint8arrays'
 import { PDS, ServerConfig, Database, MemoryBlobStore } from '../src/index'
@@ -157,16 +158,6 @@ export const runTestServer = async (
       await plcServer.destroy()
     },
   }
-}
-
-const usedLockIds = new Set()
-const uniqueLockId = () => {
-  let lockId: number
-  do {
-    lockId = 1000 + Math.ceil(1000 * Math.random())
-  } while (usedLockIds.has(lockId))
-  usedLockIds.add(lockId)
-  return lockId
 }
 
 export const adminAuth = () => {

--- a/packages/pg/with-test-db.sh
+++ b/packages/pg/with-test-db.sh
@@ -6,6 +6,7 @@
 dir=$(dirname $0)
 compose_file="$dir/docker-compose.yaml"
 
+# whether this particular script started the container or if it was running beforehand
 started_container=false
 
 trap on_sigint INT
@@ -18,8 +19,8 @@ on_sigint() {
 }
 
 if [ -z `docker ps -q --no-trunc | grep $(docker-compose -f $compose_file ps -q db_test)` ]; then
-  started_container=true
   docker compose -f $compose_file up --wait --force-recreate db_test
+  started_container=true
   echo # newline
 else
   echo "db_test already running"

--- a/packages/pg/with-test-db.sh
+++ b/packages/pg/with-test-db.sh
@@ -18,7 +18,8 @@ on_sigint() {
   exit $?
 }
 
-if [ -z `docker ps -q --no-trunc | grep $(docker-compose -f $compose_file ps -q db_test)` ]; then
+# check if the container is already running
+if [[ -z `docker compose -f $compose_file ps --format json --status running | grep db_test` ]]; then
   docker compose -f $compose_file up --wait --force-recreate db_test
   started_container=true
   echo # newline

--- a/packages/pg/with-test-db.sh
+++ b/packages/pg/with-test-db.sh
@@ -19,7 +19,8 @@ on_sigint() {
 }
 
 # check if the container is already running
-if [[ -z `docker compose -f $compose_file ps --format json --status running | grep db_test` ]]; then
+container_id=$(docker compose -f $compose_file ps --format json --status running | jq  --raw-output '.[0]."ID"')
+if [ -z $container_id ] || [ -z `docker ps -q --no-trunc | grep $container_id` ]; then
   docker compose -f $compose_file up --wait --force-recreate db_test
   started_container=true
   echo # newline


### PR DESCRIPTION
I believe the CI failures in https://github.com/bluesky-social/atproto/pull/1198 come from the following issue:

- Either the bsky or the pds test suite starts the test db
- Both test suites take advantage of it
- the first to finish closes it down
- the second test suite may not be finished with it yet

This moves startup & of the test suite to the monorepo root.

It also alters the pg script file to check if the container is already running. If not, then only the script in charge of starting up the container will tear it down.

Unrelated to this, but I also moved the `on_sigint` handler a bit higher up, so that we don't hit the awkward case where a sigint will kill the container but keep running all the tests.

---

I also noticed a merge conflict on `LOG_ENABLED=false`. Not sure which way we want that flag toggled, but I'd assume off during tests, right? I'd make for pretty noisy output unless we send all logs to some file