### PR TITLE
PDS: Remove metadata from uploaded image blobs

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -49,6 +49,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "disposable-email": "^0.2.3",
+    "exif-be-gone": "^1.4.1",
     "express": "^4.17.2",
     "express-async-errors": "^3.1.1",
     "file-type": "^16.5.4",

--- a/packages/pds/src/actor-store/blob/transactor.ts
+++ b/packages/pds/src/actor-store/blob/transactor.ts
@@ -42,6 +42,7 @@ export class BlobTransactor extends BlobReader {
     userSuggestedMime: string,
     blobStream: stream.Readable,
   ): Promise<BlobMetadata> {
+    blobStream = img.stripMetadata(blobStream)
     const [tempKey, size, sha256, imgInfo, sniffedMime] = await Promise.all([
       this.blobstore.putTemp(cloneStream(blobStream)),
       streamSize(cloneStream(blobStream)),

--- a/packages/pds/src/image/index.ts
+++ b/packages/pds/src/image/index.ts
@@ -1,7 +1,8 @@
-import { Readable } from 'stream'
+import { PassThrough, Readable, pipeline as streamPipeline } from 'stream'
 import { pipeline } from 'stream/promises'
 import sharp from 'sharp'
 import { errHasMsg } from '@atproto/common'
+import ExifTransformer from 'exif-be-gone'
 
 export async function maybeGetInfo(
   stream: Readable,
@@ -64,4 +65,13 @@ export const formatsToMimes: {
   tif: 'image/tiff',
   tiff: 'image/tiff',
   webp: 'image/webp',
+}
+
+export function stripMetadata(stream: Readable): Readable {
+  return streamPipeline(
+    stream,
+    new ExifTransformer(),
+    new PassThrough(),
+    () => {},
+  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       disposable-email:
         specifier: ^0.2.3
         version: 0.2.3
+      exif-be-gone:
+        specifier: ^1.4.1
+        version: 1.4.1
       express:
         specifier: ^4.17.2
         version: 4.18.2
@@ -6012,6 +6015,12 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
+  /@types/stream-buffers@3.0.7:
+    resolution: {integrity: sha512-azOCy05sXVXrO+qklf0c/B07H/oHaIuDDAiHPVwlk3A9Ek+ksHyTeMajLZl3r76FxpPpxem//4Te61G1iW3Giw==}
+    dependencies:
+      '@types/node': 18.17.8
+    dev: false
+
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
@@ -7883,6 +7892,13 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
+
+  /exif-be-gone@1.4.1:
+    resolution: {integrity: sha512-+x8c4hAsC8xW880sMqQEhgSX/KhMcfNuE2uaDjm0KqzuJCofbd6K47qifWJm0qSfw9rjU2D550QJiwpswf0B9Q==}
+    hasBin: true
+    dependencies:
+      '@types/stream-buffers': 3.0.7
+    dev: false
 
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}


### PR DESCRIPTION
Fixes #522 

Note that this also strips orientation and resolution metadata. I don't know if we want to limit it to only remove GPS metadata.

WIP until I can figure out how to make it configurable and add tests.