### PR TITLE
App-level retries for sqlite on pds

### DIFF
--- a/packages/common-web/tests/retry.test.ts
+++ b/packages/common-web/tests/retry.test.ts
@@ -1,0 +1,93 @@
+import { retry } from '../src/index'
+
+describe('retry', () => {
+  describe('retry()', () => {
+    it('retries until max retries', async () => {
+      let fnCalls = 0
+      let waitMsCalls = 0
+      const fn = async () => {
+        fnCalls++
+        throw new Error(`Oops ${fnCalls}!`)
+      }
+      const getWaitMs = (retries) => {
+        waitMsCalls++
+        expect(retries).toEqual(waitMsCalls - 1)
+        return 0
+      }
+      await expect(retry(fn, { maxRetries: 13, getWaitMs })).rejects.toThrow(
+        'Oops 14!',
+      )
+      expect(fnCalls).toEqual(14)
+      expect(waitMsCalls).toEqual(14)
+    })
+
+    it('retries until max wait', async () => {
+      let fnCalls = 0
+      let waitMsCalls = 0
+      const fn = async () => {
+        fnCalls++
+        throw new Error(`Oops ${fnCalls}!`)
+      }
+      const getWaitMs = (retries) => {
+        waitMsCalls++
+        expect(retries).toEqual(waitMsCalls - 1)
+        if (retries === 13) {
+          return null
+        }
+        return 0
+      }
+      await expect(
+        retry(fn, { maxRetries: Infinity, getWaitMs }),
+      ).rejects.toThrow('Oops 14!')
+      expect(fnCalls).toEqual(14)
+      expect(waitMsCalls).toEqual(14)
+    })
+
+    it('retries until non-retryable error', async () => {
+      let fnCalls = 0
+      let waitMsCalls = 0
+      const fn = async () => {
+        fnCalls++
+        throw new Error(`Oops ${fnCalls}!`)
+      }
+      const getWaitMs = (retries) => {
+        waitMsCalls++
+        expect(retries).toEqual(waitMsCalls - 1)
+        return 0
+      }
+      const retryable = (err: unknown) => err?.['message'] !== 'Oops 14!'
+      await expect(
+        retry(fn, { maxRetries: Infinity, getWaitMs, retryable }),
+      ).rejects.toThrow('Oops 14!')
+      expect(fnCalls).toEqual(14)
+      expect(waitMsCalls).toEqual(14)
+    })
+
+    it('returns latest result after retries', async () => {
+      let fnCalls = 0
+      const fn = async () => {
+        fnCalls++
+        if (fnCalls < 14) {
+          throw new Error(`Oops ${fnCalls}!`)
+        }
+        return 'ok'
+      }
+      const getWaitMs = () => 0
+      const result = await retry(fn, { maxRetries: Infinity, getWaitMs })
+      expect(result).toBe('ok')
+      expect(fnCalls).toBe(14)
+    })
+
+    it('returns result immediately on success', async () => {
+      let fnCalls = 0
+      const fn = async () => {
+        fnCalls++
+        return 'ok'
+      }
+      const getWaitMs = () => 0
+      const result = await retry(fn, { maxRetries: Infinity, getWaitMs })
+      expect(result).toBe('ok')
+      expect(fnCalls).toBe(1)
+    })
+  })
+})

--- a/packages/pds/src/account-manager/helpers/repo.ts
+++ b/packages/pds/src/account-manager/helpers/repo.ts
@@ -7,16 +7,18 @@ export const updateRoot = async (
   cid: CID,
   rev: string,
 ) => {
-  await db.db
-    .insertInto('repo_root')
-    .values({
-      did,
-      cid: cid.toString(),
-      rev,
-      indexedAt: new Date().toISOString(),
-    })
-    .onConflict((oc) =>
-      oc.column('did').doUpdateSet({ cid: cid.toString(), rev }),
-    )
-    .execute()
+  // @TODO balance risk of a race in the case of a long retry
+  await db.executeWithRetry(
+    db.db
+      .insertInto('repo_root')
+      .values({
+        did,
+        cid: cid.toString(),
+        rev,
+        indexedAt: new Date().toISOString(),
+      })
+      .onConflict((oc) =>
+        oc.column('did').doUpdateSet({ cid: cid.toString(), rev }),
+      ),
+  )
 }

--- a/packages/pds/src/account-manager/index.ts
+++ b/packages/pds/src/account-manager/index.ts
@@ -26,6 +26,7 @@ export class AccountManager {
   }
 
   async migrateOrThrow() {
+    await this.db.ensureWal()
     await getMigrator(this.db).migrateToLatestOrThrow()
   }
 

