### PR TITLE
Fix blocks in follow views

### DIFF
--- a/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
@@ -14,6 +14,7 @@ export default function (server: Server, ctx: AppContext) {
       const { ref } = db.db.dynamic
 
       const actorService = services.actor(db)
+      const graphService = services.graph(db)
 
       const subjectRes = await actorService.getActor(actor)
       if (!subjectRes) {
@@ -25,6 +26,9 @@ export default function (server: Server, ctx: AppContext) {
         .where('follow.subjectDid', '=', subjectRes.did)
         .innerJoin('actor as creator', 'creator.did', 'follow.creator')
         .where(notSoftDeletedClause(ref('creator')))
+        .whereNotExists(
+          graphService.blockQb(requester, [ref('follow.creator')]),
+        )
         .selectAll('creator')
         .select(['follow.cid as cid', 'follow.sortAt as sortAt'])
 

--- a/packages/bsky/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollows.ts
@@ -14,6 +14,7 @@ export default function (server: Server, ctx: AppContext) {
       const { ref } = db.db.dynamic
 
       const actorService = services.actor(db)
+      const graphService = services.graph(db)
 
       const creatorRes = await actorService.getActor(actor)
       if (!creatorRes) {
@@ -25,6 +26,9 @@ export default function (server: Server, ctx: AppContext) {
         .where('follow.creator', '=', creatorRes.did)
         .innerJoin('actor as subject', 'subject.did', 'follow.subjectDid')
         .where(notSoftDeletedClause(ref('subject')))
+        .whereNotExists(
+          graphService.blockQb(requester, [ref('follow.subjectDid')]),
+        )
         .selectAll('subject')
         .select(['follow.cid as cid', 'follow.sortAt as sortAt'])
 

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -43,7 +43,7 @@ export default function (server: Server, ctx: AppContext) {
         )
         .where(notSoftDeletedClause(ref('creator_repo')))
         .whereNotExists(
-          graphService.blockQb(requester, [ref('follow.subjectDid')]),
+          graphService.blockQb(requester, [ref('follow.creator')]),
         )
         .selectAll('creator')
         .select(['follow.cid as cid', 'follow.createdAt as createdAt'])

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -43,7 +43,7 @@ export default function (server: Server, ctx: AppContext) {
         )
         .where(notSoftDeletedClause(ref('subject_repo')))
         .whereNotExists(
-          graphService.blockQb(requester, [ref('follow.creator')]),
+          graphService.blockQb(requester, [ref('follow.subjectDid')]),
         )
         .selectAll('subject')
         .select(['follow.cid as cid', 'follow.createdAt as createdAt'])


### PR DESCRIPTION
Pretty sure I had subject/creator swapped in these queries.

Also looks like blocks got missed in these routes in the appview code (though that code is not yet in service), so I added them in here.

This probably needs a bit more work (or a quick followup) so that follows that violate a block relationship are not showed to any viewers - similar to how we handle blocked replies.

Closes https://github.com/bluesky-social/atproto/issues/1399