### PR TITLE
Temporary unspecced labels relating takedowns in ozone

### DIFF
--- a/packages/ozone/src/api/temp/fetchLabels.ts
+++ b/packages/ozone/src/api/temp/fetchLabels.ts
@@ -1,29 +1,44 @@
 import { Server } from '../../lexicon'
 import AppContext from '../../context'
+import {
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
+} from '../../mod-service/types'
 
 export default function (server: Server, ctx: AppContext) {
-  server.com.atproto.temp.fetchLabels(async ({ params }) => {
-    const { limit } = params
-    const since =
-      params.since !== undefined ? new Date(params.since).toISOString() : ''
-    const labelRes = await ctx.db.db
-      .selectFrom('label')
-      .selectAll()
-      .orderBy('label.cts', 'asc')
-      .where('cts', '>', since)
-      .limit(limit)
-      .execute()
+  server.com.atproto.temp.fetchLabels({
+    auth: ctx.authOptionalAccessOrRoleVerifier,
+    handler: async ({ auth, params }) => {
+      const { limit } = params
+      const since =
+        params.since !== undefined ? new Date(params.since).toISOString() : ''
+      const includeUnspeccedTakedowns =
+        auth.credentials.type === 'role' && auth.credentials.admin
+      const labelRes = await ctx.db.db
+        .selectFrom('label')
+        .selectAll()
+        .orderBy('label.cts', 'asc')
+        .where('cts', '>', since)
+        .if(!includeUnspeccedTakedowns, (q) =>
+          q.where('label.val', 'not in', [
+            UNSPECCED_TAKEDOWN_LABEL,
+            UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+          ]),
+        )
+        .limit(limit)
+        .execute()
 
-    const labels = labelRes.map((l) => ({
-      ...l,
-      cid: l.cid === '' ? undefined : l.cid,
-    }))
+      const labels = labelRes.map((l) => ({
+        ...l,
+        cid: l.cid === '' ? undefined : l.cid,
+      }))
 
-    return {
-      encoding: 'application/json',
-      body: {
-        labels,
-      },
-    }
+      return {
+        encoding: 'application/json',
+        body: {
+          labels,
+        },
+      }
+    },
   })
 }

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -24,6 +24,8 @@ import {
   ModerationEventRow,
   ModerationSubjectStatusRow,
   ReversibleModerationEvent,
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
 } from './types'
 import { ModerationEvent } from '../db/schema/moderation_event'
 import { StatusKeyset, TimeIdKeyset, paginate } from '../db/pagination'
@@ -377,7 +379,9 @@ export class ModerationService {
         )
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { create: ['!takedown'] }),
+      this.formatAndCreateLabels(subject.did, null, {
+        create: [UNSPECCED_TAKEDOWN_LABEL],
+      }),
     ])
 
     this.db.onCommit(() => {
@@ -403,7 +407,9 @@ export class ModerationService {
         })
         .returning('id')
         .execute(),
-      this.formatAndCreateLabels(subject.did, null, { negate: ['!takedown'] }),
+      this.formatAndCreateLabels(subject.did, null, {
+        negate: [UNSPECCED_TAKEDOWN_LABEL],
+      }),
     ])
 
     this.db.onCommit(() => {
@@ -426,9 +432,9 @@ export class ModerationService {
       takedownRef,
     }))
     const blobCids = subject.blobCids
