### PR TITLE
Prevent thread loops

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -255,11 +255,17 @@ const getThreadData = async (
       .orderBy('sortAt', 'desc')
       .execute(),
   ])
+  // prevent self-referential loops
+  const includedPosts = new Set<string>()
   const parentsByUri = parents.reduce((acc, parent) => {
+    if (includedPosts.has(parent.postUri)) return acc
+    includedPosts.add(parent.postUri)
     return Object.assign(acc, { [parent.postUri]: parent })
   }, {} as Record<string, FeedRow>)
   const childrenByParentUri = children.reduce((acc, child) => {
     if (!child.replyParent) return acc
+    if (includedPosts.has(child.uri)) return acc
+    includedPosts.add(child.uri)
     acc[child.replyParent] ??= []
     acc[child.replyParent].push(child)
     return acc

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -257,6 +257,7 @@ const getThreadData = async (
   ])
   // prevent self-referential loops
   const includedPosts = new Set<string>()
+  includedPosts.add(uri)
   const parentsByUri = parents.reduce((acc, parent) => {
     if (includedPosts.has(parent.postUri)) return acc
     includedPosts.add(parent.postUri)

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -258,8 +258,8 @@ const getThreadData = async (
   // prevent self-referential loops
   const includedPosts = new Set<string>([uri])
   const parentsByUri = parents.reduce((acc, parent) => {
-    if (includedPosts.has(parent.postUri)) return acc
-    includedPosts.add(parent.postUri)
+    if (includedPosts.has(parent.uri)) return acc
+    includedPosts.add(parent.uri)
     return Object.assign(acc, { [parent.postUri]: parent })
   }, {} as Record<string, FeedRow>)
   const childrenByParentUri = children.reduce((acc, child) => {

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -256,8 +256,7 @@ const getThreadData = async (
       .execute(),
   ])
   // prevent self-referential loops
-  const includedPosts = new Set<string>()
-  includedPosts.add(uri)
+  const includedPosts = new Set<string>([uri])
   const parentsByUri = parents.reduce((acc, parent) => {
     if (includedPosts.has(parent.postUri)) return acc
     includedPosts.add(parent.postUri)

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -257,8 +257,8 @@ const getThreadData = async (
   ])
   // prevent self-referential loops
   const includedPosts = new Set<string>([uri])
-  const parentsByUri = parents.reduce((acc, parent) => {
-    return Object.assign(acc, { [parent.uri]: parent })
+  const parentsByUri = parents.reduce((acc, post) => {
+    return Object.assign(acc, { [post.uri]: post })
   }, {} as Record<string, FeedRow>)
   const childrenByParentUri = children.reduce((acc, child) => {
     if (!child.replyParent) return acc

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -256,10 +256,10 @@ const getThreadData = async (
       .execute(),
   ])
   // prevent self-referential loops
-  const includedPosts = new Set<string>([uri])
+  const includedPosts = new Set<string>()
   const parentsByUri = parents.reduce((acc, parent) => {
-    if (includedPosts.has(parent.uri)) return acc
-    includedPosts.add(parent.uri)
+    if (includedPosts.has(parent.postUri)) return acc
+    includedPosts.add(parent.postUri)
     return Object.assign(acc, { [parent.postUri]: parent })
   }, {} as Record<string, FeedRow>)
   const childrenByParentUri = children.reduce((acc, child) => {


### PR DESCRIPTION
Prevent self-referential loops in threads. 

This fix should prevent even multi-hop loops such as `A -> B -> C -> A...`