### PR TITLE
auto-moderator tweaks: pass along record URI, create report for takedown action

### DIFF
--- a/packages/bsky/src/auto-moderator/abyss.ts
+++ b/packages/bsky/src/auto-moderator/abyss.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { CID } from 'multiformats/cid'
+import { AtUri } from '@atproto/syntax'
 import * as ui8 from 'uint8arrays'
 import { resolveBlob } from '../api/blob-resolver'
 import { retryHttp } from '../util/retry'
@@ -8,7 +9,7 @@ import { IdResolver } from '@atproto/identity'
 import { labelerLogger as log } from '../logger'
 
 export interface ImageFlagger {
-  scanImage(did: string, cid: CID): Promise<string[]>
+  scanImage(did: string, cid: CID, uri: AtUri): Promise<string[]>
 }
 
 export class Abyss implements ImageFlagger {
@@ -22,11 +23,11 @@ export class Abyss implements ImageFlagger {
     this.auth = basicAuth(this.password)
   }
 
-  async scanImage(did: string, cid: CID): Promise<string[]> {
+  async scanImage(did: string, cid: CID, uri: AtUri): Promise<string[]> {
     const start = Date.now()
     const res = await retryHttp(async () => {
       try {
-        return await this.makeReq(did, cid)
+        return await this.makeReq(did, cid, uri)
       } catch (err) {
         log.warn({ err, did, cid: cid.toString() }, 'abyss request failed')
         throw err
@@ -39,20 +40,24 @@ export class Abyss implements ImageFlagger {
     return this.parseRes(res)
   }
 
-  async makeReq(did: string, cid: CID): Promise<ScannerResp> {
+  async makeReq(did: string, cid: CID, uri: AtUri): Promise<ScannerResp> {
     const { stream, contentType } = await resolveBlob(
       did,
       cid,
       this.ctx.db,
       this.ctx.idResolver,
     )
-    const { data } = await axios.post(this.getReqUrl({ did }), stream, {
-      headers: {
-        'Content-Type': contentType,
-        authorization: this.auth,
+    const { data } = await axios.post(
+      this.getReqUrl({ did, uri: uri.toString() }),
+      stream,
+      {
+        headers: {
+          'Content-Type': contentType,
+          authorization: this.auth,
+        },
+        timeout: 10000,
       },
-      timeout: 10000,
-    })
+    )
     return data
   }
 
@@ -69,8 +74,8 @@ export class Abyss implements ImageFlagger {
     return labels
   }
 
-  getReqUrl(params: { did: string }) {
-    return `${this.endpoint}/xrpc/com.atproto.unspecced.scanBlob?did=${params.did}`
+  getReqUrl(params: { did: string; uri: string }) {
+    return `${this.endpoint}/xrpc/com.atproto.unspecced.scanBlob?did=${params.did}&uri=${params.uri}`
   }
 }
 

--- a/packages/bsky/src/auto-moderator/abyss.ts
+++ b/packages/bsky/src/auto-moderator/abyss.ts
@@ -75,7 +75,10 @@ export class Abyss implements ImageFlagger {
   }
 
   getReqUrl(params: { did: string; uri: string }) {
-    return `${this.endpoint}/xrpc/com.atproto.unspecced.scanBlob?did=${params.did}&uri=${params.uri}`
+    const search = new URLSearchParams(params)
+    return `${
+      this.endpoint
+    }/xrpc/com.atproto.unspecced.scanBlob?${search.toString()}`
   }
 }
 

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -248,7 +248,7 @@ export class AutoModerator {
           throw new Error('no mod push agent or uri invalidator setup')
         }
         const modSrvc = this.services.moderation(dbTxn)
-        const action = await modSrvc.report({
+        await modSrvc.report({
           // NOTE: empty reportedBy
           reasonType: REASONVIOLATION,
           subject: {

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -18,7 +18,10 @@ import { ImageUriBuilder } from '../image/uri'
 import { ImageInvalidator } from '../image/invalidator'
 import { Abyss } from './abyss'
 import { FuzzyMatcher, TextFlagger } from './fuzzy-matcher'
-import { REASONOTHER } from '../lexicon/types/com/atproto/moderation/defs'
+import {
+  REASONOTHER,
+  REASONVIOLATION,
+} from '../lexicon/types/com/atproto/moderation/defs'
 
 export class AutoModerator {
   public pushAgent?: AtpAgent
@@ -216,13 +219,12 @@ export class AutoModerator {
         uri: uri.toString(),
         blobCids: takedownCids,
         labels,
-        receiver: agent.service.toString(),
       },
       'hard takedown of record (and blobs) based on auto-matching',
     )
     if (this.pushAgent) {
       await this.pushAgent.com.atproto.moderation.createReport({
-        // NOTE: empty reportedBy
+        reportedBy: this.ctx.cfg.labelerDid,
         reasonType: REASONVIOLATION,
         subject: {
           $type: 'com.atproto.repo.strongRef',
@@ -249,12 +251,11 @@ export class AutoModerator {
         }
         const modSrvc = this.services.moderation(dbTxn)
         await modSrvc.report({
-          // NOTE: empty reportedBy
+          reportedBy: this.ctx.cfg.labelerDid,
           reasonType: REASONVIOLATION,
           subject: {
-            $type: 'com.atproto.repo.strongRef',
-            uri: uri.toString(),
-            cid: recordCid.toString(),
+            uri: uri,
+            cid: recordCid,
           },
           reason: reportReason,
         })

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -172,7 +172,7 @@ export class AutoModerator {
   async checkImgForTakedown(uri: AtUri, recordCid: CID, imgCids: CID[]) {
     if (imgCids.length < 0) return
     const results = await Promise.all(
-      imgCids.map((cid) => this.imageFlagger?.scanImage(uri.host, cid)),
+      imgCids.map((cid) => this.imageFlagger?.scanImage(uri.host, cid, uri)),
     )
     const takedownCids: CID[] = []
     for (let i = 0; i < results.length; i++) {

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -224,8 +224,12 @@ export class AutoModerator {
     )
 
     if (this.services.moderation) {
-      // directly/locally create report, even if we use pushAgent for the takedown. don't have acctual account credentials for pushAgent, only admin auth
       await this.ctx.db.transaction(async (dbTxn) => {
+        // directly/locally create report, even if we use pushAgent for the takedown. don't have acctual account credentials for pushAgent, only admin auth
+        if (!this.services.moderation) {
+          // checked above, outside the transaction
+          return
+        }
         const modSrvc = this.services.moderation(dbTxn)
         await modSrvc.report({
           reportedBy: this.ctx.cfg.labelerDid,
@@ -256,6 +260,7 @@ export class AutoModerator {
         if (!this.services.moderation) {
           throw new Error('no mod push agent or uri invalidator setup')
         }
+        const modSrvc = this.services.moderation(dbTxn)
         const action = await modSrvc.logAction({
           action: 'com.atproto.admin.defs#takedown',
           subject: { uri, cid: recordCid },

--- a/packages/bsky/tests/auto-moderator/takedowns.test.ts
+++ b/packages/bsky/tests/auto-moderator/takedowns.test.ts
@@ -7,6 +7,7 @@ import { TestNetwork } from '@atproto/dev-env'
 import { ImageRef, SeedClient } from '../seeds/client'
 import usersSeed from '../seeds/users'
 import { CID } from 'multiformats/cid'
+import { AtUri } from '@atproto/syntax'
 import { ImageFlagger } from '../../src/auto-moderator/abyss'
 import { ImageInvalidator } from '../../src/image/invalidator'
 import { sha256 } from '@atproto/crypto'
@@ -157,7 +158,7 @@ class TestInvalidator implements ImageInvalidator {
 }
 
 class TestFlagger implements ImageFlagger {
-  async scanImage(_did: string, cid: CID): Promise<string[]> {
+  async scanImage(_did: string, cid: CID, _uri: AtUri): Promise<string[]> {
     if (cid.equals(badCid1)) {
       return ['kill-it']
     } else if (cid.equals(badCid2)) {


### PR DESCRIPTION
Some polish on the auto-takedown process:

- pass record URI along to abyss for easier tracking/reporting
- log that a hard takedown is happening ("warn" log level)
- create a report, in addition to the takedown itself, as a paper trail for mod team