### PR TITLE
Update `blueskyweb.xyz` links in README.md to `bsky.social`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ make help
 
 ## About AT Protocol
 
-The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://blueskyweb.xyz). Learn more at:
+The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://bsky.social). Learn more at:
 
 - [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
 - [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
 - [Protocol Specifications](https://atproto.com/specs/atp)
-- [Blogpost on self-authenticating data structures](https://blueskyweb.xyz/blog/3-6-2022-a-self-authenticating-social-protocol)
+- [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
 
 The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
 


### PR DESCRIPTION
This PR updates the two links in README.md that point to `blueskyweb.xyz` to the equivalent `bsky.social` URLs.

On a related note: does this email address need updating or is it still valid?

https://github.com/bluesky-social/atproto/blob/9579bec720d30e40c995d09772040212c261d6fb/package.json#L5