### PR TITLE
Security: prevent timing attack

### DIFF
--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -1565,10 +1565,14 @@ type RouteRateLimitOpts<T> = {
   calcPoints?: (ctx: T) => number
 }
 type HandlerRateLimitOpts<T> = SharedRateLimitOpts<T> | RouteRateLimitOpts<T>
+type HandlerTimingOpts = {
+  constant?: number
+}
 type ConfigOf<Auth, Handler, ReqCtx> =
   | Handler
   | {
       auth?: Auth
+      timing?: HandlerTimingOpts
       rateLimit?: HandlerRateLimitOpts<ReqCtx> | HandlerRateLimitOpts<ReqCtx>[]
       handler: Handler
     }

--- a/packages/lex-cli/src/codegen/server.ts
+++ b/packages/lex-cli/src/codegen/server.ts
@@ -210,6 +210,13 @@ const indexTs = (
     })
 
     file.addTypeAlias({
+      name: 'HandlerTimingOpts',
+      type: `{
+        constant?: number
+      }`,
+    })
+
+    file.addTypeAlias({
       name: 'ConfigOf',
       typeParameters: [
         { name: 'Auth' },
@@ -220,6 +227,7 @@ const indexTs = (
         | Handler
         | {
           auth?: Auth
+          timing?: HandlerTimingOpts
           rateLimit?: HandlerRateLimitOpts<ReqCtx> | HandlerRateLimitOpts<ReqCtx>[]
           handler: Handler
         }`,

--- a/packages/pds/src/api/com/atproto/server/createSession.ts
+++ b/packages/pds/src/api/com/atproto/server/createSession.ts
@@ -19,6 +19,7 @@ export default function (server: Server, ctx: AppContext) {
         calcKey: ({ input, req }) => `${input.body.identifier}-${req.ip}`,
       },
     ],
+    timing: { constant: 500 },
     handler: async ({ input }) => {
       const { password } = input.body
       const identifier = input.body.identifier.toLowerCase()

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -1565,10 +1565,14 @@ type RouteRateLimitOpts<T> = {
   calcPoints?: (ctx: T) => number
 }
 type HandlerRateLimitOpts<T> = SharedRateLimitOpts<T> | RouteRateLimitOpts<T>
+type HandlerTimingOpts = {
+  constant?: number
+}
 type ConfigOf<Auth, Handler, ReqCtx> =
   | Handler
   | {
       auth?: Auth
+      timing?: HandlerTimingOpts
       rateLimit?: HandlerRateLimitOpts<ReqCtx> | HandlerRateLimitOpts<ReqCtx>[]
       handler: Handler
     }

--- a/packages/xrpc-server/src/timing.ts
+++ b/packages/xrpc-server/src/timing.ts
@@ -1,0 +1,28 @@
+import { wait } from '@atproto/common'
+
+export type TimingOpts<A extends [...unknown[]] = []> = {
+  constant?: number
+  constantExceeded?: (
+    info: { duration: number; expected: number },
+    ...args: A
+  ) => void
+}
+
+export function withTiming<T, A extends [...unknown[]], R>(
+  fn: (this: T, ...args: A) => R | Promise<R>,
+  { constant, constantExceeded }: TimingOpts<A>,
+): (this: T, ...args: A) => Promise<R> {
+  return async function (...args) {
+    const start = Date.now()
+    try {
+      return await fn.call(this, ...args)
+    } finally {
+      const duration = Date.now() - start
+
+      if (constant) {
+        if (duration < constant) await wait(constant - duration)
+        else constantExceeded?.({ duration, expected: constant }, ...args)
+      }
+    }
+  }
+}

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -65,7 +65,7 @@ export type XRPCReqContext = {
 
 export type XRPCHandler = (
   ctx: XRPCReqContext,
-) => Promise<HandlerOutput> | HandlerOutput | undefined
+) => Promise<HandlerOutput | undefined> | HandlerOutput | undefined
 
 export type XRPCStreamHandler = (ctx: {
   auth: HandlerAuth | undefined
@@ -143,9 +143,14 @@ export type RateLimiterStatus = {
   isFirstInDuration: boolean
 }
 
+export type HandlerTimingOpts = {
+  constant?: number
+}
+
 export type XRPCHandlerConfig = {
   rateLimit?: HandlerRateLimitOpts | HandlerRateLimitOpts[]
   auth?: AuthVerifier
+  timing?: HandlerTimingOpts
   handler: XRPCHandler
 }
 


### PR DESCRIPTION
In the current implementation; a timing attack can be used to deduce if a particular email or identifier is being used on a particulat PDS. This PR mitigates this attack by ensuring that the `createSession` handler always takes the same amount of time.