### PR TITLE
Prevent user pref races

### DIFF
--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -590,6 +590,15 @@ export class AccountService {
         `Some preferences are not in the ${namespace} namespace`,
       )
     }
+    // short-held row lock to prevent races
+    if (this.db.dialect === 'pg') {
+      await this.db.db
+        .selectFrom('user_account')
+        .selectAll()
+        .forUpdate()
+        .where('did', '=', did)
+        .executeTakeFirst()
+    }
     // get all current prefs for user and prep new pref rows
     const allPrefs = await this.db.db
       .selectFrom('user_pref')


### PR DESCRIPTION
We were getting racing updates to the `putPreferences` route that would leave the table in an inconsistent state.

This applies a row lock on the user's row in the `user_account` table to ensure that these updates get linearized. This should be a short-held lock and will block other writes while it is held.

---

This seemed like the simplest implementation to prevent conflicting writes. Other options include:
- advisory lock (similar to repo writes)
- skipping on lock and returning an error instead of waiting & overwriting
- skipping the lock & retrying
- doing integrity checks at the end of the transaction to ensure we didn't leave it in a bad state & throwing if we did
- reworking the data modeling of the user-pref table so that it's a simple atomic `UPDATE`