### PR TITLE
Ozone !takedown labels

### DIFF
--- a/packages/ozone/src/api/admin/emitModerationEvent.ts
+++ b/packages/ozone/src/api/admin/emitModerationEvent.ts
@@ -92,7 +92,6 @@ export default function (server: Server, ctx: AppContext) {
 
         if (isLabelEvent) {
           await moderationTxn.formatAndCreateLabels(
-            ctx.cfg.service.did,
             result.subjectUri ?? result.subjectDid,
             result.subjectCid,
             {

--- a/packages/ozone/src/api/temp/fetchLabels.ts
+++ b/packages/ozone/src/api/temp/fetchLabels.ts
@@ -1,29 +1,44 @@
 import { Server } from '../../lexicon'
 import AppContext from '../../context'
+import {
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
+} from '../../mod-service/types'
 
 export default function (server: Server, ctx: AppContext) {
-  server.com.atproto.temp.fetchLabels(async ({ params }) => {
-    const { limit } = params
-    const since =
-      params.since !== undefined ? new Date(params.since).toISOString() : ''
-    const labelRes = await ctx.db.db
-      .selectFrom('label')
-      .selectAll()
-      .orderBy('label.cts', 'asc')
-      .where('cts', '>', since)
-      .limit(limit)
-      .execute()
+  server.com.atproto.temp.fetchLabels({
+    auth: ctx.authOptionalAccessOrRoleVerifier,
+    handler: async ({ auth, params }) => {
+      const { limit } = params
+      const since =
+        params.since !== undefined ? new Date(params.since).toISOString() : ''
+      const includeUnspeccedTakedowns =
+        auth.credentials.type === 'role' && auth.credentials.admin
+      const labelRes = await ctx.db.db
+        .selectFrom('label')
+        .selectAll()
+        .orderBy('label.cts', 'asc')
+        .where('cts', '>', since)
+        .if(!includeUnspeccedTakedowns, (q) =>
+          q.where('label.val', 'not in', [
+            UNSPECCED_TAKEDOWN_LABEL,
+            UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+          ]),
+        )
+        .limit(limit)
+        .execute()
 
-    const labels = labelRes.map((l) => ({
-      ...l,
-      cid: l.cid === '' ? undefined : l.cid,
-    }))
+      const labels = labelRes.map((l) => ({
+        ...l,
+        cid: l.cid === '' ? undefined : l.cid,
+      }))
 
-    return {
-      encoding: 'application/json',
-      body: {
-        labels,
-      },
-    }
+      return {
+        encoding: 'application/json',
+        body: {
+          labels,
+        },
+      }
+    },
   })
 }

--- a/packages/ozone/src/context.ts
+++ b/packages/ozone/src/context.ts
@@ -65,6 +65,7 @@ export class AppContext {
       eventPusher,
       appviewAgent,
       appviewAuth,
+      cfg.service.did,
     )
 
     const communicationTemplateService = CommunicationTemplateService.creator()

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -52,6 +52,7 @@ export class DaemonContext {
       eventPusher,
       appviewAgent,
       appviewAuth,
+      cfg.service.did,
     )
     const eventReverser = new EventReverser(db, modService)
 

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -24,6 +24,8 @@ import {
   ModerationEventRow,
   ModerationSubjectStatusRow,
   ReversibleModerationEvent,
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
 } from './types'
 import { ModerationEvent } from '../db/schema/moderation_event'
 import { StatusKeyset, TimeIdKeyset, paginate } from '../db/pagination'
@@ -377,7 +379,9 @@ export class ModerationService {
         )
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { create: ['!takedown'] }),
+      this.formatAndCreateLabels(subject.did, null, {
+        create: [UNSPECCED_TAKEDOWN_LABEL],
+      }),
     ])
 
     this.db.onCommit(() => {
@@ -403,7 +407,9 @@ export class ModerationService {
         })
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { negate: ['!takedown'] }),
+      this.formatAndCreateLabels(subject.did, null, {
+        negate: [UNSPECCED_TAKEDOWN_LABEL],
+      }),
     ])
 
     this.db.onCommit(() => {
@@ -426,9 +432,9 @@ export class ModerationService {
       takedownRef,
     }))
     const blobCids = subject.blobCids
-    const labels: string[] = ['!takedown']
+    const labels: string[] = [UNSPECCED_TAKEDOWN_LABEL]
     if (blobCids && blobCids.length > 0) {
-      labels.push('!takedown-blobs')
+      labels.push(UNSPECCED_TAKEDOWN_BLOBS_LABEL)
     }
     const [recordEvts] = await Promise.all([
       this.db.db
@@ -495,10 +501,10 @@ export class ModerationService {
 
   async reverseTakedownRecord(subject: RecordSubject) {
     this.db.assertTransaction()
-    const labels: string[] = ['!takedown']
+    const labels: string[] = [UNSPECCED_TAKEDOWN_LABEL]
     const blobCids = subject.blobCids
     if (blobCids && blobCids.length > 0) {
-      labels.push('!takedown-blobs')
+      labels.push(UNSPECCED_TAKEDOWN_BLOBS_LABEL)
     }
     const [recordEvts] = await Promise.all([
       this.db.db

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -377,7 +377,7 @@ export class ModerationService {
         )
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { create: ['!purge'] }),
+      this.formatAndCreateLabels(subject.did, null, { create: ['!takedown'] }),
     ])
 
     this.db.onCommit(() => {
@@ -403,7 +403,7 @@ export class ModerationService {
         })
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { negate: ['!purge'] }),
+      this.formatAndCreateLabels(subject.did, null, { negate: ['!takedown'] }),
     ])
 
     this.db.onCommit(() => {
@@ -426,9 +426,9 @@ export class ModerationService {
       takedownRef,
     }))
     const blobCids = subject.blobCids
-    const labels: string[] = ['!purge']
+    const labels: string[] = ['!takedown']
     if (blobCids && blobCids.length > 0) {
-      labels.push('!blob-purge')
+      labels.push('!takedown-blobs')
     }
     const [recordEvts] = await Promise.all([
       this.db.db
@@ -495,10 +495,10 @@ export class ModerationService {
 
   async reverseTakedownRecord(subject: RecordSubject) {
     this.db.assertTransaction()
-    const labels: string[] = ['!purge']
+    const labels: string[] = ['!takedown']
     const blobCids = subject.blobCids
     if (blobCids && blobCids.length > 0) {
-      labels.push('!blob-purge')
+      labels.push('!takedown-blobs')
     }
     const [recordEvts] = await Promise.all([
       this.db.db

--- a/packages/ozone/src/mod-service/types.ts
+++ b/packages/ozone/src/mod-service/types.ts
@@ -30,3 +30,7 @@ export type ModEventType =
   | ComAtprotoAdminDefs.ModEventReport
   | ComAtprotoAdminDefs.ModEventMute
   | ComAtprotoAdminDefs.ModEventReverseTakedown
+
+export const UNSPECCED_TAKEDOWN_LABEL = '!unspecced-takedown'
+
+export const UNSPECCED_TAKEDOWN_BLOBS_LABEL = '!unspecced-takedown-blobs'

--- a/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!purge",
+      "val": "!takedown",
     },
     Object {
       "cid": "cids(0)",
@@ -107,7 +107,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!purge",
+      "val": "!takedown",
     },
     Object {
       "cid": "cids(0)",

--- a/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
     Object {
       "cid": "cids(0)",
@@ -107,7 +107,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
     Object {
       "cid": "cids(0)",

--- a/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
@@ -11,6 +11,14 @@ Object {
       "cid": "cids(0)",
       "cts": "1970-01-01T00:00:00.000Z",
       "neg": false,
+      "src": "user(1)",
+      "uri": "record(0)",
+      "val": "!purge",
+    },
+    Object {
+      "cid": "cids(0)",
+      "cts": "1970-01-01T00:00:00.000Z",
+      "neg": false,
       "src": "user(0)",
       "uri": "record(0)",
       "val": "self-label",
@@ -93,6 +101,14 @@ Object {
   "cid": "cids(0)",
   "indexedAt": "1970-01-01T00:00:00.000Z",
   "labels": Array [
+    Object {
+      "cid": "cids(0)",
+      "cts": "1970-01-01T00:00:00.000Z",
+      "neg": false,
+      "src": "user(1)",
+      "uri": "record(0)",
+      "val": "!purge",
+    },
     Object {
       "cid": "cids(0)",
       "cts": "1970-01-01T00:00:00.000Z",

--- a/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
@@ -8,7 +8,15 @@ Object {
   "indexedAt": "1970-01-01T00:00:00.000Z",
   "invites": Array [],
   "invitesDisabled": false,
-  "labels": Array [],
+  "labels": Array [
+    Object {
+      "cts": "1970-01-01T00:00:00.000Z",
+      "neg": false,
+      "src": "user(1)",
+      "uri": "user(0)",
+      "val": "!purge",
+    },
+  ],
   "moderation": Object {
     "subjectStatus": Object {
       "createdAt": "1970-01-01T00:00:00.000Z",

--- a/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "user(0)",
-      "val": "!purge",
+      "val": "!takedown",
     },
   ],
   "moderation": Object {

--- a/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "user(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
   ],
   "moderation": Object {

--- a/packages/ozone/tests/moderation-appeals.test.ts
+++ b/packages/ozone/tests/moderation-appeals.test.ts
@@ -39,7 +39,7 @@ describe('moderation-appeals', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'ozone_moderation_statuses',
+      dbPostgresSchema: 'ozone_moderation_appeals',
     })
     agent = network.ozone.getClient()
     pdsAgent = network.pds.getClient()

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -444,12 +444,9 @@ describe('moderation', () => {
         cid: post.cidStr,
       }
       const modService = ctx.modService(ctx.db)
-      await modService.formatAndCreateLabels(
-        ctx.cfg.service.did,
-        post.uriStr,
-        post.cidStr,
-        { create: ['kittens'] },
-      )
+      await modService.formatAndCreateLabels(post.uriStr, post.cidStr, {
+        create: ['kittens'],
+      })
       await emitLabelEvent({
         negateLabelVals: ['kittens'],
         createLabelVals: [],
@@ -464,12 +461,9 @@ describe('moderation', () => {
       })
       await expect(getRecordLabels(post.uriStr)).resolves.toEqual(['kittens'])
       // Cleanup
-      await modService.formatAndCreateLabels(
-        ctx.cfg.service.did,
-        post.uriStr,
-        post.cidStr,
-        { negate: ['kittens'] },
-      )
+      await modService.formatAndCreateLabels(post.uriStr, post.cidStr, {
+        negate: ['kittens'],
+      })
     })
 
     it('no-ops when negating an already-negated label and reverses.', async () => {
@@ -497,12 +491,9 @@ describe('moderation', () => {
       })
       await expect(getRecordLabels(post.uriStr)).resolves.toEqual(['bears'])
       // Cleanup
-      await modService.formatAndCreateLabels(
-        ctx.cfg.service.did,
-        post.uriStr,
-        post.cidStr,
-        { negate: ['bears'] },
-      )
+      await modService.formatAndCreateLabels(post.uriStr, post.cidStr, {
+        negate: ['bears'],
+      })
     })
 
     it('creates non-existing labels and reverses.', async () => {
@@ -559,12 +550,9 @@ describe('moderation', () => {
     it('creates and negates labels on a repo and reverses.', async () => {
       const { ctx } = ozone
       const modService = ctx.modService(ctx.db)
-      await modService.formatAndCreateLabels(
-        ctx.cfg.service.did,
-        sc.dids.bob,
-        null,
-        { create: ['kittens'] },
-      )
+      await modService.formatAndCreateLabels(sc.dids.bob, null, {
+        create: ['kittens'],
+      })
       await emitLabelEvent({
         createLabelVals: ['puppies'],
         negateLabelVals: ['kittens'],

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -25,6 +25,10 @@ import {
 } from '../src/lexicon/types/com/atproto/admin/defs'
 import { EventReverser } from '../src'
 import { TestOzone } from '@atproto/dev-env/src/ozone'
+import {
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
+} from '../src/mod-service/types'
 
 type BaseCreateReportParams =
   | { account: string }
@@ -654,7 +658,10 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const takedownLabel1 = await getLabel(sc.dids.bob, '!takedown')
+      const takedownLabel1 = await getLabel(
+        sc.dids.bob,
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
       expect(takedownLabel1).toBeDefined()
 
       // cleanup
@@ -677,7 +684,10 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const takedownLabel2 = await getLabel(sc.dids.bob, '!takedown')
+      const takedownLabel2 = await getLabel(
+        sc.dids.bob,
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
       expect(takedownLabel2).toBeUndefined()
     })
 
@@ -702,7 +712,7 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const takedownLabel1 = await getLabel(uri, '!takedown')
+      const takedownLabel1 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
       expect(takedownLabel1).toBeDefined()
 
       // cleanup
@@ -720,7 +730,7 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const takedownLabel2 = await getLabel(uri, '!takedown')
+      const takedownLabel2 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
       expect(takedownLabel2).toBeUndefined()
     })
 
@@ -830,6 +840,22 @@ describe('moderation', () => {
             '[SCHEDULED_REVERSAL] Reverting action as originally scheduled',
         },
       })
+    })
+
+    it('serves label when authed', async () => {
+      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+      )
+      expect(unauthed.labels.map((l) => l.val)).not.toContain(
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
+      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+        { headers: network.bsky.adminAuthHeaders() },
+      )
+      expect(authed.labels.map((l) => l.val)).toContain(
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
     })
 
     async function emitLabelEvent(
@@ -966,7 +992,10 @@ describe('moderation', () => {
     })
 
     it('creates a takedown blobs label', async () => {
-      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
+      const label = await getLabel(
+        post.ref.uriStr,
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
       expect(label).toBeDefined()
     })
 
@@ -1004,8 +1033,27 @@ describe('moderation', () => {
       expect(res.data.takedown?.applied).toBe(false)
     })
 
+    it('serves label when authed', async () => {
+      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+      )
+      expect(unauthed.labels.map((l) => l.val)).not.toContain(
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
+      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+        { headers: network.bsky.adminAuthHeaders() },
+      )
+      expect(authed.labels.map((l) => l.val)).toContain(
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
+    })
+
     it('negates takedown blobs label on reversal', async () => {
-      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
+      const label = await getLabel(
+        post.ref.uriStr,
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
       expect(label).toBeUndefined()
     })
   })

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -654,8 +654,8 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const purgeLabel1 = await getLabel(sc.dids.bob, '!purge')
-      expect(purgeLabel1).toBeDefined()
+      const takedownLabel1 = await getLabel(sc.dids.bob, '!takedown')
+      expect(takedownLabel1).toBeDefined()
 
       // cleanup
       await performReverseTakedown({ account: sc.dids.bob })
@@ -677,8 +677,8 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const purgeLabel2 = await getLabel(sc.dids.bob, '!purge')
-      expect(purgeLabel2).toBeUndefined()
+      const takedownLabel2 = await getLabel(sc.dids.bob, '!takedown')
+      expect(takedownLabel2).toBeUndefined()
     })
 
     it('fans out record takedowns', async () => {
@@ -702,8 +702,8 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const purgeLabel1 = await getLabel(uri, '!purge')
-      expect(purgeLabel1).toBeDefined()
+      const takedownLabel1 = await getLabel(uri, '!takedown')
+      expect(takedownLabel1).toBeDefined()
 
       // cleanup
       await performReverseTakedown({ content: { uri, cid } })
@@ -720,8 +720,8 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const purgeLabel2 = await getLabel(uri, '!purge')
-      expect(purgeLabel2).toBeUndefined()
+      const takedownLabel2 = await getLabel(uri, '!takedown')
+      expect(takedownLabel2).toBeUndefined()
     })
 
     it('allows full moderators to takedown.', async () => {
@@ -965,8 +965,8 @@ describe('moderation', () => {
       expect(res.data.takedown?.applied).toBe(true)
     })
 
-    it('creates a blob purge label', async () => {
-      const label = await getLabel(post.ref.uriStr, '!blob-purge')
+    it('creates a takedown blobs label', async () => {
+      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
       expect(label).toBeDefined()
     })
 
@@ -1004,8 +1004,8 @@ describe('moderation', () => {
       expect(res.data.takedown?.applied).toBe(false)
     })
 
-    it('negates blob purge label on reversal', async () => {
-      const label = await getLabel(post.ref.uriStr, '!blob-purge')
+    it('negates takedown blobs label on reversal', async () => {
+      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
       expect(label).toBeUndefined()
     })
   })


### PR DESCRIPTION
Adds two new labels to Ozone: `!takedown` and `!takedown-blobs`. These are imperative labels that instruct downstream services to remove the labels content from their indices entirely. `!takedown-blobs` has a subject of a record, and the semantic is to purge all blobs referenced by that record.

These labels are automatically applied when performing a takedown on either a repo or record.