### PR TITLE
pds: allow root domains to be handles

### DIFF
--- a/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
@@ -24,7 +24,7 @@ export default function (server: Server, ctx: AppContext) {
       did = user.did
     } else {
       const supportedHandle = ctx.cfg.identity.serviceHandleDomains.some(
-        (host) => handle.endsWith(host) || handle === host.slice(1),
+        (host) => handle.endsWith(host),
       )
       // this should be in our DB & we couldn't find it, so fail
       if (supportedHandle) {


### PR DESCRIPTION
I'm running a PDS at `https://iame.li` and I want my handle to be `@iame.li`. There's presently a check in `com.atproto.identity.resolveHandle` that disallows any domain in our `serviceHandleDomains` to be resolved as a handle. I'm not sure there's any virtue to this check, and I assume that PDS operators running PDS on the same domain as their handles will be something that comes up.

Naturally, you still need to prove that you own the domain through the regular TXT record/.well-known entry, so there shouldn't be any harm here.

This PR removes this check and adds tests to validate the other cases. I've tested it on my own PDS and my handle is once again `@iame.li`. Hooray!