### PR TITLE
Appview v2 search, post threads fix, todos

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -40,7 +40,7 @@ const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
   const { ctx, params } = inputs
 
   // @TODO
-  //add hits total
+  // add hits total
   assert(ctx.searchAgent, 'unsupported without search agent')
   const { data: res } =
     await ctx.searchAgent.api.app.bsky.unspecced.searchActorsSkeleton({

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -1,5 +1,7 @@
+import assert from 'assert'
 import AppContext from '../../../../context'
 import { Server } from '../../../../lexicon'
+import AtpAgent from '@atproto/api'
 import { mapDefined } from '@atproto/common'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/actor/searchActorsTypeahead'
 import {
@@ -36,18 +38,20 @@ export default function (server: Server, ctx: AppContext) {
 
 const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
   const { ctx, params } = inputs
-  const term = params.q ?? params.term
 
   // @TODO
   // add typeahead option
   // add hits total
+  assert(ctx.searchAgent, 'unsupported without search agent')
+  const { data: res } =
+    await ctx.searchAgent.api.app.bsky.unspecced.searchActorsSkeleton({
+      typeahead: true,
+      q: params.q ?? params.term ?? '',
+      limit: params.limit,
+    })
 
-  const res = await ctx.dataplane.searchActors({
-    term,
-    limit: params.limit,
-  })
   return {
-    dids: res.dids,
+    dids: res.actors.map(({ did }) => did),
     cursor: parseString(res.cursor),
   }
 }
@@ -83,6 +87,7 @@ type Context = {
   dataplane: DataPlaneClient
   hydrator: Hydrator
   views: Views
+  searchAgent?: AtpAgent
 }
 
 type Params = QueryParams & { viewer: string | null }

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import AppContext from '../../../../context'
 import { Server } from '../../../../lexicon'
 import AtpAgent from '@atproto/api'
@@ -38,20 +37,31 @@ export default function (server: Server, ctx: AppContext) {
 
 const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
   const { ctx, params } = inputs
+  const term = params.q ?? params.term ?? ''
 
   // @TODO
   // add typeahead option
   // add hits total
-  assert(ctx.searchAgent, 'unsupported without search agent')
-  const { data: res } =
-    await ctx.searchAgent.api.app.bsky.unspecced.searchActorsSkeleton({
-      typeahead: true,
-      q: params.q ?? params.term ?? '',
-      limit: params.limit,
-    })
 
+  if (ctx.searchAgent) {
+    const { data: res } =
+      await ctx.searchAgent.api.app.bsky.unspecced.searchActorsSkeleton({
+        typeahead: true,
+        q: term,
+        limit: params.limit,
+      })
+    return {
+      dids: res.actors.map(({ did }) => did),
+      cursor: parseString(res.cursor),
+    }
+  }
+
+  const res = await ctx.dataplane.searchActors({
+    term,
+    limit: params.limit,
+  })
   return {
-    dids: res.actors.map(({ did }) => did),
+    dids: res.dids,
     cursor: parseString(res.cursor),
   }
 }

--- a/packages/bsky/src/api/app/bsky/notification/registerPush.ts
+++ b/packages/bsky/src/api/app/bsky/notification/registerPush.ts
@@ -1,17 +1,12 @@
-import { InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.notification.registerPush({
     auth: ctx.authVerifier,
-    handler: async ({ auth, input }) => {
-      const { serviceDid } = input.body
-      if (serviceDid !== auth.artifacts.aud) {
-        throw new InvalidRequestError('Invalid serviceDid.')
-      }
-      // @TODO fix pending appview v2 buildout
-      throw new InvalidRequestError('not currently supported')
+    handler: async () => {
+      // @TODO for appview v2
+      throw new Error('unimplemented')
     },
   })
 }

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -6,13 +6,8 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.unspecced.getPopularFeedGenerators({
     auth: ctx.authOptionalVerifier,
     handler: async (_reqCtx) => {
-      // @TODO not currently supported during appview v2 buildout
-      return {
-        encoding: 'application/json',
-        body: {
-          feeds: [],
-        },
-      }
+      // @TODO for appview v2
+      throw new Error('unimplemented')
     },
   })
 }

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -10,6 +10,7 @@ export interface ServerConfigValues {
   dataplaneUrls: string[]
   dataplaneHttpVersion?: '1.1' | '2'
   dataplaneIgnoreBadTls?: boolean
+  searchEndpoint?: string
   didPlcUrl: string
   handleResolveNameservers?: string[]
   imgUriEndpoint?: string
@@ -44,6 +45,7 @@ export class ServerConfig {
     const dataplaneHttpVersion = process.env.BSKY_DATAPLANE_HTTP_VERSION || '2'
     const dataplaneIgnoreBadTls =
       process.env.BSKY_DATAPLANE_IGNORE_BAD_TLS === 'true'
+    const searchEndpoint = process.env.BSKY_SEARCH_ENDPOINT || undefined
     const adminPassword = process.env.BSKY_ADMIN_PASSWORD || 'admin'
     const moderatorPassword = process.env.BSKY_MODERATOR_PASSWORD || undefined
     const triagePassword = process.env.BSKY_TRIAGE_PASSWORD || undefined
@@ -59,6 +61,7 @@ export class ServerConfig {
       dataplaneUrls,
       dataplaneHttpVersion,
       dataplaneIgnoreBadTls,
+      searchEndpoint,
       didPlcUrl,
       handleResolveNameservers,
       imgUriEndpoint,
@@ -117,6 +120,10 @@ export class ServerConfig {
 
   get dataplaneIgnoreBadTls() {
     return this.cfg.dataplaneIgnoreBadTls
+  }
+
+  get searchEndpoint() {
+    return this.cfg.searchEndpoint
   }
 
   get handleResolveNameservers() {

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -16,6 +16,7 @@ export class AppContext {
     private opts: {
       cfg: ServerConfig
       dataplane: DataPlaneClient
+      searchAgent: AtpAgent | undefined
       hydrator: Hydrator
       views: Views
       signingKey: Keypair
@@ -31,6 +32,10 @@ export class AppContext {
 
   get dataplane(): DataPlaneClient {
     return this.opts.dataplane
+  }
+
+  get searchAgent(): AtpAgent | undefined {
+    return this.opts.searchAgent
   }
 
   get hydrator(): Hydrator {

--- a/packages/bsky/src/data-plane/client.ts
+++ b/packages/bsky/src/data-plane/client.ts
@@ -40,6 +40,18 @@ export const createDataPlaneClient = (
   }) as DataPlaneClient
 }
 
+export { Code }
+
+export const isDataplaneError = (
+  err: unknown,
+  code?: Code,
+): err is ConnectError => {
+  if (err instanceof ConnectError) {
+    return !code || err.code === code
+  }
+  return false
+}
+
 const createBaseClient = (
   baseUrl: string,
   opts: { httpVersion?: HttpVersion; rejectUnauthorized?: boolean },

--- a/packages/bsky/src/data-plane/server/routes/search.ts
+++ b/packages/bsky/src/data-plane/server/routes/search.ts
@@ -4,7 +4,7 @@ import { Database } from '../db'
 import { IndexedAtDidKeyset, TimeCidKeyset, paginate } from '../db/pagination'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
-  // @TODO not yet in use by search endpoints
+  // @TODO actor search endpoints still fall back to search service
   async searchActors(req) {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic
@@ -32,7 +32,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     }
   },
 
-  // @TODO not yet in use by search endpoints
+  // @TODO post search endpoint still falls back to search service
   async searchPosts(req) {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic

--- a/packages/bsky/src/data-plane/server/routes/search.ts
+++ b/packages/bsky/src/data-plane/server/routes/search.ts
@@ -4,6 +4,7 @@ import { Database } from '../db'
 import { IndexedAtDidKeyset, TimeCidKeyset, paginate } from '../db/pagination'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
+  // @TODO not yet in use by search endpoints
   async searchActors(req) {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic
@@ -31,6 +32,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     }
   },
 
+  // @TODO not yet in use by search endpoints
   async searchPosts(req) {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -5,6 +5,7 @@ import events from 'events'
 import { createHttpTerminator, HttpTerminator } from 'http-terminator'
 import cors from 'cors'
 import compression from 'compression'
+import AtpAgent from '@atproto/api'
 import { DidCache, IdResolver } from '@atproto/identity'
 import API, { health, wellKnown, blobResolver } from './api'
 import * as error from './error'
@@ -71,6 +72,9 @@ export class BskyAppView {
       )
     }
 
+    const searchAgent = config.searchEndpoint
+      ? new AtpAgent({ service: config.searchEndpoint })
+      : undefined
     const dataplane = createDataPlaneClient(config.dataplaneUrls, {
       httpVersion: config.dataplaneHttpVersion,
       rejectUnauthorized: !config.dataplaneIgnoreBadTls,
@@ -81,6 +85,7 @@ export class BskyAppView {
     const ctx = new AppContext({
       cfg: config,
       dataplane,
+      searchAgent,
       hydrator,
       views,
       signingKey,

--- a/packages/pds/tests/proxied/views.test.ts
+++ b/packages/pds/tests/proxied/views.test.ts
@@ -333,7 +333,8 @@ describe('proxies view requests', () => {
     expect([...pt1.data.feed, ...pt2.data.feed]).toEqual(res.data.feed)
   })
 
-  it('unspecced.getPopularFeedGenerators', async () => {
+  // @TODO disabled during appview v2 buildout
+  it.skip('unspecced.getPopularFeedGenerators', async () => {
     const res = await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
       {},
       {


### PR DESCRIPTION
A small smattering of changes:
 - using the search service for now to handle search skeletons, rather than the dataplane.
 - support receiving not-found error from dataplane thread skeleton.
 - make some endpoints fail that are not implemented on v2.