### PR TITLE
lexicons: new app.bsky.graph.getRelationships endpoint

### DIFF
--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -76,6 +76,24 @@
         "actor": { "type": "string", "format": "at-identifier" },
         "notFound": { "type": "boolean", "const": true }
       }
+    },
+    "relationship": {
+      "type": "object",
+      "description": "lists the bi-directional graph relationships between one actor (not indicated in the object), and the target actors (the DID included in the object)",
+      "required": ["did"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "following": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor follows this DID, this is the AT-URI of the follow record"
+        },
+        "followedBy": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is followed by this DID, contains the AT-URI of the follow record"
+        }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -67,6 +67,15 @@
         "muted": { "type": "boolean" },
         "blocked": { "type": "string", "format": "at-uri" }
       }
+    },
+    "notFoundActor": {
+      "type": "object",
+      "description": "indicates that a handle or DID could not be resolved",
+      "required": ["actor", "notFound"],
+      "properties": {
+        "actor": { "type": "string", "format": "at-identifier" },
+        "notFound": { "type": "boolean", "const": true }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/graph/getRelationships.json
+++ b/lexicons/app/bsky/graph/getRelationships.json
@@ -12,6 +12,7 @@
           "actor": { "type": "string", "format": "at-identifier" },
           "others": {
             "type": "array",
+            "maxLength": 30,
             "items": {
               "type": "string",
               "format": "at-identifier"

--- a/lexicons/app/bsky/graph/getRelationships.json
+++ b/lexicons/app/bsky/graph/getRelationships.json
@@ -49,17 +49,6 @@
       "required": ["did"],
       "properties": {
         "did": { "type": "string", "format": "did" },
-        "handle": { "type": "string", "format": "handle" },
-        "blocking": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor blocks this DID, this is the AT-URI of the block record or mod list record"
-        },
-        "blockedBy": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor is blocked by this DID, this is the AT-URI of the block record or mod list record"
-        },
         "following": {
           "type": "string",
           "format": "at-uri",

--- a/lexicons/app/bsky/graph/getRelationships.json
+++ b/lexicons/app/bsky/graph/getRelationships.json
@@ -31,7 +31,10 @@
               "type": "array",
               "items": {
                 "type": "union",
-                "refs": ["#relationship", "app.bsky.graph.defs#notFoundActor"]
+                "refs": [
+                  "app.bsky.graph.def#relationship",
+                  "app.bsky.graph.defs#notFoundActor"
+                ]
               }
             }
           }
@@ -43,23 +46,6 @@
           "description": "the primary actor at-identifier could not be resolved"
         }
       ]
-    },
-    "relationship": {
-      "type": "object",
-      "required": ["did"],
-      "properties": {
-        "did": { "type": "string", "format": "did" },
-        "following": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor follows this DID, this is the AT-URI of the follow record"
-        },
-        "followedBy": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor is followed by this DID, contains the AT-URI of the follow record"
-        }
-      }
     }
   }
 }

--- a/lexicons/app/bsky/graph/getRelationships.json
+++ b/lexicons/app/bsky/graph/getRelationships.json
@@ -50,32 +50,22 @@
       "properties": {
         "did": { "type": "string", "format": "did" },
         "handle": { "type": "string", "format": "handle" },
-        "blocks": {
+        "blocking": {
           "type": "string",
           "format": "at-uri",
-          "description": "if the actor blocks this DID, this is the AT-URI of the block record"
+          "description": "if the actor blocks this DID, this is the AT-URI of the block record or mod list record"
         },
-        "blocks_via_list": {
+        "blockedBy": {
           "type": "string",
           "format": "at-uri",
-          "description": "if the actor blocks this DID, because of a mod list, this is the AT-URI of the mod list record"
+          "description": "if the actor is blocked by this DID, this is the AT-URI of the block record or mod list record"
         },
-        "blocked_by": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor is blocked by this DID, this is the AT-URI of the block record"
-        },
-        "blocked_by_via_list": {
-          "type": "string",
-          "format": "at-uri",
-          "description": "if the actor is blocked by this DID, because of a mod list, this is the AT-URI of the mod list record"
-        },
-        "follows": {
+        "following": {
           "type": "string",
           "format": "at-uri",
           "description": "if the actor follows this DID, this is the AT-URI of the follow record"
         },
-        "followed_by": {
+        "followedBy": {
           "type": "string",
           "format": "at-uri",
           "description": "if the actor is followed by this DID, contains the AT-URI of the follow record"

--- a/lexicons/app/bsky/graph/getRelationships.json
+++ b/lexicons/app/bsky/graph/getRelationships.json
@@ -1,0 +1,85 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getRelationships",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates public relationships between one account, and a list of other accounts",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": { "type": "string", "format": "at-identifier" },
+          "others": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "at-identifier"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["relationships"],
+          "properties": {
+            "actor": { "type": "string", "format": "did" },
+            "relationships": {
+              "type": "array",
+              "items": {
+                "type": "union",
+                "refs": ["#relationship", "app.bsky.graph.defs#notFoundActor"]
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "ActorNotFound",
+          "description": "the primary actor at-identifier could not be resolved"
+        }
+      ]
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["did"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "handle": { "type": "string", "format": "handle" },
+        "blocks": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor blocks this DID, this is the AT-URI of the block record"
+        },
+        "blocks_via_list": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor blocks this DID, because of a mod list, this is the AT-URI of the mod list record"
+        },
+        "blocked_by": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is blocked by this DID, this is the AT-URI of the block record"
+        },
+        "blocked_by_via_list": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is blocked by this DID, because of a mod list, this is the AT-URI of the mod list record"
+        },
+        "follows": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor follows this DID, this is the AT-URI of the follow record"
+        },
+        "followed_by": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "if the actor is followed by this DID, contains the AT-URI of the follow record"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This proposes the endpoint schema for a public (not auth'd) endpoint for fetching the public bsky social graph relationships (follows and blocks) between one actor and a list of "other" actors.

The initial motivation is to use this metadata from automod, for example in the context of a reply (wanting to know the relationships with the "root" and "parent" post authors.

If this looks good, would pass off to one of the backend folks to wire up and implement. v2 implementation should be simple, re-using an existing dataplane helper.