### PR TITLE
add filter param to getAuthorFeed

### DIFF
--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "enum": ["post_and_replies", "posts", "media"], "default": "posts_and_replies"}
+          "filter": {"type": "string", "enum": ["posts_and_replies", "posts", "media"], "default": "posts_and_replies"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "knownValues": ["posts_and_replies", "posts", "media"], "default": "posts_and_replies"}
+          "filter": {"type": "string", "knownValues": ["posts_and_replies", "posts_only", "posts_with_media"], "default": "posts_and_replies"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "enum": ["posts", "post_and_replies", "media"], "default": "posts"}
+          "filter": {"type": "string", "enum": ["post_and_replies", "posts", "media"], "default": "posts_and_replies"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "knownValues": ["posts_and_replies", "posts_only", "posts_with_media"], "default": "posts_and_replies"}
+          "filter": {"type": "string", "knownValues": ["posts", "posts_no_replies", "posts_with_media"], "default": "posts"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -11,7 +11,8 @@
         "properties": {
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
-          "cursor": {"type": "string"}
+          "cursor": {"type": "string"},
+          "filter": {"type": "string", "enum": ["posts", "post_and_replies", "media"], "default": "posts"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "knownValues": ["posts", "posts_no_replies", "posts_with_media"], "default": "posts"}
+          "filter": {"type": "string", "knownValues": ["posts_with_replies", "posts_no_replies", "posts_with_media"], "default": "posts_with_replies"}
         }
       },
       "output": {

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -12,7 +12,7 @@
           "actor": {"type": "string", "format": "at-identifier"},
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"},
-          "filter": {"type": "string", "enum": ["posts_and_replies", "posts", "media"], "default": "posts_and_replies"}
+          "filter": {"type": "string", "knownValues": ["posts_and_replies", "posts", "media"], "default": "posts_and_replies"}
         }
       },
       "output": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4754,12 +4754,8 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: [
-                'posts_and_replies',
-                'posts_only',
-                'posts_with_media',
-              ],
-              default: 'posts_and_replies',
+              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
+              default: 'posts',
             },
           },
         },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4754,7 +4754,11 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts_and_replies', 'posts', 'media'],
+              knownValues: [
+                'posts_and_replies',
+                'posts_only',
+                'posts_with_media',
+              ],
               default: 'posts_and_replies',
             },
           },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4754,7 +4754,7 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              enum: ['posts_and_replies', 'posts', 'media'],
+              knownValues: ['posts_and_replies', 'posts', 'media'],
               default: 'posts_and_replies',
             },
           },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4754,8 +4754,12 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
