### PR TITLE
Don't validate known lexicons at runtime

### DIFF
--- a/packages/lex-cli/src/util.ts
+++ b/packages/lex-cli/src/util.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { join } from 'path'
-import { lexiconDoc, LexiconDoc } from '@atproto/lexicon'
+import { parseLexiconDoc, LexiconDoc } from '@atproto/lexicon'
 import { ZodError, ZodFormattedError } from 'zod'
 import chalk from 'chalk'
 import { GeneratedAPI, FileDiff } from './types'
@@ -41,8 +41,7 @@ export function readLexicon(path: string): LexiconDoc {
     typeof (obj as LexiconDoc).lexicon === 'number'
   ) {
     try {
-      lexiconDoc.parse(obj)
-      return obj as LexiconDoc
+      return parseLexiconDoc(obj)
     } catch (e) {
       console.error(`Invalid lexicon`, path)
       if (e instanceof ZodError) {

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -44,19 +44,21 @@ export class Lexicons {
    * Add a lexicon doc.
    */
   add(doc: unknown): void {
-    try {
-      lexiconDoc.parse(doc)
-    } catch (e) {
-      if (e instanceof ZodError) {
-        throw new LexiconDocMalformedError(
-          `Failed to parse schema definition ${
-            (doc as Record<string, string>).id
-          }`,
-          doc,
-          e.issues,
-        )
-      } else {
-        throw e
+    if (process.env.NODE_ENV !== 'production') {
+      try {
+        lexiconDoc.parse(doc)
+      } catch (e) {
+        if (e instanceof ZodError) {
+          throw new LexiconDocMalformedError(
+            `Failed to parse schema definition ${
+              (doc as Record<string, string>).id
+            }`,
+            doc,
+            e.issues,
+          )
+        } else {
+          throw e
+        }
       }
     }
     const validatedDoc = doc as LexiconDoc

--- a/packages/lexicon/src/lexicons.ts
+++ b/packages/lexicon/src/lexicons.ts
@@ -1,12 +1,9 @@
-import { ZodError } from 'zod'
 import {
   LexiconDoc,
-  lexiconDoc,
   LexRecord,
   LexXrpcProcedure,
   LexXrpcQuery,
   LexUserType,
-  LexiconDocMalformedError,
   LexiconDefNotFoundError,
   InvalidLexiconError,
   ValidationResult,
@@ -32,7 +29,7 @@ export class Lexicons {
   docs: Map<string, LexiconDoc> = new Map()
   defs: Map<string, LexUserType> = new Map()
 
-  constructor(docs?: unknown[]) {
+  constructor(docs?: LexiconDoc[]) {
     if (docs?.length) {
       for (const doc of docs) {
         this.add(doc)
@@ -43,26 +40,8 @@ export class Lexicons {
   /**
    * Add a lexicon doc.
    */
-  add(doc: unknown): void {
-    if (process.env.NODE_ENV !== 'production') {
-      try {
-        lexiconDoc.parse(doc)
-      } catch (e) {
-        if (e instanceof ZodError) {
-          throw new LexiconDocMalformedError(
-            `Failed to parse schema definition ${
-              (doc as Record<string, string>).id
-            }`,
-            doc,
-            e.issues,
-          )
-        } else {
-          throw e
-        }
-      }
-    }
-    const validatedDoc = doc as LexiconDoc
-    const uri = toLexUri(validatedDoc.id)
+  add(doc: LexiconDoc): void {
+    const uri = toLexUri(doc.id)
     if (this.docs.has(uri)) {
       throw new Error(`${uri} has already been registered`)
     }
@@ -70,10 +49,10 @@ export class Lexicons {
     // WARNING
     // mutates the object
     // -prf
-    resolveRefUris(validatedDoc, uri)
+    resolveRefUris(doc, uri)
 
-    this.docs.set(uri, validatedDoc)
-    for (const [defUri, def] of iterDefs(validatedDoc)) {
+    this.docs.set(uri, doc)
+    for (const [defUri, def] of iterDefs(doc)) {
       this.defs.set(defUri, def)
     }
   }

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -415,16 +415,9 @@ export function isDiscriminatedObject(
   return discriminatedObject.safeParse(value).success
 }
 
-export class LexiconDocMalformedError extends Error {
-  constructor(
-    message: string,
-    public schemaDef: unknown,
-    public issues?: z.ZodIssue[],
-  ) {
-    super(message)
-    this.schemaDef = schemaDef
-    this.issues = issues
-  }
+export function parseLexiconDoc(v: unknown): LexiconDoc {
+  lexiconDoc.parse(v)
+  return v as LexiconDoc
 }
 
 export type ValidationResult =

--- a/packages/lexicon/tests/_scaffolds/lexicons.ts
+++ b/packages/lexicon/tests/_scaffolds/lexicons.ts
@@ -1,4 +1,6 @@
-export default [
+import { LexiconDoc } from '../../src/index'
+
+const lexicons: LexiconDoc[] = [
   {
     lexicon: 1,
     id: 'com.example.kitchenSink',
@@ -521,3 +523,5 @@ export default [
     },
   },
 ]
+
+export default lexicons

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import { lexiconDoc, Lexicons } from '../src/index'
+import { LexiconDoc, Lexicons, parseLexiconDoc } from '../src/index'
 import LexiconDocs from './_scaffolds/lexicons'
 
 describe('Lexicons collection', () => {
@@ -97,7 +97,7 @@ describe('General validation', () => {
       },
     }
     expect(() => {
-      lexiconDoc.parse(schema)
+      parseLexiconDoc(schema)
     }).toThrow('Required field \\"foo\\" not defined')
   })
   it('fails when unknown fields are present', () => {
@@ -113,11 +113,11 @@ describe('General validation', () => {
     }
 
     expect(() => {
-      lexiconDoc.parse(schema)
+      parseLexiconDoc(schema)
     }).toThrow("Unrecognized key(s) in object: 'foo'")
   })
   it('fails lexicon parsing when uri is invalid', () => {
-    const schema = {
+    const schema: LexiconDoc = {
       lexicon: 1,
       id: 'com.example.invalidUri',
       defs: {
@@ -135,7 +135,7 @@ describe('General validation', () => {
     }).toThrow('Uri can only have one hash segment')
   })
   it('fails validation when ref uri has multiple hash segments', () => {
-    const schema = {
+    const schema: LexiconDoc = {
       lexicon: 1,
       id: 'com.example.invalidUri',
       defs: {
@@ -168,7 +168,7 @@ describe('General validation', () => {
     }).toThrow('Uri can only have one hash segment')
   })
   it('union handles both implicit and explicit #main', () => {
-    const schemas = [
+    const schemas: LexiconDoc[] = [
       {
         lexicon: 1,
         id: 'com.example.implicitMain',

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -5,6 +5,7 @@ import express, {
   RequestHandler,
 } from 'express'
 import {
+  LexiconDoc,
   Lexicons,
   lexToJson,
   LexXrpcProcedure,
@@ -45,7 +46,7 @@ import {
 import log from './logger'
 import { consumeMany } from './rate-limiter'
 
-export function createServer(lexicons?: unknown[], options?: Options) {
+export function createServer(lexicons?: LexiconDoc[], options?: Options) {
   return new Server(lexicons, options)
 }
 
@@ -60,7 +61,7 @@ export class Server {
   sharedRateLimiters: Record<string, RateLimiterI>
   routeRateLimiterFns: Record<string, RateLimiterConsume[]>
 
-  constructor(lexicons?: unknown[], opts?: Options) {
+  constructor(lexicons?: LexiconDoc[], opts?: Options) {
     if (lexicons) {
       this.addLexicons(lexicons)
     }
@@ -140,11 +141,11 @@ export class Server {
   // schemas
   // =
 
-  addLexicon(doc: unknown) {
+  addLexicon(doc: LexiconDoc) {
     this.lex.add(doc)
   }
 
-  addLexicons(docs: unknown[]) {
+  addLexicons(docs: LexiconDoc[]) {
     for (const doc of docs) {
       this.addLexicon(doc)
     }

--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -1,4 +1,4 @@
-import { Lexicons, ValidationError } from '@atproto/lexicon'
+import { LexiconDoc, Lexicons, ValidationError } from '@atproto/lexicon'
 import {
   getMethodSchemaHTTPMethod,
   constructMethodCallUri,
@@ -46,11 +46,11 @@ export class Client {
   // schemas
   // =
 
-  addLexicon(doc: unknown) {
+  addLexicon(doc: LexiconDoc) {
     this.lex.add(doc)
   }
 
-  addLexicons(docs: unknown[]) {
+  addLexicons(docs: LexiconDoc[]) {
     for (const doc of docs) {
       this.addLexicon(doc)
     }


### PR DESCRIPTION
Here's what I'm seeing in the app's module initialization sequence with CPU throttling on:

<img width="819" alt="Screenshot 2023-11-01 at 01 56 46" src="https://github.com/bluesky-social/atproto/assets/810438/f8d0fa47-13da-4c9d-9964-6fcd9f2322d1">

It looks like we're spending client's CPU cycles validating that our own schemas are valid. I'm not sure it makes sense for a client to do that in production. From what I understand, these schemas are known at the build time, there's no way for them to have changed by any other way than deploying our code. So if they were valid when the app was built, it seems unnecessary to check whether they're valid on every end user's computer.

Without these lines, the init time shrinks considerably:

<img width="264" alt="Screenshot 2023-11-01 at 02 01 07" src="https://github.com/bluesky-social/atproto/assets/810438/64ff6d00-e162-41c3-8201-f4ed4711c14d">

