### PR TITLE
Tweak rate limit setup for multi rate limit routes

### DIFF
--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -405,7 +405,8 @@ export class Server {
         ? config.rateLimit
         : [config.rateLimit]
       this.routeRateLimiterFns[nsid] = []
-      for (const limit of limits) {
+      for (let i = 0; i < limits.length; i++) {
+        const limit = limits[i]
         const { calcKey, calcPoints } = limit
         if (isShared(limit)) {
           const rateLimiter = this.sharedRateLimiters[limit.name]
@@ -420,7 +421,7 @@ export class Server {
         } else {
           const { durationMs, points } = limit
           const rateLimiter = this.options.rateLimits?.creator({
-            keyPrefix: nsid,
+            keyPrefix: `nsid-${i}`,
             durationMs,
             points,
             calcKey,


### PR DESCRIPTION
When setting up a route with multiple ratelimits, we were storing all of them at one redis key. This ensure they each have a unique `keyPrefix`

Closes https://github.com/bluesky-social/atproto/issues/1616