### PR TITLE
Add a test for links that end in .php

### DIFF
--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -40,6 +40,7 @@ describe('detectFacets', () => {
     'start.com/foo/bar?baz=bux#hash middle end',
     'start middle end.com/foo/bar?baz=bux#hash',
     'newline1.com\nnewline2.com',
+    'a example.com/index.php php link',
 
     'not.. a..url ..here',
     'e.g.',
@@ -155,6 +156,11 @@ describe('detectFacets', () => {
       ['newline1.com', 'https://newline1.com'],
       ['\n'],
       ['newline2.com', 'https://newline2.com'],
+    ],
+    [
+      ['a '],
+      ['example.com/index.php', 'https://example.com/index.php'],
+      [' php link'],
     ],
 
     [['not.. a..url ..here']],


### PR DESCRIPTION
Noticed when debugging a ticket that we support `.php` links but didn't have a test.