### PR TITLE
Actor service fix

### DIFF
--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - actor-service-fix
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - actor-service-fix
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/bsky/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfile.ts
@@ -23,10 +23,17 @@ export default function (server: Server, ctx: AppContext) {
           'AccountTakedown',
         )
       }
+      const profile = await actorService.views.profileDetailed(
+        actorRes,
+        requester,
+      )
+      if (!profile) {
+        throw new InvalidRequestError('Profile not found')
+      }
 
       return {
         encoding: 'application/json',
-        body: await actorService.views.profileDetailed(actorRes, requester),
+        body: profile,
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
@@ -15,7 +15,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: {
-          profiles: await actorService.views.profileDetailed(
+          profiles: await actorService.views.hydrateProfilesDetailed(
             actorsRes,
             requester,
           ),

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -55,7 +55,10 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           cursor: suggestionsRes.at(-1)?.did,
-          actors: await actorService.views.profile(suggestionsRes, viewer),
+          actors: await actorService.views.hydrateProfiles(
+            suggestionsRes,
+            viewer,
+          ),
         },
       }
     },

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -24,7 +24,9 @@ export default function (server: Server, ctx: AppContext) {
         : []
       const keyset = new SearchKeyset(sql``, sql``)
 
-      const actors = await services.actor(db).views.profile(results, requester)
+      const actors = await services
+        .actor(db)
+        .views.hydrateProfiles(results, requester)
       const filtered = actors.filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await services
         .actor(db)
-        .views.profileBasic(results, requester)
+        .views.hydrateProfilesBasic(results, requester)
 
       const filtered = actors.filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,

--- a/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
@@ -37,6 +37,9 @@ export default function (server: Server, ctx: AppContext) {
         feedsQb.execute(),
         actorService.views.profile(creatorRes, viewer),
       ])
