### PR TITLE
Support S3-compatible credentials for pds blobstore

### DIFF
--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import os from 'node:os'
 import path from 'node:path'
 import { DAY, HOUR, SECOND } from '@atproto/common'
@@ -54,15 +55,23 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     throw new Error('Cannot set both S3 and disk blobstore env vars')
   }
   if (env.blobstoreS3Bucket) {
-    blobstoreCfg = { provider: 's3', bucket: env.blobstoreS3Bucket }
-    if (env.blobstoreS3Region) {
-      blobstoreCfg.region = env.blobstoreS3Region
+    blobstoreCfg = {
+      provider: 's3',
+      bucket: env.blobstoreS3Bucket,
+      region: env.blobstoreS3Region,
+      endpoint: env.blobstoreS3Endpoint,
+      forcePathStyle: env.blobstoreS3ForcePathStyle,
     }
-    if (env.blobstoreS3Endpoint) {
-      blobstoreCfg.endpoint = env.blobstoreS3Endpoint
-    }
-    if (env.blobstoreS3ForcePathStyle !== undefined) {
-      blobstoreCfg.forcePathStyle = env.blobstoreS3ForcePathStyle
+    if (env.blobstoreS3AccessKeyId || env.blobstoreS3SecretAccessKey) {
+      if (!env.blobstoreS3AccessKeyId || !env.blobstoreS3SecretAccessKey) {
+        throw new Error(
+          'Must specify both S3 access key id and secret access key blobstore env vars',
+        )
+      }
+      blobstoreCfg.credentials = {
+        accessKeyId: env.blobstoreS3AccessKeyId,
+        secretAccessKey: env.blobstoreS3SecretAccessKey,
+      }
     }
   } else if (env.blobstoreDiskLocation) {
     blobstoreCfg = {
@@ -250,6 +259,10 @@ export type S3BlobstoreConfig = {
   region?: string
   endpoint?: string
   forcePathStyle?: boolean
+  credentials?: {
+    accessKeyId: string
+    secretAccessKey: string
+  }
 }
 
 export type DiskBlobstoreConfig = {

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import os from 'node:os'
 import path from 'node:path'
 import { DAY, HOUR, SECOND } from '@atproto/common'

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -27,6 +27,8 @@ export const readEnv = (): ServerEnvironment => {
     blobstoreS3Region: envStr('PDS_BLOBSTORE_S3_REGION'),
     blobstoreS3Endpoint: envStr('PDS_BLOBSTORE_S3_ENDPOINT'),
     blobstoreS3ForcePathStyle: envBool('PDS_BLOBSTORE_S3_FORCE_PATH_STYLE'),
+    blobstoreS3AccessKeyId: envStr('PDS_BLOBSTORE_S3_ACCESS_KEY_ID'),
+    blobstoreS3SecretAccessKey: envStr('PDS_BLOBSTORE_S3_SECRET_ACCESS_KEY'),
     // disk
     blobstoreDiskLocation: envStr('PDS_BLOBSTORE_DISK_LOCATION'),
     blobstoreDiskTmpLocation: envStr('PDS_BLOBSTORE_DISK_TMP_LOCATION'),
@@ -125,6 +127,8 @@ export type ServerEnvironment = {
   blobstoreS3Region?: string
   blobstoreS3Endpoint?: string
   blobstoreS3ForcePathStyle?: boolean
+  blobstoreS3AccessKeyId?: string
+  blobstoreS3SecretAccessKey?: string
 
   // identity
   didPlcUrl?: string

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -108,6 +108,7 @@ export class AppContext {
             region: cfg.blobstore.region,
             endpoint: cfg.blobstore.endpoint,
             forcePathStyle: cfg.blobstore.forcePathStyle,
+            credentials: cfg.blobstore.credentials,
           })
         : await DiskBlobStore.create(
             cfg.blobstore.location,


### PR DESCRIPTION
As followup to #1729, also enabling configuration of S3-compatible credentials for the PDS blobstore.  This can be used with some services such as R2.