### PR TITLE
order by `like.indexedAt` in app view

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/feed/getActorLikes'
@@ -71,7 +70,6 @@ const skeleton = async (
   let feedItemsQb = feedService
     .selectFeedItemQb()
     .innerJoin('like', 'like.subject', 'feed_item.uri')
-    .select('like.indexedAt as sortAt')
     .where('like.creator', '=', actorDid)
 
   const keyset = new FeedKeyset(ref('like.sortAt'), ref('feed_item.cid'))

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/feed/getActorLikes'
@@ -70,10 +71,12 @@ const skeleton = async (
   let feedItemsQb = feedService
     .selectFeedItemQb()
     .innerJoin('like', 'like.subject', 'feed_item.uri')
+    .select(
+      sql`coalesce("like"."indexedAt", "feed_item"."sortAt")`.as('sortAt'),
+    )
     .where('like.creator', '=', actorDid)
-    .orderBy('like.indexedAt', 'desc')
 
-  const keyset = new FeedKeyset(ref('feed_item.sortAt'), ref('feed_item.cid'))
+  const keyset = new FeedKeyset(ref('like.sortAt'), ref('feed_item.cid'))
 
   feedItemsQb = paginate(feedItemsQb, {
     limit,

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -72,7 +72,7 @@ const skeleton = async (
     .innerJoin('like', 'like.subject', 'feed_item.uri')
     .where('like.creator', '=', actorDid)
 
-  const keyset = new FeedKeyset(ref('like.sortAt'), ref('feed_item.cid'))
+  const keyset = new FeedKeyset(ref('like.sortAt'), ref('like.cid'))
 
   feedItemsQb = paginate(feedItemsQb, {
     limit,

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -71,9 +71,7 @@ const skeleton = async (
   let feedItemsQb = feedService
     .selectFeedItemQb()
     .innerJoin('like', 'like.subject', 'feed_item.uri')
-    .select(
-      sql`coalesce("like"."indexedAt", "feed_item"."sortAt")`.as('sortAt'),
-    )
+    .select('like.indexedAt as sortAt')
     .where('like.creator', '=', actorDid)
 
   const keyset = new FeedKeyset(ref('like.sortAt'), ref('feed_item.cid'))

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -71,6 +71,7 @@ const skeleton = async (
     .selectFeedItemQb()
     .innerJoin('like', 'like.subject', 'feed_item.uri')
     .where('like.creator', '=', actorDid)
+    .orderBy('like.indexedAt', 'desc')
 
   const keyset = new FeedKeyset(ref('feed_item.sortAt'), ref('feed_item.cid'))
 

--- a/packages/pds/src/app-view/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getActorLikes.ts
@@ -1,4 +1,3 @@
-import { sql } from 'kysely'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../../lexicon'
 import { FeedKeyset } from '../util/feed'
@@ -55,9 +54,6 @@ export default function (server: Server, ctx: AppContext) {
       let feedItemsQb = feedService
         .selectFeedItemQb()
         .innerJoin('like', 'like.subject', 'feed_item.uri')
-        .select(
-          sql`coalesce("like"."indexedAt", "feed_item"."sortAt")`.as('sortAt'),
-        )
         .where('like.creator', '=', actorDid)
 
       // for access-based auth, enforce blocks
@@ -67,7 +63,10 @@ export default function (server: Server, ctx: AppContext) {
         )
       }
 
-      const keyset = new FeedKeyset(ref('like.sortAt'), ref('feed_item.cid'))
+      const keyset = new FeedKeyset(
+        ref('feed_item.sortAt'),
+        ref('feed_item.cid'),
+      )
 
       feedItemsQb = paginate(feedItemsQb, {
         limit,

--- a/packages/pds/src/app-view/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/pds/src/app-view/api/app/bsky/feed/getActorLikes.ts
@@ -55,6 +55,7 @@ export default function (server: Server, ctx: AppContext) {
         .selectFeedItemQb()
         .innerJoin('like', 'like.subject', 'feed_item.uri')
         .where('like.creator', '=', actorDid)
+        .orderBy('like.indexedAt', 'desc')
 
       // for access-based auth, enforce blocks
       if (requester) {


### PR DESCRIPTION
Fixes #1574

Sort by `like.sortAt` instead of `feed_item.sortAt` **in app view only**.