### PR TITLE
Improve the types of the thread and feed preferences APIs

### DIFF
--- a/.changeset/lazy-moons-relate.md
+++ b/.changeset/lazy-moons-relate.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Improve the types of the thread and feed preferences APIs

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -6,7 +6,12 @@ import {
   AppBskyActorDefs,
   ComAtprotoRepoPutRecord,
 } from './client'
-import { BskyPreferences, BskyLabelPreference } from './types'
+import {
+  BskyPreferences,
+  BskyLabelPreference,
+  BskyFeedViewPreference,
+  BskyThreadViewPreference,
+} from './types'
 
 const FEED_VIEW_PREF_DEFAULTS = {
   hideReplies: false,
@@ -439,10 +444,7 @@ export class BskyAgent extends AtpAgent {
     })
   }
 
-  async setFeedViewPrefs(
-    feed: string,
-    pref: Omit<AppBskyActorDefs.FeedViewPref, '$type' | 'feed'>,
-  ) {
+  async setFeedViewPrefs(feed: string, pref: Partial<BskyFeedViewPreference>) {
     await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
       const existing = prefs.findLast(
         (pref) =>
@@ -461,9 +463,7 @@ export class BskyAgent extends AtpAgent {
     })
   }
 
-  async setThreadViewPrefs(
-    pref: Omit<AppBskyActorDefs.ThreadViewPref, '$type'>,
-  ) {
+  async setThreadViewPrefs(pref: Partial<BskyThreadViewPreference>) {
     await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
       const existing = prefs.findLast(
         (pref) =>

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -81,15 +81,37 @@ export type BskyLabelPreference = LabelPreference | 'show'
 // TEMP we need to permanently convert 'show' to 'ignore', for now we manually convert -prf
 
 /**
- * Bluesky preferences object
+ * Bluesky feed view preferences
+ */
+
+export interface BskyFeedViewPreference {
+  hideReplies: boolean
+  hideRepliesByUnfollowed: boolean
+  hideRepliesByLikeCount: number
+  hideReposts: boolean
+  hideQuotePosts: boolean
+  [key: string]: any
+}
+
+/**
+ * Bluesky thread view preferences
+ */
+export interface BskyThreadViewPreference {
+  sort: string
+  prioritizeFollowedUsers: boolean
+  [key: string]: any
+}
+
+/**
+ * Bluesky preferences
  */
 export interface BskyPreferences {
   feeds: {
     saved?: string[]
     pinned?: string[]
   }
-  feedViewPrefs: Record<string, Omit<AppBskyActorDefs.FeedViewPref, '$type'>>
-  threadViewPrefs: Omit<AppBskyActorDefs.ThreadViewPref, '$type'>
+  feedViewPrefs: Record<string, BskyFeedViewPreference>
+  threadViewPrefs: BskyThreadViewPreference
   adultContentEnabled: boolean
   contentLabels: Record<string, BskyLabelPreference>
   birthDate: Date | undefined

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,5 +1,4 @@
 import { LabelPreference } from './moderation/types'
-import { AppBskyActorDefs } from './client'
 
 /**
  * Used by the PersistSessionHandler to indicate what change occurred


### PR DESCRIPTION
The new preferences API for feed and thread view settings was dropping all the type information (see https://github.com/microsoft/TypeScript/issues/45367). This PR fixes that.