### PR TITLE
hotfix: prevent user-supplied rkey on posts with createRecord

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -33,7 +33,7 @@ export default function (server: Server, ctx: AppContext) {
           'Unvalidated writes are not yet supported.',
         )
       }
-      if (collection === ids.AppBskyFeedPost && rkey !== undefined) {
+      if (collection === ids.AppBskyFeedPost && rkey) {
         throw new InvalidRequestError(
           'Custom rkeys for post records are not currently supported.',
         )

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -33,6 +33,11 @@ export default function (server: Server, ctx: AppContext) {
           'Unvalidated writes are not yet supported.',
         )
       }
+      if (collection === ids.AppBskyFeedPost && rkey !== undefined) {
+        throw new InvalidRequestError(
+          'Custom rkeys for post records are not currently supported.',
+        )
+      }
 
       const swapCommitCid = swapCommit ? CID.parse(swapCommit) : undefined
 


### PR DESCRIPTION
Heads up, this PR is completely untested, but this seems like the quickest way to return to sanity

![image](https://github.com/bluesky-social/atproto/assets/13520633/75ea8fab-6e24-4741-bd22-56e94946892f)
