### PR TITLE
Polish on entryway blob uploads and gets

### DIFF
--- a/packages/api/tests/agent.test.ts
+++ b/packages/api/tests/agent.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { defaultFetchHandler } from '@atproto/xrpc'
 import {
   AtpAgent,
@@ -7,7 +6,6 @@ import {
   AtpSessionData,
 } from '..'
 import { TestNetworkNoAppView } from '@atproto/dev-env'
-import { getPdsEndpoint, isValidDidDoc } from '@atproto/common-web'
 
 describe('agent', () => {
   let network: TestNetworkNoAppView
@@ -15,9 +13,6 @@ describe('agent', () => {
   beforeAll(async () => {
     network = await TestNetworkNoAppView.create({
       dbPostgresSchema: 'api_agent',
-      pds: {
-        enableDidDocWithSession: true,
-      },
     })
   })
 
@@ -48,19 +43,16 @@ describe('agent', () => {
     expect(agent.session?.did).toEqual(res.data.did)
     expect(agent.session?.email).toEqual('user1@test.com')
     expect(agent.session?.emailConfirmed).toEqual(false)
-    assert(isValidDidDoc(res.data.didDoc))
-    expect(agent.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res.data.didDoc))
 
     const { data: sessionInfo } = await agent.api.com.atproto.server.getSession(
       {},
     )
-    expect(sessionInfo).toMatchObject({
+    expect(sessionInfo).toEqual({
       did: res.data.did,
       handle: res.data.handle,
       email: 'user1@test.com',
       emailConfirmed: false,
     })
-    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(1)
     expect(events[0]).toEqual('create')
@@ -98,18 +90,15 @@ describe('agent', () => {
     expect(agent2.session?.did).toEqual(res1.data.did)
     expect(agent2.session?.email).toEqual('user2@test.com')
     expect(agent2.session?.emailConfirmed).toEqual(false)
-    assert(isValidDidDoc(res1.data.didDoc))
-    expect(agent2.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res1.data.didDoc))
 
     const { data: sessionInfo } =
       await agent2.api.com.atproto.server.getSession({})
-    expect(sessionInfo).toMatchObject({
+    expect(sessionInfo).toEqual({
       did: res1.data.did,
       handle: res1.data.handle,
       email,
       emailConfirmed: false,
     })
-    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create')
@@ -144,18 +133,15 @@ describe('agent', () => {
     expect(agent2.hasSession).toEqual(true)
     expect(agent2.session?.handle).toEqual(res1.data.handle)
     expect(agent2.session?.did).toEqual(res1.data.did)
-    assert(isValidDidDoc(res1.data.didDoc))
-    expect(agent2.api.xrpc.uri.origin).toEqual(getPdsEndpoint(res1.data.didDoc))
 
     const { data: sessionInfo } =
       await agent2.api.com.atproto.server.getSession({})
-    expect(sessionInfo).toMatchObject({
+    expect(sessionInfo).toEqual({
       did: res1.data.did,
       handle: res1.data.handle,
       email: res1.data.email,
       emailConfirmed: false,
     })
-    expect(isValidDidDoc(sessionInfo.didDoc)).toBe(true)
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create')

--- a/packages/pds/src/api/proxy.ts
+++ b/packages/pds/src/api/proxy.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import * as express from 'express'
 import AtpAgent from '@atproto/api'
 import { Headers, XRPCError } from '@atproto/xrpc'
@@ -38,6 +39,14 @@ export const proxy = async <T>(
     }
     throw err
   }
+}
+
+export const getStreamingRequestInit = (body: Readable): RequestInit => {
+  const reqInit: RequestInit & { duplex: string } = {
+    body: Readable.toWeb(body),
+    duplex: 'half',
+  }
+  return reqInit
 }
 
 export const isThisPds = (

--- a/packages/pds/tests/entryway.test.ts
+++ b/packages/pds/tests/entryway.test.ts
@@ -12,8 +12,7 @@ import {
 } from '@atproto/dev-env'
 import { ids } from '@atproto/api/src/client/lexicons'
 
-// @TODO temporarily skipping while createAccount inputs settle
-describe.skip('entryway', () => {
+describe('entryway', () => {
   let plc: TestPlc
   let entryway: TestPds
   let entrywayAgent: AtpAgent


### PR DESCRIPTION
 - Entryway allows streaming blob uploads to pds.
 - Entryway redirects to backing pds on get-blobs.
 - Entryway create account endpoint handling the pds-behind-entryway flow (did + plc op, no email + password) for testing purposes.  Re-enable entryway tests.