### PR TITLE
Randomize suggestions

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -71,10 +71,13 @@ const skeleton = async (
   const rest = suggestions.filter((row) => row.order !== 1 && row.order !== 2)
   const limited = firstTwo.concat(shuffle(rest)).slice(0, params.limit)
 
-  const cursor = limited
-    .map((row) => row.order.toString())
-    .concat(alreadyIncluded.map((id) => id.toString()))
-    .join(':')
+  const cursor =
+    limited.length > 0
+      ? limited
+          .map((row) => row.order.toString())
+          .concat(alreadyIncluded.map((id) => id.toString()))
+          .join(':')
+      : undefined
 
   return { params, suggestions: limited, cursor }
 }

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -71,6 +71,7 @@ const skeleton = async (
   const rest = suggestions.filter((row) => row.order !== 1 && row.order !== 2)
   const limited = firstTwo.concat(shuffle(rest)).slice(0, params.limit)
 
+  // if the result set ends up getting larger, consider using a seed included in the cursor for for the randomized shuffle
   const cursor =
     limited.length > 0
       ? limited
@@ -117,7 +118,10 @@ const parseCursor = (cursor?: string): number[] => {
     return []
   }
   try {
-    return cursor.split(':').map((id) => parseInt(id))
+    return cursor
+      .split(':')
+      .map((id) => parseInt(id, 10))
+      .filter((id) => !isNaN(id))
   } catch {
     return []
   }

--- a/packages/bsky/tests/views/suggestions.test.ts
+++ b/packages/bsky/tests/views/suggestions.test.ts
@@ -80,8 +80,10 @@ describe('pds user search views', () => {
       { headers: await network.serviceHeaders(sc.dids.carol) },
     )
     expect(result3.data.actors.length).toBe(0)
-    expect(result2.data.cursor).toBeUndefined()
+    expect(result3.data.cursor).toBeUndefined()
   })
+
+  return
 
   it('fetches suggestions unauthed', async () => {
     const { data: authed } = await agent.api.app.bsky.actor.getSuggestions(

--- a/packages/bsky/tests/views/suggestions.test.ts
+++ b/packages/bsky/tests/views/suggestions.test.ts
@@ -19,10 +19,12 @@ describe('pds user search views', () => {
     await network.bsky.processAll()
 
     const suggestions = [
-      { did: sc.dids.bob, order: 1 },
-      { did: sc.dids.carol, order: 2 },
-      { did: sc.dids.dan, order: 3 },
+      { did: sc.dids.alice, order: 1 },
+      { did: sc.dids.bob, order: 2 },
+      { did: sc.dids.carol, order: 3 },
+      { did: sc.dids.dan, order: 4 },
     ]
+
     await network.bsky.ctx.db
       .getPrimary()
       .db.insertInto('suggested_follow')
@@ -63,16 +65,22 @@ describe('pds user search views', () => {
       { limit: 1 },
       { headers: await network.serviceHeaders(sc.dids.carol) },
     )
+    expect(result1.data.actors.length).toBe(1)
+    expect(result1.data.actors[0].handle).toEqual('bob.test')
+
     const result2 = await agent.api.app.bsky.actor.getSuggestions(
       { limit: 1, cursor: result1.data.cursor },
       { headers: await network.serviceHeaders(sc.dids.carol) },
     )
-
-    expect(result1.data.actors.length).toBe(1)
-    expect(result1.data.actors[0].handle).toEqual('bob.test')
-
     expect(result2.data.actors.length).toBe(1)
     expect(result2.data.actors[0].handle).toEqual('dan.test')
+
+    const result3 = await agent.api.app.bsky.actor.getSuggestions(
+      { limit: 1, cursor: result2.data.cursor },
+      { headers: await network.serviceHeaders(sc.dids.carol) },
+    )
+    expect(result3.data.actors.length).toBe(0)
+    expect(result2.data.cursor).toBeUndefined()
   })
 
   it('fetches suggestions unauthed', async () => {

--- a/packages/bsky/tests/views/suggestions.test.ts
+++ b/packages/bsky/tests/views/suggestions.test.ts
@@ -83,8 +83,6 @@ describe('pds user search views', () => {
     expect(result3.data.cursor).toBeUndefined()
   })
 
-  return
-
   it('fetches suggestions unauthed', async () => {
     const { data: authed } = await agent.api.app.bsky.actor.getSuggestions(
       {},

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -114,7 +114,7 @@ Object {
       },
     },
   ],
-  "cursor": "user(2)",
+  "cursor": "1:3",
 }
 `;
 


### PR DESCRIPTION
Return randomized suggestions instead of always in order.

However, always return the first two in order - bsky.app & atproto.com in our case

Since this breaks our previous pagination mechanism which relied on order, we prevent duplicate results by building a cursor out of all previously included ids concatenated together.