### PR TITLE
Handle sync legacy labels

### DIFF
--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -567,6 +567,16 @@ export class BskyAgent extends AtpAgent {
             !(pref.label === key && pref.labelerDid === labelerDid),
         )
         .concat([labelPref])
+        .filter((pref) => {
+          if (!legacyLabelPref) return true
+          return (
+            !AppBskyActorDefs.isContentLabelPref(pref) ||
+            !(
+              pref.label === legacyLabelPref.label &&
+              pref.labelerDid === undefined
+            )
+          )
+        })
         .concat(legacyLabelPref ? [legacyLabelPref] : [])
     })
   }

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -514,7 +514,7 @@ export class BskyAgent extends AtpAgent {
           pref.label === key &&
           pref.labelerDid === labelerDid,
       )
-      let legacyLabelPref
+      let legacyLabelPref: AppBskyActorDefs.ContentLabelPref | undefined
 
       if (labelPref) {
         labelPref.visibility = value
@@ -544,7 +544,7 @@ export class BskyAgent extends AtpAgent {
                 AppBskyActorDefs.validateContentLabelPref(pref).success &&
                 pref.label === legacyLabelValue &&
                 pref.labelerDid === undefined,
-            )
+            ) as AppBskyActorDefs.ContentLabelPref | undefined
 
             if (legacyLabelPref) {
               legacyLabelPref.visibility = value
@@ -926,10 +926,10 @@ function remapLegacyLabels(
     suggestive: 'sexual',
   }
 
-  for (const labelValue in _labels) {
-    const newLabelValue = legacyToNewMap[labelValue]!
-    if (newLabelValue) {
-      _labels[newLabelValue] = _labels[labelValue]
+  for (const labelName in _labels) {
+    const newLabelName = legacyToNewMap[labelName]!
+    if (newLabelName) {
+      _labels[newLabelName] = _labels[labelName]
     }
   }
 

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -229,7 +229,7 @@ describe('agent', () => {
     expect(labeler?.labels?.porn).toEqual('hide')
   })
 
-  it(`keeps 'graphic-media' in sync with 'gore'`, async () => {
+  it(`double-write for legacy: 'graphic-media' in sync with 'gore'`, async () => {
     const agent = new BskyAgent({ service: network.pds.url })
 
     await agent.createAccount({
@@ -238,7 +238,6 @@ describe('agent', () => {
       password: 'password',
     })
 
-    await agent.setContentLabelPref('gore', 'ignore')
     await agent.setContentLabelPref('graphic-media', 'hide')
     const a = await agent.getPreferences()
 
@@ -252,7 +251,7 @@ describe('agent', () => {
     expect(b.moderationPrefs.labels['graphic-media']).toEqual('warn')
   })
 
-  it(`keeps 'porn' in sync with 'nsfw'`, async () => {
+  it(`double-write for legacy: 'porn' in sync with 'nsfw'`, async () => {
     const agent = new BskyAgent({ service: network.pds.url })
 
     await agent.createAccount({
@@ -261,7 +260,6 @@ describe('agent', () => {
       password: 'password',
     })
 
-    await agent.setContentLabelPref('nsfw', 'ignore')
     await agent.setContentLabelPref('porn', 'hide')
     const a = await agent.getPreferences()
 
@@ -275,7 +273,7 @@ describe('agent', () => {
     expect(b.moderationPrefs.labels.porn).toEqual('warn')
   })
 
-  it(`keeps 'sexual' in sync with 'suggestive'`, async () => {
+  it(`double-write for legacy: 'sexual' in sync with 'suggestive'`, async () => {
     const agent = new BskyAgent({ service: network.pds.url })
 
     await agent.createAccount({
@@ -284,17 +282,35 @@ describe('agent', () => {
       password: 'password',
     })
 
-    await agent.setContentLabelPref('sexual', 'ignore')
-    await agent.setContentLabelPref('suggestive', 'hide')
+    await agent.setContentLabelPref('sexual', 'hide')
     const a = await agent.getPreferences()
 
     expect(a.moderationPrefs.labels.sexual).toEqual('hide')
     expect(a.moderationPrefs.labels.suggestive).toEqual('hide')
 
-    await agent.setContentLabelPref('suggestive', 'warn')
+    await agent.setContentLabelPref('sexual', 'warn')
     const b = await agent.getPreferences()
 
     expect(b.moderationPrefs.labels.sexual).toEqual('warn')
     expect(b.moderationPrefs.labels.suggestive).toEqual('warn')
+  })
+
+  it(`remaps old values to new on read`, async () => {
+    const agent = new BskyAgent({ service: network.pds.url })
+
+    await agent.createAccount({
+      handle: 'user13.test',
+      email: 'user13@test.com',
+      password: 'password',
+    })
+
+    await agent.setContentLabelPref('nsfw', 'hide')
+    await agent.setContentLabelPref('gore', 'hide')
+    await agent.setContentLabelPref('suggestive', 'hide')
+    const a = await agent.getPreferences()
+
+    expect(a.moderationPrefs.labels.porn).toEqual('hide')
+    expect(a.moderationPrefs.labels['graphic-media']).toEqual('hide')
+    expect(a.moderationPrefs.labels['sexual']).toEqual('hide')
   })
 })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -295,6 +295,25 @@ describe('agent', () => {
     expect(b.moderationPrefs.labels.suggestive).toEqual('warn')
   })
 
+  it(`double-write for legacy: filters out existing old label pref if double-written`, async () => {
+    const agent = new BskyAgent({ service: network.pds.url })
+
+    await agent.createAccount({
+      handle: 'user12.test',
+      email: 'user12@test.com',
+      password: 'password',
+    })
+
+    await agent.setContentLabelPref('nsfw', 'hide')
+    await agent.setContentLabelPref('porn', 'hide')
+    const a = await agent.app.bsky.actor.getPreferences({})
+
+    const nsfwSettings = a.data.preferences.filter(
+      (pref) => pref.label === 'nsfw',
+    )
+    expect(nsfwSettings.length).toEqual(1)
+  })
+
   it(`remaps old values to new on read`, async () => {
     const agent = new BskyAgent({ service: network.pds.url })
 


### PR DESCRIPTION
During this transition to new label names, some clients may not update immediately. This PR ensures basic backwards compat *for global label settings only* between old/new clients.

Old clients of course behave the same. Updated clients with this new SDK (once published) will double-write new labels to old labels in an effort to keep them in sync. So changes to new label settings will be reflected in the old clients.

If a user edits a setting in an older client (without the double-write), and subsequently loads their account in an updated client, this PR remaps old values to new values. This will result in the updated client showing the correct values in label settings. If the user then updates label settings in the updated, client, the double write will take effect, and the old setting will in turn be updated. Subsequent reloads of the updated client will remap old to new, but the values will be the same.