### PR TITLE
AtpAgent: RefreshSession once if resumeSession fails

### DIFF
--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -149,9 +149,10 @@ export class AtpAgent {
   ): Promise<ComAtprotoServerGetSession.Response> {
     try {
       this.session = session
-      const res = await this.api.com.atproto.server.getSession()
+      let res = await this.api.com.atproto.server.getSession()
       if (!res.success && this.session.refreshJwt) {
         await this._refreshSession()
+        res = await this.api.com.atproto.server.getSession()
       }
       if (!res.success || res.data.did !== this.session.did) {
         throw new Error('Invalid session')

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -150,6 +150,9 @@ export class AtpAgent {
     try {
       this.session = session
       const res = await this.api.com.atproto.server.getSession()
+      if (!res.success && this.session.refreshJwt) {
+        await this._refreshSession()
+      }
       if (!res.success || res.data.did !== this.session.did) {
         throw new Error('Invalid session')
       }


### PR DESCRIPTION
Attempts to refresh the session once when resuming session fails if a refreshJwt exists.