### PR TITLE
TS config: no composite

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,7 @@
     "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "composite": true
+    "isolatedModules": true
   },
   "exclude": ["node_modules", "**/*/dist"],
   "references": [


### PR DESCRIPTION
This disable [composite builds](https://www.typescriptlang.org/tsconfig#composite)

This may cause slightly slower builds (but only marginally in my quick test) but will stop the incremental build artifacts (`tsconfig.build.tsbuildinfo`) from sticking around which have been giving us footguns