### PR TITLE
Allow moderators to take and reverse actor takedowns

### DIFF
--- a/packages/bsky/src/api/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/bsky/src/api/com/atproto/admin/reverseModerationAction.ts
@@ -43,14 +43,14 @@ export default function (server: Server, ctx: AppContext) {
             'Must be a full moderator to reverse this type of action',
           )
         }
-        // if less than admin access then can reverse takedown on an account
+        // if less than moderator access then cannot reverse takedown on an account
         if (
-          !access.admin &&
+          !access.moderator &&
           existing.action === TAKEDOWN &&
           existing.subjectType === 'com.atproto.admin.defs#repoRef'
         ) {
           throw new AuthRequiredError(
-            'Must be an admin to reverse an account takedown',
+            'Must be a full moderator to reverse an account takedown',
           )
         }
 

--- a/packages/bsky/src/api/com/atproto/admin/takeModerationAction.ts
+++ b/packages/bsky/src/api/com/atproto/admin/takeModerationAction.ts
@@ -30,9 +30,9 @@ export default function (server: Server, ctx: AppContext) {
       // apply access rules
 
       // if less than admin access then can not takedown an account
-      if (!access.admin && action === TAKEDOWN && 'did' in subject) {
+      if (!access.moderator && action === TAKEDOWN && 'did' in subject) {
         throw new AuthRequiredError(
-          'Must be an admin to perform an account takedown',
+          'Must be a full moderator to perform an account takedown',
         )
       }
       // if less than moderator access then can only take ack and escalation actions

--- a/packages/bsky/tests/moderation.test.ts
+++ b/packages/bsky/tests/moderation.test.ts
@@ -961,9 +961,9 @@ describe('moderation', () => {
       )
     })
 
-    it('does not allow non-admin moderators to takedown.', async () => {
-      const attemptTakedownMod =
-        agent.api.com.atproto.admin.takeModerationAction(
+    it('allows full moderators to takedown.', async () => {
+      const { data: action } =
+        await agent.api.com.atproto.admin.takeModerationAction(
           {
             action: TAKEDOWN,
             createdBy: 'did:example:moderator',
@@ -978,9 +978,11 @@ describe('moderation', () => {
             headers: network.bsky.adminAuthHeaders('moderator'),
           },
         )
-      await expect(attemptTakedownMod).rejects.toThrow(
-        'Must be an admin to perform an account takedown',
-      )
+      // cleanup
+      await reverse(action.id)
+    })
+
+    it('does not allow non-full moderators to takedown.', async () => {
       const attemptTakedownTriage =
         agent.api.com.atproto.admin.takeModerationAction(
           {
@@ -998,7 +1000,7 @@ describe('moderation', () => {
           },
         )
       await expect(attemptTakedownTriage).rejects.toThrow(
-        'Must be an admin to perform an account takedown',
+        'Must be a full moderator to perform an account takedown',
       )
     })
 

--- a/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/reverseModerationAction.ts
@@ -43,9 +43,9 @@ export default function (server: Server, ctx: AppContext) {
             'Must be a full moderator to reverse this type of action',
           )
         }
-        // if less than admin access then can reverse takedown on an account
+        // if less than moderator access then cannot reverse takedown on an account
         if (
-          !access.admin &&
+          !access.moderator &&
           existing.action === TAKEDOWN &&
           existing.subjectType === 'com.atproto.admin.defs#repoRef'
         ) {

--- a/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
+++ b/packages/pds/src/api/com/atproto/admin/takeModerationAction.ts
@@ -30,9 +30,9 @@ export default function (server: Server, ctx: AppContext) {
       // apply access rules
 
       // if less than admin access then can not takedown an account
-      if (!access.admin && action === TAKEDOWN && 'did' in subject) {
+      if (!access.moderator && action === TAKEDOWN && 'did' in subject) {
         throw new AuthRequiredError(
-          'Must be an admin to perform an account takedown',
+          'Must be a full moderator to perform an account takedown',
         )
       }
       // if less than moderator access then can only take ack and escalation actions

--- a/packages/pds/tests/moderation.test.ts
+++ b/packages/pds/tests/moderation.test.ts
@@ -984,9 +984,9 @@ describe('moderation', () => {
       )
     })
 
-    it('does not allow non-admin moderators to takedown.', async () => {
-      const attemptTakedownMod =
-        agent.api.com.atproto.admin.takeModerationAction(
+    it('allows full moderators to takedown.', async () => {
+      const { data: action } =
+        await agent.api.com.atproto.admin.takeModerationAction(
           {
             action: TAKEDOWN,
             createdBy: 'did:example:moderator',
@@ -1001,9 +1001,11 @@ describe('moderation', () => {
             headers: { authorization: moderatorAuth() },
           },
         )
-      await expect(attemptTakedownMod).rejects.toThrow(
-        'Must be an admin to perform an account takedown',
-      )
+      // cleanup
+      await reverse(action.id)
+    })
+
+    it('does not allow non-full moderators to takedown.', async () => {
       const attemptTakedownTriage =
         agent.api.com.atproto.admin.takeModerationAction(
           {
@@ -1021,7 +1023,7 @@ describe('moderation', () => {
           },
         )
       await expect(attemptTakedownTriage).rejects.toThrow(
-        'Must be an admin to perform an account takedown',
+        'Must be a full moderator to perform an account takedown',
       )
     })
 


### PR DESCRIPTION
Just tweaking some of the role-based auth so that moderators can take and reverse actor takedowns.