### PR TITLE
Tweak schemas for entryway createAccount

### DIFF
--- a/lexicons/com/atproto/server/createAccount.json
+++ b/lexicons/com/atproto/server/createAccount.json
@@ -9,7 +9,7 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["handle", "email", "password"],
+          "required": ["handle"],
           "properties": {
             "email": { "type": "string" },
             "handle": { "type": "string", "format": "handle" },

--- a/lexicons/com/atproto/server/reserveSigningKey.json
+++ b/lexicons/com/atproto/server/reserveSigningKey.json
@@ -5,6 +5,18 @@
     "main": {
       "type": "procedure",
       "description": "Reserve a repo signing key for account creation.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "did": {
+              "type": "string",
+              "description": "The did to reserve a new did:key for"
+            }
+          }
+        }
+      },
       "output": {
         "encoding": "application/json",
         "schema": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2489,7 +2489,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['handle', 'email', 'password'],
+            required: ['handle'],
             properties: {
               email: {
                 type: 'string',
@@ -3170,6 +3170,18 @@ export const schemaDict = {
       main: {
         type: 'procedure',
         description: 'Reserve a repo signing key for account creation.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              did: {
+                type: 'string',
+                description: 'The did to reserve a new did:key for',
+              },
+            },
+          },
+        },
         output: {
           encoding: 'application/json',
           schema: {

--- a/packages/api/src/client/types/com/atproto/server/createAccount.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAccount.ts
@@ -10,11 +10,11 @@ import { CID } from 'multiformats/cid'
 export interface QueryParams {}
 
 export interface InputSchema {
-  email: string
+  email?: string
   handle: string
   did?: string
   inviteCode?: string
-  password: string
+  password?: string
   recoveryKey?: string
   plcOp?: Uint8Array
   [k: string]: unknown

--- a/packages/api/src/client/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/api/src/client/types/com/atproto/server/reserveSigningKey.ts
@@ -9,7 +9,11 @@ import { CID } from 'multiformats/cid'
 
 export interface QueryParams {}
 
-export type InputSchema = undefined
+export interface InputSchema {
+  /** The did to reserve a new did:key for */
+  did?: string
+  [k: string]: unknown
+}
 
 export interface OutputSchema {
   /** Public signing key in the form of a did:key. */
@@ -20,6 +24,7 @@ export interface OutputSchema {
 export interface CallOptions {
   headers?: Headers
   qp?: QueryParams
+  encoding: 'application/json'
 }
 
 export interface Response {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2489,7 +2489,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['handle', 'email', 'password'],
+            required: ['handle'],
             properties: {
               email: {
                 type: 'string',
@@ -3170,6 +3170,18 @@ export const schemaDict = {
       main: {
         type: 'procedure',
         description: 'Reserve a repo signing key for account creation.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              did: {
+                type: 'string',
+                description: 'The did to reserve a new did:key for',
+              },
+            },
+          },
+        },
         output: {
           encoding: 'application/json',
           schema: {

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -11,11 +11,11 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  email: string
+  email?: string
   handle: string
   did?: string
   inviteCode?: string
-  password: string
+  password?: string
   recoveryKey?: string
   plcOp?: Uint8Array
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
@@ -10,7 +10,11 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}
 
-export type InputSchema = undefined
+export interface InputSchema {
+  /** The did to reserve a new did:key for */
+  did?: string
+  [k: string]: unknown
+}
 
 export interface OutputSchema {
   /** Public signing key in the form of a did:key. */
@@ -18,7 +22,10 @@ export interface OutputSchema {
   [k: string]: unknown
 }
 
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerSuccess {
   encoding: 'application/json'

--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -21,7 +21,11 @@ export default function (server: Server, ctx: AppContext) {
     },
     handler: async ({ input, req }) => {
       const { email, password, inviteCode } = input.body
-      if (input.body.plcOp) {
+      if (!email) {
+        throw new InvalidRequestError('Missing input: "email"')
+      } else if (!password) {
+        throw new InvalidRequestError('Missing input: "password"')
+      } else if (input.body.plcOp) {
         throw new InvalidRequestError('Unsupported input: "plcOp"')
       }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1826,6 +1826,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
               },
               subject: {
                 type: 'union',
@@ -2487,7 +2489,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['handle', 'email', 'password'],
+            required: ['handle'],
             properties: {
               email: {
                 type: 'string',
@@ -3168,6 +3170,18 @@ export const schemaDict = {
       main: {
         type: 'procedure',
         description: 'Reserve a repo signing key for account creation.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              did: {
+                type: 'string',
+                description: 'The did to reserve a new did:key for',
+              },
+            },
+          },
+        },
         output: {
           encoding: 'application/json',
           schema: {

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -11,11 +11,11 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 export interface QueryParams {}
 
 export interface InputSchema {
-  email: string
+  email?: string
   handle: string
   did?: string
   inviteCode?: string
-  password: string
+  password?: string
   recoveryKey?: string
   plcOp?: Uint8Array
   [k: string]: unknown

--- a/packages/pds/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
@@ -10,7 +10,11 @@ import { HandlerAuth } from '@atproto/xrpc-server'
 
 export interface QueryParams {}
 
-export type InputSchema = undefined
+export interface InputSchema {
+  /** The did to reserve a new did:key for */
+  did?: string
+  [k: string]: unknown
+}
 
 export interface OutputSchema {
   /** Public signing key in the form of a did:key. */
@@ -18,7 +22,10 @@ export interface OutputSchema {
   [k: string]: unknown
 }
 
-export type HandlerInput = undefined
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
 
 export interface HandlerSuccess {
   encoding: 'application/json'


### PR DESCRIPTION
- Add optional did on `server.reserveSigningKey` input
- Make password and email optional on `server.createAccount` (for the delegated usecase)