### PR TITLE
Optional service config in pds distribution

### DIFF
--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -3,6 +3,7 @@ import AppContext from '../../../../context'
 import { AuthScope } from '../../../../auth-verifier'
 
 export default function (server: Server, ctx: AppContext) {
+  if (!ctx.cfg.bskyAppView) return
   server.app.bsky.actor.getPreferences({
     auth: ctx.authVerifier.access,
     handler: async ({ auth }) => {

--- a/packages/pds/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/api/app/bsky/actor/getProfile.ts
@@ -12,13 +12,15 @@ import { pipethrough } from '../../../../pipethrough'
 const METHOD_NSID = 'app.bsky.actor.getProfile'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.actor.getProfile({
     auth: ctx.authVerifier.accessOrRole,
     handler: async ({ req, auth, params }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
       const res = await pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         METHOD_NSID,
         params,
         requester ? await ctx.appviewAuthHeaders(requester) : authPassthru(req),

--- a/packages/pds/src/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/api/app/bsky/actor/getProfiles.ts
@@ -11,13 +11,15 @@ import {
 const METHOD_NSID = 'app.bsky.actor.getProfiles'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.actor.getProfiles({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
 
       const res = await pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         METHOD_NSID,
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/api/app/bsky/actor/getSuggestions.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.actor.getSuggestions({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.actor.getSuggestions',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -4,6 +4,7 @@ import AppContext from '../../../../context'
 import { AccountPreference } from '../../../../actor-store/preference/reader'
 
 export default function (server: Server, ctx: AppContext) {
+  if (!ctx.cfg.bskyAppView) return
   server.app.bsky.actor.putPreferences({
     auth: ctx.authVerifier.accessCheckTakedown,
     handler: async ({ auth, input }) => {

--- a/packages/pds/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/api/app/bsky/actor/searchActors.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.actor.searchActors({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.actor.searchActors',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.actor.searchActorsTypeahead({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.actor.searchActorsTypeahead',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/pds/src/api/app/bsky/feed/getActorFeeds.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getActorFeeds({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getActorFeeds',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getActorLikes.ts
@@ -12,13 +12,15 @@ import { pipethrough } from '../../../../pipethrough'
 const METHOD_NSID = 'app.bsky.feed.getActorLikes'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getActorLikes({
     auth: ctx.authVerifier.accessOrRole,
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
       const res = await pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         METHOD_NSID,
         params,
         requester ? await ctx.appviewAuthHeaders(requester) : authPassthru(req),

--- a/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -13,13 +13,15 @@ import { pipethrough } from '../../../../pipethrough'
 const METHOD_NSID = 'app.bsky.feed.getAuthorFeed'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getAuthorFeed({
     auth: ctx.authVerifier.accessOrRole,
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
       const res = await pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         METHOD_NSID,
         params,
         requester ? await ctx.appviewAuthHeaders(requester) : authPassthru(req),

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -3,13 +3,16 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  const { bskyAppView } = ctx.cfg
+  if (!appViewAgent || !bskyAppView) return
   server.app.bsky.feed.getFeed({
     auth: ctx.authVerifier.access,
     handler: async ({ req, params, auth }) => {
       const requester = auth.credentials.did
 
       const { data: feed } =
-        await ctx.appViewAgent.api.app.bsky.feed.getFeedGenerator(
+        await appViewAgent.api.app.bsky.feed.getFeedGenerator(
           { feed: params.feed },
           await ctx.appviewAuthHeaders(requester),
         )
@@ -21,7 +24,7 @@ export default function (server: Server, ctx: AppContext) {
       serviceAuthHeaders.headers['accept-language'] =
         req.headers['accept-language']
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getFeed',
         params,
         serviceAuthHeaders,

--- a/packages/pds/src/api/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeedGenerator.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getFeedGenerator({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getFeedGenerator',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeedGenerators.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getFeedGenerators({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getFeedGenerators',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getLikes.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getLikes({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getLikes',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getListFeed.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getListFeed({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getListFeed',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPosts.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getPosts({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getPosts',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/api/app/bsky/feed/getRepostedBy.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getRepostedBy({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getRepostedBy',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/pds/src/api/app/bsky/feed/getSuggestedFeeds.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getSuggestedFeeds({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.getSuggestedFeeds',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/api/app/bsky/feed/getTimeline.ts
@@ -11,12 +11,14 @@ import { pipethrough } from '../../../../pipethrough'
 const METHOD_NSID = 'app.bsky.feed.getTimeline'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.getTimeline({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       const res = await pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         METHOD_NSID,
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/pds/src/api/app/bsky/feed/searchPosts.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.feed.searchPosts({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.feed.searchPosts',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/api/app/bsky/graph/getBlocks.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getBlocks({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getBlocks',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollowers.ts
@@ -4,13 +4,15 @@ import { authPassthru } from '../../../proxy'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getFollowers({
     auth: ctx.authVerifier.accessOrRole,
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getFollowers',
         params,
         requester ? await ctx.appviewAuthHeaders(requester) : authPassthru(req),

--- a/packages/pds/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/api/app/bsky/graph/getFollows.ts
@@ -4,13 +4,15 @@ import { authPassthru } from '../../../proxy'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getFollows({
     auth: ctx.authVerifier.accessOrRole,
     handler: async ({ req, params, auth }) => {
       const requester =
         auth.credentials.type === 'access' ? auth.credentials.did : null
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getFollows',
         params,
         requester ? await ctx.appviewAuthHeaders(requester) : authPassthru(req),

--- a/packages/pds/src/api/app/bsky/graph/getList.ts
+++ b/packages/pds/src/api/app/bsky/graph/getList.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getList({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getList',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getListBlocks.ts
+++ b/packages/pds/src/api/app/bsky/graph/getListBlocks.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getListBlocks({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getListBlocks',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/pds/src/api/app/bsky/graph/getListMutes.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getListMutes({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getListMutes',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getLists.ts
+++ b/packages/pds/src/api/app/bsky/graph/getLists.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getLists({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getLists',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/api/app/bsky/graph/getMutes.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getMutes({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getMutes',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/pds/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.graph.getSuggestedFollowsByActor({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.graph.getSuggestedFollowsByActor',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/graph/muteActor.ts
+++ b/packages/pds/src/api/app/bsky/graph/muteActor.ts
@@ -2,12 +2,14 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.graph.muteActor({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 
-      await ctx.appViewAgent.api.app.bsky.graph.muteActor(input.body, {
+      await appViewAgent.api.app.bsky.graph.muteActor(input.body, {
         ...(await ctx.appviewAuthHeaders(requester)),
         encoding: 'application/json',
       })

--- a/packages/pds/src/api/app/bsky/graph/muteActorList.ts
+++ b/packages/pds/src/api/app/bsky/graph/muteActorList.ts
@@ -2,12 +2,14 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.graph.muteActorList({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 
-      await ctx.appViewAgent.api.app.bsky.graph.muteActorList(input.body, {
+      await appViewAgent.api.app.bsky.graph.muteActorList(input.body, {
         ...(await ctx.appviewAuthHeaders(requester)),
         encoding: 'application/json',
       })

--- a/packages/pds/src/api/app/bsky/graph/unmuteActor.ts
+++ b/packages/pds/src/api/app/bsky/graph/unmuteActor.ts
@@ -2,12 +2,14 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.graph.unmuteActor({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 
-      await ctx.appViewAgent.api.app.bsky.graph.unmuteActor(input.body, {
+      await appViewAgent.api.app.bsky.graph.unmuteActor(input.body, {
         ...(await ctx.appviewAuthHeaders(requester)),
         encoding: 'application/json',
       })

--- a/packages/pds/src/api/app/bsky/graph/unmuteActorList.ts
+++ b/packages/pds/src/api/app/bsky/graph/unmuteActorList.ts
@@ -2,12 +2,14 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.graph.unmuteActorList({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 
-      await ctx.appViewAgent.api.app.bsky.graph.unmuteActorList(input.body, {
+      await appViewAgent.api.app.bsky.graph.unmuteActorList(input.body, {
         ...(await ctx.appviewAuthHeaders(requester)),
         encoding: 'application/json',
       })

--- a/packages/pds/src/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/pds/src/api/app/bsky/notification/getUnreadCount.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.notification.getUnreadCount({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.notification.getUnreadCount',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/api/app/bsky/notification/listNotifications.ts
@@ -3,12 +3,14 @@ import AppContext from '../../../../context'
 import { pipethrough } from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.notification.listNotifications({
     auth: ctx.authVerifier.access,
     handler: async ({ params, auth }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.notification.listNotifications',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/notification/registerPush.ts
+++ b/packages/pds/src/api/app/bsky/notification/registerPush.ts
@@ -6,6 +6,8 @@ import { AtpAgent } from '@atproto/api'
 import { getDidDoc } from '../util/resolver'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.notification.registerPush({
     auth: ctx.authVerifier.accessDeactived,
     handler: async ({ auth, input }) => {
@@ -16,14 +18,11 @@ export default function (server: Server, ctx: AppContext) {
 
       const authHeaders = await ctx.serviceAuthHeaders(did, serviceDid)
 
-      if (ctx.cfg.bskyAppView.did === serviceDid) {
-        await ctx.appViewAgent.api.app.bsky.notification.registerPush(
-          input.body,
-          {
-            ...authHeaders,
-            encoding: 'application/json',
-          },
-        )
+      if (ctx.cfg.bskyAppView?.did === serviceDid) {
+        await appViewAgent.api.app.bsky.notification.registerPush(input.body, {
+          ...authHeaders,
+          encoding: 'application/json',
+        })
         return
       }
 

--- a/packages/pds/src/api/app/bsky/notification/updateSeen.ts
+++ b/packages/pds/src/api/app/bsky/notification/updateSeen.ts
@@ -2,12 +2,14 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
+  const { appViewAgent } = ctx
+  if (!appViewAgent) return
   server.app.bsky.notification.updateSeen({
     auth: ctx.authVerifier.access,
     handler: async ({ input, auth }) => {
       const requester = auth.credentials.did
 
-      await ctx.appViewAgent.api.app.bsky.notification.updateSeen(input.body, {
+      await appViewAgent.api.app.bsky.notification.updateSeen(input.body, {
         ...(await ctx.appviewAuthHeaders(requester)),
         encoding: 'application/json',
       })

--- a/packages/pds/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/pds/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -4,12 +4,14 @@ import { pipethrough } from '../../../../pipethrough'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.unspecced.getPopularFeedGenerators({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.unspecced.getPopularFeedGenerators',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/app/bsky/unspecced/getTaggedSuggestions.ts
+++ b/packages/pds/src/api/app/bsky/unspecced/getTaggedSuggestions.ts
@@ -4,12 +4,14 @@ import { pipethrough } from '../../../../pipethrough'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
 export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx.cfg
+  if (!bskyAppView) return
   server.app.bsky.unspecced.getTaggedSuggestions({
     auth: ctx.authVerifier.access,
     handler: async ({ auth, params }) => {
       const requester = auth.credentials.did
       return pipethrough(
-        ctx.cfg.bskyAppView.url,
+        bskyAppView.url,
         'app.bsky.unspecced.getTaggedSuggestions',
         params,
         await ctx.appviewAuthHeaders(requester),

--- a/packages/pds/src/api/com/atproto/admin/createCommunicationTemplate.ts
+++ b/packages/pds/src/api/com/atproto/admin/createCommunicationTemplate.ts
@@ -3,15 +3,16 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.createCommunicationTemplate({
     auth: ctx.authVerifier.role,
     handler: async ({ req, input }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.createCommunicationTemplate(
+        await moderationAgent.com.atproto.admin.createCommunicationTemplate(
           input.body,
           authPassthru(req, true),
         )
-
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/pds/src/api/com/atproto/admin/deleteCommunicationTemplate.ts
+++ b/packages/pds/src/api/com/atproto/admin/deleteCommunicationTemplate.ts
@@ -3,10 +3,12 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.deleteCommunicationTemplate({
     auth: ctx.authVerifier.role,
     handler: async ({ req, input }) => {
-      await ctx.moderationAgent.com.atproto.admin.deleteCommunicationTemplate(
+      await moderationAgent.com.atproto.admin.deleteCommunicationTemplate(
         input.body,
         authPassthru(req, true),
       )

--- a/packages/pds/src/api/com/atproto/admin/emitModerationEvent.ts
+++ b/packages/pds/src/api/com/atproto/admin/emitModerationEvent.ts
@@ -3,15 +3,16 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.emitModerationEvent({
     auth: ctx.authVerifier.role,
     handler: async ({ req, input }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.emitModerationEvent(
+        await moderationAgent.com.atproto.admin.emitModerationEvent(
           input.body,
           authPassthru(req, true),
         )
-
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/pds/src/api/com/atproto/admin/getModerationEvent.ts
+++ b/packages/pds/src/api/com/atproto/admin/getModerationEvent.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.getModerationEvent({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
       const { data } =
-        await ctx.moderationAgent.com.atproto.admin.getModerationEvent(
+        await moderationAgent.com.atproto.admin.getModerationEvent(
           params,
           authPassthru(req),
         )

--- a/packages/pds/src/api/com/atproto/admin/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRecord.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.getRecord({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
       const { data: recordDetailAppview } =
-        await ctx.moderationAgent.com.atproto.admin.getRecord(
+        await moderationAgent.com.atproto.admin.getRecord(
           params,
           authPassthru(req),
         )

--- a/packages/pds/src/api/com/atproto/admin/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/admin/getRepo.ts
@@ -3,10 +3,12 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.getRepo({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
-      const res = await ctx.moderationAgent.com.atproto.admin.getRepo(
+      const res = await moderationAgent.com.atproto.admin.getRepo(
         params,
         authPassthru(req),
       )

--- a/packages/pds/src/api/com/atproto/admin/listCommunicationTemplates.ts
+++ b/packages/pds/src/api/com/atproto/admin/listCommunicationTemplates.ts
@@ -3,15 +3,16 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.listCommunicationTemplates({
     auth: ctx.authVerifier.role,
     handler: async ({ req }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.listCommunicationTemplates(
+        await moderationAgent.com.atproto.admin.listCommunicationTemplates(
           {},
           authPassthru(req, true),
         )
-
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/pds/src/api/com/atproto/admin/queryModerationEvents.ts
+++ b/packages/pds/src/api/com/atproto/admin/queryModerationEvents.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.queryModerationEvents({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.queryModerationEvents(
+        await moderationAgent.com.atproto.admin.queryModerationEvents(
           params,
           authPassthru(req),
         )

--- a/packages/pds/src/api/com/atproto/admin/queryModerationStatuses.ts
+++ b/packages/pds/src/api/com/atproto/admin/queryModerationStatuses.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.queryModerationStatuses({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
       const { data } =
-        await ctx.moderationAgent.com.atproto.admin.queryModerationStatuses(
+        await moderationAgent.com.atproto.admin.queryModerationStatuses(
           params,
           authPassthru(req),
         )

--- a/packages/pds/src/api/com/atproto/admin/searchRepos.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchRepos.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.searchRepos({
     auth: ctx.authVerifier.role,
     handler: async ({ req, params }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.searchRepos(
+        await moderationAgent.com.atproto.admin.searchRepos(
           params,
           authPassthru(req),
         )

--- a/packages/pds/src/api/com/atproto/admin/sendEmail.ts
+++ b/packages/pds/src/api/com/atproto/admin/sendEmail.ts
@@ -43,21 +43,25 @@ export default function (server: Server, ctx: AppContext) {
         { content },
         { subject, to: account.email },
       )
-      await ctx.moderationAgent.api.com.atproto.admin.emitModerationEvent(
-        {
-          event: {
-            $type: 'com.atproto.admin.defs#modEventEmail',
-            subjectLine: subject,
-            comment,
+
+      if (ctx.moderationAgent) {
+        await ctx.moderationAgent.api.com.atproto.admin.emitModerationEvent(
+          {
+            event: {
+              $type: 'com.atproto.admin.defs#modEventEmail',
+              subjectLine: subject,
+              comment,
+            },
+            subject: {
+              $type: 'com.atproto.admin.defs#repoRef',
+              did: recipientDid,
+            },
+            createdBy: senderDid,
           },
-          subject: {
-            $type: 'com.atproto.admin.defs#repoRef',
-            did: recipientDid,
-          },
-          createdBy: senderDid,
-        },
-        { ...authPassthru(req), encoding: 'application/json' },
-      )
+          { ...authPassthru(req), encoding: 'application/json' },
+        )
+      }
+
       return {
         encoding: 'application/json',
         body: { sent: true },

--- a/packages/pds/src/api/com/atproto/admin/updateCommunicationTemplate.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateCommunicationTemplate.ts
@@ -3,11 +3,13 @@ import AppContext from '../../../../context'
 import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
+  const { moderationAgent } = ctx
+  if (!moderationAgent) return
   server.com.atproto.admin.updateCommunicationTemplate({
     auth: ctx.authVerifier.role,
     handler: async ({ req, input }) => {
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.admin.updateCommunicationTemplate(
+        await moderationAgent.com.atproto.admin.updateCommunicationTemplate(
           input.body,
           authPassthru(req, true),
         )

--- a/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
@@ -33,7 +33,7 @@ export default function (server: Server, ctx: AppContext) {
     }
 
     // this is not someone on our server, but we help with resolving anyway
-    if (!did) {
+    if (!did && ctx.appViewAgent) {
       did = await tryResolveFromAppView(ctx.appViewAgent, handle)
     }
 

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -1,11 +1,17 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.moderation.createReport({
     auth: ctx.authVerifier.accessCheckTakedown,
     handler: async ({ input, auth }) => {
       const requester = auth.credentials.did
+      if (!ctx.moderationAgent) {
+        throw new InvalidRequestError(
+          'Your hosting service is not configured with a moderation provider. Reach out to your hosting provider.',
+        )
+      }
       const { data: result } =
         await ctx.moderationAgent.com.atproto.moderation.createReport(
           input.body,

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -7,16 +7,16 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.accessCheckTakedown,
     handler: async ({ input, auth }) => {
       const requester = auth.credentials.did
-      if (!ctx.moderationAgent) {
+      if (!ctx.reportingAgent) {
         throw new InvalidRequestError(
-          'Your hosting service is not configured with a moderation provider. Reach out to your hosting provider.',
+          'Your hosting service is not configured with a moderation provider. If this seems in error, reach out to your hosting provider.',
         )
       }
       const { data: result } =
-        await ctx.moderationAgent.com.atproto.moderation.createReport(
+        await ctx.reportingAgent.com.atproto.moderation.createReport(
           input.body,
           {
-            ...(await ctx.moderationAuthHeaders(requester)),
+            ...(await ctx.reportingAuthHeaders(requester)),
             encoding: 'application/json',
           },
         )

--- a/packages/pds/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/getRecord.ts
@@ -28,6 +28,10 @@ export default function (server: Server, ctx: AppContext) {
       }
     }
 
+    if (!ctx.cfg.bskyAppView) {
+      throw new InvalidRequestError(`Could not locate record`)
+    }
+
     return await pipethrough(
       ctx.cfg.bskyAppView.url,
       'com.atproto.repo.getRecord',

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import { KeyObject, createPublicKey, createSecretKey } from 'node:crypto'
 import {
   AuthRequiredError,
@@ -97,7 +98,7 @@ export type AuthVerifierOpts = {
   dids: {
     pds: string
     entryway?: string
-    admin: string
+    admin?: string
   }
 }
 
@@ -254,6 +255,7 @@ export class AuthVerifier {
   }
 
   adminService = async (reqCtx: ReqCtx): Promise<AdminServiceOutput> => {
+    assert(this.dids.admin)
     const payload = await this.verifyServiceJwt(reqCtx, {
       aud: this.dids.entryway ?? this.dids.pds,
       iss: [this.dids.admin],

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { KeyObject, createPublicKey, createSecretKey } from 'node:crypto'
 import {
   AuthRequiredError,

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -255,7 +255,9 @@ export class AuthVerifier {
   }
 
   adminService = async (reqCtx: ReqCtx): Promise<AdminServiceOutput> => {
-    assert(this.dids.admin)
+    if (!this.dids.admin) {
+      throw new AuthRequiredError('Untrusted issuer', 'UntrustedIss')
+    }
     const payload = await this.verifyServiceJwt(reqCtx, {
       aud: this.dids.entryway ?? this.dids.pds,
       iss: [this.dids.admin],

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -168,19 +168,29 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     repoBackfillLimitMs: env.repoBackfillLimitMs ?? DAY,
   }
 
-  assert(env.bskyAppViewUrl)
-  assert(env.bskyAppViewDid)
-  const bskyAppViewCfg: ServerConfig['bskyAppView'] = {
-    url: env.bskyAppViewUrl,
-    did: env.bskyAppViewDid,
-    cdnUrlPattern: env.bskyAppViewCdnUrlPattern,
+  let bskyAppViewCfg: ServerConfig['bskyAppView'] = null
+  if (env.bskyAppViewUrl) {
+    assert(
+      env.bskyAppViewDid,
+      'if bsky appview service url is configured, must configure its did as well.',
+    )
+    bskyAppViewCfg = {
+      url: env.bskyAppViewUrl,
+      did: env.bskyAppViewDid,
+      cdnUrlPattern: env.bskyAppViewCdnUrlPattern,
+    }
   }
 
-  assert(env.modServiceUrl)
-  assert(env.modServiceDid)
-  const modServiceCfg: ServerConfig['modService'] = {
-    url: env.modServiceUrl,
-    did: env.modServiceDid,
+  let modServiceCfg: ServerConfig['modService'] = null
+  if (env.modServiceUrl) {
+    assert(
+      env.modServiceDid,
+      'if mod service url is configured, must configure its did as well.',
+    )
+    modServiceCfg = {
+      url: env.modServiceUrl,
+      did: env.modServiceDid,
+    }
   }
 
   const redisCfg: ServerConfig['redis'] = env.redisScratchAddress
@@ -233,8 +243,8 @@ export type ServerConfig = {
   email: EmailConfig | null
   moderationEmail: EmailConfig | null
   subscription: SubscriptionConfig
-  bskyAppView: BksyAppViewConfig
-  modService: ModServiceConfig
+  bskyAppView: BksyAppViewConfig | null
+  modService: ModServiceConfig | null
   redis: RedisScratchConfig | null
   rateLimits: RateLimitsConfig
   crawlers: string[]

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -193,6 +193,23 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     }
   }
 
+  let reportServiceCfg: ServerConfig['reportService'] = null
+  if (env.reportServiceUrl) {
+    assert(
+      env.reportServiceDid,
+      'if report service url is configured, must configure its did as well.',
+    )
+    reportServiceCfg = {
+      url: env.reportServiceUrl,
+      did: env.reportServiceDid,
+    }
+  }
+
+  // if there's a mod service, default report service into it
+  if (modServiceCfg && !reportServiceCfg) {
+    reportServiceCfg = modServiceCfg
+  }
+
   const redisCfg: ServerConfig['redis'] = env.redisScratchAddress
     ? {
         address: env.redisScratchAddress,
@@ -226,6 +243,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     subscription: subscriptionCfg,
     bskyAppView: bskyAppViewCfg,
     modService: modServiceCfg,
+    reportService: reportServiceCfg,
     redis: redisCfg,
     rateLimits: rateLimitsCfg,
     crawlers: crawlersCfg,
@@ -245,6 +263,7 @@ export type ServerConfig = {
   subscription: SubscriptionConfig
   bskyAppView: BksyAppViewConfig | null
   modService: ModServiceConfig | null
+  reportService: ReportServiceConfig | null
   redis: RedisScratchConfig | null
   rateLimits: RateLimitsConfig
   crawlers: string[]
@@ -351,6 +370,11 @@ export type BksyAppViewConfig = {
 }
 
 export type ModServiceConfig = {
+  url: string
+  did: string
+}
+
+export type ReportServiceConfig = {
   url: string
   did: string
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -76,6 +76,10 @@ export const readEnv = (): ServerEnvironment => {
     modServiceUrl: envStr('PDS_MOD_SERVICE_URL'),
     modServiceDid: envStr('PDS_MOD_SERVICE_DID'),
 
+    // report service
+    reportServiceUrl: envStr('PDS_REPORT_SERVICE_URL'),
+    reportServiceDid: envStr('PDS_REPORT_SERVICE_DID'),
+
     // rate limits
     rateLimitsEnabled: envBool('PDS_RATE_LIMITS_ENABLED'),
     rateLimitBypassKey: envStr('PDS_RATE_LIMIT_BYPASS_KEY'),
@@ -175,6 +179,10 @@ export type ServerEnvironment = {
   // mod service
   modServiceUrl?: string
   modServiceDid?: string
+
+  // report service
+  reportServiceUrl?: string
+  reportServiceDid?: string
 
   // rate limits
   rateLimitsEnabled?: boolean

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -45,6 +45,7 @@ export type AppContextOptions = {
   crawlers: Crawlers
   appViewAgent?: AtpAgent
   moderationAgent?: AtpAgent
+  reportingAgent?: AtpAgent
   entrywayAgent?: AtpAgent
   authVerifier: AuthVerifier
   plcRotationKey: crypto.Keypair
@@ -70,6 +71,7 @@ export class AppContext {
   public crawlers: Crawlers
   public appViewAgent: AtpAgent | undefined
   public moderationAgent: AtpAgent | undefined
+  public reportingAgent: AtpAgent | undefined
   public entrywayAgent: AtpAgent | undefined
   public authVerifier: AuthVerifier
   public plcRotationKey: crypto.Keypair
@@ -91,6 +93,7 @@ export class AppContext {
     this.crawlers = opts.crawlers
     this.appViewAgent = opts.appViewAgent
     this.moderationAgent = opts.moderationAgent
+    this.reportingAgent = opts.reportingAgent
     this.entrywayAgent = opts.entrywayAgent
     this.authVerifier = opts.authVerifier
     this.plcRotationKey = opts.plcRotationKey
@@ -168,7 +171,9 @@ export class AppContext {
     const moderationAgent = cfg.modService
       ? new AtpAgent({ service: cfg.modService.url })
       : undefined
-
+    const reportingAgent = cfg.reportService
+      ? new AtpAgent({ service: cfg.reportService.url })
+      : undefined
     const entrywayAgent = cfg.entryway
       ? new AtpAgent({ service: cfg.entryway.url })
       : undefined
@@ -236,6 +241,7 @@ export class AppContext {
       crawlers,
       appViewAgent,
       moderationAgent,
+      reportingAgent,
       entrywayAgent,
       authVerifier,
       plcRotationKey,
@@ -252,6 +258,11 @@ export class AppContext {
   async moderationAuthHeaders(did: string) {
     assert(this.cfg.modService)
     return this.serviceAuthHeaders(did, this.cfg.modService.did)
+  }
+
+  async reportingAuthHeaders(did: string) {
+    assert(this.cfg.reportService)
+    return this.serviceAuthHeaders(did, this.cfg.reportService.did)
   }
 
   async serviceAuthHeaders(did: string, aud: string) {

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -1,4 +1,5 @@
-import util from 'util'
+import util from 'node:util'
+import assert from 'node:assert'
 import AtpAgent from '@atproto/api'
 import { TestNetwork, SeedClient, RecordRef } from '@atproto/dev-env'
 import basicSeed from '../seeds/basic'
@@ -43,6 +44,7 @@ describe('proxy read after write', () => {
   })
 
   it('handles image formatting', async () => {
+    assert(network.pds.ctx.cfg.bskyAppView)
     const blob = await sc.uploadFile(
       alice,
       '../dev-env/src/seed/img/key-landscape-small.jpg',
@@ -123,6 +125,7 @@ describe('proxy read after write', () => {
   })
 
   it('handles read after write on threads with record embeds', async () => {
+    assert(network.pds.ctx.cfg.bskyAppView)
     const img = await sc.uploadFile(
       alice,
       '../dev-env/src/seed/img/key-landscape-small.jpg',


### PR DESCRIPTION
This loosens the config requirements of the pds distribution by allowing functionality provided by other services to be disabled:
 - configuring a bsky appview service is optional.
 - configuring a moderation service is optional.
 - a service specifically for receiving reports may be configured separately from the privileged moderation service.