### PR TITLE
getTimeline and getTimelineSkeleton gain excludePostTypes parameter

### DIFF
--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -9,6 +9,11 @@
         "type": "params",
         "properties": {
           "algorithm": {"type": "string"},
+          "excludePostTypes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Exclude post types: quote, reply, repost"
+          },
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"}
         }

--- a/lexicons/app/bsky/unspecced/getTimelineSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getTimelineSkeleton.json
@@ -8,6 +8,11 @@
       "parameters": {
         "type": "params",
         "properties": {
+          "excludePostTypes": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Exclude post types: quote, reply, repost"
+          },
           "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
           "cursor": {"type": "string"}
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5259,6 +5259,13 @@ export const schemaDict = {
             algorithm: {
               type: 'string',
             },
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6477,6 +6484,13 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getTimeline.ts
@@ -10,6 +10,8 @@ import * as AppBskyFeedDefs from './defs'
 
 export interface QueryParams {
   algorithm?: string
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit?: number
   cursor?: string
 }

--- a/packages/api/src/client/types/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -9,6 +9,8 @@ import { CID } from 'multiformats/cid'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit?: number
   cursor?: string
 }

--- a/packages/bsky/src/api/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -7,10 +7,16 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.unspecced.getTimelineSkeleton({
     auth: ctx.authVerifier,
     handler: async ({ auth, params }) => {
-      const { limit, cursor } = params
+      const { excludePostTypes, limit, cursor } = params
       const viewer = auth.credentials.did
 
-      const skeleton = await getTimelineSkeleton(ctx.db, viewer, limit, cursor)
+      const skeleton = await getTimelineSkeleton(
+        ctx.db,
+        viewer,
+        limit,
+        excludePostTypes,
+        cursor,
+      )
       return {
         encoding: 'application/json',
         body: skeleton,

--- a/packages/bsky/src/api/app/bsky/util/postTypeSet.ts
+++ b/packages/bsky/src/api/app/bsky/util/postTypeSet.ts
@@ -1,0 +1,37 @@
+enum PostType {
+  QUOTE = 'quote',
+  REPLY = 'reply',
+  REPOST = 'repost',
+}
+
+export class PostTypeSet {
+  static readonly POST_TYPE_VALUES = Object.values(PostType).map((v) =>
+    v.valueOf(),
+  )
+  private set: Set<string>
+  constructor(list?: string[]) {
+    this.set = PostTypeSet.toDataSet(list ?? [])
+  }
+  hasQuote() {
+    return this.has(PostType.QUOTE)
+  }
+  hasReply() {
+    return this.has(PostType.REPLY)
+  }
+  hasRepost() {
+    return this.has(PostType.REPOST)
+  }
+  has(type: string): boolean {
+    return this.set.has(type)
+  }
+  private static toDataSet(postTypes: string[]): Set<string> {
+    let set = new Set<string>()
+    for (const postType of postTypes) {
+      const normPostType = postType.toLowerCase()
+      if (PostTypeSet.POST_TYPE_VALUES.includes(normPostType)) {
+        set.add(normPostType)
+      }
+    }
+    return set
+  }
+}

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5259,6 +5259,13 @@ export const schemaDict = {
             algorithm: {
               type: 'string',
             },
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6477,6 +6484,13 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -11,6 +11,8 @@ import * as AppBskyFeedDefs from './defs'
 
 export interface QueryParams {
   algorithm?: string
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit: number
   cursor?: string
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -10,6 +10,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit: number
   cursor?: string
 }

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -5,13 +5,15 @@ import { paginate } from '../../../../../db/pagination'
 import AppContext from '../../../../../context'
 import { FeedRow } from '../../../../services/feed'
 import { filterMutesAndBlocks } from './getFeed'
+import { isView } from '../../../../../lexicon/types/app/bsky/embed/record'
+import { PostTypeSet } from '../util/postTypeSet'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getTimeline({
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      const { algorithm, limit, cursor } = params
+      const { algorithm, excludePostTypes, limit, cursor } = params
       if (algorithm && algorithm !== FeedAlgorithm.ReverseChronological) {
         throw new InvalidRequestError(`Unsupported algorithm: ${algorithm}`)
       }
@@ -30,7 +32,7 @@ export default function (server: Server, ctx: AppContext) {
       if (ctx.cfg.bskyAppViewEndpoint) {
         const res =
           await ctx.appviewAgent.api.app.bsky.unspecced.getTimelineSkeleton(
-            { limit, cursor },
+            { limit, excludePostTypes, cursor },
             await ctx.serviceAuthHeaders(requester),
           )
         const filtered = await filterMutesAndBlocks(
@@ -39,9 +41,13 @@ export default function (server: Server, ctx: AppContext) {
           limit,
           requester,
         )
-        const hydrated = await ctx.services.appView
+        let hydrated = await ctx.services.appView
           .feed(ctx.db)
           .hydrateFeed(filtered.feedItems, requester)
+        const excludePostTypeSet = new PostTypeSet(excludePostTypes)
+        if (excludePostTypeSet.hasQuote()) {
+          hydrated = hydrated.filter((post) => !isView(post.post.embed))
+        }
         return {
           encoding: 'application/json',
           body: {
@@ -57,6 +63,7 @@ export default function (server: Server, ctx: AppContext) {
       const accountService = ctx.services.account(ctx.db)
       const feedService = ctx.services.appView.feed(ctx.db)
       const graphService = ctx.services.appView.graph(ctx.db)
+      const excludePostTypeSet = new PostTypeSet(excludePostTypes)
 
       const followingIdsSubquery = db
         .selectFrom('follow')
@@ -91,6 +98,16 @@ export default function (server: Server, ctx: AppContext) {
         )
         .where('feed_item.sortAt', '>', getFeedDateThreshold(sortFrom))
 
+      // if replies are off
+      if (excludePostTypeSet.hasReply()) {
+        feedItemsQb = feedItemsQb.where('post.replyRoot', 'is', null)
+      }
+
+      // if reposts are off
+      if (excludePostTypeSet.hasRepost()) {
+        feedItemsQb = feedItemsQb.where('feed_item.type', '!=', 'repost')
+      }
+
       feedItemsQb = paginate(feedItemsQb, {
         limit,
         cursor,
@@ -99,7 +116,11 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       const feedItems: FeedRow[] = await feedItemsQb.execute()
-      const feed = await feedService.hydrateFeed(feedItems, requester)
+      let feed = await feedService.hydrateFeed(feedItems, requester)
+
+      if (excludePostTypeSet.hasQuote()) {
+        feed = feed.filter((post) => !isView(post.post.embed))
+      }
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/app-view/api/app/bsky/util/postTypeSet.ts
+++ b/packages/pds/src/app-view/api/app/bsky/util/postTypeSet.ts
@@ -1,0 +1,37 @@
+enum PostType {
+  QUOTE = 'quote',
+  REPLY = 'reply',
+  REPOST = 'repost',
+}
+
+export class PostTypeSet {
+  static readonly POST_TYPE_VALUES = Object.values(PostType).map((v) =>
+    v.valueOf(),
+  )
+  private set: Set<string>
+  constructor(list?: string[]) {
+    this.set = PostTypeSet.toDataSet(list ?? [])
+  }
+  hasQuote() {
+    return this.has(PostType.QUOTE)
+  }
+  hasReply() {
+    return this.has(PostType.REPLY)
+  }
+  hasRepost() {
+    return this.has(PostType.REPOST)
+  }
+  has(type: string): boolean {
+    return this.set.has(type)
+  }
+  private static toDataSet(postTypes: string[]): Set<string> {
+    let set = new Set<string>()
+    for (const postType of postTypes) {
+      const normPostType = postType.toLowerCase()
+      if (PostTypeSet.POST_TYPE_VALUES.includes(normPostType)) {
+        set.add(normPostType)
+      }
+    }
+    return set
+  }
+}

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5259,6 +5259,13 @@ export const schemaDict = {
             algorithm: {
               type: 'string',
             },
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6477,6 +6484,13 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            excludePostTypes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Exclude post types: quote, reply, repost',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -11,6 +11,8 @@ import * as AppBskyFeedDefs from './defs'
 
 export interface QueryParams {
   algorithm?: string
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit: number
   cursor?: string
 }

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -10,6 +10,8 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 import * as AppBskyFeedDefs from '../feed/defs'
 
 export interface QueryParams {
+  /** Exclude post types: quote, reply, repost */
+  excludePostTypes?: string[]
   limit: number
   cursor?: string
 }

--- a/packages/pds/tests/proxied/__snapshots__/timeline-skeleton.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/timeline-skeleton.test.ts.snap
@@ -2574,3 +2574,749 @@ Object {
   ],
 }
 `;
+
+exports[`proxies timeline skeleton timeline skeleton construction with excludePostTypes 1`] = `
+Object {
+  "cursor": "0000000000000::bafycid",
+  "feed": Array [
+    Object {
+      "post": Object {
+        "author": Object {
+          "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(0)",
+        "embed": Object {
+          "$type": "app.bsky.embed.record#view",
+          "record": Object {
+            "$type": "app.bsky.embed.record#viewRecord",
+            "author": Object {
+              "did": "user(1)",
+              "handle": "dan.test",
+              "labels": Array [
+                Object {
+                  "cts": "1970-01-01T00:00:00.000Z",
+                  "neg": false,
+                  "src": "did:example:labeler",
+                  "uri": "user(1)",
+                  "val": "repo-action-label",
+                },
+              ],
+              "viewer": Object {
+                "blockedBy": false,
+                "following": "record(3)",
+                "muted": false,
+              },
+            },
+            "cid": "cids(2)",
+            "embeds": Array [
+              Object {
+                "$type": "app.bsky.embed.record#view",
+                "record": Object {
+                  "$type": "app.bsky.embed.record#viewRecord",
+                  "author": Object {
+                    "did": "user(2)",
+                    "handle": "carol.test",
+                    "labels": Array [],
+                    "viewer": Object {
+                      "blockedBy": false,
+                      "followedBy": "record(6)",
+                      "following": "record(5)",
+                      "muted": false,
+                    },
+                  },
+                  "cid": "cids(3)",
+                  "indexedAt": "1970-01-01T00:00:00.000Z",
+                  "labels": Array [],
+                  "uri": "record(4)",
+                  "value": Object {
+                    "$type": "app.bsky.feed.post",
+                    "createdAt": "1970-01-01T00:00:00.000Z",
+                    "embed": Object {
+                      "$type": "app.bsky.embed.recordWithMedia",
+                      "media": Object {
+                        "$type": "app.bsky.embed.images",
+                        "images": Array [
+                          Object {
+                            "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                            "image": Object {
+                              "$type": "blob",
+                              "mimeType": "image/jpeg",
+                              "ref": Object {
+                                "$link": "cids(4)",
+                              },
+                              "size": 4114,
+                            },
+                          },
+                          Object {
+                            "alt": "tests/image/fixtures/key-alt.jpg",
+                            "image": Object {
+                              "$type": "blob",
+                              "mimeType": "image/jpeg",
+                              "ref": Object {
+                                "$link": "cids(5)",
+                              },
+                              "size": 12736,
+                            },
+                          },
+                        ],
+                      },
+                      "record": Object {
+                        "record": Object {
+                          "cid": "cids(6)",
+                          "uri": "record(7)",
+                        },
+                      },
+                    },
+                    "text": "hi im carol",
+                  },
+                },
+              },
+            ],
+            "indexedAt": "1970-01-01T00:00:00.000Z",
+            "labels": Array [],
+            "uri": "record(2)",
+            "value": Object {
+              "$type": "app.bsky.feed.post",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "embed": Object {
+                "$type": "app.bsky.embed.record",
+                "record": Object {
+                  "cid": "cids(3)",
+                  "uri": "record(4)",
+                },
+              },
+              "facets": Array [
+                Object {
+                  "features": Array [
+                    Object {
+                      "$type": "app.bsky.richtext.facet#mention",
+                      "did": "user(0)",
+                    },
+                  ],
+                  "index": Object {
+                    "byteEnd": 18,
+                    "byteStart": 0,
+                  },
+                },
+              ],
+              "text": "@alice.bluesky.xyz is the best",
+            },
+          },
+        },
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [
+          Object {
+            "cid": "cids(0)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "neg": false,
+            "src": "did:example:labeler",
+            "uri": "record(0)",
+            "val": "test-label",
+          },
+        ],
+        "likeCount": 2,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "embed": Object {
+            "$type": "app.bsky.embed.record",
+            "record": Object {
+              "cid": "cids(2)",
+              "uri": "record(2)",
+            },
+          },
+          "text": "yoohoo label_me",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(0)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+          "did": "user(3)",
+          "displayName": "bobby",
+          "handle": "bob.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(8)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(3)",
+              "uri": "record(11)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(8)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(3)",
+              "uri": "record(11)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "followedBy": "record(10)",
+            "following": "record(9)",
+            "muted": false,
+          },
+        },
+        "cid": "cids(7)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 0,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000+00:00",
+          "text": "bobby boy here",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(8)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(9)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(12)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "did": "user(1)",
+          "handle": "dan.test",
+          "labels": Array [
+            Object {
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "did:example:labeler",
+              "uri": "user(1)",
+              "val": "repo-action-label",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "following": "record(3)",
+            "muted": false,
+          },
+        },
+        "cid": "cids(2)",
+        "embed": Object {
+          "$type": "app.bsky.embed.record#view",
+          "record": Object {
+            "$type": "app.bsky.embed.record#viewRecord",
+            "author": Object {
+              "did": "user(2)",
+              "handle": "carol.test",
+              "labels": Array [],
+              "viewer": Object {
+                "blockedBy": false,
+                "followedBy": "record(6)",
+                "following": "record(5)",
+                "muted": false,
+              },
+            },
+            "cid": "cids(3)",
+            "embeds": Array [
+              Object {
+                "$type": "app.bsky.embed.recordWithMedia#view",
+                "media": Object {
+                  "$type": "app.bsky.embed.images#view",
+                  "images": Array [
+                    Object {
+                      "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                      "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                      "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                    },
+                    Object {
+                      "alt": "tests/image/fixtures/key-alt.jpg",
+                      "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                      "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                    },
+                  ],
+                },
+                "record": Object {
+                  "record": Object {
+                    "$type": "app.bsky.embed.record#viewRecord",
+                    "author": Object {
+                      "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                      "did": "user(3)",
+                      "displayName": "bobby",
+                      "handle": "bob.test",
+                      "labels": Array [
+                        Object {
+                          "cid": "cids(8)",
+                          "cts": "1970-01-01T00:00:00.000Z",
+                          "neg": false,
+                          "src": "user(3)",
+                          "uri": "record(11)",
+                          "val": "self-label-a",
+                        },
+                        Object {
+                          "cid": "cids(8)",
+                          "cts": "1970-01-01T00:00:00.000Z",
+                          "neg": false,
+                          "src": "user(3)",
+                          "uri": "record(11)",
+                          "val": "self-label-b",
+                        },
+                      ],
+                      "viewer": Object {
+                        "blockedBy": false,
+                        "followedBy": "record(10)",
+                        "following": "record(9)",
+                        "muted": false,
+                      },
+                    },
+                    "cid": "cids(6)",
+                    "indexedAt": "1970-01-01T00:00:00.000Z",
+                    "labels": Array [],
+                    "uri": "record(7)",
+                    "value": Object {
+                      "$type": "app.bsky.feed.post",
+                      "createdAt": "1970-01-01T00:00:00.000Z",
+                      "langs": Array [
+                        "en-US",
+                        "i-klingon",
+                      ],
+                      "text": "bob back at it again!",
+                    },
+                  },
+                },
+              },
+            ],
+            "indexedAt": "1970-01-01T00:00:00.000Z",
+            "labels": Array [],
+            "uri": "record(4)",
+            "value": Object {
+              "$type": "app.bsky.feed.post",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "embed": Object {
+                "$type": "app.bsky.embed.recordWithMedia",
+                "media": Object {
+                  "$type": "app.bsky.embed.images",
+                  "images": Array [
+                    Object {
+                      "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                      "image": Object {
+                        "$type": "blob",
+                        "mimeType": "image/jpeg",
+                        "ref": Object {
+                          "$link": "cids(4)",
+                        },
+                        "size": 4114,
+                      },
+                    },
+                    Object {
+                      "alt": "tests/image/fixtures/key-alt.jpg",
+                      "image": Object {
+                        "$type": "blob",
+                        "mimeType": "image/jpeg",
+                        "ref": Object {
+                          "$link": "cids(5)",
+                        },
+                        "size": 12736,
+                      },
+                    },
+                  ],
+                },
+                "record": Object {
+                  "record": Object {
+                    "cid": "cids(6)",
+                    "uri": "record(7)",
+                  },
+                },
+              },
+              "text": "hi im carol",
+            },
+          },
+        },
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 0,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "embed": Object {
+            "$type": "app.bsky.embed.record",
+            "record": Object {
+              "cid": "cids(3)",
+              "uri": "record(4)",
+            },
+          },
+          "facets": Array [
+            Object {
+              "features": Array [
+                Object {
+                  "$type": "app.bsky.richtext.facet#mention",
+                  "did": "user(0)",
+                },
+              ],
+              "index": Object {
+                "byteEnd": 18,
+                "byteStart": 0,
+              },
+            },
+          ],
+          "text": "@alice.bluesky.xyz is the best",
+        },
+        "replyCount": 0,
+        "repostCount": 1,
+        "uri": "record(2)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "did": "user(1)",
+          "handle": "dan.test",
+          "labels": Array [
+            Object {
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "did:example:labeler",
+              "uri": "user(1)",
+              "val": "repo-action-label",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "following": "record(3)",
+            "muted": false,
+          },
+        },
+        "cid": "cids(10)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 0,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "text": "dan here!",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(13)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "did": "user(2)",
+          "handle": "carol.test",
+          "labels": Array [],
+          "viewer": Object {
+            "blockedBy": false,
+            "followedBy": "record(6)",
+            "following": "record(5)",
+            "muted": false,
+          },
+        },
+        "cid": "cids(3)",
+        "embed": Object {
+          "$type": "app.bsky.embed.recordWithMedia#view",
+          "media": Object {
+            "$type": "app.bsky.embed.images#view",
+            "images": Array [
+              Object {
+                "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                "fullsize": "https://pds.public.url/image/AiDXkxVbgBksxb1nfiRn1m6S4K8_mee6o8r-UGLNzOM/rs:fit:2000:2000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+                "thumb": "https://pds.public.url/image/uc7FGfiGv0mMqmk9XiqHXrIhNymLHaex7Ge8nEhmXqo/rs:fit:1000:1000:1:0/plain/bafkreigy5p3xxceipk2o6nqtnugpft26ol6yleqhboqziino7axvdngtci@jpeg",
+              },
+              Object {
+                "alt": "tests/image/fixtures/key-alt.jpg",
+                "fullsize": "https://pds.public.url/image/xC2No-8rKVDIwIMmCiEBm9EiGLDBBOpf36PHoGf-GDw/rs:fit:2000:2000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+                "thumb": "https://pds.public.url/image/g7yazUpNwN8LKumZ2Zmn_ptQbtMLs1Pti5-GDn7H8_8/rs:fit:1000:1000:1:0/plain/bafkreifdklbbcdsyanjz3oqe5pf2omuq5ansthokxlbleagg3eenx62h7e@jpeg",
+              },
+            ],
+          },
+          "record": Object {
+            "record": Object {
+              "$type": "app.bsky.embed.record#viewRecord",
+              "author": Object {
+                "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+                "did": "user(3)",
+                "displayName": "bobby",
+                "handle": "bob.test",
+                "labels": Array [
+                  Object {
+                    "cid": "cids(8)",
+                    "cts": "1970-01-01T00:00:00.000Z",
+                    "neg": false,
+                    "src": "user(3)",
+                    "uri": "record(11)",
+                    "val": "self-label-a",
+                  },
+                  Object {
+                    "cid": "cids(8)",
+                    "cts": "1970-01-01T00:00:00.000Z",
+                    "neg": false,
+                    "src": "user(3)",
+                    "uri": "record(11)",
+                    "val": "self-label-b",
+                  },
+                ],
+                "viewer": Object {
+                  "blockedBy": false,
+                  "followedBy": "record(10)",
+                  "following": "record(9)",
+                  "muted": false,
+                },
+              },
+              "cid": "cids(6)",
+              "embeds": Array [],
+              "indexedAt": "1970-01-01T00:00:00.000Z",
+              "labels": Array [],
+              "uri": "record(7)",
+              "value": Object {
+                "$type": "app.bsky.feed.post",
+                "createdAt": "1970-01-01T00:00:00.000Z",
+                "langs": Array [
+                  "en-US",
+                  "i-klingon",
+                ],
+                "text": "bob back at it again!",
+              },
+            },
+          },
+        },
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 2,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "embed": Object {
+            "$type": "app.bsky.embed.recordWithMedia",
+            "media": Object {
+              "$type": "app.bsky.embed.images",
+              "images": Array [
+                Object {
+                  "alt": "tests/image/fixtures/key-landscape-small.jpg",
+                  "image": Object {
+                    "$type": "blob",
+                    "mimeType": "image/jpeg",
+                    "ref": Object {
+                      "$link": "cids(4)",
+                    },
+                    "size": 4114,
+                  },
+                },
+                Object {
+                  "alt": "tests/image/fixtures/key-alt.jpg",
+                  "image": Object {
+                    "$type": "blob",
+                    "mimeType": "image/jpeg",
+                    "ref": Object {
+                      "$link": "cids(5)",
+                    },
+                    "size": 12736,
+                  },
+                },
+              ],
+            },
+            "record": Object {
+              "record": Object {
+                "cid": "cids(6)",
+                "uri": "record(7)",
+              },
+            },
+          },
+          "text": "hi im carol",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(4)",
+        "viewer": Object {
+          "like": "record(14)",
+        },
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+          "did": "user(3)",
+          "displayName": "bobby",
+          "handle": "bob.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(8)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(3)",
+              "uri": "record(11)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(8)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(3)",
+              "uri": "record(11)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "followedBy": "record(10)",
+            "following": "record(9)",
+            "muted": false,
+          },
+        },
+        "cid": "cids(6)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 0,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "langs": Array [
+            "en-US",
+            "i-klingon",
+          ],
+          "text": "bob back at it again!",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(7)",
+        "viewer": Object {},
+      },
+    },
+    Object {
+      "post": Object {
+        "author": Object {
+          "avatar": "https://pds.public.url/image/KzkHFsMRQ6oAKCHCRKFA1H-rDdc7VOtvEVpUJ82TwyQ/rs:fill:1000:1000:1:0/plain/bafkreiaivizp4xldojmmpuzmiu75cmea7nq56dnntnuhzhsjcb63aou5ei@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(1)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(11)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [
+          Object {
+            "cid": "cids(11)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "neg": false,
+            "src": "user(0)",
+            "uri": "record(15)",
+            "val": "self-label",
+          },
+        ],
+        "likeCount": 0,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000Z",
+          "labels": Object {
+            "$type": "com.atproto.label.defs#selfLabels",
+            "values": Array [
+              Object {
+                "val": "self-label",
+              },
+            ],
+          },
+          "text": "hey there",
+        },
+        "replyCount": 0,
+        "repostCount": 0,
+        "uri": "record(15)",
+        "viewer": Object {},
+      },
+    },
+  ],
+}
+`;

--- a/packages/pds/tests/proxied/timeline-skeleton.test.ts
+++ b/packages/pds/tests/proxied/timeline-skeleton.test.ts
@@ -69,6 +69,18 @@ describe('proxies timeline skeleton', () => {
     expect([...pt1.data.feed, ...pt2.data.feed]).toEqual(res.data.feed)
   })
 
+  it('timeline skeleton construction with excludePostTypes', async () => {
+    const res = await agent.api.app.bsky.feed.getTimeline(
+      {
+        excludePostTypes: ['reply', 'repost', 'query'],
+      },
+      {
+        headers: { ...sc.getHeaders(alice), 'x-appview-proxy': 'true' },
+      },
+    )
+    expect(forSnapshot(res.data)).toMatchSnapshot()
+  })
+
   it('feed skeleton construction', async () => {
     const uri = AtUri.make(
       feedPublisherDid,

--- a/packages/pds/tests/views/timeline.test.ts
+++ b/packages/pds/tests/views/timeline.test.ts
@@ -129,6 +129,87 @@ describe('timeline views', () => {
     expect(defaultTL.data.feed).toEqual(reverseChronologicalTL.data.feed)
   })
 
+  it('full reverse-chronological feed', async () => {
+    const fullNoArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(fullNoArgs.data.feed.length).toEqual(13)
+
+    const fullDefaultArgs = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+      },
+      {
+        headers: sc.getHeaders(alice),
+      },
+    )
+    expect(fullDefaultArgs.data.feed.length).toEqual(
+      fullNoArgs.data.feed.length,
+    )
+  })
+
+  it('reverse-chronological feed, no reposts', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        excludePostTypes: ['repost'],
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    const POST_COUNT_NO_REPOSTS = 11
+    expect(full.data.feed.length).toEqual(POST_COUNT_NO_REPOSTS)
+  })
+
+  it('reverse-chronological feed, no replies', async () => {
+    const full = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        excludePostTypes: ['reply'],
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(full.data.feed.length).toEqual(10)
+  })
+
+  it('reverse-chronological feed, replies minimum like counts', async () => {
+    const minReplyLikeCountOneFeed = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        excludePostTypes: ['reply'],
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(minReplyLikeCountOneFeed.data.feed.length).toEqual(10)
+  })
+
+  it('reverse-chronological feed, no quotes', async () => {
+    const timelineNoQuotes = await agent.api.app.bsky.feed.getTimeline(
+      {
+        algorithm: FeedAlgorithm.ReverseChronological,
+        excludePostTypes: ['quote'],
+      },
+      { headers: sc.getHeaders(alice) },
+    )
+    expect(timelineNoQuotes.data.feed.length).toEqual(10)
+  })
+
+  it('reverse-chronological feed, no quotes, no replies, no reposts', async () => {
+    const timelineNoQuotesNoRepliesNoReposts =
+      await agent.api.app.bsky.feed.getTimeline(
+        {
+          algorithm: FeedAlgorithm.ReverseChronological,
+          excludePostTypes: ['quote', 'reply', 'repost'],
+        },
+        { headers: sc.getHeaders(alice) },
+      )
+    expect(timelineNoQuotesNoRepliesNoReposts.data.feed.length).toEqual(6)
+  })
+
   it('omits posts and reposts of muted authors.', async () => {
     await agent.api.app.bsky.graph.muteActor(
       { actor: bob },


### PR DESCRIPTION
This is a successor PR to #1400.

`app.bsky.feed.getTimeline` and `app.bsky.unspecced.getTimelineSkeleton` gain an `excludePostTypes` array parameter which can contain any combination of the following strings: `quote`, `reply`, `repost`, defaulting to an empty array (and thus, no exclusions).

This represents the middle ground between adding a parameter that's modeled after the client changes in https://github.com/bluesky-social/social-app/pull/885, while taking into account a world where `getTimelineSkeleton` exists. There would still be client-side filtering needed for the minimum like count for replies filter.

IMHO proposing just a lexicon change wouldn't have been enough to see how this could play out, so the implementation is provided as a useful discussion point.