### PR TITLE
Track blob cids on ozone mod events

### DIFF
--- a/packages/ozone/src/db/migrations/20240201T051104136Z-mod-event-blobs.ts
+++ b/packages/ozone/src/db/migrations/20240201T051104136Z-mod-event-blobs.ts
@@ -1,0 +1,15 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('moderation_event')
+    .addColumn('subjectBlobCids', 'jsonb')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('moderation_event')
+    .dropColumn('subjectBlobCids')
+    .execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -4,3 +4,4 @@
 
 export * as _20231219T205730722Z from './20231219T205730722Z-init'
 export * as _20240116T085607200Z from './20240116T085607200Z-communication-template'
+export * as _20240201T051104136Z from './20240201T051104136Z-mod-event-blobs'

--- a/packages/ozone/src/db/schema/moderation_event.ts
+++ b/packages/ozone/src/db/schema/moderation_event.ts
@@ -19,6 +19,7 @@ export interface ModerationEvent {
   subjectDid: string
   subjectUri: string | null
   subjectCid: string | null
+  subjectBlobCids: string[] | null
   createLabelVals: string | null
   negateLabelVals: string | null
   comment: string | null

--- a/packages/ozone/src/db/types.ts
+++ b/packages/ozone/src/db/types.ts
@@ -1,5 +1,5 @@
 import { Pool as PgPool } from 'pg'
-import { DynamicModule, RawBuilder, SelectQueryBuilder } from 'kysely'
+import { DynamicModule, RawBuilder, SelectQueryBuilder, sql } from 'kysely'
 
 export type DbRef = RawBuilder | ReturnType<DynamicModule['ref']>
 
@@ -12,4 +12,9 @@ export type PgOptions = {
   poolSize?: number
   poolMaxUses?: number
   poolIdleTimeoutMs?: number
+}
+
+export const jsonb = <T>(val: T) => {
+  if (val === null) return sql<T>`null`
+  return sql<T>`${JSON.stringify(val)}::jsonb`
 }

--- a/packages/ozone/src/mod-service/status.ts
+++ b/packages/ozone/src/mod-service/status.ts
@@ -12,6 +12,7 @@ import { ModerationEventRow, ModerationSubjectStatusRow } from './types'
 import { HOUR } from '@atproto/common'
 import { sql } from 'kysely'
 import { REASONAPPEAL } from '../lexicon/types/com/atproto/moderation/defs'
+import { jsonb } from '../db/types'
 
 const getSubjectStatusForModerationEvent = ({
   action,
@@ -191,9 +192,9 @@ export const adjustModerationSubjectStatus = async (
   }
 
   if (blobCids?.length) {
-    const newBlobCids = sql<string[]>`${JSON.stringify(
+    const newBlobCids = jsonb(
       blobCids,
-    )}` as unknown as ModerationSubjectStatusRow['blobCids']
+    ) as unknown as ModerationSubjectStatusRow['blobCids']
     newStatus.blobCids = newBlobCids
     subjectStatus.blobCids = newBlobCids
   }

--- a/packages/ozone/src/mod-service/subject.ts
+++ b/packages/ozone/src/mod-service/subject.ts
@@ -37,7 +37,11 @@ export const subjectFromEventRow = (row: ModerationEventRow): ModSubject => {
     row.subjectUri &&
     row.subjectCid
   ) {
-    return new RecordSubject(row.subjectUri, row.subjectCid)
+    return new RecordSubject(
+      row.subjectUri,
+      row.subjectCid,
+      row.subjectBlobCids ?? [],
+    )
   } else {
     return new RepoSubject(row.subjectDid)
   }
@@ -50,7 +54,7 @@ export const subjectFromStatusRow = (
     // Not too intuitive but the recordpath is basically <collection>/<rkey>
     // which is what the last 2 params of .make() arguments are
     const uri = AtUri.make(row.did, ...row.recordPath.split('/')).toString()
-    return new RecordSubject(uri.toString(), row.recordCid)
+    return new RecordSubject(uri.toString(), row.recordCid, row.blobCids ?? [])
   } else {
     return new RepoSubject(row.did)
   }
@@ -61,6 +65,7 @@ type SubjectInfo = {
   subjectDid: string
   subjectUri: string | null
   subjectCid: string | null
+  subjectBlobCids: string[] | null
 }
 
 export interface ModSubject {
@@ -89,6 +94,7 @@ export class RepoSubject implements ModSubject {
       subjectDid: this.did,
       subjectUri: null,
       subjectCid: null,
+      subjectBlobCids: null,
     }
   }
   lex(): RepoRef {
@@ -124,6 +130,7 @@ export class RecordSubject implements ModSubject {
       subjectDid: this.did,
       subjectUri: this.uri,
       subjectCid: this.cid,
+      subjectBlobCids: this.blobCids ?? [],
     }
   }
   lex(): StrongRef {

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -88,7 +88,7 @@ export class ModerationViews {
         comment: event.comment ?? undefined,
       },
       subject: subjectFromEventRow(event).lex(),
-      subjectBlobCids: [],
+      subjectBlobCids: event.subjectBlobCids ?? [],
       createdBy: event.createdBy,
       createdAt: event.createdAt,
       subjectHandle: event.subjectHandle ?? undefined,


### PR DESCRIPTION
By tracking blob cids on ozone moderation events, we have better book-keeping and are able to properly serve them on the `queryModerationEvents` endpoint.  One notable change here is that on a reverse-takedown event, we reverse the takedown on all blobs listed alongside the subject if that subject is takendown.  This is more true to how blob takedowns are modeled in ozone, where they are always attached to a record takedown.