--- a/packages/pds/src/actor-store/index.ts
+++ b/packages/pds/src/actor-store/index.ts
@@ -106,6 +106,7 @@ export class ActorStore {
 
     const db: ActorDb = getDb(dbLocation, this.cfg.disableWalAutoCheckpoint)
     try {
+      await db.ensureWal()
       const migrator = getMigrator(db)
       await migrator.migrateToLatestOrThrow()
     } finally {

--- a/packages/pds/src/actor-store/record/transactor.ts
+++ b/packages/pds/src/actor-store/record/transactor.ts
@@ -74,12 +74,6 @@ export class RecordTransactor extends RecordReader {
     log.info({ uri }, 'deleted indexed record')
   }
 
-  async deleteForActor(_did: string) {
-    // Not done in transaction because it would be too long, prone to contention.
-    // Also, this can safely be run multiple times if it fails.
-    await this.db.db.deleteFrom('record').execute()
-  }
-
   async removeBacklinksByUri(uri: AtUri) {
     await this.db.db
       .deleteFrom('backlink')

--- a/packages/pds/src/db/db.ts
+++ b/packages/pds/src/db/db.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import {
+  sql,
   Kysely,
   SqliteDialect,
   KyselyPlugin,
@@ -14,8 +15,7 @@ import { dbLogger } from '../logger'
 import { retrySqlite } from './util'
 
 const DEFAULT_PRAGMAS = {
-  journal_mode: 'WAL',
-  strict: 'ON',
+  strict: 'ON', // @TODO strictness should live on table defs instead
 }
 
 export class Database<Schema> {
@@ -44,6 +44,10 @@ export class Database<Schema> {
       }),
     })
     return new Database(db)
+  }
+
+  async ensureWal() {
+    await sql`PRAGMA journal_mode = WAL`.execute(this.db)
   }
 
   async transactionNoRetry<T>(

--- a/packages/pds/src/db/db.ts
+++ b/packages/pds/src/db/db.ts
@@ -79,6 +79,14 @@ export class Database<Schema> {
     return retrySqlite(() => this.transactionNoRetry(fn))
   }
 
+  async executeWithRetry<T>(query: { execute: () => Promise<T> }) {
+    if (this.isTransaction) {
+      // transaction() ensures retry on entire transaction, no need to retry individual statements.
+      return query.execute()
+    }
+    return retrySqlite(() => query.execute())
+  }
+
   onCommit(fn: () => void) {
     this.assertTransaction()
     this.commitHooks.push(fn)

--- a/packages/pds/src/db/util.ts
+++ b/packages/pds/src/db/util.ts
@@ -1,3 +1,4 @@
+import { retry } from '@atproto/common'
 import {
   DummyDriver,
   DynamicModule,
@@ -46,6 +47,42 @@ export const dummyDialect = {
     return new SqliteQueryCompiler()
   },
 }
+
+export const retrySqlite = <T>(fn: () => Promise<T>): Promise<T> => {
+  return retry(fn, {
+    retryable: retryableSqlite,
+    getWaitMs: getWaitMsSqlite,
+    maxRetries: 60, // a safety measure: getWaitMsSqlite() times out before this after 5000ms of waiting.
+  })
+}
+
+const retryableSqlite = (err: unknown) => {
+  return typeof err?.['code'] === 'string' && RETRY_ERRORS.has(err['code'])
+}
+
+// based on sqlite's backoff strategy https://github.com/sqlite/sqlite/blob/91c8e65dd4bf17d21fbf8f7073565fe1a71c8948/src/main.c#L1704-L1713
+const getWaitMsSqlite = (n: number, timeout = 5000) => {
+  if (n < 0) return null
+  let delay: number
+  let prior: number
+  if (n < DELAYS.length) {
+    delay = DELAYS[n]
+    prior = TOTALS[n]
+  } else {
+    delay = last(DELAYS)
+    prior = last(TOTALS) + delay * (n - (DELAYS.length - 1))
+  }
+  if (prior + delay > timeout) {
+    delay = timeout - prior
+    if (delay <= 0) return null
+  }
+  return delay
+}
+
+const last = <T>(arr: T[]) => arr[arr.length - 1]
+const DELAYS = [1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50, 100]
+const TOTALS = [0, 1, 3, 8, 18, 33, 53, 78, 103, 128, 178, 228]
+const RETRY_ERRORS = new Set(['SQLITE_BUSY', 'SQLITE_BUSY_SNAPSHOT'])
 
 export type Ref = ReferenceExpression<any, any>
 

--- a/packages/pds/src/did-cache/index.ts
+++ b/packages/pds/src/did-cache/index.ts
@@ -116,6 +116,7 @@ export class DidSqliteCache implements DidCache {
   }
 
   async migrateOrThrow() {
+    await this.db.ensureWal()
     await getMigrator(this.db).migrateToLatestOrThrow()
   }
 

--- a/packages/pds/src/did-cache/index.ts
+++ b/packages/pds/src/did-cache/index.ts
@@ -25,23 +25,25 @@ export class DidSqliteCache implements DidCache {
   ): Promise<void> {
     try {
       if (prevResult) {
-        await this.db.db
-          .updateTable('did_doc')
-          .set({ doc: JSON.stringify(doc), updatedAt: Date.now() })
-          .where('did', '=', did)
-          .where('updatedAt', '=', prevResult.updatedAt)
-          .execute()
+        await this.db.executeWithRetry(
+          this.db.db
+            .updateTable('did_doc')
+            .set({ doc: JSON.stringify(doc), updatedAt: Date.now() })
+            .where('did', '=', did)
+            .where('updatedAt', '=', prevResult.updatedAt),
+        )
       } else {
-        await this.db.db
-          .insertInto('did_doc')
-          .values({ did, doc: JSON.stringify(doc), updatedAt: Date.now() })
-          .onConflict((oc) =>
-            oc.column('did').doUpdateSet({
-              doc: excluded(this.db.db, 'doc'),
-              updatedAt: excluded(this.db.db, 'updatedAt'),
-            }),
-          )
-          .executeTakeFirst()
+        await this.db.executeWithRetry(
+          this.db.db
+            .insertInto('did_doc')
+            .values({ did, doc: JSON.stringify(doc), updatedAt: Date.now() })
+            .onConflict((oc) =>
+              oc.column('did').doUpdateSet({
+                doc: excluded(this.db.db, 'doc'),
+                updatedAt: excluded(this.db.db, 'updatedAt'),
+              }),
+            ),
+        )
       }
     } catch (err) {
       didCacheLogger.error({ did, doc, err }, 'failed to cache did')
@@ -98,10 +100,9 @@ export class DidSqliteCache implements DidCache {
 
   async clearEntry(did: string): Promise<void> {
     try {
-      await this.db.db
-        .deleteFrom('did_doc')
-        .where('did', '=', did)
-        .executeTakeFirst()
+      await this.db.executeWithRetry(
+        this.db.db.deleteFrom('did_doc').where('did', '=', did),
+      )
     } catch (err) {
       didCacheLogger.error({ did, err }, 'clearing did cache entry failed')
     }

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -43,6 +43,7 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
   }
 
   async start() {
+    await this.db.ensureWal()
     const migrator = getMigrator(this.db)
     await migrator.migrateToLatestOrThrow()
     const curr = await this.curr()

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -189,7 +189,9 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
   }
 
   async sequenceEvt(evt: RepoSeqInsert) {
-    await this.db.db.insertInto('repo_seq').values(evt).execute()
+    await this.db.executeWithRetry(
+      this.db.db.insertInto('repo_seq').values(evt),
+    )
     this.crawlers.notifyOfUpdate()
   }
 
@@ -213,11 +215,12 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
   }
 
   async deleteAllForUser(did: string) {
-    await this.db.db
-      .deleteFrom('repo_seq')
-      .where('did', '=', did)
-      .where('eventType', '!=', 'tombstone')
-      .execute()
+    await this.db.executeWithRetry(
+      this.db.db
+        .deleteFrom('repo_seq')
+        .where('did', '=', did)
+        .where('eventType', '!=', 'tombstone'),
+    )
   }
 }
 


### PR DESCRIPTION
The issue with sqlite's busy timeout is that it may cause unnecessary blocking in the node process.  This moves sqlite's busy timeout handling up into the application, using the same backoff/retry approach that sqlite itself employs.

 - Run transactions with busy handling.
 - Run writes outside of transactions with busy handling.
 - Move WAL mode outside of db opening, into the db creation/migration process.  This avoids a "long" (sub-millisecond) block that occurs every time a db is opened.
 - Refactor retry helper to allow different backoff strategies including max timeouts, add tests.

Some portions of this will be easier to review [ignoring whitespace changes](https://github.com/bluesky-social/atproto/pull/1871/files?w=1).