### PR TITLE
Appview limit thread recursion

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -208,6 +208,7 @@ const getParentData = (
   uri: string,
   depth: number,
 ): PostThread | ParentNotFoundError | undefined => {
+  if (depth < 1) return undefined
   const post = postsByUri[uri]
   if (!post) return new ParentNotFoundError(uri)
   return {


### PR DESCRIPTION
Just a small fix to limit thread recursion in parents in the appview. 

As was pointed out [here](https://github.com/bluesky-social/atproto/pull/1062#issuecomment-1601833585), we aren't limiting thread recursion in the appview.