### PR TITLE
Firehose Identity event

### DIFF
--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -17,7 +17,7 @@
       "message": {
         "schema": {
           "type": "union",
-          "refs": ["#commit", "#handle", "#migrate", "#tombstone", "#info"]
+          "refs": ["#commit", "#identity", "#handle", "#migrate", "#tombstone", "#info"]
         }
       },
       "errors": [
@@ -138,7 +138,7 @@
     },
     "tombstone": {
       "type": "object",
-      "description": "Indicates that an account has been deleted.",
+      "description": "Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event",
       "required": ["seq", "did", "time"],
       "properties": {
         "seq": { "type": "integer" },

--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -17,7 +17,14 @@
       "message": {
         "schema": {
           "type": "union",
-          "refs": ["#commit", "#identity", "#handle", "#migrate", "#tombstone", "#info"]
+          "refs": [
+            "#commit",
+            "#identity",
+            "#handle",
+            "#migrate",
+            "#tombstone",
+            "#info"
+          ]
         }
       },
       "errors": [

--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -104,9 +104,18 @@
         }
       }
     },
+    "identity": {
+      "type": "object",
+      "description": "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
+      "required": ["seq", "did"],
+      "properties": {
+        "seq": { "type": "integer" },
+        "did": { "type": "string", "format": "did" }
+      }
+    },
     "handle": {
       "type": "object",
-      "description": "Represents an update of the account's handle, or transition to/from invalid state.",
+      "description": "Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity.",
       "required": ["seq", "did", "handle", "time"],
       "properties": {
         "seq": { "type": "integer" },
@@ -117,7 +126,7 @@
     },
     "migrate": {
       "type": "object",
-      "description": "Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead.",
+      "description": "Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead",
       "required": ["seq", "did", "migrateTo", "time"],
       "nullable": ["migrateTo"],
       "properties": {

--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -114,10 +114,11 @@
     "identity": {
       "type": "object",
       "description": "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
-      "required": ["seq", "did"],
+      "required": ["seq", "did", "time"],
       "properties": {
         "seq": { "type": "integer" },
-        "did": { "type": "string", "format": "did" }
+        "did": { "type": "string", "format": "did" },
+        "time": { "type": "string", "format": "datetime" }
       }
     },
     "handle": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4690,7 +4690,7 @@ export const schemaDict = {
         type: 'object',
         description:
           "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
-        required: ['seq', 'did'],
+        required: ['seq', 'did', 'time'],
         properties: {
           seq: {
             type: 'integer',
@@ -4698,6 +4698,10 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+          time: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4579,6 +4579,7 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.sync.subscribeRepos#commit',
+              'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#handle',
               'lex:com.atproto.sync.subscribeRepos#migrate',
               'lex:com.atproto.sync.subscribeRepos#tombstone',
@@ -4685,10 +4686,25 @@ export const schemaDict = {
           },
         },
       },
+      identity: {
+        type: 'object',
+        description:
+          "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
+        required: ['seq', 'did'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       handle: {
         type: 'object',
         description:
-          "Represents an update of the account's handle, or transition to/from invalid state.",
+          "Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity.",
         required: ['seq', 'did', 'handle', 'time'],
         properties: {
           seq: {
@@ -4711,7 +4727,7 @@ export const schemaDict = {
       migrate: {
         type: 'object',
         description:
-          'Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead.',
+          'Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead',
         required: ['seq', 'did', 'migrateTo', 'time'],
         nullable: ['migrateTo'],
         properties: {
@@ -4733,7 +4749,8 @@ export const schemaDict = {
       },
       tombstone: {
         type: 'object',
-        description: 'Indicates that an account has been deleted.',
+        description:
+          'Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event',
         required: ['seq', 'did', 'time'],
         properties: {
           seq: {
@@ -7087,7 +7104,8 @@ export const schemaDict = {
             },
             tags: {
               type: 'array',
-              description: 'Additional non-inline tags describing this post.',
+              description:
+                'Additional hashtags, in addition to any included in post text and facets.',
               maxLength: 8,
               items: {
                 type: 'string',

--- a/packages/api/src/client/types/app/bsky/feed/post.ts
+++ b/packages/api/src/client/types/app/bsky/feed/post.ts
@@ -32,7 +32,7 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
-  /** Additional non-inline tags describing this post. */
+  /** Additional hashtags, in addition to any included in post text and facets. */
   tags?: string[]
   /** Client-declared timestamp when this post was originally created. */
   createdAt: string

--- a/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
@@ -46,7 +46,26 @@ export function validateCommit(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#commit', v)
 }
 
-/** Represents an update of the account's handle, or transition to/from invalid state. */
+/** Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache. */
+export interface Identity {
+  seq: number
+  did: string
+  [k: string]: unknown
+}
+
+export function isIdentity(v: unknown): v is Identity {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeRepos#identity'
+  )
+}
+
+export function validateIdentity(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeRepos#identity', v)
+}
+
+/** Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity. */
 export interface Handle {
   seq: number
   did: string
@@ -67,7 +86,7 @@ export function validateHandle(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#handle', v)
 }
 
-/** Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead. */
+/** Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead */
 export interface Migrate {
   seq: number
   did: string
@@ -88,7 +107,7 @@ export function validateMigrate(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#migrate', v)
 }
 
-/** Indicates that an account has been deleted. */
+/** Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event */
 export interface Tombstone {
   seq: number
   did: string

--- a/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
@@ -50,6 +50,7 @@ export function validateCommit(v: unknown): ValidationResult {
 export interface Identity {
   seq: number
   did: string
+  time: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/indexer/subscription.ts
+++ b/packages/bsky/src/indexer/subscription.ts
@@ -145,6 +145,8 @@ export class IndexerSubscription {
         await this.handleCommit(msg)
       } else if (message.isHandle(msg)) {
         await this.handleUpdateHandle(msg)
+      } else if (message.isIdentity(msg)) {
+        await this.handleIdentityEvt(msg)
       } else if (message.isTombstone(msg)) {
         await this.handleTombstone(msg)
       } else if (message.isMigrate(msg)) {
@@ -241,6 +243,10 @@ export class IndexerSubscription {
   }
 
   private async handleUpdateHandle(msg: message.Handle) {
+    await this.indexingSvc.indexHandle(msg.did, msg.time, true)
+  }
+
+  private async handleIdentityEvt(msg: message.Identity) {
     await this.indexingSvc.indexHandle(msg.did, msg.time, true)
   }
 

--- a/packages/bsky/src/ingester/subscription.ts
+++ b/packages/bsky/src/ingester/subscription.ts
@@ -156,6 +156,8 @@ function getMessageDetails(msg: Message):
     return { seq: msg.seq, repo: msg.repo, message: msg }
   } else if (message.isHandle(msg)) {
     return { seq: msg.seq, repo: msg.did, message: msg }
+  } else if (message.isIdentity(msg)) {
+    return { seq: msg.seq, repo: msg.did, message: msg }
   } else if (message.isMigrate(msg)) {
     return { seq: msg.seq, repo: msg.did, message: msg }
   } else if (message.isTombstone(msg)) {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4690,7 +4690,7 @@ export const schemaDict = {
         type: 'object',
         description:
           "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
-        required: ['seq', 'did'],
+        required: ['seq', 'did', 'time'],
         properties: {
           seq: {
             type: 'integer',
@@ -4698,6 +4698,10 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+          time: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4579,6 +4579,7 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.sync.subscribeRepos#commit',
+              'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#handle',
               'lex:com.atproto.sync.subscribeRepos#migrate',
               'lex:com.atproto.sync.subscribeRepos#tombstone',
@@ -4685,10 +4686,25 @@ export const schemaDict = {
           },
         },
       },
+      identity: {
+        type: 'object',
+        description:
+          "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
+        required: ['seq', 'did'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       handle: {
         type: 'object',
         description:
-          "Represents an update of the account's handle, or transition to/from invalid state.",
+          "Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity.",
         required: ['seq', 'did', 'handle', 'time'],
         properties: {
           seq: {
@@ -4711,7 +4727,7 @@ export const schemaDict = {
       migrate: {
         type: 'object',
         description:
-          'Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead.',
+          'Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead',
         required: ['seq', 'did', 'migrateTo', 'time'],
         nullable: ['migrateTo'],
         properties: {
@@ -4733,7 +4749,8 @@ export const schemaDict = {
       },
       tombstone: {
         type: 'object',
-        description: 'Indicates that an account has been deleted.',
+        description:
+          'Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event',
         required: ['seq', 'did', 'time'],
         properties: {
           seq: {
@@ -7087,7 +7104,8 @@ export const schemaDict = {
             },
             tags: {
               type: 'array',
-              description: 'Additional non-inline tags describing this post.',
+              description:
+                'Additional hashtags, in addition to any included in post text and facets.',
               maxLength: 8,
               items: {
                 type: 'string',

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/post.ts
@@ -32,7 +32,7 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
-  /** Additional non-inline tags describing this post. */
+  /** Additional hashtags, in addition to any included in post text and facets. */
   tags?: string[]
   /** Client-declared timestamp when this post was originally created. */
   createdAt: string

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -76,6 +76,7 @@ export function validateCommit(v: unknown): ValidationResult {
 export interface Identity {
   seq: number
   did: string
+  time: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -15,6 +15,7 @@ export interface QueryParams {
 
 export type OutputSchema =
   | Commit
+  | Identity
   | Handle
   | Migrate
   | Tombstone
@@ -71,7 +72,26 @@ export function validateCommit(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#commit', v)
 }
 
-/** Represents an update of the account's handle, or transition to/from invalid state. */
+/** Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache. */
+export interface Identity {
+  seq: number
+  did: string
+  [k: string]: unknown
+}
+
+export function isIdentity(v: unknown): v is Identity {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeRepos#identity'
+  )
+}
+
+export function validateIdentity(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeRepos#identity', v)
+}
+
+/** Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity. */
 export interface Handle {
   seq: number
   did: string
@@ -92,7 +112,7 @@ export function validateHandle(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#handle', v)
 }
 
-/** Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead. */
+/** Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead */
 export interface Migrate {
   seq: number
   did: string
@@ -113,7 +133,7 @@ export function validateMigrate(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#migrate', v)
 }
 
-/** Indicates that an account has been deleted. */
+/** Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event */
 export interface Tombstone {
   seq: number
   did: string

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -109,8 +109,6 @@ export class TestNetwork extends TestNetworkNoAppView {
         await sub.repoQueue.main.onIdle()
         return
       }
-      console.log('LAST SEQ: ', lastSeq)
-      console.log('CURSOR', partitionState.cursor)
       await wait(5)
     }
     throw new Error(`Sequence was not processed within ${timeout}ms`)

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -109,6 +109,8 @@ export class TestNetwork extends TestNetworkNoAppView {
         await sub.repoQueue.main.onIdle()
         return
       }
+      console.log('LAST SEQ: ', lastSeq)
+      console.log('CURSOR', partitionState.cursor)
       await wait(5)
     }
     throw new Error(`Sequence was not processed within ${timeout}ms`)

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4690,7 +4690,7 @@ export const schemaDict = {
         type: 'object',
         description:
           "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
-        required: ['seq', 'did'],
+        required: ['seq', 'did', 'time'],
         properties: {
           seq: {
             type: 'integer',
@@ -4698,6 +4698,10 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+          time: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4579,6 +4579,7 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.sync.subscribeRepos#commit',
+              'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#handle',
               'lex:com.atproto.sync.subscribeRepos#migrate',
               'lex:com.atproto.sync.subscribeRepos#tombstone',
@@ -4685,10 +4686,25 @@ export const schemaDict = {
           },
         },
       },
+      identity: {
+        type: 'object',
+        description:
+          "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
+        required: ['seq', 'did'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       handle: {
         type: 'object',
         description:
-          "Represents an update of the account's handle, or transition to/from invalid state.",
+          "Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity.",
         required: ['seq', 'did', 'handle', 'time'],
         properties: {
           seq: {
@@ -4711,7 +4727,7 @@ export const schemaDict = {
       migrate: {
         type: 'object',
         description:
-          'Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead.',
+          'Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead',
         required: ['seq', 'did', 'migrateTo', 'time'],
         nullable: ['migrateTo'],
         properties: {
@@ -4733,7 +4749,8 @@ export const schemaDict = {
       },
       tombstone: {
         type: 'object',
-        description: 'Indicates that an account has been deleted.',
+        description:
+          'Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event',
         required: ['seq', 'did', 'time'],
         properties: {
           seq: {
@@ -7087,7 +7104,8 @@ export const schemaDict = {
             },
             tags: {
               type: 'array',
-              description: 'Additional non-inline tags describing this post.',
+              description:
+                'Additional hashtags, in addition to any included in post text and facets.',
               maxLength: 8,
               items: {
                 type: 'string',

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/post.ts
@@ -32,7 +32,7 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
-  /** Additional non-inline tags describing this post. */
+  /** Additional hashtags, in addition to any included in post text and facets. */
   tags?: string[]
   /** Client-declared timestamp when this post was originally created. */
   createdAt: string

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -76,6 +76,7 @@ export function validateCommit(v: unknown): ValidationResult {
 export interface Identity {
   seq: number
   did: string
+  time: string
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -15,6 +15,7 @@ export interface QueryParams {
 
 export type OutputSchema =
   | Commit
+  | Identity
   | Handle
   | Migrate
   | Tombstone
@@ -71,7 +72,26 @@ export function validateCommit(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#commit', v)
 }
 
-/** Represents an update of the account's handle, or transition to/from invalid state. */
+/** Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache. */
+export interface Identity {
+  seq: number
+  did: string
+  [k: string]: unknown
+}
+
+export function isIdentity(v: unknown): v is Identity {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeRepos#identity'
+  )
+}
+
+export function validateIdentity(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeRepos#identity', v)
+}
+
+/** Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity. */
 export interface Handle {
   seq: number
   did: string
@@ -92,7 +112,7 @@ export function validateHandle(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#handle', v)
 }
 
-/** Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead. */
+/** Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead */
 export interface Migrate {
   seq: number
   did: string
@@ -113,7 +133,7 @@ export function validateMigrate(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#migrate', v)
 }
 
-/** Indicates that an account has been deleted. */
+/** Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event */
 export interface Tombstone {
   seq: number
   did: string

--- a/packages/pds/src/api/com/atproto/server/activateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/activateAccount.ts
@@ -1,7 +1,9 @@
+import { CidSet } from '@atproto/repo'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { INVALID_HANDLE } from '@atproto/syntax'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { assertValidDidDocumentForService } from './util'
-import { CidSet } from '@atproto/repo'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.activateAccount({
@@ -10,6 +12,13 @@ export default function (server: Server, ctx: AppContext) {
       const requester = auth.credentials.did
 
       await assertValidDidDocumentForService(ctx, requester)
+
+      const account = await ctx.accountManager.getAccount(requester, {
+        includeDeactivated: true,
+      })
+      if (!account) {
+        throw new InvalidRequestError('user not found', 'AccountNotFound')
+      }
 
       await ctx.accountManager.activateAccount(requester)
 
@@ -26,7 +35,12 @@ export default function (server: Server, ctx: AppContext) {
         }
       })
 
+      // @NOTE: we're over-emitting for now for backwards compatibility, can reduce this in the future
       await ctx.sequencer.sequenceIdentityEvt(requester)
+      await ctx.sequencer.sequenceHandleUpdate(
+        requester,
+        account.handle ?? INVALID_HANDLE,
+      )
       await ctx.sequencer.sequenceCommit(requester, commitData, [])
     },
   })

--- a/packages/pds/src/api/com/atproto/server/activateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/activateAccount.ts
@@ -26,6 +26,7 @@ export default function (server: Server, ctx: AppContext) {
         }
       })
 
+      await ctx.sequencer.sequenceIdentityEvt(requester)
       await ctx.sequencer.sequenceCommit(requester, commitData, [])
     },
   })

--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -69,6 +69,7 @@ export default function (server: Server, ctx: AppContext) {
 
         if (!deactivated) {
           await ctx.sequencer.sequenceCommit(did, commit, [])
+          await ctx.sequencer.sequenceIdentityEvt(did)
         }
         await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
         didDoc = await didDocForSession(ctx, did, true)

--- a/packages/pds/src/api/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteAccount.ts
@@ -44,6 +44,7 @@ export default function (server: Server, ctx: AppContext) {
       )
       await ctx.actorStore.destroy(did)
       await ctx.accountManager.deleteAccount(did)
+      await ctx.sequencer.sequenceIdentityEvt(did)
       await ctx.sequencer.sequenceTombstone(did)
       await ctx.sequencer.deleteAllForUser(did)
     },

--- a/packages/pds/src/api/com/atproto/sync/subscribeRepos.ts
+++ b/packages/pds/src/api/com/atproto/sync/subscribeRepos.ts
@@ -52,6 +52,13 @@ export default function (server: Server, ctx: AppContext) {
           time: evt.time,
           ...evt.evt,
         }
+      } else if (evt.type === 'identity') {
+        yield {
+          $type: '#identity',
+          seq: evt.seq,
+          time: evt.time,
+          ...evt.evt,
+        }
       } else if (evt.type === 'tombstone') {
         yield {
           $type: '#tombstone',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4690,7 +4690,7 @@ export const schemaDict = {
         type: 'object',
         description:
           "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
-        required: ['seq', 'did'],
+        required: ['seq', 'did', 'time'],
         properties: {
           seq: {
             type: 'integer',
@@ -4698,6 +4698,10 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+          time: {
+            type: 'string',
+            format: 'datetime',
           },
         },
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4579,6 +4579,7 @@ export const schemaDict = {
             type: 'union',
             refs: [
               'lex:com.atproto.sync.subscribeRepos#commit',
+              'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#handle',
               'lex:com.atproto.sync.subscribeRepos#migrate',
               'lex:com.atproto.sync.subscribeRepos#tombstone',
@@ -4685,10 +4686,25 @@ export const schemaDict = {
           },
         },
       },
+      identity: {
+        type: 'object',
+        description:
+          "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache.",
+        required: ['seq', 'did'],
+        properties: {
+          seq: {
+            type: 'integer',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+        },
+      },
       handle: {
         type: 'object',
         description:
-          "Represents an update of the account's handle, or transition to/from invalid state.",
+          "Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity.",
         required: ['seq', 'did', 'handle', 'time'],
         properties: {
           seq: {
@@ -4711,7 +4727,7 @@ export const schemaDict = {
       migrate: {
         type: 'object',
         description:
-          'Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead.',
+          'Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead',
         required: ['seq', 'did', 'migrateTo', 'time'],
         nullable: ['migrateTo'],
         properties: {
@@ -4733,7 +4749,8 @@ export const schemaDict = {
       },
       tombstone: {
         type: 'object',
-        description: 'Indicates that an account has been deleted.',
+        description:
+          'Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event',
         required: ['seq', 'did', 'time'],
         properties: {
           seq: {
@@ -7087,7 +7104,8 @@ export const schemaDict = {
             },
             tags: {
               type: 'array',
-              description: 'Additional non-inline tags describing this post.',
+              description:
+                'Additional hashtags, in addition to any included in post text and facets.',
               maxLength: 8,
               items: {
                 type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/post.ts
@@ -32,7 +32,7 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
-  /** Additional non-inline tags describing this post. */
+  /** Additional hashtags, in addition to any included in post text and facets. */
   tags?: string[]
   /** Client-declared timestamp when this post was originally created. */
   createdAt: string

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -76,6 +76,7 @@ export function validateCommit(v: unknown): ValidationResult {
 export interface Identity {
   seq: number
   did: string
+  time: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -15,6 +15,7 @@ export interface QueryParams {
 
 export type OutputSchema =
   | Commit
+  | Identity
   | Handle
   | Migrate
   | Tombstone
@@ -71,7 +72,26 @@ export function validateCommit(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#commit', v)
 }
 
-/** Represents an update of the account's handle, or transition to/from invalid state. */
+/** Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache. */
+export interface Identity {
+  seq: number
+  did: string
+  [k: string]: unknown
+}
+
+export function isIdentity(v: unknown): v is Identity {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.sync.subscribeRepos#identity'
+  )
+}
+
+export function validateIdentity(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.sync.subscribeRepos#identity', v)
+}
+
+/** Represents an update of the account's handle, or transition to/from invalid state. NOTE: Will be deprecated in favor of #identity. */
 export interface Handle {
   seq: number
   did: string
@@ -92,7 +112,7 @@ export function validateHandle(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#handle', v)
 }
 
-/** Represents an account moving from one PDS instance to another. NOTE: not implemented; full account migration may introduce a new message instead. */
+/** Represents an account moving from one PDS instance to another. NOTE: not implemented; account migration uses #identity instead */
 export interface Migrate {
   seq: number
   did: string
@@ -113,7 +133,7 @@ export function validateMigrate(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.sync.subscribeRepos#migrate', v)
 }
 
-/** Indicates that an account has been deleted. */
+/** Indicates that an account has been deleted. NOTE: may be deprecated in favor of #identity or a future #account event */
 export interface Tombstone {
   seq: number
   did: string

--- a/packages/pds/src/sequencer/db/schema.ts
+++ b/packages/pds/src/sequencer/db/schema.ts
@@ -5,6 +5,7 @@ export type RepoSeqEventType =
   | 'rebase'
   | 'handle'
   | 'migrate'
+  | 'identity'
   | 'tombstone'
 
 export interface RepoSeq {

--- a/packages/pds/src/sequencer/events.ts
+++ b/packages/pds/src/sequencer/events.ts
@@ -89,7 +89,7 @@ export const formatSeqIdentityEvt = async (
   }
   return {
     did,
-    eventType: 'handle',
+    eventType: 'identity',
     event: cborEncode(evt),
     sequencedAt: new Date().toISOString(),
   }

--- a/packages/pds/src/sequencer/events.ts
+++ b/packages/pds/src/sequencer/events.ts
@@ -81,6 +81,20 @@ export const formatSeqHandleUpdate = async (
   }
 }
 
+export const formatSeqIdentityEvt = async (
+  did: string,
+): Promise<RepoSeqInsert> => {
+  const evt: IdentityEvt = {
+    did,
+  }
+  return {
+    did,
+    eventType: 'handle',
+    event: cborEncode(evt),
+    sequencedAt: new Date().toISOString(),
+  }
+}
+
 export const formatSeqTombstone = async (
   did: string,
 ): Promise<RepoSeqInsert> => {
@@ -126,6 +140,11 @@ export const handleEvt = z.object({
 })
 export type HandleEvt = z.infer<typeof handleEvt>
 
+export const identityEvt = z.object({
+  did: z.string(),
+})
+export type IdentityEvt = z.infer<typeof identityEvt>
+
 export const tombstoneEvt = z.object({
   did: z.string(),
 })
@@ -143,10 +162,20 @@ type TypedHandleEvt = {
   time: string
   evt: HandleEvt
 }
+type TypedIdentityEvt = {
+  type: 'identity'
+  seq: number
+  time: string
+  evt: IdentityEvt
+}
 type TypedTombstoneEvt = {
   type: 'tombstone'
   seq: number
   time: string
   evt: TombstoneEvt
 }
-export type SeqEvt = TypedCommitEvt | TypedHandleEvt | TypedTombstoneEvt
+export type SeqEvt =
+  | TypedCommitEvt
+  | TypedHandleEvt
+  | TypedIdentityEvt
+  | TypedTombstoneEvt

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -6,6 +6,7 @@ import { CommitData } from '@atproto/repo'
 import {
   CommitEvt,
   HandleEvt,
+  IdentityEvt,
   SeqEvt,
   TombstoneEvt,
   formatSeqCommit,
@@ -145,6 +146,13 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
           seq: row.seq,
           time: row.sequencedAt,
           evt: evt as HandleEvt,
+        })
+      } else if (row.eventType === 'identity') {
+        seqEvts.push({
+          type: 'identity',
+          seq: row.seq,
+          time: row.sequencedAt,
+          evt: evt as IdentityEvt,
         })
       } else if (row.eventType === 'tombstone') {
         seqEvts.push({

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -10,6 +10,7 @@ import {
   TombstoneEvt,
   formatSeqCommit,
   formatSeqHandleUpdate,
+  formatSeqIdentityEvt,
   formatSeqTombstone,
 } from './events'
 import {
@@ -206,6 +207,11 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
 
   async sequenceHandleUpdate(did: string, handle: string) {
     const evt = await formatSeqHandleUpdate(did, handle)
+    await this.sequenceEvt(evt)
+  }
+
+  async sequenceIdentityEvt(did: string) {
+    const evt = await formatSeqIdentityEvt(did)
     await this.sequenceEvt(evt)
   }
 

--- a/packages/pds/tests/sequencer.test.ts
+++ b/packages/pds/tests/sequencer.test.ts
@@ -24,8 +24,8 @@ describe('sequencer', () => {
     await userSeed(sc)
     alice = sc.dids.alice
     bob = sc.dids.bob
-    // 6 events in userSeed
-    totalEvts = 6
+    // 10 events in userSeed
+    totalEvts = 10
   })
 
   afterAll(async () => {
@@ -63,10 +63,11 @@ describe('sequencer', () => {
 
   const evtToDbRow = (e: SeqEvt) => {
     const did = e.type === 'commit' ? e.evt.repo : e.evt.did
+    const eventType = e.type === 'commit' ? 'append' : e.type
     return {
       seq: e.seq,
       did,
-      eventType: 'append',
+      eventType,
       event: Buffer.from(cborEncode(e.evt)),
       invalidated: 0,
       sequencedAt: e.time,


### PR DESCRIPTION
Adds a new `#identity` to the firehose that prompts all downstream services to refresh their identity cache for the given DID.

This is implemented in lieu of the `#migrate` event and will eventually replace the `#handle` event as well.

In a future iteration, more information may be attached to the event such as the DID document.