### PR TITLE
adding reserved handle validation to domains outside of supported user domains

### DIFF
--- a/packages/api/src/client/types/com/atproto/server/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAccount.ts
@@ -63,6 +63,12 @@ export class HandleNotAvailableError extends XRPCError {
   }
 }
 
+export class DisallowedHandleError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export class UnsupportedDomainError extends XRPCError {
   constructor(src: XRPCError) {
     super(src.status, src.error, src.message)

--- a/packages/identifier/src/handle.ts
+++ b/packages/identifier/src/handle.ts
@@ -1,4 +1,8 @@
-import { reservedSubdomains, dangerousUnallowedSubdomains } from './reserved'
+import {
+  reservedSubdomains,
+  dangerousUnallowedSubdomains,
+  checkIfStringContainsSlurs,
+} from './reserved'
 
 export const INVALID_HANDLE = 'handle.invalid'
 
@@ -121,8 +125,7 @@ export const ensureHandleServiceConstraints = (
   if (disallowedTld) {
     throw new DisallowedDomainError('Handle TLD is invalid or disallowed')
   }
-  const handleParts = handle.split('.')
-  if (handleParts.find((handlePart) => dangerousUnallowed[handlePart])) {
+  if (checkIfStringContainsSlurs(handle, dangerousUnallowed)) {
     throw new DisallowedHandleError('Handle disallowed')
   }
   const supportedDomain = availableUserDomains.find((domain) =>

--- a/packages/identifier/src/reserved.ts
+++ b/packages/identifier/src/reserved.ts
@@ -1135,6 +1135,14 @@ const slurs = [
 export const reservedSubdomains: Record<string, boolean> = [
   ...atpSpecific,
   ...commonlyReserved,
+].reduce((acc, cur) => {
+  return {
+    ...acc,
+    [cur]: true,
+  }
+}, {})
+
+export const dangerousUnallowedSubdomains: Record<string, boolean> = [
   ...famousAccounts,
   ...slurs,
 ].reduce((acc, cur) => {

--- a/packages/identifier/src/reserved.ts
+++ b/packages/identifier/src/reserved.ts
@@ -1045,6 +1045,12 @@ const famousAccounts = [
   'portalr7',
   'rede_globo',
   'zerohora',
+
+  // 3 letter slurs included here so they don't go into include but direct comparision
+  'kkk',
+  'yid',
+  'gyp',
+  'nig',
 ]
 
 // naive, incomplete list of slurs and unacceptable words
@@ -1061,7 +1067,6 @@ const slurs = [
   'golliwogs',
   'gook',
   'gooks',
-  'gyp',
   'gyps',
   'half-breed',
   'halfbreed',
@@ -1080,7 +1085,6 @@ const slurs = [
   'kafirs',
   'kike',
   'kikes',
-  'kkk',
   'klukluxklan',
   'muzzie',
   'n1gga',
@@ -1088,7 +1092,6 @@ const slurs = [
   'nazi ',
   'negorid',
   'negress',
-  'nig',
   'nigg3r',
   'nigg4h',
   'nigga',
@@ -1128,7 +1131,6 @@ const slurs = [
   'squaws',
   'wetback',
   'wetbacks',
-  'yid',
   'yids',
 ]
 
@@ -1142,12 +1144,37 @@ export const reservedSubdomains: Record<string, boolean> = [
   }
 }, {})
 
-export const dangerousUnallowedSubdomains: Record<string, boolean> = [
-  ...famousAccounts,
-  ...slurs,
-].reduce((acc, cur) => {
-  return {
-    ...acc,
-    [cur]: true,
-  }
-}, {})
+export const dangerousUnallowedSubdomains = {
+  lowCheck: famousAccounts,
+  highCheck: slurs,
+}
+
+const weakCheck = (
+  input: string,
+  unallowedSubdomains = dangerousUnallowedSubdomains,
+): boolean => {
+  const handleParts = input.toLowerCase().split('.')
+
+  return (
+    !!unallowedSubdomains.lowCheck.find((unallowedString) =>
+      handleParts.includes(unallowedString)
+    ) )
+}
+
+const strictCheck = (
+  input: string,
+  unallowedSubdomains = dangerousUnallowedSubdomains,
+): boolean => {
+  const normalizedInput = input.toLowerCase().replace('.', '')
+
+  return (
+    !!unallowedSubdomains.highCheck.find((unallowedString) =>
+      normalizedInput.toLowerCase().includes(unallowedString),
+    )
+  )
+}
+
+export const checkIfStringContainsSlurs = (
+  input: string,
+  unallowedSubdomains = dangerousUnallowedSubdomains,
+): boolean => weakCheck(input, unallowedSubdomains) || strictCheck(input, unallowedSubdomains)

--- a/packages/identifier/tests/handle.test.ts
+++ b/packages/identifier/tests/handle.test.ts
@@ -207,7 +207,8 @@ describe('service constraints & normalization', () => {
     expectThrow('john.test.bsky.app', 'Invalid characters in handle')
     expectThrow('about.test', 'Reserved handle')
     expectThrow('atp.test', 'Reserved handle')
-    expectThrow('barackobama.test', 'Reserved handle')
+    expectThrow('barackobama.test', 'Handle disallowed')
+    expectThrow('barackobama.externalDomain', 'Handle disallowed')
 
     expectThrow('atproto.local', 'Handle TLD is invalid or disallowed')
     expectThrow('atproto.arpa', 'Handle TLD is invalid or disallowed')

--- a/packages/identifier/tests/handle.test.ts
+++ b/packages/identifier/tests/handle.test.ts
@@ -197,6 +197,7 @@ describe('service constraints & normalization', () => {
   const domains = ['.bsky.app', '.test']
   it('throw on handles that violate service constraints', () => {
     const expectThrow = (handle: string, err: string) => {
+      console.log(handle)
       expect(() => ensureHandleServiceConstraints(handle, domains)).toThrow(err)
     }
 
@@ -208,8 +209,8 @@ describe('service constraints & normalization', () => {
     expectThrow('about.test', 'Reserved handle')
     expectThrow('atp.test', 'Reserved handle')
     expectThrow('barackobama.test', 'Handle disallowed')
-    expectThrow('barackobama.externalDomain', 'Handle disallowed')
-
+    expectThrow('spi.cs.test', 'Handle disallowed')
+    expectThrow('aaaspIcsAaa.test', 'Handle disallowed')
     expectThrow('atproto.local', 'Handle TLD is invalid or disallowed')
     expectThrow('atproto.arpa', 'Handle TLD is invalid or disallowed')
     expectThrow('atproto.invalid', 'Handle TLD is invalid or disallowed')
@@ -227,5 +228,15 @@ describe('service constraints & normalization', () => {
     expect(() => normalizeAndEnsureValidHandle('JoH!n.TeST')).toThrow(
       InvalidHandleError,
     )
+  })
+
+  it('allows valid handle', () => {
+    const expectValid = (handle: string) => {
+      ensureHandleServiceConstraints(handle, domains)
+    }
+
+    expectValid('imatest.bsky.app')
+    expectValid('dolls-can-hack-too.test')
+    expectValid('itsagooddomainsir.bsky.app')
   })
 })

--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -37,7 +37,10 @@ export default function (server: Server, ctx: AppContext) {
             'Unsupported domain',
             'UnsupportedDomain',
           )
-        } else if (err instanceof ident.ReservedHandleError) {
+        } else if (
+          err instanceof ident.ReservedHandleError ||
+          err instanceof ident.DisallowedHandleError
+        ) {
           // we allow this
           req.log.info(
             { did, handle: input.body },

--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -157,7 +157,10 @@ const ensureValidHandle = async (
   } catch (err) {
     if (err instanceof ident.InvalidHandleError) {
       throw new InvalidRequestError(err.message, 'InvalidHandle')
-    } else if (err instanceof ident.ReservedHandleError) {
+    } else if (
+      err instanceof ident.ReservedHandleError ||
+      err instanceof ident.DisallowedHandleError
+    ) {
       throw new InvalidRequestError(err.message, 'HandleNotAvailable')
     } else if (err instanceof ident.UnsupportedDomainError) {
       if (input.did === undefined) {

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -338,6 +338,9 @@ describe('account', () => {
     await expect(tryHandle('jo/hn.test')).rejects.toThrow(
       'Input/handle must be a valid handle',
     )
+    await expect(tryHandle('taylorswift.test')).rejects.toThrow(
+      'Reserved handle',
+    )
     await expect(tryHandle('about.test')).rejects.toThrow('Reserved handle')
     await expect(tryHandle('atp.test')).rejects.toThrow('Reserved handle')
   })


### PR DESCRIPTION
I was able to set myself handle taylorswift.domi.zip which contains a word from reserved handles list. I noticed that com.atproto.identity.updateHandle while failed for unsupported domain error skipped other validation steps and gone directly to checking dns records. This allowed adding slurs or reserved names to your custom handle.