### PR TITLE
Pass headers to feed generator

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -39,9 +39,11 @@ export default function (server: Server, ctx: AppContext) {
       const feedService = ctx.services.feed(db)
       const viewer = auth.credentials.iss
       const headers: Record<string, string> = {}
-      for (const [key, value] of Object.entries(req.headers)) {
+      const headersToForward = ['authorization', 'accept-language']
+      for (const header of headersToForward) {
+        const value = req.headers[header]
         if (typeof value === 'string') {
-          headers[key] = value
+          headers[header] = value
         }
       }
       const { timerSkele, timerHydr, ...result } = await getFeed(

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -38,14 +38,19 @@ export default function (server: Server, ctx: AppContext) {
       const db = ctx.db.getReplica()
       const feedService = ctx.services.feed(db)
       const viewer = auth.credentials.iss
-
+      const headers: Record<string, string> = {}
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (typeof value === 'string') {
+          headers[key] = value
+        }
+      }
       const { timerSkele, timerHydr, ...result } = await getFeed(
         { ...params, viewer },
         {
           db,
           feedService,
           appCtx: ctx,
-          authorization: req.headers['authorization'],
+          headers,
         },
       )
 
@@ -127,7 +132,7 @@ type Context = {
   db: Database
   feedService: FeedService
   appCtx: AppContext
-  authorization?: string
+  headers: Record<string, string>
 }
 
 type Params = GetFeedParams & { viewer: string | null }
@@ -147,7 +152,7 @@ const skeletonFromFeedGen = async (
   ctx: Context,
   params: GetFeedParams,
 ): Promise<AlgoResponse> => {
-  const { db, appCtx, authorization } = ctx
+  const { db, appCtx, headers } = ctx
   const { feed } = params
   // Resolve and fetch feed skeleton
   const found = await db.db
@@ -185,9 +190,6 @@ const skeletonFromFeedGen = async (
   let skeleton: SkeletonOutput
   try {
     // @TODO currently passthrough auth headers from pds
-    const headers: Record<string, string> = authorization
-      ? { authorization: authorization }
-      : {}
     const result = await agent.api.app.bsky.feed.getFeedSkeleton(params, {
       headers,
     })

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -4,7 +4,7 @@ import AppContext from '../../../../context'
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getFeed({
     auth: ctx.authVerifier.access,
-    handler: async ({ params, auth }) => {
+    handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
 
       const { data: feed } =
@@ -12,9 +12,22 @@ export default function (server: Server, ctx: AppContext) {
           { feed: params.feed },
           await ctx.appviewAuthHeaders(requester),
         )
+      const serviceAuthHeaders = await ctx.serviceAuthHeaders(
+        requester,
+        feed.view.did,
+      )
+      const headersToPassThru: Record<string, string> = {}
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (typeof value === 'string') {
+          headersToPassThru[key] = value
+        }
+      }
+      const feedOpts = {
+        headers: { ...headersToPassThru, ...serviceAuthHeaders.headers },
+      }
       const res = await ctx.appViewAgent.api.app.bsky.feed.getFeed(
         params,
-        await ctx.serviceAuthHeaders(requester, feed.view.did),
+        feedOpts,
       )
       return {
         encoding: 'application/json',

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -16,14 +16,16 @@ export default function (server: Server, ctx: AppContext) {
         requester,
         feed.view.did,
       )
-      const headersToPassThru: Record<string, string> = {}
-      for (const [key, value] of Object.entries(req.headers)) {
+      const headers: Record<string, string> = {}
+      const headersToForward = ['accept-language']
+      for (const header of headersToForward) {
+        const value = req.headers[header]
         if (typeof value === 'string') {
-          headersToPassThru[key] = value
+          headers[header] = value
         }
       }
       const feedOpts = {
-        headers: { ...headersToPassThru, ...serviceAuthHeaders.headers },
+        headers: { ...headers, ...serviceAuthHeaders.headers },
       }
       const res = await ctx.appViewAgent.api.app.bsky.feed.getFeed(
         params,


### PR DESCRIPTION
Forwards headers from getFeed req to the feed generator. In light of [this PR adding an Accept-Language header to requests from the frontend](https://github.com/bluesky-social/social-app/pull/2457), this will enable feed generators to respect the user's language preferences.