### PR TITLE
enable granular perms for publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build & Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
Enables these perms only for this job. Based [on docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) I think we only need these two, but I'll keep an eye on it and can open it up only as much as needed.