### PR TITLE
Optimize timeline for limit=1

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - timeline-limit-1-opt
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/bsky/tests/views/timeline.test.ts
+++ b/packages/bsky/tests/views/timeline.test.ts
@@ -154,6 +154,20 @@ describe('timeline views', () => {
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
 
+  it('agrees what the first item is for limit=1 and other limits', async () => {
+    const { data: timeline } = await agent.api.app.bsky.feed.getTimeline(
+      { limit: 10 },
+      { headers: await network.serviceHeaders(alice) },
+    )
+    const { data: timelineLimit1 } = await agent.api.app.bsky.feed.getTimeline(
+      { limit: 1 },
+      { headers: await network.serviceHeaders(alice) },
+    )
+    expect(timeline.feed.length).toBeGreaterThan(1)
+    expect(timelineLimit1.feed.length).toEqual(1)
+    expect(timelineLimit1.feed[0].post.uri).toBe(timeline.feed[0].post.uri)
+  })
+
   it('reflects self-labels', async () => {
     const carolTL = await agent.api.app.bsky.feed.getTimeline(
       {},


### PR DESCRIPTION
On `getTimeline`, the `limit=1` case is used commonly to check if there are new items at the top of the timeline. Since it's so common, this is a shot at optimizing it.  The most common strategy that postgres takes to build a timeline is to grab all recent content from each of the user's follow, then paginate it. The downside here is that it requires grabbing all recent content from all follows, even if you only want a single result.  The approach here instead takes the single most recent post from each of the user's follows, then sorts only those and takes the top item.