### PR TITLE
Set and validate token audiences on pds v2

### DIFF
--- a/packages/pds/src/account-manager/index.ts
+++ b/packages/pds/src/account-manager/index.ts
@@ -16,7 +16,11 @@ import { StatusAttr } from '../lexicon/types/com/atproto/admin/defs'
 export class AccountManager {
   db: AccountDb
 
-  constructor(dbLocation: string, private jwtKey: KeyObject) {
+  constructor(
+    dbLocation: string,
+    private jwtKey: KeyObject,
+    private serviceDid: string,
+  ) {
     this.db = getDb(dbLocation)
   }
 
@@ -70,8 +74,9 @@ export class AccountManager {
   }) {
     const { did, handle, email, password, repoCid, repoRev, inviteCode } = opts
     const { accessJwt, refreshJwt } = await auth.createTokens({
-      jwtKey: this.jwtKey,
       did,
+      jwtKey: this.jwtKey,
+      serviceDid: this.serviceDid,
       scope: AuthScope.Access,
     })
     const refreshPayload = auth.decodeRefreshToken(refreshJwt)
@@ -128,8 +133,9 @@ export class AccountManager {
 
   async createSession(did: string, appPasswordName: string | null) {
     const { accessJwt, refreshJwt } = await auth.createTokens({
-      jwtKey: this.jwtKey,
       did,
+      jwtKey: this.jwtKey,
+      serviceDid: this.serviceDid,
       scope: appPasswordName === null ? AuthScope.Access : AuthScope.AppPass,
     })
     const refreshPayload = auth.decodeRefreshToken(refreshJwt)
@@ -165,8 +171,9 @@ export class AccountManager {
     const nextId = token.nextId ?? auth.getRefreshTokenId()
 
     const { accessJwt, refreshJwt } = await auth.createTokens({
-      jwtKey: this.jwtKey,
       did: token.did,
+      jwtKey: this.jwtKey,
+      serviceDid: this.serviceDid,
       scope:
         token.appPasswordName === null ? AuthScope.Access : AuthScope.AppPass,
       jti: nextId,

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -106,11 +106,13 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
   if (env.entrywayUrl) {
     assert(
       env.entrywayJwtVerifyKeyK256PublicKeyHex &&
-        env.entrywayPlcRotationKeyK256PublicKeyHex,
+        env.entrywayPlcRotationKeyK256PublicKeyHex &&
+        env.entrywayDid,
       'if entryway url is configured, must include all required entryway configuration',
     )
     entrywayCfg = {
       url: env.entrywayUrl,
+      did: env.entrywayDid,
       jwtPublicKeyHex: env.entrywayJwtVerifyKeyK256PublicKeyHex,
       plcRotationPublicKeyHex: env.entrywayPlcRotationKeyK256PublicKeyHex,
     }
@@ -282,6 +284,7 @@ export type IdentityConfig = {
 
 export type EntrywayConfig = {
   url: string
+  did: string
   jwtPublicKeyHex: string
   plcRotationPublicKeyHex: string
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -44,6 +44,7 @@ export const readEnv = (): ServerEnvironment => {
 
     // entryway
     entrywayUrl: envStr('PDS_ENTRYWAY_URL'),
+    entrywayDid: envStr('PDS_ENTRYWAY_DID'),
     entrywayJwtVerifyKeyK256PublicKeyHex: envStr(
       'PDS_ENTRYWAY_JWT_VERIFY_KEY_K256_PUBLIC_KEY_HEX',
     ),
@@ -142,6 +143,7 @@ export type ServerEnvironment = {
 
   // entryway
   entrywayUrl?: string
+  entrywayDid?: string
   entrywayJwtVerifyKeyK256PublicKeyHex?: string
   entrywayPlcRotationKeyK256PublicKeyHex?: string
 

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -153,7 +153,11 @@ export class AppContext {
       : undefined
 
     const jwtSecretKey = createSecretKeyObject(secrets.jwtSecret)
-    const accountManager = new AccountManager(cfg.db.accountDbLoc, jwtSecretKey)
+    const accountManager = new AccountManager(
+      cfg.db.accountDbLoc,
+      jwtSecretKey,
+      cfg.service.did,
+    )
     await accountManager.migrateOrThrow()
 
     const jwtKey = cfg.entryway
@@ -165,7 +169,11 @@ export class AppContext {
       adminPass: secrets.adminPassword,
       moderatorPass: secrets.moderatorPassword,
       triagePass: secrets.triagePassword,
-      adminServiceDid: cfg.bskyAppView.did,
+      dids: {
+        pds: cfg.service.did,
+        entryway: cfg.entryway?.did,
+        admin: cfg.bskyAppView.did,
+      },
     })
 
     const plcRotationKey =

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -252,8 +252,9 @@ describe('auth', () => {
       password: 'password',
     })
     const refreshJwt = await createRefreshToken({
-      jwtKey: network.pds.jwtSecretKey(),
       did: account.did,
+      jwtKey: network.pds.jwtSecretKey(),
+      serviceDid: network.pds.ctx.cfg.service.did,
       expiresIn: -1,
     })
     const refreshExpired = refreshSession(refreshJwt)

--- a/packages/pds/tests/entryway.test.ts
+++ b/packages/pds/tests/entryway.test.ts
@@ -24,6 +24,7 @@ describe('entryway', () => {
     plc = await TestPlc.create({})
     pds = await TestPds.create({
       entrywayUrl: `http://localhost:${entrywayPort}`,
+      entrywayDid: 'did:example:entryway',
       entrywayJwtVerifyKeyK256PublicKeyHex: getPublicHex(jwtSigningKey),
       entrywayPlcRotationKeyK256PublicKeyHex: getPublicHex(plcRotationKey),
       adminPassword: 'admin-pass',


### PR DESCRIPTION
Here we start setting and validating audience claims on access and refresh tokens on the pds.  This is particularly useful when using the pds with an entryway service, which sets the audience claim in the credentials that it generates.