### PR TITLE
Add ethnic slur for Ukrainians to reserved words

### DIFF
--- a/packages/identifier/src/reserved.ts
+++ b/packages/identifier/src/reserved.ts
@@ -1130,6 +1130,8 @@ const slurs = [
   'wetbacks',
   'yid',
   'yids',
+  'khokhol',
+  'hohol',
 ]
 
 export const reservedSubdomains: Record<string, boolean> = [


### PR DESCRIPTION
In the light of https://github.com/bluesky-social/atproto/pull/1318 I want to add more slurs to the list.

See discussion https://bsky.app/profile/mathan.dev/post/3k2fjt7rwpb2b

Wiki as a proof: https://en.wikipedia.org/wiki/Oseledets#Ethnic_slur

2 versions because there are different ways to transliterate this to latin alphabet