### PR TITLE
Dont dump stacktrace in http logger middleware

### DIFF
--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - http-logger-stack-trace
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-pds-aws.yaml
+++ b/.github/workflows/build-and-push-pds-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - http-logger-stack-trace
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/bsky/src/logger.ts
+++ b/packages/bsky/src/logger.ts
@@ -12,4 +12,12 @@ export const httpLogger: ReturnType<typeof subsystemLogger> =
 
 export const loggerMiddleware = pinoHttp({
   logger: httpLogger,
+  serializers: {
+    err: (err) => {
+      return {
+        code: err?.code,
+        message: err?.message,
+      }
+    },
+  },
 })

--- a/packages/pds/src/logger.ts
+++ b/packages/pds/src/logger.ts
@@ -16,6 +16,12 @@ export const httpLogger = subsystemLogger('pds')
 export const loggerMiddleware = pinoHttp({
   logger: httpLogger,
   serializers: {
+    err: (err) => {
+      return {
+        code: err?.code,
+        message: err?.message,
+      }
+    },
     req: (req) => {
       const serialized = pino.stdSerializers.req(req)
       const authHeader = serialized.headers.authorization || ''


### PR DESCRIPTION
Dumping stack trace for logs is expensive & we have tracing setup elsewhere. Instead we just log the error message & code.