### PR TITLE
Improve check for slurs

### DIFF
--- a/packages/identifier/src/handle.ts
+++ b/packages/identifier/src/handle.ts
@@ -136,7 +136,8 @@ export const ensureHandleServiceConstraints = (
   if (handle.length > 30) {
     throw new InvalidHandleError('Handle too long')
   }
-  if (reserved[front]) {
+  if (reserved.keys().find(handle.contains(item))) {
+    // TODO: use a proper error
     throw new ReservedHandleError('Reserved handle')
   }
 }


### PR DESCRIPTION
Check for inclusion, not exact matching

NOTE: only addresses `fucks.bsky.social`, not `fuck.custom.domain`