### PR TITLE
Appview preset image URLs

### DIFF
--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -66,7 +66,7 @@ export default function (server: Server, ctx: AppContext) {
           ? JSON.parse(listRes.descriptionFacets)
           : undefined,
         avatar: listRes.avatarCid
-          ? ctx.imgUriBuilder.getCommonSignedUri(
+          ? ctx.imgUriBuilder.getPresetUri(
               'avatar',
               listRes.creator,
               listRes.avatarCid,

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -13,8 +13,6 @@ export interface ServerConfigValues {
   didPlcUrl: string
   didCacheStaleTTL: number
   didCacheMaxTTL: number
-  imgUriSalt: string
-  imgUriKey: string
   imgUriEndpoint?: string
   blobCacheLocation?: string
   repoProvider?: string
@@ -46,11 +44,6 @@ export class ServerConfig {
       process.env.DID_CACHE_MAX_TTL,
       DAY,
     )
-    const imgUriSalt =
-      process.env.IMG_URI_SALT || '9dd04221f5755bce5f55f47464c27e1e'
-    const imgUriKey =
-      process.env.IMG_URI_KEY ||
-      'f23ecd142835025f42c3db2cf25dd813956c178392760256211f9d315f8ab4d8'
     const imgUriEndpoint = process.env.IMG_URI_ENDPOINT
     const blobCacheLocation = process.env.BLOB_CACHE_LOC
     const dbPostgresUrl =
@@ -74,8 +67,6 @@ export class ServerConfig {
       didPlcUrl,
       didCacheStaleTTL,
       didCacheMaxTTL,
-      imgUriSalt,
-      imgUriKey,
       imgUriEndpoint,
       blobCacheLocation,
       repoProvider,
@@ -142,14 +133,6 @@ export class ServerConfig {
 
   get didPlcUrl() {
     return this.cfg.didPlcUrl
-  }
-
-  get imgUriSalt() {
-    return this.cfg.imgUriSalt
-  }
-
-  get imgUriKey() {
-    return this.cfg.imgUriKey
   }
 
   get imgUriEndpoint() {

--- a/packages/bsky/src/image/invalidator.ts
+++ b/packages/bsky/src/image/invalidator.ts
@@ -1,4 +1,5 @@
 import { BlobCache } from './server'
+import { ImageUriBuilder } from './uri'
 
 // Invalidation is a general interface for propagating an image blob
 // takedown through any caches where a representation of it may be stored.
@@ -15,7 +16,13 @@ export class ImageProcessingServerInvalidator implements ImageInvalidator {
       paths.map(async (path) => {
         const [, signature] = path.split('/')
         if (!signature) throw new Error('Missing signature')
-        await this.cache.clear(signature)
+        const options = ImageUriBuilder.getOptions(path)
+        const cacheKey = [
+          options.did,
+          options.cid.toString(),
+          options.preset,
+        ].join('::')
+        await this.cache.clear(cacheKey)
       }),
     )
     const rejection = results.find(

--- a/packages/bsky/src/image/uri.ts
+++ b/packages/bsky/src/image/uri.ts
@@ -1,199 +1,67 @@
-import { createHmac } from 'crypto'
-import * as uint8arrays from 'uint8arrays'
 import { CID } from 'multiformats/cid'
 import { Options } from './util'
 
-// @NOTE if there are any additions here, ensure to include them on ImageUriBuilder.commonSignedUris
-type CommonSignedUris = 'avatar' | 'banner' | 'feed_thumbnail' | 'feed_fullsize'
+// @NOTE if there are any additions here, ensure to include them on ImageUriBuilder.presets
+export type ImagePreset =
+  | 'avatar'
+  | 'banner'
+  | 'feed_thumbnail'
+  | 'feed_fullsize'
 
-const PATH_REGEX = /^\/(.+)\/plain\/(.+?)\/(.+?)@(.+)$/
+const PATH_REGEX = /^\/(.+?)\/plain\/(.+?)\/(.+?)\.(.+?)$/
 
 export class ImageUriBuilder {
-  public endpoint: string
-  private salt: Uint8Array
-  private key: Uint8Array
+  constructor(public endpoint: string) {}
 
-  constructor(
-    endpoint: string,
-    salt: Uint8Array | string,
-    key: Uint8Array | string,
-  ) {
-    this.endpoint = endpoint
-    this.salt =
-      typeof salt === 'string' ? uint8arrays.fromString(salt, 'hex') : salt
-    this.key =
-      typeof key === 'string' ? uint8arrays.fromString(key, 'hex') : key
-  }
-
-  getSignedPath(opts: Options & BlobLocation): string {
-    const path = ImageUriBuilder.getPath(opts)
-    const saltedPath = uint8arrays.concat([
-      this.salt,
-      uint8arrays.fromString(path),
-    ])
-    const sig = hmac(this.key, saltedPath).toString('base64url')
-    return `/${sig}${path}`
-  }
-
-  getSignedUri(opts: Options & BlobLocation): string {
-    const path = this.getSignedPath(opts)
-    return this.endpoint + path
-  }
-
-  static commonSignedUris: CommonSignedUris[] = [
+  static presets: ImagePreset[] = [
     'avatar',
     'banner',
     'feed_thumbnail',
     'feed_fullsize',
   ]
 
-  getCommonSignedUri(
-    id: CommonSignedUris,
-    did: string,
-    cid: string | CID,
-  ): string {
-    if (id === 'avatar') {
-      return this.getSignedUri({
-        did,
-        cid: typeof cid === 'string' ? CID.parse(cid) : cid,
-        format: 'jpeg',
-        fit: 'cover',
-        height: 1000,
-        width: 1000,
-        min: true,
-      })
-    } else if (id === 'banner') {
-      return this.getSignedUri({
-        did,
-        cid: typeof cid === 'string' ? CID.parse(cid) : cid,
-        format: 'jpeg',
-        fit: 'cover',
-        height: 1000,
-        width: 3000,
-        min: true,
-      })
-    } else if (id === 'feed_fullsize') {
-      return this.getSignedUri({
-        did,
-        cid: typeof cid === 'string' ? CID.parse(cid) : cid,
-        format: 'jpeg',
-        fit: 'inside',
-        height: 2000,
-        width: 2000,
-        min: true,
-      })
-    } else if (id === 'feed_thumbnail') {
-      return this.getSignedUri({
-        did,
-        cid: typeof cid === 'string' ? CID.parse(cid) : cid,
-        format: 'jpeg',
-        fit: 'inside',
-        height: 1000,
-        width: 1000,
-        min: true,
-      })
-    } else {
-      const exhaustiveCheck: never = id
-      throw new Error(
-        `Unrecognized requested common uri type: ${exhaustiveCheck}`,
-      )
+  getPresetUri(id: ImagePreset, did: string, cid: string | CID): string {
+    const options = presets[id]
+    if (!options) {
+      throw new Error(`Unrecognized requested common uri type: ${id}`)
     }
-  }
-
-  getVerifiedOptions(
-    path: string,
-  ): Options & BlobLocation & { signature: string } {
-    if (path.at(0) !== '/') {
-      throw new BadPathError('Invalid path: does not start with a slash')
-    }
-    const pathParts = path.split('/') // ['', sig, 'rs:fill:...', ...]
-    const [sig] = pathParts.splice(1, 1) // ['', 'rs:fill:...', ...]
-    const unsignedPath = pathParts.join('/')
-    if (!sig || sig.includes(':')) {
-      throw new BadPathError('Invalid path: missing signature')
-    }
-    const saltedPath = uint8arrays.concat([
-      this.salt,
-      uint8arrays.fromString(unsignedPath),
-    ])
-    const validSig = hmac(this.key, saltedPath).toString('base64url')
-    if (sig !== validSig) {
-      throw new BadPathError('Invalid path: bad signature')
-    }
-    const options = ImageUriBuilder.getOptions(unsignedPath)
-    return {
-      signature: validSig,
-      ...options,
-    }
-  }
-
-  static getPath(opts: Options & BlobLocation) {
-    const fit = opts.fit === 'inside' ? 'fit' : 'fill' // fit default is 'cover'
-    const enlarge = opts.min === true ? 1 : 0 // min default is false
-    const resize = `rs:${fit}:${opts.width}:${opts.height}:${enlarge}:0` // final ':0' is for interop with imgproxy
-    const minWidth =
-      opts.min && typeof opts.min === 'object' ? `mw:${opts.min.width}` : null
-    const minHeight =
-      opts.min && typeof opts.min === 'object' ? `mh:${opts.min.height}` : null
-    const quality = opts.quality ? `q:${opts.quality}` : null
     return (
-      `/` +
-      [resize, minWidth, minHeight, quality].filter(Boolean).join('/') +
-      `/plain/${opts.did}/${opts.cid.toString()}@${opts.format}`
+      this.endpoint +
+      ImageUriBuilder.getPath({
+        preset: id,
+        did,
+        cid: typeof cid === 'string' ? CID.parse(cid) : cid,
+      })
     )
   }
 
-  static getOptions(path: string): Options & BlobLocation {
+  static getPath(opts: { preset: ImagePreset } & BlobLocation) {
+    const { format } = presets[opts.preset]
+    return `/${opts.preset}/plain/${opts.did}/${opts.cid.toString()}.${format}`
+  }
+
+  static getOptions(
+    path: string,
+  ): Options & BlobLocation & { preset: ImagePreset } {
     const match = path.match(PATH_REGEX)
     if (!match) {
       throw new BadPathError('Invalid path')
     }
-    const [, partsStr, did, cid, format] = match
-    if (format !== 'png' && format !== 'jpeg') {
+    const [, presetUnsafe, did, cid, formatUnsafe] = match
+    if (!(ImageUriBuilder.presets as string[]).includes(presetUnsafe)) {
+      throw new BadPathError('Invalid path: bad preset')
+    }
+    if (formatUnsafe !== 'jpeg' && formatUnsafe !== 'png') {
       throw new BadPathError('Invalid path: bad format')
     }
-    const parts = partsStr.split('/')
-    const resizePart = parts.find((part) => part.startsWith('rs:'))
-    const qualityPart = parts.find((part) => part.startsWith('q:'))
-    const minWidthPart = parts.find((part) => part.startsWith('mw:'))
-    const minHeightPart = parts.find((part) => part.startsWith('mh:'))
-    const [, fit, width, height, enlarge] = resizePart?.split(':') ?? []
-    const [, quality] = qualityPart?.split(':') ?? []
-    const [, minWidth] = minWidthPart?.split(':') ?? []
-    const [, minHeight] = minHeightPart?.split(':') ?? []
-    if (fit !== 'fill' && fit !== 'fit') {
-      throw new BadPathError('Invalid path: bad resize fit param')
-    }
-    if (isNaN(toInt(width)) || isNaN(toInt(height))) {
-      throw new BadPathError('Invalid path: bad resize height/width param')
-    }
-    if (enlarge !== '0' && enlarge !== '1') {
-      throw new BadPathError('Invalid path: bad resize enlarge param')
-    }
-    if (quality && isNaN(toInt(quality))) {
-      throw new BadPathError('Invalid path: bad quality param')
-    }
-    if (
-      (!minWidth && minHeight) ||
-      (minWidth && !minHeight) ||
-      (minWidth && isNaN(toInt(minWidth))) ||
-      (minHeight && isNaN(toInt(minHeight))) ||
-      (enlarge === '1' && (minHeight || minHeight))
-    ) {
-      throw new BadPathError('Invalid path: bad min width/height param')
-    }
+    const preset = presetUnsafe as ImagePreset
+    const format = formatUnsafe as Options['format']
     return {
+      ...presets[preset],
       did,
       cid: CID.parse(cid),
+      preset,
       format,
-      height: toInt(height),
-      width: toInt(width),
-      fit: fit === 'fill' ? 'cover' : 'inside',
-      quality: quality ? toInt(quality) : undefined,
-      min:
-        minWidth && minHeight
-          ? { width: toInt(minWidth), height: toInt(minHeight) }
-          : enlarge === '1',
     }
   }
 }
@@ -202,13 +70,33 @@ type BlobLocation = { cid: CID; did: string }
 
 export class BadPathError extends Error {}
 
-function toInt(str: string) {
-  if (!/^\d+$/.test(str)) {
-    return NaN // String must be all numeric
-  }
-  return parseInt(str, 10)
-}
-
-function hmac(key: Uint8Array, message: Uint8Array) {
-  return createHmac('sha256', key).update(message).digest()
+export const presets: Record<ImagePreset, Options> = {
+  avatar: {
+    format: 'jpeg',
+    fit: 'cover',
+    height: 1000,
+    width: 1000,
+    min: true,
+  },
+  banner: {
+    format: 'jpeg',
+    fit: 'cover',
+    height: 1000,
+    width: 3000,
+    min: true,
+  },
+  feed_thumbnail: {
+    format: 'jpeg',
+    fit: 'inside',
+    height: 2000,
+    width: 2000,
+    min: true,
+  },
+  feed_fullsize: {
+    format: 'jpeg',
+    fit: 'inside',
+    height: 1000,
+    width: 1000,
+    min: true,
+  },
 }

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -71,9 +71,7 @@ export class BskyAppView {
     const idResolver = new IdResolver({ plcUrl: config.didPlcUrl, didCache })
 
     const imgUriBuilder = new ImageUriBuilder(
-      config.imgUriEndpoint || `${config.publicUrl}/image`,
-      config.imgUriSalt,
-      config.imgUriKey,
+      config.imgUriEndpoint || `${config.publicUrl}/img`,
     )
 
     let imgProcessingServer: ImageProcessingServer | undefined
@@ -149,7 +147,7 @@ export class BskyAppView {
     app.use(health.createRouter(ctx))
     app.use(blobResolver.createRouter(ctx))
     if (imgProcessingServer) {
-      app.use('/image', imgProcessingServer.app)
+      app.use('/img', imgProcessingServer.app)
     }
     app.use(server.xrpc.router)
     app.use(error.handler)

--- a/packages/bsky/src/services/actor/views.ts
+++ b/packages/bsky/src/services/actor/views.ts
@@ -102,14 +102,14 @@ export class ActorViews {
     const views = results.map((result) => {
       const profileInfo = profileInfoByDid[result.did]
       const avatar = profileInfo?.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri(
+        ? this.imgUriBuilder.getPresetUri(
             'avatar',
             profileInfo.did,
             profileInfo.avatarCid,
           )
         : undefined
       const banner = profileInfo?.bannerCid
-        ? this.imgUriBuilder.getCommonSignedUri(
+        ? this.imgUriBuilder.getPresetUri(
             'banner',
             profileInfo.did,
             profileInfo.bannerCid,
@@ -216,7 +216,7 @@ export class ActorViews {
     const views = results.map((result) => {
       const profileInfo = profileInfoByDid[result.did]
       const avatar = profileInfo?.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri(
+        ? this.imgUriBuilder.getPresetUri(
             'avatar',
             profileInfo.did,
             profileInfo.avatarCid,
@@ -298,7 +298,7 @@ export class ActorViews {
           name: cur.name,
           purpose: cur.purpose,
           avatar: cur.avatarCid
-            ? this.imgUriBuilder.getCommonSignedUri(
+            ? this.imgUriBuilder.getPresetUri(
                 'avatar',
                 cur.creator,
                 cur.avatarCid,

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -169,11 +169,7 @@ export class FeedService {
           handle: cur.handle,
           displayName: cur.displayName ?? undefined,
           avatar: cur.avatarCid
-            ? this.imgUriBuilder.getCommonSignedUri(
-                'avatar',
-                cur.did,
-                cur.avatarCid,
-              )
+            ? this.imgUriBuilder.getPresetUri('avatar', cur.did, cur.avatarCid)
             : undefined,
           viewer: viewer
             ? {
@@ -323,12 +319,12 @@ export class FeedService {
       if (!isViewImages(embed)) return acc
       const postUri = new AtUri(cur.postUri)
       embed.images.push({
-        thumb: this.imgUriBuilder.getCommonSignedUri(
+        thumb: this.imgUriBuilder.getPresetUri(
           'feed_thumbnail',
           postUri.host,
           cur.imageCid,
         ),
-        fullsize: this.imgUriBuilder.getCommonSignedUri(
+        fullsize: this.imgUriBuilder.getPresetUri(
           'feed_fullsize',
           postUri.host,
           cur.imageCid,
@@ -347,7 +343,7 @@ export class FeedService {
             title: cur.title,
             description: cur.description,
             thumb: cur.thumbCid
-              ? this.imgUriBuilder.getCommonSignedUri(
+              ? this.imgUriBuilder.getPresetUri(
                   'feed_thumbnail',
                   postUri.host,
                   cur.thumbCid,

--- a/packages/bsky/src/services/feed/views.ts
+++ b/packages/bsky/src/services/feed/views.ts
@@ -140,7 +140,7 @@ export class FeedViews {
         ? JSON.parse(info.descriptionFacets)
         : undefined,
       avatar: info.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri(
+        ? this.imgUriBuilder.getPresetUri(
             'avatar',
             info.creator,
             info.avatarCid,

--- a/packages/bsky/src/services/graph/index.ts
+++ b/packages/bsky/src/services/graph/index.ts
@@ -199,7 +199,7 @@ export class GraphService {
         ? JSON.parse(list.descriptionFacets)
         : undefined,
       avatar: list.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri(
+        ? this.imgUriBuilder.getPresetUri(
             'avatar',
             list.creator,
             list.avatarCid,

--- a/packages/bsky/src/services/moderation/index.ts
+++ b/packages/bsky/src/services/moderation/index.ts
@@ -355,12 +355,8 @@ export class ModerationService {
     if (info.blobCids) {
       await Promise.all(
         info.blobCids.map(async (cid) => {
-          const paths = ImageUriBuilder.commonSignedUris.map((id) => {
-            const uri = this.imgUriBuilder.getCommonSignedUri(
-              id,
-              info.uri.host,
-              cid,
-            )
+          const paths = ImageUriBuilder.presets.map((id) => {
+            const uri = this.imgUriBuilder.getPresetUri(id, info.uri.host, cid)
             return uri.replace(this.imgUriBuilder.endpoint, '')
           })
           await this.imgInvalidator.invalidate(cid.toString(), paths)

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`feed generation does not embed taken-down feed generator records in posts 1`] = `
 Object {
   "author": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
     "did": "user(0)",
     "displayName": "bobby",
     "handle": "bob.test",
@@ -46,7 +46,7 @@ Object {
 exports[`feed generation embeds feed generator records in posts 1`] = `
 Object {
   "author": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
     "did": "user(0)",
     "displayName": "bobby",
     "handle": "bob.test",
@@ -63,7 +63,7 @@ Object {
       "$type": "app.bsky.feed.defs#generatorView",
       "cid": "cids(2)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
         "did": "user(3)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -113,7 +113,7 @@ Array [
   Object {
     "cid": "cids(0)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",
@@ -138,7 +138,7 @@ Array [
   Object {
     "cid": "cids(2)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",
@@ -163,7 +163,7 @@ Array [
   Object {
     "cid": "cids(3)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",
@@ -188,7 +188,7 @@ Array [
   Object {
     "cid": "cids(4)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",
@@ -220,7 +220,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -248,7 +248,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
         "did": "user(2)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -300,13 +300,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(5)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(5)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(5).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(5).jpeg",
             },
           ],
         },
@@ -314,7 +314,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
               "did": "user(2)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -436,7 +436,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -463,7 +463,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -526,13 +526,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(5)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(5)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(5).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(5).jpeg",
                   },
                 ],
               },
@@ -540,7 +540,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
                     "did": "user(2)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -673,7 +673,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -719,13 +719,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
             },
           ],
         },
@@ -733,7 +733,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
               "did": "user(3)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -855,7 +855,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -882,7 +882,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -918,7 +918,7 @@ Object {
   "view": Object {
     "cid": "cids(0)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "did": "user(1)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -949,7 +949,7 @@ Object {
     Object {
       "cid": "cids(0)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -974,7 +974,7 @@ Object {
     Object {
       "cid": "cids(2)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",

--- a/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
@@ -84,7 +84,7 @@ Array [
           "parent": Object {
             "$type": "app.bsky.feed.defs#postView",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(4)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(4).jpeg",
               "did": "user(1)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -102,8 +102,8 @@ Array [
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                  "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(2)/cids(5)@jpeg",
-                  "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(2)/cids(5)@jpeg",
+                  "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(2)/cids(5).jpeg",
+                  "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(2)/cids(5).jpeg",
                 },
               ],
             },
@@ -409,7 +409,7 @@ Array [
         },
       },
       Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(4)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(4).jpeg",
         "description": "hi im bob label_me",
         "did": "user(1)",
         "displayName": "bobby",
@@ -445,7 +445,7 @@ Object {
     "$type": "app.bsky.feed.defs#threadViewPost",
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -494,7 +494,7 @@ Object {
     "$type": "app.bsky.feed.defs#threadViewPost",
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",

--- a/packages/bsky/tests/_util.ts
+++ b/packages/bsky/tests/_util.ts
@@ -52,17 +52,14 @@ export const forSnapshot = (obj: unknown) => {
     if (str.match(/^\d+::bafy/)) {
       return constantKeysetCursor
     }
-    if (str.match(/\/image\/[^/]+\/.+\/did:plc:[^/]+\/[^/]+@[\w]+$/)) {
+    if (str.match(/\/img\/[^/]+\/.+\/did:plc:[^/]+\/[^/]+\.[\w]+$/)) {
       // Match image urls
       const match = str.match(
-        /\/image\/([^/]+)\/.+\/(did:plc:[^/]+)\/([^/]+)@[\w]+$/,
+        /\/img\/[^/]+\/.+\/(did:plc:[^/]+)\/([^/]+)\.[\w]+$/,
       )
       if (!match) return str
-      const [, sig, did, cid] = match
-      return str
-        .replace(sig, 'sig()')
-        .replace(did, take(users, did))
-        .replace(cid, take(cids, cid))
+      const [, did, cid] = match
+      return str.replace(did, take(users, did)).replace(cid, take(cids, cid))
     }
     let isCid: boolean
     try {

--- a/packages/bsky/tests/image/server.test.ts
+++ b/packages/bsky/tests/image/server.test.ts
@@ -6,6 +6,7 @@ import { TestNetwork } from '@atproto/dev-env'
 import { getInfo } from '../../src/image/sharp'
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
+import { ImageUriBuilder } from '../../src/image/uri'
 
 describe('image processing server', () => {
   let network: TestNetwork
@@ -16,11 +17,6 @@ describe('image processing server', () => {
   beforeAll(async () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'bsky_image_processing_server',
-      bsky: {
-        imgUriKey:
-          'f23ecd142835025f42c3db2cf25dd813956c178392760256211f9d315f8ab4d8',
-        imgUriSalt: '9dd04221f5755bce5f55f47464c27e1e',
-      },
     })
     const pdsAgent = new AtpAgent({ service: network.pds.url })
     const sc = new SeedClient(pdsAgent)
@@ -30,7 +26,7 @@ describe('image processing server', () => {
     fileDid = sc.dids.carol
     fileCid = sc.posts[fileDid][0].images[0].image.ref
     client = axios.create({
-      baseURL: `${network.bsky.url}/image`,
+      baseURL: `${network.bsky.url}/img`,
       validateStatus: () => true,
     })
   })
@@ -41,42 +37,36 @@ describe('image processing server', () => {
 
   it('processes image from blob resolver.', async () => {
     const res = await client.get(
-      network.bsky.ctx.imgUriBuilder.getSignedPath({
+      ImageUriBuilder.getPath({
+        preset: 'feed_fullsize',
         did: fileDid,
         cid: fileCid,
-        format: 'jpeg',
-        fit: 'cover',
-        width: 500,
-        height: 500,
-        min: true,
       }),
       { responseType: 'stream' },
     )
 
     const info = await getInfo(res.data)
-    expect(info).toEqual(
-      expect.objectContaining({
-        height: 500,
-        width: 500,
-        size: 67221,
-      }),
-    )
+    console.log(info)
+    expect(info).toEqual({
+      height: 580,
+      width: 1000,
+      size: 127578,
+      mime: 'image/jpeg',
+    })
     expect(res.headers).toEqual(
       expect.objectContaining({
         'content-type': 'image/jpeg',
         'cache-control': 'public, max-age=31536000',
-        'content-length': '67221',
+        'content-length': '127578',
       }),
     )
   })
 
   it('caches results.', async () => {
-    const path = network.bsky.ctx.imgUriBuilder.getSignedPath({
+    const path = ImageUriBuilder.getPath({
+      preset: 'avatar',
       did: fileDid,
       cid: fileCid,
-      format: 'jpeg',
-      width: 25, // Special number for this test
-      height: 25,
     })
     const res1 = await client.get(path, { responseType: 'arraybuffer' })
     expect(res1.headers['x-cache']).toEqual('miss')
@@ -88,32 +78,13 @@ describe('image processing server', () => {
     expect(Buffer.compare(res1.data, res3.data)).toEqual(0)
   })
 
-  it('errors on bad signature.', async () => {
-    const path = network.bsky.ctx.imgUriBuilder.getSignedPath({
-      did: fileDid,
-      cid: fileCid,
-      format: 'jpeg',
-      fit: 'cover',
-      width: 500,
-      height: 500,
-      min: true,
-    })
-    const res = await client.get(path.replace('/', '/_'), {})
-    expect(res.status).toEqual(400)
-    expect(res.data).toEqual({ message: 'Invalid path: bad signature' })
-  })
-
   it('errors on missing file.', async () => {
     const missingCid = await cidForCbor('missing-file')
     const res = await client.get(
-      network.bsky.ctx.imgUriBuilder.getSignedPath({
+      ImageUriBuilder.getPath({
+        preset: 'feed_fullsize',
         did: fileDid,
         cid: missingCid,
-        format: 'jpeg',
-        fit: 'cover',
-        width: 500,
-        height: 500,
-        min: true,
       }),
     )
     expect(res.status).toEqual(404)

--- a/packages/bsky/tests/image/uri.test.ts
+++ b/packages/bsky/tests/image/uri.test.ts
@@ -5,220 +5,80 @@ import { ImageUriBuilder, BadPathError } from '../../src/image/uri'
 describe('image uri builder', () => {
   let uriBuilder: ImageUriBuilder
   let cid: CID
-  const did = 'plc:did:xyz'
+  const did = 'did:plc:xyz'
 
   beforeAll(async () => {
-    const endpoint = 'https://example.com'
-    const salt = '9dd04221f5755bce5f55f47464c27e1e'
-    const key =
-      'f23ecd142835025f42c3db2cf25dd813956c178392760256211f9d315f8ab4d8'
-    uriBuilder = new ImageUriBuilder(endpoint, salt, key)
+    const endpoint = 'https://example.com/img'
+    uriBuilder = new ImageUriBuilder(endpoint)
     cid = await cidForCbor('test cid')
   })
 
-  it('signs and verifies uri options.', () => {
-    const path = uriBuilder.getSignedPath({
-      did,
-      cid,
-      format: 'png',
-      height: 200,
-      width: 300,
-    })
-    expect(path).toEqual(
-      `/1Hl07jYd8LUqPDAGVVw3Le2iT0OaH4l4dPbmh2lL21Y/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@png`,
+  it('generates paths.', () => {
+    expect(ImageUriBuilder.getPath({ preset: 'banner', did, cid })).toEqual(
+      `/banner/plain/${did}/${cid.toString()}.jpeg`,
     )
-    expect(uriBuilder.getVerifiedOptions(path)).toEqual({
-      signature: '1Hl07jYd8LUqPDAGVVw3Le2iT0OaH4l4dPbmh2lL21Y',
-      did,
+    expect(
+      ImageUriBuilder.getPath({ preset: 'feed_thumbnail', did, cid }),
+    ).toEqual(`/feed_thumbnail/plain/${did}/${cid.toString()}.jpeg`)
+  })
+
+  it('generates uris.', () => {
+    expect(uriBuilder.getPresetUri('banner', did, cid)).toEqual(
+      `https://example.com/img/banner/plain/${did}/${cid.toString()}.jpeg`,
+    )
+    expect(
+      uriBuilder.getPresetUri('feed_thumbnail', did, cid.toString()),
+    ).toEqual(
+      `https://example.com/img/feed_thumbnail/plain/${did}/${cid.toString()}.jpeg`,
+    )
+  })
+
+  it('parses options.', () => {
+    expect(
+      ImageUriBuilder.getOptions(`/banner/plain/${did}/${cid.toString()}.png`),
+    ).toEqual({
+      did: 'did:plc:xyz',
       cid,
-      format: 'png',
       fit: 'cover',
-      height: 200,
-      width: 300,
-      min: false,
-    })
-  })
-
-  it('errors on bad signature.', () => {
-    const tryGetVerifiedOptions = (path) => () =>
-      uriBuilder.getVerifiedOptions(path)
-
-    tryGetVerifiedOptions(
-      // Confirm this is a good signed uri
-      `/BtHM_4IOak5MOc2gOPDxbfS4_HG6VPcry2OAV03L29g/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@png`,
-    )
-
-    expect(
-      tryGetVerifiedOptions(
-        // Tamper with signature
-        `/DtHM_4IOak5MOc2gOPDxbfS4_HG6VPcry2OAV03L29g/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@png`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad signature'))
-
-    expect(
-      tryGetVerifiedOptions(
-        // Tamper with params
-        `/DtHM_4IOak5MOc2gOPDxbfS4_HG6VPcry2OAV03L29g/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad signature'))
-
-    expect(
-      tryGetVerifiedOptions(
-        // Missing signature
-        `/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: missing signature'))
-  })
-
-  it('supports basic options.', () => {
-    const path = ImageUriBuilder.getPath({
-      did,
-      cid,
       format: 'png',
-      height: 200,
-      width: 300,
-    })
-    expect(path).toEqual(
-      `/rs:fill:300:200:0:0/plain/${did}/${cid.toString()}@png`,
-    )
-    expect(ImageUriBuilder.getOptions(path)).toEqual({
-      did,
-      cid,
-      format: 'png',
-      fit: 'cover',
-      height: 200,
-      width: 300,
-      min: false,
-    })
-  })
-
-  it('supports fit option.', () => {
-    const path = ImageUriBuilder.getPath({
-      did,
-      cid,
-      format: 'png',
-      fit: 'inside',
-      height: 200,
-      width: 300,
-    })
-    expect(path).toEqual(
-      `/rs:fit:300:200:0:0/plain/${did}/${cid.toString()}@png`,
-    )
-    expect(ImageUriBuilder.getOptions(path)).toEqual({
-      did,
-      cid,
-      format: 'png',
-      fit: 'inside',
-      height: 200,
-      width: 300,
-      min: false,
-    })
-  })
-
-  it('supports min=true option.', () => {
-    const path = ImageUriBuilder.getPath({
-      did,
-      cid,
-      format: 'png',
-      height: 200,
-      width: 300,
+      height: 1000,
       min: true,
+      preset: 'banner',
+      width: 3000,
     })
-    expect(path).toEqual(
-      `/rs:fill:300:200:1:0/plain/${did}/${cid.toString()}@png`,
-    )
-    expect(ImageUriBuilder.getOptions(path)).toEqual({
-      did,
-      cid,
-      format: 'png',
-      fit: 'cover',
-      height: 200,
-      width: 300,
-      min: true,
-    })
-  })
-
-  it('supports min={height,width} option.', () => {
-    const path = ImageUriBuilder.getPath({
-      did,
-      cid,
-      format: 'jpeg',
-      height: 200,
-      width: 300,
-      min: { height: 50, width: 100 },
-    })
-    expect(path).toEqual(
-      `/rs:fill:300:200:0:0/mw:100/mh:50/plain/${did}/${cid.toString()}@jpeg`,
-    )
-    expect(ImageUriBuilder.getOptions(path)).toEqual({
-      did,
-      cid,
-      format: 'jpeg',
-      fit: 'cover',
-      height: 200,
-      width: 300,
-      min: { height: 50, width: 100 },
-    })
-  })
-
-  it('errors on bad did/cid/format part.', () => {
     expect(
-      tryGetOptions(`/rs:fill:300:200:1:0/plain/${did}/${cid.toString()}@mp4`),
-    ).toThrow(new BadPathError('Invalid path: bad format'))
-    expect(tryGetOptions(`/rs:fill:300:200:1:0/plain/@jpg`)).toThrow(
+      ImageUriBuilder.getOptions(
+        `/feed_thumbnail/plain/${did}/${cid.toString()}.jpeg`,
+      ),
+    ).toEqual({
+      did: 'did:plc:xyz',
+      cid,
+      fit: 'inside',
+      format: 'jpeg',
+      height: 2000,
+      min: true,
+      preset: 'feed_thumbnail',
+      width: 2000,
+    })
+  })
+
+  it('errors on bad url pattern.', () => {
+    expect(tryGetOptions(`/a`)).toThrow(new BadPathError('Invalid path'))
+    expect(tryGetOptions(`/banner/plain/${did}.jpeg`)).toThrow(
       new BadPathError('Invalid path'),
     )
+  })
+
+  it('errors on bad preset.', () => {
     expect(
-      tryGetOptions(`/rs:fill:300:200:1:0/plain/${did}/${cid.toString()}@`),
-    ).toThrow(new BadPathError('Invalid path'))
+      tryGetOptions(`/bad_banner/plain/${did}/${cid.toString()}.jpeg`),
+    ).toThrow(new BadPathError('Invalid path: bad preset'))
+  })
+
+  it('errors on bad format.', () => {
     expect(
-      tryGetOptions(`/rs:fill:300:200:1:0/plain/${did}/${cid.toString()}@`),
-    ).toThrow(new BadPathError('Invalid path'))
-    expect(
-      tryGetOptions(
-        `/rs:fill:300:200:1:0/plain/${did}/${cid.toString()}@x@jpeg`,
-      ),
+      tryGetOptions(`/banner/plain/${did}/${cid.toString()}.webp`),
     ).toThrow(new BadPathError('Invalid path: bad format'))
-  })
-
-  it('errors on mismatching min settings.', () => {
-    expect(
-      tryGetOptions(
-        `/rs:fill:300:200:1:0/mw:100/mh:50/plain/${did}/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad min width/height param'))
-    expect(
-      tryGetOptions(
-        `/rs:fill:300:200:0:0/mw:100/plain/${did}/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad min width/height param'))
-  })
-
-  it('errors on bad fit setting.', () => {
-    expect(
-      tryGetOptions(
-        `/rs:blah:300:200:1:0/plain/${did}/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad resize fit param'))
-  })
-
-  it('errors on bad dimension settings.', () => {
-    expect(
-      tryGetOptions(`/rs:fill:30x:200:1:0/plain/${did}/${cid.toString()}@jpeg`),
-    ).toThrow(new BadPathError('Invalid path: bad resize height/width param'))
-    expect(
-      tryGetOptions(`/rs:fill:300:20x:1:0/plain/${did}/${cid.toString()}@jpeg`),
-    ).toThrow(new BadPathError('Invalid path: bad resize height/width param'))
-    expect(
-      tryGetOptions(
-        `/rs:fill:300:200:1:0/mw:10x/mh:50/plain/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad min width/height param'))
-    expect(
-      tryGetOptions(
-        `/rs:fill:300:200:1:0/mw:100/mh:5x/plain/${did}/${cid.toString()}@jpeg`,
-      ),
-    ).toThrow(new BadPathError('Invalid path: bad min width/height param'))
   })
 
   function tryGetOptions(path: string) {

--- a/packages/bsky/tests/moderation.test.ts
+++ b/packages/bsky/tests/moderation.test.ts
@@ -1000,7 +1000,7 @@ describe('moderation', () => {
       post = sc.posts[sc.dids.carol][0]
       blob = post.images[1]
       imageUri = ctx.imgUriBuilder
-        .getCommonSignedUri(
+        .getPresetUri(
           'feed_thumbnail',
           sc.dids.carol,
           blob.image.ref.toString(),

--- a/packages/bsky/tests/views/__snapshots__/actor-search.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/actor-search.test.ts.snap
@@ -12,7 +12,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0).jpeg",
     "did": "user(1)",
     "displayName": "Carol Littel",
     "handle": "eudora-dietrich4.test",
@@ -24,7 +24,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
     "did": "user(3)",
     "displayName": "Sadie Carter",
     "handle": "shane-torphy52.test",
@@ -36,7 +36,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(0).jpeg",
     "did": "user(5)",
     "displayName": "Carlton Abernathy IV",
     "handle": "aliya-hodkiewicz.test",
@@ -57,7 +57,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(9)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(9)/cids(0).jpeg",
     "did": "user(8)",
     "displayName": "Latoya Windler",
     "handle": "carolina-mcdermott77.test",
@@ -69,7 +69,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(11)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(11)/cids(0).jpeg",
     "did": "user(10)",
     "displayName": "Rachel Kshlerin",
     "handle": "cayla-marquardt39.test",
@@ -94,7 +94,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0).jpeg",
     "did": "user(1)",
     "displayName": "Carol Littel",
     "handle": "eudora-dietrich4.test",
@@ -104,7 +104,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
     "did": "user(3)",
     "displayName": "Sadie Carter",
     "handle": "shane-torphy52.test",
@@ -114,7 +114,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(0).jpeg",
     "did": "user(5)",
     "displayName": "Carlton Abernathy IV",
     "handle": "aliya-hodkiewicz.test",
@@ -132,7 +132,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(9)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(9)/cids(0).jpeg",
     "did": "user(8)",
     "displayName": "Latoya Windler",
     "handle": "carolina-mcdermott77.test",
@@ -142,7 +142,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(11)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(11)/cids(0).jpeg",
     "did": "user(10)",
     "displayName": "Rachel Kshlerin",
     "handle": "cayla-marquardt39.test",

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -43,7 +43,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -61,8 +61,8 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
             },
           ],
         },
@@ -125,7 +125,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -154,7 +154,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -308,7 +308,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -336,7 +336,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -369,7 +369,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -385,8 +385,8 @@ Array [
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(1)/cids(2)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(1)/cids(2)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(1)/cids(2).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(1)/cids(2).jpeg",
           },
         ],
       },
@@ -450,7 +450,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -481,7 +481,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -514,7 +514,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -542,7 +542,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -610,13 +610,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
                   },
                 ],
               },
@@ -624,7 +624,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
                     "did": "user(3)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -787,7 +787,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -818,7 +818,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -867,13 +867,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
             },
           ],
         },
@@ -881,7 +881,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
               "did": "user(3)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -967,7 +967,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1043,13 +1043,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
                   },
                 ],
               },
@@ -1057,7 +1057,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                     "did": "user(4)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -1200,7 +1200,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1240,7 +1240,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1257,8 +1257,8 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
             },
           ],
         },
@@ -1321,7 +1321,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1354,7 +1354,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1509,7 +1509,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1541,7 +1541,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",

--- a/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "$type": "app.bsky.feed.defs#threadViewPost",
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -116,7 +116,7 @@ Object {
     },
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -163,7 +163,7 @@ Object {
     "$type": "app.bsky.feed.defs#threadViewPost",
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -201,7 +201,7 @@ Object {
         "$type": "app.bsky.feed.defs#threadViewPost",
         "post": Object {
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
             "did": "user(2)",
             "displayName": "bobby",
             "handle": "bob.test",
@@ -218,8 +218,8 @@ Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(3)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(3)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(3).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(3).jpeg",
               },
             ],
           },

--- a/packages/bsky/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/follows.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-eve",
       "did": "user(2)",
       "displayName": "display-eve",
@@ -20,7 +20,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-dan",
       "did": "user(4)",
       "displayName": "display-dan",
@@ -35,7 +35,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(7)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(7)/cids(0).jpeg",
       "description": "descript-bob",
       "did": "user(6)",
       "displayName": "display-bob",
@@ -50,7 +50,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(9)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(9)/cids(0).jpeg",
       "description": "descript-carol",
       "did": "user(8)",
       "displayName": "display-carol",
@@ -66,7 +66,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-alice",
     "did": "user(0)",
     "displayName": "display-alice",
@@ -86,7 +86,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-dan",
       "did": "user(2)",
       "displayName": "display-dan",
@@ -101,7 +101,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(4)",
       "displayName": "display-alice",
@@ -115,7 +115,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-bob",
     "did": "user(0)",
     "displayName": "display-bob",
@@ -137,7 +137,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-eve",
       "did": "user(2)",
       "displayName": "display-eve",
@@ -152,7 +152,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-bob",
       "did": "user(4)",
       "displayName": "display-bob",
@@ -167,7 +167,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(7)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(7)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(6)",
       "displayName": "display-alice",
@@ -181,7 +181,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-carol",
     "did": "user(0)",
     "displayName": "display-carol",
@@ -203,7 +203,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(2)",
       "displayName": "display-alice",
@@ -217,7 +217,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-dan",
     "did": "user(0)",
     "displayName": "display-dan",
@@ -239,7 +239,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "followers": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-dan",
       "did": "user(2)",
       "displayName": "display-dan",
@@ -254,7 +254,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(4)",
       "displayName": "display-alice",
@@ -268,7 +268,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-eve",
     "did": "user(0)",
     "displayName": "display-eve",
@@ -290,7 +290,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-eve",
       "did": "user(2)",
       "displayName": "display-eve",
@@ -305,7 +305,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-dan",
       "did": "user(4)",
       "displayName": "display-dan",
@@ -320,7 +320,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(7)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(7)/cids(0).jpeg",
       "description": "descript-carol",
       "did": "user(6)",
       "displayName": "display-carol",
@@ -335,7 +335,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(9)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(9)/cids(0).jpeg",
       "description": "descript-bob",
       "did": "user(8)",
       "displayName": "display-bob",
@@ -351,7 +351,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-alice",
     "did": "user(0)",
     "displayName": "display-alice",
@@ -371,7 +371,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-carol",
       "did": "user(2)",
       "displayName": "display-carol",
@@ -386,7 +386,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(4)",
       "displayName": "display-alice",
@@ -400,7 +400,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-bob",
     "did": "user(0)",
     "displayName": "display-bob",
@@ -422,7 +422,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(2)",
       "displayName": "display-alice",
@@ -436,7 +436,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-carol",
     "did": "user(0)",
     "displayName": "display-carol",
@@ -458,7 +458,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-eve",
       "did": "user(2)",
       "displayName": "display-eve",
@@ -473,7 +473,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-bob",
       "did": "user(4)",
       "displayName": "display-bob",
@@ -488,7 +488,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(7)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(7)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(6)",
       "displayName": "display-alice",
@@ -502,7 +502,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-dan",
     "did": "user(0)",
     "displayName": "display-dan",
@@ -524,7 +524,7 @@ Object {
   "cursor": "0000000000000::bafycid",
   "follows": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "descript-carol",
       "did": "user(2)",
       "displayName": "display-carol",
@@ -539,7 +539,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(0).jpeg",
       "description": "descript-alice",
       "did": "user(4)",
       "displayName": "display-alice",
@@ -553,7 +553,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "descript-eve",
     "did": "user(0)",
     "displayName": "display-eve",

--- a/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
@@ -48,7 +48,7 @@ Object {
     },
     Object {
       "actor": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
         "description": "hi im bob label_me",
         "did": "user(3)",
         "displayName": "bobby",

--- a/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`bsky views with mutes from mute lists embeds lists in posts 1`] = `
 Object {
   "author": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
     "did": "user(0)",
     "displayName": "ali",
     "handle": "alice.test",
@@ -20,7 +20,7 @@ Object {
       "$type": "app.bsky.graph.defs#listView",
       "cid": "cids(3)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -66,7 +66,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -108,7 +108,7 @@ Object {
             "following": "record(6)",
             "muted": true,
             "mutedByList": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "cid": "cids(3)",
               "indexedAt": "1970-01-01T00:00:00.000Z",
               "name": "alice mutes",
@@ -149,7 +149,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -159,7 +159,7 @@ Object {
             "following": "record(9)",
             "muted": true,
             "mutedByList": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "cid": "cids(3)",
               "indexedAt": "1970-01-01T00:00:00.000Z",
               "name": "alice mutes",
@@ -177,8 +177,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(5)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(5).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(5).jpeg",
             },
           ],
         },
@@ -250,7 +250,7 @@ Object {
     Object {
       "cid": "cids(0)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "its me!",
         "did": "user(0)",
         "displayName": "ali",
@@ -273,10 +273,10 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "cid": "cids(2)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "its me!",
         "did": "user(0)",
         "displayName": "ali",
@@ -309,7 +309,7 @@ Object {
     Object {
       "cid": "cids(0)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "its me!",
         "did": "user(0)",
         "displayName": "ali",
@@ -332,10 +332,10 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "cid": "cids(2)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "its me!",
         "did": "user(0)",
         "displayName": "ali",
@@ -375,7 +375,7 @@ Object {
           "followedBy": "record(1)",
           "muted": true,
           "mutedByList": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "cid": "cids(0)",
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "name": "alice mutes",
@@ -390,7 +390,7 @@ Object {
     },
     Object {
       "subject": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
         "description": "hi im bob label_me",
         "did": "user(2)",
         "displayName": "bobby",
@@ -402,7 +402,7 @@ Object {
           "following": "record(2)",
           "muted": true,
           "mutedByList": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "cid": "cids(0)",
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "name": "alice mutes",
@@ -417,10 +417,10 @@ Object {
     },
   ],
   "list": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
     "cid": "cids(0)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "description": "its me!",
       "did": "user(4)",
       "displayName": "ali",

--- a/packages/bsky/tests/views/__snapshots__/mutes.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/mutes.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`mute views fetches mutes for the logged-in user. 1`] = `
 Array [
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "did": "user(0)",
     "displayName": "Dr. Lowell DuBuque",
     "handle": "elta48.test",
@@ -15,7 +15,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
     "did": "user(2)",
     "displayName": "Sally Funk",
     "handle": "magnus53.test",
@@ -36,7 +36,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(0).jpeg",
     "did": "user(5)",
     "displayName": "Patrick Sawayn",
     "handle": "jeffrey-sawayn87.test",
@@ -48,7 +48,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(8)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(8)/cids(0).jpeg",
     "did": "user(7)",
     "displayName": "Kim Streich",
     "handle": "adrienne49.test",
@@ -60,7 +60,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(10)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(10)/cids(0).jpeg",
     "did": "user(9)",
     "displayName": "Carlton Abernathy IV",
     "handle": "aliya-hodkiewicz.test",
@@ -82,7 +82,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(13)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(13)/cids(0).jpeg",
     "description": "hi im bob label_me",
     "did": "user(12)",
     "displayName": "bobby",
@@ -103,7 +103,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -171,7 +171,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -189,8 +189,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(4).jpeg",
             },
           ],
         },

--- a/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
@@ -173,7 +173,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(10)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(10).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -201,7 +201,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(10)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(10).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -273,7 +273,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(10)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(10).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -305,7 +305,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(10)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(10).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -590,7 +590,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(13)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(13).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -618,7 +618,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(13)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(13).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -690,7 +690,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(13)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(13).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -722,7 +722,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(13)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(13).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -785,7 +785,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(3)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(3).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",
@@ -812,7 +812,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(3)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(3).jpeg",
       "description": "its me!",
       "did": "user(1)",
       "displayName": "ali",

--- a/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
@@ -4,7 +4,7 @@ exports[`pds posts views fetches posts 1`] = `
 Array [
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -30,7 +30,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -56,7 +56,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
@@ -106,13 +106,13 @@ Array [
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(5)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(5)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(5).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(5).jpeg",
           },
           Object {
             "alt": "tests/image/fixtures/key-alt.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(6)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(6)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(6).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(6).jpeg",
           },
         ],
       },
@@ -120,7 +120,7 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
             "did": "user(2)",
             "displayName": "bobby",
             "handle": "bob.test",
@@ -236,13 +236,13 @@ Array [
               "images": Array [
                 Object {
                   "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                  "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(5)@jpeg",
-                  "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(5)@jpeg",
+                  "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(5).jpeg",
+                  "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(5).jpeg",
                 },
                 Object {
                   "alt": "tests/image/fixtures/key-alt.jpg",
-                  "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(6)@jpeg",
-                  "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(6)@jpeg",
+                  "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(6).jpeg",
+                  "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(6).jpeg",
                 },
               ],
             },
@@ -250,7 +250,7 @@ Array [
               "record": Object {
                 "$type": "app.bsky.embed.record#viewRecord",
                 "author": Object {
-                  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+                  "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
                   "did": "user(2)",
                   "displayName": "bobby",
                   "handle": "bob.test",
@@ -361,7 +361,7 @@ Array [
   },
   Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",

--- a/packages/bsky/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/profile.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`pds profile views fetches multiple profiles 1`] = `
 Array [
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "its me!",
     "did": "user(0)",
     "displayName": "ali",
@@ -21,7 +21,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
     "description": "hi im bob label_me",
     "did": "user(2)",
     "displayName": "bobby",
@@ -67,7 +67,7 @@ Array [
 
 exports[`pds profile views fetches other's profile, with a follow 1`] = `
 Object {
-  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+  "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
   "description": "its me!",
   "did": "user(0)",
   "displayName": "ali",
@@ -104,7 +104,7 @@ Object {
 
 exports[`pds profile views fetches own profile 1`] = `
 Object {
-  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+  "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
   "description": "its me!",
   "did": "user(0)",
   "displayName": "ali",
@@ -123,8 +123,8 @@ Object {
 
 exports[`pds profile views presents avatars & banners 1`] = `
 Object {
-  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
-  "banner": "https://bsky.public.url/image/sig()/rs:fill:3000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+  "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
+  "banner": "https://bsky.public.url/img/banner/plain/user(1)/cids(1).jpeg",
   "description": "new descript",
   "did": "user(0)",
   "displayName": "ali",

--- a/packages/bsky/tests/views/__snapshots__/reposts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/reposts.test.ts.snap
@@ -33,7 +33,7 @@ Array [
     },
   },
   Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
     "description": "hi im bob label_me",
     "did": "user(3)",
     "displayName": "bobby",

--- a/packages/bsky/tests/views/__snapshots__/thread.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/thread.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -41,7 +41,7 @@ Object {
     },
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
         "did": "user(2)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -57,8 +57,8 @@ Object {
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
           },
         ],
       },
@@ -122,7 +122,7 @@ Object {
   },
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -169,7 +169,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -241,7 +241,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -257,8 +257,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(4).jpeg",
             },
           ],
         },
@@ -323,7 +323,7 @@ Object {
           "$type": "app.bsky.feed.defs#threadViewPost",
           "post": Object {
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "did": "user(0)",
               "displayName": "ali",
               "handle": "alice.test",
@@ -374,7 +374,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -445,7 +445,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -461,8 +461,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(4).jpeg",
             },
           ],
         },
@@ -532,7 +532,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -563,7 +563,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -602,7 +602,7 @@ Object {
           "$type": "app.bsky.feed.defs#threadViewPost",
           "post": Object {
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "did": "user(0)",
               "displayName": "ali",
               "handle": "alice.test",
@@ -651,7 +651,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -691,7 +691,7 @@ Object {
   },
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -741,7 +741,7 @@ Object {
   },
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -793,7 +793,7 @@ Object {
   },
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -840,7 +840,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -873,7 +873,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -889,8 +889,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(3).jpeg",
             },
           ],
         },
@@ -955,7 +955,7 @@ Object {
           "$type": "app.bsky.feed.defs#threadViewPost",
           "post": Object {
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "did": "user(0)",
               "displayName": "ali",
               "handle": "alice.test",
@@ -1006,7 +1006,7 @@ Object {
   "$type": "app.bsky.feed.defs#threadViewPost",
   "post": Object {
     "author": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -1039,7 +1039,7 @@ Object {
       "$type": "app.bsky.feed.defs#threadViewPost",
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1055,8 +1055,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(3).jpeg",
             },
           ],
         },

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -47,7 +47,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -85,7 +85,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -184,7 +184,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -294,7 +294,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -327,7 +327,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -369,7 +369,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -445,7 +445,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -472,7 +472,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -501,7 +501,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -552,7 +552,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
         "did": "user(4)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -582,7 +582,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -655,13 +655,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(10)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(10)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(10).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(10).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(11)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(11)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(11).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(11).jpeg",
             },
           ],
         },
@@ -669,7 +669,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
               "did": "user(4)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -771,7 +771,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
         "did": "user(4)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -814,7 +814,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -847,7 +847,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -923,13 +923,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
                   },
                 ],
               },
@@ -937,7 +937,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                     "did": "user(4)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -1083,7 +1083,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1121,7 +1121,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
           "did": "user(4)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1139,8 +1139,8 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
             },
           ],
         },
@@ -1203,7 +1203,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1270,7 +1270,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1297,7 +1297,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1326,7 +1326,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
         "did": "user(4)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -1344,8 +1344,8 @@ Array [
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
           },
         ],
       },
@@ -1409,7 +1409,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1436,7 +1436,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1465,7 +1465,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1628,7 +1628,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
         "did": "user(4)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -1658,7 +1658,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -1720,13 +1720,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
                   },
                 ],
               },
@@ -1734,7 +1734,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                     "did": "user(4)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -1910,13 +1910,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
             },
           ],
         },
@@ -1924,7 +1924,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
               "did": "user(4)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -2026,7 +2026,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
         "did": "user(4)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -2069,7 +2069,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -2135,13 +2135,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
                   },
                 ],
               },
@@ -2149,7 +2149,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
                     "did": "user(3)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -2292,7 +2292,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -2332,7 +2332,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -2348,8 +2348,8 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(2).jpeg",
             },
           ],
         },
@@ -2412,7 +2412,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -2482,7 +2482,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -2513,7 +2513,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -2546,7 +2546,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -2562,8 +2562,8 @@ Array [
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(2)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(2)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(2).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(2).jpeg",
           },
         ],
       },
@@ -2627,7 +2627,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -2658,7 +2658,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -2691,7 +2691,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -2857,7 +2857,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -2885,7 +2885,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -2934,13 +2934,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
             },
           ],
         },
@@ -2948,7 +2948,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
               "did": "user(3)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -3048,7 +3048,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -3089,7 +3089,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3155,13 +3155,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
                   },
                 ],
               },
@@ -3169,7 +3169,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
                     "did": "user(3)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -3314,7 +3314,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3354,7 +3354,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
           "did": "user(3)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -3371,8 +3371,8 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(2).jpeg",
             },
           ],
         },
@@ -3435,7 +3435,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -3504,7 +3504,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -3535,7 +3535,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
           "did": "user(1)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -3568,7 +3568,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3732,7 +3732,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3780,13 +3780,13 @@ Array [
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(2).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(3).jpeg",
             },
           ],
         },
@@ -3794,7 +3794,7 @@ Array [
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(5)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(5).jpeg",
               "did": "user(3)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -3893,7 +3893,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3928,7 +3928,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -3973,7 +3973,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -3990,8 +3990,8 @@ Array [
         "images": Array [
           Object {
             "alt": "tests/image/fixtures/key-landscape-small.jpg",
-            "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(4)/cids(3)@jpeg",
-            "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(4)/cids(3)@jpeg",
+            "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(4)/cids(3).jpeg",
+            "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(4)/cids(3).jpeg",
           },
         ],
       },
@@ -4055,7 +4055,7 @@ Array [
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -4086,7 +4086,7 @@ Array [
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -4119,7 +4119,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -4179,13 +4179,13 @@ Array [
                 "images": Array [
                   Object {
                     "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(3)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(3)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(3).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(3).jpeg",
                   },
                   Object {
                     "alt": "tests/image/fixtures/key-alt.jpg",
-                    "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(7)@jpeg",
-                    "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(7)@jpeg",
+                    "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(7).jpeg",
+                    "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(7).jpeg",
                   },
                 ],
               },
@@ -4193,7 +4193,7 @@ Array [
                 "record": Object {
                   "$type": "app.bsky.embed.record#viewRecord",
                   "author": Object {
-                    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+                    "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
                     "did": "user(3)",
                     "displayName": "bobby",
                     "handle": "bob.test",
@@ -4349,7 +4349,7 @@ Array [
   Object {
     "post": Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1).jpeg",
         "did": "user(3)",
         "displayName": "bobby",
         "handle": "bob.test",

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -34,9 +34,6 @@ export class TestBsky {
       didPlcUrl: cfg.plcUrl,
       publicUrl: 'https://bsky.public.url',
       serverDid,
-      imgUriSalt: '9dd04221f5755bce5f55f47464c27e1e',
-      imgUriKey:
-        'f23ecd142835025f42c3db2cf25dd813956c178392760256211f9d315f8ab4d8',
       didCacheStaleTTL: HOUR,
       didCacheMaxTTL: DAY,
       ...cfg,

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -231,7 +231,7 @@ export const forSnapshot = (obj: unknown) => {
       return constantKeysetCursor
     }
     if (str.match(/\/image\/[^/]+\/.+\/did:plc:[^/]+\/[^/]+@[\w]+$/)) {
-      // Match image urls
+      // Match image urls (pds)
       const match = str.match(
         /\/image\/([^/]+)\/.+\/(did:plc:[^/]+)\/([^/]+)@[\w]+$/,
       )
@@ -241,6 +241,15 @@ export const forSnapshot = (obj: unknown) => {
         .replace(sig, 'sig()')
         .replace(did, take(users, did))
         .replace(cid, take(cids, cid))
+    }
+    if (str.match(/\/img\/[^/]+\/.+\/did:plc:[^/]+\/[^/]+\.[\w]+$/)) {
+      // Match image urls (bsky w/ presets)
+      const match = str.match(
+        /\/img\/[^/]+\/.+\/(did:plc:[^/]+)\/([^/]+)\.[\w]+$/,
+      )
+      if (!match) return str
+      const [, did, cid] = match
+      return str.replace(did, take(users, did)).replace(cid, take(cids, cid))
     }
     if (str.startsWith('pds-public-url-')) {
       return 'invite-code'

--- a/packages/pds/tests/proxied/__snapshots__/feedgen.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/feedgen.test.ts.snap
@@ -7,7 +7,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -45,7 +45,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
             "did": "user(2)",
             "displayName": "bobby",
             "handle": "bob.test",
@@ -63,8 +63,8 @@ Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
               },
             ],
           },
@@ -127,7 +127,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -194,7 +194,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -221,7 +221,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -250,7 +250,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -268,8 +268,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
             },
           ],
         },
@@ -333,7 +333,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -360,7 +360,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -389,7 +389,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -543,7 +543,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -573,7 +573,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -619,13 +619,13 @@ Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
               },
               Object {
                 "alt": "tests/image/fixtures/key-alt.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(9)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(9)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(9).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(9).jpeg",
               },
             ],
           },
@@ -633,7 +633,7 @@ Object {
             "record": Object {
               "$type": "app.bsky.embed.record#viewRecord",
               "author": Object {
-                "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+                "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
                 "did": "user(2)",
                 "displayName": "bobby",
                 "handle": "bob.test",
@@ -717,7 +717,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
           "did": "user(2)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -751,7 +751,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`proxies view requests actor.getProfile 1`] = `
 Object {
-  "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+  "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
   "description": "hi im bob label_me",
   "did": "user(0)",
   "displayName": "bobby",
@@ -25,7 +25,7 @@ exports[`proxies view requests actor.getProfiles 1`] = `
 Object {
   "profiles": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
       "description": "its me!",
       "did": "user(0)",
       "displayName": "ali",
@@ -41,7 +41,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "hi im bob label_me",
       "did": "user(2)",
       "displayName": "bobby",
@@ -66,7 +66,7 @@ exports[`proxies view requests actor.getSuggestions 1`] = `
 Object {
   "actors": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0).jpeg",
       "description": "hi im bob label_me",
       "did": "user(1)",
       "displayName": "bobby",
@@ -97,7 +97,7 @@ exports[`proxies view requests actor.searchActor 1`] = `
 Object {
   "actors": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
       "description": "its me!",
       "did": "user(0)",
       "displayName": "ali",
@@ -110,7 +110,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "description": "hi im bob label_me",
       "did": "user(2)",
       "displayName": "bobby",
@@ -154,7 +154,7 @@ exports[`proxies view requests actor.searchActorTypeahead 1`] = `
 Object {
   "actors": Array [
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
       "did": "user(0)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -164,7 +164,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
       "did": "user(2)",
       "displayName": "bobby",
       "handle": "bob.test",
@@ -205,7 +205,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -223,8 +223,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(1)/cids(2)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(1)/cids(2)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(1)/cids(2).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(1)/cids(2).jpeg",
             },
           ],
         },
@@ -288,7 +288,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
             "did": "user(2)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -315,7 +315,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1).jpeg",
             "did": "user(2)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -344,7 +344,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -374,7 +374,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -416,7 +416,7 @@ Object {
   "view": Object {
     "cid": "cids(0)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
       "did": "user(1)",
       "displayName": "ali",
       "handle": "alice.test",
@@ -442,7 +442,7 @@ Object {
     Object {
       "cid": "cids(0)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1).jpeg",
         "did": "user(1)",
         "displayName": "ali",
         "handle": "alice.test",
@@ -469,7 +469,7 @@ Object {
   "likes": Array [
     Object {
       "actor": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
         "description": "hi im bob label_me",
         "did": "user(0)",
         "displayName": "bobby",
@@ -488,7 +488,7 @@ Object {
     },
     Object {
       "actor": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(3)/cids(0)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(0).jpeg",
         "description": "its me!",
         "did": "user(2)",
         "displayName": "ali",
@@ -513,7 +513,7 @@ Object {
   "posts": Array [
     Object {
       "author": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "did": "user(0)",
         "displayName": "bobby",
         "handle": "bob.test",
@@ -563,13 +563,13 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(3)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(3)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(3).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(3).jpeg",
             },
             Object {
               "alt": "tests/image/fixtures/key-alt.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(3)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(3)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(3)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(3)/cids(4).jpeg",
             },
           ],
         },
@@ -577,7 +577,7 @@ Object {
           "record": Object {
             "$type": "app.bsky.embed.record#viewRecord",
             "author": Object {
-              "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
               "did": "user(0)",
               "displayName": "bobby",
               "handle": "bob.test",
@@ -688,7 +688,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -764,13 +764,13 @@ Object {
                   "images": Array [
                     Object {
                       "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                      "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                      "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                      "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                      "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
                     },
                     Object {
                       "alt": "tests/image/fixtures/key-alt.jpg",
-                      "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                      "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                      "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                      "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
                     },
                   ],
                 },
@@ -778,7 +778,7 @@ Object {
                   "record": Object {
                     "$type": "app.bsky.embed.record#viewRecord",
                     "author": Object {
-                      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                       "did": "user(4)",
                       "displayName": "bobby",
                       "handle": "bob.test",
@@ -906,7 +906,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -944,7 +944,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
             "did": "user(4)",
             "displayName": "bobby",
             "handle": "bob.test",
@@ -962,8 +962,8 @@ Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
               },
             ],
           },
@@ -1026,7 +1026,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -1093,7 +1093,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -1120,7 +1120,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -1149,7 +1149,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
           "did": "user(4)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1167,8 +1167,8 @@ Object {
           "images": Array [
             Object {
               "alt": "tests/image/fixtures/key-landscape-small.jpg",
-              "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(5)/cids(4)@jpeg",
-              "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(5)/cids(4)@jpeg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4).jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4).jpeg",
             },
           ],
         },
@@ -1232,7 +1232,7 @@ Object {
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -1259,7 +1259,7 @@ Object {
         "root": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
-            "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+            "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
             "did": "user(0)",
             "displayName": "ali",
             "handle": "alice.test",
@@ -1288,7 +1288,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1442,7 +1442,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
           "did": "user(4)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1472,7 +1472,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1534,13 +1534,13 @@ Object {
                   "images": Array [
                     Object {
                       "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                      "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                      "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                      "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                      "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
                     },
                     Object {
                       "alt": "tests/image/fixtures/key-alt.jpg",
-                      "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                      "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                      "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                      "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
                     },
                   ],
                 },
@@ -1548,7 +1548,7 @@ Object {
                   "record": Object {
                     "$type": "app.bsky.embed.record#viewRecord",
                     "author": Object {
-                      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                      "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                       "did": "user(4)",
                       "displayName": "bobby",
                       "handle": "bob.test",
@@ -1706,13 +1706,13 @@ Object {
             "images": Array [
               Object {
                 "alt": "tests/image/fixtures/key-landscape-small.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(4)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(4)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(4).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(4).jpeg",
               },
               Object {
                 "alt": "tests/image/fixtures/key-alt.jpg",
-                "fullsize": "https://bsky.public.url/image/sig()/rs:fit:2000:2000:1:0/plain/user(6)/cids(5)@jpeg",
-                "thumb": "https://bsky.public.url/image/sig()/rs:fit:1000:1000:1:0/plain/user(6)/cids(5)@jpeg",
+                "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(6)/cids(5).jpeg",
+                "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(6)/cids(5).jpeg",
               },
             ],
           },
@@ -1720,7 +1720,7 @@ Object {
             "record": Object {
               "$type": "app.bsky.embed.record#viewRecord",
               "author": Object {
-                "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+                "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
                 "did": "user(4)",
                 "displayName": "bobby",
                 "handle": "bob.test",
@@ -1804,7 +1804,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(5)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(1).jpeg",
           "did": "user(4)",
           "displayName": "bobby",
           "handle": "bob.test",
@@ -1838,7 +1838,7 @@ Object {
     Object {
       "post": Object {
         "author": Object {
-          "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
           "did": "user(0)",
           "displayName": "ali",
           "handle": "alice.test",
@@ -1883,7 +1883,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0).jpeg",
       "description": "hi im bob label_me",
       "did": "user(1)",
       "displayName": "bobby",
@@ -1918,7 +1918,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
       "description": "its me!",
       "did": "user(3)",
       "displayName": "ali",
@@ -1932,7 +1932,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "hi im bob label_me",
     "did": "user(0)",
     "displayName": "bobby",
@@ -1965,7 +1965,7 @@ Object {
       },
     },
     Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
       "description": "its me!",
       "did": "user(3)",
       "displayName": "ali",
@@ -1979,7 +1979,7 @@ Object {
     },
   ],
   "subject": Object {
-    "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(0)@jpeg",
+    "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(0).jpeg",
     "description": "hi im bob label_me",
     "did": "user(0)",
     "displayName": "bobby",
@@ -2015,7 +2015,7 @@ Object {
     },
     Object {
       "subject": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(2)/cids(0)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0).jpeg",
         "description": "its me!",
         "did": "user(1)",
         "displayName": "ali",
@@ -2032,7 +2032,7 @@ Object {
   "list": Object {
     "cid": "cids(1)",
     "creator": Object {
-      "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(4)/cids(0)@jpeg",
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0).jpeg",
       "description": "hi im bob label_me",
       "did": "user(3)",
       "displayName": "bobby",
@@ -2065,7 +2065,7 @@ Object {
     Object {
       "cid": "cids(0)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "hi im bob label_me",
         "did": "user(0)",
         "displayName": "bobby",
@@ -2091,7 +2091,7 @@ Object {
     Object {
       "cid": "cids(2)",
       "creator": Object {
-        "avatar": "https://bsky.public.url/image/sig()/rs:fill:1000:1000:1:0/plain/user(1)/cids(1)@jpeg",
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1).jpeg",
         "description": "hi im bob label_me",
         "did": "user(0)",
         "displayName": "bobby",


### PR DESCRIPTION
This switches the appview from using signed image URLs to fixed, named presets. The purpose is to allow services other than the appview to build valid image URLs without opening the door to cache-busting.