### PR TITLE
make sure to await rejected promise expectations

### DIFF
--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -169,7 +169,7 @@ describe('pds author feed views', () => {
       { actor: alice },
       { headers: await network.serviceHeaders(carol) },
     )
-    expect(attempt).rejects.toThrow('Profile not found')
+    await expect(attempt).rejects.toThrow('Profile not found')
 
     // Cleanup
     await agent.api.com.atproto.admin.reverseModerationAction(

--- a/packages/pds/tests/views/author-feed.test.ts
+++ b/packages/pds/tests/views/author-feed.test.ts
@@ -200,7 +200,7 @@ describe('pds author feed views', () => {
       { actor: alice },
       { headers: sc.getHeaders(carol) },
     )
-    expect(attempt).rejects.toThrow('Profile not found')
+    await expect(attempt).rejects.toThrow('Profile not found')
 
     // Cleanup
     await reverseModerationAction(action.id)


### PR DESCRIPTION
Just noticed I had missed these — tests were passing but we'd probably see some unexpected results here at some point.