### PR TITLE
Support unauthed usage of feeds

### DIFF
--- a/packages/bsky/src/auth.ts
+++ b/packages/bsky/src/auth.ts
@@ -28,14 +28,18 @@ export const authVerifier =
     return { credentials: { did: payload.iss }, artifacts: { aud: opts.aud } }
   }
 
-export const authOptionalVerifier =
-  (idResolver: IdResolver, opts: { aud: string | null }) =>
-  async (reqCtx: { req: express.Request; res: express.Response }) => {
+export const authOptionalVerifier = (
+  idResolver: IdResolver,
+  opts: { aud: string | null },
+) => {
+  const verify = authVerifier(idResolver, opts)
+  return async (reqCtx: { req: express.Request; res: express.Response }) => {
     if (!reqCtx.req.headers.authorization) {
       return { credentials: { did: null } }
     }
-    return authVerifier(idResolver, opts)(reqCtx)
+    return verify(reqCtx)
   }
+}
 
 export const authOptionalAccessOrRoleVerifier = (
   idResolver: IdResolver,

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -94,6 +94,10 @@ export class AppContext {
     return auth.authVerifier(this.idResolver, { aud: null })
   }
 
+  get authOptionalVerifierAnyAudience() {
+    return auth.authOptionalVerifier(this.idResolver, { aud: null })
+  }
+
   get authOptionalVerifier() {
     return auth.authOptionalVerifier(this.idResolver, {
       aud: this.cfg.serverDid,

--- a/packages/bsky/src/feed-gen/best-of-follows.ts
+++ b/packages/bsky/src/feed-gen/best-of-follows.ts
@@ -1,4 +1,4 @@
-import { InvalidRequestError } from '@atproto/xrpc-server'
+import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { QueryParams as SkeletonParams } from '../lexicon/types/app/bsky/feed/getFeedSkeleton'
 import { AlgoHandler, AlgoResponse } from './types'
 import { GenericKeyset, paginate } from '../db/pagination'
@@ -7,12 +7,15 @@ import AppContext from '../context'
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  viewer: string,
+  viewer: string | null,
 ): Promise<AlgoResponse> => {
+  if (!viewer) {
+    throw new AuthRequiredError('This feed requires being logged-in')
+  }
+
   const { limit, cursor } = params
   const db = ctx.db.getReplica('feed')
   const feedService = ctx.services.feed(db)
-
   const { ref } = db.db.dynamic
 
   // candidates are ranked within a materialized view by like count, depreciated over time.

--- a/packages/bsky/src/feed-gen/bsky-team.ts
+++ b/packages/bsky/src/feed-gen/bsky-team.ts
@@ -14,7 +14,7 @@ const BSKY_TEAM: NotEmptyArray<string> = [
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  _viewer: string,
+  _viewer: string | null,
 ): Promise<AlgoResponse> => {
   const { limit = 50, cursor } = params
   const db = ctx.db.getReplica('feed')

--- a/packages/bsky/src/feed-gen/hot-classic.ts
+++ b/packages/bsky/src/feed-gen/hot-classic.ts
@@ -11,7 +11,7 @@ const NO_WHATS_HOT_LABELS: NotEmptyArray<string> = ['!no-promote']
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  _viewer: string,
+  _viewer: string | null,
 ): Promise<AlgoResponse> => {
   const { limit = 50, cursor } = params
   const db = ctx.db.getReplica('feed')

--- a/packages/bsky/src/feed-gen/mutuals.ts
+++ b/packages/bsky/src/feed-gen/mutuals.ts
@@ -3,16 +3,20 @@ import AppContext from '../context'
 import { paginate } from '../db/pagination'
 import { AlgoHandler, AlgoResponse } from './types'
 import { FeedKeyset, getFeedDateThreshold } from '../api/app/bsky/util/feed'
+import { AuthRequiredError } from '@atproto/xrpc-server'
 
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  viewer: string,
+  viewer: string | null,
 ): Promise<AlgoResponse> => {
+  if (!viewer) {
+    throw new AuthRequiredError('This feed requires being logged-in')
+  }
+
   const { limit = 50, cursor } = params
   const db = ctx.db.getReplica('feed')
   const feedService = ctx.services.feed(db)
-
   const { ref } = db.db.dynamic
 
   const mutualsSubquery = db.db

--- a/packages/bsky/src/feed-gen/types.ts
+++ b/packages/bsky/src/feed-gen/types.ts
@@ -11,7 +11,7 @@ export type AlgoResponse = {
 export type AlgoHandler = (
   ctx: AppContext,
   params: SkeletonParams,
-  requester: string,
+  viewer: string | null,
 ) => Promise<AlgoResponse>
 
 export type MountedAlgos = Record<string, AlgoHandler>

--- a/packages/bsky/src/feed-gen/whats-hot.ts
+++ b/packages/bsky/src/feed-gen/whats-hot.ts
@@ -21,7 +21,7 @@ const NO_WHATS_HOT_LABELS: NotEmptyArray<string> = [
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  _viewer: string,
+  _viewer: string | null,
 ): Promise<AlgoResponse> => {
   const { limit, cursor } = params
   const db = ctx.db.getReplica('feed')

--- a/packages/bsky/src/feed-gen/with-friends.ts
+++ b/packages/bsky/src/feed-gen/with-friends.ts
@@ -3,16 +3,20 @@ import { QueryParams as SkeletonParams } from '../lexicon/types/app/bsky/feed/ge
 import { paginate } from '../db/pagination'
 import { AlgoHandler, AlgoResponse } from './types'
 import { FeedKeyset, getFeedDateThreshold } from '../api/app/bsky/util/feed'
+import { AuthRequiredError } from '@atproto/xrpc-server'
 
 const handler: AlgoHandler = async (
   ctx: AppContext,
   params: SkeletonParams,
-  requester: string,
+  viewer: string | null,
 ): Promise<AlgoResponse> => {
+  if (!viewer) {
+    throw new AuthRequiredError('This feed requires being logged-in')
+  }
+
   const { cursor, limit = 50 } = params
   const db = ctx.db.getReplica('feed')
   const feedService = ctx.services.feed(db)
-
   const { ref } = db.db.dynamic
 
   const keyset = new FeedKeyset(ref('post.sortAt'), ref('post.cid'))
@@ -23,7 +27,7 @@ const handler: AlgoHandler = async (
     .innerJoin('follow', 'follow.subjectDid', 'post.creator')
     .innerJoin('post_agg', 'post_agg.uri', 'post.uri')
     .where('post_agg.likeCount', '>=', 5)
-    .where('follow.creator', '=', requester)
+    .where('follow.creator', '=', viewer)
     .where('post.sortAt', '>', getFeedDateThreshold(sortFrom))
 
   postsQb = paginate(postsQb, { limit, cursor, keyset, tryIndex: true })

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -204,9 +204,9 @@ Array [
         "muted": false,
       },
     },
-    "description": "Provides all feed candidates, blindly ignoring pagination limit",
+    "description": "Provides all feed candidates when authed",
     "did": "user(0)",
-    "displayName": "Bad Pagination",
+    "displayName": "Needs Auth",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "likeCount": 0,
     "uri": "record(4)",
@@ -246,9 +246,9 @@ Array [
         "muted": false,
       },
     },
-    "description": "Provides even-indexed feed candidates",
+    "description": "Provides all feed candidates, blindly ignoring pagination limit",
     "did": "user(0)",
-    "displayName": "Even",
+    "displayName": "Bad Pagination",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "likeCount": 0,
     "uri": "record(5)",
@@ -288,14 +288,56 @@ Array [
         "muted": false,
       },
     },
+    "description": "Provides even-indexed feed candidates",
+    "did": "user(0)",
+    "displayName": "Even",
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "likeCount": 0,
+    "uri": "record(6)",
+    "viewer": Object {},
+  },
+  Object {
+    "cid": "cids(6)",
+    "creator": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(1)@jpeg",
+      "description": "its me!",
+      "did": "user(1)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(1)",
+          "uri": "record(3)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(1)",
+          "uri": "record(3)",
+          "val": "self-label-b",
+        },
+      ],
+      "viewer": Object {
+        "blockedBy": false,
+        "followedBy": "record(2)",
+        "following": "record(1)",
+        "muted": false,
+      },
+    },
     "description": "Provides all feed candidates",
     "did": "user(0)",
     "displayName": "All",
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "likeCount": 2,
-    "uri": "record(6)",
+    "uri": "record(7)",
     "viewer": Object {
-      "like": "record(7)",
+      "like": "record(8)",
     },
   },
 ]
@@ -817,6 +859,280 @@ Array [
         },
       },
       "indexedAt": "1970-01-01T00:00:00.000Z",
+    },
+  },
+]
+`;
+
+exports[`feed generation getFeed resolves basic feed contents without auth. 1`] = `
+Array [
+  Object {
+    "post": Object {
+      "author": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "neg": false,
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "neg": false,
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+      },
+      "cid": "cids(0)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(0)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(0)",
+          "val": "self-label",
+        },
+      ],
+      "likeCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "labels": Object {
+          "$type": "com.atproto.label.defs#selfLabels",
+          "values": Array [
+            Object {
+              "val": "self-label",
+            },
+          ],
+        },
+        "text": "hey there",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "post": Object {
+      "author": Object {
+        "did": "user(2)",
+        "handle": "carol.test",
+        "labels": Array [],
+      },
+      "cid": "cids(3)",
+      "embed": Object {
+        "$type": "app.bsky.embed.recordWithMedia#view",
+        "media": Object {
+          "$type": "app.bsky.embed.images#view",
+          "images": Array [
+            Object {
+              "alt": "tests/sample-img/key-landscape-small.jpg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(4)@jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(4)@jpeg",
+            },
+            Object {
+              "alt": "tests/sample-img/key-alt.jpg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(5)/cids(5)@jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(5)/cids(5)@jpeg",
+            },
+          ],
+        },
+        "record": Object {
+          "record": Object {
+            "$type": "app.bsky.embed.record#viewRecord",
+            "author": Object {
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(1)@jpeg",
+              "did": "user(3)",
+              "displayName": "bobby",
+              "handle": "bob.test",
+              "labels": Array [],
+            },
+            "cid": "cids(6)",
+            "embeds": Array [],
+            "indexedAt": "1970-01-01T00:00:00.000Z",
+            "labels": Array [],
+            "uri": "record(3)",
+            "value": Object {
+              "$type": "app.bsky.feed.post",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "langs": Array [
+                "en-US",
+                "i-klingon",
+              ],
+              "text": "bob back at it again!",
+            },
+          },
+        },
+      },
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 2,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.recordWithMedia",
+          "media": Object {
+            "$type": "app.bsky.embed.images",
+            "images": Array [
+              Object {
+                "alt": "tests/sample-img/key-landscape-small.jpg",
+                "image": Object {
+                  "$type": "blob",
+                  "mimeType": "image/jpeg",
+                  "ref": Object {
+                    "$link": "cids(4)",
+                  },
+                  "size": 4114,
+                },
+              },
+              Object {
+                "alt": "tests/sample-img/key-alt.jpg",
+                "image": Object {
+                  "$type": "blob",
+                  "mimeType": "image/jpeg",
+                  "ref": Object {
+                    "$link": "cids(5)",
+                  },
+                  "size": 12736,
+                },
+              },
+            ],
+          },
+          "record": Object {
+            "record": Object {
+              "cid": "cids(6)",
+              "uri": "record(3)",
+            },
+          },
+        },
+        "text": "hi im carol",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(2)",
+    },
+  },
+  Object {
+    "post": Object {
+      "author": Object {
+        "did": "user(2)",
+        "handle": "carol.test",
+        "labels": Array [],
+      },
+      "cid": "cids(7)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "reply": Object {
+          "parent": Object {
+            "cid": "cids(8)",
+            "uri": "record(5)",
+          },
+          "root": Object {
+            "cid": "cids(8)",
+            "uri": "record(5)",
+          },
+        },
+        "text": "of course",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(4)",
+    },
+    "reply": Object {
+      "parent": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+        },
+        "cid": "cids(8)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(5)",
+      },
+      "root": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "neg": false,
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+        },
+        "cid": "cids(8)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(5)",
+      },
     },
   },
 ]


### PR DESCRIPTION
By making auth optional on `app.bsky.feed.getFeed`, we open the door to public usage of feeds via the appview if the feed chooses to support it.