### PR TITLE
Add did doc output to getSession for session resumption

### DIFF
--- a/.changeset/thick-apples-invite.md
+++ b/.changeset/thick-apples-invite.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+respect pds endpoint during session resumption

--- a/lexicons/com/atproto/server/getSession.json
+++ b/lexicons/com/atproto/server/getSession.json
@@ -14,7 +14,8 @@
             "handle": { "type": "string", "format": "handle" },
             "did": { "type": "string", "format": "did" },
             "email": { "type": "string" },
-            "emailConfirmed": { "type": "boolean" }
+            "emailConfirmed": { "type": "boolean" },
+            "didDoc": { "type": "unknown" }
           }
         }
       }

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -165,6 +165,7 @@ export class AtpAgent {
       this.session.email = res.data.email
       this.session.handle = res.data.handle
       this.session.emailConfirmed = res.data.emailConfirmed
+      this._updateApiEndpoint(res.data.didDoc)
       return res
     } catch (e) {
       this.session = undefined

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3007,6 +3007,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              didDoc: {
+                type: 'unknown',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/server/getSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/getSession.ts
@@ -16,6 +16,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  didDoc?: {}
   [k: string]: unknown
 }
 

--- a/packages/api/src/moderation/accumulator.ts
+++ b/packages/api/src/moderation/accumulator.ts
@@ -1,5 +1,4 @@
 import { AppBskyGraphDefs } from '../client/index'
-import { AtUri } from '@atproto/syntax'
 import {
   Label,
   LabelPreference,

--- a/packages/api/tests/agent.test.ts
+++ b/packages/api/tests/agent.test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import { defaultFetchHandler } from '@atproto/xrpc'
 import {
   AtpAgent,
@@ -6,6 +7,7 @@ import {
   AtpSessionData,
 } from '..'
 import { TestNetworkNoAppView } from '@atproto/dev-env'
+import { getPdsEndpoint, isValidDidDoc } from '@atproto/common-web'
 
 describe('agent', () => {
   let network: TestNetworkNoAppView
@@ -46,16 +48,19 @@ describe('agent', () => {
     expect(agent.session?.did).toEqual(res.data.did)
     expect(agent.session?.email).toEqual('user1@test.com')
     expect(agent.session?.emailConfirmed).toEqual(false)
+    assert(isValidDidDoc(res.data.didDoc))
+    expect(agent.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res.data.didDoc))
 
     const { data: sessionInfo } = await agent.api.com.atproto.server.getSession(
       {},
     )
-    expect(sessionInfo).toEqual({
+    expect(sessionInfo).toMatchObject({
       did: res.data.did,
       handle: res.data.handle,
       email: 'user1@test.com',
       emailConfirmed: false,
     })
+    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(1)
     expect(events[0]).toEqual('create')
@@ -93,15 +98,18 @@ describe('agent', () => {
     expect(agent2.session?.did).toEqual(res1.data.did)
     expect(agent2.session?.email).toEqual('user2@test.com')
     expect(agent2.session?.emailConfirmed).toEqual(false)
+    assert(isValidDidDoc(res1.data.didDoc))
+    expect(agent2.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res1.data.didDoc))
 
     const { data: sessionInfo } =
       await agent2.api.com.atproto.server.getSession({})
-    expect(sessionInfo).toEqual({
+    expect(sessionInfo).toMatchObject({
       did: res1.data.did,
       handle: res1.data.handle,
       email,
       emailConfirmed: false,
     })
+    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create')
@@ -136,15 +144,18 @@ describe('agent', () => {
     expect(agent2.hasSession).toEqual(true)
     expect(agent2.session?.handle).toEqual(res1.data.handle)
     expect(agent2.session?.did).toEqual(res1.data.did)
+    assert(isValidDidDoc(res1.data.didDoc))
+    expect(agent2.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res1.data.didDoc))
 
     const { data: sessionInfo } =
       await agent2.api.com.atproto.server.getSession({})
-    expect(sessionInfo).toEqual({
+    expect(sessionInfo).toMatchObject({
       did: res1.data.did,
       handle: res1.data.handle,
       email: res1.data.email,
       emailConfirmed: false,
     })
+    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create')

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3007,6 +3007,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              didDoc: {
+                type: 'unknown',
+              },
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
@@ -17,6 +17,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  didDoc?: {}
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3007,6 +3007,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              didDoc: {
+                type: 'unknown',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
@@ -17,6 +17,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  didDoc?: {}
   [k: string]: unknown
 }
 


### PR DESCRIPTION
I missed this one in #1727— we need a did doc hint in order for the client to start talking to the user's pds during session resumption.  So the `didDoc` field has been added to `getSession` output, bringing it in line with `createSession`, `refreshSession`, and `createAccount`.