### PR TITLE
Experimental node clustering for bsky frontends

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - timeline-limit-1-opt
+      - bsky-node-clustering
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}


### PR DESCRIPTION
Enables the ability to cluster on the bsky api frontends.  Configured on by setting `CLUSTER_WORKER_COUNT` to a value (should generally be between 2 and the number of cpus on the machine).