### PR TITLE
lex: add more identity helpers

### DIFF
--- a/lexicons/com/atproto/identity/refreshIdentity.json
+++ b/lexicons/com/atproto/identity/refreshIdentity.json
@@ -1,0 +1,46 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.sync.refreshIdentity",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Request that the server re-resolve an identity (DID and handle). The server may ignore this request, or require authentication, depending on the role, implementation, and policy of the server.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["identifier"],
+          "properties": {
+            "hostname": {
+              "type": "string",
+              "format": "at-identifier"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" },
+            "handle": {
+              "type": "string",
+              "format": "handle",
+              "description": "The validated handle of the account; or 'handle.invalid' if the handle did not resolve successfully."
+            },
+            "tombstoned": {
+              "type": "boolean",
+              "description": "If true, the DID has been deleted, and the other optional fields should be null."
+            },
+            "didDoc": {
+              "type": "unknown",
+              "description": "The complete DID document for the identity."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/identity/resolveIdentity.json
+++ b/lexicons/com/atproto/identity/resolveIdentity.json
@@ -1,0 +1,44 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.identity.resolveIdentity",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolves an identity (DID or Handle) to a full identity (DID document and verified handle).",
+      "parameters": {
+        "type": "params",
+        "required": ["identifier"],
+        "properties": {
+          "handle": {
+            "type": "string",
+            "format": "atidentifier",
+            "description": "Handle or DID to resolve."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" },
+            "handle": {
+              "type": "string",
+              "format": "handle",
+              "description": "The validated handle of the account; or 'handle.invalid' if the handle did not resolve successfully."
+            },
+            "tombstoned": {
+              "type": "boolean",
+              "description": "If true, the DID has been deleted, and the other optional fields should be null."
+            },
+            "didDoc": {
+              "type": "unknown",
+              "description": "The complete DID document for the identity."
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These are ideas/follow-ups from discussions with @dholms during account migration design.

One example use-case `refreshIdentity` is `did:web` users, or folks that manage their `did:plc` out-of-band.  In these cases, users need a way to tell their PDS that their identity has updated and should be re-resolved server-side. Another is somebody who fixes their handle, but still appears invalid from AppView; that might not result in an `#identity` event on firehose, and they might want to poke the AppView to refresh to fix it. In an expansive sense, this could be implemented by every atproto service (Relay, AppView, Mod Service, etc), with a rate-limit. We probably wouldn't want to start with that though; I left it ambiguous with "might require auth, and could be ignored".

The second is a mechanism to resolve a DID doc and handle together. This is intended for clients which don't want to bother talking to PLC, and just want to ask their PDS to resolve an identity for them. This could become more important/useful in the future if we add more DID methods. Really it just feels like a missing piece for now, in that we have `resolveHandle` but not `resolveDid` (this rolls up the functionality of the later).