### PR TITLE
Weaker repo lock

### DIFF
--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -32,7 +32,7 @@ export class SqlRepoStorage extends RepoStorage {
       .selectAll()
       .where('did', '=', this.did)
     if (this.db.dialect !== 'sqlite') {
-      builder = builder.forUpdate().skipLocked()
+      builder = builder.forNoKeyUpdate().skipLocked()
     }
     const res = await builder.executeTakeFirst()
     if (!res) return null


### PR DESCRIPTION
We were having lock contention between repo writes & an auto-vacuum on the repo_root table.

Use the slightly weaker `SELECT FOR NO KEY UPDATE` instead of `SELECT FOR UPDATE` when locking a repo_root

This lock is the weakest row lock that still conflicts with itself which is the important quality here.

https://www.postgresql.org/docs/current/explicit-locking.html