### PR TITLE
Show only replies from people you follow in Following by default

### DIFF
--- a/.changeset/ten-tools-exercise.md
+++ b/.changeset/ten-tools-exercise.md
@@ -1,0 +1,8 @@
+---
+'@atproto/ozone': minor
+'@atproto/bsky': minor
+'@atproto/api': minor
+'@atproto/pds': minor
+---
+
+Change Following feed prefs to only show replies from people you follow by default

--- a/.changeset/ten-tools-exercise.md
+++ b/.changeset/ten-tools-exercise.md
@@ -1,8 +1,8 @@
 ---
-'@atproto/ozone': minor
-'@atproto/bsky': minor
-'@atproto/api': minor
-'@atproto/pds': minor
+'@atproto/ozone': patch
+'@atproto/bsky': patch
+'@atproto/api': patch
+'@atproto/pds': patch
 ---
 
 Change Following feed prefs to only show replies from people you follow by default

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -176,7 +176,8 @@
         },
         "hideRepliesByUnfollowed": {
           "type": "boolean",
-          "description": "Hide replies in the feed if they are not by followed users."
+          "description": "Hide replies in the feed if they are not by followed users.",
+          "default": true
         },
         "hideRepliesByLikeCount": {
           "type": "integer",

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -17,7 +17,7 @@ import { sanitizeMutedWordValue } from './util'
 
 const FEED_VIEW_PREF_DEFAULTS = {
   hideReplies: false,
-  hideRepliesByUnfollowed: false,
+  hideRepliesByUnfollowed: true,
   hideRepliesByLikeCount: 0,
   hideReposts: false,
   hideQuotePosts: false,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5184,6 +5184,7 @@ export const schemaDict = {
             type: 'boolean',
             description:
               'Hide replies in the feed if they are not by followed users.',
+            default: true,
           },
           hideRepliesByLikeCount: {
             type: 'integer',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -197,7 +197,7 @@ export interface FeedViewPref {
   /** Hide replies in the feed. */
   hideReplies?: boolean
   /** Hide replies in the feed if they are not by followed users. */
-  hideRepliesByUnfollowed?: boolean
+  hideRepliesByUnfollowed: boolean
   /** Hide replies in the feed if they do not have this number of likes. */
   hideRepliesByLikeCount?: number
   /** Hide reposts in the feed. */

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -226,7 +226,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -252,7 +252,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -278,7 +278,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -306,7 +306,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -336,7 +336,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -368,7 +368,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -400,7 +400,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -432,7 +432,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -464,7 +464,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -496,7 +496,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -534,7 +534,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -566,7 +566,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -598,7 +598,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -630,7 +630,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -662,7 +662,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -694,14 +694,14 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
           },
           other: {
             hideReplies: true,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -733,14 +733,14 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
           },
           other: {
             hideReplies: true,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -772,14 +772,14 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
           },
           other: {
             hideReplies: true,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -811,14 +811,14 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
           },
           other: {
             hideReplies: true,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -907,7 +907,7 @@ describe('agent', () => {
             $type: 'app.bsky.actor.defs#feedViewPref',
             feed: 'home',
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -916,7 +916,7 @@ describe('agent', () => {
             $type: 'app.bsky.actor.defs#feedViewPref',
             feed: 'home',
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -946,7 +946,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -977,7 +977,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -1008,7 +1008,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -1039,7 +1039,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -1070,7 +1070,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: true,
-            hideRepliesByUnfollowed: true,
+            hideRepliesByUnfollowed: false,
             hideRepliesByLikeCount: 10,
             hideReposts: true,
             hideQuotePosts: true,
@@ -1089,7 +1089,7 @@ describe('agent', () => {
 
       await agent.setFeedViewPrefs('home', {
         hideReplies: false,
-        hideRepliesByUnfollowed: false,
+        hideRepliesByUnfollowed: true,
         hideRepliesByLikeCount: 0,
         hideReposts: false,
         hideQuotePosts: false,
@@ -1112,7 +1112,7 @@ describe('agent', () => {
         feedViewPrefs: {
           home: {
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,
@@ -1155,7 +1155,7 @@ describe('agent', () => {
             $type: 'app.bsky.actor.defs#feedViewPref',
             feed: 'home',
             hideReplies: false,
-            hideRepliesByUnfollowed: false,
+            hideRepliesByUnfollowed: true,
             hideRepliesByLikeCount: 0,
             hideReposts: false,
             hideQuotePosts: false,

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5184,6 +5184,7 @@ export const schemaDict = {
             type: 'boolean',
             description:
               'Hide replies in the feed if they are not by followed users.',
+            default: true,
           },
           hideRepliesByLikeCount: {
             type: 'integer',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -197,7 +197,7 @@ export interface FeedViewPref {
   /** Hide replies in the feed. */
   hideReplies?: boolean
   /** Hide replies in the feed if they are not by followed users. */
-  hideRepliesByUnfollowed?: boolean
+  hideRepliesByUnfollowed: boolean
   /** Hide replies in the feed if they do not have this number of likes. */
   hideRepliesByLikeCount?: number
   /** Hide reposts in the feed. */

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5184,6 +5184,7 @@ export const schemaDict = {
             type: 'boolean',
             description:
               'Hide replies in the feed if they are not by followed users.',
+            default: true,
           },
           hideRepliesByLikeCount: {
             type: 'integer',

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -197,7 +197,7 @@ export interface FeedViewPref {
   /** Hide replies in the feed. */
   hideReplies?: boolean
   /** Hide replies in the feed if they are not by followed users. */
-  hideRepliesByUnfollowed?: boolean
+  hideRepliesByUnfollowed: boolean
   /** Hide replies in the feed if they do not have this number of likes. */
   hideRepliesByLikeCount?: number
   /** Hide reposts in the feed. */

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5184,6 +5184,7 @@ export const schemaDict = {
             type: 'boolean',
             description:
               'Hide replies in the feed if they are not by followed users.',
+            default: true,
           },
           hideRepliesByLikeCount: {
             type: 'integer',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -197,7 +197,7 @@ export interface FeedViewPref {
   /** Hide replies in the feed. */
   hideReplies?: boolean
   /** Hide replies in the feed if they are not by followed users. */
-  hideRepliesByUnfollowed?: boolean
+  hideRepliesByUnfollowed: boolean
   /** Hide replies in the feed if they do not have this number of likes. */
   hideRepliesByLikeCount?: number
   /** Hide reposts in the feed. */


### PR DESCRIPTION
It has been a pretty common complaint that the Following feed becomes unusable when someone you follow goes on a reply spree because we're showing every single reply by default. This changes so that *by default* (if you haven't expressed a preference), we're going to show a reply if you follow *both* people in the conversation.

People who *have* expressed a particular preference will keep it.

## Test Plan

Create a new user or take an existing one who hasn’t changed this setting. Observe that their default preferences have the "Reply Filters" toggle on whereas previously they wouldn’t.  

<img width="778" alt="Screenshot 2024-03-06 at 14 56 45" src="https://github.com/bluesky-social/atproto/assets/810438/a5445184-c887-4ccd-9175-340dbbdeb94e">
