### PR TITLE
Fix unnecessary decompress-compress of Multikey

### DIFF
--- a/packages/crypto/src/did.ts
+++ b/packages/crypto/src/did.ts
@@ -68,6 +68,10 @@ export const formatDidKey = (jwtAlg: string, keyBytes: Uint8Array): string => {
   return DID_KEY_PREFIX + formatMultikey(jwtAlg, keyBytes)
 }
 
+export const formatDidKeyMultikey = (multikey: string): string => {
+  return DID_KEY_PREFIX + multikey
+}
+
 const hasPrefix = (bytes: Uint8Array, prefix: Uint8Array): boolean => {
   return uint8arrays.equals(prefix, bytes.subarray(0, prefix.byteLength))
 }

--- a/packages/identity/src/did/atproto-data.ts
+++ b/packages/identity/src/did/atproto-data.ts
@@ -28,8 +28,8 @@ export const getKey = (doc: DidDocument): string | undefined => {
   } else if (key.type === 'EcdsaSecp256k1VerificationKey2019') {
     didKey = crypto.formatDidKey(crypto.SECP256K1_JWT_ALG, keyBytes)
   } else if (key.type === 'Multikey') {
-    const parsed = crypto.parseMultikey(key.publicKeyMultibase)
-    didKey = crypto.formatDidKey(parsed.jwtAlg, parsed.keyBytes)
+    // Multikey is compressed already
+    didKey = crypto.formatDidKeyMultikey(key.publicKeyMultibase)
   }
   return didKey
 }


### PR DESCRIPTION
@dholms i didn't add new tests because imo `packages/identity/tests/did-document.test.ts` should cover it 