### PR TITLE
Fix role auth for access-or-role verifier, getBlob check on actor takedowns

### DIFF
--- a/packages/pds/src/api/com/atproto/sync/getBlob.ts
+++ b/packages/pds/src/api/com/atproto/sync/getBlob.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
   server.com.atproto.sync.getBlob({
     auth: ctx.authVerifier.optionalAccessOrRole,
     handler: async ({ params, res, auth }) => {
-      if (ctx.authVerifier.isUserOrAdmin(auth, params.did)) {
+      if (!ctx.authVerifier.isUserOrAdmin(auth, params.did)) {
         const available = await ctx.accountManager.isRepoAvailable(params.did)
         if (!available) {
           throw new InvalidRequestError('Blob not found')

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -195,15 +195,15 @@ export class AuthVerifier {
       return await this.access(ctx)
     } else {
       const creds = this.parseRoleCreds(ctx.req)
-      if (creds.status === RoleStatus.Missing) {
-        return { credentials: null }
-      } else if (creds.admin) {
+      if (creds.status === RoleStatus.Valid) {
         return {
           credentials: {
             ...creds,
             type: 'role',
           },
         }
+      } else if (creds.status === RoleStatus.Missing) {
+        return { credentials: null }
       } else {
         throw new AuthRequiredError()
       }


### PR DESCRIPTION
Two fixes here on pds v2:
 - Ensure the access-or-role auth verifier works with non-admin roles.
 - Ensure taken down actors can fetch their own blobs, admins can fetch their blobs, and others cannot fetch their blobs.