### PR TITLE
@atproto/api@0.6.9

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/api",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "yarn docgen && node ./scripts/generate-code.mjs && lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/api",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "main": "src/index.ts",
   "scripts": {
     "codegen": "yarn docgen && node ./scripts/generate-code.mjs && lex gen-api ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3536,6 +3536,9 @@ export const schemaDict = {
                 type: 'string',
                 format: 'did',
               },
+              force: {
+                type: 'boolean',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/temp/upgradeRepoVersion.ts
+++ b/packages/api/src/client/types/com/atproto/temp/upgradeRepoVersion.ts
@@ -11,6 +11,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   did: string
+  force?: boolean
   [k: string]: unknown
 }
 


### PR DESCRIPTION
There are two versions here because, oddly, the `*publish` hooks didn't run when I first ran `npm publish`, so `0.6.9` was pointing to `src/index.ts`. I've confirmed `0.6.10` is correct.