### PR TITLE
pds: set default postgresql URL to localhost

### DIFF
--- a/packages/pds/service/index.js
+++ b/packages/pds/service/index.js
@@ -97,7 +97,7 @@ const main = async () => {
 const pgUrl = ({
   username = 'postgres',
   password = 'postgres',
-  host = '0.0.0.0',
+  host = 'localhost',
   port = '5432',
   database = 'postgres',
   sslmode,


### PR DESCRIPTION
This came up in code review of https://github.com/bluesky-social/atproto/pull/974, but seems like the change wasn't actually made before merging.

This is a connection string, not binding, so `0.0.0.0` ("all addresses on all interfaces") doesn't make sense.

As a piece of standards nerdery, there are IETF/IANA efforts both to allow registrations under the `0.` class A IPv4 prefix (https://www.ietf.org/archive/id/draft-schoen-intarea-lowest-address-01.html), and I think also to enable communicating with IPv4 addresses terminating in (`.0`) (https://www.ietf.org/archive/id/draft-schoen-intarea-lowest-address-01.html). Both are controversial!