### PR TITLE
Fix auth on bsky author feed

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -7,10 +7,11 @@ import { setRepoRev } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getAuthorFeed({
-    auth: ctx.authOptionalVerifier,
+    auth: ctx.authOptionalAccessOrRoleVerifier,
     handler: async ({ params, auth, res }) => {
       const { actor, limit, cursor, filter } = params
-      const viewer = auth.credentials.did
+      const viewer =
+        auth.credentials.type === 'access' ? auth.credentials.did : null
 
       const db = ctx.db.getReplica()
       const { ref } = db.db.dynamic


### PR DESCRIPTION
The PDS passes through role auth to the appview, but the appview wasn't accepting it.  Now it does!