### PR TITLE
Don't notify user of self-likes and self-reposts

### DIFF
--- a/packages/bsky/src/services/indexing/plugins/like.ts
+++ b/packages/bsky/src/services/indexing/plugins/like.ts
@@ -53,7 +53,9 @@ const findDuplicate = async (
 
 const notifsForInsert = (obj: IndexedLike) => {
   const subjectUri = new AtUri(obj.subject)
-  return [
+  // prevent self-notifications
+  const isSelf = subjectUri.host === obj.creator
+  return isSelf ? [] : [
     {
       did: subjectUri.host,
       author: obj.creator,

--- a/packages/bsky/src/services/indexing/plugins/like.ts
+++ b/packages/bsky/src/services/indexing/plugins/like.ts
@@ -55,17 +55,19 @@ const notifsForInsert = (obj: IndexedLike) => {
   const subjectUri = new AtUri(obj.subject)
   // prevent self-notifications
   const isSelf = subjectUri.host === obj.creator
-  return isSelf ? [] : [
-    {
-      did: subjectUri.host,
-      author: obj.creator,
-      recordUri: obj.uri,
-      recordCid: obj.cid,
-      reason: 'like' as const,
-      reasonSubject: subjectUri.toString(),
-      sortAt: obj.indexedAt,
-    },
-  ]
+  return isSelf
+    ? []
+    : [
+        {
+          did: subjectUri.host,
+          author: obj.creator,
+          recordUri: obj.uri,
+          recordCid: obj.cid,
+          reason: 'like' as const,
+          reasonSubject: subjectUri.toString(),
+          sortAt: obj.indexedAt,
+        },
+      ]
 }
 
 const deleteFn = async (

--- a/packages/bsky/src/services/indexing/plugins/repost.ts
+++ b/packages/bsky/src/services/indexing/plugins/repost.ts
@@ -74,17 +74,19 @@ const notifsForInsert = (obj: IndexedRepost) => {
   const subjectUri = new AtUri(obj.subject)
   // prevent self-notifications
   const isSelf = subjectUri.host === obj.creator
-  return isSelf ? [] : [
-    {
-      did: subjectUri.host,
-      author: obj.creator,
-      recordUri: obj.uri,
-      recordCid: obj.cid,
-      reason: 'repost' as const,
-      reasonSubject: subjectUri.toString(),
-      sortAt: obj.indexedAt,
-    },
-  ]
+  return isSelf
+    ? []
+    : [
+        {
+          did: subjectUri.host,
+          author: obj.creator,
+          recordUri: obj.uri,
+          recordCid: obj.cid,
+          reason: 'repost' as const,
+          reasonSubject: subjectUri.toString(),
+          sortAt: obj.indexedAt,
+        },
+      ]
 }
 
 const deleteFn = async (

--- a/packages/bsky/src/services/indexing/plugins/repost.ts
+++ b/packages/bsky/src/services/indexing/plugins/repost.ts
@@ -72,7 +72,9 @@ const findDuplicate = async (
 
 const notifsForInsert = (obj: IndexedRepost) => {
   const subjectUri = new AtUri(obj.subject)
-  return [
+  // prevent self-notifications
+  const isSelf = subjectUri.host === obj.creator
+  return isSelf ? [] : [
     {
       did: subjectUri.host,
       author: obj.creator,

--- a/packages/bsky/tests/indexing.test.ts
+++ b/packages/bsky/tests/indexing.test.ts
@@ -267,6 +267,99 @@ describe('indexing', () => {
     await services.indexing(db).deleteRecord(...del(originalPost[0]))
   })
 
+  it('does not notify user of own like or repost', async () => {
+    const { db, services } = network.bsky.indexer.ctx
+    const createdAt = new Date().toISOString()
+
+    const originalPost = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedPost,
+      record: {
+        $type: ids.AppBskyFeedPost,
+        text: 'original post',
+        createdAt,
+      } as AppBskyFeedPost.Record,
+    })
+
+    const originalPostRef = {
+      uri: originalPost[0].toString(),
+      cid: originalPost[1].toString(),
+    }
+
+    // own actions
+    const ownLike = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedLike,
+      record: {
+        $type: ids.AppBskyFeedLike,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedLike.Record,
+    })
+    const ownRepost = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedRepost,
+      record: {
+        $type: ids.AppBskyFeedRepost,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedRepost.Record,
+    })
+
+    // other actions
+    const aliceLike = await prepareCreate({
+      did: sc.dids.alice,
+      collection: ids.AppBskyFeedLike,
+      record: {
+        $type: ids.AppBskyFeedLike,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedLike.Record,
+    })
+    const aliceRepost = await prepareCreate({
+      did: sc.dids.alice,
+      collection: ids.AppBskyFeedRepost,
+      record: {
+        $type: ids.AppBskyFeedRepost,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedRepost.Record,
+    })
+
+    await services.indexing(db).indexRecord(...originalPost)
+    await services.indexing(db).indexRecord(...ownLike)
+    await services.indexing(db).indexRecord(...ownRepost)
+    await services.indexing(db).indexRecord(...aliceLike)
+    await services.indexing(db).indexRecord(...aliceRepost)
+
+    await network.bsky.processAll()
+
+    const { data: { notifications } } = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: await network.serviceHeaders(sc.dids.bob) },
+    )
+
+    expect(notifications).toHaveLength(2)
+    expect(notifications.every(n => {
+      return n.author.did !== sc.dids.bob
+    })).toBeTruthy()
+
+    // Cleanup
+    const del = (uri: AtUri) => {
+      return prepareDelete({
+        did: uri.host,
+        collection: uri.collection,
+        rkey: uri.rkey,
+      })
+    }
+
+    await services.indexing(db).deleteRecord(...del(ownLike[0]))
+    await services.indexing(db).deleteRecord(...del(ownRepost[0]))
+    await services.indexing(db).deleteRecord(...del(aliceLike[0]))
+    await services.indexing(db).deleteRecord(...del(aliceRepost[0]))
+    await services.indexing(db).deleteRecord(...del(originalPost[0]))
+  })
+
   it('handles profile aggregations out of order.', async () => {
     const { db, services } = network.bsky.indexer.ctx
     const createdAt = new Date().toISOString()

--- a/packages/bsky/tests/indexing.test.ts
+++ b/packages/bsky/tests/indexing.test.ts
@@ -334,15 +334,19 @@ describe('indexing', () => {
 
     await network.bsky.processAll()
 
-    const { data: { notifications } } = await agent.api.app.bsky.notification.listNotifications(
+    const {
+      data: { notifications },
+    } = await agent.api.app.bsky.notification.listNotifications(
       {},
       { headers: await network.serviceHeaders(sc.dids.bob) },
     )
 
     expect(notifications).toHaveLength(2)
-    expect(notifications.every(n => {
-      return n.author.did !== sc.dids.bob
-    })).toBeTruthy()
+    expect(
+      notifications.every((n) => {
+        return n.author.did !== sc.dids.bob
+      }),
+    ).toBeTruthy()
 
     // Cleanup
     const del = (uri: AtUri) => {

--- a/packages/pds/src/app-view/services/indexing/plugins/like.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/like.ts
@@ -55,7 +55,9 @@ const findDuplicate = async (
 
 const notifsForInsert = (obj: IndexedLike) => {
   const subjectUri = new AtUri(obj.subject)
-  return [
+  // prevent self-notifications
+  const isSelf = subjectUri.host === obj.creator
+  return isSelf ? [] : [
     {
       userDid: subjectUri.host,
       author: obj.creator,

--- a/packages/pds/src/app-view/services/indexing/plugins/like.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/like.ts
@@ -57,17 +57,19 @@ const notifsForInsert = (obj: IndexedLike) => {
   const subjectUri = new AtUri(obj.subject)
   // prevent self-notifications
   const isSelf = subjectUri.host === obj.creator
-  return isSelf ? [] : [
-    {
-      userDid: subjectUri.host,
-      author: obj.creator,
-      recordUri: obj.uri,
-      recordCid: obj.cid,
-      reason: 'like' as const,
-      reasonSubject: subjectUri.toString(),
-      indexedAt: obj.indexedAt,
-    },
-  ]
+  return isSelf
+    ? []
+    : [
+        {
+          userDid: subjectUri.host,
+          author: obj.creator,
+          recordUri: obj.uri,
+          recordCid: obj.cid,
+          reason: 'like' as const,
+          reasonSubject: subjectUri.toString(),
+          indexedAt: obj.indexedAt,
+        },
+      ]
 }
 
 const deleteFn = async (

--- a/packages/pds/src/app-view/services/indexing/plugins/repost.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/repost.ts
@@ -74,7 +74,9 @@ const findDuplicate = async (
 
 const notifsForInsert = (obj: IndexedRepost) => {
   const subjectUri = new AtUri(obj.subject)
-  return [
+  // prevent self-notifications
+  const isSelf = subjectUri.host === obj.creator
+  return isSelf ? [] : [
     {
       userDid: subjectUri.host,
       author: obj.creator,

--- a/packages/pds/src/app-view/services/indexing/plugins/repost.ts
+++ b/packages/pds/src/app-view/services/indexing/plugins/repost.ts
@@ -76,17 +76,19 @@ const notifsForInsert = (obj: IndexedRepost) => {
   const subjectUri = new AtUri(obj.subject)
   // prevent self-notifications
   const isSelf = subjectUri.host === obj.creator
-  return isSelf ? [] : [
-    {
-      userDid: subjectUri.host,
-      author: obj.creator,
-      recordUri: obj.uri,
-      recordCid: obj.cid,
-      reason: 'repost' as const,
-      reasonSubject: subjectUri.toString(),
-      indexedAt: obj.indexedAt,
-    },
-  ]
+  return isSelf
+    ? []
+    : [
+        {
+          userDid: subjectUri.host,
+          author: obj.creator,
+          recordUri: obj.uri,
+          recordCid: obj.cid,
+          reason: 'repost' as const,
+          reasonSubject: subjectUri.toString(),
+          indexedAt: obj.indexedAt,
+        },
+      ]
 }
 
 const deleteFn = async (

--- a/packages/pds/tests/indexing.test.ts
+++ b/packages/pds/tests/indexing.test.ts
@@ -230,24 +230,20 @@ describe('indexing', () => {
       } as AppBskyFeedRepost.Record,
     })
 
-    await services
-      .repo(db)
-      .processWrites(
-        {
-          did: sc.dids.bob,
-          writes: [originalPost, ownLike, ownRepost],
-        },
-        1,
-      )
-    await services
-      .repo(db)
-      .processWrites(
-        {
-          did: sc.dids.alice,
-          writes: [aliceLike, aliceRepost],
-        },
-        1,
-      )
+    await services.repo(db).processWrites(
+      {
+        did: sc.dids.bob,
+        writes: [originalPost, ownLike, ownRepost],
+      },
+      1,
+    )
+    await services.repo(db).processWrites(
+      {
+        did: sc.dids.alice,
+        writes: [aliceLike, aliceRepost],
+      },
+      1,
+    )
 
     await server.processAll()
 
@@ -259,9 +255,11 @@ describe('indexing', () => {
     )
 
     expect(notifications).toHaveLength(2)
-    expect(notifications.every(n => {
-      return n.author.did !== sc.dids.bob
-    })).toBeTruthy()
+    expect(
+      notifications.every((n) => {
+        return n.author.did !== sc.dids.bob
+      }),
+    ).toBeTruthy()
 
     // Cleanup
     const del = (uri: AtUri) => {
@@ -273,31 +271,20 @@ describe('indexing', () => {
     }
 
     // Delete
-    await services
-      .repo(db)
-      .processWrites(
-        {
-          did: sc.dids.bob,
-          writes: [
-            del(originalPost.uri),
-            del(ownLike.uri),
-            del(ownRepost.uri),
-          ],
-        },
-        1,
-      )
-    await services
-      .repo(db)
-      .processWrites(
-        {
-          did: sc.dids.alice,
-          writes: [
-            del(aliceLike.uri),
-            del(aliceRepost.uri),
-          ],
-        },
-        1,
-      )
+    await services.repo(db).processWrites(
+      {
+        did: sc.dids.bob,
+        writes: [del(originalPost.uri), del(ownLike.uri), del(ownRepost.uri)],
+      },
+      1,
+    )
+    await services.repo(db).processWrites(
+      {
+        did: sc.dids.alice,
+        writes: [del(aliceLike.uri), del(aliceRepost.uri)],
+      },
+      1,
+    )
     await server.processAll()
   })
 

--- a/packages/pds/tests/indexing.test.ts
+++ b/packages/pds/tests/indexing.test.ts
@@ -1,4 +1,9 @@
-import AtpAgent, { AppBskyActorProfile, AppBskyFeedPost } from '@atproto/api'
+import AtpAgent, {
+  AppBskyActorProfile,
+  AppBskyFeedPost,
+  AppBskyFeedLike,
+  AppBskyFeedRepost,
+} from '@atproto/api'
 import { AtUri } from '@atproto/uri'
 import { CloseFn, forSnapshot, runTestServer, TestServerInfo } from './_util'
 import { SeedClient } from './seeds/client'
@@ -164,6 +169,136 @@ describe('indexing', () => {
         deleteNotifications,
       }),
     ).toMatchSnapshot()
+  })
+
+  it('does not notify user of own like or repost', async () => {
+    const { db, services } = server.ctx
+    const createdAt = new Date().toISOString()
+
+    const originalPost = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedPost,
+      record: {
+        $type: ids.AppBskyFeedPost,
+        text: 'original post',
+        createdAt,
+      } as AppBskyFeedPost.Record,
+    })
+
+    const originalPostRef = {
+      uri: originalPost.uri.toString(),
+      cid: originalPost.cid.toString(),
+    }
+
+    // own actions
+    const ownLike = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedLike,
+      record: {
+        $type: ids.AppBskyFeedLike,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedLike.Record,
+    })
+    const ownRepost = await prepareCreate({
+      did: sc.dids.bob,
+      collection: ids.AppBskyFeedRepost,
+      record: {
+        $type: ids.AppBskyFeedRepost,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedRepost.Record,
+    })
+
+    // other actions
+    const aliceLike = await prepareCreate({
+      did: sc.dids.alice,
+      collection: ids.AppBskyFeedLike,
+      record: {
+        $type: ids.AppBskyFeedLike,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedLike.Record,
+    })
+    const aliceRepost = await prepareCreate({
+      did: sc.dids.alice,
+      collection: ids.AppBskyFeedRepost,
+      record: {
+        $type: ids.AppBskyFeedRepost,
+        subject: originalPostRef,
+        createdAt,
+      } as AppBskyFeedRepost.Record,
+    })
+
+    await services
+      .repo(db)
+      .processWrites(
+        {
+          did: sc.dids.bob,
+          writes: [originalPost, ownLike, ownRepost],
+        },
+        1,
+      )
+    await services
+      .repo(db)
+      .processWrites(
+        {
+          did: sc.dids.alice,
+          writes: [aliceLike, aliceRepost],
+        },
+        1,
+      )
+
+    await server.processAll()
+
+    const {
+      data: { notifications },
+    } = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: sc.getHeaders(sc.dids.bob) },
+    )
+
+    expect(notifications).toHaveLength(2)
+    expect(notifications.every(n => {
+      return n.author.did !== sc.dids.bob
+    })).toBeTruthy()
+
+    // Cleanup
+    const del = (uri: AtUri) => {
+      return prepareDelete({
+        did: uri.host,
+        collection: uri.collection,
+        rkey: uri.rkey,
+      })
+    }
+
+    // Delete
+    await services
+      .repo(db)
+      .processWrites(
+        {
+          did: sc.dids.bob,
+          writes: [
+            del(originalPost.uri),
+            del(ownLike.uri),
+            del(ownRepost.uri),
+          ],
+        },
+        1,
+      )
+    await services
+      .repo(db)
+      .processWrites(
+        {
+          did: sc.dids.alice,
+          writes: [
+            del(aliceLike.uri),
+            del(aliceRepost.uri),
+          ],
+        },
+        1,
+      )
+    await server.processAll()
   })
 
   async function getNotifications(db: Database, uri: AtUri) {


### PR DESCRIPTION
Should fix https://github.com/bluesky-social/social-app/issues/1201

Filters out notifications for Likes and Reposts if the subject is the same as the content creator.