### PR TITLE
Prevent duplicate blocks in checkout

### DIFF
--- a/packages/repo/src/mst/mst.ts
+++ b/packages/repo/src/mst/mst.ts
@@ -694,17 +694,9 @@ export class MST {
   // Sync Protocol
 
   async writeToCarStream(car: BlockWriter): Promise<void> {
-    const entries = await this.getEntries()
     const leaves = new CidSet()
     let toFetch = new CidSet()
     toFetch.add(await this.getPointer())
-    for (const entry of entries) {
-      if (entry.isLeaf()) {
-        leaves.add(entry.value)
-      } else {
-        toFetch.add(await entry.getPointer())
-      }
-    }
     while (toFetch.size() > 0) {
       const nextLayer = new CidSet()
       const fetched = await this.storage.getBlocks(toFetch.toList())

--- a/packages/repo/tests/sync/checkout.test.ts
+++ b/packages/repo/tests/sync/checkout.test.ts
@@ -1,10 +1,11 @@
 import * as crypto from '@atproto/crypto'
-import { Repo, RepoContents, RepoVerificationError } from '../../src'
+import { CidSet, Repo, RepoContents, RepoVerificationError } from '../../src'
 import { MemoryBlockstore } from '../../src/storage'
 import * as sync from '../../src/sync'
 
 import * as util from '../_util'
 import { streamToBuffer } from '@atproto/common'
+import { CarReader } from '@ipld/car/reader'
 
 describe('Checkout Sync', () => {
   let storage: MemoryBlockstore
@@ -21,6 +22,7 @@ describe('Checkout Sync', () => {
     repo = await Repo.create(storage, repoDid, keypair)
     syncStorage = new MemoryBlockstore()
     const filled = await util.fillRepo(repo, keypair, 20)
+    // const filled = await util.fillRepo(repo, keypair, 2)
     repo = filled.repo
     repoData = filled.data
   })
@@ -48,6 +50,18 @@ describe('Checkout Sync', () => {
     }
     const hasGenesisCommit = await syncStorage.has(commitPath[0])
     expect(hasGenesisCommit).toBeFalsy()
+  })
+
+  it('does not sync duplicate blocks', async () => {
+    const carBytes = await streamToBuffer(sync.getCheckout(storage, repo.cid))
+    const car = await CarReader.fromBytes(carBytes)
+    const cids = new CidSet()
+    for await (const block of car.blocks()) {
+      if (cids.has(block.cid)) {
+        throw new Error(`duplicate block: :${block.cid.toString()}`)
+      }
+      cids.add(block.cid)
+    }
   })
 
   it('throws on a bad signature', async () => {

--- a/packages/repo/tests/sync/checkout.test.ts
+++ b/packages/repo/tests/sync/checkout.test.ts
@@ -22,7 +22,6 @@ describe('Checkout Sync', () => {
     repo = await Repo.create(storage, repoDid, keypair)
     syncStorage = new MemoryBlockstore()
     const filled = await util.fillRepo(repo, keypair, 20)
-    // const filled = await util.fillRepo(repo, keypair, 2)
     repo = filled.repo
     repoData = filled.data
   })


### PR DESCRIPTION
We were sending some duplicate blocks in checkout.

This was because we were starting with a basecase of the root node & all it's subtrees before iterating. This small change ended up propagating down each layer of the tree

Closes https://github.com/bluesky-social/atproto/issues/1255