### PR TITLE
Misc scaling

### DIFF
--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - timeline-fixes
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - timeline-fixes
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -86,6 +86,10 @@ export class TestBsky {
     return new AtpAgent({ service: this.url })
   }
 
+  async processAll() {
+    await this.ctx.backgroundQueue.processAll()
+  }
+
   async close() {
     await this.server.destroy()
   }

--- a/packages/dev-env/src/network-no-appview.ts
+++ b/packages/dev-env/src/network-no-appview.ts
@@ -37,6 +37,10 @@ export class TestNetworkNoAppView {
     return fg
   }
 
+  async processAll() {
+    await this.pds.processAll()
+  }
+
   async close() {
     await Promise.all(this.feedGens.map((fg) => fg.close()))
     await this.pds.close()

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -54,7 +54,6 @@ export class TestNetwork extends TestNetworkNoAppView {
   }
 
   async processFullSubscription(timeout = 5000) {
-    if (!this.bsky) return
     const sub = this.bsky.sub
     if (!sub) return
     const { db } = this.pds.ctx.db
@@ -76,10 +75,9 @@ export class TestNetwork extends TestNetworkNoAppView {
   }
 
   async processAll(timeout?: number) {
-    await this.pds.ctx.backgroundQueue.processAll()
-    if (!this.bsky) return
+    await this.pds.processAll()
     await this.processFullSubscription(timeout)
-    await this.bsky.ctx.backgroundQueue.processAll()
+    await this.bsky.processAll()
   }
 
   async serviceHeaders(did: string, aud?: string) {

--- a/packages/dev-env/src/pds.ts
+++ b/packages/dev-env/src/pds.ts
@@ -96,6 +96,9 @@ export class TestPds {
     })
 
     await server.start()
+
+    // we refresh label cache by hand in `processAll` instead of on a timer
+    server.ctx.labelCache.stop()
     return new TestPds(url, port, server)
   }
 
@@ -121,6 +124,12 @@ export class TestPds {
     return {
       authorization: this.adminAuth(),
     }
+  }
+
+  async processAll() {
+    await this.ctx.backgroundQueue.processAll()
+    await this.ctx.labelCache.fullRefresh()
+    await this.ctx.labelCache.catchUp()
   }
 
   async close() {

--- a/packages/dev-env/src/pds.ts
+++ b/packages/dev-env/src/pds.ts
@@ -129,7 +129,6 @@ export class TestPds {
   async processAll() {
     await this.ctx.backgroundQueue.processAll()
     await this.ctx.labelCache.fullRefresh()
-    await this.ctx.labelCache.catchUp()
   }
 
   async close() {

--- a/packages/identifier/src/reserved.ts
+++ b/packages/identifier/src/reserved.ts
@@ -864,6 +864,7 @@ const famousAccounts = [
   // reserving some large twitter accounts (top 100 by followers according to wikidata dump)
   '10ronaldinho',
   '3gerardpique',
+  'aclu',
   'adele',
   'akshaykumar',
   'aliaa08',

--- a/packages/pds/src/app-view/api/app/bsky/util/feed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/util/feed.ts
@@ -12,7 +12,7 @@ export class FeedKeyset extends TimeCidKeyset<FeedRow> {
 }
 
 // For users with sparse feeds, avoid scanning more than one week for a single page
-export const getFeedDateThreshold = (from: string | undefined, days = 3) => {
+export const getFeedDateThreshold = (from: string | undefined, days = 1) => {
   const timelineDateThreshold = from ? new Date(from) : new Date()
   timelineDateThreshold.setDate(timelineDateThreshold.getDate() - days)
   return timelineDateThreshold.toISOString()

--- a/packages/pds/src/app-view/services/actor/index.ts
+++ b/packages/pds/src/app-view/services/actor/index.ts
@@ -3,15 +3,20 @@ import { DidHandle } from '../../../db/tables/did-handle'
 import { notSoftDeletedClause } from '../../../db/util'
 import { ActorViews } from './views'
 import { ImageUriBuilder } from '../../../image/uri'
+import { LabelCache } from '../../../label-cache'
 
 export class ActorService {
-  constructor(public db: Database, public imgUriBuilder: ImageUriBuilder) {}
+  constructor(
+    public db: Database,
+    public imgUriBuilder: ImageUriBuilder,
+    public labelCache: LabelCache,
+  ) {}
 
-  static creator(imgUriBuilder: ImageUriBuilder) {
-    return (db: Database) => new ActorService(db, imgUriBuilder)
+  static creator(imgUriBuilder: ImageUriBuilder, labelCache: LabelCache) {
+    return (db: Database) => new ActorService(db, imgUriBuilder, labelCache)
   }
 
-  views = new ActorViews(this.db, this.imgUriBuilder)
+  views = new ActorViews(this.db, this.imgUriBuilder, this.labelCache)
 
   async getActor(
     handleOrDid: string,

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -8,13 +8,14 @@ import { DidHandle } from '../../../db/tables/did-handle'
 import Database from '../../../db'
 import { ImageUriBuilder } from '../../../image/uri'
 import { LabelService } from '../label'
-import { ListViewBasic } from '../../../lexicon/types/app/bsky/graph/defs'
+import { GraphService } from '../graph'
 
 export class ActorViews {
   constructor(private db: Database, private imgUriBuilder: ImageUriBuilder) {}
 
   services = {
-    label: LabelService.creator(),
+    label: LabelService.creator()(this.db),
+    graph: GraphService.creator(this.imgUriBuilder)(this.db),
   }
 
   profileDetailed(
@@ -82,17 +83,28 @@ export class ActorViews {
           .where('mutedByDid', '=', viewer)
           .select('did')
           .as('requesterMuted'),
+        this.db.db
+          .selectFrom('list_item')
+          .innerJoin('list_mute', 'list_mute.listUri', 'list_item.listUri')
+          .where('list_mute.mutedByDid', '=', viewer)
+          .whereRef('list_item.subjectDid', '=', ref('did_handle.did'))
+          .select('list_item.listUri')
+          .as('requesterMutedByList'),
       ])
 
-    const [profileInfos, labels, listMutes] = await Promise.all([
+    const [profileInfos, labels] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForSubjects(dids),
-      this.getListMutes(dids, viewer),
+      this.services.label.getLabelsForSubjects(dids),
     ])
 
     const profileInfoByDid = profileInfos.reduce((acc, info) => {
       return Object.assign(acc, { [info.did]: info })
     }, {} as Record<string, ArrayEl<typeof profileInfos>>)
+
+    const listUris: string[] = profileInfos
+      .map((a) => a.requesterMutedByList)
+      .filter((list) => !!list)
+    const listViews = await this.services.graph.getListViews(listUris, viewer)
 
     const views = results.map((result) => {
       const profileInfo = profileInfoByDid[result.did]
@@ -114,8 +126,14 @@ export class ActorViews {
         postsCount: profileInfo?.postsCount || 0,
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
-          muted: !!profileInfo?.requesterMuted || !!listMutes[result.did],
-          mutedByList: listMutes[result.did],
+          muted:
+            !!profileInfo?.requesterMuted ||
+            !!profileInfo?.requesterMutedByList,
+          mutedByList: profileInfo.requesterMutedByList
+            ? this.services.graph.formatListViewBasic(
+                listViews[profileInfo.requesterMutedByList],
+              )
+            : undefined,
           blockedBy: !!profileInfo.requesterBlockedBy,
           blocking: profileInfo.requesterBlocking || undefined,
           following: profileInfo?.requesterFollowing || undefined,
@@ -181,17 +199,28 @@ export class ActorViews {
           .where('mutedByDid', '=', viewer)
           .select('did')
           .as('requesterMuted'),
+        this.db.db
+          .selectFrom('list_item')
+          .innerJoin('list_mute', 'list_mute.listUri', 'list_item.listUri')
+          .where('list_mute.mutedByDid', '=', viewer)
+          .whereRef('list_item.subjectDid', '=', ref('did_handle.did'))
+          .select('list_item.listUri')
+          .as('requesterMutedByList'),
       ])
 
-    const [profileInfos, labels, listMutes] = await Promise.all([
+    const [profileInfos, labels] = await Promise.all([
       profileInfosQb.execute(),
-      this.services.label(this.db).getLabelsForSubjects(dids),
-      this.getListMutes(dids, viewer),
+      this.services.label.getLabelsForSubjects(dids),
     ])
 
     const profileInfoByDid = profileInfos.reduce((acc, info) => {
       return Object.assign(acc, { [info.did]: info })
     }, {} as Record<string, ArrayEl<typeof profileInfos>>)
+
+    const listUris: string[] = profileInfos
+      .map((a) => a.requesterMutedByList)
+      .filter((list) => !!list)
+    const listViews = await this.services.graph.getListViews(listUris, viewer)
 
     const views = results.map((result) => {
       const profileInfo = profileInfoByDid[result.did]
@@ -206,8 +235,14 @@ export class ActorViews {
         avatar,
         indexedAt: profileInfo?.indexedAt || undefined,
         viewer: {
-          muted: !!profileInfo?.requesterMuted || !!listMutes[result.did],
-          mutedByList: listMutes[result.did],
+          muted:
+            !!profileInfo?.requesterMuted ||
+            !!profileInfo?.requesterMutedByList,
+          mutedByList: profileInfo.requesterMutedByList
+            ? this.services.graph.formatListViewBasic(
+                listViews[profileInfo.requesterMutedByList],
+              )
+            : undefined,
           blockedBy: !!profileInfo.requesterBlockedBy,
           blocking: profileInfo.requesterBlocking || undefined,
           following: profileInfo?.requesterFollowing || undefined,
@@ -244,41 +279,6 @@ export class ActorViews {
     }))
 
     return Array.isArray(result) ? views : views[0]
-  }
-
-  async getListMutes(
-    subjects: string[],
-    mutedBy: string,
-  ): Promise<Record<string, ListViewBasic>> {
-    if (subjects.length < 1) return {}
-    const res = await this.db.db
-      .selectFrom('list_item')
-      .innerJoin('list_mute', 'list_mute.listUri', 'list_item.listUri')
-      .innerJoin('list', 'list.uri', 'list_item.listUri')
-      .where('list_mute.mutedByDid', '=', mutedBy)
-      .where('list_item.subjectDid', 'in', subjects)
-      .selectAll('list')
-      .select('list_item.subjectDid as subjectDid')
-      .execute()
-    return res.reduce(
-      (acc, cur) => ({
-        ...acc,
-        [cur.subjectDid]: {
-          uri: cur.uri,
-          cid: cur.cid,
-          name: cur.name,
-          purpose: cur.purpose,
-          avatar: cur.avatarCid
-            ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
-            : undefined,
-          viewer: {
-            muted: true,
-          },
-          indexedAt: cur.indexedAt,
-        },
-      }),
-      {} as Record<string, ListViewBasic>,
-    )
   }
 }
 

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -9,12 +9,17 @@ import Database from '../../../db'
 import { ImageUriBuilder } from '../../../image/uri'
 import { LabelService } from '../label'
 import { GraphService } from '../graph'
+import { LabelCache } from '../../../label-cache'
 
 export class ActorViews {
-  constructor(private db: Database, private imgUriBuilder: ImageUriBuilder) {}
+  constructor(
+    private db: Database,
+    private imgUriBuilder: ImageUriBuilder,
+    private labelCache: LabelCache,
+  ) {}
 
   services = {
-    label: LabelService.creator()(this.db),
+    label: LabelService.creator(this.labelCache)(this.db),
     graph: GraphService.creator(this.imgUriBuilder)(this.db),
   }
 

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -94,6 +94,7 @@ export class ActorViews {
           .where('list_mute.mutedByDid', '=', viewer)
           .whereRef('list_item.subjectDid', '=', ref('did_handle.did'))
           .select('list_item.listUri')
+          .limit(1)
           .as('requesterMutedByList'),
       ])
 
@@ -210,6 +211,7 @@ export class ActorViews {
           .where('list_mute.mutedByDid', '=', viewer)
           .whereRef('list_item.subjectDid', '=', ref('did_handle.did'))
           .select('list_item.listUri')
+          .limit(1)
           .as('requesterMutedByList'),
       ])
 

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -171,6 +171,7 @@ export class FeedService {
             .where('list_mute.mutedByDid', '=', requester)
             .whereRef('list_item.subjectDid', '=', ref('did_handle.did'))
             .select('list_item.listUri')
+            .limit(1)
             .as('requesterMutedByList'),
         ])
         .execute(),

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -29,20 +29,25 @@ import { LabelService } from '../label'
 import { ActorService } from '../actor'
 import { GraphService } from '../graph'
 import { FeedViews } from './views'
+import { LabelCache } from '../../../label-cache'
 
 export * from './types'
 
 export class FeedService {
-  constructor(public db: Database, public imgUriBuilder: ImageUriBuilder) {}
+  constructor(
+    public db: Database,
+    public imgUriBuilder: ImageUriBuilder,
+    public labelCache: LabelCache,
+  ) {}
 
-  static creator(imgUriBuilder: ImageUriBuilder) {
-    return (db: Database) => new FeedService(db, imgUriBuilder)
+  static creator(imgUriBuilder: ImageUriBuilder, labelCache: LabelCache) {
+    return (db: Database) => new FeedService(db, imgUriBuilder, labelCache)
   }
 
   views = new FeedViews(this.db, this.imgUriBuilder)
   services = {
-    label: LabelService.creator()(this.db),
-    actor: ActorService.creator(this.imgUriBuilder)(this.db),
+    label: LabelService.creator(this.labelCache)(this.db),
+    actor: ActorService.creator(this.imgUriBuilder, this.labelCache)(this.db),
     graph: GraphService.creator(this.imgUriBuilder)(this.db),
   }
 

--- a/packages/pds/src/app-view/services/graph/index.ts
+++ b/packages/pds/src/app-view/services/graph/index.ts
@@ -132,6 +132,22 @@ export class GraphService {
       },
     }
   }
+
+  formatListViewBasic(list: ListInfo) {
+    return {
+      uri: list.uri,
+      cid: list.cid,
+      name: list.name,
+      purpose: list.purpose,
+      avatar: list.avatarCid
+        ? this.imgUriBuilder.getCommonSignedUri('avatar', list.avatarCid)
+        : undefined,
+      indexedAt: list.indexedAt,
+      viewer: {
+        muted: !!list.viewerMuted,
+      },
+    }
+  }
 }
 
 type ListInfo = List & {

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -18,6 +18,7 @@ import { BackgroundQueue } from './event-stream/background-queue'
 import DidSqlCache from './did-cache'
 import { MountedAlgos } from './feed-gen/types'
 import { Crawlers } from './crawlers'
+import { LabelCache } from './label-cache'
 
 export class AppContext {
   private _appviewAgent: AtpAgent | null
@@ -39,6 +40,7 @@ export class AppContext {
       sequencer: Sequencer
       sequencerLeader: SequencerLeader
       labeler: Labeler
+      labelCache: LabelCache
       backgroundQueue: BackgroundQueue
       crawlers: Crawlers
       algos: MountedAlgos
@@ -129,6 +131,10 @@ export class AppContext {
 
   get labeler(): Labeler {
     return this.opts.labeler
+  }
+
+  get labelCache(): LabelCache {
+    return this.opts.labelCache
   }
 
   get backgroundQueue(): BackgroundQueue {

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -24,8 +24,8 @@ const handler: AlgoHandler = async (
 
   let postsQb = feedService
     .selectPostQb()
-    .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
-    .where('post_agg.likeCount', '>=', 6)
+    // .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
+    // .where('post_agg.likeCount', '>=', 6)
     .whereExists((qb) =>
       qb
         .selectFrom('follow')

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -25,7 +25,7 @@ const handler: AlgoHandler = async (
   let postsQb = feedService
     .selectPostQb()
     .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
-    .where('post_agg.likeCount', '>=', 4)
+    .where('post_agg.likeCount', '>=', 6)
     .whereExists((qb) =>
       qb
         .selectFrom('follow')

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -12,6 +12,7 @@ const handler: AlgoHandler = async (
   params: SkeletonParams,
   requester: string,
 ): Promise<AlgoResponse> => {
+  // Temporary change to only return a post notifying users that the feed is down
   return {
     feedItems: [
       {

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -25,7 +25,7 @@ const handler: AlgoHandler = async (
   let postsQb = feedService
     .selectPostQb()
     .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
-    .where('post_agg.likeCount', '>=', 5)
+    .where('post_agg.likeCount', '>=', 4)
     .whereExists((qb) =>
       qb
         .selectFrom('follow')

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -12,39 +12,42 @@ const handler: AlgoHandler = async (
   params: SkeletonParams,
   requester: string,
 ): Promise<AlgoResponse> => {
-  const { cursor, limit = 50 } = params
-  const accountService = ctx.services.account(ctx.db)
-  const feedService = ctx.services.appView.feed(ctx.db)
-  const graphService = ctx.services.appView.graph(ctx.db)
-
-  const { ref } = ctx.db.db.dynamic
-
-  const keyset = new FeedKeyset(ref('post.indexedAt'), ref('post.cid'))
-  const sortFrom = keyset.unpack(cursor)?.primary
-
-  let postsQb = feedService
-    .selectPostQb()
-    // .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
-    // .where('post_agg.likeCount', '>=', 6)
-    .whereExists((qb) =>
-      qb
-        .selectFrom('follow')
-        .where('follow.creator', '=', requester)
-        .whereRef('follow.subjectDid', '=', 'post.creator'),
-    )
-    .where((qb) =>
-      accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
-    )
-    .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
-    .where('post.indexedAt', '>', getFeedDateThreshold(sortFrom))
-
-  postsQb = paginate(postsQb, { limit, cursor, keyset, tryIndex: true })
-
-  const feedItems = await postsQb.execute()
   return {
-    feedItems,
-    cursor: keyset.packFromResult(feedItems),
+    feedItems: [],
   }
+  // const { cursor, limit = 50 } = params
+  // const accountService = ctx.services.account(ctx.db)
+  // const feedService = ctx.services.appView.feed(ctx.db)
+  // const graphService = ctx.services.appView.graph(ctx.db)
+
+  // const { ref } = ctx.db.db.dynamic
+
+  // const keyset = new FeedKeyset(ref('post.indexedAt'), ref('post.cid'))
+  // const sortFrom = keyset.unpack(cursor)?.primary
+
+  // let postsQb = feedService
+  //   .selectPostQb()
+  //   // .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
+  //   // .where('post_agg.likeCount', '>=', 6)
+  //   .whereExists((qb) =>
+  //     qb
+  //       .selectFrom('follow')
+  //       .where('follow.creator', '=', requester)
+  //       .whereRef('follow.subjectDid', '=', 'post.creator'),
+  //   )
+  //   .where((qb) =>
+  //     accountService.whereNotMuted(qb, requester, [ref('post.creator')]),
+  //   )
+  //   .whereNotExists(graphService.blockQb(requester, [ref('post.creator')]))
+  //   .where('post.indexedAt', '>', getFeedDateThreshold(sortFrom))
+
+  // postsQb = paginate(postsQb, { limit, cursor, keyset, tryIndex: true })
+
+  // const feedItems = await postsQb.execute()
+  // return {
+  //   feedItems,
+  //   cursor: keyset.packFromResult(feedItems),
+  // }
 }
 
 export default handler

--- a/packages/pds/src/feed-gen/with-friends.ts
+++ b/packages/pds/src/feed-gen/with-friends.ts
@@ -13,7 +13,20 @@ const handler: AlgoHandler = async (
   requester: string,
 ): Promise<AlgoResponse> => {
   return {
-    feedItems: [],
+    feedItems: [
+      {
+        type: 'post',
+        uri: 'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3jzinucnmbi2c',
+        cid: 'bafyreifmtn55tubbv7tefrq277nzfy4zu7ioithky276aho5ehb6w3nu6q',
+        postUri:
+          'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3jzinucnmbi2c',
+        postAuthorDid: 'did:plc:z72i7hdynmk6r22z27h6tvur',
+        originatorDid: 'did:plc:z72i7hdynmk6r22z27h6tvur',
+        replyParent: null,
+        replyRoot: null,
+        sortAt: '2023-07-01T23:04:27.853Z',
+      },
+    ],
   }
   // const { cursor, limit = 50 } = params
   // const accountService = ctx.services.account(ctx.db)

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -271,7 +271,7 @@ export class PDS {
     this.ctx.sequencerLeader.run()
     await this.ctx.sequencer.start()
     await this.ctx.db.startListeningToChannels()
-    await this.ctx.labelCache.start()
+    this.ctx.labelCache.start()
     const server = this.app.listen(this.ctx.cfg.port)
     this.server = server
     this.server.keepAliveTimeout = 90000

--- a/packages/pds/src/label-cache.ts
+++ b/packages/pds/src/label-cache.ts
@@ -1,0 +1,65 @@
+import { createDeferrable, wait } from '@atproto/common'
+import Database from './db'
+import { Label } from './db/tables/label'
+
+export class LabelCache {
+  bySubject: Record<string, Label[]> = {}
+  latestLabel = ''
+  defer = createDeferrable()
+
+  destroyed = false
+
+  constructor(public db: Database) {}
+
+  async start() {
+    const allLabels = await this.db.db.selectFrom('label').selectAll().execute()
+    this.processLabels(allLabels)
+    this.poll()
+  }
+
+  async poll() {
+    if (this.destroyed) return
+    const labels = await this.db.db
+      .selectFrom('label')
+      .selectAll()
+      .where('cts', '>', this.latestLabel)
+      .execute()
+    this.processLabels(labels)
+    this.defer = createDeferrable()
+    await wait(500)
+    this.poll()
+  }
+
+  async catchUp() {
+    await this.defer.complete
+  }
+
+  processLabels(labels: Label[]) {
+    for (const label of labels) {
+      if (label.cts > this.latestLabel) {
+        this.latestLabel = label.cts
+      }
+      this.bySubject[label.uri] ??= []
+      this.bySubject[label.uri].push(label)
+    }
+    this.defer.resolve()
+  }
+
+  stop() {
+    this.destroyed = true
+  }
+
+  forSubject(subject: string, includeNeg = false): Label[] {
+    const labels = this.bySubject[subject] ?? []
+    return includeNeg ? labels : labels.filter((l) => l.neg === 0)
+  }
+
+  forSubjects(subjects: string[], includeNeg?: boolean): Label[] {
+    let labels: Label[] = []
+    for (const subject of subjects) {
+      const subLabels = this.forSubject(subject, includeNeg)
+      labels = [...labels, ...subLabels]
+    }
+    return labels
+  }
+}

--- a/packages/pds/src/label-cache.ts
+++ b/packages/pds/src/label-cache.ts
@@ -1,11 +1,10 @@
-import { createDeferrable, wait } from '@atproto/common'
+import { wait } from '@atproto/common'
 import Database from './db'
 import { Label } from './db/tables/label'
 
 export class LabelCache {
   bySubject: Record<string, Label[]> = {}
   latestLabel = ''
-  defer = createDeferrable()
   refreshes = 0
 
   destroyed = false
@@ -41,13 +40,8 @@ export class LabelCache {
       await this.partialRefresh()
       this.refreshes++
     }
-    this.defer = createDeferrable()
     await wait(500)
     this.poll()
-  }
-
-  async catchUp() {
-    await this.defer.complete
   }
 
   processLabels(labels: Label[]) {
@@ -58,7 +52,6 @@ export class LabelCache {
       this.bySubject[label.uri] ??= []
       this.bySubject[label.uri].push(label)
     }
-    this.defer.resolve()
   }
 
   wipeCache() {

--- a/packages/pds/src/label-cache.ts
+++ b/packages/pds/src/label-cache.ts
@@ -34,7 +34,7 @@ export class LabelCache {
 
   async poll() {
     if (this.destroyed) return
-    if (this.refreshes >= 60) {
+    if (this.refreshes >= 120) {
       await this.fullRefresh()
       this.refreshes = 0
     } else {
@@ -42,7 +42,7 @@ export class LabelCache {
       this.refreshes++
     }
     this.defer = createDeferrable()
-    await wait(1000)
+    await wait(500)
     this.poll()
   }
 
@@ -76,9 +76,14 @@ export class LabelCache {
 
   forSubjects(subjects: string[], includeNeg?: boolean): Label[] {
     let labels: Label[] = []
+    const alreadyAdded = new Set<string>()
     for (const subject of subjects) {
+      if (alreadyAdded.has(subject)) {
+        continue
+      }
       const subLabels = this.forSubject(subject, includeNeg)
       labels = [...labels, ...subLabels]
+      alreadyAdded.add(subject)
     }
     return labels
   }

--- a/packages/pds/src/sequencer/outbox.ts
+++ b/packages/pds/src/sequencer/outbox.ts
@@ -108,14 +108,14 @@ export class Outbox {
       const evts = await this.sequencer.requestSeqRange({
         earliestTime: backfillTime,
         earliestSeq: this.lastSeen > -1 ? this.lastSeen : backfillCursor,
-        limit: 10,
+        limit: 100,
       })
       for (const evt of evts) {
         yield evt
       }
       // if we're within 50 of the sequencer, we call it good & switch to cutover
       const seqCursor = this.sequencer.lastSeen ?? -1
-      if (seqCursor - this.lastSeen < 10) break
+      if (seqCursor - this.lastSeen < 100) break
       if (evts.length < 1) break
     }
   }

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -106,7 +106,7 @@ export class SequencerLeader {
     const unsequenced = await this.getUnsequenced()
     const chunks = chunkArray(unsequenced, 2000)
     for (const chunk of chunks) {
-      await this.db.transaction((dbTxn) => {
+      await this.db.transaction(async (dbTxn) => {
         await Promise.all(
           chunk.map((row) =>
             dbTxn.db
@@ -115,8 +115,8 @@ export class SequencerLeader {
               .where('id', '=', row.id)
               .execute(),
           ),
-        ),
-          await this.db.notify('outgoing_repo_seq')
+        )
+        await this.db.notify('outgoing_repo_seq')
       })
     }
   }

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -104,7 +104,7 @@ export class SequencerLeader {
 
   async sequenceOutgoing() {
     const unsequenced = await this.getUnsequenced()
-    const chunks = chunkArray(unsequenced, 5000)
+    const chunks = chunkArray(unsequenced, 10000)
     for (const chunk of chunks) {
       await this.db.transaction((dbTxn) =>
         Promise.all(

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -108,16 +108,17 @@ export class SequencerLeader {
     for (const chunk of chunks) {
       await this.db.transaction(async (dbTxn) => {
         await Promise.all(
-          chunk.map((row) =>
-            dbTxn.db
+          chunk.map(async (row) => {
+            await dbTxn.db
               .updateTable('repo_seq')
               .set({ seq: this.nextSeqVal() })
               .where('id', '=', row.id)
-              .execute(),
-          ),
+              .execute()
+            await this.db.notify('outgoing_repo_seq')
+          }),
         )
-        await this.db.notify('outgoing_repo_seq')
       })
+      await this.db.notify('outgoing_repo_seq')
     }
   }
 

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -104,7 +104,7 @@ export class SequencerLeader {
 
   async sequenceOutgoing() {
     const unsequenced = await this.getUnsequenced()
-    const chunks = chunkArray(unsequenced, 10000)
+    const chunks = chunkArray(unsequenced, 2000)
     for (const chunk of chunks) {
       await this.db.transaction((dbTxn) =>
         Promise.all(
@@ -117,8 +117,8 @@ export class SequencerLeader {
           ),
         ),
       )
+      await this.db.notify('outgoing_repo_seq')
     }
-    await this.db.notify('outgoing_repo_seq')
   }
 
   async getUnsequenced() {

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -106,8 +106,8 @@ export class SequencerLeader {
     const unsequenced = await this.getUnsequenced()
     const chunks = chunkArray(unsequenced, 2000)
     for (const chunk of chunks) {
-      await this.db.transaction((dbTxn) =>
-        Promise.all(
+      await this.db.transaction((dbTxn) => {
+        await Promise.all(
           chunk.map((row) =>
             dbTxn.db
               .updateTable('repo_seq')
@@ -116,8 +116,8 @@ export class SequencerLeader {
               .execute(),
           ),
         ),
-      )
-      await this.db.notify('outgoing_repo_seq')
+          await this.db.notify('outgoing_repo_seq')
+      })
     }
   }
 

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -104,7 +104,7 @@ export class SequencerLeader {
 
   async sequenceOutgoing() {
     const unsequenced = await this.getUnsequenced()
-    const chunks = chunkArray(unsequenced, 2000)
+    const chunks = chunkArray(unsequenced, 5000)
     for (const chunk of chunks) {
       await this.db.transaction((dbTxn) =>
         Promise.all(

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -126,7 +126,7 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
     try {
       const evts = await this.requestSeqRange({
         earliestSeq: this.lastSeen,
-        limit: 10,
+        limit: 50,
       })
       if (evts.length > 0) {
         this.emit('events', evts)

--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -17,6 +17,7 @@ import { Labeler } from '../labeler'
 import { LabelService } from '../app-view/services/label'
 import { BackgroundQueue } from '../event-stream/background-queue'
 import { Crawlers } from '../crawlers'
+import { LabelCache } from '../label-cache'
 
 export function createServices(resources: {
   repoSigningKey: crypto.Keypair
@@ -25,6 +26,7 @@ export function createServices(resources: {
   imgUriBuilder: ImageUriBuilder
   imgInvalidator: ImageInvalidator
   labeler: Labeler
+  labelCache: LabelCache
   backgroundQueue: BackgroundQueue
   crawlers: Crawlers
 }): Services {
@@ -35,6 +37,7 @@ export function createServices(resources: {
     imgUriBuilder,
     imgInvalidator,
     labeler,
+    labelCache,
     backgroundQueue,
     crawlers,
   } = resources
@@ -57,11 +60,11 @@ export function createServices(resources: {
       imgInvalidator,
     ),
     appView: {
-      actor: ActorService.creator(imgUriBuilder),
+      actor: ActorService.creator(imgUriBuilder, labelCache),
       graph: GraphService.creator(imgUriBuilder),
-      feed: FeedService.creator(imgUriBuilder),
+      feed: FeedService.creator(imgUriBuilder, labelCache),
       indexing: IndexingService.creator(backgroundQueue),
-      label: LabelService.creator(),
+      label: LabelService.creator(labelCache),
     },
   }
 }

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -25,6 +25,7 @@ export type TestServerInfo = {
   url: string
   ctx: AppContext
   close: CloseFn
+  processAll: () => Promise<void>
 }
 
 export type TestServerOpts = {
@@ -154,12 +155,20 @@ export const runTestServer = async (
   const pdsServer = await pds.start()
   const pdsPort = (pdsServer.address() as AddressInfo).port
 
+  // we refresh label cache by hand in `processAll` instead of on a timer
+  pds.ctx.labelCache.stop()
+
   return {
     url: `http://localhost:${pdsPort}`,
     ctx: pds.ctx,
     close: async () => {
       await pds.destroy()
       await plcServer.destroy()
+    },
+    processAll: async () => {
+      await pds.ctx.backgroundQueue.processAll()
+      await pds.ctx.labelCache.fullRefresh()
+      await pds.ctx.labelCache.catchUp()
     },
   }
 }

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -168,7 +168,6 @@ export const runTestServer = async (
     processAll: async () => {
       await pds.ctx.backgroundQueue.processAll()
       await pds.ctx.labelCache.fullRefresh()
-      await pds.ctx.labelCache.catchUp()
     },
   }
 }

--- a/packages/pds/tests/account-deletion.test.ts
+++ b/packages/pds/tests/account-deletion.test.ts
@@ -146,7 +146,7 @@ describe('account deletion', () => {
       did: carol.did,
       password: carol.password,
     })
-    await server.ctx.backgroundQueue.processAll() // Finish background hard-deletions
+    await server.processAll() // Finish background hard-deletions
   })
 
   it('no longer lets the user log in', async () => {

--- a/packages/pds/tests/algos/hot-classic.test.ts
+++ b/packages/pds/tests/algos/hot-classic.test.ts
@@ -35,7 +35,7 @@ describe('algo hot-classic', () => {
 
     alice = sc.dids.alice
     bob = sc.dids.bob
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
   })
 
   afterAll(async () => {
@@ -63,7 +63,7 @@ describe('algo hot-classic', () => {
       await sc.like(sc.dids[name], two.ref)
       await sc.like(sc.dids[name], three.ref)
     }
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const res = await agent.api.app.bsky.feed.getFeed(
       { feed: feedUri },

--- a/packages/pds/tests/algos/whats-hot.test.ts
+++ b/packages/pds/tests/algos/whats-hot.test.ts
@@ -38,7 +38,7 @@ describe('algo whats-hot', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     carol = sc.dids.carol
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
   })
 
   afterAll(async () => {
@@ -76,7 +76,7 @@ describe('algo whats-hot', () => {
         await sc.like(sc.dids[name], five.ref)
       }
     }
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     // move the 3rd post 5 hours into the past to check gravity
     await server.ctx.db.db

--- a/packages/pds/tests/algos/with-friends.test.ts
+++ b/packages/pds/tests/algos/with-friends.test.ts
@@ -40,7 +40,7 @@ describe.skip('algo with friends', () => {
     carol = sc.dids.carol
     dan = sc.dids.dan
 
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/blob-deletes.test.ts
+++ b/packages/pds/tests/blob-deletes.test.ts
@@ -58,7 +58,7 @@ describe('blob deletes', () => {
     )
     const post = await sc.post(alice, 'test', undefined, [img])
     await sc.deletePost(alice, post.ref.uri)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(0)
@@ -80,7 +80,7 @@ describe('blob deletes', () => {
     )
     await updateProfile(sc, alice, img.image, img.image)
     await updateProfile(sc, alice, img2.image, img2.image)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(1)
@@ -109,7 +109,7 @@ describe('blob deletes', () => {
     )
     await updateProfile(sc, alice, img.image, img.image)
     await updateProfile(sc, alice, img.image, img2.image)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(2)
@@ -160,7 +160,7 @@ describe('blob deletes', () => {
       },
       { encoding: 'application/json', headers: sc.getHeaders(alice) },
     )
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const dbBlobs = await getDbBlobsForDid(alice)
     expect(dbBlobs.length).toBe(1)

--- a/packages/pds/tests/event-stream/sync.test.ts
+++ b/packages/pds/tests/event-stream/sync.test.ts
@@ -68,6 +68,7 @@ describe('sync', () => {
         services.repo(dbTxn).indexWrites(writes, now),
       )
     }
+    await server.processAll()
     // Check indexed timeline
     const aliceTL = await agent.api.app.bsky.feed.getTimeline(
       {},

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -38,7 +38,7 @@ describe('feed generation', () => {
     agent = network.pds.getClient()
     sc = new SeedClient(agent)
     await basicSeed(sc)
-    await network.pds.ctx.backgroundQueue.processAll()
+    await network.processAll()
     alice = sc.dids.alice
     const allUri = AtUri.make(alice, 'app.bsky.feed.generator', 'all')
     const feedUriBadPagination = AtUri.make(

--- a/packages/pds/tests/indexing.test.ts
+++ b/packages/pds/tests/indexing.test.ts
@@ -82,7 +82,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.alice, writes: [createRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterCreate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -95,7 +95,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.alice, writes: [updateRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterUpdate = await agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -108,7 +108,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.alice, writes: [deleteRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterDelete = agent.api.app.bsky.feed.getPostThread(
       { uri: uri.toString() },
@@ -157,7 +157,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.dan, writes: [createRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterCreate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -170,7 +170,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.dan, writes: [updateRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterUpdate = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },
@@ -183,7 +183,7 @@ describe('indexing', () => {
     await services
       .repo(db)
       .processWrites({ did: sc.dids.dan, writes: [deleteRecord] }, 1)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const getAfterDelete = await agent.api.app.bsky.actor.getProfile(
       { actor: sc.dids.dan },

--- a/packages/pds/tests/labeler/labeler.test.ts
+++ b/packages/pds/tests/labeler/labeler.test.ts
@@ -1,6 +1,6 @@
 import { AtUri, BlobRef } from '@atproto/api'
 import stream from 'stream'
-import { runTestServer, CloseFn } from '../_util'
+import { runTestServer, CloseFn, TestServerInfo } from '../_util'
 import { Labeler } from '../../src/labeler'
 import { AppContext, Database } from '../../src'
 import { BlobStore, cidForRecord } from '@atproto/repo'
@@ -11,6 +11,7 @@ import { LabelService } from '../../src/app-view/services/label'
 import { BackgroundQueue } from '../../src/event-stream/background-queue'
 
 describe('labeler', () => {
+  let server: TestServerInfo
   let close: CloseFn
   let labeler: Labeler
   let labelSrvc: LabelService
@@ -21,7 +22,7 @@ describe('labeler', () => {
   let goodBlob: BlobRef
 
   beforeAll(async () => {
-    const server = await runTestServer({
+    server = await runTestServer({
       dbPostgresSchema: 'views_author_feed',
     })
     close = server.close
@@ -63,6 +64,7 @@ describe('labeler', () => {
     const uri = postUri()
     labeler.processRecord(uri, post)
     await labeler.processAll()
+    await server.ctx.labelCache.catchUp()
     const labels = await labelSrvc.getLabels(uri.toString())
     expect(labels.length).toBe(1)
     expect(labels[0]).toMatchObject({
@@ -100,6 +102,7 @@ describe('labeler', () => {
     const uri = postUri()
     labeler.processRecord(uri, post)
     await labeler.processAll()
+    await server.ctx.labelCache.catchUp()
     const dbLabels = await labelSrvc.getLabels(uri.toString())
     const labels = dbLabels.map((row) => row.val).sort()
     expect(labels).toEqual(
@@ -119,6 +122,7 @@ describe('labeler', () => {
         cts: new Date().toISOString(),
       })
       .execute()
+    await server.ctx.labelCache.catchUp()
 
     const labels = await labelSrvc.getLabelsForProfile('did:example:alice')
     // 4 from earlier & then just added one

--- a/packages/pds/tests/labeler/labeler.test.ts
+++ b/packages/pds/tests/labeler/labeler.test.ts
@@ -64,7 +64,7 @@ describe('labeler', () => {
     const uri = postUri()
     labeler.processRecord(uri, post)
     await labeler.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
     const labels = await labelSrvc.getLabels(uri.toString())
     expect(labels.length).toBe(1)
     expect(labels[0]).toMatchObject({
@@ -102,7 +102,7 @@ describe('labeler', () => {
     const uri = postUri()
     labeler.processRecord(uri, post)
     await labeler.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
     const dbLabels = await labelSrvc.getLabels(uri.toString())
     const labels = dbLabels.map((row) => row.val).sort()
     expect(labels).toEqual(
@@ -122,7 +122,7 @@ describe('labeler', () => {
         cts: new Date().toISOString(),
       })
       .execute()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
 
     const labels = await labelSrvc.getLabelsForProfile('did:example:alice')
     // 4 from earlier & then just added one

--- a/packages/pds/tests/migrations/blob-creator.test.ts
+++ b/packages/pds/tests/migrations/blob-creator.test.ts
@@ -4,7 +4,7 @@ import { cidForCbor, TID } from '@atproto/common'
 import { Kysely } from 'kysely'
 import { AtUri } from '@atproto/uri'
 
-describe('blob creator migration', () => {
+describe.skip('blob creator migration', () => {
   let db: Database
   let rawDb: Kysely<any>
 

--- a/packages/pds/tests/migrations/indexed-at-on-record.test.ts
+++ b/packages/pds/tests/migrations/indexed-at-on-record.test.ts
@@ -4,7 +4,7 @@ import { dataToCborBlock, TID } from '@atproto/common'
 import { AtUri } from '@atproto/uri'
 import { Kysely } from 'kysely'
 
-describe('indexedAt on record migration', () => {
+describe.skip('indexedAt on record migration', () => {
   let db: Database
   let rawDb: Kysely<any>
 

--- a/packages/pds/tests/migrations/post-hierarchy.test.ts
+++ b/packages/pds/tests/migrations/post-hierarchy.test.ts
@@ -5,7 +5,7 @@ import usersSeed from '../seeds/users'
 import threadSeed, { walk, item, Item } from '../seeds/thread'
 import { CloseFn, runTestServer } from '../_util'
 
-describe('post hierarchy migration', () => {
+describe.skip('post hierarchy migration', () => {
   let db: Database
   let close: CloseFn
   let sc: SeedClient

--- a/packages/pds/tests/migrations/repo-sync-data-pt2.test.ts
+++ b/packages/pds/tests/migrations/repo-sync-data-pt2.test.ts
@@ -5,7 +5,7 @@ import { CloseFn, runTestServer } from '../_util'
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
 
-describe('repo sync data migration', () => {
+describe.skip('repo sync data migration', () => {
   let db: Database
   let rawDb: Kysely<any>
   let close: CloseFn

--- a/packages/pds/tests/migrations/repo-sync-data.test.ts
+++ b/packages/pds/tests/migrations/repo-sync-data.test.ts
@@ -5,7 +5,7 @@ import { TID } from '@atproto/common'
 import { Kysely } from 'kysely'
 import { CID } from 'multiformats/cid'
 
-describe('repo sync data migration', () => {
+describe.skip('repo sync data migration', () => {
   let db: Database
   let rawDb: Kysely<any>
   let memoryStore: MemoryBlockstore

--- a/packages/pds/tests/migrations/user-partitioned-cids.test.ts
+++ b/packages/pds/tests/migrations/user-partitioned-cids.test.ts
@@ -5,7 +5,7 @@ import { Kysely } from 'kysely'
 import { Block } from 'multiformats/block'
 import * as uint8arrays from 'uint8arrays'
 
-describe('user partitioned cids migration', () => {
+describe.skip('user partitioned cids migration', () => {
   let db: Database
   let rawDb: Kysely<any>
 

--- a/packages/pds/tests/migrations/user-table-did-pkey.test.ts
+++ b/packages/pds/tests/migrations/user-table-did-pkey.test.ts
@@ -2,7 +2,7 @@ import { Database } from '../../src'
 import { randomStr } from '@atproto/crypto'
 import { Kysely } from 'kysely'
 
-describe('user table did pkey migration', () => {
+describe.skip('user table did pkey migration', () => {
   let db: Database
   let rawDb: Kysely<any>
 

--- a/packages/pds/tests/moderation.test.ts
+++ b/packages/pds/tests/moderation.test.ts
@@ -292,7 +292,7 @@ describe('moderation', () => {
         password: 'password',
         token: deletionToken,
       })
-      await server.ctx.backgroundQueue.processAll()
+      await server.processAll()
       // Take action on deleted content
       const { data: action } =
         await agent.api.com.atproto.admin.takeModerationAction(

--- a/packages/pds/tests/proxied/feedgen.test.ts
+++ b/packages/pds/tests/proxied/feedgen.test.ts
@@ -36,7 +36,6 @@ describe('feedgen proxy view', () => {
       sc.getHeaders(sc.dids.alice),
     )
     await network.processAll()
-    await network.bsky.ctx.backgroundQueue.processAll()
     // mock getFeedGenerator() for use by pds's getFeed since we don't have a proper feedGenDid or feed publisher
     FeedNS.prototype.getFeedGenerator = async function (params, opts) {
       if (params?.feed === feedUri.toString()) {

--- a/packages/pds/tests/views/actor-search.test.ts
+++ b/packages/pds/tests/views/actor-search.test.ts
@@ -28,8 +28,7 @@ describe('pds user search views', () => {
     sc = new SeedClient(agent)
     await usersBulkSeed(sc)
     headers = sc.getHeaders(Object.values(sc.dids)[0])
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/actor-search.test.ts
+++ b/packages/pds/tests/views/actor-search.test.ts
@@ -29,6 +29,7 @@ describe('pds user search views', () => {
     await usersBulkSeed(sc)
     headers = sc.getHeaders(Object.values(sc.dids)[0])
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -33,8 +33,7 @@ describe('pds author feed views', () => {
     bob = sc.dids.bob
     carol = sc.dids.carol
     dan = sc.dids.dan
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -34,6 +34,7 @@ describe('pds author feed views', () => {
     carol = sc.dids.carol
     dan = sc.dids.dan
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -44,6 +44,7 @@ describe('pds views with blocking', () => {
       'alice replies to dan',
     )
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/blocks.test.ts
+++ b/packages/pds/tests/views/blocks.test.ts
@@ -43,8 +43,7 @@ describe('pds views with blocking', () => {
       sc.posts[dan][0].ref,
       'alice replies to dan',
     )
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/follows.test.ts
+++ b/packages/pds/tests/views/follows.test.ts
@@ -28,6 +28,7 @@ describe('pds follow views', () => {
     await followsSeed(sc)
     alice = sc.dids.alice
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/follows.test.ts
+++ b/packages/pds/tests/views/follows.test.ts
@@ -27,8 +27,7 @@ describe('pds follow views', () => {
     sc = new SeedClient(agent)
     await followsSeed(sc)
     alice = sc.dids.alice
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/likes.test.ts
+++ b/packages/pds/tests/views/likes.test.ts
@@ -29,6 +29,7 @@ describe('pds like views', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/likes.test.ts
+++ b/packages/pds/tests/views/likes.test.ts
@@ -28,8 +28,7 @@ describe('pds like views', () => {
     await likesSeed(sc)
     alice = sc.dids.alice
     bob = sc.dids.bob
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/mute-lists.test.ts
+++ b/packages/pds/tests/views/mute-lists.test.ts
@@ -31,6 +31,7 @@ describe('pds views with mutes from mute lists', () => {
     await sc.follow(carol, dan)
     await sc.follow(dan, carol)
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/mute-lists.test.ts
+++ b/packages/pds/tests/views/mute-lists.test.ts
@@ -30,8 +30,7 @@ describe('pds views with mutes from mute lists', () => {
     // add follows to ensure mutes work even w follows
     await sc.follow(carol, dan)
     await sc.follow(dan, carol)
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/mutes.test.ts
+++ b/packages/pds/tests/views/mutes.test.ts
@@ -32,8 +32,7 @@ describe('mute views', () => {
         { headers: sc.getHeaders(silas), encoding: 'application/json' },
       )
     }
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/mutes.test.ts
+++ b/packages/pds/tests/views/mutes.test.ts
@@ -33,6 +33,7 @@ describe('mute views', () => {
       )
     }
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -33,8 +33,7 @@ describe('pds notification views', () => {
     sc = new SeedClient(agent)
     await basicSeed(sc)
     alice = sc.dids.alice
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {
@@ -76,8 +75,7 @@ describe('pds notification views', () => {
       sc.replies[alice][0].ref,
       'indeed',
     )
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
 
     const notifCountAlice =
       await agent.api.app.bsky.notification.getUnreadCount(

--- a/packages/pds/tests/views/notifications.test.ts
+++ b/packages/pds/tests/views/notifications.test.ts
@@ -34,6 +34,7 @@ describe('pds notification views', () => {
     await basicSeed(sc)
     alice = sc.dids.alice
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {
@@ -76,6 +77,7 @@ describe('pds notification views', () => {
       'indeed',
     )
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
 
     const notifCountAlice =
       await agent.api.app.bsky.notification.getUnreadCount(

--- a/packages/pds/tests/views/popular.test.ts
+++ b/packages/pds/tests/views/popular.test.ts
@@ -55,6 +55,7 @@ describe('popular views', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/popular.test.ts
+++ b/packages/pds/tests/views/popular.test.ts
@@ -54,8 +54,7 @@ describe('popular views', () => {
 
     alice = sc.dids.alice
     bob = sc.dids.bob
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {
@@ -83,7 +82,7 @@ describe('popular views', () => {
       await sc.like(sc.dids[name], two.ref)
       await sc.like(sc.dids[name], three.ref)
     }
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const res = await agent.api.app.bsky.unspecced.getPopular(
       {},

--- a/packages/pds/tests/views/posts.test.ts
+++ b/packages/pds/tests/views/posts.test.ts
@@ -16,6 +16,7 @@ describe('pds posts views', () => {
     sc = new SeedClient(agent)
     await basicSeed(sc)
     await server.ctx.labeler.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/posts.test.ts
+++ b/packages/pds/tests/views/posts.test.ts
@@ -15,8 +15,7 @@ describe('pds posts views', () => {
     agent = new AtpAgent({ service: server.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
-    await server.ctx.labeler.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -27,8 +27,7 @@ describe('pds profile views', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     dan = sc.dids.dan
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/profile.test.ts
+++ b/packages/pds/tests/views/profile.test.ts
@@ -28,6 +28,7 @@ describe('pds profile views', () => {
     bob = sc.dids.bob
     dan = sc.dids.dan
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/reposts.test.ts
+++ b/packages/pds/tests/views/reposts.test.ts
@@ -23,6 +23,7 @@ describe('pds repost views', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/reposts.test.ts
+++ b/packages/pds/tests/views/reposts.test.ts
@@ -22,8 +22,7 @@ describe('pds repost views', () => {
     await repostsSeed(sc)
     alice = sc.dids.alice
     bob = sc.dids.bob
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/suggestions.test.ts
+++ b/packages/pds/tests/views/suggestions.test.ts
@@ -17,6 +17,7 @@ describe('pds user search views', () => {
     sc = new SeedClient(agent)
     await basicSeed(sc)
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
 
     const suggestions = [
       { did: sc.dids.bob, order: 1 },

--- a/packages/pds/tests/views/suggestions.test.ts
+++ b/packages/pds/tests/views/suggestions.test.ts
@@ -16,8 +16,7 @@ describe('pds user search views', () => {
     agent = new AtpAgent({ service: server.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
 
     const suggestions = [
       { did: sc.dids.bob, order: 1 },

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -33,6 +33,7 @@ describe('pds thread views', () => {
     agent = new AtpAgent({ service: server.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
+    await server.ctx.labelCache.catchUp()
     alice = sc.dids.alice
     bob = sc.dids.bob
     carol = sc.dids.carol

--- a/packages/pds/tests/views/thread.test.ts
+++ b/packages/pds/tests/views/thread.test.ts
@@ -33,7 +33,7 @@ describe('pds thread views', () => {
     agent = new AtpAgent({ service: server.url })
     sc = new SeedClient(agent)
     await basicSeed(sc)
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
     alice = sc.dids.alice
     bob = sc.dids.bob
     carol = sc.dids.carol
@@ -42,7 +42,7 @@ describe('pds thread views', () => {
   beforeAll(async () => {
     // Add a repost of a reply so that we can confirm viewer state in the thread
     await sc.repost(bob, sc.replies[alice][0].ref)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
   })
 
   afterAll(async () => {
@@ -141,7 +141,7 @@ describe('pds thread views', () => {
       'Reply reply',
     )
     indexes.aliceReplyReply = sc.replies[alice].length - 1
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const thread1 = await agent.api.app.bsky.feed.getPostThread(
       { uri: sc.posts[alice][indexes.aliceRoot].ref.uriStr },
@@ -150,7 +150,7 @@ describe('pds thread views', () => {
     expect(forSnapshot(thread1.data.thread)).toMatchSnapshot()
 
     await sc.deletePost(bob, sc.replies[bob][indexes.bobReply].ref.uri)
-    await server.ctx.backgroundQueue.processAll()
+    await server.processAll()
 
     const thread2 = await agent.api.app.bsky.feed.getPostThread(
       { uri: sc.posts[alice][indexes.aliceRoot].ref.uriStr },

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -56,6 +56,7 @@ describe('timeline views', () => {
         { create: ['kind'] },
       )
     await server.ctx.backgroundQueue.processAll()
+    await server.ctx.labelCache.catchUp()
   })
 
   afterAll(async () => {

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -55,8 +55,7 @@ describe('timeline views', () => {
         labelPostB.cidStr,
         { create: ['kind'] },
       )
-    await server.ctx.backgroundQueue.processAll()
-    await server.ctx.labelCache.catchUp()
+    await server.processAll()
   })
 
   afterAll(async () => {


### PR DESCRIPTION
This was a bit of a catchall branch for dealing with scaling the PDS.

Included in here:
- move labels to an in-memory cache that is routinely refreshed. this abstraction will likely stick around but become more mature over time
- inline mute list queries into post hydration instead of as a separate post
- do sequencing of multiple firehose evts within a tx
- cache blocks from most recent commit before mutating a repo
- increase pagination sizes for sequencer polling & sequencer outbox
- temporarily disable Popular with Friends
- adjust feed date threshold for getTimeline from 3 -> 1