### PR TITLE
Improve invite code counting

### DIFF
--- a/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
@@ -66,13 +66,16 @@ export default function (server: Server, ctx: AppContext) {
           }))
           await ctx.db.transaction(async (dbTxn) => {
             await dbTxn.db.insertInto('invite_code').values(rows).execute()
-            const forUser = await dbTxn.db
+            const finalRoutineInviteCodes = await dbTxn.db
               .selectFrom('invite_code')
               .where('forUser', '=', requester)
               .where('createdBy', '!=', 'admin') // dont count admin-gifted codes aginast the user
               .selectAll()
               .execute()
-            if (forUser.length > routineCodes.length + toCreate) {
+            if (
+              finalRoutineInviteCodes.length >
+              routineCodes.length + toCreate
+            ) {
               throw new InvalidRequestError(
                 'attempted to create additional codes in another request',
                 'DuplicateCreate',

--- a/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
@@ -2,6 +2,7 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { genInvCodes } from './util'
 import { InvalidRequestError } from '@atproto/xrpc-server'
+import { CodeDetail } from '../../../../services/account'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.getAccountInviteCodes({
@@ -20,40 +21,18 @@ export default function (server: Server, ctx: AppContext) {
           .executeTakeFirstOrThrow(),
         accntSrvc.getAccountInviteCodes(requester),
       ])
-      const unusedCodes = userCodes.filter(
-        (row) => !row.disabled && row.available > row.uses.length,
-      )
 
       let created: string[] = []
 
-      // if the user wishes to create available codes & the server allows that,
-      // we determine the number to create by dividing their account lifetime by the interval at which they can create codes
-      // if an invite epoch is provided, we only calculate available invites since that epoch
-      // we allow a max of 5 open codes at a given time
-      // note: even if a user is disabled from future invites, we still create the invites for bookkeeping, we just immediately disable them as well
       const now = new Date().toISOString()
       if (createAvailable && ctx.cfg.userInviteInterval !== null) {
-        // for the sake of generating routine interval codes, we do not count explicitly gifted admin codes
-        const routineCodes = userCodes.filter(
-          (code) => code.createdBy !== 'admin',
-        )
-        const unusedRoutineCodes = unusedCodes.filter(
-          (code) => code.createdBy !== 'admin',
-        )
-        const userCreatedAt = new Date(user.createdAt).getTime()
-        const epochLifespan =
-          Date.now() - Math.max(userCreatedAt, ctx.cfg.userInviteEpoch)
-        const couldCreate = Math.floor(
-          epochLifespan / ctx.cfg.userInviteInterval,
-        )
-        const epochCodes = routineCodes.filter(
-          (code) =>
-            new Date(code.createdAt).getTime() > ctx.cfg.userInviteEpoch,
-        )
-        const toCreate = Math.min(
-          5 - unusedRoutineCodes.length,
-          couldCreate - epochCodes.length,
-        )
+        const { toCreate, total } = await calculateCodesToCreate({
+          did: requester,
+          userCreatedAt: new Date(user.createdAt).getTime(),
+          codes: userCodes,
+          epoch: ctx.cfg.userInviteEpoch,
+          interval: ctx.cfg.userInviteInterval,
+        })
         if (toCreate > 0) {
           created = genInvCodes(ctx.cfg, toCreate)
           const rows = created.map((code) => ({
@@ -72,10 +51,7 @@ export default function (server: Server, ctx: AppContext) {
               .where('createdBy', '!=', 'admin') // dont count admin-gifted codes aginast the user
               .selectAll()
               .execute()
-            if (
-              finalRoutineInviteCodes.length >
-              routineCodes.length + toCreate
-            ) {
+            if (finalRoutineInviteCodes.length > total) {
               throw new InvalidRequestError(
                 'attempted to create additional codes in another request',
                 'DuplicateCreate',
@@ -85,10 +61,8 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
-      const preexisting = includeUsed ? userCodes : unusedCodes
-
       const allCodes = [
-        ...preexisting,
+        ...userCodes,
         ...created.map((code) => ({
           code: code,
           available: 1,
@@ -100,7 +74,11 @@ export default function (server: Server, ctx: AppContext) {
         })),
       ]
 
-      const filtered = allCodes.filter((code) => !code.disabled)
+      const filtered = allCodes.filter((code) => {
+        if (code.disabled) return false
+        if (!includeUsed && code.uses.length >= code.available) return false
+        return true
+      })
 
       return {
         encoding: 'application/json',
@@ -110,4 +88,42 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+// if the user wishes to create available codes & the server allows that,
+// we determine the number to create by dividing their account lifetime by the interval at which they can create codes
+// if an invite epoch is provided, we only calculate available invites since that epoch
+// we allow a max of 5 open codes at a given time
+// note: even if a user is disabled from future invites, we still create the invites for bookkeeping, we just immediately disable them as well
+const calculateCodesToCreate = async (opts: {
+  did: string
+  userCreatedAt: number
+  codes: CodeDetail[]
+  epoch: number
+  interval: number
+}): Promise<{ toCreate: number; total: number }> => {
+  // for the sake of generating routine interval codes, we do not count explicitly gifted admin codes
+  const routineCodes = opts.codes.filter((code) => code.createdBy !== 'admin')
+  const unusedRoutineCodes = routineCodes.filter(
+    (row) => !row.disabled && row.available > row.uses.length,
+  )
+  const userLifespan = Date.now() - opts.userCreatedAt
+  const couldCreateTotal = userLifespan / opts.interval
+  const userTimeBeforeEpoch = opts.epoch - opts.userCreatedAt
+  const couldCreateBeforeEpoch = Math.max(
+    userTimeBeforeEpoch / opts.interval,
+    0,
+  )
+  const couldCreate = Math.floor(couldCreateTotal - couldCreateBeforeEpoch)
+  const epochCodes = routineCodes.filter(
+    (code) => new Date(code.createdAt).getTime() > opts.epoch,
+  )
+  const toCreate = Math.min(
+    5 - unusedRoutineCodes.length,
+    couldCreate - epochCodes.length,
+  )
+  return {
+    toCreate,
+    total: routineCodes.length + toCreate,
+  }
 }

--- a/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
@@ -69,6 +69,7 @@ export default function (server: Server, ctx: AppContext) {
             const forUser = await dbTxn.db
               .selectFrom('invite_code')
               .where('forUser', '=', requester)
+              .where('createdBy', '!=', 'admin') // dont count admin-gifted codes aginast the user
               .selectAll()
               .execute()
             if (forUser.length > routineCodes.length + toCreate) {

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -484,7 +484,7 @@ export class AccountService {
     return uses
   }
 
-  async getAccountInviteCodes(did: string) {
+  async getAccountInviteCodes(did: string): Promise<CodeDetail[]> {
     const res = await this.selectInviteCodesQb()
       .where('forAccount', '=', did)
       .execute()
@@ -593,7 +593,7 @@ export class AccountService {
 
 export type UserPreference = Record<string, unknown> & { $type: string }
 
-type CodeDetail = {
+export type CodeDetail = {
   code: string
   available: number
   disabled: boolean

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -1,37 +1,17 @@
 import { once, EventEmitter } from 'events'
-import AtpAgent, {
-  ComAtprotoServerCreateAccount,
-  ComAtprotoServerResetPassword,
-} from '@atproto/api'
+import AtpAgent, { ComAtprotoServerResetPassword } from '@atproto/api'
 import { IdResolver } from '@atproto/identity'
 import * as crypto from '@atproto/crypto'
 import Mail from 'nodemailer/lib/mailer'
 import { AppContext, Database } from '../src'
 import * as util from './_util'
 import { ServerMailer } from '../src/mailer'
-import { DAY } from '@atproto/common'
-import { genInvCodes } from '../src/api/com/atproto/server/util'
 
 const email = 'alice@test.com'
 const handle = 'alice.test'
 const password = 'test123'
 const passwordAlt = 'test456'
 const minsToMs = 60 * 1000
-
-const createInviteCode = async (
-  agent: AtpAgent,
-  uses: number,
-  forUser?: string,
-): Promise<string> => {
-  const res = await agent.api.com.atproto.server.createInviteCode(
-    { useCount: uses, forUser },
-    {
-      headers: { authorization: util.adminAuth() },
-      encoding: 'application/json',
-    },
-  )
-  return res.data.code
-}
 
 describe('account', () => {
   let serverUrl: string
@@ -47,9 +27,6 @@ describe('account', () => {
 
   beforeAll(async () => {
     const server = await util.runTestServer({
-      inviteRequired: true,
-      userInviteInterval: DAY,
-      userInviteEpoch: Date.now() - 3 * DAY,
       termsOfServiceUrl: 'https://example.com/tos',
       privacyPolicyUrl: '/privacy-policy',
       dbPostgresSchema: 'account',
@@ -79,20 +56,9 @@ describe('account', () => {
     }
   })
 
-  let inviteCode: string
-
-  it('creates an invite code', async () => {
-    inviteCode = await createInviteCode(agent, 1)
-    const split = inviteCode.split('-')
-    const host = split.slice(0, -2).join('.')
-    const code = split.slice(-2).join('-')
-    expect(host).toBe('pds.public.url') // Hostname of public url
-    expect(code.length).toBe(11)
-  })
-
   it('serves the accounts system config', async () => {
     const res = await agent.api.com.atproto.server.describeServer({})
-    expect(res.data.inviteCodeRequired).toBe(true)
+    expect(res.data.inviteCodeRequired).toBe(false)
     expect(res.data.availableUserDomains[0]).toBe('.test')
     expect(typeof res.data.inviteCodeRequired).toBe('boolean')
     expect(res.data.links?.privacyPolicy).toBe(
@@ -106,21 +72,8 @@ describe('account', () => {
       email: 'bad-handle@test.com',
       handle: 'did:bad-handle.test',
       password: 'asdf',
-      inviteCode,
     })
     await expect(promise).rejects.toThrow('Input/handle must be a valid handle')
-  })
-
-  it('fails on bad invite code', async () => {
-    const promise = agent.api.com.atproto.server.createAccount({
-      email,
-      handle,
-      password,
-      inviteCode: 'fake-invite',
-    })
-    await expect(promise).rejects.toThrow(
-      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
-    )
   })
 
   let did: string
@@ -131,7 +84,6 @@ describe('account', () => {
       email,
       handle,
       password,
-      inviteCode,
     })
     did = res.data.did
     jwt = res.data.accessJwt
@@ -151,13 +103,11 @@ describe('account', () => {
   })
 
   it('allows a custom set recovery key', async () => {
-    const inviteCode = await createInviteCode(agent, 1)
     const recoveryKey = (await crypto.EcdsaKeypair.create()).did()
     const res = await agent.api.com.atproto.server.createAccount({
       email: 'custom-recovery@test.com',
       handle: 'custom-recovery.test',
       password: 'custom-recovery',
-      inviteCode,
       recoveryKey,
     })
 
@@ -171,7 +121,6 @@ describe('account', () => {
   })
 
   it('allows a user to bring their own DID', async () => {
-    const inviteCode = await createInviteCode(agent, 1)
     const userKey = await crypto.Secp256k1Keypair.create()
     const handle = 'byo-did.test'
     const did = await ctx.plcClient.createDid({
@@ -191,7 +140,6 @@ describe('account', () => {
       handle,
       did,
       password: 'byo-did-pass',
-      inviteCode,
     })
 
     expect(res.data.handle).toEqual(handle)
@@ -199,7 +147,6 @@ describe('account', () => {
   })
 
   it('requires that the did a user brought be correctly set up for the server', async () => {
-    const inviteCode = await createInviteCode(agent, 1)
     const userKey = await crypto.Secp256k1Keypair.create()
     const baseDidInfo = {
       signingKey: ctx.repoSigningKey.did(),
@@ -216,7 +163,6 @@ describe('account', () => {
       email: 'byo-did@test.com',
       handle: 'byo-did.test',
       password: 'byo-did-pass',
-      inviteCode,
     }
 
     const did1 = await ctx.plcClient.createDid({
@@ -313,7 +259,6 @@ describe('account', () => {
   })
 
   it('disallows duplicate email addresses and handles', async () => {
-    const inviteCode = await createInviteCode(agent, 2)
     const email = 'bob@test.com'
     const handle = 'bob.test'
     const password = 'test123'
@@ -321,7 +266,6 @@ describe('account', () => {
       email,
       handle,
       password,
-      inviteCode,
     })
 
     await expect(
@@ -329,7 +273,6 @@ describe('account', () => {
         email: email.toUpperCase(),
         handle: 'carol.test',
         password,
-        inviteCode,
       }),
     ).rejects.toThrow('Email already taken: BOB@TEST.COM')
 
@@ -338,19 +281,16 @@ describe('account', () => {
         email: 'carol@test.com',
         handle: handle.toUpperCase(),
         password,
-        inviteCode,
       }),
     ).rejects.toThrow('Handle already taken: bob.test')
   })
 
   it('disallows improperly formatted handles', async () => {
-    const inviteCode = await createInviteCode(agent, 1)
     const tryHandle = async (handle: string) => {
       await agent.api.com.atproto.server.createAccount({
         email: 'john@test.com',
         handle,
         password: 'test123',
-        inviteCode,
       })
     }
     await expect(tryHandle('did:john')).rejects.toThrow(
@@ -391,66 +331,19 @@ describe('account', () => {
     await expect(tryHandle('atp.test')).rejects.toThrow('Reserved handle')
   })
 
-  it('fails on used up invite code', async () => {
-    const promise = agent.api.com.atproto.server.createAccount({
-      email: 'bob@test.com',
-      handle: 'bob.test',
-      password: 'asdf',
-      inviteCode,
-    })
-    await expect(promise).rejects.toThrow(
-      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
-    )
-  })
-
-  it('handles racing invite code uses', async () => {
-    const inviteCode = await createInviteCode(agent, 1)
-    const COUNT = 10
-
-    let successes = 0
-    let failures = 0
-    const promises: Promise<unknown>[] = []
-    for (let i = 0; i < COUNT; i++) {
-      const attempt = async () => {
-        try {
-          await agent.api.com.atproto.server.createAccount({
-            email: `user${i}@test.com`,
-            handle: `user${i}.test`,
-            password: `password`,
-            inviteCode,
-          })
-          successes++
-        } catch (err) {
-          failures++
-        }
-      }
-      promises.push(attempt())
-    }
-    await Promise.all(promises)
-    expect(successes).toBe(1)
-    expect(failures).toBe(9)
-  })
-
   it('handles racing signups for same handle', async () => {
     const COUNT = 10
 
-    const invite1 = await createInviteCode(agent, COUNT)
-    const invite2 = await createInviteCode(agent, COUNT)
-
     let successes = 0
     let failures = 0
     const promises: Promise<unknown>[] = []
     for (let i = 0; i < COUNT; i++) {
       const attempt = async () => {
         try {
-          // Use two invites to ensure per-invite locking doesn't
-          // give the appearance of fixing a race for handle.
-          const invite = i % 2 ? invite1 : invite2
           await agent.api.com.atproto.server.createAccount({
             email: `matching@test.com`,
             handle: `matching.test`,
             password: `password`,
-            inviteCode: invite,
           })
           successes++
         } catch (err) {
@@ -638,156 +531,5 @@ describe('account', () => {
         password,
       }),
     ).resolves.toBeDefined()
-  })
-
-  it('allow users to get available user invites', async () => {
-    // first pretend account was made 2 days in the past
-    const twoDaysAgo = new Date(Date.now() - 2 * DAY).toISOString()
-    await ctx.db.db
-      .updateTable('user_account')
-      .set({ createdAt: twoDaysAgo })
-      .where('did', '=', did)
-      .execute()
-    const res1 = await agent.api.com.atproto.server.getAccountInviteCodes()
-    expect(res1.data.codes.length).toBe(2)
-
-    // use both invites and confirm we can't get any more
-    await ctx.db.db
-      .insertInto('invite_code_use')
-      .values(
-        res1.data.codes.map((code) => ({
-          code: code.code,
-          usedBy: 'did:example:test',
-          usedAt: new Date().toISOString(),
-        })),
-      )
-      .execute()
-    const res2 = await agent.api.com.atproto.server.getAccountInviteCodes()
-    expect(res2.data.codes.length).toBe(2)
-  })
-
-  it('creates invites based on epoch', async () => {
-    // pretend account was made 10 days ago
-    const tenDaysAgo = new Date(Date.now() - 10 * DAY).toISOString()
-    await ctx.db.db
-      .updateTable('user_account')
-      .set({ createdAt: tenDaysAgo })
-      .where('did', '=', did)
-      .execute()
-
-    // we have a 3 day epoch so should still get 1 code
-    const res = await agent.api.com.atproto.server.getAccountInviteCodes({
-      includeUsed: false,
-    })
-    expect(res.data.codes.length).toBe(1)
-    const res2 = await agent.api.com.atproto.server.getAccountInviteCodes()
-    expect(res2.data.codes.length).toBe(3)
-
-    // we pad their account with some additional used codes from the past which should not change anything
-    const inviteRows = genInvCodes(ctx.cfg, 10).map((code) => ({
-      code: code,
-      availableUses: 1,
-      disabled: 0 as const,
-      forUser: did,
-      createdBy: did,
-      createdAt: new Date(Date.now() - 5 * DAY).toISOString(),
-    }))
-    await ctx.db.db.insertInto('invite_code').values(inviteRows).execute()
-    await ctx.db.db
-      .insertInto('invite_code_use')
-      .values(
-        inviteRows.map((row) => ({
-          code: row.code,
-          usedBy: 'did:example:test',
-          usedAt: new Date().toISOString(),
-        })),
-      )
-      .execute()
-
-    const res3 = await agent.api.com.atproto.server.getAccountInviteCodes({
-      includeUsed: false,
-    })
-    expect(res3.data.codes.length).toBe(1)
-  })
-
-  it('prevents use of disabled codes', async () => {
-    const first = await createInviteCode(agent, 1)
-    const accntCodes =
-      await agent.api.com.atproto.server.getAccountInviteCodes()
-    const second = accntCodes.data.codes[0].code
-
-    // disabled first by code & second by did
-    await agent.api.com.atproto.admin.disableInviteCodes(
-      {
-        codes: [first],
-        accounts: [did],
-      },
-      {
-        headers: { authorization: util.adminAuth() },
-        encoding: 'application/json',
-      },
-    )
-
-    const attempt = async (code: string) => {
-      await agent.api.com.atproto.server.createAccount({
-        email: 'disable@test.com',
-        handle: 'disable.test',
-        inviteCode: code,
-        password: 'disabled',
-      })
-    }
-
-    await expect(attempt(first)).rejects.toThrow(
-      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
-    )
-    await expect(attempt(second)).rejects.toThrow(
-      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
-    )
-  })
-
-  it('does not allow disabling all admin codes', async () => {
-    const attempt = agent.api.com.atproto.admin.disableInviteCodes(
-      {
-        accounts: ['admin'],
-      },
-      {
-        headers: { authorization: util.adminAuth() },
-        encoding: 'application/json',
-      },
-    )
-    await expect(attempt).rejects.toThrow('cannot disable admin invite codes')
-  })
-
-  it('creates many invite codes', async () => {
-    const accounts = ['did:example:one', 'did:example:two', 'did:example:three']
-    const res = await agent.api.com.atproto.server.createInviteCodes(
-      {
-        useCount: 2,
-        codeCount: 2,
-        forAccounts: accounts,
-      },
-      {
-        headers: { authorization: util.adminAuth() },
-        encoding: 'application/json',
-      },
-    )
-    expect(res.data.codes.length).toBe(3)
-    const fromDb = await ctx.db.db
-      .selectFrom('invite_code')
-      .selectAll()
-      .where('forUser', 'in', accounts)
-      .execute()
-    expect(fromDb.length).toBe(6)
-    const dbCodesByUser = {}
-    for (const row of fromDb) {
-      expect(row.disabled).toBe(0)
-      expect(row.availableUses).toBe(2)
-      dbCodesByUser[row.forUser] ??= []
-      dbCodesByUser[row.forUser].push(row.code)
-    }
-    for (const { account, codes } of res.data.codes) {
-      expect(codes.length).toBe(2)
-      expect(codes.sort()).toEqual(dbCodesByUser[account].sort())
-    }
   })
 })

--- a/packages/pds/tests/invite-codes.test.ts
+++ b/packages/pds/tests/invite-codes.test.ts
@@ -151,8 +151,8 @@ describe('account', () => {
       await account.agent.api.com.atproto.server.getAccountInviteCodes()
     expect(res1.data.codes.length).toBe(2)
 
-    // then pretend account was made 10 days ago
-    const tenDaysAgo = new Date(Date.now() - 10 * DAY).toISOString()
+    // then pretend account was made ever so slightly over 10 days ago
+    const tenDaysAgo = new Date(Date.now() - 10.01 * DAY).toISOString()
     await ctx.db.db
       .updateTable('user_account')
       .set({ createdAt: tenDaysAgo })

--- a/packages/pds/tests/invite-codes.test.ts
+++ b/packages/pds/tests/invite-codes.test.ts
@@ -151,7 +151,7 @@ describe('account', () => {
       await account.agent.api.com.atproto.server.getAccountInviteCodes()
     expect(res1.data.codes.length).toBe(2)
 
-    // then pretend account was made 10 days ago
+    // then pretend account was made 15 days ago
     const tenDaysAgo = new Date(Date.now() - 10 * DAY).toISOString()
     await ctx.db.db
       .updateTable('user_account')
@@ -159,7 +159,7 @@ describe('account', () => {
       .where('did', '=', account.did)
       .execute()
 
-    // we have a 3 day epoch so should still get 1 code
+    // we have a 3 day epoch so should still get 3 code
     const res2 =
       await account.agent.api.com.atproto.server.getAccountInviteCodes()
     expect(res2.data.codes.length).toBe(3)

--- a/packages/pds/tests/invite-codes.test.ts
+++ b/packages/pds/tests/invite-codes.test.ts
@@ -151,7 +151,7 @@ describe('account', () => {
       await account.agent.api.com.atproto.server.getAccountInviteCodes()
     expect(res1.data.codes.length).toBe(2)
 
-    // then pretend account was made 15 days ago
+    // then pretend account was made 10 days ago
     const tenDaysAgo = new Date(Date.now() - 10 * DAY).toISOString()
     await ctx.db.db
       .updateTable('user_account')

--- a/packages/pds/tests/invite-codes.test.ts
+++ b/packages/pds/tests/invite-codes.test.ts
@@ -1,0 +1,333 @@
+import AtpAgent, { ComAtprotoServerCreateAccount } from '@atproto/api'
+import * as crypto from '@atproto/crypto'
+import { AppContext } from '../src'
+import * as util from './_util'
+import { DAY } from '@atproto/common'
+import { genInvCodes } from '../src/api/com/atproto/server/util'
+
+describe('account', () => {
+  let serverUrl: string
+  let ctx: AppContext
+  let agent: AtpAgent
+  let close: util.CloseFn
+
+  beforeAll(async () => {
+    const server = await util.runTestServer({
+      inviteRequired: true,
+      userInviteInterval: DAY,
+      userInviteEpoch: Date.now() - 3 * DAY,
+      dbPostgresSchema: 'invite_codes',
+    })
+    close = server.close
+    ctx = server.ctx
+    serverUrl = server.url
+    agent = new AtpAgent({ service: serverUrl })
+  })
+
+  afterAll(async () => {
+    await close()
+  })
+
+  it('describes the fact that invites are required', async () => {
+    const res = await agent.api.com.atproto.server.describeServer({})
+    expect(res.data.inviteCodeRequired).toBe(true)
+  })
+
+  it('succeeds with a valid code', async () => {
+    const code = await createInviteCode(agent, 1)
+    await createAccountWithInvite(agent, code)
+  })
+
+  it('fails on bad invite code', async () => {
+    const promise = createAccountWithInvite(agent, 'fake-invite')
+    await expect(promise).rejects.toThrow(
+      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
+    )
+  })
+
+  it('fails on used up invite code', async () => {
+    const code = await createInviteCode(agent, 2)
+    await createAccountsWithInvite(agent, code, 2)
+    const promise = createAccountWithInvite(agent, code)
+    await expect(promise).rejects.toThrow(
+      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
+    )
+  })
+
+  it('handles racing invite code uses', async () => {
+    const inviteCode = await createInviteCode(agent, 1)
+    const COUNT = 10
+
+    let successes = 0
+    let failures = 0
+    const promises: Promise<unknown>[] = []
+    for (let i = 0; i < COUNT; i++) {
+      const attempt = async () => {
+        try {
+          await createAccountWithInvite(agent, inviteCode)
+          successes++
+        } catch (err) {
+          failures++
+        }
+      }
+      promises.push(attempt())
+    }
+    await Promise.all(promises)
+    expect(successes).toBe(1)
+    expect(failures).toBe(9)
+  })
+
+  it('allow users to get available user invites', async () => {
+    const account = await makeLoggedInAccount(agent)
+
+    // no codes available yet
+    const res1 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res1.data.codes.length).toBe(0)
+
+    // next, pretend account was made 2 days in the past
+    const twoDaysAgo = new Date(Date.now() - 2 * DAY).toISOString()
+    await ctx.db.db
+      .updateTable('user_account')
+      .set({ createdAt: twoDaysAgo })
+      .where('did', '=', account.did)
+      .execute()
+    const res2 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res2.data.codes.length).toBe(2)
+
+    // use both invites and confirm we can't get any more
+    for (const code of res2.data.codes) {
+      await createAccountWithInvite(agent, code.code)
+    }
+
+    const res3 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res3.data.codes.length).toBe(2)
+  })
+
+  it('admin gifted codes to not impact a users avilable codes', async () => {
+    const account = await makeLoggedInAccount(agent)
+
+    // again, pretend account was made 2 days ago
+    const twoDaysAgo = new Date(Date.now() - 2 * DAY).toISOString()
+    await ctx.db.db
+      .updateTable('user_account')
+      .set({ createdAt: twoDaysAgo })
+      .where('did', '=', account.did)
+      .execute()
+
+    await createInviteCode(agent, 1, account.did)
+    await createInviteCode(agent, 1, account.did)
+    await createInviteCode(agent, 1, account.did)
+
+    const res =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res.data.codes.length).toBe(5)
+
+    const fromAdmin = res.data.codes.filter(
+      (code) => code.createdBy === 'admin',
+    )
+    expect(fromAdmin.length).toBe(3)
+
+    const fromSelf = res.data.codes.filter(
+      (code) => code.createdBy === account.did,
+    )
+    expect(fromSelf.length).toBe(2)
+  })
+
+  it('creates invites based on epoch', async () => {
+    const account = await makeLoggedInAccount(agent)
+
+    // first, pretend account was made 2 days ago & get those two codes
+    const twoDaysAgo = new Date(Date.now() - 2 * DAY).toISOString()
+    await ctx.db.db
+      .updateTable('user_account')
+      .set({ createdAt: twoDaysAgo })
+      .where('did', '=', account.did)
+      .execute()
+
+    const res1 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res1.data.codes.length).toBe(2)
+
+    // then pretend account was made 10 days ago
+    const tenDaysAgo = new Date(Date.now() - 10 * DAY).toISOString()
+    await ctx.db.db
+      .updateTable('user_account')
+      .set({ createdAt: tenDaysAgo })
+      .where('did', '=', account.did)
+      .execute()
+
+    // we have a 3 day epoch so should still get 1 code
+    const res2 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes()
+    expect(res2.data.codes.length).toBe(3)
+
+    // use up these codes
+    for (const code of res2.data.codes) {
+      await createAccountWithInvite(agent, code.code)
+    }
+
+    // we pad their account with some additional unused codes from the past which should not allow them to generate anymore
+    const inviteRows = genInvCodes(ctx.cfg, 10).map((code) => ({
+      code: code,
+      availableUses: 1,
+      disabled: 0 as const,
+      forUser: account.did,
+      createdBy: account.did,
+      createdAt: new Date(Date.now() - 5 * DAY).toISOString(),
+    }))
+    await ctx.db.db.insertInto('invite_code').values(inviteRows).execute()
+    const res3 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes({
+        includeUsed: false,
+      })
+    expect(res3.data.codes.length).toBe(10)
+
+    // no we use the codes which should still not allow them to generate anymore
+    await ctx.db.db
+      .insertInto('invite_code_use')
+      .values(
+        inviteRows.map((row) => ({
+          code: row.code,
+          usedBy: 'did:example:test',
+          usedAt: new Date().toISOString(),
+        })),
+      )
+      .execute()
+
+    const res4 =
+      await account.agent.api.com.atproto.server.getAccountInviteCodes({
+        includeUsed: false,
+      })
+    expect(res4.data.codes.length).toBe(0)
+  })
+
+  it('prevents use of disabled codes', async () => {
+    const first = await createInviteCode(agent, 1)
+    const account = await makeLoggedInAccount(agent)
+    const second = await createInviteCode(agent, 1, account.did)
+
+    // disabled first by code & second by did
+    await agent.api.com.atproto.admin.disableInviteCodes(
+      {
+        codes: [first],
+        accounts: [account.did],
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+
+    await expect(createAccountWithInvite(agent, first)).rejects.toThrow(
+      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
+    )
+    await expect(createAccountWithInvite(agent, second)).rejects.toThrow(
+      ComAtprotoServerCreateAccount.InvalidInviteCodeError,
+    )
+  })
+
+  it('does not allow disabling all admin codes', async () => {
+    const attempt = agent.api.com.atproto.admin.disableInviteCodes(
+      {
+        accounts: ['admin'],
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+    await expect(attempt).rejects.toThrow('cannot disable admin invite codes')
+  })
+
+  it('creates many invite codes', async () => {
+    const accounts = ['did:example:one', 'did:example:two', 'did:example:three']
+    const res = await agent.api.com.atproto.server.createInviteCodes(
+      {
+        useCount: 2,
+        codeCount: 2,
+        forAccounts: accounts,
+      },
+      {
+        headers: { authorization: util.adminAuth() },
+        encoding: 'application/json',
+      },
+    )
+    expect(res.data.codes.length).toBe(3)
+    const fromDb = await ctx.db.db
+      .selectFrom('invite_code')
+      .selectAll()
+      .where('forUser', 'in', accounts)
+      .execute()
+    expect(fromDb.length).toBe(6)
+    const dbCodesByUser = {}
+    for (const row of fromDb) {
+      expect(row.disabled).toBe(0)
+      expect(row.availableUses).toBe(2)
+      dbCodesByUser[row.forUser] ??= []
+      dbCodesByUser[row.forUser].push(row.code)
+    }
+    for (const { account, codes } of res.data.codes) {
+      expect(codes.length).toBe(2)
+      expect(codes.sort()).toEqual(dbCodesByUser[account].sort())
+    }
+  })
+})
+
+const createInviteCode = async (
+  agent: AtpAgent,
+  uses: number,
+  forAccount?: string,
+): Promise<string> => {
+  const res = await agent.api.com.atproto.server.createInviteCode(
+    { useCount: uses, forAccount },
+    {
+      headers: { authorization: util.adminAuth() },
+      encoding: 'application/json',
+    },
+  )
+  return res.data.code
+}
+
+const createAccountWithInvite = async (agent: AtpAgent, code: string) => {
+  const name = crypto.randomStr(5, 'base32')
+  const res = await agent.api.com.atproto.server.createAccount({
+    email: `${name}@test.com`,
+    handle: `${name}.test`,
+    password: name,
+    inviteCode: code,
+  })
+  return {
+    ...res.data,
+    password: name,
+  }
+}
+
+const createAccountsWithInvite = async (
+  agent: AtpAgent,
+  code: string,
+  count = 0,
+) => {
+  for (let i = 0; i < count; i++) {
+    await createAccountWithInvite(agent, code)
+  }
+}
+
+const makeLoggedInAccount = async (
+  agent: AtpAgent,
+): Promise<{ did: string; agent: AtpAgent }> => {
+  const code = await createInviteCode(agent, 1)
+  const account = await createAccountWithInvite(agent, code)
+  const did = account.did
+  const loggedInAgent = new AtpAgent({ service: agent.service.toString() })
+  await loggedInAgent.login({
+    identifier: account.handle,
+    password: account.password,
+  })
+  return {
+    did,
+    agent: loggedInAgent,
+  }
+}


### PR DESCRIPTION
We no longer count admin-gifted invites against a user routine interval invites

I also took the time to split invites out into their own test suite & made it a bit more robust