### PR TITLE
Add a note to README about depending on jq and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ make build
 make test
 
 # run a local PDS and AppView with fake test accounts and data
+# (this requires a global installation of `jq` and `docker`)
 make run-dev-env
 
 # show all other commands


### PR DESCRIPTION
You find that out when you try to run the command, but IMO an explicit mention in README always helps adjust expectations.