### PR TITLE
pds: actually validate tlds

### DIFF
--- a/packages/pds/src/handle/index.ts
+++ b/packages/pds/src/handle/index.ts
@@ -14,7 +14,7 @@ export const normalizeAndValidateHandle = async (opts: {
   // base formatting validation
   const handle = baseNormalizeAndValidate(opts.handle)
   // tld validation
-  if (!ident.isValidTld) {
+  if (!ident.isValidTld(handle)) {
     throw new InvalidRequestError(
       'Handle TLD is invalid or disallowed',
       'InvalidHandle',


### PR DESCRIPTION
tlds have not been appropriately checked since 6b51ecb due to what appears to be a typo/oversight (checking whether the function exists -- which is always true -- rather than calling it)

this pr fixes it so that tlds are once again validated