### PR TITLE
syntax: disallow .example and .alt TLDs

### DIFF
--- a/packages/syntax/src/handle.ts
+++ b/packages/syntax/src/handle.ts
@@ -10,6 +10,8 @@ export const DISALLOWED_TLDS = [
   '.invalid',
   '.localhost',
   '.internal',
+  '.example',
+  '.alt',
   // policy could concievably change on ".onion" some day
   '.onion',
   // NOTE: .test is allowed in testing and devopment. In practical terms


### PR DESCRIPTION
Alt is new and for non-DNS resolution: https://www.rfc-editor.org/rfc/rfc9476.txt

Example is for things like written docs and we shouldn't try to resolve them on the net.