### PR TITLE
Entryway-to-pds account deletion flow

### DIFF
--- a/lexicons/com/atproto/admin/deleteAccount.json
+++ b/lexicons/com/atproto/admin/deleteAccount.json
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.deleteAccount",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Delete a user account as an administrator.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -8,6 +8,7 @@ import {
 import { schemas } from './lexicons'
 import { CID } from 'multiformats/cid'
 import * as ComAtprotoAdminDefs from './types/com/atproto/admin/defs'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -145,6 +146,7 @@ import * as AppBskyUnspeccedSearchActorsSkeleton from './types/app/bsky/unspecce
 import * as AppBskyUnspeccedSearchPostsSkeleton from './types/app/bsky/unspecced/searchPostsSkeleton'
 
 export * as ComAtprotoAdminDefs from './types/com/atproto/admin/defs'
+export * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 export * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 export * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 export * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -367,6 +369,17 @@ export class AdminNS {
 
   constructor(service: AtpServiceClient) {
     this._service = service
+  }
+
+  deleteAccount(
+    data?: ComAtprotoAdminDeleteAccount.InputSchema,
+    opts?: ComAtprotoAdminDeleteAccount.CallOptions,
+  ): Promise<ComAtprotoAdminDeleteAccount.Response> {
+    return this._service.xrpc
+      .call('com.atproto.admin.deleteAccount', opts?.qp, data, opts)
+      .catch((e) => {
+        throw ComAtprotoAdminDeleteAccount.toKnownErr(e)
+      })
   }
 
   disableAccountInvites(

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7574,6 +7597,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/api/src/client/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/api/src/client/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,32 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+  qp?: QueryParams
+  encoding: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -9,6 +9,7 @@ import {
   StreamAuthVerifier,
 } from '@atproto/xrpc-server'
 import { schemas } from './lexicons'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -193,6 +194,17 @@ export class AdminNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  deleteAccount<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminDeleteAccount.Handler<ExtractAuth<AV>>,
+      ComAtprotoAdminDeleteAccount.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.deleteAccount' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   disableAccountInvites<AV extends AuthVerifier>(

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7574,6 +7597,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,38 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -2,7 +2,7 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { UserPreference } from '../../../../services/account'
 import { InvalidRequestError } from '@atproto/xrpc-server'
-import { authPassthru, proxy } from '../../../proxy'
+import { authPassthru, ensureThisPds, proxy } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.actor.putPreferences({
@@ -21,6 +21,8 @@ export default function (server: Server, ctx: AppContext) {
       if (proxied !== null) {
         return proxied
       }
+
+      ensureThisPds(ctx, auth.credentials.pdsDid)
 
       const { preferences } = input.body
       const requester = auth.credentials.did

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -1,6 +1,11 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
-import { authPassthru, proxy, resultPassthru } from '../../../proxy'
+import {
+  authPassthru,
+  ensureThisPds,
+  proxy,
+  resultPassthru,
+} from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.moderation.createReport({
@@ -20,6 +25,8 @@ export default function (server: Server, ctx: AppContext) {
       if (proxied !== null) {
         return proxied
       }
+
+      ensureThisPds(ctx, auth.credentials.pdsDid)
 
       const requester = auth.credentials.did
       const { data: result } =

--- a/packages/pds/src/api/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteAccount.ts
@@ -1,8 +1,13 @@
 import { MINUTE } from '@atproto/common'
-import { AuthRequiredError, UpstreamFailureError } from '@atproto/xrpc-server'
+import {
+  AuthRequiredError,
+  InvalidRequestError,
+  UpstreamFailureError,
+} from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { isThisPds } from '../../../proxy'
+import { retryHttp } from '../../../../util/retry'
 
 const REASON_ACCT_DELETION = 'account_deletion'
 
@@ -14,19 +19,24 @@ export default function (server: Server, ctx: AppContext) {
     },
     handler: async ({ input, req }) => {
       const { did, password, token } = input.body
-      const validPass = await ctx.services
-        .account(ctx.db)
-        .verifyAccountPassword(did, password)
+      const accountService = ctx.services.account(ctx.db)
+      const validPass = await accountService.verifyAccountPassword(
+        did,
+        password,
+      )
       if (!validPass) {
         throw new AuthRequiredError('Invalid did or password')
       }
 
-      await ctx.services
-        .account(ctx.db)
-        .assertValidToken(did, 'delete_account', token)
+      const account = await accountService.getAccount(did, true)
+      if (!account) {
+        throw new InvalidRequestError('account not found', 'AccountNotFound')
+      }
+
+      await accountService.assertValidToken(did, 'delete_account', token)
 
       await ctx.db.transaction(async (dbTxn) => {
-        const accountService = ctx.services.account(dbTxn)
+        const accountTxn = ctx.services.account(dbTxn)
         const moderationTxn = ctx.services.moderation(dbTxn)
         const currState = await moderationTxn.getRepoTakedownState(did)
         // Do not disturb an existing takedown, continue with account deletion
@@ -36,38 +46,45 @@ export default function (server: Server, ctx: AppContext) {
             ref: REASON_ACCT_DELETION,
           })
         }
-        await accountService.deleteEmailToken(did, 'delete_account')
+        await accountTxn.deleteEmailToken(did, 'delete_account')
       })
 
-      ctx.backgroundQueue.add(async (db) => {
-        // in the background perform the hard account deletion work
+      const { pdsDid } = account
+      if (ctx.cfg.service.isEntryway && pdsDid && !isThisPds(ctx, pdsDid)) {
         try {
-          const recordService = ctx.services.record(db)
-          const repoService = ctx.services.repo(db)
-          const accountService = ctx.services.account(db)
-          const account = await accountService.getAccount(did, true)
-          const pdsDid = account?.pdsDid
-          await recordService.deleteForActor(did)
-          await repoService.deleteRepo(did)
-          await accountService.deleteAccount(did)
-          // propagate to pds behind entryway, or sequence tombstone on this pds
-          if (ctx.cfg.service.isEntryway && pdsDid && !isThisPds(ctx, pdsDid)) {
-            const pds = await accountService.getPds(pdsDid, { cached: true })
-            if (!pds) {
-              throw new UpstreamFailureError('unknown pds')
-            }
-            // both entryway and pds behind it need to clean-up account state, then pds sequences tombstone.
-            // the long flow is: pds(server.deleteAccount) -> entryway(server.deleteAccount) -> pds(admin.deleteAccount)
-            const agent = ctx.pdsAgents.get(pds.host)
-            await agent.com.atproto.admin.deleteAccount(
+          const pds = await accountService.getPds(pdsDid, { cached: true })
+          if (!pds) {
+            throw new UpstreamFailureError('unknown pds')
+          }
+          // both entryway and pds behind it need to clean-up account state, then pds sequences tombstone.
+          // the long flow is: pds(server.deleteAccount) -> entryway(server.deleteAccount) -> pds(admin.deleteAccount)
+          const agent = ctx.pdsAgents.get(pds.host)
+          await retryHttp(() =>
+            agent.com.atproto.admin.deleteAccount(
               { did },
               {
                 encoding: 'application/json',
                 headers: ctx.authVerifier.createAdminRoleHeaders(),
               },
-            )
-          } else {
-            await accountService.sequenceTombstone(did)
+            ),
+          )
+        } catch (err) {
+          req.log.error(
+            { did, pdsDid, err },
+            'account deletion failed on pds behind entryway',
+          )
+        }
+      }
+
+      ctx.backgroundQueue.add(async (db) => {
+        // in the background perform the hard account deletion work
+        try {
+          await ctx.services.record(db).deleteForActor(did)
+          await ctx.services.repo(db).deleteRepo(did)
+          await ctx.services.account(db).deleteAccount(did)
+          if (!ctx.cfg.service.isEntryway || isThisPds(ctx, pdsDid)) {
+            // if this is the user's pds sequence the tombstone, otherwise taken care of by their pds behind the entryway.
+            await ctx.services.account(db).sequenceTombstone(did)
           }
         } catch (err) {
           req.log.error({ did, err }, 'account deletion failed')

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -9,6 +9,7 @@ import {
   StreamAuthVerifier,
 } from '@atproto/xrpc-server'
 import { schemas } from './lexicons'
+import * as ComAtprotoAdminDeleteAccount from './types/com/atproto/admin/deleteAccount'
 import * as ComAtprotoAdminDisableAccountInvites from './types/com/atproto/admin/disableAccountInvites'
 import * as ComAtprotoAdminDisableInviteCodes from './types/com/atproto/admin/disableInviteCodes'
 import * as ComAtprotoAdminEnableAccountInvites from './types/com/atproto/admin/enableAccountInvites'
@@ -193,6 +194,17 @@ export class AdminNS {
 
   constructor(server: Server) {
     this._server = server
+  }
+
+  deleteAccount<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoAdminDeleteAccount.Handler<ExtractAuth<AV>>,
+      ComAtprotoAdminDeleteAccount.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.admin.deleteAccount' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 
   disableAccountInvites<AV extends AuthVerifier>(

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -710,6 +710,29 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoAdminDeleteAccount: {
+    lexicon: 1,
+    id: 'com.atproto.admin.deleteAccount',
+    defs: {
+      main: {
+        type: 'procedure',
+        description: 'Delete a user account as an administrator.',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['did'],
+            properties: {
+              did: {
+                type: 'string',
+                format: 'did',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   ComAtprotoAdminDisableAccountInvites: {
     lexicon: 1,
     id: 'com.atproto.admin.disableAccountInvites',
@@ -7574,6 +7597,7 @@ export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',
+  ComAtprotoAdminDeleteAccount: 'com.atproto.admin.deleteAccount',
   ComAtprotoAdminDisableAccountInvites:
     'com.atproto.admin.disableAccountInvites',
   ComAtprotoAdminDisableInviteCodes: 'com.atproto.admin.disableInviteCodes',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -1,0 +1,38 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+
+export interface QueryParams {}
+
+export interface InputSchema {
+  did: string
+  [k: string]: unknown
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | void
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -387,6 +387,13 @@ export class AccountService {
       .execute()
   }
 
+  async sequenceTombstone(did: string): Promise<void> {
+    const seqEvt = await sequencer.formatSeqTombstone(did)
+    await this.db.transaction(async (txn) => {
+      await sequencer.sequenceEvt(txn, seqEvt)
+    })
+  }
+
   async adminView(did: string): Promise<AccountView | null> {
     const accountQb = this.db.db
       .selectFrom('did_handle')

--- a/packages/pds/src/services/account/index.ts
+++ b/packages/pds/src/services/account/index.ts
@@ -385,10 +385,6 @@ export class AccountService {
       .deleteFrom('did_handle')
       .where('did_handle.did', '=', did)
       .execute()
-    const seqEvt = await sequencer.formatSeqTombstone(did)
-    await this.db.transaction(async (txn) => {
-      await sequencer.sequenceEvt(txn, seqEvt)
-    })
   }
 
   async adminView(did: string): Promise<AccountView | null> {

--- a/packages/pds/src/util/retry.ts
+++ b/packages/pds/src/util/retry.ts
@@ -1,0 +1,65 @@
+// @NOTE nabbed from @atproto/bsky utils. not DRYing it up now to avoid big fork between main and entryway.
+import { wait } from '@atproto/common'
+import { ResponseType, XRPCError } from '@atproto/xrpc'
+
+export async function retry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const { max = 3, retryable = () => true } = opts
+  let retries = 0
+  let doneError: unknown
+  while (!doneError) {
+    try {
+      if (retries) await backoff(retries)
+      return await fn()
+    } catch (err) {
+      const willRetry = retries < max && retryable(err)
+      if (!willRetry) doneError = err
+      retries += 1
+    }
+  }
+  throw doneError
+}
+
+export async function retryHttp<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  return retry(fn, { retryable: retryableHttp, ...opts })
+}
+
+export function retryableHttp(err: unknown) {
+  if (err instanceof XRPCError) {
+    if (err.status === ResponseType.Unknown) return true
+    return retryableHttpStatusCodes.has(err.status)
+  }
+  return false
+}
+
+const retryableHttpStatusCodes = new Set([
+  408, 425, 429, 500, 502, 503, 504, 522, 524,
+])
+
+type RetryOptions = {
+  max?: number
+  retryable?: (err: unknown) => boolean
+}
+
+// Waits exponential backoff with max and jitter: ~50, ~100, ~200, ~400, ~800, ~1000, ~1000, ...
+async function backoff(n: number, multiplier = 50, max = 1000) {
+  const exponentialMs = Math.pow(2, n) * multiplier
+  const ms = Math.min(exponentialMs, max)
+  await wait(jitter(ms))
+}
+
+// Adds randomness +/-15% of value
+function jitter(value: number) {
+  const delta = value * 0.15
+  return value + randomRange(-delta, delta)
+}
+
+function randomRange(from: number, to: number) {
+  const rand = Math.random() * (to - from)
+  return rand + from
+}

--- a/packages/pds/tests/sync/subscribe-repos.test.ts
+++ b/packages/pds/tests/sync/subscribe-repos.test.ts
@@ -351,6 +351,7 @@ describe('repo subscribe repos', () => {
       await ctx.services.record(db).deleteForActor(did)
       await ctx.services.repo(db).deleteRepo(did)
       await ctx.services.account(db).deleteAccount(did)
+      await ctx.services.account(db).sequenceTombstone(did)
     }
 
     const ws = new WebSocket(
@@ -381,6 +382,7 @@ describe('repo subscribe repos', () => {
     await ctx.services.record(db).deleteForActor(baddie3)
     await ctx.services.repo(db).deleteRepo(baddie3)
     await ctx.services.account(db).deleteAccount(baddie3)
+    await ctx.services.account(db).sequenceTombstone(baddie3)
 
     const ws = new WebSocket(
       `ws://${serverHost}/xrpc/com.atproto.sync.subscribeRepos?cursor=${-1}`,


### PR DESCRIPTION
Pairs with #1819 to implement the account deletion flow between the pds and its entryway.  This work contains the work done on the entryway.  Also contains a couple additional `ensureThisPds()` calls where possible to ensure all preferences and reports are being channeled to the pds properly right after a migration.