### PR TITLE
add optional `ILIKE` query to `getPopularFeedGenerators`

### DIFF
--- a/lexicons/app/bsky/unspecced/getPopularFeedGenerators.json
+++ b/lexicons/app/bsky/unspecced/getPopularFeedGenerators.json
@@ -9,7 +9,8 @@
         "type": "params",
         "properties": {
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
-          "cursor": {"type": "string"}
+          "cursor": {"type": "string"},
+          "query": {"type": "string"}
         }
       },
       "output": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6297,6 +6297,9 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            query: {
+              type: 'string',
+            },
           },
         },
         output: {
@@ -6327,7 +6330,7 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'A skeleton of a timeline',
+        description: 'A skeleton of a timeline - UNSPECCED & WILL GO AWAY SOON',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/api/src/client/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -11,6 +11,7 @@ import * as AppBskyFeedDefs from '../feed/defs'
 export interface QueryParams {
   limit?: number
   cursor?: string
+  query?: string
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -29,9 +29,10 @@ export default function (server: Server, ctx: AppContext) {
         ])
 
       if (query) {
-        inner = inner.where(qb => qb
-          .where('feed_generator.displayName', 'ilike', `%${query}%`)
-          .orWhere('feed_generator.description', 'ilike', `%${query}%`)
+        inner = inner.where((qb) =>
+          qb
+            .where('feed_generator.displayName', 'ilike', `%${query}%`)
+            .orWhere('feed_generator.description', 'ilike', `%${query}%`),
         )
       }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6297,6 +6297,9 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            query: {
+              type: 'string',
+            },
           },
         },
         output: {
@@ -6327,7 +6330,7 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'A skeleton of a timeline',
+        description: 'A skeleton of a timeline - UNSPECCED & WILL GO AWAY SOON',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -12,6 +12,7 @@ import * as AppBskyFeedDefs from '../feed/defs'
 export interface QueryParams {
   limit: number
   cursor?: string
+  query?: string
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -148,11 +148,13 @@ export default function (server: Server, ctx: AppContext) {
         ])
 
       if (query) {
-        inner = inner.where((qb) =>
+        // like is case-insensitive is sqlite, and ilike is not supported
+        const operator = ctx.db.dialect === 'pg' ? 'ilike' : 'like'
+        inner = inner.where(qb => (
           qb
-            .where('feed_generator.displayName', 'ilike', `%${query}%`)
-            .orWhere('feed_generator.description', 'ilike', `%${query}%`),
-        )
+            .where('feed_generator.displayName', operator, `%${query}%`)
+            .orWhere('feed_generator.description', operator, `%${query}%`)
+        ))
       }
 
       let builder = ctx.db.db.selectFrom(inner.as('feed_gens')).selectAll()

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -148,9 +148,10 @@ export default function (server: Server, ctx: AppContext) {
         ])
 
       if (query) {
-        inner = inner.where(qb => qb
-          .where('feed_generator.displayName', 'ilike', `%${query}%`)
-          .orWhere('feed_generator.description', 'ilike', `%${query}%`)
+        inner = inner.where((qb) =>
+          qb
+            .where('feed_generator.displayName', 'ilike', `%${query}%`)
+            .orWhere('feed_generator.description', 'ilike', `%${query}%`),
         )
       }
 

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -150,11 +150,11 @@ export default function (server: Server, ctx: AppContext) {
       if (query) {
         // like is case-insensitive is sqlite, and ilike is not supported
         const operator = ctx.db.dialect === 'pg' ? 'ilike' : 'like'
-        inner = inner.where(qb => (
+        inner = inner.where((qb) =>
           qb
             .where('feed_generator.displayName', operator, `%${query}%`)
-            .orWhere('feed_generator.description', operator, `%${query}%`)
-        ))
+            .orWhere('feed_generator.description', operator, `%${query}%`),
+        )
       }
 
       let builder = ctx.db.db.selectFrom(inner.as('feed_gens')).selectAll()

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -131,11 +131,11 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       const db = ctx.db.db
-      const { limit, cursor } = params
+      const { limit, cursor, query } = params
       const { ref } = db.dynamic
       const feedService = ctx.services.appView.feed(ctx.db)
 
-      const inner = ctx.db.db
+      let inner = ctx.db.db
         .selectFrom('feed_generator')
         .select([
           'uri',
@@ -146,6 +146,13 @@ export default function (server: Server, ctx: AppContext) {
             .select(countAll.as('count'))
             .as('likeCount'),
         ])
+
+      if (query) {
+        inner = inner.where(qb => qb
+          .where('feed_generator.displayName', 'ilike', `%${query}%`)
+          .orWhere('feed_generator.description', 'ilike', `%${query}%`)
+        )
+      }
 
       let builder = ctx.db.db.selectFrom(inner.as('feed_gens')).selectAll()
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6297,6 +6297,9 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            query: {
+              type: 'string',
+            },
           },
         },
         output: {
@@ -6327,7 +6330,7 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'A skeleton of a timeline',
+        description: 'A skeleton of a timeline - UNSPECCED & WILL GO AWAY SOON',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -12,6 +12,7 @@ import * as AppBskyFeedDefs from '../feed/defs'
 export interface QueryParams {
   limit: number
   cursor?: string
+  query?: string
 }
 
 export type InputSchema = undefined

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -336,6 +336,16 @@ describe('feed generation', () => {
         resFull.data.feeds,
       )
     })
+
+    it('searches', async () => {
+      const res =
+        await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
+          { query: 'pagination' },
+          { headers: sc.getHeaders(sc.dids.bob) },
+        )
+
+      expect(res.data.feeds[0].displayName).toBe('Bad Pagination')
+    })
   })
 
   describe('getFeed', () => {

--- a/packages/pds/tests/feed-generation.test.ts
+++ b/packages/pds/tests/feed-generation.test.ts
@@ -338,11 +338,10 @@ describe('feed generation', () => {
     })
 
     it('searches', async () => {
-      const res =
-        await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
-          { query: 'pagination' },
-          { headers: sc.getHeaders(sc.dids.bob) },
-        )
+      const res = await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
+        { query: 'pagination' },
+        { headers: sc.getHeaders(sc.dids.bob) },
+      )
 
       expect(res.data.feeds[0].displayName).toBe('Bad Pagination')
     })


### PR DESCRIPTION
Adds an optional `query` query param to `getPopularFeedGenerators` in order to optionally apply an `ILIKE` operator on `displayName` and `description` to match Ansh's [current client-side search](https://github.com/bluesky-social/social-app/pull/1031/files#diff-b85a98a45a6674a667a38278b8fb39914d1c5316959c5dc5476d73c1d842ea81R89-R90).