### PR TITLE
Patch up a couple sqlite tests

### DIFF
--- a/packages/pds/src/sequencer/events.ts
+++ b/packages/pds/src/sequencer/events.ts
@@ -35,6 +35,7 @@ export const sequenceEvt = async (dbTxn: Database, evt: RepoSeqInsert) => {
       .set({ seq: res.id })
       .where('id', '=', res.id)
       .execute()
+    await dbTxn.notify('outgoing_repo_seq')
   }
 }
 

--- a/packages/pds/src/sequencer/sequencer-leader.ts
+++ b/packages/pds/src/sequencer/sequencer-leader.ts
@@ -140,6 +140,7 @@ export class SequencerLeader {
   }
 
   async isCaughtUp(): Promise<boolean> {
+    if (this.db.dialect === 'sqlite') return true
     const unsequenced = await this.getUnsequenced()
     return unsequenced.length === 0
   }

--- a/packages/pds/tests/algos/whats-hot.test.ts
+++ b/packages/pds/tests/algos/whats-hot.test.ts
@@ -46,6 +46,8 @@ describe('algo whats-hot', () => {
   })
 
   it('returns well liked posts', async () => {
+    if (server.ctx.db.dialect === 'sqlite') return
+
     const img = await sc.uploadFile(
       alice,
       'tests/image/fixtures/key-landscape-small.jpg',
@@ -101,6 +103,8 @@ describe('algo whats-hot', () => {
   })
 
   it('paginates', async () => {
+    if (server.ctx.db.dialect === 'sqlite') return
+
     const res = await agent.api.app.bsky.feed.getFeed(
       { feed: feedUri },
       { headers: sc.getHeaders(alice) },

--- a/packages/pds/tests/sequencer.test.ts
+++ b/packages/pds/tests/sequencer.test.ts
@@ -81,7 +81,7 @@ describe('sequencer', () => {
 
   const caughtUp = (outbox: Outbox): (() => Promise<boolean>) => {
     return async () => {
-      const leaderCaughtUp = await server.ctx.sequencerLeader.isCaughtUp()
+      const leaderCaughtUp = await server.ctx.sequencerLeader?.isCaughtUp()
       if (!leaderCaughtUp) return false
       const lastEvt = await outbox.sequencer.curr()
       if (!lastEvt) return true


### PR DESCRIPTION
Sequence leader:
- this gets turned off on sqlite, but we weren't putting out any notifies for outgoing repo events so nothing was getting polled from the DB
 
Whats hot:
- we don't construct/refresh the materialized view in sqlite, so we just skip these tests for now