### PR TITLE
Appview v2: handle empty cursor on list notifications

### DIFF
--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -54,7 +54,7 @@ const skeleton = async (
   ])
   return {
     notifs: res.notifications,
-    cursor: res.cursor,
+    cursor: res.cursor || undefined,
     lastSeenNotifs: lastSeenRes.timestamp?.toDate().toISOString(),
   }
 }


### PR DESCRIPTION
Appview v2 needs to handle empty cursors coming from the dataplane, looks like this one on `listNotifications` was just missed.