### PR TITLE
Send ticks during import

### DIFF
--- a/packages/common-web/src/async.ts
+++ b/packages/common-web/src/async.ts
@@ -132,6 +132,7 @@ export class AsyncBuffer<T> {
 
   throw(err: unknown) {
     this.toThrow = err
+    this.closed = true
     this.resolve()
   }
 

--- a/packages/common-web/src/async.ts
+++ b/packages/common-web/src/async.ts
@@ -90,6 +90,10 @@ export class AsyncBuffer<T> {
     return this.buffer.length
   }
 
+  get isClosed(): boolean {
+    return this.closed
+  }
+
   resetPromise() {
     this.promise = new Promise<void>((r) => (this.resolve = r))
   }


### PR DESCRIPTION
The connection for import may be getting aborted because the PDS is doing work and does not send data fast enough to keep the connection open.

This introduces a simple mechanism to send data on the connection at least every second to try to ensure that it stays alive