### PR TITLE
Fix app.bsky.graph.getSuggestedFollowsByActor lexicon output

### DIFF
--- a/lexicons/app/bsky/graph/getSuggestedFollowsByActor.json
+++ b/lexicons/app/bsky/graph/getSuggestedFollowsByActor.json
@@ -22,7 +22,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "app.bsky.actor.defs#profileViewDetailed"
               }
             }
           }


### PR DESCRIPTION
Hi! Python SDK fails on the profile view model because the server returns the profile view **detailed** model instead. including banner, followers count, etc. More info: https://github.com/MarshalX/atproto/issues/205

so either: 
1. lexicon is wrong
2. the server returns the wrong model

thanks 