### PR TITLE
Improve xrpc server error handling

### DIFF
--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -34,6 +34,7 @@ import {
   RateLimiterI,
   RateLimiterConsume,
   isShared,
+  RateLimitExceededError,
 } from './types'
 import {
   decodeQueryParams,
@@ -247,7 +248,10 @@ export class Server {
 
         // handle rate limits
         if (consumeRateLimit) {
-          await consumeRateLimit(reqCtx)
+          const result = await consumeRateLimit(reqCtx)
+          if (result instanceof RateLimitExceededError) {
+            return next(result)
+          }
         }
 
         // run the handler
@@ -475,14 +479,23 @@ function createAuthMiddleware(verifier: AuthVerifier): RequestHandler {
 const errorMiddleware: ErrorRequestHandler = function (err, req, res, next) {
   const locals: RequestLocals | undefined = req[kRequestLocals]
   const methodSuffix = locals ? ` method ${locals.nsid}` : ''
-  if (err instanceof XRPCError) {
-    log.error(err, `error in xrpc${methodSuffix}`)
-  } else {
+  const xrpcError = XRPCError.fromError(err)
+  if (xrpcError instanceof InternalServerError) {
+    // log trace for unhandled exceptions
     log.error(err, `unhandled exception in xrpc${methodSuffix}`)
+  } else {
+    // do not log trace for known xrpc errors
+    log.error(
+      {
+        status: xrpcError.type,
+        message: xrpcError.message,
+        name: xrpcError.customErrorName,
+      },
+      `error in xrpc${methodSuffix}`,
+    )
   }
   if (res.headersSent) {
     return next(err)
   }
-  const xrpcError = XRPCError.fromError(err)
   return res.status(xrpcError.type).json(xrpcError.payload)
 }

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -95,7 +95,7 @@ export interface RateLimiterI {
 export type RateLimiterConsume = (
   ctx: XRPCReqContext,
   opts?: { calcKey?: CalcKeyFn; calcPoints?: CalcPointsFn },
-) => Promise<RateLimiterStatus | null>
+) => Promise<RateLimiterStatus | RateLimitExceededError | null>
 
 export type RateLimiterCreator = (opts: {
   keyPrefix: string
@@ -224,7 +224,7 @@ export class ForbiddenError extends XRPCError {
 
 export class RateLimitExceededError extends XRPCError {
   constructor(
-    status: RateLimiterStatus,
+    public status: RateLimiterStatus,
     errorMessage?: string,
     customErrorName?: string,
   ) {


### PR DESCRIPTION
Dynamically getting the stack for errors can be expensive.

Two changes:
- don't throw on rate limiter exceeded, instead return the error and just pass it to `next`
- don't log full error (included stack trace) for known xrpc errors. Instead, just log their status/message/name. Still log stack trace for internal server errors