### PR TITLE
Only pass through known params on timeline skeleton

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -19,7 +19,7 @@ export default function (server: Server, ctx: AppContext) {
       if (ctx.canProxy(req)) {
         const res =
           await ctx.appviewAgent.api.app.bsky.unspecced.getTimelineSkeleton(
-            params,
+            { limit, cursor },
             await ctx.serviceAuthHeaders(requester),
           )
         const filtered = await filterMutesAndBlocks(


### PR DESCRIPTION
Skeleton handler didn't like passing through the algorithm param