### PR TITLE
Report separate error on getProfile for account suspension

### DIFF
--- a/packages/bsky/src/services/moderation/index.ts
+++ b/packages/bsky/src/services/moderation/index.ts
@@ -327,6 +327,7 @@ export class ModerationService {
     const res = await this.db.db
       .selectFrom('moderation_subject_status')
       .where('did', '=', did)
+      .where('recordPath', '=', '')
       .where('suspendUntil', '>', new Date().toISOString())
       .select('did')
       .limit(1)

--- a/packages/bsky/src/services/moderation/index.ts
+++ b/packages/bsky/src/services/moderation/index.ts
@@ -323,6 +323,17 @@ export class ModerationService {
     return subjectsDueForReversal
   }
 
+  async isSubjectSuspended(did: string): Promise<boolean> {
+    const res = await this.db.db
+      .selectFrom('moderation_subject_status')
+      .where('did', '=', did)
+      .where('suspendUntil', '>', new Date().toISOString())
+      .select('did')
+      .limit(1)
+      .executeTakeFirst()
+    return !!res
+  }
+
   async revertState({
     createdBy,
     createdAt,


### PR DESCRIPTION
When accessing a takendown profile, check if the takedown is a temporary suspension or permanent