### PR TITLE
Fix muted word sanitization

### DIFF
--- a/.changeset/rotten-actors-dance.md
+++ b/.changeset/rotten-actors-dance.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Fix double sanitization bug when editing muted words.

--- a/.changeset/sour-gorillas-unite.md
+++ b/.changeset/sour-gorillas-unite.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Handle has emoji in mute words

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -565,16 +565,106 @@ export class BskyAgent extends AtpAgent {
     })
   }
 
-  async upsertMutedWords(mutedWords: AppBskyActorDefs.MutedWord[]) {
-    await updateMutedWords(this, mutedWords, 'upsert')
+  async upsertMutedWords(newMutedWords: AppBskyActorDefs.MutedWord[]) {
+    await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
+      let mutedWordsPref = prefs.findLast(
+        (pref) =>
+          AppBskyActorDefs.isMutedWordsPref(pref) &&
+          AppBskyActorDefs.validateMutedWordsPref(pref).success,
+      )
+
+      if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
+        for (const updatedWord of newMutedWords) {
+          let foundMatch = false
+          const sanitizedUpdatedValue = updatedWord.value.replace(/^#/, '')
+
+          // was trimmed down to an empty string e.g. single `#`
+          if (!sanitizedUpdatedValue) continue
+
+          for (const existingItem of mutedWordsPref.items) {
+            if (existingItem.value === sanitizedUpdatedValue) {
+              existingItem.targets = Array.from(
+                new Set([...existingItem.targets, ...updatedWord.targets]),
+              )
+              foundMatch = true
+              break
+            }
+          }
+
+          if (!foundMatch) {
+            mutedWordsPref.items.push({
+              ...updatedWord,
+              value: sanitizedUpdatedValue,
+            })
+          }
+        }
+      } else {
+        // if the pref doesn't exist, create it
+        mutedWordsPref = {
+          items: newMutedWords.map((w) => ({
+            ...w,
+            value: w.value.replace(/^#/, ''),
+          })),
+        }
+      }
+
+      return prefs
+        .filter((p) => !AppBskyActorDefs.isMutedWordsPref(p))
+        .concat([
+          { ...mutedWordsPref, $type: 'app.bsky.actor.defs#mutedWordsPref' },
+        ])
+    })
   }
 
   async updateMutedWord(mutedWord: AppBskyActorDefs.MutedWord) {
-    await updateMutedWords(this, [mutedWord], 'update')
+    await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
+      let mutedWordsPref = prefs.findLast(
+        (pref) =>
+          AppBskyActorDefs.isMutedWordsPref(pref) &&
+          AppBskyActorDefs.validateMutedWordsPref(pref).success,
+      )
+
+      if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
+        for (const existingItem of mutedWordsPref.items) {
+          if (existingItem.value === mutedWord.value) {
+            existingItem.targets = mutedWord.targets
+            break
+          }
+        }
+      }
+
+      return prefs
+        .filter((p) => !AppBskyActorDefs.isMutedWordsPref(p))
+        .concat([
+          { ...mutedWordsPref, $type: 'app.bsky.actor.defs#mutedWordsPref' },
+        ])
+    })
   }
 
   async removeMutedWord(mutedWord: AppBskyActorDefs.MutedWord) {
-    await updateMutedWords(this, [mutedWord], 'remove')
+    await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
+      let mutedWordsPref = prefs.findLast(
+        (pref) =>
+          AppBskyActorDefs.isMutedWordsPref(pref) &&
+          AppBskyActorDefs.validateMutedWordsPref(pref).success,
+      )
+
+      if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
+        for (let i = 0; i < mutedWordsPref.items.length; i++) {
+          const existing = mutedWordsPref.items[i]
+          if (existing.value === mutedWord.value) {
+            mutedWordsPref.items.splice(i, 1)
+            break
+          }
+        }
+      }
+
+      return prefs
+        .filter((p) => !AppBskyActorDefs.isMutedWordsPref(p))
+        .concat([
+          { ...mutedWordsPref, $type: 'app.bsky.actor.defs#mutedWordsPref' },
+        ])
+    })
   }
 
   async hidePost(postUri: string) {
@@ -644,73 +734,6 @@ async function updateFeedPreferences(
       .concat([feedsPref])
   })
   return res
