### PR TITLE
Support http2 client for appview dataplane

### DIFF
--- a/.github/workflows/build-and-push-bsky-ghcr.yaml
+++ b/.github/workflows/build-and-push-bsky-ghcr.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - bav-v2-drop-pg
+      - bav-v2-config-pass1
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -8,6 +8,8 @@ export interface ServerConfigValues {
   serverDid: string
   feedGenDid?: string
   dataplaneUrl: string
+  dataplaneHttpVersion?: '1.1' | '2'
+  dataplaneIgnoreBadTls?: boolean
   didPlcUrl: string
   handleResolveNameservers?: string[]
   imgUriEndpoint?: string
@@ -36,10 +38,14 @@ export class ServerConfig {
     const imgUriEndpoint = process.env.BSKY_IMG_URI_ENDPOINT
     const blobCacheLocation = process.env.BSKY_BLOB_CACHE_LOC
     const dataplaneUrl = process.env.BSKY_DATAPLANE_URL
+    const dataplaneHttpVersion = process.env.BSKY_DATAPLANE_HTTP_VERSION || '2'
+    const dataplaneIgnoreBadTls =
+      process.env.BSKY_DATAPLANE_IGNORE_BAD_TLS === 'true'
     const adminPassword = process.env.BSKY_ADMIN_PASSWORD || 'admin'
     const moderatorPassword = process.env.BSKY_MODERATOR_PASSWORD || undefined
     const triagePassword = process.env.BSKY_TRIAGE_PASSWORD || undefined
     assert(dataplaneUrl)
+    assert(dataplaneHttpVersion === '1.1' || dataplaneHttpVersion === '2')
     return new ServerConfig({
       version,
       debugMode,
@@ -48,6 +54,8 @@ export class ServerConfig {
       serverDid,
       feedGenDid,
       dataplaneUrl,
+      dataplaneHttpVersion,
+      dataplaneIgnoreBadTls,
       didPlcUrl,
       handleResolveNameservers,
       imgUriEndpoint,
@@ -98,6 +106,14 @@ export class ServerConfig {
 
   get dataplaneUrl() {
     return this.cfg.dataplaneUrl
+  }
+
+  get dataplaneHttpVersion() {
+    return this.cfg.dataplaneHttpVersion
+  }
+
+  get dataplaneIgnoreBadTls() {
+    return this.cfg.dataplaneIgnoreBadTls
   }
 
   get handleResolveNameservers() {

--- a/packages/bsky/src/data-plane/client.ts
+++ b/packages/bsky/src/data-plane/client.ts
@@ -7,11 +7,13 @@ type HttpVersion = '1.1' | '2'
 
 export const createDataPlaneClient = (
   baseUrl: string,
-  httpVersion: HttpVersion = '2',
+  opts: { httpVersion?: HttpVersion; rejectUnauthorized?: boolean },
 ) => {
+  const { httpVersion = '2', rejectUnauthorized = false } = opts
   const transport = createConnectTransport({
     baseUrl,
     httpVersion,
+    nodeOptions: { rejectUnauthorized },
   })
   return createPromiseClient(Service, transport)
 }

--- a/packages/bsky/src/data-plane/client.ts
+++ b/packages/bsky/src/data-plane/client.ts
@@ -9,7 +9,7 @@ export const createDataPlaneClient = (
   baseUrl: string,
   opts: { httpVersion?: HttpVersion; rejectUnauthorized?: boolean },
 ) => {
-  const { httpVersion = '2', rejectUnauthorized = false } = opts
+  const { httpVersion = '2', rejectUnauthorized = true } = opts
   const transport = createConnectTransport({
     baseUrl,
     httpVersion,

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -77,7 +77,7 @@ export class BskyAppView {
 
     const dataplane = createDataPlaneClient(config.dataplaneUrl, {
       httpVersion: config.dataplaneHttpVersion,
-      rejectUnauthorized: config.dataplaneIgnoreBadTls,
+      rejectUnauthorized: !config.dataplaneIgnoreBadTls,
     })
     const hydrator = new Hydrator(dataplane)
     const views = new Views(imgUriBuilder)

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -75,7 +75,10 @@ export class BskyAppView {
       )
     }
 
-    const dataplane = createDataPlaneClient(config.dataplaneUrl, '1.1')
+    const dataplane = createDataPlaneClient(config.dataplaneUrl, {
+      httpVersion: config.dataplaneHttpVersion,
+      rejectUnauthorized: config.dataplaneIgnoreBadTls,
+    })
     const hydrator = new Hydrator(dataplane)
     const views = new Views(imgUriBuilder)
 

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -56,6 +56,7 @@ export class TestBsky {
       publicUrl: 'https://bsky.public.url',
       serverDid,
       dataplaneUrl: `http://localhost:${dataplanePort}`,
+      dataplaneHttpVersion: '1.1',
       ...cfg,
       adminPassword: ADMIN_PASSWORD,
       moderatorPassword: MOD_PASSWORD,


### PR DESCRIPTION
Support using http2 to talk to the dataplane.  Also supports an option to ignore tls for testing and local usage.