### PR TITLE
Automod: create reports using emitModerationAction

### DIFF
--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - auto-mod-tweak
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-bsky-aws.yaml
+++ b/.github/workflows/build-and-push-bsky-aws.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - auto-mod-tweak
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -146,7 +146,7 @@ export class AutoModerator {
         comment: `Automatically flagged for possible slurs: ${matches.join(
           ', ',
         )}`,
-        reasonType: REASONOTHER,
+        reportType: REASONOTHER,
       },
       subject: formattedSubject,
       createdBy: this.ctx.cfg.serverDid,
@@ -208,7 +208,7 @@ export class AutoModerator {
       event: {
         $type: 'com.atproto.admin.defs#modEventReport',
         comment: reportReason,
-        reasonType: REASONVIOLATION,
+        reportType: REASONVIOLATION,
       },
       subject: {
         $type: 'com.atproto.repo.strongRef',

--- a/packages/bsky/src/auto-moderator/index.ts
+++ b/packages/bsky/src/auto-moderator/index.ts
@@ -139,11 +139,17 @@ export class AutoModerator {
             uri: subject.uri.toString(),
             cid: subject.cid.toString(),
           }
-    await this.pushAgent.api.com.atproto.moderation.createReport({
-      reasonType: REASONOTHER,
-      reason: `Automatically flagged for possible slurs: ${matches.join(', ')}`,
+
+    await this.pushAgent.api.com.atproto.admin.emitModerationEvent({
+      event: {
+        $type: 'com.atproto.admin.defs#modEventReport',
+        comment: `Automatically flagged for possible slurs: ${matches.join(
+          ', ',
+        )}`,
+        reasonType: REASONOTHER,
+      },
       subject: formattedSubject,
-      reportedBy: this.ctx.cfg.serverDid,
+      createdBy: this.ctx.cfg.serverDid,
     })
   }
 
@@ -198,15 +204,18 @@ export class AutoModerator {
       'hard takedown of record (and blobs) based on auto-matching',
     )
 
-    await this.pushAgent.com.atproto.moderation.createReport({
-      reportedBy: this.ctx.cfg.serverDid,
-      reasonType: REASONVIOLATION,
+    await this.pushAgent.api.com.atproto.admin.emitModerationEvent({
+      event: {
+        $type: 'com.atproto.admin.defs#modEventReport',
+        comment: reportReason,
+        reasonType: REASONVIOLATION,
+      },
       subject: {
         $type: 'com.atproto.repo.strongRef',
         uri: uri.toString(),
         cid: recordCid.toString(),
       },
-      reason: reportReason,
+      createdBy: this.ctx.cfg.serverDid,
     })
 
     await this.pushAgent.com.atproto.admin.emitModerationEvent({


### PR DESCRIPTION
Use `emitModerationAction` to create a report from automod rather than `createReport`. This simplifies the possible communication/auth flows between automod & ozone