-}
-
-/**
- * A helper specifically for updating muted words preferences
- */
-async function updateMutedWords(
-  agent: BskyAgent,
-  updatedMutedWords: AppBskyActorDefs.MutedWord[],
-  action: 'upsert' | 'update' | 'remove',
-) {
-  await updatePreferences(agent, (prefs: AppBskyActorDefs.Preferences) => {
-    let mutedWordsPref = prefs.findLast(
-      (pref) =>
-        AppBskyActorDefs.isMutedWordsPref(pref) &&
-        AppBskyActorDefs.validateMutedWordsPref(pref).success,
-    )
-
-    if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
-      if (action === 'upsert' || action === 'update') {
-        for (const updatedWord of updatedMutedWords) {
-          let foundMatch = false
-          for (const existingItem of mutedWordsPref.items) {
-            if (existingItem.value === updatedWord.value) {
-              existingItem.targets =
-                action === 'upsert'
-                  ? Array.from(
-                      new Set([
-                        ...existingItem.targets,
-                        ...updatedWord.targets,
-                      ]),
-                    )
-                  : updatedWord.targets
-              foundMatch = true
-              break
-            }
-          }
-
-          if (action === 'upsert' && !foundMatch) {
-            mutedWordsPref.items.push(updatedWord)
-          }
-        }
-      } else if (action === 'remove') {
-        for (const updatedWord of updatedMutedWords) {
-          for (let i = 0; i < mutedWordsPref.items.length; i++) {
-            const existing = mutedWordsPref.items[i]
-            if (existing.value === updatedWord.value) {
-              mutedWordsPref.items.splice(i, 1)
-              break
-            }
-          }
-        }
-      }
-    } else {
-      // if the pref doesn't exist, create it
-      if (action === 'upsert') {
-        mutedWordsPref = {
-          items: updatedMutedWords,
-        }
-      }
-    }
-
-    return prefs
-      .filter((p) => !AppBskyActorDefs.isMutedWordsPref(p))
-      .concat([
-        { ...mutedWordsPref, $type: 'app.bsky.actor.defs#mutedWordsPref' },
-      ])
-  })
 }
 
 async function updateHiddenPost(

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -576,7 +576,7 @@ export class BskyAgent extends AtpAgent {
       if (mutedWordsPref && AppBskyActorDefs.isMutedWordsPref(mutedWordsPref)) {
         for (const updatedWord of newMutedWords) {
           let foundMatch = false
-          const sanitizedUpdatedValue = updatedWord.value.replace(/^#/, '')
+          const sanitizedUpdatedValue = sanitizeMuteWordValue(updatedWord.value)
 
           // was trimmed down to an empty string e.g. single `#`
           if (!sanitizedUpdatedValue) continue
@@ -603,7 +603,7 @@ export class BskyAgent extends AtpAgent {
         mutedWordsPref = {
           items: newMutedWords.map((w) => ({
             ...w,
-            value: w.value.replace(/^#/, ''),
+            value: sanitizeMuteWordValue(w.value),
           })),
         }
       }
@@ -764,4 +764,8 @@ async function updateHiddenPost(
       .filter((p) => !AppBskyActorDefs.isInterestsPref(p))
       .concat([{ ...pref, $type: 'app.bsky.actor.defs#hiddenPostsPref' }])
   })
+}
+
+function sanitizeMuteWordValue(value: string) {
+  return value.replace(/^#(?!\ufe0f)/, '')
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1202,17 +1202,19 @@ describe('agent', () => {
         await agent.upsertMutedWords([
           { value: 'hashtag', targets: ['content'] },
         ])
+        // is sanitized to `hashtag`
         await agent.upsertMutedWords([{ value: '#hashtag', targets: ['tag'] }])
+
         const { mutedWords } = await agent.getPreferences()
+
+        expect(mutedWords.find((m) => m.value === '#hashtag')).toBeFalsy()
+        // merged with existing
         expect(mutedWords.find((m) => m.value === 'hashtag')).toStrictEqual({
           value: 'hashtag',
-          targets: ['content'],
+          targets: ['content', 'tag'],
         })
-        expect(mutedWords.find((m) => m.value === '#hashtag')).toStrictEqual({
-          value: '#hashtag',
-          targets: ['tag'],
-        })
-        expect(mutedWords.filter((m) => m.value === '#hashtag').length).toBe(1)
+        // only one added
+        expect(mutedWords.filter((m) => m.value === 'hashtag').length).toBe(1)
       })
 
       it('updateMutedWord', async () => {
@@ -1240,15 +1242,21 @@ describe('agent', () => {
         expect(mutedWords.find((m) => m.value === 'no_exist')).toBeFalsy()
       })
 
-      it('updateMutedWord with #', async () => {
+      it('updateMutedWord with #, does not update', async () => {
+        await agent.upsertMutedWords([
+          {
+            value: '#just_a_tag',
+            targets: ['tag'],
+          },
+        ])
         await agent.updateMutedWord({
-          value: 'hashtag',
+          value: '#just_a_tag',
           targets: ['tag', 'content'],
         })
         const { mutedWords } = await agent.getPreferences()
-        expect(mutedWords.find((m) => m.value === 'hashtag')).toStrictEqual({
-          value: 'hashtag',
-          targets: ['tag', 'content'],
+        expect(mutedWords.find((m) => m.value === 'just_a_tag')).toStrictEqual({
+          value: 'just_a_tag',
+          targets: ['tag'],
         })
       })
 
@@ -1265,19 +1273,41 @@ describe('agent', () => {
         expect(mutedWords.find((m) => m.value === 'tag_then_none')).toBeFalsy()
       })
 
-      it('removeMutedWord with #', async () => {
+      it('removeMutedWord with #, no match, no removal', async () => {
         await agent.removeMutedWord({ value: '#hashtag', targets: [] })
         const { mutedWords } = await agent.getPreferences()
 
-        expect(mutedWords.find((m) => m.value === '#hashtag')).toBeFalsy()
+        // was inserted with #hashtag, but we don't sanitize on remove
         expect(mutedWords.find((m) => m.value === 'hashtag')).toBeTruthy()
+      })
+
+      it('single-hash #', async () => {
+        const prev = await agent.getPreferences()
+        const length = prev.mutedWords.length
+        await agent.upsertMutedWords([{ value: '#', targets: [] }])
+        const end = await agent.getPreferences()
+
+        // sanitized to empty string, not inserted
+        expect(end.mutedWords.length).toEqual(length)
       })
 
       it('multi-hash ##', async () => {
         await agent.upsertMutedWords([{ value: '##', targets: [] }])
         const { mutedWords } = await agent.getPreferences()
 
-        expect(mutedWords.find((m) => m.value === '##')).toBeTruthy()
+        expect(mutedWords.find((m) => m.value === '#')).toBeTruthy()
+      })
+
+      it('multi-hash ##hashtag', async () => {
+        await agent.upsertMutedWords([{ value: '##hashtag', targets: [] }])
+        const a = await agent.getPreferences()
+
+        expect(a.mutedWords.find((w) => w.value === '#hashtag')).toBeTruthy()
+
+        await agent.removeMutedWord({ value: '#hashtag', targets: [] })
+        const b = await agent.getPreferences()
+
+        expect(b.mutedWords.find((w) => w.value === '#hashtag')).toBeFalsy()
       })
     })
 

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1309,6 +1309,30 @@ describe('agent', () => {
 
         expect(b.mutedWords.find((w) => w.value === '#hashtag')).toBeFalsy()
       })
+
+      it('hash emoji #️⃣', async () => {
+        await agent.upsertMutedWords([{ value: '#️⃣', targets: [] }])
+        const { mutedWords } = await agent.getPreferences()
+
+        expect(mutedWords.find((m) => m.value === '#️⃣')).toBeTruthy()
+
+        await agent.removeMutedWord({ value: '#️⃣', targets: [] })
+        const end = await agent.getPreferences()
+
+        expect(end.mutedWords.find((m) => m.value === '#️⃣')).toBeFalsy()
+      })
+
+      it('hash emoji ##️⃣', async () => {
+        await agent.upsertMutedWords([{ value: '##️⃣', targets: [] }])
+        const { mutedWords } = await agent.getPreferences()
+
+        expect(mutedWords.find((m) => m.value === '#️⃣')).toBeTruthy()
+
+        await agent.removeMutedWord({ value: '#️⃣', targets: [] })
+        const end = await agent.getPreferences()
+
+        expect(end.mutedWords.find((m) => m.value === '#️⃣')).toBeFalsy()
+      })
     })
 
     describe('hidden posts', () => {

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1204,12 +1204,15 @@ describe('agent', () => {
         ])
         await agent.upsertMutedWords([{ value: '#hashtag', targets: ['tag'] }])
         const { mutedWords } = await agent.getPreferences()
-        expect(mutedWords.find((m) => m.value === '#hashtag')).toBeFalsy()
         expect(mutedWords.find((m) => m.value === 'hashtag')).toStrictEqual({
           value: 'hashtag',
-          targets: ['content', 'tag'],
+          targets: ['content'],
         })
-        expect(mutedWords.filter((m) => m.value === 'hashtag').length).toBe(1)
+        expect(mutedWords.find((m) => m.value === '#hashtag')).toStrictEqual({
+          value: '#hashtag',
+          targets: ['tag'],
+        })
+        expect(mutedWords.filter((m) => m.value === '#hashtag').length).toBe(1)
       })
 
       it('updateMutedWord', async () => {
@@ -1266,7 +1269,15 @@ describe('agent', () => {
         await agent.removeMutedWord({ value: '#hashtag', targets: [] })
         const { mutedWords } = await agent.getPreferences()
 
-        expect(mutedWords.find((m) => m.value === 'hashtag')).toBeFalsy()
+        expect(mutedWords.find((m) => m.value === '#hashtag')).toBeFalsy()
+        expect(mutedWords.find((m) => m.value === 'hashtag')).toBeTruthy()
+      })
+
+      it('multi-hash ##', async () => {
+        await agent.upsertMutedWords([{ value: '##', targets: [] }])
+        const { mutedWords } = await agent.getPreferences()
+
+        expect(mutedWords.find((m) => m.value === '##')).toBeTruthy()
       })
     })
 


### PR DESCRIPTION
`##hashtag` is a valid tag based on the parsing we shipped ~5 months ago. Today, [users noticed](https://bsky.app/profile/josiah.lol/post/3kmjejr4fux26) that muting `##` added a muted word to their prefs (`#`), great, but they then could not remove.

This is because `##` was being truncated down to `#` by this sanitization. Then, when trying to remove, it was further being truncated down to an empty string, hence no match, hence no removal.

So this PR fixes support for tags like `##hashtag` AND allows removal of existing muted words only containing `#` **by only sanitizing on insert.** On update/remove, we expect an exact match.

I re-split these CRUD actions out and updated some naming for clarity.

Update: because it was closely related, I added `#️⃣` and `##️⃣` handling as well.