### PR TITLE
bsky: add top-level and robots.txt endpoints

### DIFF
--- a/packages/bsky/src/api/health.ts
+++ b/packages/bsky/src/api/health.ts
@@ -5,6 +5,20 @@ import AppContext from '../context'
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
 
+  router.get('/', function (req, res) {
+    res.type('text/plain')
+    res.send(
+      'This is an AT Protocol Application View (AppView) for the "bsky.app" application: https://github.com/bluesky-social/atproto\n\nMost API routes are under /xrpc/',
+    )
+  })
+
+  router.get('/robots.txt', function (req, res) {
+    res.type('text/plain')
+    res.send(
+      '# Hello Friends!\n\n# Crawling the public parts of the API is allowed. HTTP 429 ("backoff") status codes are used for rate-limiting. Up to a handful concurrent requests should be ok.\nUser-agent: *\nAllow: /',
+    )
+  })
+
   router.get('/xrpc/_health', async function (req, res) {
     const { version } = ctx.cfg
     const db = ctx.db.getPrimary()


### PR DESCRIPTION
These provide helpful context (instead of just a generic 404). We might *also* want to set up load-balancer redirects, but having some default HTTP 200 has been helpful for, eg, local dev.

The robots.txt in particular will show up for public.api.bsky.app

Mostly copied these from the PDS equivalents.