### PR TITLE
:sparkles: Move appealed subject's review state to escalated

### DIFF
--- a/packages/ozone/src/mod-service/status.ts
+++ b/packages/ozone/src/mod-service/status.ts
@@ -179,6 +179,9 @@ export const adjustModerationSubjectStatus = async (
     subjectStatus.appealed = true
     newStatus.lastAppealedAt = createdAt
     subjectStatus.lastAppealedAt = createdAt
+    // Set reviewState to escalated when appeal events are emitted
+    subjectStatus.reviewState = REVIEWESCALATED
+    newStatus.reviewState = REVIEWESCALATED
   }
 
   if (

--- a/packages/ozone/tests/moderation-appeals.test.ts
+++ b/packages/ozone/tests/moderation-appeals.test.ts
@@ -118,7 +118,7 @@ describe('moderation-appeals', () => {
       })
 
       // Verify that appeal status changed when appeal report was emitted by moderator
-      const status = await assertBobsPostStatus(REVIEWOPEN, true)
+      const status = await assertBobsPostStatus(REVIEWESCALATED, true)
       expect(status?.appealedAt).not.toBeNull()
 
       // Create a report as normal user for carol's post
@@ -143,7 +143,11 @@ describe('moderation-appeals', () => {
         subject: getCarolPostSubject(),
       })
       // Verify that the appeal status on carol's post is true
-      await assertSubjectStatus(getCarolPostSubject().uri, REVIEWOPEN, true)
+      await assertSubjectStatus(
+        getCarolPostSubject().uri,
+        REVIEWESCALATED,
+        true,
+      )
     })
     it('allows multiple appeals and updates last appealed timestamp', async () => {
       // Resolve appeal with acknowledge
@@ -155,7 +159,7 @@ describe('moderation-appeals', () => {
         createdBy: sc.dids.carol,
       })
 
-      const previousStatus = await assertBobsPostStatus(REVIEWOPEN, false)
+      const previousStatus = await assertBobsPostStatus(REVIEWESCALATED, false)
 
       await emitModerationEvent({
         event: {
@@ -167,7 +171,7 @@ describe('moderation-appeals', () => {
       })
 
       // Verify that even after the appeal event by bob for his post, the appeal status is true again with new timestamp
-      const newStatus = await assertBobsPostStatus(REVIEWOPEN, true)
+      const newStatus = await assertBobsPostStatus(REVIEWESCALATED, true)
       expect(
         new Date(`${previousStatus?.lastAppealedAt}`).getTime(),
       ).toBeLessThan(new Date(`${newStatus?.lastAppealedAt}`).getTime())
@@ -210,7 +214,11 @@ describe('moderation-appeals', () => {
         createdBy: sc.dids.alice,
       })
 
-      await assertSubjectStatus(getAlicesPostSubject().uri, REVIEWOPEN, true)
+      await assertSubjectStatus(
+        getAlicesPostSubject().uri,
+        REVIEWESCALATED,
+        true,
+      )
 
       // Bob reports it again
       await emitModerationEvent({
@@ -222,8 +230,12 @@ describe('moderation-appeals', () => {
         createdBy: sc.dids.bob,
       })
 
-      // Assert that the status is still REVIEWOPEN, as report events are meant to do
-      await assertSubjectStatus(getAlicesPostSubject().uri, REVIEWOPEN, true)
+      // Assert that the status is still REVIEWESCALATED, as report events are meant to do
+      await assertSubjectStatus(
+        getAlicesPostSubject().uri,
+        REVIEWESCALATED,
+        true,
+      )
 
       // Emit an escalation event
       await emitModerationEvent({


### PR DESCRIPTION
Since we want appealed subjects to only show up on escalation queue, this PR sets the `reviewState` to `reviewEscalated`.