### PR TITLE
Fix typo in bsky test: purpose is #modlist not #blocklist

### DIFF
--- a/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
@@ -335,7 +335,7 @@ Object {
       "description": "blah blah",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "name": "new list",
-      "purpose": "app.bsky.graph.defs#blocklist",
+      "purpose": "app.bsky.graph.defs#modlist",
       "uri": "record(0)",
       "viewer": Object {
         "blocked": "record(1)",
@@ -379,7 +379,7 @@ Object {
       "description": "big list of blocks",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "name": "alice blocks",
-      "purpose": "app.bsky.graph.defs#blocklist",
+      "purpose": "app.bsky.graph.defs#modlist",
       "uri": "record(4)",
       "viewer": Object {
         "blocked": "record(5)",
@@ -430,7 +430,7 @@ Object {
       "description": "blah blah",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "name": "new list",
-      "purpose": "app.bsky.graph.defs#blocklist",
+      "purpose": "app.bsky.graph.defs#modlist",
       "uri": "record(0)",
       "viewer": Object {
         "muted": false,
@@ -473,7 +473,7 @@ Object {
       "description": "big list of blocks",
       "indexedAt": "1970-01-01T00:00:00.000Z",
       "name": "alice blocks",
-      "purpose": "app.bsky.graph.defs#blocklist",
+      "purpose": "app.bsky.graph.defs#modlist",
       "uri": "record(3)",
       "viewer": Object {
         "blocked": "record(4)",
@@ -554,7 +554,7 @@ Object {
     "description": "big list of blocks",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "name": "alice blocks",
-    "purpose": "app.bsky.graph.defs#blocklist",
+    "purpose": "app.bsky.graph.defs#modlist",
     "uri": "record(0)",
     "viewer": Object {
       "blocked": "record(1)",

--- a/packages/bsky/tests/views/block-lists.test.ts
+++ b/packages/bsky/tests/views/block-lists.test.ts
@@ -58,7 +58,7 @@ describe('pds views with blocking from block lists', () => {
       { repo: alice },
       {
         name: 'alice blocks',
-        purpose: 'app.bsky.graph.defs#blocklist',
+        purpose: 'app.bsky.graph.defs#modlist',
         description: 'big list of blocks',
         avatar: avatar.image,
         createdAt: new Date().toISOString(),
@@ -335,7 +335,7 @@ describe('pds views with blocking from block lists', () => {
       { repo: alice },
       {
         name: 'new list',
-        purpose: 'app.bsky.graph.defs#blocklist',
+        purpose: 'app.bsky.graph.defs#modlist',
         description: 'blah blah',
         createdAt: new Date().toISOString(),
       },


### PR DESCRIPTION
(Correct me if I'm wrong) The purpose of a blocklist should be `#modlist` so I think this test is just a typo. Doesn't affect behaviors but might be unclear to folks.