### PR TITLE
Perform pessimistic handle check when updating handle

### DIFF
--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -47,6 +47,14 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
+      // Pessimistic check to handle spam: also enforced by updateHandle() and the db.
+      const available = await ctx.services
+        .account(ctx.db)
+        .isHandleAvailable(handle)
+      if (!available) {
+        throw new InvalidRequestError(`Handle already taken: ${handle}`)
+      }
+
       const seqHandleTok = await ctx.db.transaction(async (dbTxn) => {
         let tok: HandleSequenceToken
         try {

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -160,6 +160,7 @@ export class AccountService {
       .set({ handle })
       .where('did', '=', did)
       .whereNotExists(
+        // @NOTE see also condition in isHandleAvailable()
         this.db.db
           .selectFrom('did_handle')
           .where('handle', '=', handle)
@@ -176,6 +177,16 @@ export class AccountService {
     this.db.assertTransaction()
     const seqEvt = await sequencer.formatSeqHandleUpdate(tok.did, tok.handle)
     await sequencer.sequenceEvt(this.db, seqEvt)
+  }
+
+  async isHandleAvailable(handle: string) {
+    // @NOTE see also condition in updateHandle()
+    const found = await this.db.db
+      .selectFrom('did_handle')
+      .where('handle', '=', handle)
+      .select('handle')
+      .executeTakeFirst()
+    return !found
   }
 
   async updateEmail(did: string, email: string) {


### PR DESCRIPTION
Allows us to bail early for taken handles.