### PR TITLE
Provide proper error for updating to an email that's already in use

### DIFF
--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -57,3 +57,11 @@ export const dummyDialect = {
 export type DbRef = RawBuilder | ReturnType<DynamicModule['ref']>
 
 export type AnyQb = SelectQueryBuilder<any, any, any>
+
+export const isErrUniqueViolation = (err: unknown) => {
+  const code = err?.['code']
+  return (
+    code === '23505' || // postgres, see https://www.postgresql.org/docs/current/errcodes-appendix.html
+    code === 'SQLITE_CONSTRAINT_UNIQUE' // sqlite, see https://www.sqlite.org/rescode.html#constraint_unique
+  )
+}

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -8,7 +8,11 @@ import * as scrypt from '../../db/scrypt'
 import { UserAccountEntry } from '../../db/tables/user-account'
 import { DidHandle } from '../../db/tables/did-handle'
 import { RepoRoot } from '../../db/tables/repo-root'
-import { countAll, notSoftDeletedClause } from '../../db/util'
+import {
+  countAll,
+  isErrUniqueViolation,
+  notSoftDeletedClause,
+} from '../../db/util'
 import { paginate, TimeCidKeyset } from '../../db/pagination'
 import * as sequencer from '../../sequencer'
 import { AppPassword } from '../../lexicon/types/com/atproto/server/createAppPassword'
@@ -187,11 +191,19 @@ export class AccountService {
   }
 
   async updateEmail(did: string, email: string) {
-    await this.db.db
-      .updateTable('user_account')
-      .set({ email: email.toLowerCase(), emailConfirmedAt: null })
-      .where('did', '=', did)
-      .executeTakeFirst()
+    try {
+      await this.db.db
+        .updateTable('user_account')
+        .set({ email: email.toLowerCase(), emailConfirmedAt: null })
+        .where('did', '=', did)
+        .executeTakeFirst()
+    } catch (err) {
+      if (isErrUniqueViolation(err)) {
+        throw new UserAlreadyExistsError()
+      } else {
+        throw err
+      }
+    }
   }
 
   async updateUserPassword(did: string, password: string) {

--- a/packages/pds/tests/email-confirmation.test.ts
+++ b/packages/pds/tests/email-confirmation.test.ts
@@ -194,6 +194,19 @@ describe('email confirmation', () => {
     )
   })
 
+  it('fails email update with in-use email', async () => {
+    const attempt = agent.api.com.atproto.server.updateEmail(
+      {
+        email: 'bob@test.com',
+        token: updateToken,
+      },
+      { headers: sc.getHeaders(alice.did), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow(
+      'This email address is already in use, please use a different email.',
+    )
+  })
+
   it('updates email', async () => {
     await agent.api.com.atproto.server.updateEmail(
       {


### PR DESCRIPTION
Previously users would receive a 500 when attempting to change their email to one that is already in use.  With this change they should receive a 400 with an actionable error message.