### PR TITLE
Bump pkg versions

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/identity",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "license": "MIT",
   "repository": {

--- a/packages/xrpc/package.json
+++ b/packages/xrpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/xrpc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "scripts": {
     "prettier": "prettier --check src/",


### PR DESCRIPTION
- bump `@atproto-xrpc` -> 0.3.0
- bump `@atproto-identity` -> 0.2.0
- publish new `@atproto-syntax` at 0.1.0

Closes https://github.com/bluesky-social/atproto/issues/1495