### PR TITLE
Switch backup handle nameservers to backup xrpc resolver

### DIFF
--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -67,7 +67,10 @@ export class HandleResolver {
     )
     url.searchParams.set('handle', handle)
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(1000) })
+      const timeout = (
+        AbortSignal as unknown as AbortSignalWithTimeout
+      ).timeout(1000)
+      const res = await fetch(url, { signal: timeout })
       const resp = await res.json()
       const did = resp?.did
       if (typeof did === 'string' && did.startsWith('did:')) {
@@ -87,4 +90,8 @@ export class HandleResolver {
     }
     return found[0].slice(PREFIX.length)
   }
+}
+
+type AbortSignalWithTimeout = AbortSignal & {
+  timeout(ms: number): AbortSignal
 }

--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -67,7 +67,7 @@ export class HandleResolver {
     )
     url.searchParams.set('handle', handle)
     try {
-      const res = await fetch(url)
+      const res = await fetch(url, { signal: AbortSignal.timeout(1000) })
       const resp = await res.json()
       const did = resp?.did
       if (typeof did === 'string' && did.startsWith('did:')) {

--- a/packages/identity/src/id-resolver.ts
+++ b/packages/identity/src/id-resolver.ts
@@ -10,7 +10,7 @@ export class IdResolver {
     const { timeout = 3000, plcUrl, didCache } = opts
     this.handle = new HandleResolver({
       timeout,
-      backupNameservers: opts.backupNameservers,
+      backupResolverHost: opts.backupResolverHost,
     })
     this.did = new DidResolver({ timeout, plcUrl, didCache })
   }

--- a/packages/identity/src/types.ts
+++ b/packages/identity/src/types.ts
@@ -4,12 +4,12 @@ export type IdentityResolverOpts = {
   timeout?: number
   plcUrl?: string
   didCache?: DidCache
-  backupNameservers?: string[]
+  backupResolverHost?: string
 }
 
 export type HandleResolverOpts = {
   timeout?: number
-  backupNameservers?: string[]
+  backupResolverHost?: string
 }
 
 export type DidResolverOpts = {

--- a/packages/identity/tests/handle-resolver.test.ts
+++ b/packages/identity/tests/handle-resolver.test.ts
@@ -2,7 +2,7 @@ import { HandleResolver } from '../src'
 
 jest.mock('dns/promises', () => {
   return {
-    resolveTxt: (handle: string) => {
+    resolveTxt: (handle: string): string[][] => {
       if (handle === '_atproto.simple.test') {
         return [['did=did:example:simpleDid']]
       }
@@ -32,6 +32,7 @@ jest.mock('dns/promises', () => {
       if (handle === '_atproto.multi.test') {
         return [['did=did:example:firstDid'], ['did=did:example:secondDid']]
       }
+      return []
     },
   }
 })

--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -36,7 +36,7 @@ export interface ServerConfigValues {
   databaseLocation?: string
 
   availableUserDomains: string[]
-  handleResolveNameservers?: string[]
+  backupHandleResolverHost?: string
 
   imgUriSalt: string
   imgUriKey: string
@@ -139,9 +139,8 @@ export class ServerConfig {
       ? process.env.AVAILABLE_USER_DOMAINS.split(',')
       : []
 
-    const handleResolveNameservers = process.env.HANDLE_RESOLVE_NAMESERVERS
-      ? process.env.HANDLE_RESOLVE_NAMESERVERS.split(',')
-      : []
+    const backupHandleResolverHost =
+      process.env.BACKUP_HANDLE_RESOLVER_HOST || undefined
 
     const imgUriSalt =
       process.env.IMG_URI_SALT || '9dd04221f5755bce5f55f47464c27e1e'
@@ -223,7 +222,7 @@ export class ServerConfig {
       termsOfServiceUrl,
       databaseLocation,
       availableUserDomains,
-      handleResolveNameservers,
+      backupHandleResolverHost,
       imgUriSalt,
       imgUriKey,
       imgUriEndpoint,
@@ -381,8 +380,8 @@ export class ServerConfig {
     return this.cfg.availableUserDomains
   }
 
-  get handleResolveNameservers() {
-    return this.cfg.handleResolveNameservers
+  get backupHandleResolverHost() {
+    return this.cfg.backupHandleResolverHost
   }
 
   get imgUriSalt() {

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -101,7 +101,7 @@ export class PDS {
     const idResolver = new IdResolver({
       plcUrl: config.didPlcUrl,
       didCache,
-      backupNameservers: config.handleResolveNameservers,
+      backupResolverHost: config.backupHandleResolverHost,
     })
 
     const messageDispatcher = new MessageDispatcher()


### PR DESCRIPTION
Gives a little more control to sidestep backup DNS nameservers that are resolving handshake domains.