### PR TITLE
Add APIs for getting and setting account owner birth age

### DIFF
--- a/lexicons/com/atproto/server/createAccount.json
+++ b/lexicons/com/atproto/server/createAccount.json
@@ -16,7 +16,8 @@
             "did": {"type": "string", "format": "did"},
             "inviteCode": {"type": "string"},
             "password": {"type": "string"},
-            "recoveryKey": {"type": "string"}
+            "recoveryKey": {"type": "string"},
+            "birthDate": {"type": "string", "format": "date"}
           }
         }
       },

--- a/lexicons/com/atproto/server/describeAccount.json
+++ b/lexicons/com/atproto/server/describeAccount.json
@@ -1,0 +1,19 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.describeAccount",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get information about the current session's account.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "birthAge": {"type": "number", "description": "The user's birth age in years. If undefined, the user has not specified a birth date."}
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/server/updateAccount.json
+++ b/lexicons/com/atproto/server/updateAccount.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.updateAccount",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Update an account information.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "birthDate": {"type": "string", "format": "date"}
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": []
+    }
+  }
+}


### PR DESCRIPTION
For moderation purposes, we need to store the user's birth date and tell the application their age (in order to enable/disable adult content). We want to ask for the birth date but only reveal the age via the APIs, and at this stage the age shouldn't be published to other users. (In the future users may want to put their age in their profiles but that's not in the scope of this task.)

Tasks: 

- [ ] Finalize lexicons
- [ ] Update database to store birth age
- [ ] Implement API routes