### PR TITLE
Plumb feed items and cids to dataplane, avoid empty calls

### DIFF
--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -765,7 +765,7 @@ message GetListFeedRequest {
 }
 
 message GetListFeedResponse {
-  repeated string uris = 1;
+  repeated FeedItem items = 1;
   string cursor = 2;
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -8,6 +8,7 @@ import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { mapDefined } from '@atproto/common'
 import { parseString } from '../../../../hydration/util'
+import { FeedItem } from '../../../../hydration/feed'
 
 export default function (server: Server, ctx: AppContext) {
   const getListFeed = createPipeline(
@@ -47,7 +48,7 @@ export const skeleton = async (inputs: {
     cursor: params.cursor,
   })
   return {
-    uris: res.uris,
+    items: res.uris.map((uri) => ({ post: { uri } })),
     cursor: parseString(res.cursor),
   }
 }
@@ -58,7 +59,7 @@ const hydration = async (inputs: {
   skeleton: Skeleton
 }): Promise<HydrationState> => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydrateFeedPosts(skeleton.uris, params.viewer)
+  return ctx.hydrator.hydrateFeedItems(skeleton.items, params.viewer)
 }
 
 const noBlocksOrMutes = (inputs: {
@@ -67,8 +68,8 @@ const noBlocksOrMutes = (inputs: {
   hydration: HydrationState
 }): Skeleton => {
   const { ctx, skeleton, hydration } = inputs
-  skeleton.uris = skeleton.uris.filter((uri) => {
-    const bam = ctx.views.feedItemBlocksAndMutes(uri, hydration)
+  skeleton.items = skeleton.items.filter((item) => {
+    const bam = ctx.views.feedItemBlocksAndMutes(item, hydration)
     return (
       !bam.authorBlocked &&
       !bam.authorMuted &&
@@ -85,8 +86,8 @@ const presentation = (inputs: {
   hydration: HydrationState
 }) => {
   const { ctx, skeleton, hydration } = inputs
-  const feed = mapDefined(skeleton.uris, (uri) =>
-    ctx.views.feedViewPost(uri, hydration),
+  const feed = mapDefined(skeleton.items, (item) =>
+    ctx.views.feedViewPost(item, hydration),
   )
   return { feed, cursor: skeleton.cursor }
 }
@@ -100,6 +101,6 @@ type Context = {
 type Params = QueryParams & { viewer: string | null }
 
 type Skeleton = {
-  uris: string[]
+  items: FeedItem[]
   cursor?: string
 }

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -48,7 +48,12 @@ export const skeleton = async (inputs: {
     cursor: params.cursor,
   })
   return {
-    items: res.uris.map((uri) => ({ post: { uri } })),
+    items: res.items.map((item) => ({
+      post: { uri: item.uri, cid: item.cid || undefined },
+      repost: item.repost
+        ? { uri: item.repost, cid: item.repostCid || undefined }
+        : undefined,
+    })),
     cursor: parseString(res.cursor),
   }
 }

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -64,7 +64,10 @@ const hydration = async (
   inputs: HydrationFnInput<Context, Params, Skeleton>,
 ) => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydrateThreadPosts(skeleton.uris, params.viewer)
+  return ctx.hydrator.hydrateThreadPosts(
+    skeleton.uris.map((uri) => ({ uri })),
+    params.viewer,
+  )
 }
 
 const presentation = (

--- a/packages/bsky/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPosts.ts
@@ -33,7 +33,10 @@ const hydration = async (inputs: {
   skeleton: Skeleton
 }) => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydratePosts(skeleton.posts, params.viewer)
+  return ctx.hydrator.hydratePosts(
+    skeleton.posts.map((uri) => ({ uri })),
+    params.viewer,
+  )
 }
 
 const noBlocks = (inputs: {

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -8,6 +8,7 @@ import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
 import { mapDefined } from '@atproto/common'
+import { FeedItem } from '../../../../hydration/feed'
 
 export default function (server: Server, ctx: AppContext) {
   const getTimeline = createPipeline(
@@ -47,7 +48,12 @@ export const skeleton = async (inputs: {
     cursor: params.cursor,
   })
   return {
-    uris: res.items.map((item) => item.repost || item.uri),
+    items: res.items.map((item) => ({
+      post: { uri: item.uri, cid: item.cid || undefined },
+      repost: item.repost
+        ? { uri: item.repost, cid: item.repostCid || undefined }
+        : undefined,
+    })),
     cursor: parseString(res.cursor),
   }
 }
@@ -58,7 +64,7 @@ const hydration = async (inputs: {
   skeleton: Skeleton
 }): Promise<HydrationState> => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydrateFeedPosts(skeleton.uris, params.viewer)
+  return ctx.hydrator.hydrateFeedItems(skeleton.items, params.viewer)
 }
 
 const noBlocksOrMutes = (inputs: {
@@ -67,8 +73,8 @@ const noBlocksOrMutes = (inputs: {
   hydration: HydrationState
 }): Skeleton => {
   const { ctx, skeleton, hydration } = inputs
-  skeleton.uris = skeleton.uris.filter((uri) => {
-    const bam = ctx.views.feedItemBlocksAndMutes(uri, hydration)
+  skeleton.items = skeleton.items.filter((item) => {
+    const bam = ctx.views.feedItemBlocksAndMutes(item, hydration)
     return (
       !bam.authorBlocked &&
       !bam.authorMuted &&
@@ -85,8 +91,8 @@ const presentation = (inputs: {
   hydration: HydrationState
 }) => {
   const { ctx, skeleton, hydration } = inputs
-  const feed = mapDefined(skeleton.uris, (uri) =>
-    ctx.views.feedViewPost(uri, hydration),
+  const feed = mapDefined(skeleton.items, (item) =>
+    ctx.views.feedViewPost(item, hydration),
   )
   return { feed, cursor: skeleton.cursor }
 }
@@ -100,6 +106,6 @@ type Context = {
 type Params = QueryParams & { viewer: string }
 
 type Skeleton = {
-  uris: string[]
+  items: FeedItem[]
   cursor?: string
 }

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -52,7 +52,10 @@ const hydration = async (
   inputs: HydrationFnInput<Context, Params, Skeleton>,
 ) => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydratePosts(skeleton.posts, params.viewer)
+  return ctx.hydrator.hydratePosts(
+    skeleton.posts.map((uri) => ({ uri })),
+    params.viewer,
+  )
 }
 
 const noBlocks = (inputs: RulesFnInput<Context, Params, Skeleton>) => {

--- a/packages/bsky/src/api/app/bsky/unspecced/getTimelineSkeleton.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTimelineSkeleton.ts
@@ -1,9 +1,7 @@
 import { Server } from '../../../../lexicon'
-import { ids } from '../../../../lexicon/lexicons'
 import AppContext from '../../../../context'
 import { skeleton } from '../feed/getTimeline'
 import { toSkeletonItem } from '../../../feed-gen/types'
-import { urisByCollection } from '../../../../hydration/util'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
 export default function (server: Server, ctx: AppContext) {
@@ -12,15 +10,10 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params }) => {
       const viewer = auth.credentials.did
       const result = await skeleton({ ctx, params: { ...params, viewer } })
-      const collections = urisByCollection(result.uris)
-      const reposts = await ctx.hydrator.feed.getReposts(
-        collections.get(ids.AppBskyFeedRepost) ?? [],
-      )
-      const feed = result.uris.map((uri) => {
-        const repost = reposts.get(uri)
+      const feed = result.items.map((item) => {
         return toSkeletonItem({
-          itemUri: uri,
-          postUri: repost ? repost.record.subject.uri : uri,
+          postUri: item.post.uri,
+          itemUri: item.repost ? item.repost.uri : item.post.uri,
         })
       })
       return {

--- a/packages/bsky/src/api/feed-gen/types.ts
+++ b/packages/bsky/src/api/feed-gen/types.ts
@@ -1,4 +1,5 @@
 import AppContext from '../../context'
+import { FeedItem } from '../../hydration/feed'
 import { SkeletonFeedPost } from '../../lexicon/types/app/bsky/feed/defs'
 import { QueryParams as SkeletonParams } from '../../lexicon/types/app/bsky/feed/getFeedSkeleton'
 
@@ -32,4 +33,12 @@ export const toSkeletonItem = (feedItem: {
           $type: 'app.bsky.feed.defs#skeletonReasonRepost',
           repost: feedItem.itemUri,
         },
+})
+
+export const toFeedItem = (feedItem: AlgoResponseItem): FeedItem => ({
+  post: { uri: feedItem.postUri },
+  repost:
+    feedItem.itemUri === feedItem.postUri
+      ? undefined
+      : { uri: feedItem.itemUri },
 })

--- a/packages/bsky/src/data-plane/gen/bsky_pb.ts
+++ b/packages/bsky/src/data-plane/gen/bsky_pb.ts
@@ -5400,9 +5400,9 @@ export class GetListFeedRequest extends Message<GetListFeedRequest> {
  */
 export class GetListFeedResponse extends Message<GetListFeedResponse> {
   /**
-   * @generated from field: repeated string uris = 1;
+   * @generated from field: repeated bsky.FeedItem items = 1;
    */
-  uris: string[] = [];
+  items: FeedItem[] = [];
 
   /**
    * @generated from field: string cursor = 2;
@@ -5417,7 +5417,7 @@ export class GetListFeedResponse extends Message<GetListFeedResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "bsky.GetListFeedResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "uris", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 1, name: "items", kind: "message", T: FeedItem, repeated: true },
     { no: 2, name: "cursor", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 

--- a/packages/bsky/src/data-plane/server/routes/feeds.ts
+++ b/packages/bsky/src/data-plane/server/routes/feeds.ts
@@ -124,7 +124,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     const feedItems = await builder.execute()
 
     return {
-      uris: feedItems.map((item) => item.uri), // @TODO consider switching to FeedItemInfo[]
+      items: feedItems.map((item) => ({ uri: item.uri, cid: item.cid })),
       cursor: keyset.packFromResult(feedItems),
     }
   },

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -50,7 +50,9 @@ export class ActorHydrator {
 
   async getDids(handleOrDids: string[]): Promise<(string | undefined)[]> {
     const handles = handleOrDids.filter((actor) => !actor.startsWith('did:'))
-    const res = await this.dataplane.getDidsByHandles({ handles })
+    const res = handles.length
+      ? await this.dataplane.getDidsByHandles({ handles })
+      : { dids: [] }
     const didByHandle = handles.reduce((acc, cur, i) => {
       const did = res.dids[i]
       if (did && did.length > 0) {
@@ -70,6 +72,7 @@ export class ActorHydrator {
   }
 
   async getActors(dids: string[], includeTakedowns = false): Promise<Actors> {
+    if (!dids.length) return new HydrationMap<Actor>()
     const res = await this.dataplane.getActors({ dids })
     return dids.reduce((acc, did, i) => {
       const actor = res.actors[i]
@@ -95,6 +98,7 @@ export class ActorHydrator {
     dids: string[],
     viewer: string,
   ): Promise<ProfileViewerStates> {
+    if (!dids.length) return new HydrationMap<ProfileViewerState>()
     const res = await this.dataplane.getRelationships({
       actorDid: viewer,
       targetDids: dids,
@@ -119,6 +123,7 @@ export class ActorHydrator {
   }
 
   async getProfileAggregates(dids: string[]): Promise<ProfileAggs> {
+    if (!dids.length) return new HydrationMap<ProfileAgg>()
     const counts = await this.dataplane.getCountsForUsers({ dids })
     return dids.reduce((acc, did, i) => {
       return acc.set(did, {

--- a/packages/bsky/src/hydration/feed.ts
+++ b/packages/bsky/src/hydration/feed.ts
@@ -4,7 +4,13 @@ import { Record as LikeRecord } from '../lexicon/types/app/bsky/feed/like'
 import { Record as RepostRecord } from '../lexicon/types/app/bsky/feed/repost'
 import { Record as FeedGenRecord } from '../lexicon/types/app/bsky/feed/generator'
 import { Record as ThreadgateRecord } from '../lexicon/types/app/bsky/feed/threadgate'
-import { HydrationMap, RecordInfo, parseRecord, parseString } from './util'
+import {
+  HydrationMap,
+  RecordInfo,
+  parseRecord,
+  parseString,
+  split,
+} from './util'
 import { AtUri } from '@atproto/syntax'
 import { ids } from '../lexicon/lexicons'
 
@@ -50,22 +56,36 @@ export type FeedGenViewerStates = HydrationMap<FeedGenViewerState>
 export type Threadgate = RecordInfo<ThreadgateRecord>
 export type Threadgates = HydrationMap<Threadgate>
 
+export type ItemRef = { uri: string; cid?: string }
+export type FeedItem = { post: ItemRef; repost?: ItemRef }
+
 export class FeedHydrator {
   constructor(public dataplane: DataPlaneClient) {}
 
-  async getPosts(uris: string[], includeTakedowns = false): Promise<Posts> {
-    const res = await this.dataplane.getPostRecords({ uris })
-    return uris.reduce((acc, uri, i) => {
+  async getPosts(
+    uris: string[],
+    includeTakedowns = false,
+    given = new HydrationMap<Post>(),
+  ): Promise<Posts> {
+    const [have, need] = split(uris, (uri) => given.has(uri))
+    const base = have.reduce(
+      (acc, uri) => acc.set(uri, given.get(uri) ?? null),
+      new HydrationMap<Post>(),
+    )
+    if (!need.length) return base
+    const res = await this.dataplane.getPostRecords({ uris: need })
+    return need.reduce((acc, uri, i) => {
       const record = parseRecord<PostRecord>(res.records[i], includeTakedowns)
       const violatesThreadGate = res.meta[i].violatesThreadGate
       return acc.set(uri, record ? { ...record, violatesThreadGate } : null)
-    }, new HydrationMap<Post>())
+    }, base)
   }
 
   async getPostViewerStates(
     uris: string[],
     viewer: string,
   ): Promise<PostViewerStates> {
+    if (!uris.length) return new HydrationMap<PostViewerState>()
     const [likes, reposts] = await Promise.all([
       this.dataplane.getLikesByActorAndSubjects({
         actorDid: viewer,
@@ -84,10 +104,10 @@ export class FeedHydrator {
     }, new HydrationMap<PostViewerState>())
   }
 
-  async getPostAggregates(uris: string[]): Promise<PostAggs> {
-    const refs = uris.map((uri) => ({ uri }))
+  async getPostAggregates(refs: ItemRef[]): Promise<PostAggs> {
+    if (!refs.length) return new HydrationMap<PostAgg>()
     const counts = await this.dataplane.getInteractionCounts({ refs })
-    return uris.reduce((acc, uri, i) => {
+    return refs.reduce((acc, { uri }, i) => {
       return acc.set(uri, {
         likes: counts.likes[i] ?? 0,
         reposts: counts.reposts[i] ?? 0,
@@ -100,6 +120,7 @@ export class FeedHydrator {
     uris: string[],
     includeTakedowns = false,
   ): Promise<FeedGens> {
+    if (!uris.length) return new HydrationMap<FeedGen>()
     const res = await this.dataplane.getFeedGeneratorRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<FeedGenRecord>(
@@ -114,6 +135,7 @@ export class FeedHydrator {
     uris: string[],
     viewer: string,
   ): Promise<FeedGenViewerStates> {
+    if (!uris.length) return new HydrationMap<FeedGenViewerState>()
     const likes = await this.dataplane.getLikesByActorAndSubjects({
       actorDid: viewer,
       refs: uris.map((uri) => ({ uri })),
@@ -125,10 +147,10 @@ export class FeedHydrator {
     }, new HydrationMap<FeedGenViewerState>())
   }
 
-  async getFeedGenAggregates(uris: string[]): Promise<FeedGenAggs> {
-    const refs = uris.map((uri) => ({ uri }))
+  async getFeedGenAggregates(refs: ItemRef[]): Promise<FeedGenAggs> {
+    if (!refs.length) return new HydrationMap<FeedGenAgg>()
     const likes = await this.dataplane.getLikeCounts({ refs })
-    return uris.reduce((acc, uri, i) => {
+    return refs.reduce((acc, { uri }, i) => {
       return acc.set(uri, {
         likes: likes.counts[i] ?? 0,
       })
@@ -139,6 +161,7 @@ export class FeedHydrator {
     postUris: string[],
     includeTakedowns = false,
   ): Promise<Threadgates> {
+    if (!postUris.length) return new HydrationMap<Threadgate>()
     const uris = postUris.map((uri) => {
       const parsed = new AtUri(uri)
       return AtUri.make(
@@ -159,6 +182,7 @@ export class FeedHydrator {
 
   // @TODO may not be supported yet by data plane
   async getLikes(uris: string[], includeTakedowns = false): Promise<Likes> {
+    if (!uris.length) return new HydrationMap<Like>()
     const res = await this.dataplane.getLikeRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<LikeRecord>(res.records[i], includeTakedowns)
@@ -167,6 +191,7 @@ export class FeedHydrator {
   }
 
   async getReposts(uris: string[], includeTakedowns = false): Promise<Reposts> {
+    if (!uris.length) return new HydrationMap<Repost>()
     const res = await this.dataplane.getRepostRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<RepostRecord>(res.records[i], includeTakedowns)

--- a/packages/bsky/src/hydration/feed.ts
+++ b/packages/bsky/src/hydration/feed.ts
@@ -82,21 +82,21 @@ export class FeedHydrator {
   }
 
   async getPostViewerStates(
-    uris: string[],
+    refs: ItemRef[],
     viewer: string,
   ): Promise<PostViewerStates> {
-    if (!uris.length) return new HydrationMap<PostViewerState>()
+    if (!refs.length) return new HydrationMap<PostViewerState>()
     const [likes, reposts] = await Promise.all([
       this.dataplane.getLikesByActorAndSubjects({
         actorDid: viewer,
-        refs: uris.map((uri) => ({ uri })),
+        refs,
       }),
       this.dataplane.getRepostsByActorAndSubjects({
         actorDid: viewer,
-        refs: uris.map((uri) => ({ uri })),
+        refs,
       }),
     ])
-    return uris.reduce((acc, uri, i) => {
+    return refs.reduce((acc, { uri }, i) => {
       return acc.set(uri, {
         like: parseString(likes.uris[i]),
         repost: parseString(reposts.uris[i]),

--- a/packages/bsky/src/hydration/graph.ts
+++ b/packages/bsky/src/hydration/graph.ts
@@ -71,6 +71,7 @@ export class GraphHydrator {
   constructor(public dataplane: DataPlaneClient) {}
 
   async getLists(uris: string[], includeTakedowns = false): Promise<Lists> {
+    if (!uris.length) return new HydrationMap<List>()
     const res = await this.dataplane.getListRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<ListRecord>(res.records[i], includeTakedowns)
@@ -83,6 +84,7 @@ export class GraphHydrator {
     uris: string[],
     includeTakedowns = false,
   ): Promise<ListItems> {
+    if (!uris.length) return new HydrationMap<ListItem>()
     const res = await this.dataplane.getListItemRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<ListItemRecord>(
@@ -97,6 +99,7 @@ export class GraphHydrator {
     uris: string[],
     viewer: string,
   ): Promise<ListViewerStates> {
+    if (!uris.length) return new HydrationMap<ListViewerState>()
     const mutesAndBlocks = await Promise.all(
       uris.map((uri) => this.getMutesAndBlocks(uri, viewer)),
     )
@@ -131,6 +134,7 @@ export class GraphHydrator {
   }
 
   async getBidirectionalBlocks(pairs: RelationshipPair[]): Promise<Blocks> {
+    if (!pairs.length) return new Blocks()
     const deduped = dedupePairs(pairs).map(([a, b]) => ({ a, b }))
     const res = await this.dataplane.getBlockExistence({ pairs: deduped })
     const blocks = new Blocks()
@@ -142,6 +146,7 @@ export class GraphHydrator {
   }
 
   async getFollows(uris: string[], includeTakedowns = false): Promise<Follows> {
+    if (!uris.length) return new HydrationMap<Follow>()
     const res = await this.dataplane.getFollowRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<FollowRecord>(res.records[i], includeTakedowns)
@@ -150,6 +155,7 @@ export class GraphHydrator {
   }
 
   async getBlocks(uris: string[], includeTakedowns = false): Promise<Follows> {
+    if (!uris.length) return new HydrationMap<Block>()
     const res = await this.dataplane.getBlockRecords({ uris })
     return uris.reduce((acc, uri, i) => {
       const record = parseRecord<BlockRecord>(res.records[i], includeTakedowns)

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -36,6 +36,8 @@ import {
   PostAggs,
   PostViewerStates,
   Threadgates,
+  FeedItem,
+  ItemRef,
 } from './feed'
 
 export type HydrationState = {
@@ -195,11 +197,17 @@ export class Hydrator {
   //     - profile
   //       - list basic
   async hydratePosts(
-    uris: string[],
+    refs: ItemRef[],
     viewer: string | null,
     includeTakedowns = false,
+    state: HydrationState = {},
   ): Promise<HydrationState> {
-    const postsLayer0 = await this.feed.getPosts(uris, includeTakedowns)
+    const uris = refs.map((ref) => ref.uri)
+    const postsLayer0 = await this.feed.getPosts(
+      uris,
+      includeTakedowns,
+      state.posts,
+    )
     // first level embeds plus thread roots we haven't fetched yet
     const urisLayer1 = nestedRecordUrisFromPosts(postsLayer0)
     const additionalRootUris = rootUrisFromPosts(postsLayer0) // supports computing threadgates
@@ -245,7 +253,7 @@ export class Hydrator {
       listState,
       feedGenState,
     ] = await Promise.all([
-      this.feed.getPostAggregates(uris),
+      this.feed.getPostAggregates(refs),
       viewer ? this.feed.getPostViewerStates(uris, viewer) : undefined,
       this.label.getLabelsForSubjects(allPostUris),
       this.hydratePostBlocks(posts),
@@ -320,14 +328,13 @@ export class Hydrator {
   //     - list basic
   //   - post
   //     - ...
-  async hydrateFeedPosts(
-    uris: string[],
+  async hydrateFeedItems(
+    items: FeedItem[],
     viewer: string | null,
     includeTakedowns = false,
   ): Promise<HydrationState> {
-    const collectionUris = urisByCollection(uris)
-    const postUris = collectionUris.get(ids.AppBskyFeedPost) ?? []
-    const repostUris = collectionUris.get(ids.AppBskyFeedRepost) ?? []
+    const postUris = items.map((item) => item.post.uri)
+    const repostUris = mapDefined(items, (item) => item.repost?.uri)
     const [posts, reposts, repostProfileState] = await Promise.all([
       this.feed.getPosts(postUris, includeTakedowns),
       this.feed.getReposts(repostUris),
@@ -337,36 +344,19 @@ export class Hydrator {
         includeTakedowns,
       ),
     ])
-    const repostPostUris = mapDefined(
-      [...reposts.values()],
-      (repost) => repost?.record.subject.uri,
-    )
-    const repostPosts = await this.feed.getPosts(
-      repostPostUris,
-      includeTakedowns,
-    )
-    const repostedAndReplyUris: string[] = []
-    repostPosts.forEach((post, uri) => {
-      repostedAndReplyUris.push(uri)
-      if (post?.record.reply) {
-        repostedAndReplyUris.push(
-          post.record.reply.root.uri,
-          post.record.reply.parent.uri,
-        )
-      }
-    })
-    posts.forEach((post) => {
-      if (post?.record.reply) {
-        repostedAndReplyUris.push(
-          post.record.reply.root.uri,
-          post.record.reply.parent.uri,
-        )
+    const postAndReplyRefs: ItemRef[] = []
+    posts.forEach((post, uri) => {
+      if (!post) return
+      postAndReplyRefs.push({ uri, cid: post.cid.toString() })
+      if (post.record.reply) {
+        postAndReplyRefs.push(post.record.reply.root, post.record.reply.parent)
       }
     })
     const postState = await this.hydratePosts(
-      [...postUris, ...repostedAndReplyUris],
+      postAndReplyRefs,
       viewer,
       includeTakedowns,
+      { posts },
     )
     return mergeManyStates(postState, repostProfileState, {
       reposts,
@@ -385,10 +375,10 @@ export class Hydrator {
   //     - profile
   //       - list basic
   async hydrateThreadPosts(
-    uris: string[],
+    refs: ItemRef[],
     viewer: string | null,
   ): Promise<HydrationState> {
-    return this.hydratePosts(uris, viewer)
+    return this.hydratePosts(refs, viewer)
   }
 
   // app.bsky.feed.defs#generatorView
@@ -396,13 +386,13 @@ export class Hydrator {
   //   - profile
   //     - list basic
   async hydrateFeedGens(
-    uris: string[],
+    uris: string[], // @TODO any way to get refs here?
     viewer: string | null,
   ): Promise<HydrationState> {
     const [feedgens, feedgenAggs, feedgenViewers, profileState] =
       await Promise.all([
         this.feed.getFeedGens(uris),
-        this.feed.getFeedGenAggregates(uris),
+        this.feed.getFeedGenAggregates(uris.map((uri) => ({ uri }))),
         viewer ? this.feed.getFeedGenViewerStates(uris, viewer) : undefined,
         this.hydrateProfiles(uris.map(didFromUri), viewer),
       ])
@@ -618,4 +608,9 @@ const mergeManyStates = (...states: HydrationState[]) => {
 
 const mergeManyMaps = <T>(...maps: HydrationMap<T>[]) => {
   return maps.reduce(mergeMaps, undefined as HydrationMap<T> | undefined)
+}
+
+const notIn = (uris: string[], map?: HydrationMap<unknown>) => {
+  if (!map) return uris
+  return uris.filter((uri) => !map.has(uri))
 }

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -254,7 +254,7 @@ export class Hydrator {
       feedGenState,
     ] = await Promise.all([
       this.feed.getPostAggregates(refs),
-      viewer ? this.feed.getPostViewerStates(uris, viewer) : undefined,
+      viewer ? this.feed.getPostViewerStates(refs, viewer) : undefined,
       this.label.getLabelsForSubjects(allPostUris),
       this.hydratePostBlocks(posts),
       this.hydrateProfiles(

--- a/packages/bsky/src/hydration/label.ts
+++ b/packages/bsky/src/hydration/label.ts
@@ -13,6 +13,7 @@ export class LabelHydrator {
     subjects: string[],
     issuers?: string[],
   ): Promise<Labels> {
+    if (!subjects.length) return new HydrationMap<Label[]>()
     const res = await this.dataplane.getLabels({ subjects, issuers })
     return res.labels.reduce((acc, cur) => {
       const label = parseJsonBytes(cur) as Label | undefined

--- a/packages/bsky/src/hydration/util.ts
+++ b/packages/bsky/src/hydration/util.ts
@@ -76,3 +76,19 @@ export const urisByCollection = (uris: string[]): Map<string, string[]> => {
   }
   return result
 }
+
+export const split = <T>(
+  items: T[],
+  predicate: (item: T) => boolean,
+): [T[], T[]] => {
+  const yes: T[] = []
+  const no: T[] = []
+  for (const item of items) {
+    if (predicate(item)) {
+      yes.push(item)
+    } else {
+      no.push(item)
+    }
+  }
+  return [yes, no]
+}

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -46,7 +46,7 @@ import {
   isRecordWithMedia,
 } from './types'
 import { Label } from '../hydration/label'
-import { Repost } from '../hydration/feed'
+import { FeedItem, Repost } from '../hydration/feed'
 import { RecordInfo } from '../hydration/util'
 import { Notification } from '../data-plane/gen/bsky_pb'
 
@@ -268,7 +268,7 @@ export class Views {
   // ------------
 
   feedItemBlocksAndMutes(
-    uri: string,
+    item: FeedItem,
     state: HydrationState,
   ): {
     originatorMuted: boolean
@@ -276,24 +276,15 @@ export class Views {
     authorMuted: boolean
     authorBlocked: boolean
   } {
-    const parsed = new AtUri(uri)
-    if (parsed.collection === ids.AppBskyFeedRepost) {
-      const repost = state.reposts?.get(uri)
-      const postUri = repost?.record.subject.uri
-      const postDid = postUri ? creatorFromUri(postUri) : undefined
-      return {
-        originatorMuted: this.viewerMuteExists(parsed.hostname, state),
-        originatorBlocked: this.viewerBlockExists(parsed.hostname, state),
-        authorMuted: !!postDid && this.viewerMuteExists(postDid, state),
-        authorBlocked: !!postDid && this.viewerBlockExists(postDid, state),
-      }
-    } else {
-      return {
-        originatorMuted: this.viewerMuteExists(parsed.hostname, state),
-        originatorBlocked: this.viewerBlockExists(parsed.hostname, state),
-        authorMuted: this.viewerMuteExists(parsed.hostname, state),
-        authorBlocked: this.viewerBlockExists(parsed.hostname, state),
-      }
+    const authorDid = creatorFromUri(item.post.uri)
+    const originatorDid = item.repost
+      ? creatorFromUri(item.repost.uri)
+      : authorDid
+    return {
+      originatorMuted: this.viewerMuteExists(originatorDid, state),
+      originatorBlocked: this.viewerBlockExists(originatorDid, state),
+      authorMuted: this.viewerMuteExists(authorDid, state),
+      authorBlocked: this.viewerBlockExists(authorDid, state),
     }
   }
 
@@ -397,29 +388,28 @@ export class Views {
     }
   }
 
-  feedViewPost(uri: string, state: HydrationState): FeedViewPost | undefined {
+  feedViewPost(
+    item: FeedItem,
+    state: HydrationState,
+  ): FeedViewPost | undefined {
     // no block violating posts in feeds
-    if (state.postBlocks?.get(uri)?.reply) return undefined
-    const parsedUri = new AtUri(uri)
-    const postInfo = state.posts?.get(uri)
-    let postUri: AtUri
+    if (state.postBlocks?.get(item.post.uri)?.reply) return undefined
+    const postInfo = state.posts?.get(item.post.uri)
     let reason: ReasonRepost | undefined
-    if (parsedUri.collection === ids.AppBskyFeedRepost) {
-      const repost = state.reposts?.get(uri)
+    if (item.repost) {
+      const repost = state.reposts?.get(item.repost.uri)
       if (!repost) return
-      reason = this.reasonRepost(parsedUri.hostname, repost, state)
+      if (repost.record.subject.uri !== item.post.uri) return
+      reason = this.reasonRepost(creatorFromUri(item.repost.uri), repost, state)
       if (!reason) return
-      postUri = new AtUri(repost.record.subject.uri)
-    } else {
-      postUri = parsedUri
     }
-    const post = this.post(postUri.toString(), state)
+    const post = this.post(item.post.uri, state)
     if (!post) return
     return {
       post,
       reason,
       reply: !postInfo?.violatesThreadGate
-        ? this.replyRef(postUri.toString(), state)
+        ? this.replyRef(item.post.uri, state)
         : undefined,
     }
   }


### PR DESCRIPTION
A few improvements here to the appview:
 - take advantage of feed items containing both post and repost uris.
 - plumb uris+cids together through to dataplane methods where applicable (mostly for interaction counts and post viewer state).
 - avoid calling into dataplane with empty lists.