### PR TITLE
repo: commit prev as nullable, but non-optional

### DIFF
--- a/.changeset/angry-chicken-float.md
+++ b/.changeset/angry-chicken-float.md
@@ -1,0 +1,5 @@
+---
+'@atproto/repo': patch
+---
+
+repo commit object prev field is nullable, but no longer nullable

--- a/packages/repo/src/types.ts
+++ b/packages/repo/src/types.ts
@@ -16,7 +16,7 @@ const unsignedCommit = z.object({
   data: common.cid,
   rev: z.string(),
   // `prev` added for backwards compatibility with v2, no requirement of keeping around history
-  prev: common.cid.nullable().optional(),
+  prev: common.cid.nullable(),
 })
 export type UnsignedCommit = z.infer<typeof unsignedCommit> & { sig?: never }
 
@@ -25,7 +25,7 @@ const commit = z.object({
   version: z.literal(3),
   data: common.cid,
   rev: z.string(),
-  prev: common.cid.nullable().optional(),
+  prev: common.cid.nullable(),
   sig: common.bytes,
 })
 export type Commit = z.infer<typeof commit>


### PR DESCRIPTION
To match spec change: https://github.com/bluesky-social/atproto-website/pull/291

Decided not to bite of subscription event schema changes in this PR. The fields are already marked as deprecated there.