### PR TITLE
Increase appview keepalive

### DIFF
--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -204,6 +204,7 @@ export class BskyAppView {
     }
     const server = this.app.listen(this.ctx.cfg.port)
     this.server = server
+    server.keepAliveTimeout = 90000
     this.terminator = createHttpTerminator({ server })
     await events.once(server, 'listening')
     const { port } = server.address() as AddressInfo


### PR DESCRIPTION
Increase keepalive to 90s to match PDS. Prevents 502s from load balancer idle timeout.