### PR TITLE
Pin alpine version temporarily for pds docker build

### DIFF
--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine as build
+# @NOTE just a temp fix: alpine3.19 breaks sharp install, see nodejs/docker-node#2009
+FROM node:18-alpine3.18 as build
 
 RUN npm install -g pnpm
 

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -36,7 +36,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline > 
 WORKDIR services/pds
 
 # Uses assets from build stage to reduce build size
-FROM node:18-alpine
+FROM node:18-alpine3.18
 
 RUN apk add --update dumb-init
 

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -1,4 +1,5 @@
 # @NOTE just a temp fix: alpine3.19 breaks sharp install, see nodejs/docker-node#2009
+# see additional reference to this image further down.
 FROM node:18-alpine3.18 as build
 
 RUN npm install -g pnpm


### PR DESCRIPTION
There's an incompatibility between sharp and the version of alpine linux used in the pds's docker build.  It started surfacing when the the node docker image updated their version of alpine. This pins alpine linux to the most recent working version.

The longer-term fix will likely be to upgrade sharp and alpine linux at the same time.  I tried to get this going, but transitive dependencies with the entryway got in the way.

Ref: https://github.com/nodejs/docker-node/issues/2009