### PR TITLE
Support label issuer tied to appview v2

### DIFF
--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -11,6 +11,7 @@ export interface ServerConfigValues {
   dataplaneHttpVersion?: '1.1' | '2'
   dataplaneIgnoreBadTls?: boolean
   didPlcUrl: string
+  labelsFromIssuerDids?: string[]
   handleResolveNameservers?: string[]
   imgUriEndpoint?: string
   blobCacheLocation?: string
@@ -45,6 +46,9 @@ export class ServerConfig {
     const dataplaneHttpVersion = process.env.BSKY_DATAPLANE_HTTP_VERSION || '2'
     const dataplaneIgnoreBadTls =
       process.env.BSKY_DATAPLANE_IGNORE_BAD_TLS === 'true'
+    const labelsFromIssuerDids = process.env.BSKY_LABELS_FROM_ISSUER_DIDS
+      ? process.env.BSKY_LABELS_FROM_ISSUER_DIDS.split(',')
+      : []
     const adminPassword = process.env.BSKY_ADMIN_PASSWORD
     assert(adminPassword)
     const moderatorPassword = process.env.BSKY_MODERATOR_PASSWORD
@@ -67,6 +71,7 @@ export class ServerConfig {
       dataplaneHttpVersion,
       dataplaneIgnoreBadTls,
       didPlcUrl,
+      labelsFromIssuerDids,
       handleResolveNameservers,
       imgUriEndpoint,
       blobCacheLocation,
@@ -125,6 +130,10 @@ export class ServerConfig {
 
   get dataplaneIgnoreBadTls() {
     return this.cfg.dataplaneIgnoreBadTls
+  }
+
+  get labelsFromIssuerDids() {
+    return this.cfg.labelsFromIssuerDids ?? []
   }
 
   get handleResolveNameservers() {

--- a/packages/bsky/src/data-plane/server/routes/labels.ts
+++ b/packages/bsky/src/data-plane/server/routes/labels.ts
@@ -5,14 +5,14 @@ import { Database } from '../db'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getLabels(req) {
-    // @TODO add in issues param
-    const { subjects } = req
-    if (subjects.length === 0) {
+    const { subjects, issuers } = req
+    if (subjects.length === 0 || issuers.length === 0) {
       return { records: [] }
     }
     const res = await db.db
       .selectFrom('label')
       .where('uri', 'in', subjects)
+      .where('src', 'in', issuers)
       .selectAll()
       .execute()
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -74,11 +74,14 @@ export class Hydrator {
   graph: GraphHydrator
   label: LabelHydrator
 
-  constructor(public dataplane: DataPlaneClient) {
+  constructor(
+    public dataplane: DataPlaneClient,
+    public opts?: { labelsFromIssuerDids?: string[] },
+  ) {
     this.actor = new ActorHydrator(dataplane)
     this.feed = new FeedHydrator(dataplane)
     this.graph = new GraphHydrator(dataplane)
-    this.label = new LabelHydrator(dataplane)
+    this.label = new LabelHydrator(dataplane, opts)
   }
 
   // app.bsky.actor.defs#profileView

--- a/packages/bsky/src/hydration/label.ts
+++ b/packages/bsky/src/hydration/label.ts
@@ -7,12 +7,18 @@ export type { Label } from '../lexicon/types/com/atproto/label/defs'
 export type Labels = HydrationMap<Label[]>
 
 export class LabelHydrator {
-  constructor(public dataplane: DataPlaneClient) {}
+  constructor(
+    public dataplane: DataPlaneClient,
+    public opts?: { labelsFromIssuerDids?: string[] },
+  ) {}
 
   async getLabelsForSubjects(
     subjects: string[],
     issuers?: string[],
   ): Promise<Labels> {
+    issuers = ([] as string[])
+      .concat(issuers ?? [])
+      .concat(this.opts?.labelsFromIssuerDids ?? [])
     const res = await this.dataplane.getLabels({ subjects, issuers })
     return res.labels.reduce((acc, cur) => {
       const label = parseJsonBytes(cur) as Label | undefined

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -84,7 +84,9 @@ export class BskyAppView {
       httpVersion: config.dataplaneHttpVersion,
       rejectUnauthorized: !config.dataplaneIgnoreBadTls,
     })
-    const hydrator = new Hydrator(dataplane)
+    const hydrator = new Hydrator(dataplane, {
+      labelsFromIssuerDids: config.labelsFromIssuerDids,
+    })
     const views = new Views(imgUriBuilder)
 
     const ctx = new AppContext({

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -52,6 +52,7 @@ export class TestBsky {
       dataplaneUrls: [`http://localhost:${dataplanePort}`],
       dataplaneHttpVersion: '1.1',
       modServiceDid: cfg.modServiceDid ?? 'did:example:invalidMod',
+      labelsFromIssuerDids: ['did:example:labeler'], // this did is also used as the labeler in seeds
       ...cfg,
       adminPassword: ADMIN_PASSWORD,
       moderatorPassword: MOD_PASSWORD,

--- a/packages/dev-env/src/seed/basic.ts
+++ b/packages/dev-env/src/seed/basic.ts
@@ -182,7 +182,7 @@ const createLabel = async (
       val: opts.val,
       cts: new Date().toISOString(),
       neg: false,
-      src: 'did:example:labeler',
+      src: 'did:example:labeler', // this did is also configured on labelsFromIssuerDids
     })
     .execute()
 }


### PR DESCRIPTION
When talking to the dataplane, the appview may want to specify one or more labelers from which it always receives labels.  This adds a configuration `BSKY_LABELS_FROM_ISSUER_DIDS` which may be a comma-separated list of labeler dids.