### PR TITLE
Hashtag fixes

### DIFF
--- a/.changeset/big-humans-sell.md
+++ b/.changeset/big-humans-sell.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Fixes around hashtag parsing

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -244,12 +244,12 @@ describe('detectFacets', () => {
       ['text #', [], []],
       ['text # text', [], []],
       [
-        'body #thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        ['thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
-        [{ byteStart: 5, byteEnd: 71 }],
+        'body #thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ['thisisa64characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        [{ byteStart: 5, byteEnd: 70 }],
       ],
       [
-        'body #thisisa65characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab',
+        'body #thisisa65characterstring_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         [],
         [],
       ],
@@ -297,6 +297,8 @@ describe('detectFacets', () => {
           { byteStart: 17, byteEnd: 22 },
         ],
       ],
+      ['#️⃣tag', ['tag'], [{ byteStart: 0, byteEnd: 8 }]],
+      ['#️⃣ should not be parsed as tag', [], []],
     ]
 
     for (const [input, tags, indices] of inputs) {


### PR DESCRIPTION
Closes #2242

Alternate fix to #2242, where hashtag emojis are normalized, along with some other change like having it check if it's more than 64 characters rather than 65