### PR TITLE
Additional @atproto/api 0.6.24 changeset

### DIFF
--- a/.changeset/spotty-guests-taste.md
+++ b/.changeset/spotty-guests-taste.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Contains breaking lexicon changes: removing legacy com.atproto admin endpoints, making uri field required on app.bsky list views.


### PR DESCRIPTION
> Contains breaking lexicon changes: removing legacy com.atproto admin endpoints, making uri field required on app.bsky list views.