### PR TITLE
Add preferences helpers to SDK

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,3 +1,5 @@
+import { LabelPreference } from './moderation/types'
+
 /**
  * Used by the PersistSessionHandler to indicate what change occurred
  */
@@ -69,4 +71,22 @@ export type AtpAgentFetchHandler = (
  */
 export interface AtpAgentGlobalOpts {
   fetch: AtpAgentFetchHandler
+}
+
+/**
+ * Content-label preference
+ */
+export type BskyLabelPreference = LabelPreference | 'show'
+// TEMP we need to permanently convert 'show' to 'ignore', for now we manually convert -prf
+
+/**
+ * Bluesky preferences object
+ */
+export interface BskyPreferences {
+  feeds: {
+    saved?: string[]
+    pinned?: string[]
+  }
+  adultContentEnabled: boolean
+  contentLabels: Record<string, BskyLabelPreference>
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -200,4 +200,153 @@ describe('agent', () => {
       await expect(agent.deleteFollow('foo')).rejects.toThrow('Not logged in')
     })
   })
+
+  describe('preferences methods', () => {
+    it('gets and sets preferences correctly', async () => {
+      const agent = new BskyAgent({ service: server.url })
+
+      await agent.createAccount({
+        handle: 'user5.test',
+        email: 'user5@test.com',
+        password: 'password',
+      })
+
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: { pinned: undefined, saved: undefined },
+        adultContentEnabled: false,
+        contentLabels: {},
+      })
+
+      await agent.setAdultContentEnabled(true)
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: { pinned: undefined, saved: undefined },
+        adultContentEnabled: true,
+        contentLabels: {},
+      })
+
+      await agent.setAdultContentEnabled(false)
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: { pinned: undefined, saved: undefined },
+        adultContentEnabled: false,
+        contentLabels: {},
+      })
+
+      await agent.setContentLabelPref('impersonation', 'warn')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: { pinned: undefined, saved: undefined },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'warn',
+        },
+      })
+
+      await agent.setContentLabelPref('spam', 'show') // will convert to 'ignore'
+      await agent.setContentLabelPref('impersonation', 'hide')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: { pinned: undefined, saved: undefined },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.addSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: [],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.removePinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: [],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: [],
+          saved: [],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake2')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: [
+            'at://bob.com/app.bsky.feed.generator/fake',
+            'at://bob.com/app.bsky.feed.generator/fake2',
+          ],
+          saved: [
+            'at://bob.com/app.bsky.feed.generator/fake',
+            'at://bob.com/app.bsky.feed.generator/fake2',
+          ],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+
+      await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
+      await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+        },
+        adultContentEnabled: false,
+        contentLabels: {
+          impersonation: 'hide',
+          spam: 'ignore',
+        },
+      })
+    })
+  })
 })


### PR DESCRIPTION
Adds a set of helper functions to the SDK for controlling the preferences.

```typescript
getPreferences(): Promise<BskyPreferences>
setSavedFeeds(saved: string[], pinned: string[])
addSavedFeed(v: string)
removeSavedFeed(v: string)
addPinnedFeed(v: string)
removePinnedFeed(v: string)
setAdultContentEnabled(v: boolean)
setContentLabelPref(key: string, value: BskyLabelPreference)
```