### PR TITLE
Add `parentAuthor` to `feedViewPost`

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -49,6 +49,10 @@
       "properties": {
         "post": { "type": "ref", "ref": "#postView" },
         "reply": { "type": "ref", "ref": "#replyRef" },
+        "replyParentAuthor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileViewBasic"
+        },
         "reason": { "type": "union", "refs": ["#reasonRepost"] }
       }
     },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6001,6 +6001,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#replyRef',
           },
+          replyParentAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+          },
           reason: {
             type: 'union',
             refs: ['lex:app.bsky.feed.defs#reasonRepost'],

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -68,6 +68,7 @@ export function validateViewerState(v: unknown): ValidationResult {
 export interface FeedViewPost {
   post: PostView
   reply?: ReplyRef
+  replyParentAuthor?: AppBskyActorDefs.ProfileViewBasic
   reason?: ReasonRepost | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6001,6 +6001,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#replyRef',
           },
+          replyParentAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+          },
           reason: {
             type: 'union',
             refs: ['lex:app.bsky.feed.defs#reasonRepost'],

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -68,6 +68,7 @@ export function validateViewerState(v: unknown): ValidationResult {
 export interface FeedViewPost {
   post: PostView
   reply?: ReplyRef
+  replyParentAuthor?: AppBskyActorDefs.ProfileViewBasic
   reason?: ReasonRepost | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/bsky/src/services/feed/index.ts
+++ b/packages/bsky/src/services/feed/index.ts
@@ -270,17 +270,16 @@ export class FeedService {
         viewer ? [...dids].map((did) => [viewer, did]) : [],
       ),
     ])
-
-    // add any uris that would be required to display a "reply to" label in the feed
+    // add any dids that would be required to display a "reply to" label in the feed
     if (parentUris) {
       for (const uri of parentUris) {
         const post = posts[uri]
         if (isPostRecord(post.record) && post.record.reply) {
-          dids.add(new AtUri(post.record.reply?.parent.uri).hostname)
+          const did = new AtUri(post.record.reply?.parent.uri).hostname
+          dids.add(did)
         }
       }
     }
-
     // profileState for labels and bam handled above, profileHydration() shouldn't fetch additional
     const [profileState, blocks, lists] = await Promise.all([
       this.services.actor.views.profileHydration(

--- a/packages/bsky/src/services/feed/views.ts
+++ b/packages/bsky/src/services/feed/views.ts
@@ -189,7 +189,6 @@ export class FeedViews {
             root: replyRoot,
             parent: replyParent,
           }
-
           if (isPostRecord(replyParent.record) && replyParent.record.reply) {
             const did = new AtUri(replyParent.record.reply.parent.uri).hostname
             feedPost['parentAuthor'] = actors[did]

--- a/packages/bsky/src/services/feed/views.ts
+++ b/packages/bsky/src/services/feed/views.ts
@@ -6,6 +6,7 @@ import {
   GeneratorView,
   PostView,
 } from '../../lexicon/types/app/bsky/feed/defs'
+import { isRecord as isPostRecord } from '../../lexicon/types/app/bsky/feed/post'
 import {
   Main as EmbedImages,
   isMain as isEmbedImages,
@@ -187,6 +188,11 @@ export class FeedViews {
           feedPost['reply'] = {
             root: replyRoot,
             parent: replyParent,
+          }
+
+          if (isPostRecord(replyParent.record) && replyParent.record.reply) {
+            const did = new AtUri(replyParent.record.reply.parent.uri).hostname
+            feedPost['parentAuthor'] = actors[did]
           }
         }
       }

--- a/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/indexing.test.ts.snap
@@ -46,6 +46,15 @@ Array [
         },
       },
       Object {
+        "parentAuthor": Object {
+          "did": "user(0)",
+          "handle": "alice.test",
+          "labels": Array [],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
         "post": Object {
           "author": Object {
             "did": "user(0)",

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -3,6 +3,34 @@
 exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 1`] = `
 Array [
   Object {
+    "parentAuthor": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(1)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(1)",
+          "val": "self-label-b",
+        },
+      ],
+      "viewer": Object {
+        "blockedBy": false,
+        "muted": false,
+      },
+    },
     "post": Object {
       "author": Object {
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
@@ -1135,6 +1163,35 @@ Array [
 exports[`pds author feed views fetches full author feeds for self (sorted, minimal viewer state). 4`] = `
 Array [
   Object {
+    "parentAuthor": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(2)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(2)",
+          "val": "self-label-b",
+        },
+      ],
+      "viewer": Object {
+        "blockedBy": false,
+        "followedBy": "record(1)",
+        "muted": false,
+      },
+    },
     "post": Object {
       "author": Object {
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
@@ -1587,6 +1644,36 @@ Array [
 exports[`pds author feed views reflects fetching user's state in the feed. 1`] = `
 Array [
   Object {
+    "parentAuthor": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(3)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(3)",
+          "val": "self-label-b",
+        },
+      ],
+      "viewer": Object {
+        "blockedBy": false,
+        "followedBy": "record(2)",
+        "following": "record(1)",
+        "muted": false,
+      },
+    },
     "post": Object {
       "author": Object {
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",

--- a/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
@@ -3,6 +3,36 @@
 exports[`list feed views fetches list feed 1`] = `
 Array [
   Object {
+    "parentAuthor": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(3)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "neg": false,
+          "src": "user(0)",
+          "uri": "record(3)",
+          "val": "self-label-b",
+        },
+      ],
+      "viewer": Object {
+        "blockedBy": false,
+        "followedBy": "record(2)",
+        "following": "record(1)",
+        "muted": false,
+      },
+    },
     "post": Object {
       "author": Object {
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6001,6 +6001,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#replyRef',
           },
+          replyParentAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+          },
           reason: {
             type: 'union',
             refs: ['lex:app.bsky.feed.defs#reasonRepost'],

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -68,6 +68,7 @@ export function validateViewerState(v: unknown): ValidationResult {
 export interface FeedViewPost {
   post: PostView
   reply?: ReplyRef
+  replyParentAuthor?: AppBskyActorDefs.ProfileViewBasic
   reason?: ReasonRepost | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6001,6 +6001,10 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.feed.defs#replyRef',
           },
+          replyParentAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+          },
           reason: {
             type: 'union',
             refs: ['lex:app.bsky.feed.defs#reasonRepost'],

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -68,6 +68,7 @@ export function validateViewerState(v: unknown): ValidationResult {
 export interface FeedViewPost {
   post: PostView
   reply?: ReplyRef
+  replyParentAuthor?: AppBskyActorDefs.ProfileViewBasic
   reason?: ReasonRepost | { $type: string; [k: string]: unknown }
   [k: string]: unknown
 }


### PR DESCRIPTION
Prefacing this with this is the first time I've really dug at this repo, definitely might have made a mistake but hopefully it's a small enough change where there wasn't much room to. Also, feel free to hate `parentAuthor`, normally I'd ask and figure that out beforehand but since this was kind of born out of "let me play with this thing..." figured I'd just push up and we can discuss.

Also, no idea if this accounts for v2 changes. If it doesn't, hopefully it at least serves as an example of what we'd like to see here.

## Why

Right now the `feedViewPost` returns a post and it's parent `postView` in the `feedViewPost`'s reply ref. However, there is no information given for the parent's parent (parent 2, we'll call it). There's very little information that we need for parent 2, but we do need to have the handle/display name of parent 2's author. This lets us display the "Reply to..." label on the post.

As a result, right now in the app (and most third party apps), this requires us making a separate query for `getProfile`, as seen below. Especially in the case of third party clients, this seems to have been a headscratcher for multiple people. And, while our client is doing some caching to limit the number of times we query `getProfile`, it's likely that not every client is doing so.

![Screenshot 2024-02-26 at 1 39 45 AM](https://github.com/bluesky-social/atproto/assets/153161762/3be8e542-c1b5-472b-8e93-35c91eac7bf2)

The `getProfile` calls add up quickly, and easily outnumber the requests we are making for the timeline itself. Especially on initial loads, the number of `getProfile` queries can add up to around 15-20. Each subsequent page that we load from `getTimeline` or `getFeed` usually has ~5 queries to `getProfile` that we have to make.

While we could alternatively batch the `getProfile` requests into a single `getProfiles` request, this doesn't eliminate the UX downside to having to query for this data separately. There's a brief period of time (brief on a good connection, a weaker one would have a fairly significant delay in displaying this additional data) where we can't even display the text for the "Reply to..." label.

## How

It seems the simplest way that we can add this information is done in three steps.

1. Create a separate set of post URIs of `replyParent`s when we create the `feedItemRefs`. We'll call this `parentUris`.
2. After getting all of the post infos in `feedHydration`, looping through this `parentUris`  and matching them to their respective post info. There, we can get the parent's reply ref (if there is one), and get the additional DID we need to look up. We add that DID to the `dids` set that is used after getting post infos.
3. Update the `feedViewPost` lexicon and add a `parentAuthor` field, which is a `profileViewBasic` of parent 2's author.

![Screenshot 2024-02-26 at 1 31 50 AM](https://github.com/bluesky-social/atproto/assets/153161762/8d3f77d2-5237-46e0-bf0b-43a3929610aa)