### PR TITLE
Fix uint8arrays version mismatch

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -27,6 +27,6 @@
     "@noble/curves": "^1.1.0",
     "key-encoder": "^2.0.3",
     "multiformats": "^9.6.4",
-    "uint8arrays": "^4.0.4"
+    "uint8arrays": "3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,11 +9250,6 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multiformats@^11.0.0:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.2.tgz#b14735efc42cd8581e73895e66bebb9752151b60"
-  integrity sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==
-
 multiformats@^9.4.2, multiformats@^9.5.4, multiformats@^9.6.4:
   version "9.9.0"
   resolved "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz"
@@ -11672,13 +11667,6 @@ uint8arrays@3.0.0:
   integrity sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==
   dependencies:
     multiformats "^9.4.2"
-
-uint8arrays@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-4.0.4.tgz#3254e01aeb166a3f35e66e60e4e37002f4ea13fd"
-  integrity sha512-AOoA66e/A7zoXm1mgzQjGmkWDTvCrS3ttWXLHFtlVAwMobLcaOA7G7WRNNAcyfjjYdFDtkEK6njRDX7hZLIO9Q==
-  dependencies:
-    multiformats "^11.0.0"
 
 umask@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
A new version of uint8arrays snuck in in https://github.com/bluesky-social/atproto/pull/1218

We want to stay fixed at 3.0.0