### PR TITLE
app.bsky.feed.getTimeline gets optional filtering parameters

### DIFF
--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -10,7 +10,7 @@
         "properties": {
           "algorithm": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
-          "minReplyLikeCount": {"type": "integer", "minimum": 0, "maximum": 25, "default": 2},
+          "minReplyLikeCount": {"type": "integer", "minimum": 0, "maximum": 25, "default": 0},
           "showQuotePosts": {"type": "boolean", "default": true},
           "showReplies": {"type": "boolean", "default": true},
           "showReposts": {"type": "boolean", "default": true},

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -11,9 +11,9 @@
           "algorithm": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "minReplyLikeCount": {"type": "integer", "minimum": 0, "maximum": 25, "default": 0},
-          "showQuotePosts": {"type": "boolean", "default": true},
-          "showReplies": {"type": "boolean", "default": true},
-          "showReposts": {"type": "boolean", "default": true},
+          "includeQuotePosts": {"type": "boolean", "default": true},
+          "includeReplies": {"type": "boolean", "default": true},
+          "includeReposts": {"type": "boolean", "default": true},
           "cursor": {"type": "string"}
         }
       },

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -10,6 +10,10 @@
         "properties": {
           "algorithm": {"type": "string"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+          "minReplyLikeCount": {"type": "integer", "minimum": 0, "maximum": 25, "default": 2},
+          "showQuotePosts": {"type": "boolean", "default": true},
+          "showReplies": {"type": "boolean", "default": true},
+          "showReposts": {"type": "boolean", "default": true},
           "cursor": {"type": "string"}
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5203,6 +5203,24 @@ export const schemaDict = {
               maximum: 100,
               default: 50,
             },
+            minReplyLikeCount: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 25,
+              default: 2,
+            },
+            showQuotePosts: {
+              type: 'boolean',
+              default: true,
+            },
+            showReplies: {
+              type: 'boolean',
+              default: true,
+            },
+            showReposts: {
+              type: 'boolean',
+              default: true,
+            },
             cursor: {
               type: 'string',
             },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5207,7 +5207,7 @@ export const schemaDict = {
               type: 'integer',
               minimum: 0,
               maximum: 25,
-              default: 2,
+              default: 0,
             },
             showQuotePosts: {
               type: 'boolean',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5209,15 +5209,15 @@ export const schemaDict = {
               maximum: 25,
               default: 0,
             },
-            showQuotePosts: {
+            includeQuotePosts: {
               type: 'boolean',
               default: true,
             },
-            showReplies: {
+            includeReplies: {
               type: 'boolean',
               default: true,
             },
-            showReposts: {
+            includeReposts: {
               type: 'boolean',
               default: true,
             },

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -11,6 +11,10 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   algorithm?: string
   limit?: number
+  minReplyLikeCount?: number
+  showQuotePosts?: boolean
+  showReplies?: boolean
+  showReposts?: boolean
   cursor?: string
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -12,9 +12,9 @@ export interface QueryParams {
   algorithm?: string
   limit?: number
   minReplyLikeCount?: number
-  showQuotePosts?: boolean
-  showReplies?: boolean
-  showReposts?: boolean
+  includeQuotePosts?: boolean
+  includeReplies?: boolean
+  includeReposts?: boolean
   cursor?: string
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -12,9 +12,9 @@ export default function (server: Server, ctx: AppContext) {
       const {
         algorithm,
         minReplyLikeCount,
-        showQuotePosts,
-        showReplies,
-        showReposts,
+        includeQuotePosts,
+        includeReplies,
+        includeReposts,
         limit,
         cursor,
       } = params
@@ -43,12 +43,12 @@ export default function (server: Server, ctx: AppContext) {
       let feedItemsQb = feedService.selectFeedItemQb()
 
       // if replies are off
-      if (!showReplies) {
+      if (!includeReplies) {
         feedItemsQb = feedItemsQb.where('post.replyRoot', 'is', null)
       }
 
       // if reposts are off
-      if (!showReposts) {
+      if (!includeReposts) {
         feedItemsQb = feedItemsQb.where('feed_item.type', '!=', 'repost')
       }
 
@@ -83,9 +83,9 @@ export default function (server: Server, ctx: AppContext) {
       const feedItems = await feedItemsQb.execute()
       let feed = await feedService.hydrateFeed(feedItems, viewer)
 
-      // showReplies
+      // includeReplies
       // apply minReplyLikeCount
-      if (showReplies && minReplyLikeCount > 0) {
+      if (includeReplies && minReplyLikeCount > 0) {
         feed = feed.filter((post) => {
           let showPost = true
           if (post.reply && post.post.likeCount !== undefined) {
@@ -94,10 +94,10 @@ export default function (server: Server, ctx: AppContext) {
           return showPost
         })
       }
-      /* else if showReplies is false, we've already filtered out replies */
+      /* else if includeReplies is false, we've already filtered out replies */
 
-      // showQuotePosts
-      if (!showQuotePosts) {
+      // includeQuotePosts
+      if (!includeQuotePosts) {
         feed = feed.filter((post) => !isView(post.post.embed))
       }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5203,6 +5203,24 @@ export const schemaDict = {
               maximum: 100,
               default: 50,
             },
+            minReplyLikeCount: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 25,
+              default: 2,
+            },
+            showQuotePosts: {
+              type: 'boolean',
+              default: true,
+            },
+            showReplies: {
+              type: 'boolean',
+              default: true,
+            },
+            showReposts: {
+              type: 'boolean',
+              default: true,
+            },
             cursor: {
               type: 'string',
             },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5207,7 +5207,7 @@ export const schemaDict = {
               type: 'integer',
               minimum: 0,
               maximum: 25,
-              default: 2,
+              default: 0,
             },
             showQuotePosts: {
               type: 'boolean',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5209,15 +5209,15 @@ export const schemaDict = {
               maximum: 25,
               default: 0,
             },
-            showQuotePosts: {
+            includeQuotePosts: {
               type: 'boolean',
               default: true,
             },
-            showReplies: {
+            includeReplies: {
               type: 'boolean',
               default: true,
             },
-            showReposts: {
+            includeReposts: {
               type: 'boolean',
               default: true,
             },

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -12,6 +12,10 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   algorithm?: string
   limit: number
+  minReplyLikeCount: number
+  showQuotePosts: boolean
+  showReplies: boolean
+  showReposts: boolean
   cursor?: string
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -13,9 +13,9 @@ export interface QueryParams {
   algorithm?: string
   limit: number
   minReplyLikeCount: number
-  showQuotePosts: boolean
-  showReplies: boolean
-  showReposts: boolean
+  includeQuotePosts: boolean
+  includeReplies: boolean
+  includeReposts: boolean
   cursor?: string
 }
 

--- a/packages/bsky/tests/views/timeline.test.ts
+++ b/packages/bsky/tests/views/timeline.test.ts
@@ -156,6 +156,104 @@ describe('timeline views', () => {
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
 
+  it('full reverse-chronological feed', async () => {
+    const fullNoArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(fullNoArgs.data.feed.length).toEqual(7)
+
+    const fullDefaultArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: true,
+        minReplyLikeCount: 0,
+        showReposts: true,
+        showQuotePosts: true,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(fullDefaultArgs.data.feed.length).toEqual(
+      fullNoArgs.data.feed.length,
+    )
+  })
+
+  it('reverse-chronological feed, no reposts', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReposts: false,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    const POST_COUNT_NO_REPOSTS = 6
+    expect(full.data.feed.length).toEqual(POST_COUNT_NO_REPOSTS)
+  })
+
+  it('reverse-chronological feed, no replies', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: false,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(full.data.feed.length).toEqual(5)
+  })
+
+  it('reverse-chronological feed, replies minimum like counts', async () => {
+    const minReplyLikeCountOneFeed = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: true,
+        minReplyLikeCount: 1,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(minReplyLikeCountOneFeed.data.feed.length).toEqual(5)
+
+    const minReplyLikeCountTwentyFiveFeed =
+      await agent.api.app.bsky.feed.getTimeline(
+        {
+          algorithm: FeedAlgorithm.ReverseChronological,
+          showReplies: true,
+          minReplyLikeCount: 25,
+        },
+        { headers: await network.serviceHeaders(carol) },
+      )
+    expect(minReplyLikeCountTwentyFiveFeed.data.feed.length).toEqual(5)
+    console.log(
+      'feed',
+      JSON.stringify(minReplyLikeCountTwentyFiveFeed.data.feed, null, 2),
+    )
+  })
+
+  it('reverse-chronological feed, no quotes', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showQuotePosts: false,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(full.data.feed.length).toEqual(5)
+  })
+
+  it('reverse-chronological feed, no quotes, no replies, no reposts', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showQuotePosts: false,
+        showReplies: false,
+        showReposts: false,
+      },
+      { headers: await network.serviceHeaders(carol) },
+    )
+    expect(full.data.feed.length).toEqual(3)
+  })
+
   it('blocks posts, reposts, replies by actor takedown', async () => {
     const actionResults = await Promise.all(
       [bob, carol].map((did) =>

--- a/packages/bsky/tests/views/timeline.test.ts
+++ b/packages/bsky/tests/views/timeline.test.ts
@@ -168,10 +168,10 @@ describe('timeline views', () => {
     const fullDefaultArgs = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: true,
+        includeReplies: true,
         minReplyLikeCount: 0,
-        showReposts: true,
-        showQuotePosts: true,
+        includeReposts: true,
+        includeQuotePosts: true,
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -184,7 +184,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReposts: false,
+        includeReposts: false,
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -196,7 +196,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: false,
+        includeReplies: false,
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -207,7 +207,7 @@ describe('timeline views', () => {
     const minReplyLikeCountOneFeed = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: true,
+        includeReplies: true,
         minReplyLikeCount: 1,
       },
       { headers: await network.serviceHeaders(carol) },
@@ -218,7 +218,7 @@ describe('timeline views', () => {
       await agent.api.app.bsky.feed.getTimeline(
         {
           algorithm: FeedAlgorithm.ReverseChronological,
-          showReplies: true,
+          includeReplies: true,
           minReplyLikeCount: 25,
         },
         { headers: await network.serviceHeaders(carol) },
@@ -234,7 +234,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showQuotePosts: false,
+        includeQuotePosts: false,
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -245,9 +245,9 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showQuotePosts: false,
-        showReplies: false,
-        showReposts: false,
+        includeQuotePosts: false,
+        includeReplies: false,
+        includeReposts: false,
       },
       { headers: await network.serviceHeaders(carol) },
     )

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -54,8 +54,12 @@ export default function (server: Server, ctx: AppContext) {
 
       const db = ctx.db.db
       const { ref } = db.dynamic
-      const { minReplyLikeCount, showQuotePosts, showReplies, showReposts } =
-        params
+      const {
+        minReplyLikeCount,
+        includeQuotePosts,
+        includeReplies,
+        includeReposts,
+      } = params
 
       const accountService = ctx.services.account(ctx.db)
       const feedService = ctx.services.appView.feed(ctx.db)
@@ -75,12 +79,12 @@ export default function (server: Server, ctx: AppContext) {
       let feedItemsQb = feedService.selectFeedItemQb()
 
       // if replies are off
-      if (!showReplies) {
+      if (!includeReplies) {
         feedItemsQb = feedItemsQb.where('post.replyRoot', 'is', null)
       }
 
       // if reposts are off
-      if (!showReposts) {
+      if (!includeReposts) {
         feedItemsQb = feedItemsQb.where('feed_item.type', '!=', 'repost')
       }
 
@@ -115,9 +119,9 @@ export default function (server: Server, ctx: AppContext) {
       const feedItems: FeedRow[] = await feedItemsQb.execute()
       let feed = await feedService.hydrateFeed(feedItems, requester)
 
-      // showReplies
+      // includeReplies
       // apply minReplyLikeCount
-      if (showReplies && minReplyLikeCount > 0) {
+      if (includeReplies && minReplyLikeCount > 0) {
         feed = feed.filter((post) => {
           let showPost = true
           if (post.reply && post.post.likeCount !== undefined) {
@@ -126,10 +130,10 @@ export default function (server: Server, ctx: AppContext) {
           return showPost
         })
       }
-      /* else if showReplies is false, we've already filtered out replies */
+      /* else if includeReplies is false, we've already filtered out replies */
 
-      // showQuotePosts
-      if (!showQuotePosts) {
+      // includeQuotePosts
+      if (!includeQuotePosts) {
         feed = feed.filter((post) => !isView(post.post.embed))
       }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5203,6 +5203,24 @@ export const schemaDict = {
               maximum: 100,
               default: 50,
             },
+            minReplyLikeCount: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 25,
+              default: 2,
+            },
+            showQuotePosts: {
+              type: 'boolean',
+              default: true,
+            },
+            showReplies: {
+              type: 'boolean',
+              default: true,
+            },
+            showReposts: {
+              type: 'boolean',
+              default: true,
+            },
             cursor: {
               type: 'string',
             },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1652,7 +1652,7 @@ export const schemaDict = {
       },
       reasonSexual: {
         type: 'token',
-        description: 'Unwanted or mis-labeled sexual content',
+        description: 'Unwanted or mislabeled sexual content',
       },
       reasonRude: {
         type: 'token',
@@ -5209,15 +5209,15 @@ export const schemaDict = {
               maximum: 25,
               default: 0,
             },
-            showQuotePosts: {
+            includeQuotePosts: {
               type: 'boolean',
               default: true,
             },
-            showReplies: {
+            includeReplies: {
               type: 'boolean',
               default: true,
             },
-            showReposts: {
+            includeReposts: {
               type: 'boolean',
               default: true,
             },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5207,7 +5207,7 @@ export const schemaDict = {
               type: 'integer',
               minimum: 0,
               maximum: 25,
-              default: 2,
+              default: 0,
             },
             showQuotePosts: {
               type: 'boolean',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -12,6 +12,10 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   algorithm?: string
   limit: number
+  minReplyLikeCount: number
+  showQuotePosts: boolean
+  showReplies: boolean
+  showReposts: boolean
   cursor?: string
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -13,9 +13,9 @@ export interface QueryParams {
   algorithm?: string
   limit: number
   minReplyLikeCount: number
-  showQuotePosts: boolean
-  showReplies: boolean
-  showReposts: boolean
+  includeQuotePosts: boolean
+  includeReplies: boolean
+  includeReposts: boolean
   cursor?: string
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/moderation/defs.ts
@@ -21,7 +21,7 @@ export const REASONSPAM = 'com.atproto.moderation.defs#reasonSpam'
 export const REASONVIOLATION = 'com.atproto.moderation.defs#reasonViolation'
 /** Misleading identity, affiliation, or content */
 export const REASONMISLEADING = 'com.atproto.moderation.defs#reasonMisleading'
-/** Unwanted or mis-labeled sexual content */
+/** Unwanted or mislabeled sexual content */
 export const REASONSEXUAL = 'com.atproto.moderation.defs#reasonSexual'
 /** Rude, harassing, explicit, or otherwise unwelcoming behavior */
 export const REASONRUDE = 'com.atproto.moderation.defs#reasonRude'

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -128,6 +128,108 @@ describe('timeline views', () => {
     expect(defaultTL.data.feed).toEqual(reverseChronologicalTL.data.feed)
   })
 
+  it('full reverse-chronological feed', async () => {
+    const fullNoArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(fullNoArgs.data.feed.length).toEqual(13)
+
+    const fullDefaultArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: true,
+        minReplyLikeCount: 0,
+        showReposts: true,
+        showQuotePosts: true,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(fullDefaultArgs.data.feed.length).toEqual(
+      fullNoArgs.data.feed.length,
+    )
+  })
+
+  it('reverse-chronological feed, no reposts', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReposts: false,
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    const POST_COUNT_NO_REPOSTS = 11
+    expect(full.data.feed.length).toEqual(POST_COUNT_NO_REPOSTS)
+  })
+
+  it('reverse-chronological feed, no replies', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: false,
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(full.data.feed.length).toEqual(10)
+  })
+
+  it('reverse-chronological feed, replies minimum like counts', async () => {
+    const minReplyLikeCountOneFeed = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showReplies: true,
+        minReplyLikeCount: 1,
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(minReplyLikeCountOneFeed.data.feed.length).toEqual(10)
+
+    const minReplyLikeCountTwentyFiveFeed =
+      await agent.api.app.bsky.feed.getTimeline(
+        {
+          algorithm: FeedAlgorithm.ReverseChronological,
+          showReplies: true,
+          minReplyLikeCount: 25,
+        },
+        { headers: sc.getHeaders(alice) },
+      )
+    expect(minReplyLikeCountTwentyFiveFeed.data.feed.length).toEqual(10)
+    console.log(
+      'feed',
+      JSON.stringify(minReplyLikeCountTwentyFiveFeed.data.feed, null, 2),
+    )
+  })
+
+  it('reverse-chronological feed, no quotes', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showQuotePosts: false,
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(full.data.feed.length).toEqual(10)
+  })
+
+  it('reverse-chronological feed, no quotes, no replies, no reposts', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        showQuotePosts: false,
+        showReplies: false,
+        showReposts: false,
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(full.data.feed.length).toEqual(6)
+  })
+
   it('omits posts and reposts of muted authors.', async () => {
     await agent.api.app.bsky.graph.muteActor(
       { actor: bob },

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -142,10 +142,10 @@ describe('timeline views', () => {
     const fullDefaultArgs = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: true,
+        includeReplies: true,
         minReplyLikeCount: 0,
-        showReposts: true,
-        showQuotePosts: true,
+        includeReposts: true,
+        includeQuotePosts: true,
       },
       {
         headers: sc.getHeaders(alice),
@@ -160,7 +160,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReposts: false,
+        includeReposts: false,
       },
       { headers: sc.getHeaders(alice) },
     )
@@ -172,7 +172,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: false,
+        includeReplies: false,
       },
       { headers: sc.getHeaders(alice) },
     )
@@ -183,7 +183,7 @@ describe('timeline views', () => {
     const minReplyLikeCountOneFeed = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showReplies: true,
+        includeReplies: true,
         minReplyLikeCount: 1,
       },
       { headers: sc.getHeaders(alice) },
@@ -194,7 +194,7 @@ describe('timeline views', () => {
       await agent.api.app.bsky.feed.getTimeline(
         {
           algorithm: FeedAlgorithm.ReverseChronological,
-          showReplies: true,
+          includeReplies: true,
           minReplyLikeCount: 25,
         },
         { headers: sc.getHeaders(alice) },
@@ -210,7 +210,7 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showQuotePosts: false,
+        includeQuotePosts: false,
       },
       { headers: sc.getHeaders(alice) },
     )
@@ -221,9 +221,9 @@ describe('timeline views', () => {
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
         algorithm: FeedAlgorithm.ReverseChronological,
-        showQuotePosts: false,
-        showReplies: false,
-        showReposts: false,
+        includeQuotePosts: false,
+        includeReplies: false,
+        includeReposts: false,
       },
       { headers: sc.getHeaders(alice) },
     )


### PR DESCRIPTION
This mirrors functionality from the Home Feed content preferences settings in social-app https://github.com/bluesky-social/social-app/pull/885 by adding the following optional parameters to `app.bsky.feed.getTimeline`:

```
minReplyLikeCount?: number
includeQuotePosts?: boolean
includeReplies?: boolean
includeReposts?: boolean
```

For starters, all default values are backwards-compatible with the present implementation.

Next, social-app could call `app.bsky.feed.getTimeline` with these parameters and push the filtering closer to the DB.

There's probably room for optimization around reply like counts, but I couldn't see a straightforward way to add it to the query builder.