### PR TITLE
lexicons: more string limits

### DIFF
--- a/.changeset/odd-kids-warn.md
+++ b/.changeset/odd-kids-warn.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+additional app.bsky.feed.post Lexicon string format limits

--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -18,8 +18,16 @@
       "required": ["uri", "title", "description"],
       "properties": {
         "uri": { "type": "string", "format": "uri" },
-        "title": { "type": "string" },
-        "description": { "type": "string" },
+        "title": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "description": {
+          "type": "string",
+          "maxGraphemes": 1000,
+          "maxLength": 10000
+        },
         "thumb": {
           "type": "blob",
           "accept": ["image/*"],
@@ -42,8 +50,16 @@
       "required": ["uri", "title", "description"],
       "properties": {
         "uri": { "type": "string", "format": "uri" },
-        "title": { "type": "string" },
-        "description": { "type": "string" },
+        "title": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "description": {
+          "type": "string",
+          "maxGraphemes": 1000,
+          "maxLength": 10000
+        },
         "thumb": { "type": "string" }
       }
     }

--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -60,7 +60,7 @@
           "maxGraphemes": 1000,
           "maxLength": 10000
         },
-        "thumb": { "type": "string" }
+        "thumb": { "type": "string", "format": "uri" }
       }
     }
   }

--- a/lexicons/app/bsky/embed/images.json
+++ b/lexicons/app/bsky/embed/images.json
@@ -23,7 +23,11 @@
           "accept": ["image/*"],
           "maxSize": 1000000
         },
-        "alt": { "type": "string" },
+        "alt": {
+          "type": "string",
+          "maxGraphemes": 5000,
+          "maxLength": 50000
+        },
         "aspectRatio": { "type": "ref", "ref": "#aspectRatio" }
       }
     },
@@ -53,7 +57,11 @@
       "properties": {
         "thumb": { "type": "string" },
         "fullsize": { "type": "string" },
-        "alt": { "type": "string" },
+        "alt": {
+          "type": "string",
+          "maxGraphemes": 5000,
+          "maxLength": 50000
+        },
         "aspectRatio": { "type": "ref", "ref": "#aspectRatio" }
       }
     }

--- a/lexicons/app/bsky/embed/images.json
+++ b/lexicons/app/bsky/embed/images.json
@@ -55,8 +55,8 @@
       "type": "object",
       "required": ["thumb", "fullsize", "alt"],
       "properties": {
-        "thumb": { "type": "string" },
-        "fullsize": { "type": "string" },
+        "thumb": { "type": "string", "format": "uri" },
+        "fullsize": { "type": "string", "format": "uri" },
         "alt": {
           "type": "string",
           "maxGraphemes": 5000,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4744,9 +4744,13 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'blob',
@@ -4775,12 +4779,17 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4816,6 +4825,8 @@ export const schemaDict = {
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',
@@ -4859,12 +4870,16 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4744,9 +4744,13 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'blob',
@@ -4775,12 +4779,17 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4816,6 +4825,8 @@ export const schemaDict = {
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',
@@ -4859,12 +4870,16 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4744,9 +4744,13 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'blob',
@@ -4775,12 +4779,17 @@ export const schemaDict = {
           },
           title: {
             type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
           },
           description: {
             type: 'string',
+            maxGraphemes: 1000,
+            maxLength: 10000,
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4816,6 +4825,8 @@ export const schemaDict = {
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',
@@ -4859,12 +4870,16 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
           },
           alt: {
             type: 'string',
+            maxGraphemes: 5000,
+            maxLength: 50000,
           },
           aspectRatio: {
             type: 'ref',


### PR DESCRIPTION
The most sensitive thing here is putting a (very long!) length limit on alt text. I believe this is long enough to not cause accessibility issues, but can update if needed.

The motivation is that an issue with very long embed image descriptions came up that has been causing records to be discarded by golang code. We'll separately work around that by bumping limits in the CBOR library (cborgen), but I think communicating some reasonable limit on these fields is helpful. This isn't intended to be antagonistic; the current problematic records seem to have huge values *by mistake* not intentionally.

While I was at it I did an informal review of all the "string" fields in records (I might have missed a couple, this was an informal scan).

These are technically violations of Lexicon stability, so need a bunch of review and buy-in on these. I'm not strident about these changes, but I think they are worth re-visiting, and this is probably our last chance to push them through.

- I think the URL fields being format=uri would be uncontroversial
- The embed description limits will invalidate a small handful of real-world records
- I don't know how many real-world records the alt-text limit might cause. I expect very few but we might want to verify before merging that.

The specific values are somewhat arbitrary. I chose "large" ones to minimize the change in behavior (given that there are no limits right now).

Haven't run codegen, would do that just before merging.

cc: @whyrusleeping w/r/t embed description length