### PR TITLE
Appview v2: don't apply missing modlists

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -95,10 +95,7 @@ const hydration = async (inputs: {
   const [feedPostState, profileViewerState = {}] = await Promise.all([
     ctx.hydrator.hydrateFeedItems(skeleton.items, params.viewer),
     params.viewer
-      ? ctx.hydrator.actor.getProfileViewerStates(
-          [skeleton.actor.did],
-          params.viewer,
-        )
+      ? ctx.hydrator.hydrateProfileViewers([skeleton.actor.did], params.viewer)
       : undefined,
   ])
   return mergeStates(feedPostState, profileViewerState)

--- a/packages/bsky/src/api/app/bsky/graph/getRelationships.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getRelationships.ts
@@ -14,7 +14,10 @@ export default function (server: Server, ctx: AppContext) {
           },
         }
       }
-      const res = await ctx.hydrator.actor.getProfileViewerStates(others, actor)
+      const res = await ctx.hydrator.actor.getProfileViewerStatesNaive(
+        others,
+        actor,
+      )
       const relationships = others.map((did) => {
         const subject = res.get(did)
         return subject

--- a/packages/bsky/src/data-plane/server/routes/relationships.ts
+++ b/packages/bsky/src/data-plane/server/routes/relationships.ts
@@ -26,8 +26,6 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
         db.db
           .selectFrom('list_item')
           .innerJoin('list_mute', 'list_mute.listUri', 'list_item.listUri')
-          .innerJoin('list', 'list.uri', 'list_item.listUri')
-          .where('list.purpose', '=', 'app.bsky.graph.defs#modlist')
           .where('list_mute.mutedByDid', '=', actorDid)
           .whereRef('list_item.subjectDid', '=', ref('actor.did'))
           .select('list_item.listUri')
@@ -47,8 +45,6 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
         db.db
           .selectFrom('list_item')
           .innerJoin('list_block', 'list_block.subjectUri', 'list_item.listUri')
-          .innerJoin('list', 'list.uri', 'list_item.listUri')
-          .where('list.purpose', '=', 'app.bsky.graph.defs#modlist')
           .where('list_block.creator', '=', actorDid)
           .whereRef('list_item.subjectDid', '=', ref('actor.did'))
           .select('list_item.listUri')
@@ -56,8 +52,6 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
         db.db
           .selectFrom('list_item')
           .innerJoin('list_block', 'list_block.subjectUri', 'list_item.listUri')
-          .innerJoin('list', 'list.uri', 'list_item.listUri')
-          .where('list.purpose', '=', 'app.bsky.graph.defs#modlist')
           .where('list_item.subjectDid', '=', actorDid)
           .whereRef('list_block.creator', '=', ref('actor.did'))
           .select('list_item.listUri')

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -106,7 +106,10 @@ export class ActorHydrator {
     }, new HydrationMap<Actor>())
   }
 
-  async getProfileViewerStates(
+  // "naive" because this method does not verify the existence of the list itself
+  // a later check in the main hydrator will remove list uris that have been deleted or
+  // repurposed to "curate lists"
+  async getProfileViewerStatesNaive(
     dids: string[],
     viewer: string,
   ): Promise<ProfileViewerStates> {

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -567,6 +567,7 @@ const listUrisFromProfileViewer = (item: ProfileViewerState | null) => {
   if (item?.blockingByList) {
     listUris.push(item.blockingByList)
   }
+  // blocked-by list does not appear in views, but will be used to evaluate the existence of a block between users.
   if (item?.blockedByList) {
     listUris.push(item.blockedByList)
   }


### PR DESCRIPTION
When hydrating a profile basic, check to ensure that relevant mod lists both exist & are have a purpose of being modlists. If the list does not exist as a modlist, then remove it from profile viewer state so that it does not affect filtering & views