### PR TITLE
Bugfix: fetchLabels

### DIFF
--- a/packages/bsky/src/api/com/atproto/temp/fetchLabels.ts
+++ b/packages/bsky/src/api/com/atproto/temp/fetchLabels.ts
@@ -7,13 +7,18 @@ export default function (server: Server, ctx: AppContext) {
     const db = ctx.db.getReplica()
     const since =
       params.since !== undefined ? new Date(params.since).toISOString() : ''
-    const labels = await db.db
+    const labelRes = await db.db
       .selectFrom('label')
       .selectAll()
       .orderBy('label.cts', 'asc')
       .where('cts', '>', since)
       .limit(limit)
       .execute()
+
+    const labels = labelRes.map((l) => ({
+      ...l,
+      cid: l.cid === '' ? undefined : l.cid,
+    }))
 
     return {
       encoding: 'application/json',

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -60,7 +60,7 @@ export function decodeQueryParam(
   if (type === 'float') {
     return Number(String(value))
   } else if (type === 'integer') {
-    return Number(String(value)) | 0
+    return Number(String(value)) || 0
   } else if (type === 'boolean') {
     return value === 'true'
   }

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -60,7 +60,7 @@ export function decodeQueryParam(
   if (type === 'float') {
     return Number(String(value))
   } else if (type === 'integer') {
-    return Number(String(value)) || 0
+    return parseInt(String(value), 10) || 0
   } else if (type === 'boolean') {
     return value === 'true'
   }

--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -115,7 +115,6 @@ export class ServiceClient {
         this.baseClient.lex.assertValidXrpcOutput(methodNsid, res.body)
       } catch (e: any) {
         if (e instanceof ValidationError) {
-          console.log(e)
           throw new XRPCInvalidResponseError(methodNsid, e, res.body)
         } else {
           throw e

--- a/packages/xrpc/src/client.ts
+++ b/packages/xrpc/src/client.ts
@@ -115,6 +115,7 @@ export class ServiceClient {
         this.baseClient.lex.assertValidXrpcOutput(methodNsid, res.body)
       } catch (e: any) {
         if (e instanceof ValidationError) {
+          console.log(e)
           throw new XRPCInvalidResponseError(methodNsid, e, res.body)
         } else {
           throw e


### PR DESCRIPTION
Two issues: 
- we weren't correctly formatting undefined cids on method output
- for large integer query params were getting messed up by an xrpc util - we were using the bitwise OR operator (`|`) instead of the logical OR operator (`||`) to recover from unparseable numbers