### PR TITLE
Do not parse hashtag emoji as tag

### DIFF
--- a/.changeset/dull-hotels-beam.md
+++ b/.changeset/dull-hotels-beam.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Prevent hashtag emoji from being parsed as a tag

--- a/.changeset/short-suits-destroy.md
+++ b/.changeset/short-suits-destroy.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Properly calculate length of tag

--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -70,7 +70,7 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
     }
   }
   {
-    const re = /(?:^|\s)(#[^\d\s]\S*)(?=\s)?/g
+    const re = /(?:^|\s)(#(?!\ufe0f)[^\d\s]\S*)(?=\s)?/g
     while ((match = re.exec(text.utf16))) {
       let [tag] = match
       const hasLeadingSpace = /^\s/.test(tag)

--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -70,27 +70,25 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
     }
   }
   {
-    const re = /(?:^|\s)(#(?!\ufe0f)[^\d\s]\S*)(?=\s)?/g
+    const re = /(^|\s)#((?!\ufe0f)[^\d\s]\S*)(?=\s)?/g
     while ((match = re.exec(text.utf16))) {
-      let [tag] = match
-      const hasLeadingSpace = /^\s/.test(tag)
+      let [, leading, tag] = match
 
       tag = tag.trim().replace(/\p{P}+$/gu, '') // strip ending punctuation
 
-      // inclusive of #, max of 64 chars
-      if (tag.length > 66) continue
+      if (tag.length === 0 || tag.length > 64) continue
 
-      const index = match.index + (hasLeadingSpace ? 1 : 0)
+      const index = match.index + leading.length
 
       facets.push({
         index: {
           byteStart: text.utf16IndexToUtf8Index(index),
-          byteEnd: text.utf16IndexToUtf8Index(index + tag.length), // inclusive of last char
+          byteEnd: text.utf16IndexToUtf8Index(index + 1 + tag.length),
         },
         features: [
           {
             $type: 'app.bsky.richtext.facet#tag',
-            tag: tag.replace(/^#/, ''),
+            tag: tag,
           },
         ],
       })

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -244,12 +244,12 @@ describe('detectFacets', () => {
       ['text #', [], []],
       ['text # text', [], []],
       [
-        'body #thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        ['thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        [{ byteStart: 5, byteEnd: 71 }],
+        'body #thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ['thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        [{ byteStart: 5, byteEnd: 70 }],
       ],
       [
-        'body #thisisa65characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab',
+        'body #thisisa65characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab',
         [],
         [],
       ],

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -297,6 +297,7 @@ describe('detectFacets', () => {
           { byteStart: 17, byteEnd: 22 },
         ],
       ],
+      ['this #️⃣tag should not be a tag', [], []]
     ]
 
     for (const [input, tags, indices] of inputs) {

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -297,7 +297,7 @@ describe('detectFacets', () => {
           { byteStart: 17, byteEnd: 22 },
         ],
       ],
-      ['this #️⃣tag should not be a tag', [], []]
+      ['this #️⃣tag should not be a tag', [], []],
     ]
 
     for (const [input, tags, indices] of inputs) {


### PR DESCRIPTION
Closes #2243

Fixes the issue where #️⃣ is being parsed as an emoji because it starts with the same char code as regular hashtag, as the emoji is composed of 0x23 (#) 0xfe0f (variation selector) 0x20e3 (keycap)

Fixes length calculation as well