-              default: 'posts',
+              knownValues: [
+                'posts_with_replies',
+                'posts_no_replies',
+                'posts_with_media',
+              ],
+              default: 'posts_with_replies',
             },
           },
         },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4752,6 +4752,11 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            filter: {
+              type: 'string',
+              enum: ['posts_and_replies', 'posts', 'media'],
+              default: 'posts_and_replies',
+            },
           },
         },
         output: {

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -12,7 +12,11 @@ export interface QueryParams {
   actor: string
   limit?: number
   cursor?: string
-  filter?: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
+  filter?:
+    | 'posts_with_replies'
+    | 'posts_no_replies'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -12,7 +12,11 @@ export interface QueryParams {
   actor: string
   limit?: number
   cursor?: string
-  filter?: 'posts_and_replies' | 'posts' | 'media' | (string & {})
+  filter?:
+    | 'posts_and_replies'
+    | 'posts_only'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -12,6 +12,7 @@ export interface QueryParams {
   actor: string
   limit?: number
   cursor?: string
+  filter?: 'posts_and_replies' | 'posts' | 'media'
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -12,11 +12,7 @@ export interface QueryParams {
   actor: string
   limit?: number
   cursor?: string
-  filter?:
-    | 'posts_and_replies'
-    | 'posts_only'
-    | 'posts_with_media'
-    | (string & {})
+  filter?: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getAuthorFeed.ts
@@ -12,7 +12,7 @@ export interface QueryParams {
   actor: string
   limit?: number
   cursor?: string
-  filter?: 'posts_and_replies' | 'posts' | 'media'
+  filter?: 'posts_and_replies' | 'posts' | 'media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -56,7 +56,8 @@ export default function (server: Server, ctx: AppContext) {
         feedItemsQb = feedItemsQb.whereExists((qb) =>
           qb
             .selectFrom('post_embed_image')
-            .where('post_embed_image.postUri', '=', 'feed_item.postUri'),
+            .select('post_embed_image.postUri')
+            .whereRef('post_embed_image.postUri', '=', 'feed_item.postUri'),
         )
       } else if (filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -53,9 +53,10 @@ export default function (server: Server, ctx: AppContext) {
 
       if (filter === 'posts_with_media') {
         // only posts with media
-        feedItemsQb = feedItemsQb.whereExists(qb =>
-          qb.selectFrom('post_embed_image')
-            .where('post_embed_image.postUri', '=', 'feed_item.postUri')
+        feedItemsQb = feedItemsQb.whereExists((qb) =>
+          qb
+            .selectFrom('post_embed_image')
+            .where('post_embed_image.postUri', '=', 'feed_item.postUri'),
         )
       } else if (filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -51,14 +51,14 @@ export default function (server: Server, ctx: AppContext) {
         .selectFeedItemQb()
         .where('originatorDid', '=', did)
 
-      if (filter === 'media') {
+      if (filter === 'posts_with_media') {
         // only posts with media
         feedItemsQb = feedItemsQb.innerJoin(
           'post_embed_image',
           'post_embed_image.postUri',
           'feed_item.postUri',
         )
-      } else if (filter === 'posts') {
+      } else if (filter === 'posts_only') {
         // only posts, no replies
         feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
       }

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -53,10 +53,9 @@ export default function (server: Server, ctx: AppContext) {
 
       if (filter === 'posts_with_media') {
         // only posts with media
-        feedItemsQb = feedItemsQb.innerJoin(
-          'post_embed_image',
-          'post_embed_image.postUri',
-          'feed_item.postUri',
+        feedItemsQb = feedItemsQb.whereExists(qb =>
+          qb.selectFrom('post_embed_image')
+            .where('post_embed_image.postUri', '=', 'feed_item.postUri')
         )
       } else if (filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -58,7 +58,7 @@ export default function (server: Server, ctx: AppContext) {
           'post_embed_image.postUri',
           'feed_item.postUri',
         )
-      } else if (filter === 'posts_only') {
+      } else if (filter === 'posts_no_replies') {
         // only posts, no replies
         feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
       }

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getAuthorFeed({
     auth: ctx.authOptionalVerifier,
     handler: async ({ params, auth }) => {
-      const { actor, limit, cursor } = params
+      const { actor, limit, cursor, filter } = params
       const viewer = auth.credentials.did
       const db = ctx.db.db
       const { ref } = db.dynamic
@@ -46,9 +46,22 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
+      // defaults to posts, reposts, and replies
       let feedItemsQb = feedService
         .selectFeedItemQb()
         .where('originatorDid', '=', did)
+
+      if (filter === 'media') {
+        // only posts with media
+        feedItemsQb = feedItemsQb.innerJoin(
+          'post_embed_image',
+          'post_embed_image.postUri',
+          'feed_item.postUri',
+        )
+      } else if (filter === 'posts') {
+        // only posts, no replies
+        feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
+      }
 
       if (viewer !== null) {
         feedItemsQb = feedItemsQb.where((qb) =>

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4754,12 +4754,8 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: [
-                'posts_and_replies',
-                'posts_only',
-                'posts_with_media',
-              ],
-              default: 'posts_and_replies',
+              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
+              default: 'posts',
             },
           },
         },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4754,7 +4754,11 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts_and_replies', 'posts', 'media'],
+              knownValues: [
+                'posts_and_replies',
+                'posts_only',
+                'posts_with_media',
+              ],
               default: 'posts_and_replies',
             },
           },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4754,7 +4754,7 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              enum: ['posts_and_replies', 'posts', 'media'],
+              knownValues: ['posts_and_replies', 'posts', 'media'],
               default: 'posts_and_replies',
             },
           },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4754,8 +4754,12 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
-              default: 'posts',
+              knownValues: [
+                'posts_with_replies',
+                'posts_no_replies',
+                'posts_with_media',
+              ],
+              default: 'posts_with_replies',
             },
           },
         },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4752,6 +4752,11 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            filter: {
+              type: 'string',
+              enum: ['posts_and_replies', 'posts', 'media'],
+              default: 'posts_and_replies',
+            },
           },
         },
         output: {

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts_and_replies' | 'posts' | 'media'
+  filter: 'posts_and_replies' | 'posts' | 'media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,6 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
+  filter: 'posts_and_replies' | 'posts' | 'media'
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,11 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
+  filter:
+    | 'posts_with_replies'
+    | 'posts_no_replies'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,11 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts_and_replies' | 'posts' | 'media' | (string & {})
+  filter:
+    | 'posts_and_replies'
+    | 'posts_only'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,11 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter:
-    | 'posts_and_replies'
-    | 'posts_only'
-    | 'posts_with_media'
-    | (string & {})
+  filter: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -263,7 +263,7 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
 
     const { data: postsOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
-      { actor: carol, filter: 'posts_only' },
+      { actor: carol, filter: 'posts_no_replies' },
     )
 
     expect(

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -5,7 +5,8 @@ import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
 import { TAKEDOWN } from '@atproto/api/src/client/types/com/atproto/admin/defs'
 import { isRecord } from '../../src/lexicon/types/app/bsky/feed/post'
-import { validateMain as isEmbedRecordWithMedia } from '../../src/lexicon/types/app/bsky/embed/recordWithMedia'
+import { isView as isEmbedRecordWithMedia } from '../../src/lexicon/types/app/bsky/embed/recordWithMedia'
+import { isView as isImageEmbed } from '../../src/lexicon/types/app/bsky/embed/images'
 
 describe('pds author feed views', () => {
   let network: TestNetwork
@@ -247,7 +248,8 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
     expect(
       allFeed.feed.some(({ post }) => {
-        return isEmbedRecordWithMedia(post.record)
+        return isEmbedRecordWithMedia(post.embed) &&
+          isImageEmbed(post.embed?.media)
       }),
     ).toBeTruthy()
 
@@ -258,7 +260,8 @@ describe('pds author feed views', () => {
 
     expect(
       mediaFeed.feed.every(({ post }) => {
-        return isEmbedRecordWithMedia(post.record)
+        return isEmbedRecordWithMedia(post.embed) &&
+          isImageEmbed(post.embed?.media)
       }),
     ).toBeTruthy()
 

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -268,7 +268,7 @@ describe('pds author feed views', () => {
 
     expect(
       postsOnlyFeed.feed.every(({ post }) => {
-        return isRecord(post.record) && !Boolean(post.record.reply)
+        return isRecord(post.record) && !post.record.reply
       }),
     ).toBeTruthy()
   })

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -260,10 +260,11 @@ describe('pds author feed views', () => {
       actor: carol,
       filter: 'posts_with_media',
     })
-    const { data: imagesOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed({
-      actor: bob,
-      filter: 'posts_with_media',
-    })
+    const { data: imagesOnlyFeed } =
+      await agent.api.app.bsky.feed.getAuthorFeed({
+        actor: bob,
+        filter: 'posts_with_media',
+      })
 
     expect(
       mediaFeed.feed.every(({ post }) => {

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -248,8 +248,9 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
     expect(
       allFeed.feed.some(({ post }) => {
-        return isEmbedRecordWithMedia(post.embed) &&
-          isImageEmbed(post.embed?.media)
+        return (
+          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+        )
       }),
     ).toBeTruthy()
 
@@ -260,8 +261,9 @@ describe('pds author feed views', () => {
 
     expect(
       mediaFeed.feed.every(({ post }) => {
-        return isEmbedRecordWithMedia(post.embed) &&
-          isImageEmbed(post.embed?.media)
+        return (
+          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+        )
       }),
     ).toBeTruthy()
 

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -253,7 +253,7 @@ describe('pds author feed views', () => {
 
     const { data: mediaFeed } = await agent.api.app.bsky.feed.getAuthorFeed({
       actor: carol,
-      filter: 'media',
+      filter: 'posts_with_media',
     })
 
     expect(
@@ -263,7 +263,7 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
 
     const { data: postsOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
-      { actor: carol, filter: 'posts' },
+      { actor: carol, filter: 'posts_only' },
     )
 
     expect(

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -249,7 +249,9 @@ describe('pds author feed views', () => {
     expect(
       allFeed.feed.some(({ post }) => {
         return (
-          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+          (isEmbedRecordWithMedia(post.embed) &&
+            isImageEmbed(post.embed?.media)) ||
+          isImageEmbed(post.embed)
         )
       }),
     ).toBeTruthy()
@@ -258,12 +260,23 @@ describe('pds author feed views', () => {
       actor: carol,
       filter: 'posts_with_media',
     })
+    const { data: imagesOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed({
+      actor: bob,
+      filter: 'posts_with_media',
+    })
 
     expect(
       mediaFeed.feed.every(({ post }) => {
         return (
-          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+          (isEmbedRecordWithMedia(post.embed) &&
+            isImageEmbed(post.embed?.media)) ||
+          isImageEmbed(post.embed)
         )
+      }),
+    ).toBeTruthy()
+    expect(
+      imagesOnlyFeed.feed.every(({ post }) => {
+        return isImageEmbed(post.embed)
       }),
     ).toBeTruthy()
 

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -42,7 +42,7 @@ export default function (server: Server, ctx: AppContext) {
           'post_embed_image.postUri',
           'feed_item.postUri',
         )
-      } else if (params.filter === 'posts_only') {
+      } else if (params.filter === 'posts_no_replies') {
         // only posts, no replies
         feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
       }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -37,10 +37,9 @@ export default function (server: Server, ctx: AppContext) {
 
       if (params.filter === 'posts_with_media') {
         // only posts with media
-        feedItemsQb = feedItemsQb.innerJoin(
-          'post_embed_image',
-          'post_embed_image.postUri',
-          'feed_item.postUri',
+        feedItemsQb = feedItemsQb.whereExists(qb =>
+          qb.selectFrom('post_embed_image')
+            .where('post_embed_image.postUri', '=', 'feed_item.postUri')
         )
       } else if (params.filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -37,9 +37,10 @@ export default function (server: Server, ctx: AppContext) {
 
       if (params.filter === 'posts_with_media') {
         // only posts with media
-        feedItemsQb = feedItemsQb.whereExists(qb =>
-          qb.selectFrom('post_embed_image')
-            .where('post_embed_image.postUri', '=', 'feed_item.postUri')
+        feedItemsQb = feedItemsQb.whereExists((qb) =>
+          qb
+            .selectFrom('post_embed_image')
+            .where('post_embed_image.postUri', '=', 'feed_item.postUri'),
         )
       } else if (params.filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -32,7 +32,20 @@ export default function (server: Server, ctx: AppContext) {
       const feedService = ctx.services.appView.feed(ctx.db)
       const graphService = ctx.services.appView.graph(ctx.db)
 
+      // defaults to posts, reposts, and replies
       let feedItemsQb = getFeedItemsQb(ctx, { actor })
+
+      if (params.filter === 'media') {
+        // only posts with media
+        feedItemsQb = feedItemsQb.innerJoin(
+          'post_embed_image',
+          'post_embed_image.postUri',
+          'feed_item.postUri',
+        )
+      } else if (params.filter === 'posts') {
+        // only posts, no replies
+        feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
+      }
 
       // for access-based auth, enforce blocks and mutes
       if (requester) {

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -40,7 +40,8 @@ export default function (server: Server, ctx: AppContext) {
         feedItemsQb = feedItemsQb.whereExists((qb) =>
           qb
             .selectFrom('post_embed_image')
-            .where('post_embed_image.postUri', '=', 'feed_item.postUri'),
+            .select('post_embed_image.postUri')
+            .whereRef('post_embed_image.postUri', '=', 'feed_item.postUri'),
         )
       } else if (params.filter === 'posts_no_replies') {
         // only posts, no replies

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -35,14 +35,14 @@ export default function (server: Server, ctx: AppContext) {
       // defaults to posts, reposts, and replies
       let feedItemsQb = getFeedItemsQb(ctx, { actor })
 
-      if (params.filter === 'media') {
+      if (params.filter === 'posts_with_media') {
         // only posts with media
         feedItemsQb = feedItemsQb.innerJoin(
           'post_embed_image',
           'post_embed_image.postUri',
           'feed_item.postUri',
         )
-      } else if (params.filter === 'posts') {
+      } else if (params.filter === 'posts_only') {
         // only posts, no replies
         feedItemsQb = feedItemsQb.where('post.replyParent', 'is', null)
       }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4754,12 +4754,8 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: [
-                'posts_and_replies',
-                'posts_only',
-                'posts_with_media',
-              ],
-              default: 'posts_and_replies',
+              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
+              default: 'posts',
             },
           },
         },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4754,7 +4754,11 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts_and_replies', 'posts', 'media'],
+              knownValues: [
+                'posts_and_replies',
+                'posts_only',
+                'posts_with_media',
+              ],
               default: 'posts_and_replies',
             },
           },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4754,7 +4754,7 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              enum: ['posts_and_replies', 'posts', 'media'],
+              knownValues: ['posts_and_replies', 'posts', 'media'],
               default: 'posts_and_replies',
             },
           },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4754,8 +4754,12 @@ export const schemaDict = {
             },
             filter: {
               type: 'string',
-              knownValues: ['posts', 'posts_no_replies', 'posts_with_media'],
-              default: 'posts',
+              knownValues: [
+                'posts_with_replies',
+                'posts_no_replies',
+                'posts_with_media',
+              ],
+              default: 'posts_with_replies',
             },
           },
         },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4752,6 +4752,11 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            filter: {
+              type: 'string',
+              enum: ['posts_and_replies', 'posts', 'media'],
+              default: 'posts_and_replies',
+            },
           },
         },
         output: {

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts_and_replies' | 'posts' | 'media'
+  filter: 'posts_and_replies' | 'posts' | 'media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,6 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
+  filter: 'posts_and_replies' | 'posts' | 'media'
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,11 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
+  filter:
+    | 'posts_with_replies'
+    | 'posts_no_replies'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,7 +13,11 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter: 'posts_and_replies' | 'posts' | 'media' | (string & {})
+  filter:
+    | 'posts_and_replies'
+    | 'posts_only'
+    | 'posts_with_media'
+    | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -13,11 +13,7 @@ export interface QueryParams {
   actor: string
   limit: number
   cursor?: string
-  filter:
-    | 'posts_and_replies'
-    | 'posts_only'
-    | 'posts_with_media'
-    | (string & {})
+  filter: 'posts' | 'posts_no_replies' | 'posts_with_media' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -312,7 +312,7 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
 
     const { data: postsOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
-      { actor: carol, filter: 'posts_only' },
+      { actor: carol, filter: 'posts_no_replies' },
       { headers: sc.getHeaders(alice) },
     )
 

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -318,7 +318,7 @@ describe('pds author feed views', () => {
 
     expect(
       postsOnlyFeed.feed.every(({ post }) => {
-        return isRecord(post.record) && !Boolean(post.record.reply)
+        return isRecord(post.record) && !post.record.reply
       }),
     ).toBeTruthy()
   })

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -293,7 +293,9 @@ describe('pds author feed views', () => {
     expect(
       allFeed.feed.some(({ post }) => {
         return (
-          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+          (isEmbedRecordWithMedia(post.embed) &&
+            isImageEmbed(post.embed?.media)) ||
+          isImageEmbed(post.embed)
         )
       }),
     ).toBeTruthy()
@@ -307,12 +309,28 @@ describe('pds author feed views', () => {
         headers: sc.getHeaders(alice),
       },
     )
+    const { data: imagesOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
+      {
+        actor: bob,
+        filter: 'posts_with_media',
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
 
     expect(
       mediaFeed.feed.every(({ post }) => {
         return (
-          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+          (isEmbedRecordWithMedia(post.embed) &&
+            isImageEmbed(post.embed?.media)) ||
+          isImageEmbed(post.embed)
         )
+      }),
+    ).toBeTruthy()
+    expect(
+      imagesOnlyFeed.feed.every(({ post }) => {
+        return isImageEmbed(post.embed)
       }),
     ).toBeTruthy()
 

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -298,7 +298,7 @@ describe('pds author feed views', () => {
     const { data: mediaFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
       {
         actor: carol,
-        filter: 'media',
+        filter: 'posts_with_media',
       },
       {
         headers: sc.getHeaders(alice),
@@ -312,7 +312,7 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
 
     const { data: postsOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
-      { actor: carol, filter: 'posts' },
+      { actor: carol, filter: 'posts_only' },
       { headers: sc.getHeaders(alice) },
     )
 

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -292,8 +292,9 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
     expect(
       allFeed.feed.some(({ post }) => {
-        return isEmbedRecordWithMedia(post.embed) &&
-          isImageEmbed(post.embed?.media)
+        return (
+          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+        )
       }),
     ).toBeTruthy()
 
@@ -309,8 +310,9 @@ describe('pds author feed views', () => {
 
     expect(
       mediaFeed.feed.every(({ post }) => {
-        return isEmbedRecordWithMedia(post.embed) &&
-          isImageEmbed(post.embed?.media)
+        return (
+          isEmbedRecordWithMedia(post.embed) && isImageEmbed(post.embed?.media)
+        )
       }),
     ).toBeTruthy()
 

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -309,15 +309,16 @@ describe('pds author feed views', () => {
         headers: sc.getHeaders(alice),
       },
     )
-    const { data: imagesOnlyFeed } = await agent.api.app.bsky.feed.getAuthorFeed(
-      {
-        actor: bob,
-        filter: 'posts_with_media',
-      },
-      {
-        headers: sc.getHeaders(alice),
-      },
-    )
+    const { data: imagesOnlyFeed } =
+      await agent.api.app.bsky.feed.getAuthorFeed(
+        {
+          actor: bob,
+          filter: 'posts_with_media',
+        },
+        {
+          headers: sc.getHeaders(alice),
+        },
+      )
 
     expect(
       mediaFeed.feed.every(({ post }) => {

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -10,7 +10,8 @@ import {
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
 import { isRecord } from '../../src/lexicon/types/app/bsky/feed/post'
-import { validateMain as isEmbedRecordWithMedia } from '../../src/lexicon/types/app/bsky/embed/recordWithMedia'
+import { isView as isEmbedRecordWithMedia } from '../../src/lexicon/types/app/bsky/embed/recordWithMedia'
+import { isView as isImageEmbed } from '../../src/lexicon/types/app/bsky/embed/images'
 
 describe('pds author feed views', () => {
   let agent: AtpAgent
@@ -291,7 +292,8 @@ describe('pds author feed views', () => {
     ).toBeTruthy()
     expect(
       allFeed.feed.some(({ post }) => {
-        return isEmbedRecordWithMedia(post.record)
+        return isEmbedRecordWithMedia(post.embed) &&
+          isImageEmbed(post.embed?.media)
       }),
     ).toBeTruthy()
 
@@ -307,7 +309,8 @@ describe('pds author feed views', () => {
 
     expect(
       mediaFeed.feed.every(({ post }) => {
-        return isEmbedRecordWithMedia(post.record)
+        return isEmbedRecordWithMedia(post.embed) &&
+          isImageEmbed(post.embed?.media)
       }),
     ).toBeTruthy()
 


### PR DESCRIPTION
Adds a `filter` parameter to the `getAuthorFeed` query so that we can return `posts` (the default, includes replies), `posts_no_replies`, and only `posts_with_media`.