### PR TITLE
atproto data model interop test files

### DIFF
--- a/interop-test-files/data-model/data-model-fixtures.json
+++ b/interop-test-files/data-model/data-model-fixtures.json
@@ -1,0 +1,60 @@
+[
+  {
+	"json": {	
+      	"string": "abc",
+      	"unicode": "a~öñ©⽘☎𓋓😀👨‍👩‍👧‍👧",
+      	"integer": 123,
+      	"bool": true,
+      	"null": null,
+      	"array": ["abc", "def", "ghi"],
+      	"object": {
+        	"string": "abc",
+        	"number": 123,
+        	"bool": true,
+        	"arr": ["abc", "def", "ghi"]
+      	}
+    },
+    "cbor_base64": "p2Rib29s9WRudWxs9mVhcnJheYNjYWJjY2RlZmNnaGlmb2JqZWN0pGNhcnKDY2FiY2NkZWZjZ2hpZGJvb2z1Zm51bWJlchh7ZnN0cmluZ2NhYmNmc3RyaW5nY2FiY2dpbnRlZ2VyGHtndW5pY29kZXgvYX7DtsOxwqnivZjimI7wk4uT8J+YgPCfkajigI3wn5Gp4oCN8J+Rp+KAjfCfkac",
+    "cid": "bafyreiclp443lavogvhj3d2ob2cxbfuscni2k5jk7bebjzg7khl3esabwq"
+  },
+  {
+	"json": {
+      "a": {
+        "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+      },
+      "b": {
+        "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0"
+      },
+      "c": {
+        "$type": "blob",
+        "ref": {
+        	"$link": "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity"
+        },
+        "mimeType": "image/jpeg",
+        "size": 10000
+      }
+    },
+    "cbor_base64": "o2Fh2CpYJQABcRIgZQYqWloA/BbXPGlEI3zLwVscSnI0SJM2iR0JF0GiOdBhYlggnFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI1hY6RjcmVm2CpYJQABVRIgQljP/3j2E2l2l1Y/kmyR5dNXTS6iWuftktbr/COjiJ5kc2l6ZRknEGUkdHlwZWRibG9iaG1pbWVUeXBlamltYWdlL2pwZWc",
+    "cid": "bafyreihldkhcwijkde7gx4rpkkuw7pl6lbyu5gieunyc7ihactn5bkd2nm"
+  },
+  {
+    "json":	{
+      "a": {
+        "b": [
+          {
+            "d": [
+              {"$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"},
+              {"$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"}
+            ],
+            "e": [
+              { "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0" },
+              { "$bytes": "iE+sPoHobU9tSIqGI+309LLCcWQIRmEXwxcoDt19tas" }
+            ]
+          }
+        ]
+      }
+    },
+  	"cbor_base64": "oWFhoWFigaJhZILYKlglAAFxEiBlBipaWgD8Ftc8aUQjfMvBWxxKcjRIkzaJHQkXQaI50NgqWCUAAXESIGUGKlpaAPwW1zxpRCN8y8FbHEpyNEiTNokdCRdBojnQYWWCWCCcURGO8suLD2qbjkmuof1BPPILYu7Vdvid7r6wGsLMjVggiE+sPoHobU9tSIqGI+309LLCcWQIRmEXwxcoDt19tas",
+  	"cid": "bafyreid3imdulnhgeytpf6uk7zahjvrsqlofkmm5b5ub2maw4kqus6jp4i"
+  }
+]

--- a/interop-test-files/data-model/data-model-invalid.json
+++ b/interop-test-files/data-model/data-model-invalid.json
@@ -1,0 +1,111 @@
+[
+  {
+  	"note": "top-level not an object",
+	"json": "blah"
+  },
+  {
+  	"note": "float",
+	"json": {
+		"rcrd": {
+        	"$type": "com.example.blah",
+        	"a": 123.456,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "record with $type null",
+	"json": {
+		"rcrd": {
+        	"$type": null,
+        	"a": 123,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "record with $type wrong type",
+	"json": {
+		"rcrd": {
+        	"$type": 123,
+        	"a": 123,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "record with empty $type string",
+	"json": {
+		"rcrd": {
+        	"$type": "",
+        	"a": 123,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "blob with string size",
+	"json": {
+		"blb": {
+        	"$type": "blob",
+        	"ref": {
+        		"$link": "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity"
+        	},
+        	"mimeType": "image/jpeg",
+        	"size": "10000"
+		}
+	}
+  },
+  {
+  	"note": "blob with missing key",
+	"json": {
+		"blb": {
+        	"$type": "blob",
+        	"mimeType": "image/jpeg",
+        	"size": 10000
+		}
+	}
+  },
+  {
+  	"note": "bytes with wrong field type",
+	"json": {
+		"lnk": {
+			"$bytes": [1,2,3]
+		}
+	}
+  },
+  {
+  	"note": "bytes with extra fields",
+	"json": {
+		"lnk": {
+			"$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0",
+			"other": "blah"
+		}
+	}
+  },
+  {
+  	"note": "link with wrong field type",
+	"json": {
+		"lnk": {
+			"$link": 1234
+		}
+	}
+  },
+  {
+  	"note": "link with bogus CID",
+	"json": {
+		"lnk": {
+			"$link": "."
+		}
+	}
+  },
+  {
+  	"note": "link with extra fields",
+	"json": {
+		"lnk": {
+			"$link": "bafkreiccldh766hwcnuxnf2wh6jgzepf2nlu2lvcllt63eww5p6chi4ity",
+			"other": "blah"
+		}
+	}
+  }
+]

--- a/interop-test-files/data-model/data-model-valid.json
+++ b/interop-test-files/data-model/data-model-valid.json
@@ -1,0 +1,48 @@
+[
+  {
+  	"note": "trivial record",
+	"json": {
+		"rcrd": {
+        	"$type": "com.example.blah",
+        	"a": 123,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "float, but integer-like",
+	"json": {
+		"rcrd": {
+        	"$type": "com.example.blah",
+        	"a": 123.0,
+        	"b": "blah"
+		}
+	}
+  },
+  {
+  	"note": "empty list and object",
+	"json": {
+		"rcrd": {
+        	"$type": "com.example.blah",
+        	"a": [],
+        	"b": {}
+		}
+	}
+  },
+  {
+  	"note": "list of nullable",
+	"json": {
+		"arr": [1,2,null]
+	}
+  },
+  {
+  	"note": "list of lists",
+	"json": {
+		"arr": [
+			[1,2,3],
+			[4,5,6]
+		],
+		"arr2": [null, null, null]
+	}
+  }
+]


### PR DESCRIPTION
These are copied over from the golang implementation (indigo).

I can see where to hook in the generic IPLD JSON/CBOR conversion code for testing, but not where to test validation of records when lexicon is unknown.

I also thought I had some blob-extraction tests in this format, but guess not.