### PR TITLE
Add seenAt time to listNotifications

### DIFF
--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -28,7 +28,8 @@
             "notifications": {
               "type": "array",
               "items": { "type": "ref", "ref": "#notification" }
-            }
+            },
+            "seenAt": { "type": "string", "format": "datetime" }
           }
         }
       }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -7325,6 +7325,10 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.notification.listNotifications#notification',
                 },
               },
+              seenAt: {
+                type: 'string',
+                format: 'datetime',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -20,6 +20,7 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   notifications: Notification[]
+  seenAt?: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -148,7 +148,7 @@ const presentation = (state: HydrationState) => {
       labels: [...recordLabels, ...recordSelfLabels],
     }
   })
-  return { notifications, cursor }
+  return { notifications, cursor, seenAt: lastSeenNotifs }
 }
 
 const getRecordMap = async (

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -7325,6 +7325,10 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.notification.listNotifications#notification',
                 },
               },
+              seenAt: {
+                type: 'string',
+                format: 'datetime',
+              },
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -21,6 +21,7 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   notifications: Notification[]
+  seenAt?: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -176,6 +176,13 @@ describe('notification views', () => {
         encoding: 'application/json',
       },
     )
+    const full2 = await agent.api.app.bsky.notification.listNotifications(
+      {},
+      { headers: await network.serviceHeaders(alice) },
+    )
+    expect(full2.data.notifications.length).toBe(full.data.notifications.length)
+    expect(full2.data.seenAt).toEqual(seenAt)
+
     const notifCount = await agent.api.app.bsky.notification.getUnreadCount(
       {},
       { headers: await network.serviceHeaders(alice) },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -7325,6 +7325,10 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.notification.listNotifications#notification',
                 },
               },
+              seenAt: {
+                type: 'string',
+                format: 'datetime',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -21,6 +21,7 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   notifications: Notification[]
+  seenAt?: string
   [k: string]: unknown
 }
 


### PR DESCRIPTION
Adds the optional field `seenAt` to `listNotifications` which allows a service to inform the client of their currently tracked last seen time.