### PR TITLE
:bug: Only ignore reports for specific at-uri when ignoreSubject contains at-uri

### DIFF
--- a/packages/bsky/src/services/moderation/index.ts
+++ b/packages/bsky/src/services/moderation/index.ts
@@ -104,12 +104,31 @@ export class ModerationService {
           .orWhere('subjectUri', '=', subject)
       })
     }
+
     if (ignoreSubjects?.length) {
-      builder = builder.where((qb) => {
-        return qb
-          .where('subjectDid', 'not in', ignoreSubjects)
-          .where('subjectUri', 'not in', ignoreSubjects)
+      const ignoreUris: string[] = []
+      const ignoreDids: string[] = []
+
+      ignoreSubjects.forEach((subject) => {
+        if (subject.startsWith('at://')) {
+          ignoreUris.push(subject)
+        } else if (subject.startsWith('did:')) {
+          ignoreDids.push(subject)
+        }
       })
+
+      if (ignoreDids.length) {
+        builder = builder.where('subjectDid', 'not in', ignoreDids)
+      }
+      if (ignoreUris.length) {
+        builder = builder.where((qb) => {
+          // Without the null condition, postgres will ignore all reports where `subjectUri` is null
+          // which will make all the account reports be ignored as well
+          return qb
+            .where('subjectUri', 'not in', ignoreUris)
+            .orWhere('subjectUri', 'is', null)
+        })
+      }
     }
 
     if (reporters?.length) {


### PR DESCRIPTION
Due to the way postgres handles null values, when we try to ignore reports for a specific `subjectUri`, the previous query was also ignoring all reports with `subjectUri=null` (so basically, all account reports).