### PR TITLE
Simplify moderation fanout to configured url

### DIFF
--- a/packages/bsky/src/api/com/atproto/admin/reverseModerationAction.ts
+++ b/packages/bsky/src/api/com/atproto/admin/reverseModerationAction.ts
@@ -85,9 +85,9 @@ export default function (server: Server, ctx: AppContext) {
         return { result, restored }
       })
 
-      if (restored) {
-        const { did, subjects } = restored
-        const agent = await ctx.pdsAdminAgent(did)
+      if (restored && ctx.moderationPushAgent) {
+        const agent = ctx.moderationPushAgent
+        const { subjects } = restored
         const results = await Promise.allSettled(
           subjects.map((subject) =>
             retryHttp(() =>

--- a/packages/bsky/src/api/com/atproto/admin/takeModerationAction.ts
+++ b/packages/bsky/src/api/com/atproto/admin/takeModerationAction.ts
@@ -111,10 +111,10 @@ export default function (server: Server, ctx: AppContext) {
         return { result, takenDown }
       })
 
-      if (takenDown) {
+      if (takenDown && ctx.moderationPushAgent) {
+        const agent = ctx.moderationPushAgent
         const { did, subjects } = takenDown
         if (did && subjects.length > 0) {
-          const agent = await ctx.pdsAdminAgent(did)
           const results = await Promise.allSettled(
             subjects.map((subject) =>
               retryHttp(() =>

--- a/packages/bsky/src/api/com/atproto/admin/util.ts
+++ b/packages/bsky/src/api/com/atproto/admin/util.ts
@@ -9,8 +9,9 @@ export const getPdsAccountInfo = async (
   ctx: AppContext,
   did: string,
 ): Promise<AccountView | null> => {
+  const agent = ctx.moderationPushAgent
+  if (!agent) return null
   try {
-    const agent = await ctx.pdsAdminAgent(did)
     const res = await agent.api.com.atproto.admin.getAccountInfo({ did })
     return res.data
   } catch (err) {

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -23,7 +23,7 @@ export interface ServerConfigValues {
   adminPassword: string
   moderatorPassword?: string
   triagePassword?: string
-  moderationActionReverseUrl?: string
+  moderationPushUrl?: string
 }
 
 export class ServerConfig {
@@ -78,8 +78,8 @@ export class ServerConfig {
     const moderatorPassword = process.env.MODERATOR_PASSWORD || undefined
     const triagePassword = process.env.TRIAGE_PASSWORD || undefined
     const labelerDid = process.env.LABELER_DID || 'did:example:labeler'
-    const moderationActionReverseUrl =
-      overrides?.moderationActionReverseUrl ||
+    const moderationPushUrl =
+      overrides?.moderationPushUrl ||
       process.env.MODERATION_PUSH_URL ||
       undefined
     return new ServerConfig({
@@ -104,7 +104,7 @@ export class ServerConfig {
       adminPassword,
       moderatorPassword,
       triagePassword,
-      moderationActionReverseUrl,
+      moderationPushUrl,
       ...stripUndefineds(overrides ?? {}),
     })
   }
@@ -206,8 +206,8 @@ export class ServerConfig {
     return this.cfg.triagePassword
   }
 
-  get moderationActionReverseUrl() {
-    return this.cfg.moderationActionReverseUrl
+  get moderationPushUrl() {
+    return this.cfg.moderationPushUrl
   }
 }
 

--- a/packages/bsky/src/db/periodic-moderation-action-reversal.ts
+++ b/packages/bsky/src/db/periodic-moderation-action-reversal.ts
@@ -3,7 +3,6 @@ import { Leader } from './leader'
 import { dbLogger } from '../logger'
 import AppContext from '../context'
 import AtpAgent from '@atproto/api'
-import { buildBasicAuth } from '../auth'
 import { LabelService } from '../services/label'
 import { ModerationActionRow } from '../services/moderation'
 
@@ -18,14 +17,7 @@ export class PeriodicModerationActionReversal {
   pushAgent?: AtpAgent
 
   constructor(private appContext: AppContext) {
-    if (appContext.cfg.moderationActionReverseUrl) {
-      const url = new URL(appContext.cfg.moderationActionReverseUrl)
-      this.pushAgent = new AtpAgent({ service: url.origin })
-      this.pushAgent.api.setHeader(
-        'authorization',
-        buildBasicAuth(url.username, url.password),
-      )
-    }
+    this.pushAgent = appContext.moderationPushAgent
   }
 
   // invert label creation & negations

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -40,6 +40,7 @@ export class TestNetwork extends TestNetworkNoAppView {
       dbPostgresSchema: `appview_${dbPostgresSchema}`,
       dbPrimaryPostgresUrl: dbPostgresUrl,
       redisHost,
+      moderationPushUrl: `http://admin:${ADMIN_PASSWORD}@localhost:${pdsPort}`,
       ...params.bsky,
     })
     const pds = await TestPds.create({


### PR DESCRIPTION
The moderation functionality on the appview would fan out status changes to the affected user's pds.  We may want to do something like that eventually, but for now we simplify down to a single configured url.