### PR TITLE
Appview v2 initial implementation for getPopularFeedGenerators

### DIFF
--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -1,13 +1,35 @@
+import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
+import { parseString } from '../../../../hydration/util'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
+// @TODO currently mirrors getSuggestedFeeds and ignores the "query" param.
+// In the future may take into consideration popularity via likes w/ its own dataplane endpoint.
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.unspecced.getPopularFeedGenerators({
     auth: ctx.authVerifier.standardOptional,
-    handler: async (_reqCtx) => {
-      // @TODO for appview v2
-      throw new Error('unimplemented')
+    handler: async ({ auth, params }) => {
+      const viewer = auth.credentials.iss
+
+      const suggestedRes = await ctx.dataplane.getSuggestedFeeds({
+        actorDid: viewer ?? undefined,
+        limit: params.limit,
+        cursor: params.cursor,
+      })
+      const uris = suggestedRes.uris
+      const hydration = await ctx.hydrator.hydrateFeedGens(uris, viewer)
+      const feedViews = mapDefined(uris, (uri) =>
+        ctx.views.feedGenerator(uri, hydration),
+      )
+
+      return {
+        encoding: 'application/json',
+        body: {
+          feeds: feedViews,
+          cursor: parseString(suggestedRes.cursor),
+        },
+      }
     },
   })
 }


### PR DESCRIPTION
For the time being just going to piggyback off of the `GetSuggestedFeeds` dataplane endpoint to support `getPopularFeedGenerators` in appview v2.  In the future we may have a separate one to support this use case.