### PR TITLE
Don't create unnecessary error objects

### DIFF
--- a/.changeset/brave-swans-kiss.md
+++ b/.changeset/brave-swans-kiss.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+prevent unnecessary throw/catch on uri syntax

--- a/packages/syntax/src/aturi_validation.ts
+++ b/packages/syntax/src/aturi_validation.ts
@@ -38,13 +38,13 @@ export const ensureValidAtUri = (uri: string) => {
   }
 
   try {
-    ensureValidHandle(parts[2])
-  } catch {
-    try {
+    if (parts[2].startsWith('did:')) {
       ensureValidDid(parts[2])
-    } catch {
-      throw new Error('ATURI authority must be a valid handle or DID')
+    } else {
+      ensureValidHandle(parts[2])
     }
+  } catch {
+    throw new Error('ATURI authority must be a valid handle or DID')
   }
 
   if (parts.length >= 4) {


### PR DESCRIPTION
Creating error objects is not super cheap because it requires the runtime to capture a stack trace. Currently we're creating a lot of error objects every time we handle a response because of this logic.

This logic tries to validate that something is *either* a DID or a handle by trying to validate one option in a try, and falling back to validating another option in a catch. However, DIDs and handles are mutually exclusive, and we can always tell early which validation function to use. So let's do that so that we don't create throwaway error objects on non-exceptional situations.

## Before

I enabled "pause on caught exceptions" and tried to paginate Notifications.

https://github.com/bluesky-social/atproto/assets/810438/dc62fbc8-c773-44b1-a5de-7b816e81a069

## After

https://github.com/bluesky-social/atproto/assets/810438/ed97c174-6385-4cd6-a243-bcf79586142c

