### PR TITLE
Pass along hitsTotal and cursor from searchPostsSkeleton

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -55,6 +55,7 @@ const skeleton = async (
     params,
     postUris: res.data.posts.map((a) => a.uri),
     cursor: res.data.cursor,
+    hitsTotal: res.data.hitsTotal,
   }
 }
 
@@ -104,7 +105,7 @@ const presentation = (state: HydrationState, ctx: Context) => {
       state.lists,
     ),
   )
-  return { posts: postViews }
+  return { posts: postViews, cursor: state.cursor, hitsTotal: state.hitsTotal }
 }
 
 type Context = {
@@ -119,6 +120,7 @@ type Params = QueryParams & { viewer: string | null }
 type SkeletonState = {
   params: Params
   postUris: string[]
+  hitsTotal?: number
   cursor?: string
 }
 


### PR DESCRIPTION
We weren't passing along additional output data from `searchPostsSkeleton`

Closes https://github.com/bluesky-social/atproto/issues/1856