### PR TITLE
Move timeline construction to appview

### DIFF
--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -26,7 +26,8 @@ export default function (server: Server, ctx: AppContext) {
           body: res.data,
         }
       }
-      if (ctx.canProxyFeedConstruction(req)) {
+
+      if (ctx.cfg.bskyAppViewEndpoint) {
         const res =
           await ctx.appviewAgent.api.app.bsky.unspecced.getTimelineSkeleton(
             { limit, cursor },


### PR DESCRIPTION
no longer require proxy header