### PR TITLE
Add temp.fetchLabels method

### DIFF
--- a/lexicons/com/atproto/temp/fetchLabels.json
+++ b/lexicons/com/atproto/temp/fetchLabels.json
@@ -1,0 +1,35 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.temp.fetchLabels",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Find labels relevant to the provided URI patterns.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "since": { "type": "integer" },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 250,
+            "default": 50
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["labels"],
+          "properties": {
+            "labels": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/temp/fetchLabels.json
+++ b/lexicons/com/atproto/temp/fetchLabels.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Find labels relevant to the provided URI patterns.",
+      "description": "Fetch all labels from a labeler created after a certain date.",
       "parameters": {
         "type": "params",
         "properties": {

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -78,6 +78,7 @@ import * as ComAtprotoSyncListRepos from './types/com/atproto/sync/listRepos'
 import * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
 import * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 import * as ComAtprotoSyncSubscribeRepos from './types/com/atproto/sync/subscribeRepos'
+import * as ComAtprotoTempFetchLabels from './types/com/atproto/temp/fetchLabels'
 import * as AppBskyActorDefs from './types/app/bsky/actor/defs'
 import * as AppBskyActorGetPreferences from './types/app/bsky/actor/getPreferences'
 import * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
@@ -215,6 +216,7 @@ export * as ComAtprotoSyncListRepos from './types/com/atproto/sync/listRepos'
 export * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
 export * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 export * as ComAtprotoSyncSubscribeRepos from './types/com/atproto/sync/subscribeRepos'
+export * as ComAtprotoTempFetchLabels from './types/com/atproto/temp/fetchLabels'
 export * as AppBskyActorDefs from './types/app/bsky/actor/defs'
 export * as AppBskyActorGetPreferences from './types/app/bsky/actor/getPreferences'
 export * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
@@ -349,6 +351,7 @@ export class AtprotoNS {
   repo: RepoNS
   server: ServerNS
   sync: SyncNS
+  temp: TempNS
 
   constructor(service: AtpServiceClient) {
     this._service = service
@@ -359,6 +362,7 @@ export class AtprotoNS {
     this.repo = new RepoNS(service)
     this.server = new ServerNS(service)
     this.sync = new SyncNS(service)
+    this.temp = new TempNS(service)
   }
 }
 
@@ -1118,6 +1122,25 @@ export class SyncNS {
       .call('com.atproto.sync.requestCrawl', opts?.qp, data, opts)
       .catch((e) => {
         throw ComAtprotoSyncRequestCrawl.toKnownErr(e)
+      })
+  }
+}
+
+export class TempNS {
+  _service: AtpServiceClient
+
+  constructor(service: AtpServiceClient) {
+    this._service = service
+  }
+
+  fetchLabels(
+    params?: ComAtprotoTempFetchLabels.QueryParams,
+    opts?: ComAtprotoTempFetchLabels.CallOptions,
+  ): Promise<ComAtprotoTempFetchLabels.Response> {
+    return this._service.xrpc
+      .call('com.atproto.temp.fetchLabels', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoTempFetchLabels.toKnownErr(e)
       })
   }
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3901,7 +3901,8 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'Find labels relevant to the provided URI patterns.',
+        description:
+          'Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3895,6 +3895,46 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoTempFetchLabels: {
+    lexicon: 1,
+    id: 'com.atproto.temp.fetchLabels',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Find labels relevant to the provided URI patterns.',
+        parameters: {
+          type: 'params',
+          properties: {
+            since: {
+              type: 'integer',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 250,
+              default: 50,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['labels'],
+            properties: {
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.label.defs#label',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyActorDefs: {
     lexicon: 1,
     id: 'app.bsky.actor.defs',
@@ -7659,6 +7699,7 @@ export const ids = {
   ComAtprotoSyncNotifyOfUpdate: 'com.atproto.sync.notifyOfUpdate',
   ComAtprotoSyncRequestCrawl: 'com.atproto.sync.requestCrawl',
   ComAtprotoSyncSubscribeRepos: 'com.atproto.sync.subscribeRepos',
+  ComAtprotoTempFetchLabels: 'com.atproto.temp.fetchLabels',
   AppBskyActorDefs: 'app.bsky.actor.defs',
   AppBskyActorGetPreferences: 'app.bsky.actor.getPreferences',
   AppBskyActorGetProfile: 'app.bsky.actor.getProfile',

--- a/packages/api/src/client/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/api/src/client/types/com/atproto/temp/fetchLabels.ts
@@ -1,0 +1,37 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { Headers, XRPCError } from '@atproto/xrpc'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { isObj, hasProp } from '../../../../util'
+import { lexicons } from '../../../../lexicons'
+import { CID } from 'multiformats/cid'
+import * as ComAtprotoLabelDefs from '../label/defs'
+
+export interface QueryParams {
+  since?: number
+  limit?: number
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export interface CallOptions {
+  headers?: Headers
+}
+
+export interface Response {
+  success: boolean
+  headers: Headers
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+  }
+  return e
+}

--- a/packages/bsky/src/api/com/atproto/temp/fetchLabels.ts
+++ b/packages/bsky/src/api/com/atproto/temp/fetchLabels.ts
@@ -1,0 +1,25 @@
+import { Server } from '../../../../lexicon'
+import AppContext from '../../../../context'
+
+export default function (server: Server, ctx: AppContext) {
+  server.com.atproto.temp.fetchLabels(async ({ params }) => {
+    const { limit } = params
+    const db = ctx.db.getReplica()
+    const since =
+      params.since !== undefined ? new Date(params.since).toISOString() : ''
+    const labels = await db.db
+      .selectFrom('label')
+      .selectAll()
+      .orderBy('label.cts', 'asc')
+      .where('cts', '>', since)
+      .limit(limit)
+      .execute()
+
+    return {
+      encoding: 'application/json',
+      body: {
+        labels,
+      },
+    }
+  })
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -53,6 +53,7 @@ import getModerationReport from './com/atproto/admin/getModerationReport'
 import getModerationReports from './com/atproto/admin/getModerationReports'
 import resolveHandle from './com/atproto/identity/resolveHandle'
 import getRecord from './com/atproto/repo/getRecord'
+import fetchLabels from './com/atproto/temp/fetchLabels'
 
 export * as health from './health'
 
@@ -116,5 +117,6 @@ export default function (server: Server, ctx: AppContext) {
   getModerationReports(server, ctx)
   resolveHandle(server, ctx)
   getRecord(server, ctx)
+  fetchLabels(server, ctx)
   return server
 }

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -75,6 +75,7 @@ import * as ComAtprotoSyncListRepos from './types/com/atproto/sync/listRepos'
 import * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
 import * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 import * as ComAtprotoSyncSubscribeRepos from './types/com/atproto/sync/subscribeRepos'
+import * as ComAtprotoTempFetchLabels from './types/com/atproto/temp/fetchLabels'
 import * as AppBskyActorGetPreferences from './types/app/bsky/actor/getPreferences'
 import * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
 import * as AppBskyActorGetProfiles from './types/app/bsky/actor/getProfiles'
@@ -175,6 +176,7 @@ export class AtprotoNS {
   repo: RepoNS
   server: ServerNS
   sync: SyncNS
+  temp: TempNS
 
   constructor(server: Server) {
     this._server = server
@@ -185,6 +187,7 @@ export class AtprotoNS {
     this.repo = new RepoNS(server)
     this.server = new ServerNS(server)
     this.sync = new SyncNS(server)
+    this.temp = new TempNS(server)
   }
 }
 
@@ -967,6 +970,25 @@ export class SyncNS {
   ) {
     const nsid = 'com.atproto.sync.subscribeRepos' // @ts-ignore
     return this._server.xrpc.streamMethod(nsid, cfg)
+  }
+}
+
+export class TempNS {
+  _server: Server
+
+  constructor(server: Server) {
+    this._server = server
+  }
+
+  fetchLabels<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoTempFetchLabels.Handler<ExtractAuth<AV>>,
+      ComAtprotoTempFetchLabels.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.temp.fetchLabels' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3901,7 +3901,8 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'Find labels relevant to the provided URI patterns.',
+        description:
+          'Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3895,6 +3895,46 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoTempFetchLabels: {
+    lexicon: 1,
+    id: 'com.atproto.temp.fetchLabels',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Find labels relevant to the provided URI patterns.',
+        parameters: {
+          type: 'params',
+          properties: {
+            since: {
+              type: 'integer',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 250,
+              default: 50,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['labels'],
+            properties: {
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.label.defs#label',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyActorDefs: {
     lexicon: 1,
     id: 'app.bsky.actor.defs',
@@ -7659,6 +7699,7 @@ export const ids = {
   ComAtprotoSyncNotifyOfUpdate: 'com.atproto.sync.notifyOfUpdate',
   ComAtprotoSyncRequestCrawl: 'com.atproto.sync.requestCrawl',
   ComAtprotoSyncSubscribeRepos: 'com.atproto.sync.subscribeRepos',
+  ComAtprotoTempFetchLabels: 'com.atproto.temp.fetchLabels',
   AppBskyActorDefs: 'app.bsky.actor.defs',
   AppBskyActorGetPreferences: 'app.bsky.actor.getPreferences',
   AppBskyActorGetProfile: 'app.bsky.actor.getProfile',

--- a/packages/bsky/src/lexicon/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/temp/fetchLabels.ts
@@ -1,0 +1,47 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoLabelDefs from '../label/defs'
+
+export interface QueryParams {
+  since?: number
+  limit: number
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -75,6 +75,7 @@ import * as ComAtprotoSyncListRepos from './types/com/atproto/sync/listRepos'
 import * as ComAtprotoSyncNotifyOfUpdate from './types/com/atproto/sync/notifyOfUpdate'
 import * as ComAtprotoSyncRequestCrawl from './types/com/atproto/sync/requestCrawl'
 import * as ComAtprotoSyncSubscribeRepos from './types/com/atproto/sync/subscribeRepos'
+import * as ComAtprotoTempFetchLabels from './types/com/atproto/temp/fetchLabels'
 import * as AppBskyActorGetPreferences from './types/app/bsky/actor/getPreferences'
 import * as AppBskyActorGetProfile from './types/app/bsky/actor/getProfile'
 import * as AppBskyActorGetProfiles from './types/app/bsky/actor/getProfiles'
@@ -175,6 +176,7 @@ export class AtprotoNS {
   repo: RepoNS
   server: ServerNS
   sync: SyncNS
+  temp: TempNS
 
   constructor(server: Server) {
     this._server = server
@@ -185,6 +187,7 @@ export class AtprotoNS {
     this.repo = new RepoNS(server)
     this.server = new ServerNS(server)
     this.sync = new SyncNS(server)
+    this.temp = new TempNS(server)
   }
 }
 
@@ -967,6 +970,25 @@ export class SyncNS {
   ) {
     const nsid = 'com.atproto.sync.subscribeRepos' // @ts-ignore
     return this._server.xrpc.streamMethod(nsid, cfg)
+  }
+}
+
+export class TempNS {
+  _server: Server
+
+  constructor(server: Server) {
+    this._server = server
+  }
+
+  fetchLabels<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      ComAtprotoTempFetchLabels.Handler<ExtractAuth<AV>>,
+      ComAtprotoTempFetchLabels.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'com.atproto.temp.fetchLabels' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
   }
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3901,7 +3901,8 @@ export const schemaDict = {
     defs: {
       main: {
         type: 'query',
-        description: 'Find labels relevant to the provided URI patterns.',
+        description:
+          'Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3895,6 +3895,46 @@ export const schemaDict = {
       },
     },
   },
+  ComAtprotoTempFetchLabels: {
+    lexicon: 1,
+    id: 'com.atproto.temp.fetchLabels',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Find labels relevant to the provided URI patterns.',
+        parameters: {
+          type: 'params',
+          properties: {
+            since: {
+              type: 'integer',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 250,
+              default: 50,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['labels'],
+            properties: {
+              labels: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:com.atproto.label.defs#label',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyActorDefs: {
     lexicon: 1,
     id: 'app.bsky.actor.defs',
@@ -7659,6 +7699,7 @@ export const ids = {
   ComAtprotoSyncNotifyOfUpdate: 'com.atproto.sync.notifyOfUpdate',
   ComAtprotoSyncRequestCrawl: 'com.atproto.sync.requestCrawl',
   ComAtprotoSyncSubscribeRepos: 'com.atproto.sync.subscribeRepos',
+  ComAtprotoTempFetchLabels: 'com.atproto.temp.fetchLabels',
   AppBskyActorDefs: 'app.bsky.actor.defs',
   AppBskyActorGetPreferences: 'app.bsky.actor.getPreferences',
   AppBskyActorGetProfile: 'app.bsky.actor.getProfile',

--- a/packages/pds/src/lexicon/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/temp/fetchLabels.ts
@@ -1,0 +1,47 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import express from 'express'
+import { ValidationResult, BlobRef } from '@atproto/lexicon'
+import { lexicons } from '../../../../lexicons'
+import { isObj, hasProp } from '../../../../util'
+import { CID } from 'multiformats/cid'
+import { HandlerAuth } from '@atproto/xrpc-server'
+import * as ComAtprotoLabelDefs from '../label/defs'
+
+export interface QueryParams {
+  since?: number
+  limit: number
+}
+
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  labels: ComAtprotoLabelDefs.Label[]
+  [k: string]: unknown
+}
+
+export type HandlerInput = undefined
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+export type HandlerReqCtx<HA extends HandlerAuth = never> = {
+  auth: HA
+  params: QueryParams
+  input: HandlerInput
+  req: express.Request
+  res: express.Response
+}
+export type Handler<HA extends HandlerAuth = never> = (
+  ctx: HandlerReqCtx<HA>,
+) => Promise<HandlerOutput> | HandlerOutput


### PR DESCRIPTION
This is a temporary method for fetching all labels from a labeler based on time.

This is being introduced in lieu of [`com.atproto.label.subscribeLabels`](https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/label/subscribeLabels.json) to avoid implemented a new streaming interface on the current appview. However, the expectation is that it will be used in a similar manner - to stay up to date with a given labeler's entire label set.