### PR TITLE
lexicons: Remove empty array to make roundtriping work

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -304,7 +304,6 @@
     },
     "moderation": {
       "type": "object",
-      "required": [],
       "properties": {
         "currentAction": { "type": "ref", "ref": "#actionViewCurrent" }
       }


### PR DESCRIPTION
I'm writing a lexicon schema generator. As part of that I want to test whether I can round trip all lexicons from json to my structs that represent a lexicon, and back to json.

However, with this, when serializing, the current code doesn't emit a value here, due to the fact that when an array is empty,
I skip serializing the key, and when the key is absent in deserializing, I use an empty array.

This let's me have a schema like:

```rust
struct Object {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   required: Vec<String>
   ...
}
```

which is much nicer to work with than

```rust
struct Object {
    #[serde(skip_serializing_if = "Option::is_none")]
    required: Option<Vec<String>,
    ...
}
```

To make tests pass locally, I've [patched the lexicon definition](https://github.com/aDotInTheVoid/triphosphate/commit/8df0c4cda507b4461b0055dcdd8e1ab2b85be383#diff-917e3b3e341df60444017a48293ea672aaf8c9257af4dada3de37095bb003e6dL307), however I'd like to not use a different lexicon to upstream. The way I understand it, this won't change anything about how your lexicon tools work.