### PR TITLE
Tidy feed generator language headers

### DIFF
--- a/packages/bsky/src/feed-gen/types.ts
+++ b/packages/bsky/src/feed-gen/types.ts
@@ -5,6 +5,7 @@ import { FeedRow } from '../services/feed'
 
 export type AlgoResponse = {
   feedItems: FeedRow[]
+  resHeaders?: Record<string, string>
   cursor?: string
 }
 

--- a/packages/common-web/src/util.ts
+++ b/packages/common-web/src/util.ts
@@ -1,12 +1,12 @@
 export const noUndefinedVals = <T>(
-  obj: Record<string, T>,
+  obj: Record<string, T | undefined>,
 ): Record<string, T> => {
   Object.keys(obj).forEach((k) => {
     if (obj[k] === undefined) {
       delete obj[k]
     }
   })
-  return obj
+  return obj as Record<string, T>
 }
 
 export const jitter = (maxMs: number) => {

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -1,11 +1,10 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
-import { forwardResHeader } from '@atproto/xrpc-server/src/util'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getFeed({
     auth: ctx.authVerifier.access,
-    handler: async ({ req, res, params, auth }) => {
+    handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
 
       const { data: feed } =
@@ -20,15 +19,17 @@ export default function (server: Server, ctx: AppContext) {
       // forward accept-language header to upstream services
       serviceAuthHeaders.headers['accept-language'] =
         req.headers['accept-language']
-      const feedRes = await ctx.appViewAgent.api.app.bsky.feed.getFeed(
+      const res = await ctx.appViewAgent.api.app.bsky.feed.getFeed(
         params,
         serviceAuthHeaders,
       )
-      forwardResHeader(res, feedRes.headers, 'content-language')
 
       return {
         encoding: 'application/json',
-        body: feedRes.data,
+        body: res.data,
+        headers: {
+          'content-language': res.headers['content-language'],
+        },
       }
     },
   })

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -1,5 +1,6 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
+import { noUndefinedVals } from '@atproto/common'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getFeed({
@@ -27,9 +28,9 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: res.data,
-        headers: {
+        headers: noUndefinedVals({
           'content-language': res.headers['content-language'],
-        },
+        }),
       }
     },
   })

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -11,7 +11,6 @@ import {
   LexXrpcSubscription,
 } from '@atproto/lexicon'
 import { forwardStreamErrors, MaxSizeChecker } from '@atproto/common'
-import { Headers as XrpcHeaders } from '@atproto/xrpc'
 import {
   UndecodedParams,
   Params,

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -269,17 +269,6 @@ function decodeBodyStream(
   return stream
 }
 
-export function forwardResHeader(
-  res: express.Response,
-  headers: XrpcHeaders,
-  headerName: string,
-) {
-  const val = headers[headerName]
-  if (val) {
-    res.setHeader(headerName, val)
-  }
-}
-
 export function serverTimingHeader(timings: ServerTiming[]) {
   return timings
     .map((timing) => {

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -11,6 +11,7 @@ import {
   LexXrpcSubscription,
 } from '@atproto/lexicon'
 import { forwardStreamErrors, MaxSizeChecker } from '@atproto/common'
+import { Headers as XrpcHeaders } from '@atproto/xrpc'
 import {
   UndecodedParams,
   Params,
@@ -266,6 +267,17 @@ function decodeBodyStream(
   }
 
   return stream
+}
+
+export function forwardResHeader(
+  res: express.Response,
+  headers: XrpcHeaders,
+  headerName: string,
+) {
+  const val = headers[headerName]
+  if (val) {
+    res.setHeader(headerName, val)
+  }
 }
 
 export function serverTimingHeader(timings: ServerTiming[]) {


### PR DESCRIPTION
Building on https://github.com/bluesky-social/atproto/pull/2030

Tidy code a bit to bring it in line with our style & forward `content-language` header on responses to make the negotiation symmetrical