### PR TITLE
fix(pds): include aspectRatio on read-sticky posts

### DIFF
--- a/packages/pds/src/services/local/index.ts
+++ b/packages/pds/src/services/local/index.ts
@@ -220,6 +220,7 @@ export class LocalService {
           did,
           img.image.ref.toString(),
         ),
+        aspectRatio: img.aspectRatio,
         alt: img.alt,
       }))
       return {

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -141,6 +141,7 @@ describe('proxy read after write', () => {
           images: [
             {
               image: img.image,
+              aspectRatio: { height: 2, width: 1 },
               alt: 'alt text',
             },
           ],
@@ -190,6 +191,7 @@ describe('proxy read after write', () => {
         img.image.ref.toString(),
       ),
     )
+    expect(imgs.images[0].aspectRatio).toEqual({ height: 2, width: 1 })
     expect(replies[0].replies?.length).toBe(1)
     // @ts-ignore
     expect(replies[0].replies[0].post.uri).toEqual(replyRes2.uri)

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -192,6 +192,7 @@ describe('proxy read after write', () => {
       ),
     )
     expect(imgs.images[0].aspectRatio).toEqual({ height: 2, width: 1 })
+    expect(imgs.images[0].alt).toBe('alt text')
     expect(replies[0].replies?.length).toBe(1)
     // @ts-ignore
     expect(replies[0].replies[0].post.uri).toEqual(replyRes2.uri)


### PR DESCRIPTION
- adds missing `aspectRatio` property when providing read-sticky posts
- adds missing test case for alt text