### PR TITLE
Get rate limit ip correctly

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -137,6 +137,7 @@ export class PDS {
     )
 
     const app = express()
+    app.set('trust proxy', true)
     app.use(cors())
     app.use(loggerMiddleware)
     app.use(compression())

--- a/packages/xrpc-server/src/index.ts
+++ b/packages/xrpc-server/src/index.ts
@@ -5,4 +5,4 @@ export * from './stream'
 export * from './rate-limiter'
 
 export type { ServerTiming } from './util'
-export { getReqIp, serverTimingHeader, ServerTimer } from './util'
+export { serverTimingHeader, ServerTimer } from './util'

--- a/packages/xrpc-server/src/rate-limiter.ts
+++ b/packages/xrpc-server/src/rate-limiter.ts
@@ -14,7 +14,6 @@ import {
   RateLimiterStatus,
   XRPCReqContext,
 } from './types'
-import { getReqIp } from './util'
 
 export type RateLimiterOpts = {
   keyPrefix: string
@@ -155,5 +154,5 @@ export const getTightestLimit = (
   return lowest
 }
 
-const defaultKey: CalcKeyFn = (ctx: XRPCReqContext) => getReqIp(ctx.req)
+const defaultKey: CalcKeyFn = (ctx: XRPCReqContext) => ctx.req.ip
 const defaultPoints: CalcPointsFn = () => 1

--- a/packages/xrpc-server/src/rate-limiter.ts
+++ b/packages/xrpc-server/src/rate-limiter.ts
@@ -154,5 +154,7 @@ export const getTightestLimit = (
   return lowest
 }
 
+// when using a proxy, ensure headers are getting forwarded correctly: `app.set('trust proxy', true)`
+// https://expressjs.com/en/guide/behind-proxies.html
 const defaultKey: CalcKeyFn = (ctx: XRPCReqContext) => ctx.req.ip
 const defaultPoints: CalcPointsFn = () => 1

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -268,10 +268,6 @@ function decodeBodyStream(
   return stream
 }
 
-export const getReqIp = (req: express.Request): string => {
-  return req.ips.at(-1) ?? req.ip
-}
-
 export function serverTimingHeader(timings: ServerTiming[]) {
   return timings
     .map((timing) => {


### PR DESCRIPTION
To get the ip of the client for rate limiting correctly we need to do 2 things:
- tell express to trust the proxy that it's receiving the req from (in this case the loadbalancer)
- grab the _leftmost_ (not _rightmost_) ip from the XFF header. `req.ip` does this

for reference: https://expressjs.com/en/guide/behind-proxies.html