### PR TITLE
com.atproto.sync.subscribeRepos lexicon: add #repoOp description

### DIFF
--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -104,6 +104,7 @@
     },
     "repoOp": {
       "type": "object",
+      "description": "A repo operation, ie a write of a single record. For creates and updates, cid is the record's CID as of this operation. For deletes, it's null.",
       "required": ["action", "path", "cid"],
       "nullable": ["cid"],
       "properties": {


### PR DESCRIPTION
specifically, note that it's null for deletes. for https://github.com/bluesky-social/atproto/discussions/1252 , cc @DavidBuchanan314

thanks in advance!