### PR TITLE
Better propagate errors on repo streams

### DIFF
--- a/packages/repo/tests/util.test.ts
+++ b/packages/repo/tests/util.test.ts
@@ -1,0 +1,21 @@
+import { dataToCborBlock, wait } from '@atproto/common'
+import { writeCar } from '../src'
+
+describe('Utils', () => {
+  describe('writeCar()', () => {
+    it('propagates errors', async () => {
+      const iterate = async () => {
+        const iter = writeCar(null, async (car) => {
+          await wait(1)
+          const block = await dataToCborBlock({ test: 1 })
+          await car.put(block)
+          throw new Error('Oops!')
+        })
+        for await (const bytes of iter) {
+          // no-op
+        }
+      }
+      await expect(iterate).rejects.toThrow('Oops!')
+    })
+  })
+})

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -235,6 +235,7 @@ export class Server {
           } else if (output?.body instanceof Readable) {
             res.header('Content-Type', output.encoding)
             res.status(200)
+            res.once('error', (err) => res.destroy(err))
             forwardStreamErrors(output.body, res)
             output.body.pipe(res)
           } else if (output) {

--- a/packages/xrpc-server/tests/responses.test.ts
+++ b/packages/xrpc-server/tests/responses.test.ts
@@ -1,0 +1,77 @@
+import * as http from 'http'
+import getPort from 'get-port'
+import xrpc, { ServiceClient } from '@atproto/xrpc'
+import { byteIterableToStream } from '@atproto/common'
+import { createServer, closeServer } from './_util'
+import * as xrpcServer from '../src'
+
+const LEXICONS = [
+  {
+    lexicon: 1,
+    id: 'io.example.readableStream',
+    defs: {
+      main: {
+        type: 'query',
+        parameters: {
+          type: 'params',
+          properties: {
+            shouldErr: { type: 'boolean' },
+          },
+        },
+        output: {
+          encoding: 'application/vnd.ipld.car',
+        },
+      },
+    },
+  },
+]
+
+describe('Responses', () => {
+  let s: http.Server
+  const server = xrpcServer.createServer(LEXICONS)
+  server.method(
+    'io.example.readableStream',
+    async (ctx: { params: xrpcServer.Params }) => {
+      async function* iter(): AsyncIterable<Uint8Array> {
+        for (let i = 0; i < 5; i++) {
+          yield new Uint8Array([i])
+        }
+        if (ctx.params.shouldErr) {
+          throw new Error('error')
+        }
+      }
+      return {
+        encoding: 'application/vnd.ipld.car',
+        body: byteIterableToStream(iter()),
+      }
+    },
+  )
+  xrpc.addLexicons(LEXICONS)
+
+  let client: ServiceClient
+  let url: string
+  beforeAll(async () => {
+    const port = await getPort()
+    s = await createServer(port, server)
+    url = `http://localhost:${port}`
+    client = xrpc.service(url)
+  })
+  afterAll(async () => {
+    await closeServer(s)
+  })
+
+  it('returns readable streams of bytes', async () => {
+    const res = await client.call('io.example.readableStream', {
+      shouldErr: false,
+    })
+    const expected = new Uint8Array([0, 1, 2, 3, 4])
+    expect(res.data).toEqual(expected)
+  })
+
+  it('handles errs on readable streams of bytes', async () => {
+    const attempt = client.call('io.example.readableStream', {
+      shouldErr: true,
+    })
+    await expect(attempt).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
Car writer was not properly handling errors, so we wrap it in a stream to better propagate them

xrpc-server was mishandling errors when serving a streaming req & making it the whole server's problem