### PR TITLE
Add personal-details user preference with birth date

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -134,6 +134,16 @@
           }
         }
       }
+    },
+    "personalDetailsPref": {
+      "type": "object",
+      "properties": {
+        "birthDate": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The birth date of the owner of the account."
+        }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -94,7 +94,12 @@
       "type": "array",
       "items": {
         "type": "union",
-        "refs": ["#adultContentPref", "#contentLabelPref", "#savedFeedsPref"]
+        "refs": [
+          "#adultContentPref",
+          "#contentLabelPref",
+          "#savedFeedsPref",
+          "#personalDetailsPref"
+        ]
       }
     },
     "adultContentPref": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3714,6 +3714,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#personalDetailsPref',
           ],
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3760,6 +3760,16 @@ export const schemaDict = {
           },
         },
       },
+      personalDetailsPref: {
+        type: 'object',
+        properties: {
+          birthDate: {
+            type: 'string',
+            format: 'datetime',
+            description: 'The birth date of the owner of the account.',
+          },
+        },
+      },
     },
   },
   AppBskyActorGetPreferences: {

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -108,6 +108,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | PersonalDetailsPref
   | { $type: string; [k: string]: unknown }
 )[]
 

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -163,3 +163,21 @@ export function isSavedFeedsPref(v: unknown): v is SavedFeedsPref {
 export function validateSavedFeedsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#savedFeedsPref', v)
 }
+
+export interface PersonalDetailsPref {
+  /** The birth date of the owner of the account. */
+  birthDate?: string
+  [k: string]: unknown
+}
+
+export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#personalDetailsPref'
+  )
+}
+
+export function validatePersonalDetailsPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3714,6 +3714,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#personalDetailsPref',
           ],
         },
       },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3760,6 +3760,16 @@ export const schemaDict = {
           },
         },
       },
+      personalDetailsPref: {
+        type: 'object',
+        properties: {
+          birthDate: {
+            type: 'string',
+            format: 'datetime',
+            description: 'The birth date of the owner of the account.',
+          },
+        },
+      },
     },
   },
   AppBskyActorGetPreferences: {

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -108,6 +108,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | PersonalDetailsPref
   | { $type: string; [k: string]: unknown }
 )[]
 

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -163,3 +163,21 @@ export function isSavedFeedsPref(v: unknown): v is SavedFeedsPref {
 export function validateSavedFeedsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#savedFeedsPref', v)
 }
+
+export interface PersonalDetailsPref {
+  /** The birth date of the owner of the account. */
+  birthDate?: string
+  [k: string]: unknown
+}
+
+export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#personalDetailsPref'
+  )
+}
+
+export function validatePersonalDetailsPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3714,6 +3714,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#personalDetailsPref',
           ],
         },
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3760,6 +3760,16 @@ export const schemaDict = {
           },
         },
       },
+      personalDetailsPref: {
+        type: 'object',
+        properties: {
+          birthDate: {
+            type: 'string',
+            format: 'datetime',
+            description: 'The birth date of the owner of the account.',
+          },
+        },
+      },
     },
   },
   AppBskyActorGetPreferences: {

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -108,6 +108,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | PersonalDetailsPref
   | { $type: string; [k: string]: unknown }
 )[]
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -163,3 +163,21 @@ export function isSavedFeedsPref(v: unknown): v is SavedFeedsPref {
 export function validateSavedFeedsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#savedFeedsPref', v)
 }
+
+export interface PersonalDetailsPref {
+  /** The birth date of the owner of the account. */
+  birthDate?: string
+  [k: string]: unknown
+}
+
+export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#personalDetailsPref'
+  )
+}
+
+export function validatePersonalDetailsPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}


### PR DESCRIPTION
Replaces https://github.com/bluesky-social/atproto/pull/1533

For moderation purposes, we need to store the user's birth date and tell the application their age (in order to enable/disable adult content). When we introduce OAuth and permissioning to the system, we'll be able to control access to this set of preferences using its NSID. For now, it will be available to any app that the user signs into with a main password or app password.