### PR TITLE
Remove legacy repo sync impl

### DIFF
--- a/packages/pds/src/api/com/atproto/sync/deprecated/getCheckout.ts
+++ b/packages/pds/src/api/com/atproto/sync/deprecated/getCheckout.ts
@@ -6,7 +6,6 @@ import SqlRepoStorage, {
 } from '../../../../../sql-repo-storage'
 import AppContext from '../../../../../context'
 import { isUserOrAdmin } from '../../../../../auth'
-import { getFullRepo } from '@atproto/repo'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.sync.getCheckout({
@@ -24,20 +23,15 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const storage = new SqlRepoStorage(ctx.db, did)
-      const head = await storage.getRoot()
-      if (!head) {
-        throw new InvalidRequestError(`Could not find repo for DID: ${did}`)
+      let carStream: AsyncIterable<Uint8Array>
+      try {
+        carStream = await storage.getCarStream()
+      } catch (err) {
+        if (err instanceof RepoRootNotFoundError) {
+          throw new InvalidRequestError(`Could not find repo for DID: ${did}`)
+        }
+        throw err
       }
-      const carStream = getFullRepo(storage, head)
-      // let carStream: AsyncIterable<Uint8Array>
-      // try {
-      //   carStream = await storage.getCarStream()
-      // } catch (err) {
-      //   if (err instanceof RepoRootNotFoundError) {
-      //     throw new InvalidRequestError(`Could not find repo for DID: ${did}`)
-      //   }
-      //   throw err
-      // }
 
       return {
         encoding: 'application/vnd.ipld.car',

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -25,9 +25,7 @@ export default function (server: Server, ctx: AppContext) {
       const storage = new SqlRepoStorage(ctx.db, did)
       let carStream: AsyncIterable<Uint8Array>
       try {
-        carStream = since
-          ? await storage.getCarStream(since)
-          : await storage.getCarStreamLegacy()
+        carStream = await storage.getCarStream(since)
       } catch (err) {
         if (err instanceof RepoRootNotFoundError) {
           throw new InvalidRequestError(`Could not find repo for DID: ${did}`)

--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -206,44 +206,6 @@ export class SqlRepoStorage extends ReadableBlockstore implements RepoStorage {
     }
   }
 
-  async getCarStreamLegacy() {
-    const root = await this.getRoot()
-    if (!root) {
-      throw new RepoRootNotFoundError()
-    }
-    return writeCarStream(root, async (car) => {
-      let cursor: CID | undefined = undefined
-      do {
-        const res = await this.getBlockRangeLegacy(cursor)
-        for (const row of res) {
-          await car.put({
-            cid: CID.parse(row.cid),
-            bytes: row.content,
-          })
-        }
-        const lastRow = res.at(-1)
-        if (lastRow) {
-          cursor = CID.parse(lastRow.cid)
-        } else {
-          cursor = undefined
-        }
-      } while (cursor)
-    })
-  }
-
-  async getBlockRangeLegacy(cursor?: CID) {
-    let builder = this.db.db
-      .selectFrom('ipld_block')
-      .where('creator', '=', this.did)
-      .select(['cid', 'content'])
-      .orderBy('cid', 'asc')
-      .limit(500)
-    if (cursor) {
-      builder = builder.where('cid', '>', cursor.toString())
-    }
-    return builder.execute()
-  }
-
   async getCarStream(since?: string) {
     const root = await this.getRoot()
     if (!root) {


### PR DESCRIPTION
We kept around the legacy repo sync impl while repos were migrating. But we can remove now that migration is done