### PR TITLE
Bugfix: handle contention

### DIFF
--- a/packages/bsky/src/services/indexing/index.ts
+++ b/packages/bsky/src/services/indexing/index.ts
@@ -144,24 +144,22 @@ export class IndexingService {
     const handle: string | null =
       did === handleToDid ? atpData.handle.toLowerCase() : null
 
-    if (actor && actor.handle !== handle) {
-      const actorWithHandle =
-        handle !== null
-          ? await this.db.db
-              .selectFrom('actor')
-              .where('handle', '=', handle)
-              .selectAll()
-              .executeTakeFirst()
-          : null
+    const actorWithHandle =
+      handle !== null
+        ? await this.db.db
+            .selectFrom('actor')
+            .where('handle', '=', handle)
+            .selectAll()
+            .executeTakeFirst()
+        : null
 
-      // handle contention
-      if (handle && actorWithHandle && did !== actorWithHandle.did) {
-        await this.db.db
-          .updateTable('actor')
-          .where('actor.did', '=', actorWithHandle.did)
-          .set({ handle: null })
-          .execute()
-      }
+    // handle contention
+    if (handle && actorWithHandle && did !== actorWithHandle.did) {
+      await this.db.db
+        .updateTable('actor')
+        .where('actor.did', '=', actorWithHandle.did)
+        .set({ handle: null })
+        .execute()
     }
 
     const actorInfo = { handle, indexedAt: timestamp }


### PR DESCRIPTION
There was an case in handle contention that we weren't correctly handling: a _new_ account is created that correctly uses a handle for a previously indexed account