### PR TITLE
Async car reader

### DIFF
--- a/packages/repo/src/util.ts
+++ b/packages/repo/src/util.ts
@@ -94,12 +94,10 @@ export const carToBlocks = async (
 ): Promise<{ roots: CID[]; blocks: BlockMap }> => {
   const roots = await car.getRoots()
   const blocks = new BlockMap()
-  if (car._iterable) {
-    for await (const block of verifyIncomingCarBlocks(car._iterable)) {
-      blocks.set(block.cid, block.bytes)
-      // break up otherwise "synchronous" work in car parsing
-      await setImmediate()
-    }
+  for await (const block of verifyIncomingCarBlocks(car)) {
+    blocks.set(block.cid, block.bytes)
+    // break up otherwise "synchronous" work in car parsing
+    await setImmediate()
   }
   return {
     roots,


### PR DESCRIPTION
`CarReader` reads and parses the whole car file before iterating over blocks. This reading and parsing, though async, does not leave room for event loop scheduling, so we break it up with `setImmediate`.

As well, we undo a change that I made that buffered the whole car file before parsing and instead just pass the car stream into the reader