### PR TITLE
Improve handling of `resumeSession` failures

### DIFF
--- a/.changeset/chilled-ghosts-enjoy.md
+++ b/.changeset/chilled-ghosts-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@atproto/api': patch
+'@atproto/api': minor
 ---
 
 Improve `resumeSession` event emission. It will no longer double emit when some

--- a/.changeset/chilled-ghosts-enjoy.md
+++ b/.changeset/chilled-ghosts-enjoy.md
@@ -1,0 +1,8 @@
+---
+'@atproto/api': patch
+---
+
+Improve `resumeSession` event emission. It will no longer double emit when some
+requests fail, and the `create-failed` event has been replaced by `expired`
+where appropriate, and with a new event `network-error` where appropriate or an
+unknown error occurs.

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -175,7 +175,7 @@ export class AtpAgent {
     } catch (e) {
       this.session = undefined
 
-      if (e instanceof XRPCError && e.error) {
+      if (e instanceof XRPCError) {
         /*
          * `ExpiredToken` and `InvalidToken` are handled in
          * `this_refreshSession`, and emit an `expired` event there.

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -176,11 +176,20 @@ export class AtpAgent {
       this.session = undefined
 
       if (e instanceof XRPCError && e.error) {
-        // `ExpiredToken` and `InvalidToken` are handled by the `this._refreshSession`
-        if (['AuthMissing', 'InvalidDID'].includes(e.error)) {
+        /*
+         * `ExpiredToken` and `InvalidToken` are handled in
+         * `this_refreshSession`, and emit an `expired` event there.
+         *
+         * `AuthMissing` is a respose from `getSession`, and happens AFTER the
+         * initial `expired` event is sent. If we handle that here, we'll
+         * double-emit `expired`.
+         *
+         * `InvalidDID` is emit above, and should be handled here.
+         *
+         * Everything else is unexpected.
+         */
+        if (['InvalidDID'].includes(e.error)) {
           this._persistSession?.('expired', undefined)
-        } else {
-          this._persistSession?.('network-error', undefined)
         }
       } else {
         this._persistSession?.('network-error', undefined)

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -170,7 +170,7 @@ export class AtpAgent {
       this.session.handle = res.data.handle
       this.session.emailConfirmed = res.data.emailConfirmed
       this._updateApiEndpoint(res.data.didDoc)
-      this._persistSession?.('create', this.session)
+      this._persistSession?.('update', this.session)
       return res
     } catch (e) {
       this.session = undefined

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -160,7 +160,11 @@ export class AtpAgent {
       this.session = session
       const res = await this.api.com.atproto.server.getSession()
       if (res.data.did !== this.session.did) {
-        throw new XRPCError(ResponseType.InvalidRequest, 'Invalid session', 'InvalidDID')
+        throw new XRPCError(
+          ResponseType.InvalidRequest,
+          'Invalid session',
+          'InvalidDID',
+        )
       }
       this.session.email = res.data.email
       this.session.handle = res.data.handle

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -190,6 +190,8 @@ export class AtpAgent {
          */
         if (['InvalidDID'].includes(e.error)) {
           this._persistSession?.('expired', undefined)
+        } else if (['InternalServerError'].includes(e.error)) {
+          this._persistSession?.('network-error', undefined)
         }
       } else {
         this._persistSession?.('network-error', undefined)

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -180,18 +180,14 @@ export class AtpAgent {
          * `ExpiredToken` and `InvalidToken` are handled in
          * `this_refreshSession`, and emit an `expired` event there.
          *
-         * `AuthMissing` is a respose from `getSession`, and happens AFTER the
-         * initial `expired` event is sent. If we handle that here, we'll
-         * double-emit `expired`.
-         *
-         * `InvalidDID` is emit above, and should be handled here.
-         *
-         * Everything else is unexpected.
+         * Everything else is handled here.
          */
-        if (['InvalidDID'].includes(e.error)) {
-          this._persistSession?.('expired', undefined)
-        } else if (['InternalServerError'].includes(e.error)) {
+        if (
+          [1, 408, 425, 429, 500, 502, 503, 504, 522, 524].includes(e.status)
+        ) {
           this._persistSession?.('network-error', undefined)
+        } else {
+          this._persistSession?.('expired', undefined)
         }
       } else {
         this._persistSession?.('network-error', undefined)

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -3,7 +3,12 @@ import { LabelPreference } from './moderation/types'
 /**
  * Used by the PersistSessionHandler to indicate what change occurred
  */
-export type AtpSessionEvent = 'create' | 'create-failed' | 'update' | 'expired'
+export type AtpSessionEvent =
+  | 'create'
+  | 'create-failed'
+  | 'update'
+  | 'expired'
+  | 'network-error'
 
 /**
  * Used by AtpAgent to store active sessions

--- a/packages/api/tests/agent.test.ts
+++ b/packages/api/tests/agent.test.ts
@@ -343,7 +343,7 @@ describe('agent', () => {
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create-failed')
-    expect(events[1]).toEqual('create-failed')
+    expect(events[1]).toEqual('network-error')
     expect(sessions.length).toEqual(2)
     expect(typeof sessions[0]).toEqual('undefined')
     expect(typeof sessions[1]).toEqual('undefined')

--- a/packages/api/tests/agent.test.ts
+++ b/packages/api/tests/agent.test.ts
@@ -159,7 +159,7 @@ describe('agent', () => {
 
     expect(events.length).toEqual(2)
     expect(events[0]).toEqual('create')
-    expect(events[1]).toEqual('create')
+    expect(events[1]).toEqual('update')
     expect(sessions.length).toEqual(2)
     expect(sessions[0]?.accessJwt).toEqual(agent1.session?.accessJwt)
     expect(sessions[1]?.accessJwt).toEqual(agent2.session?.accessJwt)

--- a/packages/pds/src/account-manager/helpers/auth.ts
+++ b/packages/pds/src/account-manager/helpers/auth.ts
@@ -42,7 +42,7 @@ export const createAccessToken = (opts: {
     jwtKey,
     serviceDid,
     scope = AuthScope.Access,
-    expiresIn = '5s',
+    expiresIn = '120mins',
   } = opts
   const signer = new jose.SignJWT({ scope })
     .setProtectedHeader({ alg: 'HS256' }) // only symmetric keys supported

--- a/packages/pds/src/account-manager/helpers/auth.ts
+++ b/packages/pds/src/account-manager/helpers/auth.ts
@@ -42,7 +42,7 @@ export const createAccessToken = (opts: {
     jwtKey,
     serviceDid,
     scope = AuthScope.Access,
-    expiresIn = '120mins',
+    expiresIn = '5s',
   } = opts
   const signer = new jose.SignJWT({ scope })
     .setProtectedHeader({ alg: 'HS256' }) // only symmetric keys supported


### PR DESCRIPTION
**Motivation:** flaky networks currently result in the app nuking JWTs, effectively logging the user out. We want to log out the user if the session is invalid, but for other unknowns, we can keep it around on-device until we get a legit response from our server that says otherwise.

This PR adds an additional `AtpSessionEvent` event, `network-error`, and emits that event from `resumeSession` if we catch an unexpected exception.