### PR TITLE
Ozone delegates email sending to actor's pds

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -585,6 +585,10 @@
           "type": "string",
           "description": "The subject line of the email sent to the user."
         },
+        "content": {
+          "type": "string",
+          "description": "The content of the email sent to the user."
+        },
         "comment": {
           "type": "string",
           "description": "Additional comment about the outgoing comm."

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -897,6 +897,10 @@ export const schemaDict = {
             type: 'string',
             description: 'The subject line of the email sent to the user.',
           },
+          content: {
+            type: 'string',
+            description: 'The content of the email sent to the user.',
+          },
           comment: {
             type: 'string',
             description: 'Additional comment about the outgoing comm.',

--- a/packages/api/src/client/types/com/atproto/admin/defs.ts
+++ b/packages/api/src/client/types/com/atproto/admin/defs.ts
@@ -704,6 +704,8 @@ export function validateModEventUnmute(v: unknown): ValidationResult {
 export interface ModEventEmail {
   /** The subject line of the email sent to the user. */
   subjectLine: string
+  /** The content of the email sent to the user. */
+  content?: string
   /** Additional comment about the outgoing comm. */
   comment?: string
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -897,6 +897,10 @@ export const schemaDict = {
             type: 'string',
             description: 'The subject line of the email sent to the user.',
           },
+          content: {
+            type: 'string',
+            description: 'The content of the email sent to the user.',
+          },
           comment: {
             type: 'string',
             description: 'Additional comment about the outgoing comm.',

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
@@ -704,6 +704,8 @@ export function validateModEventUnmute(v: unknown): ValidationResult {
 export interface ModEventEmail {
   /** The subject line of the email sent to the user. */
   subjectLine: string
+  /** The content of the email sent to the user. */
+  content?: string
   /** Additional comment about the outgoing comm. */
   comment?: string
   [k: string]: unknown

--- a/packages/dev-env/src/ozone.ts
+++ b/packages/dev-env/src/ozone.ts
@@ -34,6 +34,7 @@ export class TestOzone {
     const port = config.port || (await getPort())
     const url = `http://localhost:${port}`
     const env: ozone.OzoneEnvironment = {
+      devMode: true,
       version: '0.0.0',
       port,
       didPlcUrl: config.plcUrl,

--- a/packages/ozone/src/api/admin/emitModerationEvent.ts
+++ b/packages/ozone/src/api/admin/emitModerationEvent.ts
@@ -22,7 +22,6 @@ export default function (server: Server, ctx: AppContext) {
       const isTakedownEvent = isModEventTakedown(event)
       const isReverseTakedownEvent = isModEventReverseTakedown(event)
       const isLabelEvent = isModEventLabel(event)
-      const isEmailEvent = isModEventEmail(event)
       const subject = subjectFromInput(
         input.body.subject,
         input.body.subjectBlobCids,
@@ -78,17 +77,17 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
-      if (isEmailEvent && typeof event.meta?.['content'] === 'string') {
+      if (isModEventEmail(event) && event.content) {
         // sending email prior to logging the event to avoid a long transaction below
         if (!subject.isRepo()) {
           throw new InvalidRequestError(
             'Email can only be sent to a repo subject',
           )
         }
-        const content = event.meta['content']
+        const { content, subjectLine } = event
         await retryHttp(() =>
           ctx.modService(db).sendEmail({
-            subject: event.subjectLine,
+            subject: subjectLine,
             content,
             recipientDid: subject.did,
           }),

--- a/packages/ozone/src/config/config.ts
+++ b/packages/ozone/src/config/config.ts
@@ -13,6 +13,7 @@ export const envToCfg = (env: OzoneEnvironment): OzoneConfig => {
     publicUrl: env.publicUrl,
     did: env.serverDid,
     version: env.version,
+    devMode: env.devMode,
   }
 
   assert(env.dbPostgresUrl)
@@ -71,6 +72,7 @@ export type ServiceConfig = {
   publicUrl: string
   did: string
   version?: string
+  devMode?: boolean
 }
 
 export type DatabaseConfig = {

--- a/packages/ozone/src/config/env.ts
+++ b/packages/ozone/src/config/env.ts
@@ -1,8 +1,9 @@
-import { envInt, envList, envStr } from '@atproto/common'
+import { envBool, envInt, envList, envStr } from '@atproto/common'
 
 export const readEnv = (): OzoneEnvironment => {
   return {
     nodeEnv: envStr('NODE_ENV'),
+    devMode: envBool('OZONE_DEV_MODE'),
     version: envStr('OZONE_VERSION'),
     port: envInt('OZONE_PORT'),
     publicUrl: envStr('OZONE_PUBLIC_URL'),
@@ -27,6 +28,7 @@ export const readEnv = (): OzoneEnvironment => {
 
 export type OzoneEnvironment = {
   nodeEnv?: string
+  devMode?: boolean
   version?: string
   port?: number
   publicUrl?: string

--- a/packages/ozone/src/context.ts
+++ b/packages/ozone/src/context.ts
@@ -58,8 +58,6 @@ export class AppContext {
         aud,
         keypair: signingKey,
       })
-    const appviewAuth = async () =>
-      cfg.appview.did ? createAuthHeaders(cfg.appview.did) : undefined
 
     const backgroundQueue = new BackgroundQueue(db)
     const eventPusher = new EventPusher(db, createAuthHeaders, {
@@ -67,21 +65,23 @@ export class AppContext {
       pds: cfg.pds ?? undefined,
     })
 
+    const idResolver = new IdResolver({
+      plcUrl: cfg.identity.plcUrl,
+    })
+
     const modService = ModerationService.creator(
+      cfg,
       backgroundQueue,
+      idResolver,
       eventPusher,
       appviewAgent,
-      appviewAuth,
+      createAuthHeaders,
       cfg.service.did,
       overrides?.imgInvalidator,
       cfg.cdn.paths,
     )
 
     const communicationTemplateService = CommunicationTemplateService.creator()
-
-    const idResolver = new IdResolver({
-      plcUrl: cfg.identity.plcUrl,
-    })
 
     const sequencer = new Sequencer(db)
 

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -7,6 +7,7 @@ import { EventPusher } from './event-pusher'
 import { EventReverser } from './event-reverser'
 import { ModerationService, ModerationServiceCreator } from '../mod-service'
 import { BackgroundQueue } from '../background'
+import { IdResolver } from '@atproto/identity'
 
 export type DaemonContextOptions = {
   db: Database
@@ -39,21 +40,26 @@ export class DaemonContext {
         keypair: signingKey,
       })
 
-    const appviewAuth = async () =>
-      cfg.appview.did ? createAuthHeaders(cfg.appview.did) : undefined
-
     const eventPusher = new EventPusher(db, createAuthHeaders, {
       appview: cfg.appview,
       pds: cfg.pds ?? undefined,
     })
+
     const backgroundQueue = new BackgroundQueue(db)
+    const idResolver = new IdResolver({
+      plcUrl: cfg.identity.plcUrl,
+    })
+
     const modService = ModerationService.creator(
+      cfg,
       backgroundQueue,
+      idResolver,
       eventPusher,
       appviewAgent,
-      appviewAuth,
+      createAuthHeaders,
       cfg.service.did,
     )
+
     const eventReverser = new EventReverser(db, modService)
 
     return new DaemonContext({

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -897,6 +897,10 @@ export const schemaDict = {
             type: 'string',
             description: 'The subject line of the email sent to the user.',
           },
+          content: {
+            type: 'string',
+            description: 'The content of the email sent to the user.',
+          },
           comment: {
             type: 'string',
             description: 'Additional comment about the outgoing comm.',

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/defs.ts
@@ -704,6 +704,8 @@ export function validateModEventUnmute(v: unknown): ValidationResult {
 export interface ModEventEmail {
   /** The subject line of the email sent to the user. */
   subjectLine: string
+  /** The content of the email sent to the user. */
+  content?: string
   /** Additional comment about the outgoing comm. */
   comment?: string
   [k: string]: unknown

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -1,9 +1,13 @@
+import net from 'node:net'
+import { Insertable, sql } from 'kysely'
 import { CID } from 'multiformats/cid'
 import { AtUri, INVALID_HANDLE } from '@atproto/syntax'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { addHoursToDate } from '@atproto/common'
+import { IdResolver } from '@atproto/identity'
+import AtpAgent from '@atproto/api'
 import { Database } from '../db'
-import { AppviewAuth, ModerationViews } from './views'
+import { AuthHeaders, ModerationViews } from './views'
 import { Main as StrongRef } from '../lexicon/types/com/atproto/repo/strongRef'
 import {
   isModEventComment,
@@ -30,9 +34,7 @@ import {
 } from './types'
 import { ModerationEvent } from '../db/schema/moderation_event'
 import { StatusKeyset, TimeIdKeyset, paginate } from '../db/pagination'
-import AtpAgent from '@atproto/api'
 import { Label } from '../lexicon/types/com/atproto/label/defs'
-import { Insertable, sql } from 'kysely'
 import {
   ModSubject,
   RecordSubject,
@@ -46,26 +48,31 @@ import { BackgroundQueue } from '../background'
 import { EventPusher } from '../daemon'
 import { ImageInvalidator } from '../image-invalidator'
 import { httpLogger as log } from '../logger'
+import { OzoneConfig } from '../config'
 
 export type ModerationServiceCreator = (db: Database) => ModerationService
 
 export class ModerationService {
   constructor(
     public db: Database,
+    public cfg: OzoneConfig,
     public backgroundQueue: BackgroundQueue,
+    public idResolver: IdResolver,
     public eventPusher: EventPusher,
     public appviewAgent: AtpAgent,
-    private appviewAuth: AppviewAuth,
+    private createAuthHeaders: (aud: string) => Promise<AuthHeaders>,
     public serverDid: string,
     public imgInvalidator?: ImageInvalidator,
     public cdnPaths?: string[],
   ) {}
 
   static creator(
+    cfg: OzoneConfig,
     backgroundQueue: BackgroundQueue,
+    idResolver: IdResolver,
     eventPusher: EventPusher,
     appviewAgent: AtpAgent,
-    appviewAuth: AppviewAuth,
+    createAuthHeaders: (aud: string) => Promise<AuthHeaders>,
     serverDid: string,
     imgInvalidator?: ImageInvalidator,
     cdnPaths?: string[],
@@ -73,17 +80,21 @@ export class ModerationService {
     return (db: Database) =>
       new ModerationService(
         db,
+        cfg,
         backgroundQueue,
+        idResolver,
         eventPusher,
         appviewAgent,
-        appviewAuth,
+        createAuthHeaders,
         serverDid,
         imgInvalidator,
         cdnPaths,
       )
   }
 
-  views = new ModerationViews(this.db, this.appviewAgent, this.appviewAuth)
+  views = new ModerationViews(this.db, this.appviewAgent, () =>
+    this.createAuthHeaders(this.cfg.appview.did),
+  )
 
   async getEvent(id: number): Promise<ModerationEventRow | undefined> {
     return await this.db.db
@@ -903,6 +914,49 @@ export class ModerationService {
       )
       .execute()
   }
+
+  async sendEmail(opts: {
+    content: string
+    recipientDid: string
+    subject: string
+  }) {
+    const { subject, content, recipientDid } = opts
+    const { pds } = await this.idResolver.did.resolveAtprotoData(recipientDid)
+    const url = new URL(pds)
+    if (!this.cfg.service.devMode && !isSafeUrl(url)) {
+      throw new InvalidRequestError('Invalid pds service in DID doc')
+    }
+    const agent = new AtpAgent({ service: url })
+    const { data: serverInfo } =
+      await agent.api.com.atproto.server.describeServer()
+    if (serverInfo.did !== `did:web:${url.hostname}`) {
+      // @TODO do bidirectional check once implemented. in the meantime,
+      // matching did to hostname we're talking to is pretty good.
+      throw new InvalidRequestError('Invalid pds service in DID doc')
+    }
+    const { data: delivery } = await agent.api.com.atproto.admin.sendEmail(
+      {
+        subject,
+        content,
+        recipientDid,
+        senderDid: this.cfg.service.did,
+      },
+      {
+        encoding: 'application/json',
+        ...(await this.createAuthHeaders(serverInfo.did)),
+      },
+    )
+    if (!delivery.sent) {
+      throw new InvalidRequestError('Email was accepted but not sent')
+    }
+  }
+}
+
+const isSafeUrl = (url: URL) => {
+  if (url.protocol !== 'https:') return false
+  if (!url.hostname || url.hostname === 'localhost') return false
+  if (net.isIP(url.hostname) === 0) return false
+  return true
 }
 
 const TAKEDOWNS = ['pds_takedown' as const, 'appview_takedown' as const]

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -302,6 +302,9 @@ export class ModerationService {
 
     if (isModEventEmail(event)) {
       meta.subjectLine = event.subjectLine
+      if (event.content) {
+        meta.content = event.content
+      }
     }
 
     const subjectInfo = subject.info()

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -26,20 +26,17 @@ import { REASONOTHER } from '../lexicon/types/com/atproto/moderation/defs'
 import { subjectFromEventRow, subjectFromStatusRow } from './subject'
 import { formatLabel } from './util'
 
-export type AppviewAuth = () => Promise<
-  | {
-      headers: {
-        authorization: string
-      }
-    }
-  | undefined
->
+export type AuthHeaders = {
+  headers: {
+    authorization: string
+  }
+}
 
 export class ModerationViews {
   constructor(
     private db: Database,
     private appviewAgent: AtpAgent,
-    private appviewAuth: AppviewAuth,
+    private appviewAuth: () => Promise<AuthHeaders>,
   ) {}
 
   async getAccoutInfosByDid(dids: string[]): Promise<Map<string, AccountView>> {

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -151,6 +151,7 @@ export class ModerationViews {
       eventView.event = {
         ...eventView.event,
         subjectLine: event.meta?.subjectLine ?? '',
+        content: event.meta?.content,
       }
     }
 

--- a/packages/ozone/tests/moderation-events.test.ts
+++ b/packages/ozone/tests/moderation-events.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert'
+import EventEmitter, { once } from 'node:events'
+import Mail from 'nodemailer/lib/mailer'
 import { TestNetwork, SeedClient, basicSeed } from '@atproto/dev-env'
 import AtpAgent, {
   ComAtprotoAdminDefs,
@@ -419,6 +421,53 @@ describe('moderation-events', () => {
           $type: 'com.atproto.admin.defs#modEventReverseTakedown',
         },
         subjectBlobCids: [post.images[0].image.ref.toString()],
+      })
+    })
+  })
+
+  describe('email event', () => {
+    let sendMailOriginal
+    const mailCatcher = new EventEmitter()
+    const getMailFrom = async (promise): Promise<Mail.Options> => {
+      const result = await Promise.all([once(mailCatcher, 'mail'), promise])
+      return result[0][0]
+    }
+
+    beforeAll(() => {
+      const mailer = network.pds.ctx.moderationMailer
+      // Catch emails for use in tests
+      sendMailOriginal = mailer.transporter.sendMail
+      mailer.transporter.sendMail = async (opts) => {
+        const result = await sendMailOriginal.call(mailer.transporter, opts)
+        mailCatcher.emit('mail', opts)
+        return result
+      }
+    })
+
+    afterAll(() => {
+      network.pds.ctx.moderationMailer.transporter.sendMail = sendMailOriginal
+    })
+
+    it('sends email via pds.', async () => {
+      const mail = await getMailFrom(
+        emitModerationEvent({
+          event: {
+            $type: 'com.atproto.admin.defs#modEventEmail',
+            comment: 'Reaching out to Alice',
+            subjectLine: 'Hello',
+            content: 'Hey Alice, how are you?',
+          },
+          subject: {
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: sc.dids.alice,
+          },
+          createdBy: sc.dids.bob,
+        }),
+      )
+      expect(mail).toEqual({
+        to: 'alice@test.com',
+        subject: 'Hello',
+        html: 'Hey Alice, how are you?',
       })
     })
   })

--- a/packages/pds/src/api/com/atproto/admin/sendEmail.ts
+++ b/packages/pds/src/api/com/atproto/admin/sendEmail.ts
@@ -1,23 +1,23 @@
+import assert from 'node:assert'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
-import { authPassthru, resultPassthru } from '../../../proxy'
+import { resultPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.sendEmail({
-    auth: ctx.authVerifier.role,
-    handler: async ({ req, input, auth }) => {
-      if (!auth.credentials.admin && !auth.credentials.moderator) {
+    auth: ctx.authVerifier.roleOrAdminService,
+    handler: async ({ input, auth }) => {
+      if (auth.credentials.type === 'role' && !auth.credentials.moderator) {
         throw new AuthRequiredError('Insufficient privileges')
       }
 
       const {
         content,
         recipientDid,
-        senderDid,
-        subject = 'Message from Bluesky moderator',
-        comment,
+        subject = 'Message via your PDS',
       } = input.body
+
       const account = await ctx.accountManager.getAccount(recipientDid, {
         includeDeactivated: true,
         includeTakenDown: true,
@@ -27,11 +27,15 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       if (ctx.entrywayAgent) {
+        assert(ctx.cfg.entryway)
         return resultPassthru(
-          await ctx.entrywayAgent.com.atproto.admin.sendEmail(
-            input.body,
-            authPassthru(req, true),
-          ),
+          await ctx.entrywayAgent.com.atproto.admin.sendEmail(input.body, {
+            encoding: 'application/json',
+            ...(await ctx.serviceAuthHeaders(
+              recipientDid,
+              ctx.cfg.entryway?.did,
+            )),
+          }),
         )
       }
 
@@ -43,24 +47,6 @@ export default function (server: Server, ctx: AppContext) {
         { content },
         { subject, to: account.email },
       )
-
-      if (ctx.moderationAgent) {
-        await ctx.moderationAgent.api.com.atproto.admin.emitModerationEvent(
-          {
-            event: {
-              $type: 'com.atproto.admin.defs#modEventEmail',
-              subjectLine: subject,
-              comment,
-            },
-            subject: {
-              $type: 'com.atproto.admin.defs#repoRef',
-              did: recipientDid,
-            },
-            createdBy: senderDid,
-          },
-          { ...authPassthru(req), encoding: 'application/json' },
-        )
-      }
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -897,6 +897,10 @@ export const schemaDict = {
             type: 'string',
             description: 'The subject line of the email sent to the user.',
           },
+          content: {
+            type: 'string',
+            description: 'The content of the email sent to the user.',
+          },
           comment: {
             type: 'string',
             description: 'Additional comment about the outgoing comm.',

--- a/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
@@ -704,6 +704,8 @@ export function validateModEventUnmute(v: unknown): ValidationResult {
 export interface ModEventEmail {
   /** The subject line of the email sent to the user. */
   subjectLine: string
+  /** The content of the email sent to the user. */
+  content?: string
   /** Additional comment about the outgoing comm. */
   comment?: string
   [k: string]: unknown


### PR DESCRIPTION
When an email event is sent to `emitModerationEvent` on ozone and the input includes `meta.content`, ozone attempts to prompt the user's pds to send an email.  Since `meta.content` is not typically included, this change is backwards compatible.  Pals with #2271.