### PR TITLE
Add bin for launching dev-env with an appview

### DIFF
--- a/packages/dev-env/build.js
+++ b/packages/dev-env/build.js
@@ -14,7 +14,7 @@ if (process.argv.includes('--update-main-to-dist')) {
 
 require('esbuild').build({
   logLevel: 'info',
-  entryPoints: ['src/index.ts', 'src/bin.ts'],
+  entryPoints: ['src/index.ts', 'src/bin.ts', 'src/bin-network.ts'],
   bundle: true,
   sourcemap: true,
   outdir: 'dist',

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -13,6 +13,7 @@
     "build": "node ./build.js",
     "postbuild": "tsc --build tsconfig.build.json",
     "start": "node dist/bin.js",
+    "start:network": "../dev-infra/with-test-redis-and-db.sh node dist/bin-network.js",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/dev-env/src/bin-network.ts
+++ b/packages/dev-env/src/bin-network.ts
@@ -1,0 +1,40 @@
+import { generateMockSetup } from './mock'
+import { TestNetwork } from './network'
+
+const run = async () => {
+  console.log(`
+██████╗
+██╔═══██╗
+██║██╗██║
+██║██║██║
+╚█║████╔╝
+ ╚╝╚═══╝  protocol
+
+[ created by Bluesky ]`)
+
+  const network = await TestNetwork.create({
+    pds: {
+      port: 2583,
+      publicUrl: 'http://localhost:2583',
+      dbPostgresSchema: 'pds',
+    },
+    bsky: {
+      dbPostgresSchema: 'bsky',
+    },
+    plc: { port: 2582 },
+  })
+  await generateMockSetup(network)
+
+  console.log(
+    `👤 DID Placeholder server started http://localhost:${network.plc.port}`,
+  )
+  console.log(
+    `🌞 Personal Data server started http://localhost:${network.pds.port}`,
+  )
+  console.log(`🌅 Bsky Appview started http://localhost:${network.bsky.port}`)
+  for (const fg of network.feedGens) {
+    console.log(`🤖 Feed Generator started http://localhost:${fg.port}`)
+  }
+}
+
+run()


### PR DESCRIPTION
This creates a separate script `yarn start:network` for launching a dev-env with an appview, using Postgres & Redis.

Soon this will replace the old dev-env, but we'll need to discuss what exactly that looks like