### PR TITLE
Handle missing creator on lists and feed generators

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
@@ -1,4 +1,5 @@
 import { InvalidRequestError } from '@atproto/xrpc-server'
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { TimeCidKeyset, paginate } from '../../../../db/pagination'
@@ -42,7 +43,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError(`Actor not found: ${actor}`)
       }
 
-      const feeds = feedsRes.map((row) => {
+      const feeds = mapDefined(feedsRes, (row) => {
         const feed = {
           ...row,
           viewer: viewer ? { like: row.viewerLike } : undefined,

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
@@ -55,6 +55,9 @@ export default function (server: Server, ctx: AppContext) {
         feedInfo,
         profiles,
       )
+      if (!feedView) {
+        throw new InvalidRequestError('could not find feed')
+      }
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { FeedGenInfo, FeedService } from '../../../../services/feed'
@@ -60,7 +61,7 @@ const hydration = async (state: SkeletonState, ctx: Context) => {
 
 const presentation = (state: HydrationState, ctx: Context) => {
   const { feedService } = ctx
-  const feeds = state.generators.map((gen) =>
+  const feeds = mapDefined(state.generators, (gen) =>
     feedService.views.formatFeedGeneratorView(gen, state.profiles),
   )
   return { feeds }

--- a/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
@@ -23,7 +24,7 @@ export default function (server: Server, ctx: AppContext) {
       const creators = genList.map((gen) => gen.creator)
       const profiles = await actorService.views.profilesBasic(creators, viewer)
 
-      const feedViews = genList.map((gen) =>
+      const feedViews = mapDefined(genList, (gen) =>
         feedService.views.formatFeedGeneratorView(gen, profiles),
       )
 

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -98,6 +98,9 @@ const presentation = (state: HydrationState, ctx: Context) => {
     throw new InvalidRequestError(`Actor not found: ${list.handle}`)
   }
   const listView = graphService.formatListView(list, actors)
+  if (!listView) {
+    throw new InvalidRequestError('List not found')
+  }
   const items = mapDefined(listItems, (item) => {
     const subject = actors[item.did]
     if (!subject) return

--- a/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/graph/getListBlocks'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
@@ -89,7 +90,7 @@ const presentation = (state: HydrationState, ctx: Context) => {
     profileState,
     params.viewer,
   )
-  const lists = listInfos.map((list) =>
+  const lists = mapDefined(listInfos, (list) =>
     graphService.formatListView(list, actors),
   )
   return { lists, cursor }

--- a/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
 import AppContext from '../../../../context'
@@ -34,7 +35,7 @@ export default function (server: Server, ctx: AppContext) {
       const actorService = ctx.services.actor(db)
       const profiles = await actorService.views.profiles(listsRes, requester)
 
-      const lists = listsRes.map((row) =>
+      const lists = mapDefined(listsRes, (row) =>
         graphService.formatListView(row, profiles),
       )
 

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -1,3 +1,4 @@
+import { mapDefined } from '@atproto/common'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import { paginate, TimeCidKeyset } from '../../../../db/pagination'
@@ -39,7 +40,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError(`Actor not found: ${actor}`)
       }
 
-      const lists = listsRes.map((row) =>
+      const lists = mapDefined(listsRes, (row) =>
         graphService.formatListView(row, profiles),
       )
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -57,7 +57,9 @@ export default function (server: Server, ctx: AppContext) {
         const gen = genInfos[row.uri]
         if (!gen) continue
         const view = feedService.views.formatFeedGeneratorView(gen, profiles)
-        genViews.push(view)
+        if (view) {
+          genViews.push(view)
+        }
       }
 
       return {

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -411,14 +411,26 @@ export class FeedService {
     for (const uri of nestedUris) {
       const collection = new AtUri(uri).collection
       if (collection === ids.AppBskyFeedGenerator && feedGenInfos[uri]) {
-        recordEmbedViews[uri] = {
-          $type: 'app.bsky.feed.defs#generatorView',
-          ...this.views.formatFeedGeneratorView(feedGenInfos[uri], actorInfos),
+        const genView = this.views.formatFeedGeneratorView(
+          feedGenInfos[uri],
+          actorInfos,
+        )
+        if (genView) {
+          recordEmbedViews[uri] = {
+            $type: 'app.bsky.feed.defs#generatorView',
+            ...genView,
+          }
         }
       } else if (collection === ids.AppBskyGraphList && listViews[uri]) {
-        recordEmbedViews[uri] = {
-          $type: 'app.bsky.graph.defs#listView',
-          ...this.services.graph.formatListView(listViews[uri], actorInfos),
+        const listView = this.services.graph.formatListView(
+          listViews[uri],
+          actorInfos,
+        )
+        if (listView) {
+          recordEmbedViews[uri] = {
+            $type: 'app.bsky.graph.defs#listView',
+            ...listView,
+          }
         }
       } else if (collection === ids.AppBskyFeedPost && feedState.posts[uri]) {
         const formatted = this.views.formatPostView(

--- a/packages/bsky/src/services/feed/views.ts
+++ b/packages/bsky/src/services/feed/views.ts
@@ -62,8 +62,11 @@ export class FeedViews {
   formatFeedGeneratorView(
     info: FeedGenInfo,
     profiles: ActorInfoMap,
-  ): GeneratorView {
+  ): GeneratorView | undefined {
     const profile = profiles[info.creator]
+    if (!profile) {
+      return undefined
+    }
     return {
       uri: info.uri,
       cid: info.cid,

--- a/packages/bsky/src/services/graph/index.ts
+++ b/packages/bsky/src/services/graph/index.ts
@@ -4,6 +4,10 @@ import { ImageUriBuilder } from '../../image/uri'
 import { valuesList } from '../../db/util'
 import { ListInfo } from './types'
 import { ActorInfoMap } from '../actor'
+import {
+  ListView,
+  ListViewBasic,
+} from '../../lexicon/types/app/bsky/graph/defs'
 
 export * from './types'
 
@@ -235,7 +239,10 @@ export class GraphService {
     )
   }
 
-  formatListView(list: ListInfo, profiles: ActorInfoMap) {
+  formatListView(list: ListInfo, profiles: ActorInfoMap): ListView | undefined {
+    if (!profiles[list.creator]) {
+      return undefined
+    }
     return {
       ...this.formatListViewBasic(list),
       creator: profiles[list.creator],
@@ -243,10 +250,11 @@ export class GraphService {
       descriptionFacets: list.descriptionFacets
         ? JSON.parse(list.descriptionFacets)
         : undefined,
+      indexedAt: list.sortAt,
     }
   }
 
-  formatListViewBasic(list: ListInfo) {
+  formatListViewBasic(list: ListInfo): ListViewBasic {
     return {
       uri: list.uri,
       cid: list.cid,


### PR DESCRIPTION
When the creator was missing (for instance in the case of a takedown), we were returning improperly formatted list & feed gen views. Now if the creator is missing, we just do not return the relevant view