### PR TITLE
Fix writing duplicate blocks in sync.getRepo

### DIFF
--- a/packages/pds/src/sql-repo-storage.ts
+++ b/packages/pds/src/sql-repo-storage.ts
@@ -229,12 +229,6 @@ export class SqlRepoStorage extends ReadableBlockstore implements RepoStorage {
         const res = await this.getBlockRange(since, cursor)
         await writePromise
         writePromise = writeRows(res)
-        for (const row of res) {
-          await car.put({
-            cid: CID.parse(row.cid),
-            bytes: row.content,
-          })
-        }
         const lastRow = res.at(-1)
         if (lastRow && lastRow.repoRev) {
           cursor = {

--- a/packages/repo/src/util.ts
+++ b/packages/repo/src/util.ts
@@ -95,7 +95,7 @@ export const readCar = async (
   const roots = await car.getRoots()
   const blocks = new BlockMap()
   for await (const block of verifyIncomingCarBlocks(car.blocks())) {
-    await blocks.set(block.cid, block.bytes)
+    blocks.set(block.cid, block.bytes)
   }
   return {
     roots,


### PR DESCRIPTION
I think this was just a little hiccup from recent code shuffling around `getCarStream()`.  The blocks are written once from the call to `writeRows()` but were also getting written again inline.