### PR TITLE
PDS v2 entryway account deletion

### DIFF
--- a/lexicons/com/atproto/admin/deleteAccount.json
+++ b/lexicons/com/atproto/admin/deleteAccount.json
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.deleteAccount",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Delete a user account as an administrator.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -8,6 +8,7 @@ import {
 import { schemas } from './lexicons'
 import { CID } from 'multiformats/cid'
 import * as ComAtprotoAdminDefs from './types/com/atproto/admin/defs'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -148,6 +149,7 @@ import * as AppBskyUnspeccedSearchActorsSkeleton from './types/app/bsky/unspecce
 import * as AppBskyUnspeccedSearchPostsSkeleton from './types/app/bsky/unspecced/searchPostsSkeleton'
 
 export * as ComAtprotoAdminDefs from './types/com/atproto/admin/defs'
+export * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 export * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 export * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 export * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -375,6 +377,17 @@ export class AdminNS {
 
   constructor(service: AtpServiceClient) {
     this._service = service
+  }
+
+  deleteAccount(
+    data?: ComAtprotoAdminDeleteAccount.InputSchema,
+    opts?: ComAtprotoAdminDeleteAccount.CallOptions,
+  ): Promise<ComAtprotoAdminDeleteAccount.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.deleteAccount', opts?.qp, data, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminDeleteAccount.toKnownErr(e)
+      })
   }
 
   disableAccountInvites(

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7700,6 +7723,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/api/src/client/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/api/src/client/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,32 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+  qp?: QueryParams
+  encoding: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -9,6 +9,7 @@ import {
   StreamAuthVerifier,
 } from '@atproto/xrpc-server'
 import { schemas } from './lexicons'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -198,6 +199,17 @@ export class AdminNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  deleteAccount<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminDeleteAccount.Handler<ExtractAuth<AV>>,
+      ComAtprotoAdminDeleteAccount.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.deleteAccount' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   disableAccountInvites<AV extends AuthVerifier>(

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7700,6 +7723,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,38 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/api/com/atproto/admin/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,19 @@
+import { AuthRequiredError } from '@atproto/xrpc-server'
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.admin.deleteAccount({
+    auth: ctx.authVerifier.role,
+    handler: async ({ input, auth }) => {
+      if (!auth.credentials.admin) {
+        throw new AuthRequiredError('Must be an admin to delete an account')
+      }
+      const { did } = input.body
+      await ctx.actorStore.destroy(did)
+      await ctx.accountManager.deleteAccount(did)
+      await ctx.sequencer.sequenceTombstone(did)
+      await ctx.sequencer.deleteAllForUser(did)
+    },
+  })
+}

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -20,6 +20,7 @@ import getInviteCodes from './getInviteCodes'
 import updateAccountHandle from './updateAccountHandle'
 import updateAccountEmail from './updateAccountEmail'
 import sendEmail from './sendEmail'
+import deleteAccount from './deleteAccount'
 
 export default function (server: Server, ctx: AppContext) {
   resolveModerationReports(server, ctx)
@@ -42,4 +43,5 @@ export default function (server: Server, ctx: AppContext) {
   updateAccountHandle(server, ctx)
   updateAccountEmail(server, ctx)
   sendEmail(server, ctx)
+  deleteAccount(server, ctx)
 }

--- a/packages/pds/src/api/com/atproto/admin/sendEmail.ts
+++ b/packages/pds/src/api/com/atproto/admin/sendEmail.ts
@@ -17,7 +17,7 @@ export default function (server: Server, ctx: AppContext) {
         subject = 'Message from Bluesky moderator',
       } = input.body
       const account = await ctx.accountManager.getAccount(recipientDid)
-      if (!account?.email) {
+      if (!account) {
         throw new InvalidRequestError('Recipient not found')
       }
 

--- a/packages/pds/src/api/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteAccount.ts
@@ -1,17 +1,31 @@
-import { AuthRequiredError } from '@atproto/xrpc-server'
+import { MINUTE } from '@atproto/common'
+import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
-import { MINUTE } from '@atproto/common'
+import { authPassthru } from '../../../proxy'
 
-// @TODO create a similar admin endpoint to support entryway usage
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.deleteAccount({
     rateLimit: {
       durationMs: 5 * MINUTE,
       points: 50,
     },
-    handler: async ({ input }) => {
+    handler: async ({ input, req }) => {
       const { did, password, token } = input.body
+
+      const account = await ctx.accountManager.getAccount(did, true)
+      if (!account) {
+        throw new InvalidRequestError('account not found')
+      }
+
+      if (ctx.entrywayAgent) {
+        await ctx.entrywayAgent.com.atproto.server.deleteAccount(
+          input.body,
+          authPassthru(req, true),
+        )
+        return
+      }
+
       const validPass = await ctx.accountManager.verifyAccountPassword(
         did,
         password,

--- a/packages/pds/src/api/com/atproto/server/requestAccountDelete.ts
+++ b/packages/pds/src/api/com/atproto/server/requestAccountDelete.ts
@@ -9,7 +9,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, req }) => {
       const did = auth.credentials.did
       const account = await ctx.accountManager.getAccount(did)
-      if (!account?.email) {
+      if (!account) {
         throw new InvalidRequestError('account not found')
       }
 

--- a/packages/pds/src/api/com/atproto/server/requestEmailUpdate.ts
+++ b/packages/pds/src/api/com/atproto/server/requestEmailUpdate.ts
@@ -9,7 +9,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, req }) => {
       const did = auth.credentials.did
       const account = await ctx.accountManager.getAccount(did)
-      if (!account?.email) {
+      if (!account) {
         throw new InvalidRequestError('account not found')
       }
 

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -9,6 +9,7 @@ import {
   StreamAuthVerifier,
 } from '@atproto/xrpc-server'
 import { schemas } from './lexicons'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -198,6 +199,17 @@ export class AdminNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  deleteAccount<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminDeleteAccount.Handler<ExtractAuth<AV>>,
+      ComAtprotoAdminDeleteAccount.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.deleteAccount' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   disableAccountInvites<AV extends AuthVerifier>(

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7700,6 +7723,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,38 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput


### PR DESCRIPTION
Implements a new `com.atproto.admin.deleteAccount` endpoint on pds v2.  This supports account deletion across a pds and its entryway.  The proposed flow for account deletion  across a pds and its entryway is:
```
pds(server.deleteAccount)            [dumb proxy to entryway]
  -> entryway(server.deleteAccount)  [performs acct deletion on entryway then calls to pds]
  -> pds(admin.deleteAccount)        [performs acct deletion on pds]
```

