### PR TITLE
Appview v2: utilize sorted-at field in bsky protos

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -72,7 +72,7 @@ const presentation = (inputs: {
   const { ctx, params, skeleton, hydration } = inputs
   const likeViews = mapDefined(skeleton.likes, (uri) => {
     const like = hydration.likes?.get(uri)
-    if (!like || !like.indexedAt || !like.record) {
+    if (!like || !like.record) {
       return
     }
     const creatorDid = creatorFromUri(uri)
@@ -83,7 +83,7 @@ const presentation = (inputs: {
     return {
       actor,
       createdAt: normalizeDatetimeAlways(like.record.createdAt),
-      indexedAt: like.indexedAt.toISOString(),
+      indexedAt: like.sortedAt.toISOString(),
     }
   })
   return {

--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -17,7 +17,7 @@ export default function (server: Server, ctx: AppContext) {
           did,
           handle: info.handle ?? INVALID_HANDLE,
           relatedRecords: info.profile ? [info.profile] : undefined,
-          indexedAt: (info.indexedAt ?? new Date(0)).toISOString(),
+          indexedAt: (info.sortedAt ?? new Date(0)).toISOString(),
         }
       })
 

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -8,7 +8,7 @@ export type Actor = {
   handle?: string
   profile?: ProfileRecord
   profileCid?: CID
-  indexedAt?: Date
+  sortedAt?: Date
   takendown: boolean
 }
 
@@ -88,7 +88,7 @@ export class ActorHydrator {
         handle: parseString(actor.handle),
         profile: parseRecordBytes<ProfileRecord>(profile?.record),
         profileCid: parseCid(profile?.cid),
-        indexedAt: profile?.indexedAt?.toDate(),
+        sortedAt: profile?.sortedAt?.toDate(),
         takendown: actor.takenDown ?? false,
       })
     }, new HydrationMap<Actor>())

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -546,10 +546,10 @@ export class Hydrator {
       )
       if (!actor?.profile || !actor?.profileCid) return undefined
       return {
-        record: actor?.profile,
-        cid: actor?.profileCid,
-        indexedAt: actor?.indexedAt,
-        takenDown: actor?.takendown,
+        record: actor.profile,
+        cid: actor.profileCid,
+        sortedAt: actor.sortedAt ?? new Date(0), // @NOTE will be present since profile record is present
+        takenDown: actor.takendown,
       }
     }
   }
@@ -674,9 +674,4 @@ const mergeManyStates = (...states: HydrationState[]) => {
 
 const mergeManyMaps = <T>(...maps: HydrationMap<T>[]) => {
   return maps.reduce(mergeMaps, undefined as HydrationMap<T> | undefined)
-}
-
-const notIn = (uris: string[], map?: HydrationMap<unknown>) => {
-  if (!map) return uris
-  return uris.filter((uri) => !map.has(uri))
 }

--- a/packages/bsky/src/hydration/util.ts
+++ b/packages/bsky/src/hydration/util.ts
@@ -16,7 +16,7 @@ export class HydrationMap<T> extends Map<string, T | null> {
 export type RecordInfo<T> = {
   record: T
   cid: CID
-  indexedAt?: Date
+  sortedAt: Date
   takenDown: boolean
 }
 
@@ -29,9 +29,9 @@ export const parseRecord = <T>(
   }
   const record = parseRecordBytes<T>(entry.record)
   const cid = parseCid(entry.cid)
-  const indexedAt = entry.indexedAt?.toDate()
+  const sortedAt = entry.sortedAt?.toDate() ?? new Date(0)
   if (!record || !cid) return
-  return { record, cid, indexedAt, takenDown: entry.takenDown }
+  return { record, cid, sortedAt, takenDown: entry.takenDown }
 }
 
 export const parseRecordBytes = <T>(

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -19,7 +19,7 @@ import {
   ThreadgateView,
 } from '../lexicon/types/app/bsky/feed/defs'
 import { ListView, ListViewBasic } from '../lexicon/types/app/bsky/graph/defs'
-import { compositeTime, creatorFromUri, parseThreadGate } from './util'
+import { creatorFromUri, parseThreadGate } from './util'
 import { mapDefined } from '@atproto/common'
 import { isListRule } from '../lexicon/types/app/bsky/feed/threadgate'
 import { isSelfLabels } from '../lexicon/types/com/atproto/label/defs'
@@ -109,7 +109,7 @@ export class Views {
     return {
       ...basicView,
       description: actor.profile?.description || undefined,
-      indexedAt: actor.indexedAt?.toISOString(),
+      indexedAt: actor.sortedAt?.toISOString(),
     }
   }
 
@@ -204,10 +204,7 @@ export class Views {
       creator,
       description: list.record.description,
       descriptionFacets: list.record.descriptionFacets,
-      indexedAt: compositeTime(
-        normalizeDatetimeAlways(list.record.createdAt),
-        list.indexedAt?.toISOString(),
-      ),
+      indexedAt: list.sortedAt.toISOString(),
     }
   }
 
@@ -230,10 +227,7 @@ export class Views {
             list.record.avatar.ref,
           )
         : undefined,
-      indexedAt: compositeTime(
-        normalizeDatetimeAlways(list.record.createdAt),
-        list.indexedAt?.toISOString(),
-      ),
+      indexedAt: list.sortedAt.toISOString(),
       viewer: listViewer
         ? {
             muted: !!listViewer.viewerMuted,
@@ -318,10 +312,7 @@ export class Views {
             like: viewer.like,
           }
         : undefined,
-      indexedAt: compositeTime(
-        normalizeDatetimeAlways(feedgen.record.createdAt),
-        feedgen.indexedAt?.toISOString(),
-      ),
+      indexedAt: feedgen.sortedAt.toISOString(),
     }
   }
 
@@ -373,7 +364,7 @@ export class Views {
       replyCount: aggs?.replies,
       repostCount: aggs?.reposts,
       likeCount: aggs?.likes,
-      indexedAt: (post.indexedAt ?? new Date()).toISOString(),
+      indexedAt: post.sortedAt.toISOString(),
       viewer: viewer
         ? {
             repost: viewer.repost,
@@ -479,11 +470,10 @@ export class Views {
   ): ReasonRepost | undefined {
     const creator = this.profileBasic(creatorDid, state)
     if (!creator) return
-    if (!repost.indexedAt) return
     return {
       $type: 'app.bsky.feed.defs#reasonRepost',
       by: creator,
-      indexedAt: repost.indexedAt.toISOString(),
+      indexedAt: repost.sortedAt.toISOString(),
     }
   }
 

--- a/packages/bsky/src/views/util.ts
+++ b/packages/bsky/src/views/util.ts
@@ -8,14 +8,6 @@ import {
 } from '../lexicon/types/app/bsky/feed/threadgate'
 import { isMention } from '../lexicon/types/app/bsky/richtext/facet'
 
-const now = () => {
-  return new Date().toISOString()
-}
-
-export const compositeTime = (createdAt = now(), indexedAt = now()): string => {
-  return createdAt < indexedAt ? createdAt : indexedAt
-}
-
 export const creatorFromUri = (uri: string): string => {
   return new AtUri(uri).hostname
 }


### PR DESCRIPTION
We can defer to the bsky dataplane for sorted-at times on records.  This is generally a composite of the record's creation and indexed times.