### PR TITLE
Timeline index pref

### DIFF
--- a/.changeset/silly-ligers-poke.md
+++ b/.changeset/silly-ligers-poke.md
@@ -2,4 +2,4 @@
 '@atproto/api': patch
 ---
 
-Added followingIndex to savedFeedsPref
+Added timelineIndex to savedFeedsPref

--- a/.changeset/silly-ligers-poke.md
+++ b/.changeset/silly-ligers-poke.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Added followingIndex to savedFeedsPref

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -145,7 +145,7 @@
             "format": "at-uri"
           }
         },
-        "followingIndex": {
+        "timelineIndex": {
           "type": "integer"
         }
       }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -144,6 +144,9 @@
             "type": "string",
             "format": "at-uri"
           }
+        },
+        "followingIndex": {
+          "type": "integer"
         }
       }
     },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4832,6 +4832,9 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
+          followingIndex: {
+            type: 'integer',
+          },
         },
       },
       personalDetailsPref: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4832,7 +4832,7 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
-          followingIndex: {
+          timelineIndex: {
             type: 'integer',
           },
         },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -155,7 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
-  followingIndex?: number
+  timelineIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -155,6 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
+  followingIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4832,6 +4832,9 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
+          followingIndex: {
+            type: 'integer',
+          },
         },
       },
       personalDetailsPref: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4832,7 +4832,7 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
-          followingIndex: {
+          timelineIndex: {
             type: 'integer',
           },
         },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,7 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
-  followingIndex?: number
+  timelineIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,6 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
+  followingIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4832,6 +4832,9 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
+          followingIndex: {
+            type: 'integer',
+          },
         },
       },
       personalDetailsPref: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4832,7 +4832,7 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
-          followingIndex: {
+          timelineIndex: {
             type: 'integer',
           },
         },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,7 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
-  followingIndex?: number
+  timelineIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,6 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
+  followingIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4832,6 +4832,9 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
+          followingIndex: {
+            type: 'integer',
+          },
         },
       },
       personalDetailsPref: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4832,7 +4832,7 @@ export const schemaDict = {
               format: 'at-uri',
             },
           },
-          followingIndex: {
+          timelineIndex: {
             type: 'integer',
           },
         },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,7 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
-  followingIndex?: number
+  timelineIndex?: number
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -155,6 +155,7 @@ export function validateContentLabelPref(v: unknown): ValidationResult {
 export interface SavedFeedsPref {
   pinned: string[]
   saved: string[]
+  followingIndex?: number
   [k: string]: unknown
 }
 


### PR DESCRIPTION
Adds an optional pref to `savedFeedsPref` for storing the index of the basic timeline so that it doesn't always need to be the first feed.