### PR TITLE
Fix timing on appview v2 repo rev header

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfile.ts
@@ -14,11 +14,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, res }) => {
       const { viewer, canViewTakedowns } = ctx.authVerifier.parseCreds(auth)
 
-      const [result, repoRev] = await Promise.all([
-        getProfile({ ...params, viewer, canViewTakedowns }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getProfile(
+        { ...params, viewer, canViewTakedowns },
+        ctx,
+      )
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {

--- a/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
@@ -14,11 +14,9 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, res }) => {
       const viewer = auth.credentials.iss
 
-      const [result, repoRev] = await Promise.all([
-        getProfile({ ...params, viewer }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getProfile({ ...params, viewer }, ctx)
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -24,11 +24,9 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, res }) => {
       const viewer = auth.credentials.iss
 
-      const [result, repoRev] = await Promise.all([
-        getActorLikes({ ...params, viewer }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getActorLikes({ ...params, viewer }, ctx)
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -29,11 +29,9 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, res }) => {
       const { viewer } = ctx.authVerifier.parseCreds(auth)
 
-      const [result, repoRev] = await Promise.all([
-        getAuthorFeed({ ...params, viewer }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getAuthorFeed({ ...params, viewer }, ctx)
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -22,11 +22,9 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, res }) => {
       const viewer = auth.credentials.iss
 
-      const [result, repoRev] = await Promise.all([
-        getListFeed({ ...params, viewer }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getListFeed({ ...params, viewer }, ctx)
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -22,11 +22,9 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, res }) => {
       const viewer = auth.credentials.iss
 
-      const [result, repoRev] = await Promise.all([
-        getTimeline({ ...params, viewer }, ctx),
-        ctx.hydrator.actor.getRepoRevSafe(viewer),
-      ])
+      const result = await getTimeline({ ...params, viewer }, ctx)
 
+      const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
       setRepoRev(res, repoRev)
 
       return {


### PR DESCRIPTION
Repo rev is processed last on record ingestion but is being grabbed first on view construction.

Change the order of fetching repoRev to the last thing we do before sending the response out. 

This will cause read-after-write behavior to err on the side of not showing the post rather than showing duplicates