### PR TITLE
Return Like URIs when fetching a page of likes

### DIFF
--- a/lexicons/app/bsky/feed/getLikes.json
+++ b/lexicons/app/bsky/feed/getLikes.json
@@ -33,10 +33,11 @@
     },
     "like": {
       "type": "object",
-      "required": ["indexedAt", "createdAt", "actor"],
+      "required": ["indexedAt", "createdAt", "uri", "actor"],
       "properties": {
         "indexedAt": {"type": "string", "format": "datetime"},
         "createdAt": {"type": "string", "format": "datetime"},
+        "uri": {"type": "string", "format": "at-uri"},
         "actor": {"type": "ref", "ref": "app.bsky.actor.defs#profileView"}
       }
     }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5030,7 +5030,7 @@ export const schemaDict = {
       },
       like: {
         type: 'object',
-        required: ['indexedAt', 'createdAt', 'actor'],
+        required: ['indexedAt', 'createdAt', 'uri', 'actor'],
         properties: {
           indexedAt: {
             type: 'string',
@@ -5039,6 +5039,10 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
           actor: {
             type: 'ref',

--- a/packages/api/src/client/types/app/bsky/feed/getLikes.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getLikes.ts
@@ -44,6 +44,7 @@ export function toKnownErr(e: any) {
 export interface Like {
   indexedAt: string
   createdAt: string
+  uri: string
   actor: AppBskyActorDefs.ProfileView
   [k: string]: unknown
 }

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -21,6 +21,7 @@ export default function (server: Server, ctx: AppContext) {
         .selectAll('creator')
         .select([
           'like.cid as cid',
+          'like.uri as like_uri',
           'like.createdAt as createdAt',
           'like.indexedAt as indexedAt',
           'like.sortAt as sortAt',
@@ -47,6 +48,7 @@ export default function (server: Server, ctx: AppContext) {
           ? {
               createdAt: row.createdAt,
               indexedAt: row.indexedAt,
+              uri: row.like_uri,
               actor: actors[row.did],
             }
           : undefined,

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5030,7 +5030,7 @@ export const schemaDict = {
       },
       like: {
         type: 'object',
-        required: ['indexedAt', 'createdAt', 'actor'],
+        required: ['indexedAt', 'createdAt', 'uri', 'actor'],
         properties: {
           indexedAt: {
             type: 'string',
@@ -5039,6 +5039,10 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
           actor: {
             type: 'ref',

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -51,6 +51,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 export interface Like {
   indexedAt: string
   createdAt: string
+  uri: string
   actor: AppBskyActorDefs.ProfileView
   [k: string]: unknown
 }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -40,6 +40,7 @@ export default function (server: Server, ctx: AppContext) {
         .selectAll('creator')
         .select([
           'like.cid as cid',
+          'like.uri as like_uri',
           'like.createdAt as createdAt',
           'like.indexedAt as indexedAt',
         ])
@@ -65,6 +66,7 @@ export default function (server: Server, ctx: AppContext) {
           ? {
               createdAt: row.createdAt,
               indexedAt: row.indexedAt,
+              uri: row.like_uri,
               actor: actors[row.did],
             }
           : undefined,

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5030,7 +5030,7 @@ export const schemaDict = {
       },
       like: {
         type: 'object',
-        required: ['indexedAt', 'createdAt', 'actor'],
+        required: ['indexedAt', 'createdAt', 'uri', 'actor'],
         properties: {
           indexedAt: {
             type: 'string',
@@ -5039,6 +5039,10 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
           actor: {
             type: 'ref',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -51,6 +51,7 @@ export type Handler<HA extends HandlerAuth = never> = (ctx: {
 export interface Like {
   indexedAt: string
   createdAt: string
+  uri: string
   actor: AppBskyActorDefs.ProfileView
   [k: string]: unknown
 }


### PR DESCRIPTION
The `getLikes` endpoint returns a page of likes but it doesn't provide the URI of the like records which makes it impossible to lookup the like record from the response. This change adds the like URI to the paginated response.