### PR TITLE
deprecate packages and update docs

### DIFF
--- a/.changeset/tasty-countries-approve.md
+++ b/.changeset/tasty-countries-approve.md
@@ -1,0 +1,8 @@
+---
+'@atproto/identifier': patch
+'@atproto/syntax': patch
+'@atproto/nsid': patch
+'@atproto/uri': patch
+---
+
+Officially deprecate the `nsid`, `uri` and `identifier` packages and direct users towards the new package, `@atproto/syntax`.

--- a/packages/identifier/README.md
+++ b/packages/identifier/README.md
@@ -1,5 +1,8 @@
 # Identifier
 
+> This package is now deprecated. Please use `@atproto/syntax`, which is the
+> successor to this package and provides the same interfaces.
+
 Validation logic for AT identifiers - DIDs & Handles
 
 ## Usage

--- a/packages/nsid/README.md
+++ b/packages/nsid/README.md
@@ -1,5 +1,8 @@
 # NameSpaced IDs (NSID) API
 
+> This package is now deprecated. Please use `@atproto/syntax`, which is the
+> successor to this package and provides the same interfaces.
+
 ## Usage
 
 ```typescript

--- a/packages/syntax/README.md
+++ b/packages/syntax/README.md
@@ -5,11 +5,7 @@ Validation logic for AT identifiers - DIDs, Handles, NSIDs, and AT URIs.
 ## Usage
 
 ```typescript
-import {
-  isValidHandle,
-  ensureValidHandle,
-  isValidDid,
-} from '@atproto/syntax'
+import { isValidHandle, ensureValidHandle, isValidDid } from '@atproto/syntax'
 
 isValidHandle('alice.test') // returns true
 ensureValidHandle('alice.test') // returns void

--- a/packages/syntax/README.md
+++ b/packages/syntax/README.md
@@ -56,6 +56,12 @@ uri.collection // => 'com.example.post'
 uri.rkey // => '1234'
 ```
 
+## Prior Work
+
+This package is a combination of three previous packaged published under the
+`@atproto` namespace: `nsid`, `uri`, and `identifier`. Those packages are
+deprecated and this package is their successor.
+
 ## License
 
 MIT

--- a/packages/syntax/README.md
+++ b/packages/syntax/README.md
@@ -1,11 +1,15 @@
 # Syntax
 
-Validation logic for AT identifiers - DIDs, Handles, NSIDs, and AT URIs
+Validation logic for AT identifiers - DIDs, Handles, NSIDs, and AT URIs.
 
 ## Usage
 
 ```typescript
-import * as identifier from '@atproto/syntax'
+import {
+  isValidHandle,
+  ensureValidHandle,
+  isValidDid,
+} from '@atproto/syntax'
 
 isValidHandle('alice.test') // returns true
 ensureValidHandle('alice.test') // returns void

--- a/packages/uri/README.md
+++ b/packages/uri/README.md
@@ -1,5 +1,8 @@
 # ATP URI API
 
+> This package is now deprecated. Please use `@atproto/syntax`, which is the
+> successor to this package and provides the same interfaces.
+
 ## Usage
 
 ```typescript


### PR DESCRIPTION
This will patch `nsid`, `uri` and `identifier`, as well as `syntax`, and bump any packages that depend on `syntax` as well.

Once these are published with the deprecation notice, we can deprecate them in npm as well.