### PR TITLE
fix(xrpc-server): properly parse & process content-encoding

### DIFF
--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -4,7 +4,21 @@ import {
   PassThrough,
   Transform,
   TransformCallback,
+  Duplex,
 } from 'stream'
+
+// TODO: Replace this with Node.JS's compose once it is stable
+export const compose = (
+  readable: Readable,
+  ...transforms: Duplex[]
+): Readable => {
+  let stream: Readable = readable
+  for (const transform of transforms) {
+    forwardStreamErrors(stream, transform)
+    stream = stream.pipe(transform)
+  }
+  return stream
+}
 
 export const forwardStreamErrors = (...streams: Stream[]) => {
   for (let i = 0; i < streams.length; ++i) {

--- a/packages/xrpc/src/types.ts
+++ b/packages/xrpc/src/types.ts
@@ -37,6 +37,7 @@ export enum ResponseType {
   Forbidden = 403,
   XRPCNotSupported = 404,
   PayloadTooLarge = 413,
+  UnsupportedMediaType = 415,
   RateLimitExceeded = 429,
   InternalServerError = 500,
   MethodNotImplemented = 501,


### PR DESCRIPTION
[content-encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) can contain multiple values (comma separated).

- The current implementation ignores any unknown value it received (including comma separated values). This PR generates an error when unknown algorithms are provided.
- The current implementation uses `createDeflate` instead of `createInflate` to decompress bytes encoded using the `deflate` algo. This PR changes that.
- The current implementation will allow `content-length` headers that are not a number. This PR ensures that the parsing of the number did not result in `NaN`.