### PR TITLE
lex: tweak deprecation note

### DIFF
--- a/lexicons/com/atproto/temp/fetchLabels.json
+++ b/lexicons/com/atproto/temp/fetchLabels.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Fetch all labels from a labeler created after a certain date. DEPRECATED: use queryLabels or subscribeLabels instead",
+      "description": "DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date.",
       "parameters": {
         "type": "params",
         "properties": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4867,7 +4867,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'Fetch all labels from a labeler created after a certain date. DEPRECATED: use queryLabels or subscribeLabels instead',
+          'DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4867,7 +4867,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'Fetch all labels from a labeler created after a certain date. DEPRECATED: use queryLabels or subscribeLabels instead',
+          'DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4867,7 +4867,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'Fetch all labels from a labeler created after a certain date. DEPRECATED: use queryLabels or subscribeLabels instead',
+          'DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4867,7 +4867,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'Fetch all labels from a labeler created after a certain date. DEPRECATED: use queryLabels or subscribeLabels instead',
+          'DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date.',
         parameters: {
           type: 'params',
           properties: {


### PR DESCRIPTION
The motivation with this is that the docs site hides deprecated endpoint, and the behavior was updated to only do this when "deprecation" is the first word of the description (to avoid hiding some endpoints which just talk about deprecation).