### PR TITLE
identity: parse support for newer DID document format (Multikey)

### DIFF
--- a/packages/crypto/src/const.ts
+++ b/packages/crypto/src/const.ts
@@ -1,6 +1,7 @@
 export const P256_DID_PREFIX = new Uint8Array([0x80, 0x24])
 export const SECP256K1_DID_PREFIX = new Uint8Array([0xe7, 0x01])
-export const BASE58_DID_PREFIX = 'did:key:z' // z is the multibase prefix for base58btc byte encoding
+export const BASE58_MULTIBASE_PREFIX = 'z'
+export const DID_KEY_PREFIX = 'did:key:'
 
 export const P256_JWT_ALG = 'ES256'
 export const SECP256K1_JWT_ALG = 'ES256K'

--- a/packages/identity/src/did/atproto-data.ts
+++ b/packages/identity/src/did/atproto-data.ts
@@ -10,7 +10,7 @@ export const getDid = (doc: DidDocument): string => {
 }
 
 export const getKey = (doc: DidDocument): string | undefined => {
-  let did = getDid(doc)
+  const did = getDid(doc)
   let keys = doc.verificationMethod
   if (!keys) return undefined
   if (typeof keys !== 'object') return undefined

--- a/packages/identity/src/did/atproto-data.ts
+++ b/packages/identity/src/did/atproto-data.ts
@@ -32,8 +32,7 @@ export const getKey = (doc: DidDocument): string | undefined => {
   } else if (found.type === 'EcdsaSecp256k1VerificationKey2019') {
     didKey = crypto.formatDidKey(crypto.SECP256K1_JWT_ALG, keyBytes)
   } else if (found.type === 'Multikey') {
-    const foundKey = `did:key:${found.publicKeyMultibase}`
-    const parsed = crypto.parseDidKey(foundKey)
+    const parsed = crypto.parseMultikey(found.publicKeyMultibase)
     didKey = crypto.formatDidKey(parsed.jwtAlg, parsed.keyBytes)
   }
   return didKey

--- a/packages/identity/src/did/atproto-data.ts
+++ b/packages/identity/src/did/atproto-data.ts
@@ -113,13 +113,16 @@ const getServiceEndpoint = (
   doc: DidDocument,
   opts: { id: string; type: string },
 ) => {
+  const did = getDid(doc)
   let services = doc.service
   if (!services) return undefined
   if (typeof services !== 'object') return undefined
   if (!Array.isArray(services)) {
     services = [services]
   }
-  const found = services.find((service) => service.id === opts.id)
+  const found = services.find(
+    (service) => service.id === opts.id || service.id === `${did}${opts.id}`,
+  )
   if (!found) return undefined
   if (found.type !== opts.type) {
     return undefined

--- a/packages/identity/tests/did-document.test.ts
+++ b/packages/identity/tests/did-document.test.ts
@@ -1,4 +1,4 @@
-import { DidResolver, validateDidDoc, ensureAtpDocument } from '../src'
+import { DidResolver, ensureAtpDocument } from '../src'
 
 describe('did parsing', () => {
   it('throws on bad DID document', async () => {
@@ -18,7 +18,7 @@ describe('did parsing', () => {
   ],
   "yarg": [ ]
 }`
-    let resolver = new DidResolver({})
+    const resolver = new DidResolver({})
     expect(() => {
       resolver.validateDidDoc(did, JSON.parse(docJson))
     }).toThrow()
@@ -51,7 +51,7 @@ describe('did parsing', () => {
     }
   ]
 }`
-    let resolver = new DidResolver({})
+    const resolver = new DidResolver({})
     const doc = resolver.validateDidDoc(did, JSON.parse(docJson))
     const atpData = ensureAtpDocument(doc)
     expect(atpData.did).toEqual(did)
@@ -90,7 +90,7 @@ describe('did parsing', () => {
     }
   ]
 }`
-    let resolver = new DidResolver({})
+    const resolver = new DidResolver({})
     const doc = resolver.validateDidDoc(did, JSON.parse(docJson))
     const atpData = ensureAtpDocument(doc)
     expect(atpData.did).toEqual(did)

--- a/packages/identity/tests/did-document.test.ts
+++ b/packages/identity/tests/did-document.test.ts
@@ -1,0 +1,103 @@
+import { DidResolver, validateDidDoc, ensureAtpDocument } from '../src'
+
+describe('did parsing', () => {
+  it('throws on bad DID document', async () => {
+    const did = 'did:plc:yk4dd2qkboz2yv6tpubpc6co'
+    const docJson = `{
+  "ideep": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+  "blah": [
+    "https://dholms.xyz"
+  ],
+  "zoot": [
+    {
+      "id": "#elsewhere",
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "controller": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+      "publicKeyMultibase": "zQYEBzXeuTM9UR3rfvNag6L3RNAs5pQZyYPsomTsgQhsxLdEgCrPTLgFna8yqCnxPpNT7DBk6Ym3dgPKNu86vt9GR"
+    }
+  ],
+  "yarg": [ ]
+}`
+    let resolver = new DidResolver({})
+    expect(() => {
+      resolver.validateDidDoc(did, JSON.parse(docJson))
+    }).toThrow()
+  })
+
+  it('parses legacy DID format, extracts atpData', async () => {
+    const did = 'did:plc:yk4dd2qkboz2yv6tpubpc6co'
+    const docJson = `{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/secp256k1-2019/v1"
+  ],
+  "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+  "alsoKnownAs": [
+    "at://dholms.xyz"
+  ],
+  "verificationMethod": [
+    {
+      "id": "#atproto",
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "controller": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+      "publicKeyMultibase": "zQYEBzXeuTM9UR3rfvNag6L3RNAs5pQZyYPsomTsgQhsxLdEgCrPTLgFna8yqCnxPpNT7DBk6Ym3dgPKNu86vt9GR"
+    }
+  ],
+  "service": [
+    {
+      "id": "#atproto_pds",
+      "type": "AtprotoPersonalDataServer",
+      "serviceEndpoint": "https://bsky.social"
+    }
+  ]
+}`
+    let resolver = new DidResolver({})
+    const doc = resolver.validateDidDoc(did, JSON.parse(docJson))
+    const atpData = ensureAtpDocument(doc)
+    expect(atpData.did).toEqual(did)
+    expect(atpData.handle).toEqual('dholms.xyz')
+    expect(atpData.pds).toEqual('https://bsky.social')
+    expect(atpData.signingKey).toEqual(
+      'did:key:zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF',
+    )
+  })
+
+  it('parses newer Multikey DID format, extracts atpData', async () => {
+    const did = 'did:plc:yk4dd2qkboz2yv6tpubpc6co'
+    const docJson = `{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1",
+    "https://w3id.org/security/suites/secp256k1-2019/v1"
+  ],
+  "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+  "alsoKnownAs": [
+    "at://dholms.xyz"
+  ],
+  "verificationMethod": [
+    {
+      "id": "did:plc:yk4dd2qkboz2yv6tpubpc6co#atproto",
+      "type": "Multikey",
+      "controller": "did:plc:yk4dd2qkboz2yv6tpubpc6co",
+      "publicKeyMultibase": "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF"
+    }
+  ],
+  "service": [
+    {
+      "id": "#atproto_pds",
+      "type": "AtprotoPersonalDataServer",
+      "serviceEndpoint": "https://bsky.social"
+    }
+  ]
+}`
+    let resolver = new DidResolver({})
+    const doc = resolver.validateDidDoc(did, JSON.parse(docJson))
+    const atpData = ensureAtpDocument(doc)
+    expect(atpData.did).toEqual(did)
+    expect(atpData.handle).toEqual('dholms.xyz')
+    expect(atpData.pds).toEqual('https://bsky.social')
+    expect(atpData.signingKey).toEqual(
+      'did:key:zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF',
+    )
+  })
+})


### PR DESCRIPTION
Adds support for parsing DID Documents with newer changes:

- `Multikey` `verificationMethod` type, in which case the key type is inferred from `publicKeyMultibase`, which includes multicodec prefix (like `did:key` does)
- support for `verificationMethod` `id` being bare `#atproto` or full DID URL plus fragement (eg, `did:plc:yk4dd2qkboz2yv6tpubpc6co#atproto`)

Implementation is a bit weird here, hacking in use of `did:key` for parsing. We might want to expose a raw "parseMulticodecMultibase" or something in the crypto library.

cc: @dholms 