### PR TITLE
lexicons: Add `"minimum": 0` to count integers.

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -65,9 +65,9 @@
         },
         "avatar": { "type": "string" },
         "banner": { "type": "string" },
-        "followersCount": {"type": "integer"},
-        "followsCount": {"type": "integer"},
-        "postsCount": {"type": "integer"},
+        "followersCount": {"type": "integer", "minimum": 0},
+        "followsCount": {"type": "integer", "minimum": 0},
+        "postsCount": {"type": "integer", "minimum": 0},
         "indexedAt": {"type": "string", "format": "datetime"},
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -19,9 +19,9 @@
             "app.bsky.embed.recordWithMedia#view"
           ]
         },
-        "replyCount": {"type": "integer"},
-        "repostCount": {"type": "integer"},
-        "likeCount": {"type": "integer"},
+        "replyCount": {"type": "integer", "minimum": 0},
+        "repostCount": {"type": "integer", "minimum": 0},
+        "likeCount": {"type": "integer", "minimum": 0},
         "indexedAt": {"type": "string", "format": "datetime"},
         "viewer": {"type": "ref", "ref": "#viewerState"},
         "labels": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3652,12 +3652,15 @@ export const schemaDict = {
           },
           followersCount: {
             type: 'integer',
+            minimum: 0,
           },
           followsCount: {
             type: 'integer',
+            minimum: 0,
           },
           postsCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',
@@ -4342,12 +4345,15 @@ export const schemaDict = {
           },
           replyCount: {
             type: 'integer',
+            minimum: 0,
           },
           repostCount: {
             type: 'integer',
+            minimum: 0,
           },
           likeCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3652,12 +3652,15 @@ export const schemaDict = {
           },
           followersCount: {
             type: 'integer',
+            minimum: 0,
           },
           followsCount: {
             type: 'integer',
+            minimum: 0,
           },
           postsCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',
@@ -4342,12 +4345,15 @@ export const schemaDict = {
           },
           replyCount: {
             type: 'integer',
+            minimum: 0,
           },
           repostCount: {
             type: 'integer',
+            minimum: 0,
           },
           likeCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3652,12 +3652,15 @@ export const schemaDict = {
           },
           followersCount: {
             type: 'integer',
+            minimum: 0,
           },
           followsCount: {
             type: 'integer',
+            minimum: 0,
           },
           postsCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',
@@ -4342,12 +4345,15 @@ export const schemaDict = {
           },
           replyCount: {
             type: 'integer',
+            minimum: 0,
           },
           repostCount: {
             type: 'integer',
+            minimum: 0,
           },
           likeCount: {
             type: 'integer',
+            minimum: 0,
           },
           indexedAt: {
             type: 'string',


### PR DESCRIPTION
There's no case when these count's could be negative. By encoding this in the lexicons, it allows generators for languages with support for unsigned integers to use them here.