### PR TITLE
Codegen `ErrorName` enum for each resource

### DIFF
--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -530,7 +530,6 @@ export const schemaDict = {
       },
       moderation: {
         type: 'object',
-        required: [],
         properties: {
           currentAction: {
             type: 'ref',
@@ -1652,7 +1651,7 @@ export const schemaDict = {
       },
       reasonSexual: {
         type: 'token',
-        description: 'Unwanted or mis-labeled sexual content',
+        description: 'Unwanted or mislabeled sexual content',
       },
       reasonRude: {
         type: 'token',

--- a/packages/api/src/client/types/app/bsky/actor/getPreferences.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getPreferences.ts
@@ -27,6 +27,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/getProfile.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfile.ts
@@ -25,6 +25,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/getProfiles.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getProfiles.ts
@@ -29,6 +29,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/api/src/client/types/app/bsky/actor/getSuggestions.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/putPreferences.ts
+++ b/packages/api/src/client/types/app/bsky/actor/putPreferences.ts
@@ -26,6 +26,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/searchActors.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActors.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -30,6 +30,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/describeFeedGenerator.ts
+++ b/packages/api/src/client/types/app/bsky/feed/describeFeedGenerator.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getActorFeeds.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getActorFeeds.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -44,10 +44,15 @@ export class BlockedByActorError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  BlockedActor = 'BlockedActor',
+  BlockedByActor = 'BlockedByActor',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'BlockedActor') return new BlockedActorError(e)
-    if (e.error === 'BlockedByActor') return new BlockedByActorError(e)
+    if (e.error === ErrorName.BlockedActor) return new BlockedActorError(e)
+    if (e.error === ErrorName.BlockedByActor) return new BlockedByActorError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/feed/getFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeed.ts
@@ -38,9 +38,13 @@ export class UnknownFeedError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  UnknownFeed = 'UnknownFeed',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'UnknownFeed') return new UnknownFeedError(e)
+    if (e.error === ErrorName.UnknownFeed) return new UnknownFeedError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeedGenerator.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeedGenerators.ts
@@ -29,6 +29,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeedSkeleton.ts
@@ -38,9 +38,13 @@ export class UnknownFeedError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  UnknownFeed = 'UnknownFeed',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'UnknownFeed') return new UnknownFeedError(e)
+    if (e.error === ErrorName.UnknownFeed) return new UnknownFeedError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/feed/getLikes.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getLikes.ts
@@ -35,6 +35,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -41,9 +41,13 @@ export class NotFoundError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  NotFound = 'NotFound',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'NotFound') return new NotFoundError(e)
+    if (e.error === ErrorName.NotFound) return new NotFoundError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/app/bsky/feed/getPosts.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPosts.ts
@@ -29,6 +29,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getRepostedBy.ts
@@ -35,6 +35,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getBlocks.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getBlocks.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollowers.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getFollows.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getFollows.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getList.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getList.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getListMutes.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getListMutes.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getLists.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getLists.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/getMutes.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getMutes.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/muteActor.ts
+++ b/packages/api/src/client/types/app/bsky/graph/muteActor.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/muteActorList.ts
+++ b/packages/api/src/client/types/app/bsky/graph/muteActorList.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/unmuteActor.ts
+++ b/packages/api/src/client/types/app/bsky/graph/unmuteActor.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/graph/unmuteActorList.ts
+++ b/packages/api/src/client/types/app/bsky/graph/unmuteActorList.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/notification/getUnreadCount.ts
+++ b/packages/api/src/client/types/app/bsky/notification/getUnreadCount.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
+++ b/packages/api/src/client/types/app/bsky/notification/updateSeen.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/unspecced/getPopular.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPopular.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -37,9 +37,13 @@ export class UnknownFeedError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  UnknownFeed = 'UnknownFeed',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'UnknownFeed') return new UnknownFeedError(e)
+    if (e.error === ErrorName.UnknownFeed) return new UnknownFeedError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/disableAccountInvites.ts
+++ b/packages/api/src/client/types/com/atproto/admin/disableAccountInvites.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/disableInviteCodes.ts
+++ b/packages/api/src/client/types/com/atproto/admin/disableInviteCodes.ts
@@ -26,6 +26,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/enableAccountInvites.ts
+++ b/packages/api/src/client/types/com/atproto/admin/enableAccountInvites.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getInviteCodes.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getInviteCodes.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getModerationAction.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationAction.ts
@@ -25,6 +25,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationActions.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getModerationReport.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationReport.ts
@@ -25,6 +25,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getModerationReports.ts
@@ -46,6 +46,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRecord.ts
@@ -32,9 +32,13 @@ export class RecordNotFoundError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  RecordNotFound = 'RecordNotFound',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'RecordNotFound') return new RecordNotFoundError(e)
+    if (e.error === ErrorName.RecordNotFound) return new RecordNotFoundError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/admin/getRepo.ts
@@ -31,9 +31,13 @@ export class RepoNotFoundError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  RepoNotFound = 'RepoNotFound',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'RepoNotFound') return new RepoNotFoundError(e)
+    if (e.error === ErrorName.RepoNotFound) return new RepoNotFoundError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/rebaseRepo.ts
+++ b/packages/api/src/client/types/com/atproto/admin/rebaseRepo.ts
@@ -40,10 +40,16 @@ export class ConcurrentWritesError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+  ConcurrentWrites = 'ConcurrentWrites',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
-    if (e.error === 'ConcurrentWrites') return new ConcurrentWritesError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
+    if (e.error === ErrorName.ConcurrentWrites)
+      return new ConcurrentWritesError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/resolveModerationReports.ts
+++ b/packages/api/src/client/types/com/atproto/admin/resolveModerationReports.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/api/src/client/types/com/atproto/admin/reverseModerationAction.ts
@@ -31,6 +31,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/searchRepos.ts
+++ b/packages/api/src/client/types/com/atproto/admin/searchRepos.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/sendEmail.ts
+++ b/packages/api/src/client/types/com/atproto/admin/sendEmail.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/takeModerationAction.ts
+++ b/packages/api/src/client/types/com/atproto/admin/takeModerationAction.ts
@@ -49,9 +49,14 @@ export class SubjectHasActionError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  SubjectHasAction = 'SubjectHasAction',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'SubjectHasAction') return new SubjectHasActionError(e)
+    if (e.error === ErrorName.SubjectHasAction)
+      return new SubjectHasActionError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/admin/updateAccountEmail.ts
+++ b/packages/api/src/client/types/com/atproto/admin/updateAccountEmail.ts
@@ -27,6 +27,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/api/src/client/types/com/atproto/admin/updateAccountHandle.ts
@@ -26,6 +26,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/identity/resolveHandle.ts
+++ b/packages/api/src/client/types/com/atproto/identity/resolveHandle.ts
@@ -29,6 +29,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/identity/updateHandle.ts
+++ b/packages/api/src/client/types/com/atproto/identity/updateHandle.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/label/queryLabels.ts
+++ b/packages/api/src/client/types/com/atproto/label/queryLabels.ts
@@ -35,6 +35,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/moderation/createReport.ts
+++ b/packages/api/src/client/types/com/atproto/moderation/createReport.ts
@@ -47,6 +47,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/moderation/defs.ts
+++ b/packages/api/src/client/types/com/atproto/moderation/defs.ts
@@ -21,7 +21,7 @@ export const REASONSPAM = 'com.atproto.moderation.defs#reasonSpam'
 export const REASONVIOLATION = 'com.atproto.moderation.defs#reasonViolation'
 /** Misleading identity, affiliation, or content */
 export const REASONMISLEADING = 'com.atproto.moderation.defs#reasonMisleading'
