### PR TITLE
mark dev/service packages as private

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@atproto/bsky",
   "version": "0.0.3",
   "license": "MIT",

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@atproto/dev-env",
   "version": "0.2.3",
   "main": "src/index.ts",

--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@atproto/lex-cli",
   "version": "0.2.0",
   "bin": {

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@atproto/pds",
   "version": "0.1.12",
   "license": "MIT",


### PR DESCRIPTION
This should prevent these from being published, simply because we don't need them to be. [See docs](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages).

This **will not** prevent these packages from being referenced in changesets, and their versions will be bumped as well. Just never published to npm.