### PR TITLE
Fix read after write on threads when posting a media embed

### DIFF
--- a/packages/pds/src/services/local/index.ts
+++ b/packages/pds/src/services/local/index.ts
@@ -230,12 +230,14 @@ export class LocalService {
       const { uri, title, description, thumb } = embed.external
       return {
         $type: 'app.bsky.embed.external#view',
-        uri,
-        title,
-        description,
-        thumb: thumb
-          ? this.getImageUrl('feed_thumbnail', did, thumb.ref.toString())
-          : undefined,
+        external: {
+          uri,
+          title,
+          description,
+          thumb: thumb
+            ? this.getImageUrl('feed_thumbnail', did, thumb.ref.toString())
+            : undefined,
+        },
       }
     }
   }


### PR DESCRIPTION
We weren't wrapping it in an `external` container.

Added some tests for external & image embeds