### PR TITLE
Require bluesky-social/atproto for .github/workflows/build-and-push-*

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   bsky-container-aws:
+    if: github.repository == 'bluesky-social/atproto'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-push-bsky-ghcr.yaml
+++ b/.github/workflows/build-and-push-bsky-ghcr.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   bsky-container-ghcr:
+    if: github.repository == 'bluesky-social/atproto'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   pds-container-aws:
+    if: github.repository == 'bluesky-social/atproto'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   pds-container-ghcr:
+    if: github.repository == 'bluesky-social/atproto'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The build and push images actions fail for forks which in turn create a lot of failure noise.

This PR runs the actions only for the original `bluesky-social/atproto` repository on the `main` branch.

Do not merge if you wish to build and push main branches from other repositories.