### PR TITLE
skip plc updateHandle when operating on a did:web identity

### DIFF
--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -42,7 +42,10 @@ export default function (server: Server, ctx: AppContext) {
             throw new InvalidRequestError('Handle does not match DID doc')
           }
         } else {
-          await ctx.plcClient.updateHandle(did, ctx.plcRotationKey, handle)
+          // plc does not manage did:web identities
+          if (!did.startsWith('did:web')) {
+            await ctx.plcClient.updateHandle(did, ctx.plcRotationKey, handle)
+          }
         }
         await ctx.accountManager.updateHandle(did, handle)
       }

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -51,7 +51,10 @@ export default function (server: Server, ctx: AppContext) {
           throw new InvalidRequestError(`Handle already taken: ${handle}`)
         }
       } else {
-        await ctx.plcClient.updateHandle(requester, ctx.plcRotationKey, handle)
+        // plc does not manage did:web identities
+        if (!requester.startsWith('did:web')) {
+          await ctx.plcClient.updateHandle(requester, ctx.plcRotationKey, handle)
+        }
         await ctx.accountManager.updateHandle(requester, handle)
       }
 


### PR DESCRIPTION
I recently embarked on a journey to adopt a did:web identity, following some really great prior art from https://github.com/L11R/bsky-did-web and https://github.com/bluesky-social/atproto/issues/2100#issuecomment-1962505672.

I created the did:web identity no problem, but then later I wanted to change my handle to `malpercio.dev` instead of `malpercio.pds.malpercio.dev`. Alas, when running either `updateHandle` or `updateAccountHandle`, I'd be met with:
```
2024/02/28 06:02PM 50 Request failed with status code 404 | pid=7 hostname=a8413112136c name=xrpc-server status=404 msg=error in xrpc method com.atproto.identity.updateHandle
```

After some debugging, I discovered that the source of the 404 was a call to `plcClient.updateHandle`, with error `DID not registered: did:web:malpercio.dev`.

In a local running copy of my PDS, I commented out the plcClient.updateHandle call, et voilà, my handle was updated.

This is a rather naive fix to help others not fall into this same trap, fully recognizing that the broader onboarding process for did:web could be improved, this may make a future PDS admin's life a little easier in the short term. 🙂 

Link to a discussion in the AT Protocol PDS Admins for some additional context: https://discord.com/channels/1207024379549061120/1207050328063610923/1212912254836809798