### PR TITLE
powerdns backend for pds

### DIFF
--- a/packages/pds/src/config.ts
+++ b/packages/pds/src/config.ts
@@ -72,6 +72,15 @@ export interface ServerConfigValues {
   bskyAppViewCdnUrlPattern?: string
 
   crawlersToNotify?: string[]
+
+  powerDnsPipePath?: string
+  powerDnsNameServer?: string
+  powerDnsRecordTtl?: number
+  powerDnsSoaEmail?: string
+  powerDnsSoaRefresh?: number
+  powerDnsSoaRetry?: number
+  powerDnsSoaExpire?: number
+  powerDnsSoaMinimum?: number
 }
 
 export class ServerConfig {
@@ -227,6 +236,30 @@ export class ServerConfig {
     const crawlersToNotify =
       crawlersEnv && crawlersEnv.length > 0 ? crawlersEnv.split(',') : []
 
+    const powerDnsPipePath = nonemptyString(process.env.POWERDNS_PIPE_PATH)
+    const powerDnsNameServer = nonemptyString(process.env.POWERDNS_NAME_SERVER)
+    const powerDnsRecordTtl = parseIntWithFallback(
+      process.env.POWERDNS_RECORD_TTL,
+      3600,
+    )
+    const powerDnsSoaRefresh = parseIntWithFallback(
+      process.env.POWERDNS_SOA_REFRESH,
+      86400,
+    )
+    const powerDnsSoaEmail = nonemptyString(process.env.POWERDNS_SOA_EMAIL)
+    const powerDnsSoaRetry = parseIntWithFallback(
+      process.env.POWERDNS_SOA_RETRY,
+      7200,
+    )
+    const powerDnsSoaExpire = parseIntWithFallback(
+      process.env.POWERDNS_SOA_EXPIRE,
+      3600000,
+    )
+    const powerDnsSoaMinimum = parseIntWithFallback(
+      process.env.POWERDNS_SOA_MINIMUM,
+      3600,
+    )
+
     return new ServerConfig({
       debugMode,
       version,
@@ -281,6 +314,14 @@ export class ServerConfig {
       bskyAppViewProxy,
       bskyAppViewCdnUrlPattern,
       crawlersToNotify,
+      powerDnsPipePath,
+      powerDnsNameServer,
+      powerDnsRecordTtl,
+      powerDnsSoaEmail,
+      powerDnsSoaRefresh,
+      powerDnsSoaRetry,
+      powerDnsSoaExpire,
+      powerDnsSoaMinimum,
       ...overrides,
     })
   }
@@ -525,6 +566,38 @@ export class ServerConfig {
 
   get crawlersToNotify() {
     return this.cfg.crawlersToNotify
+  }
+
+  get powerDnsPipePath() {
+    return this.cfg.powerDnsPipePath
+  }
+
+  get powerDnsNameServer() {
+    return this.cfg.powerDnsNameServer
+  }
+
+  get powerDnsRecordTtl() {
+    return this.cfg.powerDnsRecordTtl
+  }
+
+  get powerDnsSoaEmail() {
+    return this.cfg.powerDnsSoaEmail
+  }
+
+  get powerDnsSoaRefresh() {
+    return this.cfg.powerDnsSoaRefresh
+  }
+
+  get powerDnsSoaRetry() {
+    return this.cfg.powerDnsSoaRetry
+  }
+
+  get powerDnsSoaExpire() {
+    return this.cfg.powerDnsSoaExpire
+  }
+
+  get powerDnsSoaMinimum() {
+    return this.cfg.powerDnsSoaMinimum
   }
 }
 

--- a/packages/pds/src/powerdns.ts
+++ b/packages/pds/src/powerdns.ts
@@ -1,0 +1,131 @@
+import net from 'node:net'
+
+import type { AppContext } from './context'
+
+function emailToRname(email: string): string {
+  const [username, domain] = email.split('@')
+  const escaped = username.replace('.', '\\.')
+  return `${escaped}.${domain}`
+}
+
+function buildAuthority(
+  nameServer: string,
+  email: string,
+  serial: number,
+  refresh: number,
+  retry: number,
+  expire: number,
+  minimumTtl: number,
+): string {
+  return [
+    nameServer,
+    emailToRname(email),
+    serial,
+    refresh,
+    retry,
+    expire,
+    minimumTtl,
+  ].join(' ')
+}
+
+export class PowerDnsBackend {
+  ctx: AppContext
+  server: net.Server
+
+  constructor(ctx: AppContext) {
+    this.ctx = ctx
+    this.server = net.createServer(this.onSocket)
+  }
+
+  start() {
+    this.server.listen(this.ctx.cfg.powerDnsPipePath)
+  }
+
+  destroy(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.close((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+
+  async resolve(qtype: string, qname: string): Promise<string | null> {
+    const qnameLower = qname.toLowerCase()
+
+    const pdsDomain = this.ctx.cfg.availableUserDomains.find((d: string) =>
+      qnameLower.endsWith(d),
+    )
+    if (pdsDomain == null) {
+      return null
+    }
+
+    if (qtype === 'SOA') {
+      return buildAuthority(
+        this.ctx.cfg.powerDnsNameServer!,
+        this.ctx.cfg.powerDnsSoaEmail!,
+        this.getSerial(),
+        this.ctx.cfg.powerDnsSoaRefresh!,
+        this.ctx.cfg.powerDnsSoaRetry!,
+        this.ctx.cfg.powerDnsSoaExpire!,
+        this.ctx.cfg.powerDnsSoaMinimum!,
+      )
+    }
+
+    if (qtype === 'TXT') {
+      const user = await this.ctx.services
+        .account(this.ctx.db)
+        .getAccount(qnameLower, true)
+      if (user) {
+        return `did=${user.did}`
+      }
+      return null
+    }
+
+    return null
+  }
+
+  getSerial(): number {
+    // TODO: return db write timestamp or smth?
+    return 1
+  }
+
+  onSocket = (socket: net.Socket) => {
+    socket.setEncoding('utf8')
+
+    const write = (result: any) => {
+      const message = JSON.stringify(result)
+      socket.write(message)
+    }
+
+    socket.on('data', async (data: string) => {
+      const message = JSON.parse(data)
+
+      switch (message.method) {
+        case 'initialize':
+          write(true)
+          break
+        case 'lookup': {
+          const { qtype, qname } = message.parameters
+          const content = await this.resolve(qtype, qname)
+          if (content == null) {
+            write(false)
+          } else {
+            write([
+              {
+                qtype,
+                qname,
+                ttl: this.ctx.cfg.powerDnsRecordTtl,
+                content,
+              },
+            ])
+          }
+          break
+        }
+        default:
+          write(false)
+          break
+      }
+    })
+  }
+}


### PR DESCRIPTION
PowerDNS is a popular dns server with an interesting feature. While most dns servers are backed by a standard database, pdns can be backed by a unix domain socket, allowing it to connect to other programs and serve useful information for them: https://doc.powerdns.com/authoritative/backends/remote.html

This PR contains my experimentation with hooking up a pdns backend for providing handle verification.