### PR TITLE
Enable appview proxy in dev-env full network

### DIFF
--- a/packages/dev-env/src/bin-network.ts
+++ b/packages/dev-env/src/bin-network.ts
@@ -24,6 +24,7 @@ const run = async () => {
     },
     plc: { port: 2582 },
   })
+  await enableProxy(network)
   await generateMockSetup(network)
 
   console.log(
@@ -39,3 +40,39 @@ const run = async () => {
 }
 
 run()
+
+// @TODO remove once we remove proxy runtime flags
+const enableProxy = async (network: TestNetwork) => {
+  const flags = [
+    'appview-proxy:app.bsky.feed.getAuthorFeed',
+    'appview-proxy:app.bsky.graph.getFollowers',
+    'appview-proxy:app.bsky.feed.getPosts',
+    'appview-proxy:app.bsky.graph.getFollows',
+    'appview-proxy:app.bsky.feed.getLikes',
+    'appview-proxy:app.bsky.feed.getRepostedBy',
+    'appview-proxy:app.bsky.feed.getPostThread',
+    'appview-proxy:app.bsky.actor.getProfile',
+    'appview-proxy:app.bsky.actor.getProfiles',
+    'appview-proxy:app.bsky.feed.getTimeline',
+    'appview-proxy:app.bsky.feed.getSuggestions',
+    'appview-proxy:app.bsky.feed.getFeed',
+    'appview-proxy:app.bsky.feed.getActorFeeds',
+    'appview-proxy:app.bsky.feed.getActorLikes',
+    'appview-proxy:app.bsky.feed.getFeedGenerator',
+    'appview-proxy:app.bsky.feed.getFeedGenerators',
+    'appview-proxy:app.bsky.feed.getBlocks',
+    'appview-proxy:app.bsky.feed.getList',
+    'appview-proxy:app.bsky.notification.listNotifications',
+    'appview-proxy:app.bsky.feed.getLists',
+    'appview-proxy:app.bsky.feed.getListMutes',
+    'appview-proxy:com.atproto.repo.getRecord',
+    'appview-proxy:com.atproto.identity.resolveHandle',
+    'appview-proxy:app.bsky.notification.getUnreadCount',
+    'appview-proxy:app.bsky.actor.searchActorsTypeahead',
+    'appview-proxy:app.bsky.actor.searchActors',
+  ]
+  await network.pds.ctx.db.db
+    .insertInto('runtime_flag')
+    .values(flags.map((name) => ({ name, value: '10' })))
+    .execute()
+}


### PR DESCRIPTION
Proxy is behind runtime flags, so enable the proxying on all routes when using the full network in dev-env