### PR TITLE
Emit handle updates on account state changes

### DIFF
--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -69,6 +69,7 @@ export default function (server: Server, ctx: AppContext) {
 
         if (!deactivated) {
           await ctx.sequencer.sequenceCommit(did, commit, [])
+          await ctx.sequencer.sequenceHandleUpdate(did, handle)
         }
         await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
         didDoc = await didDocForSession(ctx, did, true)

--- a/packages/pds/src/api/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteAccount.ts
@@ -1,4 +1,5 @@
 import { MINUTE } from '@atproto/common'
+import { INVALID_HANDLE } from '@atproto/syntax'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
@@ -44,6 +45,7 @@ export default function (server: Server, ctx: AppContext) {
       )
       await ctx.actorStore.destroy(did)
       await ctx.accountManager.deleteAccount(did)
+      await ctx.sequencer.sequenceHandleUpdate(did, INVALID_HANDLE)
       await ctx.sequencer.sequenceTombstone(did)
       await ctx.sequencer.deleteAllForUser(did)
     },

--- a/packages/pds/tests/sequencer.test.ts
+++ b/packages/pds/tests/sequencer.test.ts
@@ -24,8 +24,8 @@ describe('sequencer', () => {
     await userSeed(sc)
     alice = sc.dids.alice
     bob = sc.dids.bob
-    // 6 events in userSeed
-    totalEvts = 6
+    // 10 events in userSeed
+    totalEvts = 10
   })
 
   afterAll(async () => {
@@ -63,10 +63,11 @@ describe('sequencer', () => {
 
   const evtToDbRow = (e: SeqEvt) => {
     const did = e.type === 'commit' ? e.evt.repo : e.evt.did
+    const eventType = e.type === 'commit' ? 'append' : e.type
     return {
       seq: e.seq,
       did,
-      eventType: 'append',
+      eventType,
       event: Buffer.from(cborEncode(e.evt)),
       invalidated: 0,
       sequencedAt: e.time,


### PR DESCRIPTION
We're planning to spec & implement new `#identity` and `#account` events on the firehose, but for now, `#handle` is the only event that is treated as an identity refresh & passed through the relay, so we emit it on account state changes