### PR TITLE
Handle revalidation

### DIFF
--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -15,6 +15,7 @@ export interface ServerConfigValues {
   didPlcUrl: string
   didCacheStaleTTL: number
   didCacheMaxTTL: number
+  handleResolveNameservers?: string[]
   imgUriEndpoint?: string
   blobCacheLocation?: string
   labelerDid: string
@@ -44,6 +45,9 @@ export class ServerConfig {
       process.env.DID_CACHE_MAX_TTL,
       DAY,
     )
+    const handleResolveNameservers = process.env.HANDLE_RESOLVE_NAMESERVERS
+      ? process.env.HANDLE_RESOLVE_NAMESERVERS.split(',')
+      : []
     const imgUriEndpoint = process.env.IMG_URI_ENDPOINT
     const blobCacheLocation = process.env.BLOB_CACHE_LOC
     const dbPrimaryPostgresUrl =
@@ -85,6 +89,7 @@ export class ServerConfig {
       didPlcUrl,
       didCacheStaleTTL,
       didCacheMaxTTL,
+      handleResolveNameservers,
       imgUriEndpoint,
       blobCacheLocation,
       labelerDid,
@@ -153,7 +158,11 @@ export class ServerConfig {
   }
 
   get didCacheMaxTTL() {
-    return this.cfg.didCacheStaleTTL
+    return this.cfg.didCacheMaxTTL
+  }
+
+  get handleResolveNameservers() {
+    return this.cfg.handleResolveNameservers
   }
 
   get didPlcUrl() {

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -66,7 +66,11 @@ export class BskyAppView {
       config.didCacheStaleTTL,
       config.didCacheMaxTTL,
     )
-    const idResolver = new IdResolver({ plcUrl: config.didPlcUrl, didCache })
+    const idResolver = new IdResolver({
+      plcUrl: config.didPlcUrl,
+      didCache,
+      backupNameservers: config.handleResolveNameservers,
+    })
 
     const imgUriBuilder = new ImageUriBuilder(
       config.imgUriEndpoint || `${config.publicUrl}/img`,

--- a/packages/bsky/src/indexer/config.ts
+++ b/packages/bsky/src/indexer/config.ts
@@ -12,6 +12,7 @@ export interface IndexerConfigValues {
   didPlcUrl: string
   didCacheStaleTTL: number
   didCacheMaxTTL: number
+  handleResolveNameservers?: string[]
   labelerDid: string
   hiveApiKey?: string
   labelerKeywords: Record<string, string>
@@ -54,6 +55,9 @@ export class IndexerConfig {
       process.env.DID_CACHE_MAX_TTL,
       DAY,
     )
+    const handleResolveNameservers = process.env.HANDLE_RESOLVE_NAMESERVERS
+      ? process.env.HANDLE_RESOLVE_NAMESERVERS.split(',')
+      : []
     const labelerDid = process.env.LABELER_DID || 'did:example:labeler'
     const labelerPushUrl =
       overrides?.labelerPushUrl || process.env.LABELER_PUSH_URL || undefined
@@ -86,6 +90,7 @@ export class IndexerConfig {
       didPlcUrl,
       didCacheStaleTTL,
       didCacheMaxTTL,
+      handleResolveNameservers,
       labelerDid,
       labelerPushUrl,
       hiveApiKey,
@@ -137,6 +142,10 @@ export class IndexerConfig {
 
   get didCacheMaxTTL() {
     return this.cfg.didCacheMaxTTL
+  }
+
+  get handleResolveNameservers() {
+    return this.cfg.handleResolveNameservers
   }
 
   get labelerDid() {

--- a/packages/bsky/src/indexer/index.ts
+++ b/packages/bsky/src/indexer/index.ts
@@ -36,7 +36,11 @@ export class BskyIndexer {
       cfg.didCacheStaleTTL,
       cfg.didCacheMaxTTL,
     )
-    const idResolver = new IdResolver({ plcUrl: cfg.didPlcUrl, didCache })
+    const idResolver = new IdResolver({
+      plcUrl: cfg.didPlcUrl,
+      didCache,
+      backupNameservers: cfg.handleResolveNameservers,
+    })
     const backgroundQueue = new BackgroundQueue(db)
     let labeler: Labeler
     if (cfg.hiveApiKey) {

--- a/packages/bsky/src/services/indexing/index.ts
+++ b/packages/bsky/src/services/indexing/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@atproto/repo'
 import { AtUri } from '@atproto/uri'
 import { IdResolver, getPds } from '@atproto/identity'
-import { DAY, chunkArray } from '@atproto/common'
+import { DAY, HOUR, chunkArray } from '@atproto/common'
 import { ValidationError } from '@atproto/lexicon'
 import { PrimaryDatabase } from '../../db'
 import * as Post from './plugins/post'
@@ -28,6 +28,7 @@ import { subLogger } from '../../logger'
 import { retryHttp } from '../../util/retry'
 import { Labeler } from '../../labeler'
 import { BackgroundQueue } from '../../background'
+import { Actor } from '../../db/tables/actor'
 
 export class IndexingService {
   records: {
@@ -118,13 +119,7 @@ export class IndexingService {
       .where('did', '=', did)
       .selectAll()
       .executeTakeFirst()
-    const timestampAt = new Date(timestamp)
-    const lastIndexedAt = actor && new Date(actor.indexedAt)
-    const needsReindex =
-      force ||
-      !lastIndexedAt ||
-      timestampAt.getTime() - lastIndexedAt.getTime() > DAY
-    if (!needsReindex) {
+    if (!force && !needsHandleReindex(actor, timestamp)) {
       return
     }
     const atpData = await this.idResolver.did.resolveAtprotoData(did, true)
@@ -356,4 +351,15 @@ function* walkContentsWithCids(contents: RepoContentsWithCids) {
       yield { collection, rkey, cid, record: value }
     }
   }
+}
+
+const needsHandleReindex = (actor: Actor | undefined, timestamp: string) => {
+  if (!actor) return true
+  const timeDiff =
+    new Date(timestamp).getTime() - new Date(actor.indexedAt).getTime()
+  // revalidate daily
+  if (timeDiff > DAY) return true
+  // revalidate more aggressively for invalidated handles
+  if (actor.handle === null && timeDiff > HOUR) return true
+  return false
 }

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -27,11 +27,7 @@ export default function (server: Server, ctx: AppContext) {
 
       let seqHandleTok: HandleSequenceToken
       if (handleDid) {
-        if (handleDid !== requester) {
-          throw new InvalidRequestError(`Handle already taken: ${handle}`)
-        } else {
-          seqHandleTok = { did: requester, handle: handle }
-        }
+        seqHandleTok = { did: requester, handle: handle }
       } else {
         seqHandleTok = await ctx.db.transaction(async (dbTxn) => {
           let tok: HandleSequenceToken

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -21,12 +21,12 @@ export default function (server: Server, ctx: AppContext) {
 
       // Pessimistic check to handle spam: also enforced by updateHandle() and the db.
       const handleDid = await ctx.services.account(ctx.db).getHandleDid(handle)
-      if (handleDid !== requester) {
-        throw new InvalidRequestError(`Handle already taken: ${handle}`)
-      }
 
       let seqHandleTok: HandleSequenceToken
       if (handleDid) {
+        if (handleDid !== requester) {
+          throw new InvalidRequestError(`Handle already taken: ${handle}`)
+        }
         seqHandleTok = { did: requester, handle: handle }
       } else {
         seqHandleTok = await ctx.db.transaction(async (dbTxn) => {

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -179,14 +179,14 @@ export class AccountService {
     await sequencer.sequenceEvt(this.db, seqEvt)
   }
 
-  async isHandleAvailable(handle: string) {
+  async getHandleDid(handle: string): Promise<string | null> {
     // @NOTE see also condition in updateHandle()
     const found = await this.db.db
       .selectFrom('did_handle')
       .where('handle', '=', handle)
-      .select('handle')
+      .selectAll()
       .executeTakeFirst()
-    return !found
+    return found?.did ?? null
   }
 
   async updateEmail(did: string, email: string) {

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -130,6 +130,13 @@ describe('handles', () => {
     await expect(attempt).rejects.toThrow('Handle already taken: bob.test')
   })
 
+  it('handle updates are idempotent', async () => {
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'Bob.test' },
+      { headers: sc.getHeaders(bob), encoding: 'application/json' },
+    )
+  })
+
   it('if handle update fails, it does not update their did document', async () => {
     const data = await idResolver.did.resolveAtprotoData(alice)
     expect(data.handle).toBe(newHandle)


### PR DESCRIPTION
Makes it easier to get back on track if your account has an "invalid handle"
- makes update handle idempotent - except for publishing a handle update event - as a way to prompt downstream services to revalidate your handle
- the same on the admin route so that we can aid users in getting back on track
- while we generally revalidate handles every 24hrs, revalidate "invalid" handles every hour to more quickly get users back on track


Closes https://github.com/bluesky-social/atproto/issues/1473