### PR TITLE
Add changeset for #1790

### DIFF
--- a/.changeset/dry-cameras-hang.md
+++ b/.changeset/dry-cameras-hang.md
@@ -1,0 +1,7 @@
+---
+'@atproto/lexicon': minor
+'@atproto/xrpc': minor
+'@atproto/xrpc-server': minor
+---
+
+Methods that accepts lexicons now take `LexiconDoc` type instead of `unknown`


### PR DESCRIPTION
I want to release https://github.com/bluesky-social/atproto/pull/1790 so we can update the client and get the perf win.

I tried to word the change from the perspective of someone updating (they might have to explicitly declare the type).