+      if (!creatorProfile) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
       const profiles = { [creatorProfile.did]: creatorProfile }
 
       const feeds = feedsRes.map((row) => {

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import AppContext from '../../../../context'
@@ -41,17 +42,23 @@ export default function (server: Server, ctx: AppContext) {
         .actor(db)
         .views.profiles(likesRes, requester)
 
+      const likes = mapDefined(likesRes, (row) =>
+        actors[row.did]
+          ? {
+              createdAt: row.createdAt,
+              indexedAt: row.indexedAt,
+              actor: actors[row.did],
+            }
+          : undefined,
+      )
+
       return {
         encoding: 'application/json',
         body: {
           uri,
           cid,
           cursor: keyset.packFromResult(likesRes),
-          likes: likesRes.map((row) => ({
-            createdAt: row.createdAt,
-            indexedAt: row.indexedAt,
-            actor: actors[row.did],
-          })),
+          likes,
         },
       }
     },

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -37,7 +37,9 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       const likesRes = await builder.execute()
-      const actors = await services.actor(db).views.profile(likesRes, requester)
+      const actors = await services
+        .actor(db)
+        .views.profiles(likesRes, requester)
 
       return {
         encoding: 'application/json',
@@ -45,10 +47,10 @@ export default function (server: Server, ctx: AppContext) {
           uri,
           cid,
           cursor: keyset.packFromResult(likesRes),
-          likes: likesRes.map((row, i) => ({
+          likes: likesRes.map((row) => ({
             createdAt: row.createdAt,
             indexedAt: row.indexedAt,
-            actor: actors[i],
+            actor: actors[row.did],
           })),
         },
       }

--- a/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
@@ -34,7 +34,7 @@ export default function (server: Server, ctx: AppContext) {
       const repostedByRes = await builder.execute()
       const repostedBy = await services
         .actor(db)
-        .views.profile(repostedByRes, requester)
+        .views.hydrateProfiles(repostedByRes, requester)
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
@@ -33,7 +33,10 @@ export default function (server: Server, ctx: AppContext) {
       const blocksRes = await blocksReq.execute()
 
       const actorService = services.actor(db)
-      const blocks = await actorService.views.profile(blocksRes, requester)
+      const blocks = await actorService.views.hydrateProfiles(
+        blocksRes,
+        requester,
+      )
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
@@ -37,9 +37,12 @@ export default function (server: Server, ctx: AppContext) {
 
       const followersRes = await followersReq.execute()
       const [followers, subject] = await Promise.all([
-        actorService.views.profile(followersRes, requester),
+        actorService.views.hydrateProfiles(followersRes, requester),
         actorService.views.profile(subjectRes, requester),
       ])
+      if (!subject) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollows.ts
@@ -37,9 +37,12 @@ export default function (server: Server, ctx: AppContext) {
 
       const followsRes = await followsReq.execute()
       const [follows, subject] = await Promise.all([
-        actorService.views.profile(followsRes, requester),
+        actorService.views.hydrateProfiles(followsRes, requester),
         actorService.views.profile(creatorRes, requester),
       ])
+      if (!subject) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -2,7 +2,6 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import AppContext from '../../../../context'
-import { ProfileView } from '../../../../lexicon/types/app/bsky/actor/defs'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.graph.getList({
@@ -40,20 +39,16 @@ export default function (server: Server, ctx: AppContext) {
       const itemsRes = await itemsReq.execute()
 
       const actorService = services.actor(db)
-      const profiles = await actorService.views.profile(itemsRes, requester)
-      const profilesMap = profiles.reduce(
-        (acc, cur) => ({
-          ...acc,
-          [cur.did]: cur,
-        }),
-        {} as Record<string, ProfileView>,
-      )
+      const profiles = await actorService.views.profiles(itemsRes, requester)
 
       const items = itemsRes.map((item) => ({
-        subject: profilesMap[item.did],
+        subject: profiles[item.did],
       }))
 
       const creator = await actorService.views.profile(listRes, requester)
+      if (!creator) {
+        throw new InvalidRequestError(`Actor not found: ${listRes.handle}`)
+      }
 
       const subject = {
         uri: listRes.uri,

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -39,11 +39,12 @@ export default function (server: Server, ctx: AppContext) {
       const itemsRes = await itemsReq.execute()
 
       const actorService = services.actor(db)
-      const profiles = await actorService.views.profiles(itemsRes, requester)
+      const profiles = await actorService.views.hydrateProfiles(
+        itemsRes,
+        requester,
+      )
 
-      const items = itemsRes.map((item) => ({
-        subject: profiles[item.did],
-      }))
+      const items = profiles.map((subject) => ({ subject }))
 
       const creator = await actorService.views.profile(listRes, requester)
       if (!creator) {

--- a/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
@@ -1,7 +1,6 @@
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import AppContext from '../../../../context'
-import { ProfileView } from '../../../../lexicon/types/app/bsky/actor/defs'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.graph.getListMutes({
@@ -33,17 +32,10 @@ export default function (server: Server, ctx: AppContext) {
       const listsRes = await listsReq.execute()
 
       const actorService = ctx.services.actor(ctx.db)
-      const profiles = await actorService.views.profile(listsRes, requester)
-      const profilesMap = profiles.reduce(
-        (acc, cur) => ({
-          ...acc,
-          [cur.did]: cur,
-        }),
-        {} as Record<string, ProfileView>,
-      )
+      const profiles = await actorService.views.profiles(listsRes, requester)
 
       const lists = listsRes.map((row) =>
-        graphService.formatListView(row, profilesMap),
+        graphService.formatListView(row, profiles),
       )
 
       return {

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -35,6 +35,9 @@ export default function (server: Server, ctx: AppContext) {
         listsReq.execute(),
         actorService.views.profile(creatorRes, requester),
       ])
+      if (!creator) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
       const profileMap = {
         [creator.did]: creator,
       }

--- a/packages/bsky/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getMutes.ts
@@ -38,7 +38,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           cursor: keyset.packFromResult(mutesRes),
-          mutes: await actorService.views.profile(mutesRes, requester),
+          mutes: await actorService.views.hydrateProfiles(mutesRes, requester),
         },
       }
     },

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -78,7 +78,7 @@ export default function (server: Server, ctx: AppContext) {
       const labelService = ctx.services.label(ctx.db)
       const recordUris = notifs.map((notif) => notif.uri)
       const [authors, labels] = await Promise.all([
-        actorService.views.profile(
+        actorService.views.profiles(
           notifs.map((notif) => ({
             did: notif.authorDid,
             handle: notif.authorHandle,
@@ -90,10 +90,10 @@ export default function (server: Server, ctx: AppContext) {
         labelService.getLabelsForUris(recordUris),
       ])
 
-      const notifications = notifs.map((notif, i) => ({
+      const notifications = notifs.map((notif) => ({
         uri: notif.uri,
         cid: notif.cid,
-        author: authors[i],
+        author: authors[notif.authorDid],
         reason: notif.reason,
         reasonSubject: notif.reasonSubject || undefined,
         record: jsonStringToLex(notif.recordJson) as Record<string, unknown>,

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -1,5 +1,6 @@
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { jsonStringToLex } from '@atproto/lexicon'
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import AppContext from '../../../../context'
@@ -90,17 +91,21 @@ export default function (server: Server, ctx: AppContext) {
         labelService.getLabelsForUris(recordUris),
       ])
 
-      const notifications = notifs.map((notif) => ({
-        uri: notif.uri,
-        cid: notif.cid,
-        author: authors[notif.authorDid],
-        reason: notif.reason,
-        reasonSubject: notif.reasonSubject || undefined,
-        record: jsonStringToLex(notif.recordJson) as Record<string, unknown>,
-        isRead: seenAt ? notif.indexedAt <= seenAt : false,
-        indexedAt: notif.indexedAt,
-        labels: labels[notif.uri] ?? [],
-      }))
+      const notifications = mapDefined(notifs, (notif) => {
+        const author = authors[notif.authorDid]
+        if (!author) return undefined
+        return {
+          uri: notif.uri,
+          cid: notif.cid,
+          author,
+          reason: notif.reason,
+          reasonSubject: notif.reasonSubject || undefined,
+          record: jsonStringToLex(notif.recordJson) as Record<string, unknown>,
+          isRead: seenAt ? notif.indexedAt <= seenAt : false,
+          indexedAt: notif.indexedAt,
+          labels: labels[notif.uri] ?? [],
+        }
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/services/actor/views.ts
+++ b/packages/bsky/src/services/actor/views.ts
@@ -289,7 +289,7 @@ export class ActorViews {
               followedBy: cur?.requesterFollowedBy || undefined,
             }
           : undefined,
-        labels: skipLabels ? actorLabels : undefined,
+        labels: skipLabels ? undefined : actorLabels,
       }
       acc[cur.did] = profile
       return acc

--- a/packages/bsky/src/services/actor/views.ts
+++ b/packages/bsky/src/services/actor/views.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { INVALID_HANDLE } from '@atproto/identifier'
 import {
   ProfileViewDetailed,
@@ -107,6 +108,7 @@ export class ActorViews {
     const listViews = await this.services.graph.getListViews(listUris, viewer)
 
     return profileInfos.reduce((acc, cur) => {
+      const actorLabels = labels[cur.did] ?? []
       const avatar = cur?.avatarCid
         ? this.imgUriBuilder.getCommonSignedUri(
             'avatar',
@@ -121,6 +123,12 @@ export class ActorViews {
             cur.bannerCid,
           )
         : undefined
+      const mutedByList =
+        cur.requesterMutedByList && listViews[cur.requesterMutedByList]
+          ? this.services.graph.formatListViewBasic(
+              listViews[cur.requesterMutedByList],
+            )
+          : undefined
       const profile = {
         did: cur.did,
         handle: cur.handle ?? INVALID_HANDLE,
@@ -137,21 +145,15 @@ export class ActorViews {
               following: cur?.requesterFollowing || undefined,
               followedBy: cur?.requesterFollowedBy || undefined,
               muted: !!cur?.requesterMuted || !!cur.requesterMutedByList,
-              mutedByList: cur.requesterMutedByList
-                ? this.services.graph.formatListViewBasic(
-                    listViews[cur.requesterMutedByList],
-                  )
-                : undefined,
+              mutedByList,
               blockedBy: !!cur.requesterBlockedBy,
               blocking: cur.requesterBlocking || undefined,
             }
           : undefined,
-        labels: labels[cur.did] ?? [],
+        labels: skipLabels ? undefined : actorLabels,
       }
-      return {
-        ...acc,
-        [cur.did]: profile,
-      }
+      acc[cur.did] = profile
+      return acc
     }, {} as Record<string, ProfileViewDetailed>)
   }
 
@@ -161,7 +163,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileViewDetailed[]> {
     const profiles = await this.profilesDetailed(results, viewer, opts)
-    return hydrateOrdered(results, profiles)
+    return mapDefined(results, (result) => profiles[result.did])
   }
 
   async profileDetailed(
@@ -256,6 +258,7 @@ export class ActorViews {
     const listViews = await this.services.graph.getListViews(listUris, viewer)
 
     return profileInfos.reduce((acc, cur) => {
+      const actorLabels = labels[cur.did] ?? []
       const avatar = cur?.avatarCid
         ? this.imgUriBuilder.getCommonSignedUri(
             'avatar',
@@ -263,6 +266,12 @@ export class ActorViews {
             cur.avatarCid,
           )
         : undefined
+      const mutedByList =
+        cur.requesterMutedByList && listViews[cur.requesterMutedByList]
+          ? this.services.graph.formatListViewBasic(
+              listViews[cur.requesterMutedByList],
+            )
+          : undefined
       const profile = {
         did: cur.did,
         handle: cur.handle ?? INVALID_HANDLE,
@@ -273,23 +282,17 @@ export class ActorViews {
         viewer: viewer
           ? {
               muted: !!cur?.requesterMuted || !!cur.requesterMutedByList,
-              mutedByList: cur.requesterMutedByList
-                ? this.services.graph.formatListViewBasic(
-                    listViews[cur.requesterMutedByList],
-                  )
-                : undefined,
+              mutedByList,
               blockedBy: !!cur.requesterBlockedBy,
               blocking: cur.requesterBlocking || undefined,
               following: cur?.requesterFollowing || undefined,
               followedBy: cur?.requesterFollowedBy || undefined,
             }
           : undefined,
-        labels: labels[cur.did] ?? [],
+        labels: skipLabels ? actorLabels : undefined,
       }
-      return {
-        ...acc,
-        [cur.did]: profile,
-      }
+      acc[cur.did] = profile
+      return acc
     }, {} as Record<string, ProfileView>)
   }
 
@@ -299,7 +302,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileView[]> {
     const profiles = await this.profiles(results, viewer, opts)
-    return hydrateOrdered(results, profiles)
+    return mapDefined(results, (result) => profiles[result.did])
   }
 
   async profile(
@@ -319,19 +322,17 @@ export class ActorViews {
   ): Promise<Record<string, ProfileViewBasic>> {
     if (results.length === 0) return {}
     const profiles = await this.profiles(results, viewer, opts)
-    return Object.values(profiles).reduce(
-      (acc, cur) => ({
-        ...acc,
-        [cur.did]: {
-          did: cur.did,
-          handle: cur.handle,
-          displayName: cur.displayName,
-          avatar: cur.avatar,
-          viewer: cur.viewer,
-        },
-      }),
-      {} as Record<string, ProfileViewBasic>,
-    )
+    return Object.values(profiles).reduce((acc, cur) => {
+      const profile = {
+        did: cur.did,
+        handle: cur.handle,
+        displayName: cur.displayName,
+        avatar: cur.avatar,
+        viewer: cur.viewer,
+      }
+      acc[cur.did] = profile
+      return acc
+    }, {} as Record<string, ProfileViewBasic>)
   }
 
   async hydrateProfilesBasic(
@@ -340,7 +341,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileViewBasic[]> {
     const profiles = await this.profilesBasic(results, viewer, opts)
-    return hydrateOrdered(results, profiles)
+    return mapDefined(results, (result) => profiles[result.did])
   }
 
   async profileBasic(
@@ -354,16 +355,3 @@ export class ActorViews {
 }
 
 type ActorResult = Actor
-
-const hydrateOrdered = <T>(
-  results: ActorResult[],
-  profiles: Record<string, T>,
-): T[] => {
-  const ordered: T[] = []
-  for (const result of results) {
-    if (profiles[result.did]) {
-      ordered.push(profiles[result.did])
-    }
-  }
-  return ordered
-}

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -191,27 +191,30 @@ export class FeedService {
     const listViews = await this.services.graph.getListViews(listUris, viewer)
     return actors.reduce((acc, cur) => {
       const actorLabels = labels[cur.did] ?? []
+      const avatar = cur.avatarCid
+        ? this.imgUriBuilder.getCommonSignedUri(
+            'avatar',
+            cur.did,
+            cur.avatarCid,
+          )
+        : undefined
+      const mutedByList =
+        cur.requesterMutedByList && listViews[cur.requesterMutedByList]
+          ? this.services.graph.formatListViewBasic(
+              listViews[cur.requesterMutedByList],
+            )
+          : undefined
       return {
         ...acc,
         [cur.did]: {
           did: cur.did,
           handle: cur.handle ?? INVALID_HANDLE,
           displayName: cur.displayName ?? undefined,
-          avatar: cur.avatarCid
-            ? this.imgUriBuilder.getCommonSignedUri(
-                'avatar',
-                cur.did,
-                cur.avatarCid,
-              )
-            : undefined,
+          avatar,
           viewer: viewer
             ? {
                 muted: !!cur?.requesterMuted || !!cur?.requesterMutedByList,
-                mutedByList: cur.requesterMutedByList
-                  ? this.services.graph.formatListViewBasic(
-                      listViews[cur.requesterMutedByList],
-                    )
-                  : undefined,
+                mutedByList,
                 blockedBy: !!cur?.requesterBlockedBy,
                 blocking: cur?.requesterBlocking || undefined,
                 following: cur?.requesterFollowing || undefined,

--- a/packages/common-web/src/arrays.ts
+++ b/packages/common-web/src/arrays.ts
@@ -1,0 +1,13 @@
+export const mapDefined = <T, S>(
+  arr: T[],
+  fn: (obj: T) => S | undefined,
+): S[] => {
+  const output: S[] = []
+  for (const item of arr) {
+    const val = fn(item)
+    if (val !== undefined) {
+      output.push(val)
+    }
+  }
+  return output
+}

--- a/packages/common-web/src/index.ts
+++ b/packages/common-web/src/index.ts
@@ -1,6 +1,7 @@
 export * as check from './check'
 export * as util from './util'
 
+export * from './arrays'
 export * from './async'
 export * from './util'
 export * from './tid'

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
@@ -34,10 +34,17 @@ export default function (server: Server, ctx: AppContext) {
           'AccountTakedown',
         )
       }
+      const profile = await actorService.views.profileDetailed(
+        actorRes,
+        requester,
+      )
+      if (!profile) {
+        throw new InvalidRequestError('Profile not found')
+      }
 
       return {
         encoding: 'application/json',
-        body: await actorService.views.profileDetailed(actorRes, requester),
+        body: profile,
       }
     },
   })

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
@@ -22,15 +22,14 @@ export default function (server: Server, ctx: AppContext) {
       const actorService = services.appView.actor(db)
 
       const actorsRes = await actorService.getActors(actors)
-      const profiles = await actorService.views.hydrateProfilesDetailed(
-        actorsRes,
-        requester,
-      )
 
       return {
         encoding: 'application/json',
         body: {
-          profiles,
+          profiles: await actorService.views.hydrateProfilesDetailed(
+            actorsRes,
+            requester,
+          ),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
       const actorService = services.appView.actor(db)
 
       const actorsRes = await actorService.getActors(actors)
-      const profiles = await actorService.views.profilesDetailed(
+      const profiles = await actorService.views.hydrateProfilesDetailed(
         actorsRes,
         requester,
       )
@@ -30,7 +30,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: {
-          profiles: Object.values(profiles),
+          profiles,
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
@@ -22,14 +22,15 @@ export default function (server: Server, ctx: AppContext) {
       const actorService = services.appView.actor(db)
 
       const actorsRes = await actorService.getActors(actors)
+      const profiles = await actorService.views.profilesDetailed(
+        actorsRes,
+        requester,
+      )
 
       return {
         encoding: 'application/json',
         body: {
-          profiles: await actorService.views.profileDetailed(
-            actorsRes,
-            requester,
-          ),
+          profiles: Object.values(profiles),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
@@ -64,14 +64,15 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const suggestionsRes = await suggestionsQb.execute()
+      const profiles = await services.appView
+        .actor(ctx.db)
+        .views.profiles(suggestionsRes, requester)
 
       return {
         encoding: 'application/json',
         body: {
           cursor: suggestionsRes.at(-1)?.did,
-          actors: await services.appView
-            .actor(ctx.db)
-            .views.profile(suggestionsRes, requester),
+          actors: Object.values(profiles),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
@@ -64,15 +64,13 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const suggestionsRes = await suggestionsQb.execute()
-      const profiles = await services.appView
-        .actor(ctx.db)
-        .views.profiles(suggestionsRes, requester)
-
       return {
         encoding: 'application/json',
         body: {
           cursor: suggestionsRes.at(-1)?.did,
-          actors: Object.values(profiles),
+          actors: await services.appView
+            .actor(ctx.db)
+            .views.hydrateProfiles(suggestionsRes, requester),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -52,9 +52,9 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await services.appView
         .actor(db)
-        .views.profiles(results, requester)
+        .views.hydrateProfiles(results, requester)
 
-      const filtered = Object.values(actors).filter(
+      const filtered = actors.filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -52,9 +52,9 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await services.appView
         .actor(db)
-        .views.profile(results, requester)
+        .views.profiles(results, requester)
 
-      const filtered = actors.filter(
+      const filtered = Object.values(actors).filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -48,9 +48,9 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await services.appView
         .actor(db)
-        .views.profileBasic(results, requester)
+        .views.profilesBasic(results, requester)
 
-      const filtered = actors.filter(
+      const filtered = Object.values(actors).filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -48,9 +48,9 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await services.appView
         .actor(db)
-        .views.profilesBasic(results, requester)
+        .views.hydrateProfilesBasic(results, requester)
 
-      const filtered = Object.values(actors).filter(
+      const filtered = actors.filter(
         (actor) => !actor.viewer?.blocking && !actor.viewer?.blockedBy,
       )
 

--- a/packages/pds/src/app-view/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getActorFeeds.ts
@@ -48,6 +48,10 @@ export default function (server: Server, ctx: AppContext) {
         feedsQb.execute(),
         actorService.views.profile(creatorRes, requester),
       ])
+      if (!creatorProfile) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
+
       const profiles = { [creatorProfile.did]: creatorProfile }
 
       const feeds = feedsRes.map((row) =>

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../../db/pagination'
 import AppContext from '../../../../../context'
@@ -59,17 +60,23 @@ export default function (server: Server, ctx: AppContext) {
         .actor(db)
         .views.profiles(likesRes, requester)
 
+      const likes = mapDefined(likesRes, (row) =>
+        actors[row.did]
+          ? {
+              createdAt: row.createdAt,
+              indexedAt: row.indexedAt,
+              actor: actors[row.did],
+            }
+          : undefined,
+      )
+
       return {
         encoding: 'application/json',
         body: {
           uri,
           cid,
           cursor: keyset.packFromResult(likesRes),
-          likes: likesRes.map((row) => ({
-            createdAt: row.createdAt,
-            indexedAt: row.indexedAt,
-            actor: actors[row.did],
-          })),
+          likes,
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -57,7 +57,7 @@ export default function (server: Server, ctx: AppContext) {
       const likesRes = await builder.execute()
       const actors = await services.appView
         .actor(db)
-        .views.profile(likesRes, requester)
+        .views.profiles(likesRes, requester)
 
       return {
         encoding: 'application/json',
@@ -65,10 +65,10 @@ export default function (server: Server, ctx: AppContext) {
           uri,
           cid,
           cursor: keyset.packFromResult(likesRes),
-          likes: likesRes.map((row, i) => ({
+          likes: likesRes.map((row) => ({
             createdAt: row.createdAt,
             indexedAt: row.indexedAt,
-            actor: actors[i],
+            actor: actors[row.did],
           })),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -58,14 +58,14 @@ export default function (server: Server, ctx: AppContext) {
       const repostedByRes = await builder.execute()
       const repostedBy = await services.appView
         .actor(db)
-        .views.profiles(repostedByRes, requester)
+        .views.hydrateProfiles(repostedByRes, requester)
 
       return {
         encoding: 'application/json',
         body: {
           uri,
           cid,
-          repostedBy: Object.values(repostedBy),
+          repostedBy: repostedBy,
           cursor: keyset.packFromResult(repostedByRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -65,7 +65,7 @@ export default function (server: Server, ctx: AppContext) {
         body: {
           uri,
           cid,
-          repostedBy: repostedBy,
+          repostedBy,
           cursor: keyset.packFromResult(repostedByRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -58,14 +58,14 @@ export default function (server: Server, ctx: AppContext) {
       const repostedByRes = await builder.execute()
       const repostedBy = await services.appView
         .actor(db)
-        .views.profile(repostedByRes, requester)
+        .views.profiles(repostedByRes, requester)
 
       return {
         encoding: 'application/json',
         body: {
           uri,
           cid,
-          repostedBy,
+          repostedBy: Object.values(repostedBy),
           cursor: keyset.packFromResult(repostedByRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
@@ -56,12 +56,15 @@ export default function (server: Server, ctx: AppContext) {
       const blocksRes = await blocksReq.execute()
 
       const actorService = services.appView.actor(db)
-      const blocks = await actorService.views.profiles(blocksRes, requester)
+      const blocks = await actorService.views.hydrateProfiles(
+        blocksRes,
+        requester,
+      )
 
       return {
         encoding: 'application/json',
         body: {
-          blocks: Object.values(blocks),
+          blocks,
           cursor: keyset.packFromResult(blocksRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
@@ -56,12 +56,12 @@ export default function (server: Server, ctx: AppContext) {
       const blocksRes = await blocksReq.execute()
 
       const actorService = services.appView.actor(db)
-      const blocks = await actorService.views.profile(blocksRes, requester)
+      const blocks = await actorService.views.profiles(blocksRes, requester)
 
       return {
         encoding: 'application/json',
         body: {
-          blocks,
+          blocks: Object.values(blocks),
           cursor: keyset.packFromResult(blocksRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -71,7 +71,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           subject,
-          followers: followers,
+          followers,
           cursor: keyset.packFromResult(followersRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -60,15 +60,18 @@ export default function (server: Server, ctx: AppContext) {
 
       const followersRes = await followersReq.execute()
       const [followers, subject] = await Promise.all([
-        actorService.views.profile(followersRes, requester),
+        actorService.views.profiles(followersRes, requester),
         actorService.views.profile(subjectRes, requester),
       ])
+      if (!subject) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
 
       return {
         encoding: 'application/json',
         body: {
           subject,
-          followers,
+          followers: Object.values(followers),
           cursor: keyset.packFromResult(followersRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -60,7 +60,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const followersRes = await followersReq.execute()
       const [followers, subject] = await Promise.all([
-        actorService.views.profiles(followersRes, requester),
+        actorService.views.hydrateProfiles(followersRes, requester),
         actorService.views.profile(subjectRes, requester),
       ])
       if (!subject) {
@@ -71,7 +71,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           subject,
-          followers: Object.values(followers),
+          followers: followers,
           cursor: keyset.packFromResult(followersRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -60,15 +60,18 @@ export default function (server: Server, ctx: AppContext) {
 
       const followsRes = await followsReq.execute()
       const [follows, subject] = await Promise.all([
-        actorService.views.profile(followsRes, requester),
+        actorService.views.profiles(followsRes, requester),
         actorService.views.profile(creatorRes, requester),
       ])
+      if (!subject) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
 
       return {
         encoding: 'application/json',
         body: {
           subject,
-          follows,
+          follows: Object.values(follows),
           cursor: keyset.packFromResult(followsRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -71,7 +71,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           subject,
-          follows: follows,
+          follows,
           cursor: keyset.packFromResult(followsRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -60,7 +60,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const followsRes = await followsReq.execute()
       const [follows, subject] = await Promise.all([
-        actorService.views.profiles(followsRes, requester),
+        actorService.views.hydrateProfiles(followsRes, requester),
         actorService.views.profile(creatorRes, requester),
       ])
       if (!subject) {
@@ -71,7 +71,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           subject,
-          follows: Object.values(follows),
+          follows: follows,
           cursor: keyset.packFromResult(followsRes),
         },
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
@@ -2,7 +2,6 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../../db/pagination'
 import AppContext from '../../../../../context'
-import { ProfileView } from '../../../../../lexicon/types/app/bsky/actor/defs'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.graph.getList({
@@ -51,20 +50,16 @@ export default function (server: Server, ctx: AppContext) {
       const itemsRes = await itemsReq.execute()
 
       const actorService = services.appView.actor(db)
-      const profiles = await actorService.views.profile(itemsRes, requester)
-      const profilesMap = profiles.reduce(
-        (acc, cur) => ({
-          ...acc,
-          [cur.did]: cur,
-        }),
-        {} as Record<string, ProfileView>,
-      )
+      const profiles = await actorService.views.profiles(itemsRes, requester)
 
       const items = itemsRes.map((item) => ({
-        subject: profilesMap[item.did],
+        subject: profiles[item.did],
       }))
 
       const creator = await actorService.views.profile(listRes, requester)
+      if (!creator) {
+        throw new InvalidRequestError(`Actor not found: ${listRes.handle}`)
+      }
 
       const subject = {
         uri: listRes.uri,

--- a/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
@@ -50,11 +50,12 @@ export default function (server: Server, ctx: AppContext) {
       const itemsRes = await itemsReq.execute()
 
       const actorService = services.appView.actor(db)
-      const profiles = await actorService.views.profiles(itemsRes, requester)
+      const profiles = await actorService.views.hydrateProfiles(
+        itemsRes,
+        requester,
+      )
 
-      const items = itemsRes.map((item) => ({
-        subject: profiles[item.did],
-      }))
+      const items = profiles.map((subject) => ({ subject }))
 
       const creator = await actorService.views.profile(listRes, requester)
       if (!creator) {

--- a/packages/pds/src/app-view/api/app/bsky/graph/getListMutes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getListMutes.ts
@@ -1,7 +1,6 @@
 import { Server } from '../../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../../db/pagination'
 import AppContext from '../../../../../context'
-import { ProfileView } from '../../../../../lexicon/types/app/bsky/actor/defs'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.graph.getListMutes({
@@ -44,17 +43,10 @@ export default function (server: Server, ctx: AppContext) {
       const listsRes = await listsReq.execute()
 
       const actorService = ctx.services.appView.actor(ctx.db)
-      const profiles = await actorService.views.profile(listsRes, requester)
-      const profilesMap = profiles.reduce(
-        (acc, cur) => ({
-          ...acc,
-          [cur.did]: cur,
-        }),
-        {} as Record<string, ProfileView>,
-      )
+      const profiles = await actorService.views.profiles(listsRes, requester)
 
       const lists = listsRes.map((row) =>
-        graphService.formatListView(row, profilesMap),
+        graphService.formatListView(row, profiles),
       )
 
       return {

--- a/packages/pds/src/app-view/api/app/bsky/graph/getLists.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getLists.ts
@@ -46,6 +46,9 @@ export default function (server: Server, ctx: AppContext) {
         listsReq.execute(),
         actorService.views.profile(creatorRes, requester),
       ])
+      if (!creator) {
+        throw new InvalidRequestError(`Actor not found: ${actor}`)
+      }
       const profileMap = {
         [creator.did]: creator,
       }

--- a/packages/pds/src/app-view/api/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getMutes.ts
@@ -51,7 +51,7 @@ export default function (server: Server, ctx: AppContext) {
         encoding: 'application/json',
         body: {
           cursor: keyset.packFromResult(mutesRes),
-          mutes: await actorService.views.profile(mutesRes, requester),
+          mutes: await actorService.views.hydrateProfiles(mutesRes, requester),
         },
       }
     },

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -127,13 +127,13 @@ export default function (server: Server, ctx: AppContext) {
         return acc
       }, {} as Record<string, Uint8Array>)
 
-      const notifications = notifs.flatMap((notif, i) => {
+      const notifications = notifs.flatMap((notif) => {
         const bytes = bytesByCid[notif.cid]
         if (!bytes) return [] // Filter out
         return {
           uri: notif.uri,
           cid: notif.cid,
-          author: authors[i],
+          author: authors[notif.authorDid],
           reason: notif.reason,
           reasonSubject: notif.reasonSubject || undefined,
           record: common.cborBytesToRecord(bytes),

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -127,9 +127,10 @@ export default function (server: Server, ctx: AppContext) {
         return acc
       }, {} as Record<string, Uint8Array>)
 
-      const notifications = notifs.flatMap((notif) => {
+      const notifications = common.mapDefined(notifs, (notif) => {
         const bytes = bytesByCid[notif.cid]
-        if (!bytes) return [] // Filter out
+        const author = authors[notif.authorDid]
+        if (!bytes || !author) return undefined
         return {
           uri: notif.uri,
           cid: notif.cid,

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -112,7 +112,7 @@ export default function (server: Server, ctx: AppContext) {
       const recordUris = notifs.map((notif) => notif.uri)
       const [blocks, authors, labels] = await Promise.all([
         blocksQb ? blocksQb.execute() : emptyBlocksResult,
-        actorService.views.profile(
+        actorService.views.profiles(
           notifs.map((notif) => ({
             did: notif.authorDid,
             handle: notif.authorHandle,

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -1,4 +1,3 @@
-import { ArrayEl } from '@atproto/common'
 import {
   ProfileViewDetailed,
   ProfileView,
@@ -24,23 +23,12 @@ export class ActorViews {
     graph: GraphService.creator(this.imgUriBuilder)(this.db),
   }
 
-  profileDetailed(
-    result: ActorResult,
+  async profilesDetailed(
+    results: ActorResult[],
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewDetailed>
-  profileDetailed(
-    result: ActorResult[],
-    viewer: string,
-    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewDetailed[]>
-  async profileDetailed(
-    result: ActorResult | ActorResult[],
-    viewer: string,
-    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewDetailed | ProfileViewDetailed[]> {
-    const results = Array.isArray(result) ? result : [result]
-    if (results.length === 0) return []
+  ): Promise<Record<string, ProfileViewDetailed>> {
+    if (results.length === 0) return {}
 
     const { ref } = this.db.db.dynamic
     const { skipLabels = false, includeSoftDeleted = false } = opts ?? {}
@@ -58,6 +46,7 @@ export class ActorViews {
       )
       .select([
         'did_handle.did as did',
+        'did_handle.handle as handle',
         'profile.uri as profileUri',
         'profile.displayName as displayName',
         'profile.description as description',
@@ -112,72 +101,65 @@ export class ActorViews {
       this.services.label.getLabelsForSubjects(skipLabels ? [] : dids),
     ])
 
-    const profileInfoByDid = profileInfos.reduce((acc, info) => {
-      return Object.assign(acc, { [info.did]: info })
-    }, {} as Record<string, ArrayEl<typeof profileInfos>>)
-
     const listUris: string[] = profileInfos
       .map((a) => a.requesterMutedByList)
       .filter((list) => !!list)
     const listViews = await this.services.graph.getListViews(listUris, viewer)
 
-    const views = results.map((result) => {
-      const profileInfo = profileInfoByDid[result.did]
-      const avatar = profileInfo?.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri('avatar', profileInfo.avatarCid)
+    return profileInfos.reduce((acc, cur) => {
+      const avatar = cur?.avatarCid
+        ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
         : undefined
-      const banner = profileInfo?.bannerCid
-        ? this.imgUriBuilder.getCommonSignedUri('banner', profileInfo.bannerCid)
+      const banner = cur?.bannerCid
+        ? this.imgUriBuilder.getCommonSignedUri('banner', cur.bannerCid)
         : undefined
-      return {
-        did: result.did,
-        handle: result.handle,
-        displayName: truncateUtf8(profileInfo?.displayName, 64) || undefined,
-        description: truncateUtf8(profileInfo?.description, 256) || undefined,
+      const profile = {
+        did: cur.did,
+        handle: cur.handle,
+        displayName: truncateUtf8(cur?.displayName, 64) || undefined,
+        description: truncateUtf8(cur?.description, 256) || undefined,
         avatar,
         banner,
-        followsCount: profileInfo?.followsCount || 0,
-        followersCount: profileInfo?.followersCount || 0,
-        postsCount: profileInfo?.postsCount || 0,
-        indexedAt: profileInfo?.indexedAt || undefined,
+        followsCount: cur?.followsCount || 0,
+        followersCount: cur?.followersCount || 0,
+        postsCount: cur?.postsCount || 0,
+        indexedAt: cur?.indexedAt || undefined,
         viewer: {
-          muted:
-            !!profileInfo?.requesterMuted ||
-            !!profileInfo?.requesterMutedByList,
-          mutedByList: profileInfo.requesterMutedByList
+          muted: !!cur?.requesterMuted || !!cur?.requesterMutedByList,
+          mutedByList: cur.requesterMutedByList
             ? this.services.graph.formatListViewBasic(
-                listViews[profileInfo.requesterMutedByList],
+                listViews[cur.requesterMutedByList],
               )
             : undefined,
-          blockedBy: !!profileInfo.requesterBlockedBy,
-          blocking: profileInfo.requesterBlocking || undefined,
-          following: profileInfo?.requesterFollowing || undefined,
-          followedBy: profileInfo?.requesterFollowedBy || undefined,
+          blockedBy: !!cur.requesterBlockedBy,
+          blocking: cur.requesterBlocking || undefined,
+          following: cur?.requesterFollowing || undefined,
+          followedBy: cur?.requesterFollowedBy || undefined,
         },
-        labels: labels[result.did] ?? [],
+        labels: labels[cur.did] ?? [],
       }
-    })
-
-    return Array.isArray(result) ? views : views[0]
+      return {
+        ...acc,
+        [cur.did]: profile,
+      }
+    }, {} as Record<string, ProfileViewDetailed>)
   }
 
-  profile(
+  async profileDetailed(
     result: ActorResult,
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileView>
-  profile(
-    result: ActorResult[],
+  ): Promise<ProfileViewDetailed | null> {
+    const profiles = await this.profilesDetailed([result], viewer, opts)
+    return profiles[result.did] ?? null
+  }
+
+  async profiles(
+    results: ActorResult[],
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileView[]>
-  async profile(
-    result: ActorResult | ActorResult[],
-    viewer: string,
-    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileView | ProfileView[]> {
-    const results = Array.isArray(result) ? result : [result]
-    if (results.length === 0) return []
+  ): Promise<Record<string, ProfileView>> {
+    if (results.length === 0) return {}
 
     const { ref } = this.db.db.dynamic
     const { skipLabels = false, includeSoftDeleted = false } = opts ?? {}
@@ -193,6 +175,7 @@ export class ActorViews {
       )
       .select([
         'did_handle.did as did',
+        'did_handle.handle as handle',
         'profile.uri as profileUri',
         'profile.displayName as displayName',
         'profile.description as description',
@@ -243,78 +226,84 @@ export class ActorViews {
       this.services.label.getLabelsForSubjects(skipLabels ? [] : dids),
     ])
 
-    const profileInfoByDid = profileInfos.reduce((acc, info) => {
-      return Object.assign(acc, { [info.did]: info })
-    }, {} as Record<string, ArrayEl<typeof profileInfos>>)
-
     const listUris: string[] = profileInfos
       .map((a) => a.requesterMutedByList)
       .filter((list) => !!list)
     const listViews = await this.services.graph.getListViews(listUris, viewer)
 
-    const views = results.map((result) => {
-      const profileInfo = profileInfoByDid[result.did]
-      const avatar = profileInfo?.avatarCid
-        ? this.imgUriBuilder.getCommonSignedUri('avatar', profileInfo.avatarCid)
+    return profileInfos.reduce((acc, cur) => {
+      const avatar = cur?.avatarCid
+        ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
         : undefined
-      return {
-        did: result.did,
-        handle: result.handle,
-        displayName: truncateUtf8(profileInfo?.displayName, 64) || undefined,
-        description: truncateUtf8(profileInfo?.description, 256) || undefined,
+      const profile = {
+        did: cur.did,
+        handle: cur.handle,
+        displayName: truncateUtf8(cur?.displayName, 64) || undefined,
+        description: truncateUtf8(cur?.description, 256) || undefined,
         avatar,
-        indexedAt: profileInfo?.indexedAt || undefined,
+        indexedAt: cur?.indexedAt || undefined,
         viewer: {
-          muted:
-            !!profileInfo?.requesterMuted ||
-            !!profileInfo?.requesterMutedByList,
-          mutedByList: profileInfo.requesterMutedByList
+          muted: !!cur?.requesterMuted || !!cur?.requesterMutedByList,
+          mutedByList: cur.requesterMutedByList
             ? this.services.graph.formatListViewBasic(
-                listViews[profileInfo.requesterMutedByList],
+                listViews[cur.requesterMutedByList],
               )
             : undefined,
-          blockedBy: !!profileInfo.requesterBlockedBy,
-          blocking: profileInfo.requesterBlocking || undefined,
-          following: profileInfo?.requesterFollowing || undefined,
-          followedBy: profileInfo?.requesterFollowedBy || undefined,
+          blockedBy: !!cur.requesterBlockedBy,
+          blocking: cur.requesterBlocking || undefined,
+          following: cur?.requesterFollowing || undefined,
+          followedBy: cur?.requesterFollowedBy || undefined,
         },
-        labels: labels[result.did] ?? [],
+        labels: labels[cur.did] ?? [],
       }
-    })
-
-    return Array.isArray(result) ? views : views[0]
+      return {
+        ...acc,
+        [cur.did]: profile,
+      }
+    }, {} as Record<string, ProfileView>)
   }
 
-  // @NOTE keep in sync with feedService.getActorViews()
-  profileBasic(
+  async profile(
     result: ActorResult,
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewBasic>
-  profileBasic(
-    result: ActorResult[],
+  ): Promise<ProfileView | null> {
+    const profiles = await this.profiles([result], viewer, opts)
+    return profiles[result.did] ?? null
+  }
+
+  // @NOTE keep in sync with feedService.getActorViews()
+  async profilesBasic(
+    results: ActorResult[],
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewBasic[]>
+  ): Promise<Record<string, ProfileViewBasic>> {
+    if (results.length === 0) return {}
+
+    const profiles = await this.profiles(results, viewer, opts)
+
+    return Object.values(profiles).reduce((acc, cur) => {
+      return {
+        ...acc,
+        [cur.did]: {
+          did: cur.did,
+          handle: cur.handle,
+          displayName: truncateUtf8(cur.displayName, 64) || undefined,
+          avatar: cur.avatar,
+          viewer: cur.viewer,
+          labels: cur.labels,
+        },
+      }
+    }, {} as Record<string, ProfileViewBasic>)
+  }
+
   async profileBasic(
-    result: ActorResult | ActorResult[],
+    result: ActorResult,
     viewer: string,
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
-  ): Promise<ProfileViewBasic | ProfileViewBasic[]> {
-    const results = Array.isArray(result) ? result : [result]
-    if (results.length === 0) return []
-
-    const profiles = await this.profile(results, viewer, opts)
-    const views = profiles.map((view) => ({
-      did: view.did,
-      handle: view.handle,
-      displayName: truncateUtf8(view.displayName, 64) || undefined,
-      avatar: view.avatar,
-      viewer: view.viewer,
-      labels: view.labels,
-    }))
-
-    return Array.isArray(result) ? views : views[0]
+  ): Promise<ProfileViewBasic | null> {
+    const profiles = await this.profilesBasic([result], viewer, opts)
+    return profiles[result.did] ?? null
   }
 }
 

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -151,13 +151,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileViewDetailed[]> {
     const profiles = await this.profilesDetailed(results, viewer, opts)
-    const ordered: ProfileViewDetailed[] = []
-    for (const result of results) {
-      if (profiles[result.did]) {
-        ordered.push(profiles[result.did])
-      }
-    }
-    return ordered
+    return hydrateOrdered(results, profiles)
   }
 
   async profileDetailed(
@@ -284,13 +278,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileView[]> {
     const profiles = await this.profiles(results, viewer, opts)
-    const ordered: ProfileView[] = []
-    for (const result of results) {
-      if (profiles[result.did]) {
-        ordered.push(profiles[result.did])
-      }
-    }
-    return ordered
+    return hydrateOrdered(results, profiles)
   }
 
   async profile(
@@ -333,13 +321,7 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<ProfileViewBasic[]> {
     const profiles = await this.profilesBasic(results, viewer, opts)
-    const ordered: ProfileViewBasic[] = []
-    for (const result of results) {
-      if (profiles[result.did]) {
-        ordered.push(profiles[result.did])
-      }
-    }
-    return ordered
+    return hydrateOrdered(results, profiles)
   }
 
   async profileBasic(
@@ -364,4 +346,17 @@ function truncateUtf8(str: string | null | undefined, length: number) {
     return decoder.decode(truncated).replace(/\uFFFD$/, '')
   }
   return str
+}
+
+const hydrateOrdered = <T>(
+  results: ActorResult[],
+  profiles: Record<string, T>,
+): T[] => {
+  const ordered: T[] = []
+  for (const result of results) {
+    if (profiles[result.did]) {
+      ordered.push(profiles[result.did])
+    }
+  }
+  return ordered
 }

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -297,11 +297,9 @@ export class ActorViews {
     opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
   ): Promise<Record<string, ProfileViewBasic>> {
     if (results.length === 0) return {}
-
     const profiles = await this.profiles(results, viewer, opts)
-
-    return Object.values(profiles).reduce((acc, cur) => {
-      return {
+    return Object.values(profiles).reduce(
+      (acc, cur) => ({
         ...acc,
         [cur.did]: {
           did: cur.did,
@@ -311,8 +309,9 @@ export class ActorViews {
           viewer: cur.viewer,
           labels: cur.labels,
         },
-      }
-    }, {} as Record<string, ProfileViewBasic>)
+      }),
+      {} as Record<string, ProfileViewBasic>,
+    )
   }
 
   async hydrateProfilesBasic(

--- a/packages/pds/src/app-view/services/actor/views.ts
+++ b/packages/pds/src/app-view/services/actor/views.ts
@@ -145,6 +145,21 @@ export class ActorViews {
     }, {} as Record<string, ProfileViewDetailed>)
   }
 
+  async hydrateProfilesDetailed(
+    results: ActorResult[],
+    viewer: string,
+    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
+  ): Promise<ProfileViewDetailed[]> {
+    const profiles = await this.profilesDetailed(results, viewer, opts)
+    const ordered: ProfileViewDetailed[] = []
+    for (const result of results) {
+      if (profiles[result.did]) {
+        ordered.push(profiles[result.did])
+      }
+    }
+    return ordered
+  }
+
   async profileDetailed(
     result: ActorResult,
     viewer: string,
@@ -263,6 +278,21 @@ export class ActorViews {
     }, {} as Record<string, ProfileView>)
   }
 
+  async hydrateProfiles(
+    results: ActorResult[],
+    viewer: string,
+    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
+  ): Promise<ProfileView[]> {
+    const profiles = await this.profiles(results, viewer, opts)
+    const ordered: ProfileView[] = []
+    for (const result of results) {
+      if (profiles[result.did]) {
+        ordered.push(profiles[result.did])
+      }
+    }
+    return ordered
+  }
+
   async profile(
     result: ActorResult,
     viewer: string,
@@ -295,6 +325,21 @@ export class ActorViews {
         },
       }
     }, {} as Record<string, ProfileViewBasic>)
+  }
+
+  async hydrateProfilesBasic(
+    results: ActorResult[],
+    viewer: string,
+    opts?: { skipLabels?: boolean; includeSoftDeleted?: boolean },
+  ): Promise<ProfileViewBasic[]> {
+    const profiles = await this.profilesBasic(results, viewer, opts)
+    const ordered: ProfileViewBasic[] = []
+    for (const result of results) {
+      if (profiles[result.did]) {
+        ordered.push(profiles[result.did])
+      }
+    }
+    return ordered
   }
 
   async profileBasic(

--- a/packages/pds/src/app-view/services/feed/index.ts
+++ b/packages/pds/src/app-view/services/feed/index.ts
@@ -192,22 +192,25 @@ export class FeedService {
     )
     return actors.reduce((acc, cur) => {
       const actorLabels = labels[cur.did] ?? []
+      const avatar = cur.avatarCid
+        ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
+        : undefined
+      const mutedByList =
+        cur.requesterMutedByList && listViews[cur.requesterMutedByList]
+          ? this.services.graph.formatListViewBasic(
+              listViews[cur.requesterMutedByList],
+            )
+          : undefined
       return {
         ...acc,
         [cur.did]: {
           did: cur.did,
           handle: cur.handle,
           displayName: truncateUtf8(cur.displayName, 64) || undefined,
-          avatar: cur.avatarCid
-            ? this.imgUriBuilder.getCommonSignedUri('avatar', cur.avatarCid)
-            : undefined,
+          avatar,
           viewer: {
             muted: !!cur?.requesterMuted || !!cur?.requesterMutedByList,
-            mutedByList: cur.requesterMutedByList
-              ? this.services.graph.formatListViewBasic(
-                  listViews[cur.requesterMutedByList],
-                )
-              : undefined,
+            mutedByList,
             blockedBy: !!cur?.requesterBlockedBy,
             blocking: cur?.requesterBlocking || undefined,
             following: cur?.requesterFollowing || undefined,


### PR DESCRIPTION
Fixing some bugs introduced in https://github.com/bluesky-social/atproto/pull/1412

Refactors the appview to return a map of records. Introduce separate methods for returning either an individual record, or an ordered hydrated list (which skips over non-existant actors). 

Also refactor requesterMutedBy in appview actor service (Closes https://github.com/bluesky-social/atproto/issues/1411)