### PR TITLE
Handle negative ISO year for indexing

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/bsky"
   },
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
@@ -48,6 +48,7 @@
     "http-errors": "^2.0.0",
     "http-terminator": "^3.2.0",
     "ioredis": "^5.3.2",
+    "iso-datestring-validator": "^2.2.2",
     "kysely": "^0.22.0",
     "multiformats": "^9.6.4",
     "p-queue": "^6.6.2",

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/bsky"
   },
-  "main": "src/index.js",
+  "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/bsky"
   },
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/bsky/src/services/indexing/util.ts
+++ b/packages/bsky/src/services/indexing/util.ts
@@ -1,3 +1,5 @@
+import { isValidISODateString } from 'iso-datestring-validator'
+
 // Normalize date strings to simplified ISO so that the lexical sort preserves temporal sort.
 // Rather than failing on an invalid date format, returns valid unix epoch.
 export function toSimplifiedISOSafe(dateStr: string) {
@@ -5,5 +7,10 @@ export function toSimplifiedISOSafe(dateStr: string) {
   if (isNaN(date.getTime())) {
     return new Date(0).toISOString()
   }
-  return date.toISOString() // YYYY-MM-DDTHH:mm:ss.sssZ
+  const iso = date.toISOString()
+  if (!isValidISODateString(iso)) {
+    // Occurs in rare cases, e.g. where resulting UTC year is negative. These also don't preserve lexical sort.
+    return new Date(0).toISOString()
+  }
+  return iso // YYYY-MM-DDTHH:mm:ss.sssZ
 }

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/pds"
   },
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
@@ -55,6 +55,7 @@
     "http-errors": "^2.0.0",
     "http-terminator": "^3.2.0",
     "ioredis": "^5.3.2",
+    "iso-datestring-validator": "^2.2.2",
     "jsonwebtoken": "^8.5.1",
     "kysely": "^0.22.0",
     "lru-cache": "^10.0.1",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/pds"
   },
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bluesky-social/atproto.git",
     "directory": "packages/pds"
   },
-  "main": "src/index.js",
+  "main": "src/index.ts",
   "bin": "dist/bin.ts",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/pds/src/app-view/services/indexing/util.ts
+++ b/packages/pds/src/app-view/services/indexing/util.ts
@@ -1,3 +1,5 @@
+import { isValidISODateString } from 'iso-datestring-validator'
+
 // Normalize date strings to simplified ISO so that the lexical sort preserves temporal sort.
 // Rather than failing on an invalid date format, returns valid unix epoch.
 export function toSimplifiedISOSafe(dateStr: string) {
@@ -5,5 +7,10 @@ export function toSimplifiedISOSafe(dateStr: string) {
   if (isNaN(date.getTime())) {
     return new Date(0).toISOString()
   }
-  return date.toISOString() // YYYY-MM-DDTHH:mm:ss.sssZ
+  const iso = date.toISOString()
+  if (!isValidISODateString(iso)) {
+    // Occurs in rare cases, e.g. where resulting UTC year is negative. These also don't preserve lexical sort.
+    return new Date(0).toISOString()
+  }
+  return iso // YYYY-MM-DDTHH:mm:ss.sssZ
 }


### PR DESCRIPTION
Negative ISO years break lexical sorting, and are generally poorly behaved.  No records we're dealing with would reasonably have a negative year, so we avoid that case in appview indexing.