### PR TITLE
Enable updateEmail with no token & no app password

### DIFF
--- a/packages/pds/src/api/com/atproto/server/updateEmail.ts
+++ b/packages/pds/src/api/com/atproto/server/updateEmail.ts
@@ -5,7 +5,7 @@ import disposable from 'disposable-email'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.updateEmail({
-    auth: ctx.accessVerifierCheckTakedown,
+    auth: ctx.accessVerifierNotAppPassword,
     handler: async ({ auth, input }) => {
       const did = auth.credentials.did
       const { token, email } = input.body

--- a/packages/pds/src/api/com/atproto/server/updateEmail.ts
+++ b/packages/pds/src/api/com/atproto/server/updateEmail.ts
@@ -18,10 +18,7 @@ export default function (server: Server, ctx: AppContext) {
       if (!user) {
         throw new InvalidRequestError('user not found')
       }
-      if (!user.emailConfirmedAt) {
-        throw new InvalidRequestError('email must be confirmed (temporary)')
-      }
-      // require valid token
+      // require valid token if user email is confirmed
       if (user.emailConfirmedAt) {
         if (!token) {
           throw new InvalidRequestError(

--- a/packages/pds/tests/email-confirmation.test.ts
+++ b/packages/pds/tests/email-confirmation.test.ts
@@ -60,49 +60,27 @@ describe('email confirmation', () => {
     expect(session.data.emailConfirmed).toEqual(false)
   })
 
-  it('disallows email update when unverified', async () => {
+  it('allows email update without token when unverified', async () => {
     const res = await agent.api.com.atproto.server.requestEmailUpdate(
       undefined,
       { headers: sc.getHeaders(alice.did) },
     )
     expect(res.data.tokenRequired).toBe(false)
 
-    const attempt = agent.api.com.atproto.server.updateEmail(
+    await agent.api.com.atproto.server.updateEmail(
       {
         email: 'new-alice@example.com',
       },
       { headers: sc.getHeaders(alice.did), encoding: 'application/json' },
     )
-    await expect(attempt).rejects.toThrow()
     const session = await agent.api.com.atproto.server.getSession(
       {},
       { headers: sc.getHeaders(alice.did) },
     )
-    expect(session.data.email).toEqual(alice.email)
+    expect(session.data.email).toEqual('new-alice@example.com')
     expect(session.data.emailConfirmed).toEqual(false)
+    alice.email = session.data.email
   })
-
-  // it('allows email update without token when unverified', async () => {
-  //   const res = await agent.api.com.atproto.server.requestEmailUpdate(
-  //     undefined,
-  //     { headers: sc.getHeaders(alice.did) },
-  //   )
-  //   expect(res.data.tokenRequired).toBe(false)
-
-  //   await agent.api.com.atproto.server.updateEmail(
-  //     {
-  //       email: 'new-alice@example.com',
-  //     },
-  //     { headers: sc.getHeaders(alice.did), encoding: 'application/json' },
-  //   )
-  //   const session = await agent.api.com.atproto.server.getSession(
-  //     {},
-  //     { headers: sc.getHeaders(alice.did) },
-  //   )
-  //   expect(session.data.email).toEqual('new-alice@example.com')
-  //   expect(session.data.emailConfirmed).toEqual(false)
-  //   alice.email = session.data.email
-  // })
 
   let confirmToken
 


### PR DESCRIPTION
Now that the client feature is out, allow updating an account's email without a confirmation taken as long as the account has not verified their email yet.

For added security, we only allow this with a non-app-password credential