### PR TITLE
Miscellaneous query optimizations on appview

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -89,8 +89,8 @@ export const skeleton = async (
 
   if (filter === 'posts_with_media') {
     feedItemsQb = feedItemsQb
-      // and only your own posts/reposts
-      .where('post.creator', '=', actorDid)
+      // only your own posts
+      .where('type', '=', 'post')
       // only posts with media
       .whereExists((qb) =>
         qb

--- a/packages/bsky/src/services/actor/index.ts
+++ b/packages/bsky/src/services/actor/index.ts
@@ -66,7 +66,13 @@ export class ActorService {
           qb = qb.orWhere('actor.did', 'in', dids)
         }
         if (handles.length) {
-          qb = qb.orWhere('actor.handle', 'in', handles)
+          qb = qb.orWhere(
+            'actor.handle',
+            'in',
+            handles.length === 1
+              ? [handles[0], handles[0]] // a silly (but worthwhile) optimization to avoid usage of actor_handle_tgrm_idx
+              : handles,
+          )
         }
         return qb
       })


### PR DESCRIPTION
Three miscellaneous query optimizations here:
 - On the author feed `posts_with_media` filter, we simplify the condition that ensures only the user's own posts are displayed (i.e. not media in their reposts).  By not referencing the `post` table here the query loosens, allowing it to do more filtering early in the query plan and make better use of the cursor index.  Hoping to see lower IO on this query.
 - The query for notification skeleton was a bit bloated with joins and returned columns that went unused.  By fetching notification record contents separate from the skeleton, the intent is to make simpler queries that postgres is able to cache more efficiently.  Hoping to see lower IO on this query.
 - Fetching a single actor by handle occurs on many routes, and was hitting a degenerate case.  Postgres would choose the gist trigram index originally used for typeahead search rather than the unique btree index on `handle`.  The btree index is much quicker, so we've employed a little trick to ensure it's chosen instead of the trigram index.