### PR TITLE
Fix sanitization, improve test to catch

### DIFF
--- a/.changeset/lovely-dogs-run.md
+++ b/.changeset/lovely-dogs-run.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Fix mute word upsert logic by ensuring we're comparing sanitized word values

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -668,24 +668,24 @@ async function updateMutedWords(
 
     if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
       if (action === 'upsert' || action === 'update') {
-        for (const newItem of mutedWords) {
+        for (const word of mutedWords) {
           let foundMatch = false
 
           for (const existingItem of mutedWordsPref.items) {
-            if (existingItem.value === newItem.value) {
+            if (existingItem.value === sanitizeMutedWord(word).value) {
               existingItem.targets =
                 action === 'upsert'
                   ? Array.from(
-                      new Set([...existingItem.targets, ...newItem.targets]),
+                      new Set([...existingItem.targets, ...word.targets]),
                     )
-                  : newItem.targets
+                  : word.targets
               foundMatch = true
               break
             }
           }
 
           if (action === 'upsert' && !foundMatch) {
-            mutedWordsPref.items.push(sanitizeMutedWord(newItem))
+            mutedWordsPref.items.push(sanitizeMutedWord(word))
           }
         }
       } else if (action === 'remove') {

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1199,10 +1199,17 @@ describe('agent', () => {
       })
 
       it('upsertMutedWords with #', async () => {
+        await agent.upsertMutedWords([
+          { value: 'hashtag', targets: ['content'] },
+        ])
         await agent.upsertMutedWords([{ value: '#hashtag', targets: ['tag'] }])
         const { mutedWords } = await agent.getPreferences()
         expect(mutedWords.find((m) => m.value === '#hashtag')).toBeFalsy()
-        expect(mutedWords.find((m) => m.value === 'hashtag')).toBeTruthy()
+        expect(mutedWords.find((m) => m.value === 'hashtag')).toStrictEqual({
+          value: 'hashtag',
+          targets: ['content', 'tag'],
+        })
+        expect(mutedWords.filter((m) => m.value === 'hashtag').length).toBe(1)
       })
 
       it('updateMutedWord', async () => {


### PR DESCRIPTION
Missed a sanitization and the test didn't catch due to the order the calls were made. Sanitized, updated test: should only insert one entry for `hashtag`. 