### PR TITLE
Check recent likes for suggested follows

### DIFF
--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -78,6 +78,7 @@ async function getSkeleton(
         .selectFrom('like')
         .where('creator', '=', params.actor)
         .select(sql`split_part(subject, '/', 3)`.as('subjectDid'))
+        .orderBy('sortAt', 'desc')
         .limit(1000) // limit to 1000
         .as('likes'),
     )


### PR DESCRIPTION
When calculating suggested follows, do so off of recent likes.

Previously, we were not ordering, and my quick testing showed that it was grabbing old likes which is not representative of the account current interests