### PR TITLE
Add runit to the services/bsky Dockerfile

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -35,7 +35,10 @@ WORKDIR services/bsky
 # Uses assets from build stage to reduce build size
 FROM node:20.11-alpine
 
-RUN apk add --update dumb-init
+# dumb-init is used to handle signals properly.
+# runit is installed so it can be (optionally) used for logging via svlogd.
+RUN apk add --update dumb-init runit
+
 
 # Avoid zombie processes, handle signal forwarding
 ENTRYPOINT ["dumb-init", "--"]


### PR DESCRIPTION
Installing the `runit` package in the services/bsky Dockerfile in order to enable the use of `svlogd` for high performance logging rather than Docker daemon logging.

*Note:* This won't affect anyone that doesn't explicitly override the container's default command.