### PR TITLE
Appview - use sortAt

### DIFF
--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -210,7 +210,7 @@ export class FeedService {
         'post.uri as uri',
         'post.cid as cid',
         'post.creator as creator',
-        'post.indexedAt as indexedAt',
+        'post.sortAt as indexedAt',
         'record.json as recordJson',
         'post_agg.likeCount as likeCount',
         'post_agg.repostCount as repostCount',

--- a/packages/bsky/src/services/feed/views.ts
+++ b/packages/bsky/src/services/feed/views.ts
@@ -150,7 +150,7 @@ export class FeedViews {
       viewer: {
         like: info.viewerLike ?? undefined,
       },
-      indexedAt: info.indexedAt,
+      indexedAt: info.sortAt,
     }
   }
 

--- a/packages/bsky/src/services/graph/index.ts
+++ b/packages/bsky/src/services/graph/index.ts
@@ -205,7 +205,7 @@ export class GraphService {
             list.avatarCid,
           )
         : undefined,
-      indexedAt: list.indexedAt,
+      indexedAt: list.sortAt,
       viewer: {
         muted: !!list.viewerMuted,
       },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
@@ -9,7 +9,6 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
       if (ctx.canProxy(req)) {
-        console.log('HERE')
         const res = await ctx.appviewAgent.api.app.bsky.actor.getProfile(
           params,
           await ctx.serviceAuthHeaders(requester),
@@ -19,7 +18,6 @@ export default function (server: Server, ctx: AppContext) {
           body: res.data,
         }
       }
-      console.log('NO PROXY')
 
       const { actor } = params
       const { db, services } = ctx

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
@@ -9,6 +9,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
       if (ctx.canProxy(req)) {
+        console.log('HERE')
         const res = await ctx.appviewAgent.api.app.bsky.actor.getProfile(
           params,
           await ctx.serviceAuthHeaders(requester),
@@ -18,6 +19,7 @@ export default function (server: Server, ctx: AppContext) {
           body: res.data,
         }
       }
+      console.log('NO PROXY')
 
       const { actor } = params
       const { db, services } = ctx


### PR DESCRIPTION
Return `sortAt` in appview queries instead of `indexedAt`

This is a composite timestamp that is `min(createdAt, indexedAt)` & will stop a newly spun up appview service from naively returning the time it encountered a post