### PR TITLE
Add missing dependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,6 +25,7 @@
     "@atproto/common-web": "*",
     "@atproto/syntax": "*",
     "@atproto/xrpc": "*",
+    "multiformats": "^9.9.0",
     "tlds": "^1.234.0",
     "typed-emitter": "^2.1.0"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@atproto/common-web": "*",
+    "@atproto/lexicon": "*",
     "@atproto/syntax": "*",
     "@atproto/xrpc": "*",
     "multiformats": "^9.9.0",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@atproto/crypto": "*",
+    "@atproto/repo": "*",
     "@aws-sdk/client-cloudfront": "^3.261.0",
     "@aws-sdk/client-kms": "^3.196.0",
     "@aws-sdk/client-s3": "^3.224.0",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/lib-storage": "^3.226.0",
     "@noble/curves": "^1.1.0",
     "key-encoder": "^2.0.3",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "uint8arrays": "3.0.0"
   }
 }

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -50,7 +50,7 @@
     "ioredis": "^5.3.2",
     "iso-datestring-validator": "^2.2.2",
     "kysely": "^0.22.0",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "p-queue": "^6.6.2",
     "pg": "^8.10.0",
     "pino": "^8.6.1",

--- a/packages/common-web/package.json
+++ b/packages/common-web/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "graphemer": "^1.4.0",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "uint8arrays": "3.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,7 @@
     "@atproto/common-web": "*",
     "@ipld/dag-cbor": "^7.0.3",
     "cbor-x": "^1.5.1",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "pino": "^8.6.1"
   }
 }

--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -22,11 +22,12 @@
     "directory": "packages/lex-cli"
   },
   "dependencies": {
-    "@atproto/syntax": "*",
     "@atproto/lexicon": "*",
+    "@atproto/syntax": "*",
     "chalk": "^5.1.1",
     "commander": "^9.4.0",
     "ts-morph": "^16.0.0",
-    "yesno": "^0.4.0"
+    "yesno": "^0.4.0",
+    "zod": "^3.21.4"
   }
 }

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -27,7 +27,7 @@
     "@atproto/common-web": "*",
     "@atproto/syntax": "*",
     "iso-datestring-validator": "^2.2.2",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "zod": "^3.21.4"
   }
 }

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -39,6 +39,7 @@
     "@atproto/identity": "*",
     "@atproto/lexicon": "*",
     "@atproto/repo": "*",
+    "@atproto/xrpc": "*",
     "@atproto/xrpc-server": "*",
     "@did-plc/lib": "^0.0.1",
     "better-sqlite3": "^7.6.2",
@@ -67,7 +68,8 @@
     "pino-http": "^8.2.1",
     "sharp": "^0.31.2",
     "typed-emitter": "^2.1.0",
-    "uint8arrays": "3.0.0"
+    "uint8arrays": "3.0.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@atproto/api": "*",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -58,7 +58,7 @@
     "jsonwebtoken": "^8.5.1",
     "kysely": "^0.22.0",
     "lru-cache": "^10.0.1",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "nodemailer": "^6.8.0",
     "nodemailer-html-to-text": "^3.2.0",
     "p-queue": "^6.6.2",

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/pds"
   },
   "main": "src/index.ts",
-  "bin": "dist/bin.ts",
+  "bin": "dist/bin.js",
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/*",
     "build": "node ./build.js",

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -34,7 +34,7 @@
     "@atproto/syntax": "*",
     "@ipld/car": "^3.2.3",
     "@ipld/dag-cbor": "^7.0.0",
-    "multiformats": "^9.6.4",
+    "multiformats": "^9.9.0",
     "uint8arrays": "3.0.0",
     "zod": "^3.21.4"
   }

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -43,6 +43,6 @@
     "@types/http-errors": "^2.0.1",
     "@types/ws": "^8.5.4",
     "get-port": "^6.1.2",
-    "multiformats": "^9.6.4"
+    "multiformats": "^9.9.0"
   }
 }


### PR DESCRIPTION
I'm using PNPM locally, which doesn't allow implicit dependency sharing between packages, so I found these missing dependencies as a result. I had to update the `multiformats` version everywhere to keep a single version in the lockfile.