### PR TITLE
Lower applyWrites limit

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -34,8 +34,8 @@ export default function (server: Server, ctx: AppContext) {
           'Unvalidated writes are not yet supported.',
         )
       }
-      if (tx.writes.length > 200) {
-        throw new InvalidRequestError('Too many writes. Max: 200')
+      if (tx.writes.length > 10) {
+        throw new InvalidRequestError('Too many writes. Max: 10')
       }
 
       let writes: PreparedWrite[]


### PR DESCRIPTION
We had a higher limit on `applyWrites` when repos had history because batch writes would prevent repo history increase.

However, now that repos are a-historical, that benefit isn't needed. So `applyWrites` is really meant for applying transactional writes.

Business logic that requires > 10 transactional records is rare