-/** Unwanted or mis-labeled sexual content */
+/** Unwanted or mislabeled sexual content */
 export const REASONSEXUAL = 'com.atproto.moderation.defs#reasonSexual'
 /** Rude, harassing, explicit, or otherwise unwelcoming behavior */
 export const REASONRUDE = 'com.atproto.moderation.defs#reasonRude'

--- a/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
+++ b/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
@@ -36,9 +36,13 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -49,9 +49,13 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/deleteRecord.ts
@@ -40,9 +40,13 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/repo/describeRepo.ts
+++ b/packages/api/src/client/types/com/atproto/repo/describeRepo.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/repo/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/getRecord.ts
@@ -37,6 +37,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -41,6 +41,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/repo/putRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/putRecord.ts
@@ -51,9 +51,13 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/repo/rebaseRepo.ts
+++ b/packages/api/src/client/types/com/atproto/repo/rebaseRepo.ts
@@ -40,10 +40,16 @@ export class ConcurrentWritesError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidSwap = 'InvalidSwap',
+  ConcurrentWrites = 'ConcurrentWrites',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
-    if (e.error === 'ConcurrentWrites') return new ConcurrentWritesError(e)
+    if (e.error === ErrorName.InvalidSwap) return new InvalidSwapError(e)
+    if (e.error === ErrorName.ConcurrentWrites)
+      return new ConcurrentWritesError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/repo/uploadBlob.ts
+++ b/packages/api/src/client/types/com/atproto/repo/uploadBlob.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAccount.ts
@@ -81,15 +81,31 @@ export class IncompatibleDidDocError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  InvalidHandle = 'InvalidHandle',
+  InvalidPassword = 'InvalidPassword',
+  InvalidInviteCode = 'InvalidInviteCode',
+  HandleNotAvailable = 'HandleNotAvailable',
+  UnsupportedDomain = 'UnsupportedDomain',
+  UnresolvableDid = 'UnresolvableDid',
+  IncompatibleDidDoc = 'IncompatibleDidDoc',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'InvalidHandle') return new InvalidHandleError(e)
-    if (e.error === 'InvalidPassword') return new InvalidPasswordError(e)
-    if (e.error === 'InvalidInviteCode') return new InvalidInviteCodeError(e)
-    if (e.error === 'HandleNotAvailable') return new HandleNotAvailableError(e)
-    if (e.error === 'UnsupportedDomain') return new UnsupportedDomainError(e)
-    if (e.error === 'UnresolvableDid') return new UnresolvableDidError(e)
-    if (e.error === 'IncompatibleDidDoc') return new IncompatibleDidDocError(e)
+    if (e.error === ErrorName.InvalidHandle) return new InvalidHandleError(e)
+    if (e.error === ErrorName.InvalidPassword)
+      return new InvalidPasswordError(e)
+    if (e.error === ErrorName.InvalidInviteCode)
+      return new InvalidInviteCodeError(e)
+    if (e.error === ErrorName.HandleNotAvailable)
+      return new HandleNotAvailableError(e)
+    if (e.error === ErrorName.UnsupportedDomain)
+      return new UnsupportedDomainError(e)
+    if (e.error === ErrorName.UnresolvableDid)
+      return new UnresolvableDidError(e)
+    if (e.error === ErrorName.IncompatibleDidDoc)
+      return new IncompatibleDidDocError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
@@ -34,9 +34,14 @@ export class AccountTakedownError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  AccountTakedown = 'AccountTakedown',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'AccountTakedown') return new AccountTakedownError(e)
+    if (e.error === ErrorName.AccountTakedown)
+      return new AccountTakedownError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/createInviteCode.ts
+++ b/packages/api/src/client/types/com/atproto/server/createInviteCode.ts
@@ -32,6 +32,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/createInviteCodes.ts
+++ b/packages/api/src/client/types/com/atproto/server/createInviteCodes.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/createSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/createSession.ts
@@ -43,9 +43,14 @@ export class AccountTakedownError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  AccountTakedown = 'AccountTakedown',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'AccountTakedown') return new AccountTakedownError(e)
+    if (e.error === ErrorName.AccountTakedown)
+      return new AccountTakedownError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/deleteAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/deleteAccount.ts
@@ -39,10 +39,15 @@ export class InvalidTokenError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  ExpiredToken = 'ExpiredToken',
+  InvalidToken = 'InvalidToken',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'ExpiredToken') return new ExpiredTokenError(e)
-    if (e.error === 'InvalidToken') return new InvalidTokenError(e)
+    if (e.error === ErrorName.ExpiredToken) return new ExpiredTokenError(e)
+    if (e.error === ErrorName.InvalidToken) return new InvalidTokenError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/deleteSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/deleteSession.ts
@@ -21,6 +21,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/describeServer.ts
+++ b/packages/api/src/client/types/com/atproto/server/describeServer.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/api/src/client/types/com/atproto/server/getAccountInviteCodes.ts
@@ -36,9 +36,14 @@ export class DuplicateCreateError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  DuplicateCreate = 'DuplicateCreate',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'DuplicateCreate') return new DuplicateCreateError(e)
+    if (e.error === ErrorName.DuplicateCreate)
+      return new DuplicateCreateError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/getSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/getSession.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/api/src/client/types/com/atproto/server/listAppPasswords.ts
@@ -32,9 +32,14 @@ export class AccountTakedownError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  AccountTakedown = 'AccountTakedown',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'AccountTakedown') return new AccountTakedownError(e)
+    if (e.error === ErrorName.AccountTakedown)
+      return new AccountTakedownError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/refreshSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/refreshSession.ts
@@ -36,9 +36,14 @@ export class AccountTakedownError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  AccountTakedown = 'AccountTakedown',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'AccountTakedown') return new AccountTakedownError(e)
+    if (e.error === ErrorName.AccountTakedown)
+      return new AccountTakedownError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/requestAccountDelete.ts
+++ b/packages/api/src/client/types/com/atproto/server/requestAccountDelete.ts
@@ -21,6 +21,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/requestPasswordReset.ts
+++ b/packages/api/src/client/types/com/atproto/server/requestPasswordReset.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/server/resetPassword.ts
+++ b/packages/api/src/client/types/com/atproto/server/resetPassword.ts
@@ -38,10 +38,15 @@ export class InvalidTokenError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  ExpiredToken = 'ExpiredToken',
+  InvalidToken = 'InvalidToken',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'ExpiredToken') return new ExpiredTokenError(e)
-    if (e.error === 'InvalidToken') return new InvalidTokenError(e)
+    if (e.error === ErrorName.ExpiredToken) return new ExpiredTokenError(e)
+    if (e.error === ErrorName.InvalidToken) return new InvalidTokenError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/revokeAppPassword.ts
+++ b/packages/api/src/client/types/com/atproto/server/revokeAppPassword.ts
@@ -25,6 +25,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getBlob.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getBlob.ts
@@ -26,6 +26,8 @@ export interface Response {
   data: Uint8Array
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getBlocks.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getBlocks.ts
@@ -25,6 +25,8 @@ export interface Response {
   data: Uint8Array
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getCheckout.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getCheckout.ts
@@ -26,6 +26,8 @@ export interface Response {
   data: Uint8Array
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getCommitPath.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getCommitPath.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getHead.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getHead.ts
@@ -35,9 +35,13 @@ export class HeadNotFoundError extends XRPCError {
   }
 }
 
+export enum ErrorName {
+  HeadNotFound = 'HeadNotFound',
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
-    if (e.error === 'HeadNotFound') return new HeadNotFoundError(e)
+    if (e.error === ErrorName.HeadNotFound) return new HeadNotFoundError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/sync/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRecord.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: Uint8Array
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/getRepo.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRepo.ts
@@ -28,6 +28,8 @@ export interface Response {
   data: Uint8Array
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/listBlobs.ts
+++ b/packages/api/src/client/types/com/atproto/sync/listBlobs.ts
@@ -33,6 +33,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/listRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/listRepos.ts
@@ -30,6 +30,8 @@ export interface Response {
   data: OutputSchema
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/api/src/client/types/com/atproto/sync/notifyOfUpdate.ts
@@ -26,6 +26,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/api/src/client/types/com/atproto/sync/requestCrawl.ts
@@ -26,6 +26,8 @@ export interface Response {
   headers: Headers
 }
 
+export enum ErrorName {}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
   }

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -611,6 +611,12 @@ function genClientXrpcCommon(
     customErrors.push({ name: error.name, cls: name })
   }
 
+  file.addEnum({
+    isExported: true,
+    name: 'ErrorName',
+    members: customErrors.map(e => ({ name: e.name, value: e.name }))
+  })
+
   // export function toKnownErr(err: any) {...}
   const toKnownErrFn = file.addFunction({
     name: 'toKnownErr',
@@ -621,7 +627,7 @@ function genClientXrpcCommon(
     [
       `if (e instanceof XRPCError) {`,
       ...customErrors.map(
-        (err) => `if (e.error === '${err.name}') return new ${err.cls}(e)`,
+        (err) => `if (e.error === ErrorName.${err.name}) return new ${err.cls}(e)`,
       ),
       `}`,
       `return e`,

--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -614,7 +614,7 @@ function genClientXrpcCommon(
   file.addEnum({
     isExported: true,
     name: 'ErrorName',
-    members: customErrors.map(e => ({ name: e.name, value: e.name }))
+    members: customErrors.map((e) => ({ name: e.name, value: e.name })),
   })
 
   // export function toKnownErr(err: any) {...}
@@ -627,7 +627,8 @@ function genClientXrpcCommon(
     [
       `if (e instanceof XRPCError) {`,
       ...customErrors.map(
-        (err) => `if (e.error === ErrorName.${err.name}) return new ${err.cls}(e)`,
+        (err) =>
+          `if (e.error === ErrorName.${err.name}) return new ${err.cls}(e)`,
       ),
       `}`,
       `return e`,


### PR DESCRIPTION
Small quality-of-life update. Updates `lex-cli` to generate a `ErrorName` enum that maps possible error values as specified by the lexicon configs.

Usage example:

```ts
import { AppBskyFeedGetAuthorFeed } from '@atproto/api'
import { InvalidRequestError } from '@atproto/xrpc-server'

throw new InvalidRequestError(
  `Requester is blocked by actor: ${actor}`,
  AppBskyFeedGetAuthorFeed.ErrorName.BlockedByActor // instead of a string 'BlockedByActor'
)
```

Is `ErrorName` naming OK?