### PR TITLE
use 127.0.0.1 in with-test-db.sh for colima

### DIFF
--- a/packages/pg/with-test-db.sh
+++ b/packages/pg/with-test-db.sh
@@ -34,7 +34,7 @@ export PGHOST=localhost
 export PGUSER=pg
 export PGPASSWORD=password
 export PGDATABASE=postgres
-export DB_POSTGRES_URL="postgresql://pg:password@localhost:5433/postgres"
+export DB_POSTGRES_URL="postgresql://pg:password@127.0.0.1:5433/postgres"
 "$@"
 code=$?
 


### PR DESCRIPTION
So, since Docker Desktop has licensing issues, some folks use colima for
running containers on their macOS machines (The licensing exempted
CLI-only version of Docker only exists on Linux).

Unfortunately, colima binds host ports only on the IPv4 localhost
address (`127.0.0.1`) while the atproto postgres clients will attempt to
connect to the IPv6 localhost address (`::1`) that macOS sets in
/etc/hosts.  See https://github.com/abiosoft/colima/issues/583 and
https://github.com/lima-vm/lima/issues/1330 for the tickets against
colima. (Docker Desktop binds to both IPv4 and IPv6 localhost addresses
and so doesn't have this issue.)

To workaround this silly issue, we can use `localhost` within the docker
containers and docker-compose, but need to set the `DB_POSTGRES_URL` env
var to use the IPv4 localhost explicitly.

(Asking folks to edit /etc/hosts causes other tools to break and will be
overridden on each OS upgrade.)
