### PR TITLE
update pds getFeed to use new errors

### DIFF
--- a/lexicons/app/bsky/feed/getFeed.json
+++ b/lexicons/app/bsky/feed/getFeed.json
@@ -29,7 +29,11 @@
         }
       },
       "errors": [
-        {"name": "UnknownFeed"}
+        {"name": "UnknownFeed"},
+        {"name": "FeedUnavailable"},
+        {"name": "FeedNotFound"},
+        {"name": "InvalidFeedResponse"},
+        {"name": "InvalidFeedConfig"}
       ]
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4818,6 +4818,18 @@ export const schemaDict = {
           {
             name: 'UnknownFeed',
           },
+          {
+            name: 'FeedUnavailable',
+          },
+          {
+            name: 'FeedNotFound',
+          },
+          {
+            name: 'InvalidFeedResponse',
+          },
+          {
+            name: 'InvalidFeedConfig',
+          },
         ],
       },
     },

--- a/packages/api/src/client/types/app/bsky/feed/getFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeed.ts
@@ -38,13 +38,48 @@ export class UnknownFeedError extends XRPCError {
   }
 }
 
+export class FeedUnavailableError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class FeedNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class InvalidFeedResponseError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
+export class InvalidFeedConfigError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message)
+  }
+}
+
 export enum ErrorName {
   UnknownFeed = 'UnknownFeed',
+  FeedUnavailable = 'FeedUnavailable',
+  FeedNotFound = 'FeedNotFound',
+  InvalidFeedResponse = 'InvalidFeedResponse',
+  InvalidFeedConfig = 'InvalidFeedConfig',
 }
 
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
     if (e.error === ErrorName.UnknownFeed) return new UnknownFeedError(e)
+    if (e.error === ErrorName.FeedUnavailable)
+      return new FeedUnavailableError(e)
+    if (e.error === ErrorName.FeedNotFound) return new FeedNotFoundError(e)
+    if (e.error === ErrorName.InvalidFeedResponse)
+      return new InvalidFeedResponseError(e)
+    if (e.error === ErrorName.InvalidFeedConfig)
+      return new InvalidFeedConfigError(e)
   }
   return e
 }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
@@ -133,7 +133,7 @@ async function skeletonFromFeedGen(
   const fgEndpoint = getFeedGen(resolved)
   if (!fgEndpoint) {
     throw new InvalidRequestError(
-      `Invalid feed benerator service details in DID document: ${feedDid}`,
+      `Invalid feed generator service details in DID document: ${feedDid}`,
       AppBskyFeedGetFeed.ErrorName.InvalidFeedConfig,
     )
   }


### PR DESCRIPTION
Example usage of #1420 

NB: using the `ErrorName` enums will mean we create many more possible error values in the Lexicon defs.