### PR TITLE
Make plc op unknown object rather than bytes

### DIFF
--- a/lexicons/com/atproto/server/createAccount.json
+++ b/lexicons/com/atproto/server/createAccount.json
@@ -17,7 +17,7 @@
             "inviteCode": { "type": "string" },
             "password": { "type": "string" },
             "recoveryKey": { "type": "string" },
-            "plcOp": { "type": "bytes" }
+            "plcOp": { "type": "unknown" }
           }
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2512,7 +2512,7 @@ export const schemaDict = {
                 type: 'string',
               },
               plcOp: {
-                type: 'bytes',
+                type: 'unknown',
               },
             },
           },

--- a/packages/api/src/client/types/com/atproto/server/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAccount.ts
@@ -16,7 +16,7 @@ export interface InputSchema {
   inviteCode?: string
   password: string
   recoveryKey?: string
-  plcOp?: Uint8Array
+  plcOp?: {}
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2512,7 +2512,7 @@ export const schemaDict = {
                 type: 'string',
               },
               plcOp: {
-                type: 'bytes',
+                type: 'unknown',
               },
             },
           },

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -17,7 +17,7 @@ export interface InputSchema {
   inviteCode?: string
   password: string
   recoveryKey?: string
-  plcOp?: Uint8Array
+  plcOp?: {}
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1826,6 +1826,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
               },
               subject: {
                 type: 'union',
@@ -2510,7 +2512,7 @@ export const schemaDict = {
                 type: 'string',
               },
               plcOp: {
-                type: 'bytes',
+                type: 'unknown',
               },
             },
           },

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -17,7 +17,7 @@ export interface InputSchema {
   inviteCode?: string
   password: string
   recoveryKey?: string
-  plcOp?: Uint8Array
+  plcOp?: {}
   [k: string]: unknown
 }
 


### PR DESCRIPTION
Updates `plcOp` parameter on the `createAccount` lexicon to be `unknown` rather than `bytes`. The idea here is that we should be mirroring the PLC API more closely, while still leaving the value opaque relative to lexicon.