### PR TITLE
Trim whitespace when processing dids

### DIFF
--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -50,7 +50,7 @@ export class HandleResolver {
     const url = new URL('/.well-known/atproto-did', `https://${handle}`)
     try {
       const res = await fetch(url, { signal })
-      const did = await res.text()
+      const did = (await res.text()).trim()
       if (typeof did === 'string' && did.startsWith('did:')) {
         return did
       }

--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -50,8 +50,7 @@ export class HandleResolver {
     const url = new URL('/.well-known/atproto-did', `https://${handle}`)
     try {
       const res = await fetch(url, { signal })
-      const asciiText = (await res.text()).replace(/[^\x00-\x7F]/g, "")
-      const did = asciiText.split('\n')[0].trim()
+      const did = (await res.text()).split('\n')[0].trim()
       if (typeof did === 'string' && did.startsWith('did:')) {
         return did
       }

--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -50,7 +50,8 @@ export class HandleResolver {
     const url = new URL('/.well-known/atproto-did', `https://${handle}`)
     try {
       const res = await fetch(url, { signal })
-      const did = (await res.text()).trim()
+      const asciiText = (await res.text()).replace(/[^\x00-\x7F]/g, "")
+      const did = asciiText.split('\n')[0].trim()
       if (typeof did === 'string' && did.startsWith('did:')) {
         return did
       }


### PR DESCRIPTION
I had some issues when enabling a custom domain using the .well-known file method because of the EOL character – as the code currently stands, any `did` followed by an EOL character is passed for verification as:

```
"responseBody": {
  "did": "<did>\n"
}
```

The presence of the trailing newline character leads to the user receiving the error "The server gave an invalid response and may be out of date". I solved the issue by removing the EOL character from my `did` file, but it would be neater if this was done for the user – especially as the EOL character is added by default by most Unix editors.