### PR TITLE
Enforce properties field on lexicon object schemas

### DIFF
--- a/lexicons/app/bsky/feed/threadgate.json
+++ b/lexicons/app/bsky/feed/threadgate.json
@@ -25,11 +25,13 @@
     },
     "mentionRule": {
       "type": "object",
-      "description": "Allow replies from actors mentioned in your post."
+      "description": "Allow replies from actors mentioned in your post.",
+      "properties": {}
     },
     "followingRule": {
       "type": "object",
-      "description": "Allow replies from actors you follow."
+      "description": "Allow replies from actors you follow.",
+      "properties": {}
     },
     "listRule": {
       "type": "object",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5693,10 +5693,12 @@ export const schemaDict = {
       mentionRule: {
         type: 'object',
         description: 'Allow replies from actors mentioned in your post.',
+        properties: {},
       },
       followingRule: {
         type: 'object',
         description: 'Allow replies from actors you follow.',
+        properties: {},
       },
       listRule: {
         type: 'object',

--- a/packages/api/src/client/types/app/bsky/feed/threadgate.ts
+++ b/packages/api/src/client/types/app/bsky/feed/threadgate.ts
@@ -32,7 +32,9 @@ export function validateRecord(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors mentioned in your post. */
-export interface MentionRule {}
+export interface MentionRule {
+  [k: string]: unknown
+}
 
 export function isMentionRule(v: unknown): v is MentionRule {
   return (
@@ -47,7 +49,9 @@ export function validateMentionRule(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors you follow. */
-export interface FollowingRule {}
+export interface FollowingRule {
+  [k: string]: unknown
+}
 
 export function isFollowingRule(v: unknown): v is FollowingRule {
   return (

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5693,10 +5693,12 @@ export const schemaDict = {
       mentionRule: {
         type: 'object',
         description: 'Allow replies from actors mentioned in your post.',
+        properties: {},
       },
       followingRule: {
         type: 'object',
         description: 'Allow replies from actors you follow.',
+        properties: {},
       },
       listRule: {
         type: 'object',

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/threadgate.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/threadgate.ts
@@ -32,7 +32,9 @@ export function validateRecord(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors mentioned in your post. */
-export interface MentionRule {}
+export interface MentionRule {
+  [k: string]: unknown
+}
 
 export function isMentionRule(v: unknown): v is MentionRule {
   return (
@@ -47,7 +49,9 @@ export function validateMentionRule(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors you follow. */
-export interface FollowingRule {}
+export interface FollowingRule {
+  [k: string]: unknown
+}
 
 export function isFollowingRule(v: unknown): v is FollowingRule {
   return (

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -173,11 +173,9 @@ export const lexObject = z
     description: z.string().optional(),
     required: z.string().array().optional(),
     nullable: z.string().array().optional(),
-    properties: z
-      .record(
-        z.union([lexRefVariant, lexIpldType, lexArray, lexBlob, lexPrimitive]),
-      )
-      .optional(),
+    properties: z.record(
+      z.union([lexRefVariant, lexIpldType, lexArray, lexBlob, lexPrimitive]),
+    ),
   })
   .strict()
   .superRefine(requiredPropertiesRefinement)

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5693,10 +5693,12 @@ export const schemaDict = {
       mentionRule: {
         type: 'object',
         description: 'Allow replies from actors mentioned in your post.',
+        properties: {},
       },
       followingRule: {
         type: 'object',
         description: 'Allow replies from actors you follow.',
+        properties: {},
       },
       listRule: {
         type: 'object',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/threadgate.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/threadgate.ts
@@ -32,7 +32,9 @@ export function validateRecord(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors mentioned in your post. */
-export interface MentionRule {}
+export interface MentionRule {
+  [k: string]: unknown
+}
 
 export function isMentionRule(v: unknown): v is MentionRule {
   return (
@@ -47,7 +49,9 @@ export function validateMentionRule(v: unknown): ValidationResult {
 }
 
 /** Allow replies from actors you follow. */
-export interface FollowingRule {}
+export interface FollowingRule {
+  [k: string]: unknown
+}
 
 export function isFollowingRule(v: unknown): v is FollowingRule {
   return (


### PR DESCRIPTION
Re: https://github.com/bluesky-social/atproto/issues/1615

We should enforce the semantic that objects have a `properties` field declared