-    const labels: string[] = ['!takedown']
+    const labels: string[] = [UNSPECCED_TAKEDOWN_LABEL]
     if (blobCids && blobCids.length > 0) {
-      labels.push('!takedown-blobs')
+      labels.push(UNSPECCED_TAKEDOWN_BLOBS_LABEL)
     }
     const [recordEvts] = await Promise.all([
       this.db.db
@@ -495,10 +501,10 @@ export class ModerationService {
 
   async reverseTakedownRecord(subject: RecordSubject) {
     this.db.assertTransaction()
-    const labels: string[] = ['!takedown']
+    const labels: string[] = [UNSPECCED_TAKEDOWN_LABEL]
     const blobCids = subject.blobCids
     if (blobCids && blobCids.length > 0) {
-      labels.push('!takedown-blobs')
+      labels.push(UNSPECCED_TAKEDOWN_BLOBS_LABEL)
     }
     const [recordEvts] = await Promise.all([
       this.db.db

--- a/packages/ozone/src/mod-service/types.ts
+++ b/packages/ozone/src/mod-service/types.ts
@@ -30,3 +30,7 @@ export type ModEventType =
   | ComAtprotoAdminDefs.ModEventReport
   | ComAtprotoAdminDefs.ModEventMute
   | ComAtprotoAdminDefs.ModEventReverseTakedown
+
+export const UNSPECCED_TAKEDOWN_LABEL = '!unspecced-takedown'
+
+export const UNSPECCED_TAKEDOWN_BLOBS_LABEL = '!unspecced-takedown-blobs'

--- a/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
@@ -13,7 +13,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
     Object {
       "cid": "cids(0)",
@@ -107,7 +107,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "record(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
     Object {
       "cid": "cids(0)",

--- a/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       "neg": false,
       "src": "user(1)",
       "uri": "user(0)",
-      "val": "!takedown",
+      "val": "!unspecced-takedown",
     },
   ],
   "moderation": Object {

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -25,6 +25,10 @@ import {
 } from '../src/lexicon/types/com/atproto/admin/defs'
 import { EventReverser } from '../src'
 import { TestOzone } from '@atproto/dev-env/src/ozone'
+import {
+  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+  UNSPECCED_TAKEDOWN_LABEL,
+} from '../src/mod-service/types'
 
 type BaseCreateReportParams =
   | { account: string }
@@ -654,7 +658,10 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const takedownLabel1 = await getLabel(sc.dids.bob, '!takedown')
+      const takedownLabel1 = await getLabel(
+        sc.dids.bob,
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
       expect(takedownLabel1).toBeDefined()
 
       // cleanup
@@ -677,7 +684,10 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const takedownLabel2 = await getLabel(sc.dids.bob, '!takedown')
+      const takedownLabel2 = await getLabel(
+        sc.dids.bob,
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
       expect(takedownLabel2).toBeUndefined()
     })
 
@@ -702,7 +712,7 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const takedownLabel1 = await getLabel(uri, '!takedown')
+      const takedownLabel1 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
       expect(takedownLabel1).toBeDefined()
 
       // cleanup
@@ -720,7 +730,7 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const takedownLabel2 = await getLabel(uri, '!takedown')
+      const takedownLabel2 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
       expect(takedownLabel2).toBeUndefined()
     })
 
@@ -830,6 +840,22 @@ describe('moderation', () => {
             '[SCHEDULED_REVERSAL] Reverting action as originally scheduled',
         },
       })
+    })
+
+    it('serves label when authed', async () => {
+      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+      )
+      expect(unauthed.labels.map((l) => l.val)).not.toContain(
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
+      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+        { headers: network.bsky.adminAuthHeaders() },
+      )
+      expect(authed.labels.map((l) => l.val)).toContain(
+        UNSPECCED_TAKEDOWN_LABEL,
+      )
     })
 
     async function emitLabelEvent(
@@ -966,7 +992,10 @@ describe('moderation', () => {
     })
 
     it('creates a takedown blobs label', async () => {
-      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
+      const label = await getLabel(
+        post.ref.uriStr,
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
       expect(label).toBeDefined()
     })
 
@@ -1004,8 +1033,27 @@ describe('moderation', () => {
       expect(res.data.takedown?.applied).toBe(false)
     })
 
+    it('serves label when authed', async () => {
+      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+      )
+      expect(unauthed.labels.map((l) => l.val)).not.toContain(
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
+      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
+        {},
+        { headers: network.bsky.adminAuthHeaders() },
+      )
+      expect(authed.labels.map((l) => l.val)).toContain(
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
+    })
+
     it('negates takedown blobs label on reversal', async () => {
-      const label = await getLabel(post.ref.uriStr, '!takedown-blobs')
+      const label = await getLabel(
+        post.ref.uriStr,
+        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
+      )
       expect(label).toBeUndefined()
     })
   })


### PR DESCRIPTION
While the names/semantics of these labels get nailed down, move to a clearly unspecced label for relating takedowns.  Based on top of #2069.