### PR TITLE
Runtime flags in PDS, appview-proxy flags

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -56,6 +56,7 @@
     "http-terminator": "^3.2.0",
     "jsonwebtoken": "^8.5.1",
     "kysely": "^0.22.0",
+    "lru-cache": "^10.0.1",
     "multiformats": "^9.6.4",
     "nodemailer": "^6.8.0",
     "nodemailer-html-to-text": "^3.2.0",

--- a/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
@@ -34,7 +34,7 @@ export default function (server: Server, ctx: AppContext) {
 
     // this is not someone on our server, but we help with resolving anyway
 
-    if (!did && ctx.canProxyRead(req)) {
+    if (!did && (await ctx.canProxyRead(req))) {
       did = await tryResolveFromAppview(ctx.appviewAgent, handle)
     }
 

--- a/packages/pds/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/getRecord.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
       }
     }
 
-    if (ctx.canProxyRead(req)) {
+    if (await ctx.canProxyRead(req)) {
       const res = await ctx.appviewAgent.api.com.atproto.repo.getRecord(params)
       return {
         encoding: 'application/json',

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfile.ts
@@ -13,7 +13,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, auth, params }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.actor.getProfile(
           params,
           requester

--- a/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getProfiles.ts
@@ -9,7 +9,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.actor.getProfiles(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/getSuggestions.ts
@@ -7,7 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.actor.getSuggestions(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActors.ts
@@ -16,7 +16,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.actor.searchActors(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/app-view/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,7 +14,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res =
           await ctx.appviewAgent.api.app.bsky.actor.searchActorsTypeahead(
             params,

--- a/packages/pds/src/app-view/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getActorFeeds.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getActorFeeds(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getAuthorFeed.ts
@@ -15,7 +15,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getAuthorFeed(
           params,
           requester

--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeed.ts
@@ -30,7 +30,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
 
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const { data: feed } =
           await ctx.appviewAgent.api.app.bsky.feed.getFeedGenerator(
             { feed: params.feed },

--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeedGenerator.ts
@@ -12,7 +12,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getFeedGenerator(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getFeedGenerators.ts
@@ -6,7 +6,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getFeedGenerators(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getLikes.ts
@@ -9,7 +9,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getLikes(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPostThread.ts
@@ -47,7 +47,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         try {
           const res = await ctx.appviewAgent.api.app.bsky.feed.getPostThread(
             params,

--- a/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getPosts.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getPosts(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getRepostedBy.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getRepostedBy(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getTimeline.ts
@@ -19,7 +19,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError(`Unsupported algorithm: ${algorithm}`)
       }
 
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.feed.getTimeline(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getBlocks.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getBlocks(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollowers.ts
@@ -11,7 +11,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getFollowers(
           params,
           requester

--- a/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getFollows.ts
@@ -11,7 +11,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getFollows(
           params,
           requester

--- a/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getList.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getList(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/graph/getListMutes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getListMutes.ts
@@ -7,7 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getListMutes(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/graph/getLists.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getLists.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getLists(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/graph/getMutes.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res = await ctx.appviewAgent.api.app.bsky.graph.getMutes(
           params,
           await ctx.serviceAuthHeaders(requester),

--- a/packages/pds/src/app-view/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/getUnreadCount.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, auth, params }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res =
           await ctx.appviewAgent.api.app.bsky.notification.getUnreadCount(
             params,

--- a/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/app-view/api/app/bsky/notification/listNotifications.ts
@@ -12,7 +12,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const res =
           await ctx.appviewAgent.api.app.bsky.notification.listNotifications(
             params,

--- a/packages/pds/src/app-view/api/app/bsky/unspecced.ts
+++ b/packages/pds/src/app-view/api/app/bsky/unspecced.ts
@@ -27,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.accessVerifier,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
-      if (ctx.canProxyRead(req)) {
+      if (await ctx.canProxyRead(req, requester)) {
         const hotClassicUri = Object.keys(ctx.algos).find((uri) =>
           uri.endsWith('/hot-classic'),
         )

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -201,11 +201,13 @@ export class AppContext {
     if (req.get('x-appview-proxy') !== undefined) {
       return true
     }
-    if (!did) {
-      return false
-    }
     // e.g. /xrpc/a.b.c.d/ -> a.b.c.d/ -> a.b.c.d
     const endpoint = req.path.replace('/xrpc/', '').replaceAll('/', '')
+    if (!did) {
+      // when no did assigned, only proxy reads if threshold is at max of 10
+      const threshold = this.runtimeFlags.appviewProxy.getThreshold(endpoint)
+      return threshold === 10
+    }
     return await this.runtimeFlags.appviewProxy.shouldProxy(endpoint, did)
   }
 

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -21,6 +21,7 @@ import { MountedAlgos } from './feed-gen/types'
 import { Crawlers } from './crawlers'
 import { LabelCache } from './label-cache'
 import { ContentReporter } from './content-reporter'
+import { RuntimeFlags } from './runtime-flags'
 
 export class AppContext {
   constructor(
@@ -42,6 +43,7 @@ export class AppContext {
       sequencerLeader: SequencerLeader | null
       labeler: Labeler
       labelCache: LabelCache
+      runtimeFlags: RuntimeFlags
       contentReporter?: ContentReporter
       backgroundQueue: BackgroundQueue
       appviewAgent?: AtpAgent
@@ -138,6 +140,10 @@ export class AppContext {
     return this.opts.labelCache
   }
 
+  get runtimeFlags(): RuntimeFlags {
+    return this.opts.runtimeFlags
+  }
+
   get contentReporter(): ContentReporter | undefined {
     return this.opts.contentReporter
   }
@@ -185,12 +191,22 @@ export class AppContext {
     return this.opts.appviewAgent
   }
 
-  canProxyRead(req: express.Request): boolean {
-    return (
-      this.cfg.bskyAppViewProxy &&
-      this.cfg.bskyAppViewEndpoint !== undefined &&
-      req.get('x-appview-proxy') !== undefined
-    )
+  async canProxyRead(
+    req: express.Request,
+    did?: string | null,
+  ): Promise<boolean> {
+    if (!this.cfg.bskyAppViewProxy || !this.cfg.bskyAppViewEndpoint) {
+      return false
+    }
+    if (req.get('x-appview-proxy') !== undefined) {
+      return true
+    }
+    if (!did) {
+      return false
+    }
+    // e.g. /xrpc/a.b.c.d/ -> a.b.c.d/ -> a.b.c.d
+    const endpoint = req.path.replace('/xrpc/', '').replaceAll('/', '')
+    return await this.runtimeFlags.appviewProxy.shouldProxy(endpoint, did)
   }
 
   canProxyFeedConstruction(req: express.Request): boolean {

--- a/packages/pds/src/db/database-schema.ts
+++ b/packages/pds/src/db/database-schema.ts
@@ -23,9 +23,11 @@ import * as listMute from './tables/list-mute'
 import * as label from './tables/label'
 import * as repoSeq from './tables/repo-seq'
 import * as appMigration from './tables/app-migration'
+import * as runtimeFlag from './tables/runtime-flag'
 import * as appView from '../app-view/db'
 
 export type DatabaseSchemaType = appView.DatabaseSchemaType &
+  runtimeFlag.PartialDB &
   appMigration.PartialDB &
   userAccount.PartialDB &
   userState.PartialDB &

--- a/packages/pds/src/db/migrations/20230818T134357818Z-runtime-flags.ts
+++ b/packages/pds/src/db/migrations/20230818T134357818Z-runtime-flags.ts
@@ -1,0 +1,13 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('runtime_flag')
+    .addColumn('name', 'varchar', (col) => col.primaryKey())
+    .addColumn('value', 'varchar', (col) => col.notNull())
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('runtime_flag').execute()
+}

--- a/packages/pds/src/db/migrations/index.ts
+++ b/packages/pds/src/db/migrations/index.ts
@@ -61,3 +61,4 @@ export * as _20230801T195109532Z from './20230801T195109532Z-remove-moderation-f
 export * as _20230807T035309811Z from './20230807T035309811Z-feed-item-delete-invite-for-user-idx'
 export * as _20230808T172813122Z from './20230808T172813122Z-repo-rev'
 export * as _20230810T203412859Z from './20230810T203412859Z-action-duration'
+export * as _20230818T134357818Z from './20230818T134357818Z-runtime-flags'

--- a/packages/pds/src/db/tables/runtime-flag.ts
+++ b/packages/pds/src/db/tables/runtime-flag.ts
@@ -1,0 +1,8 @@
+export interface RuntimeFlag {
+  name: string
+  value: string
+}
+
+export const tableName = 'runtime_flag'
+
+export type PartialDB = { [tableName]: RuntimeFlag }

--- a/packages/pds/src/runtime-flags.ts
+++ b/packages/pds/src/runtime-flags.ts
@@ -61,17 +61,19 @@ class AppviewProxyFlags {
 
   constructor(private runtimeFlags: RuntimeFlags) {}
 
-  async shouldProxy(endpoint: string, did?: string) {
+  getThreshold(endpoint: string) {
     const val = this.runtimeFlags.get(`appview-proxy:${endpoint}`) || '0'
     const threshold = parseInt(val, 10)
-    if (threshold === 0 || !appviewFlagIsValid(threshold)) {
+    return appviewFlagIsValid(threshold) ? threshold : 0
+  }
+
+  async shouldProxy(endpoint: string, did: string) {
+    const threshold = this.getThreshold(endpoint)
+    if (threshold === 0) {
       return false
     }
     if (threshold === 10) {
       return true
-    }
-    if (!did) {
-      return false
     }
     // threshold is 0 to 10 inclusive, partitions are 0 to 9 inclusive.
     const partition = await this.partitionCache.fetch(did)

--- a/packages/pds/src/runtime-flags.ts
+++ b/packages/pds/src/runtime-flags.ts
@@ -1,0 +1,77 @@
+import { wait } from '@atproto/common'
+import { randomIntFromSeed } from '@atproto/crypto'
+import { LRUCache } from 'lru-cache'
+import Database from './db'
+import { labelerLogger as log } from './logger'
+
+type AppviewProxyFlagName = `appview-proxy:${string}`
+
+export type FlagName = AppviewProxyFlagName
+
+export class RuntimeFlags {
+  destroyed = false
+  private flags = new Map<string, string>()
+  public appviewProxy = new AppviewProxyFlags(this)
+
+  constructor(public db: Database) {}
+
+  async start() {
+    await this.refresh()
+    this.poll()
+  }
+
+  destroy() {
+    this.destroyed = true
+  }
+
+  get(flag: FlagName) {
+    return this.flags.get(flag) || null
+  }
+
+  async refresh() {
+    const flags = await this.db.db
+      .selectFrom('runtime_flag')
+      .selectAll()
+      .execute()
+    this.flags = new Map()
+    for (const flag of flags) {
+      this.flags.set(flag.name, flag.value)
+    }
+  }
+
+  async poll() {
+    try {
+      if (this.destroyed) return
+      await this.refresh()
+    } catch (err) {
+      log.error({ err }, 'runtime flags failed to refresh')
+    }
+    await wait(5000)
+    this.poll()
+  }
+}
+
+class AppviewProxyFlags {
+  private partitionCache = new LRUCache({
+    max: 50000,
+    fetchMethod(did: string) {
+      return randomIntFromSeed(did, 10)
+    },
+  })
+
+  constructor(private runtimeFlags: RuntimeFlags) {}
+
+  async shouldProxy(endpoint: string, did: string) {
+    const val = this.runtimeFlags.get(`appview-proxy:${endpoint}`) || '0'
+    const threshold = parseInt(val, 10)
+    if (threshold !== 0 && !appviewFlagIsValid(threshold)) {
+      return false
+    }
+    const partition = await this.partitionCache.fetch(did)
+    return partition !== undefined && partition < threshold
+  }
+}
+
+const appviewFlagIsValid = (val: number) => {
+  return 0 <= val && val < 10
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,6 +8935,11 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lru-cache@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"


### PR DESCRIPTION
This implements a simple little system for runtime flags in the pds.  Flags are all pulled and cached every 5 seconds for in-mem lookups.

Also implements one set of flags to support appview proxy switchover.  Flag names take the form `appview-proxy:app.bsky.feed.getTimeline` including the endpoint nsid.  The values are integers from `0` to `10` inclusive, which controls how much traffic (`0` none -> `10` all) is proxied.  The assignments are by requester did, which are each assigned a number from `0` to `9`.  A given did is proxied if its assigned number is less than the flag value for the given endpoint.