### PR TITLE
Entryway update handle flow, pds and agent caching

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/pds",
-  "version": "0.3.0-entryway.0",
+  "version": "0.3.0-entryway.1",
   "license": "MIT",
   "description": "Reference implementation of atproto Personal Data Server (PDS)",
   "keywords": [

--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -1,4 +1,8 @@
-import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
+import {
+  AuthRequiredError,
+  InvalidRequestError,
+  UpstreamFailureError,
+} from '@atproto/xrpc-server'
 import { normalizeAndValidateHandle } from '../../../../handle'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
@@ -7,6 +11,7 @@ import {
   UserAlreadyExistsError,
 } from '../../../../services/account'
 import { httpLogger } from '../../../../logger'
+import { isThisPds } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.updateAccountHandle({
@@ -45,6 +50,30 @@ export default function (server: Server, ctx: AppContext) {
           await ctx.plcClient.updateHandle(did, ctx.plcRotationKey, handle)
           return tok
         })
+      }
+
+      const { pdsDid } = existingAccnt
+      if (ctx.cfg.service.isEntryway && !isThisPds(ctx, pdsDid)) {
+        const pds =
+          pdsDid &&
+          (await ctx.services.account(ctx.db).getPds(pdsDid, { cached: true }))
+        if (!pds) {
+          throw new UpstreamFailureError('unknown pds')
+        }
+        // the pds emits the handle event on the firehose, but the entryway is responsible for updating the did doc.
+        // the long flow is: pds(identity.updateHandle) -> entryway(identity.updateHandle) -> pds(admin.updateAccountHandle)
+        const agent = ctx.pdsAgents.get(pds.host)
+        await agent.com.atproto.admin.updateAccountHandle(
+          {
+            did,
+            handle: input.body.handle,
+          },
+          {
+            encoding: 'application/json',
+            headers: ctx.authVerifier.createAdminRoleHeaders(),
+          },
+        )
+        return // do not sequence handle event on the entryway
       }
 
       try {

--- a/packages/pds/src/api/proxy.ts
+++ b/packages/pds/src/api/proxy.ts
@@ -17,7 +17,7 @@ export const proxy = async <T>(
     return null // skip proxying
   }
   const accountService = ctx.services.account(ctx.db)
-  const pds = pdsDid && (await accountService.getPds(pdsDid))
+  const pds = pdsDid && (await accountService.getPds(pdsDid, { cached: true }))
   if (!pds) {
     throw new UpstreamFailureError('unknown pds')
   }

--- a/packages/pds/src/api/proxy.ts
+++ b/packages/pds/src/api/proxy.ts
@@ -21,10 +21,8 @@ export const proxy = async <T>(
   if (!pds) {
     throw new UpstreamFailureError('unknown pds')
   }
-  // @TODO reuse agents
-  const agent = new AtpAgent({ service: getPdsEndpoint(pds.host) })
   try {
-    return await fn(agent)
+    return await fn(ctx.pdsAgents.get(pds.host))
   } catch (err) {
     // @TODO may need to pass through special lexicon errors
     if (
@@ -40,14 +38,6 @@ export const proxy = async <T>(
     }
     throw err
   }
-}
-
-export const getPdsEndpoint = (host: string) => {
-  const service = new URL(`https://${host}`)
-  if (service.hostname === 'localhost') {
-    service.protocol = 'http:'
-  }
-  return service.origin
 }
 
 export const isThisPds = (

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -290,6 +290,17 @@ export class AuthVerifier {
     return { status: Invalid, admin: false, moderator: false, triage: false }
   }
 
+  createAdminRoleHeaders = () => {
+    return {
+      authorization:
+        'Basic ' +
+        ui8.toString(
+          ui8.fromString(`admin:${this._adminPass}`, 'utf8'),
+          'base64pad',
+        ),
+    }
+  }
+
   isUserOrAdmin(
     auth: AccessOutput | RoleOutput | NullOutput,
     did: string,

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -20,6 +20,7 @@ import { Crawlers } from './crawlers'
 import { DiskBlobStore } from './storage'
 import { getRedisClient } from './redis'
 import { RuntimeFlags } from './runtime-flags'
+import { PdsAgents } from './pds-agents'
 
 export type AppContextOptions = {
   db: Database
@@ -38,6 +39,7 @@ export type AppContextOptions = {
   crawlers: Crawlers
   appViewAgent: AtpAgent
   authVerifier: AuthVerifier
+  pdsAgents: PdsAgents
   repoSigningKey: crypto.Keypair
   plcRotationKey: crypto.Keypair
   cfg: ServerConfig
@@ -60,6 +62,7 @@ export class AppContext {
   public crawlers: Crawlers
   public appViewAgent: AtpAgent
   public authVerifier: AuthVerifier
+  public pdsAgents: PdsAgents
   public repoSigningKey: crypto.Keypair
   public plcRotationKey: crypto.Keypair
   public cfg: ServerConfig
@@ -81,6 +84,7 @@ export class AppContext {
     this.crawlers = opts.crawlers
     this.appViewAgent = opts.appViewAgent
     this.authVerifier = opts.authVerifier
+    this.pdsAgents = opts.pdsAgents
     this.repoSigningKey = opts.repoSigningKey
     this.plcRotationKey = opts.plcRotationKey
     this.cfg = opts.cfg
@@ -191,6 +195,8 @@ export class AppContext {
       crawlers,
     })
 
+    const pdsAgents = new PdsAgents()
+
     return new AppContext({
       db,
       blobstore,
@@ -210,6 +216,7 @@ export class AppContext {
       authVerifier,
       repoSigningKey,
       plcRotationKey,
+      pdsAgents,
       cfg,
       ...(overrides ?? {}),
     })

--- a/packages/pds/src/pds-agents.ts
+++ b/packages/pds/src/pds-agents.ts
@@ -1,0 +1,22 @@
+import AtpAgent from '@atproto/api'
+
+export class PdsAgents {
+  // @NOTE only use with entries in the pds table, not for e.g. arbitrary entries found in did documents.
+  private cache = new Map<string, AtpAgent>()
+  get(host: string) {
+    const agent =
+      this.cache.get(host) ?? new AtpAgent({ service: getPdsEndpoint(host) })
+    if (!this.cache.has(host)) {
+      this.cache.set(host, agent)
+    }
+    return agent
+  }
+}
+
+export const getPdsEndpoint = (host: string) => {
+  const service = new URL(`https://${host}`)
+  if (service.hostname === 'localhost') {
+    service.protocol = 'http:'
+  }
+  return service.origin
+}

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -666,7 +666,7 @@ type AccountInfo = UserAccountEntry &
 
 export class PdsCache {
   private all: PdsResult[] | undefined
-  private individual: Map<string, PdsResult>
+  private individual = new Map<string, PdsResult>()
   get(did: string) {
     return this.individual.get(did)
   }

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -1,4 +1,4 @@
-import { sql } from 'kysely'
+import { Selectable, sql } from 'kysely'
 import { randomStr } from '@atproto/crypto'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { MINUTE, lessThanAgoMs } from '@atproto/common'
@@ -15,12 +15,13 @@ import { AppPassword } from '../../lexicon/types/com/atproto/server/createAppPas
 import { EmailTokenPurpose } from '../../db/tables/email-token'
 import { getRandomToken } from '../../api/com/atproto/server/util'
 import { OptionalJoin } from '../../db/types'
+import { Pds } from '../../db/tables/pds'
 
 export class AccountService {
-  constructor(public db: Database) {}
+  constructor(public db: Database, private pdsCache: PdsCache) {}
 
-  static creator() {
-    return (db: Database) => new AccountService(db)
+  static creator(pdsCache: PdsCache) {
+    return (db: Database) => new AccountService(db, pdsCache)
   }
 
   // @TODO decouple account from repo_root, move takedownId.
@@ -601,13 +602,18 @@ export class AccountService {
     }
   }
 
-  // @TODO cache w/ in-mem lookup
-  async getPds(pdsDid: string) {
-    return await this.db.db
+  // @NOTE cached due to heavy usage in proxy logic
+  async getPds(pdsDid: string, opts?: { cached: boolean }) {
+    if (opts?.cached && this.pdsCache.has(pdsDid)) {
+      return this.pdsCache.get(pdsDid)
+    }
+    const pds = await this.db.db
       .selectFrom('pds')
       .where('did', '=', pdsDid)
       .selectAll()
       .executeTakeFirst()
+    if (pds) this.pdsCache.set(pdsDid, pds)
+    return pds
   }
 }
 
@@ -648,3 +654,5 @@ export type HandleSequenceToken = { did: string; handle: string }
 type AccountInfo = UserAccountEntry &
   DidHandle &
   OptionalJoin<RepoRoot> & { pdsDid: string | null }
+
+export class PdsCache extends Map<string, Selectable<Pds>> {}

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -84,10 +84,10 @@ export class AccountService {
         qb.where(notSoftDeletedClause(ref('user_account'))),
       )
       .where('email', '=', email.toLowerCase())
-      .select(['pds.did as pdsDid'])
-      .selectAll('user_account')
+      .selectAll('repo_root') // first so that its possibly-null vals don't shadow other cols
       .selectAll('did_handle')
-      .selectAll('repo_root')
+      .selectAll('user_account')
+      .select(['pds.did as pdsDid'])
       .executeTakeFirst()
     return found || null
   }

--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -54,7 +54,7 @@ export function createServices(resources: {
       appViewDid,
       appViewCdnUrlPattern,
     ),
-    moderation: ModerationService.creator(blobstore),
+    moderation: ModerationService.creator(blobstore, pdsCache),
   }
 }
 

--- a/packages/pds/src/services/index.ts
+++ b/packages/pds/src/services/index.ts
@@ -2,7 +2,7 @@ import { AtpAgent } from '@atproto/api'
 import * as crypto from '@atproto/crypto'
 import { BlobStore } from '@atproto/repo'
 import Database from '../db'
-import { AccountService } from './account'
+import { AccountService, PdsCache } from './account'
 import { AuthService } from './auth'
 import { RecordService } from './record'
 import { RepoService } from './repo'
@@ -36,8 +36,9 @@ export function createServices(resources: {
     backgroundQueue,
     crawlers,
   } = resources
+  const pdsCache = new PdsCache()
   return {
-    account: AccountService.creator(),
+    account: AccountService.creator(pdsCache),
     auth: AuthService.creator(identityDid, authKeys),
     record: RecordService.creator(),
     repo: RepoService.creator(

--- a/packages/pds/src/services/moderation/index.ts
+++ b/packages/pds/src/services/moderation/index.ts
@@ -10,15 +10,20 @@ import { ModerationViews } from './views'
 import SqlRepoStorage from '../../sql-repo-storage'
 import { TAKEDOWN } from '../../lexicon/types/com/atproto/admin/defs'
 import { addHoursToDate } from '../../util/date'
+import { PdsCache } from '../account'
 
 export class ModerationService {
-  constructor(public db: Database, public blobstore: BlobStore) {}
+  constructor(
+    public db: Database,
+    public blobstore: BlobStore,
+    public pdsCache: PdsCache,
+  ) {}
 
-  static creator(blobstore: BlobStore) {
-    return (db: Database) => new ModerationService(db, blobstore)
+  static creator(blobstore: BlobStore, pdsCache: PdsCache) {
+    return (db: Database) => new ModerationService(db, blobstore, pdsCache)
   }
 
-  views = new ModerationViews(this.db)
+  views = new ModerationViews(this.db, this.pdsCache)
 
   services = {
     record: RecordService.creator(),

--- a/packages/pds/src/services/moderation/views.ts
+++ b/packages/pds/src/services/moderation/views.ts
@@ -17,17 +17,17 @@ import {
 } from '../../lexicon/types/com/atproto/admin/defs'
 import { OutputSchema as ReportOutput } from '../../lexicon/types/com/atproto/moderation/createReport'
 import { ModerationAction } from '../../db/tables/moderation'
-import { AccountService } from '../account'
+import { AccountService, PdsCache } from '../account'
 import { RecordService } from '../record'
 import { ModerationReportRowWithHandle } from '.'
 import { ids } from '../../lexicon/lexicons'
 import { OptionalJoin } from '../../db/types'
 
 export class ModerationViews {
-  constructor(private db: Database) {}
+  constructor(private db: Database, private pdsCache: PdsCache) {}
 
   services = {
-    account: AccountService.creator(),
+    account: AccountService.creator(this.pdsCache),
     record: RecordService.creator(),
   }
 


### PR DESCRIPTION
A few misc fixes, improvements, and tweaks to the entryway setup:
 - Fix `getAccountByEmail()` which was giving a `null` for the user's did.
 - Cache `getPds(did)` results which is in the hot path of proxying.
 - Cache `AtpAgent`s for the entryway's pdses.
 - Update entryway flow for updating account handles: should use pds's `admin.updateAccountHandle` endpoint to avoid entryway and pds `identity.updateHandle` routes depending on each other.
 - Only include `didDoc` alongside credentials when the pds endpoint is one of the entryway's pdses.