### PR TITLE
Updated semantics for atproto labelers header

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -63,6 +63,7 @@
     "pino": "^8.15.0",
     "pino-http": "^8.2.1",
     "sharp": "^0.32.6",
+    "structured-headers": "^1.0.1",
     "typed-emitter": "^2.1.0",
     "uint8arrays": "3.0.0"
   },

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -11,6 +11,7 @@ import {
 import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getSuggestions = createPipeline(
@@ -30,6 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -14,6 +14,7 @@ import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const searchActors = createPipeline(
@@ -32,6 +33,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: results,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,6 +14,7 @@ import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const searchActorsTypeahead = createPipeline(
@@ -35,6 +36,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: results,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
@@ -12,7 +12,7 @@ import {
 import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getActorFeeds = createPipeline(
@@ -31,6 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -3,7 +3,7 @@ import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/feed/getActorLikes'
 import AppContext from '../../../../context'
-import { clearlyBadCursor, setRepoRev } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 import { createPipeline } from '../../../../pipeline'
 import {
   HydrateCtx,
@@ -25,7 +25,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.app.bsky.feed.getActorLikes({
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ params, auth, req, res }) => {
+    handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = { labelers, viewer }
@@ -33,11 +33,14 @@ export default function (server: Server, ctx: AppContext) {
       const result = await getActorLikes({ ...params, hydrateCtx }, ctx)
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
-      setRepoRev(res, repoRev)
 
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({
+          repoRev,
+          labelers,
+        }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -28,6 +28,7 @@ import {
   isDataplaneError,
   unpackIdentityServices,
 } from '../../../../data-plane'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getFeed = createPipeline(
@@ -47,16 +48,19 @@ export default function (server: Server, ctx: AppContext) {
         'accept-language': req.headers['accept-language'],
       })
       // @NOTE feed cursors should not be affected by appview swap
-      const { timerSkele, timerHydr, resHeaders, ...result } = await getFeed(
-        { ...params, hydrateCtx, headers },
-        ctx,
-      )
+      const {
+        timerSkele,
+        timerHydr,
+        resHeaders: feedResHeaders,
+        ...result
+      } = await getFeed({ ...params, hydrateCtx, headers }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
         headers: {
-          ...(resHeaders ?? {}),
+          ...(feedResHeaders ?? {}),
+          ...resHeaders({ labelers }),
           'server-timing': serverTimingHeader([timerSkele, timerHydr]),
         },
       }

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
@@ -8,6 +8,7 @@ import {
   isDataplaneError,
   unpackIdentityServices,
 } from '../../../../data-plane'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getFeedGenerator({
@@ -63,6 +64,7 @@ export default function (server: Server, ctx: AppContext) {
           isOnline: true,
           isValid: true,
         },
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
@@ -9,6 +9,7 @@ import {
   Hydrator,
 } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getFeedGenerators = createPipeline(
@@ -27,6 +28,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: view,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -12,7 +12,7 @@ import {
 import { Views } from '../../../../views'
 import { parseString } from '../../../../hydration/util'
 import { creatorFromUri } from '../../../../views/util'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getLikes = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -27,6 +27,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -1,7 +1,7 @@
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/feed/getListFeed'
 import AppContext from '../../../../context'
-import { clearlyBadCursor, setRepoRev } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 import { createPipeline } from '../../../../pipeline'
 import {
   HydrateCtx,
@@ -23,7 +23,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.app.bsky.feed.getListFeed({
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ params, auth, req, res }) => {
+    handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = { labelers, viewer }
@@ -31,11 +31,11 @@ export default function (server: Server, ctx: AppContext) {
       const result = await getListFeed({ ...params, hydrateCtx }, ctx)
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
-      setRepoRev(res, repoRev)
 
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers, repoRev }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -6,7 +6,7 @@ import {
   OutputSchema,
 } from '../../../../lexicon/types/app/bsky/feed/getPostThread'
 import AppContext from '../../../../context'
-import { setRepoRev } from '../../../util'
+import { ATPROTO_REPO_REV, resHeaders } from '../../../util'
 import {
   HydrationFnInput,
   PresentationFnInput,
@@ -37,16 +37,21 @@ export default function (server: Server, ctx: AppContext) {
         result = await getPostThread({ ...params, hydrateCtx }, ctx)
       } catch (err) {
         const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
-        setRepoRev(res, repoRev)
+        if (repoRev) {
+          res.setHeader(ATPROTO_REPO_REV, repoRev)
+        }
         throw err
       }
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
-      setRepoRev(res, repoRev)
 
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({
+          repoRev,
+          labelers,
+        }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPosts.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
 import { creatorFromUri } from '../../../../views/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getPosts = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -25,6 +26,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: results,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
@@ -11,7 +11,7 @@ import {
 import { Views } from '../../../../views'
 import { parseString } from '../../../../hydration/util'
 import { creatorFromUri } from '../../../../views/util'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getRepostedBy = createPipeline(
@@ -31,6 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
@@ -2,6 +2,7 @@ import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { parseString } from '../../../../hydration/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getSuggestedFeeds({
@@ -31,6 +32,7 @@ export default function (server: Server, ctx: AppContext) {
           feeds: feedViews,
           cursor: parseString(suggestedRes.cursor),
         },
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -1,7 +1,7 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/feed/getTimeline'
-import { clearlyBadCursor, setRepoRev } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 import { createPipeline } from '../../../../pipeline'
 import {
   HydrateCtx,
@@ -23,7 +23,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.app.bsky.feed.getTimeline({
     auth: ctx.authVerifier.standard,
-    handler: async ({ params, auth, req, res }) => {
+    handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = { labelers, viewer }
@@ -31,11 +31,11 @@ export default function (server: Server, ctx: AppContext) {
       const result = await getTimeline({ ...params, hydrateCtx }, ctx)
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
-      setRepoRev(res, repoRev)
 
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers, repoRev }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -15,6 +15,7 @@ import { Views } from '../../../../views'
 import { DataPlaneClient } from '../../../../data-plane'
 import { parseString } from '../../../../hydration/util'
 import { creatorFromUri } from '../../../../views/util'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const searchPosts = createPipeline(
@@ -33,6 +34,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: results,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getBlocks = createPipeline(skeleton, hydration, noRules, presentation)
@@ -25,6 +25,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
@@ -17,7 +17,7 @@ import {
   mergeStates,
 } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getFollowers = createPipeline(
@@ -41,6 +41,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollows.ts
@@ -16,7 +16,7 @@ import {
   mergeStates,
 } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getFollows = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -36,6 +36,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -16,7 +16,7 @@ import {
   mergeStates,
 } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 import { ListItemInfo } from '../../../../proto/bsky_pb'
 
 export default function (server: Server, ctx: AppContext) {
@@ -31,6 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getListBlocks = createPipeline(
@@ -30,6 +30,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getListMutes = createPipeline(
@@ -30,6 +30,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getLists = createPipeline(skeleton, hydration, noRules, presentation)
@@ -26,6 +26,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getMutes.ts
@@ -11,7 +11,7 @@ import {
   createPipeline,
   noRules,
 } from '../../../../pipeline'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getMutes = createPipeline(skeleton, hydration, noRules, presentation)
@@ -25,6 +25,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const getSuggestedFollowsByActor = createPipeline(
@@ -33,6 +34,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/labeler/getServices.ts
+++ b/packages/bsky/src/api/app/bsky/labeler/getServices.ts
@@ -1,6 +1,7 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { mapDefined } from '@atproto/common'
+import { resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   server.app.bsky.labeler.getServices({
@@ -38,6 +39,7 @@ export default function (server: Server, ctx: AppContext) {
         body: {
           views,
         },
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -14,7 +14,7 @@ import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Views } from '../../../../views'
 import { Notification } from '../../../../proto/bsky_pb'
 import { didFromUri } from '../../../../hydration/util'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
   const listNotifications = createPipeline(
@@ -33,6 +33,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -2,7 +2,7 @@ import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { parseString } from '../../../../hydration/util'
-import { clearlyBadCursor } from '../../../util'
+import { clearlyBadCursor, resHeaders } from '../../../util'
 
 // THIS IS A TEMPORARY UNSPECCED ROUTE
 // @TODO currently mirrors getSuggestedFeeds and ignores the "query" param.
@@ -53,6 +53,7 @@ export default function (server: Server, ctx: AppContext) {
           feeds: feedViews,
           cursor,
         },
+        headers: resHeaders({ labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -1,9 +1,24 @@
-import express from 'express'
+import { ParsedLabelers, formatLabelerHeader } from '../util'
 
-export const setRepoRev = (res: express.Response, rev: string | null) => {
-  if (rev !== null) {
-    res.setHeader('Atproto-Repo-Rev', rev)
+export const ATPROTO_CONTENT_LABELERS = 'Atproto-Content-Labelers'
+export const ATPROTO_REPO_REV = 'Atproto-Repo-Rev'
+
+type ResHeaderOpts = {
+  labelers: ParsedLabelers
+  repoRev: string | null
+}
+
+export const resHeaders = (
+  opts: Partial<ResHeaderOpts>,
+): Record<string, string> => {
+  const headers = {}
+  if (opts.labelers) {
+    headers[ATPROTO_CONTENT_LABELERS] = formatLabelerHeader(opts.labelers)
   }
+  if (opts.repoRev) {
+    headers[ATPROTO_REPO_REV] = opts.repoRev
+  }
+  return headers
 }
 
 export const clearlyBadCursor = (cursor?: string) => {

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -16,6 +16,7 @@ import {
   defaultLabelerHeader,
   parseLabelerHeader,
 } from './util'
+import { httpLogger as log } from './logger'
 
 export class AppContext {
   constructor(
@@ -88,8 +89,15 @@ export class AppContext {
 
   reqLabelers(req: express.Request): ParsedLabelers {
     const val = req.header('atproto-accept-labelers')
-    if (!val) return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
-    return parseLabelerHeader(val)
+    let parsed: ParsedLabelers | null
+    try {
+      parsed = parseLabelerHeader(val)
+    } catch (err) {
+      parsed = null
+      log.info({ err, val }, 'failed to parse labeler header')
+    }
+    if (!parsed) return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
+    return parsed
   }
 }
 

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -9,9 +9,13 @@ import { DataPlaneClient } from './data-plane/client'
 import { Hydrator } from './hydration/hydrator'
 import { Views } from './views'
 import { AuthVerifier } from './auth-verifier'
-import { dedupeStrs } from '@atproto/common'
 import { BsyncClient } from './bsync'
 import { CourierClient } from './courier'
+import {
+  ParsedLabelers,
+  defaultLabelerHeader,
+  parseLabelerHeader,
+} from './util'
 
 export class AppContext {
   constructor(
@@ -82,15 +86,10 @@ export class AppContext {
     })
   }
 
-  reqLabelers(req: express.Request): string[] {
-    const val = req.header('atproto-labelers')
-    if (!val) return this.cfg.labelsFromIssuerDids
-    return dedupeStrs(
-      val
-        .split(',')
-        .map((did) => did.trim())
-        .slice(0, 10),
-    )
+  reqLabelers(req: express.Request): ParsedLabelers {
+    const val = req.header('atproto-accept-labelers')
+    if (!val) return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
+    return parseLabelerHeader(val)
   }
 }
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -45,9 +45,10 @@ import {
   FeedItem,
   ItemRef,
 } from './feed'
+import { ParsedLabelers } from '../util'
 
 export type HydrateCtx = {
-  labelers: string[]
+  labelers: ParsedLabelers
   viewer: string | null
 }
 
@@ -136,7 +137,10 @@ export class Hydrator {
   ): Promise<HydrationState> {
     const [actors, labels, profileViewersState] = await Promise.all([
       this.actor.getActors(dids, includeTakedowns),
-      this.label.getLabelsForSubjects(labelSubjectsForDid(dids), ctx.labelers),
+      this.label.getLabelsForSubjects(
+        labelSubjectsForDid(dids),
+        ctx.labelers.dids,
+      ),
       this.hydrateProfileViewers(dids, ctx),
     ])
     return mergeStates(profileViewersState ?? {}, {
@@ -297,7 +301,7 @@ export class Hydrator {
     ] = await Promise.all([
       this.feed.getPostAggregates(refs),
       ctx.viewer ? this.feed.getPostViewerStates(refs, ctx.viewer) : undefined,
-      this.label.getLabelsForSubjects(allPostUris, ctx.labelers),
+      this.label.getLabelsForSubjects(allPostUris, ctx.labelers.dids),
       this.hydratePostBlocks(posts),
       this.hydrateProfiles(allPostUris.map(didFromUri), ctx, includeTakedowns),
       this.hydrateLists([...nestedListUris, ...gateListUris], ctx),
@@ -491,7 +495,7 @@ export class Hydrator {
         this.feed.getLikes(likeUris), // reason: like
         this.feed.getReposts(repostUris), // reason: repost
         this.graph.getFollows(followUris), // reason: follow
-        this.label.getLabelsForSubjects(uris, ctx.labelers),
+        this.label.getLabelsForSubjects(uris, ctx.labelers.dids),
         this.hydrateProfiles(uris.map(didFromUri), ctx),
       ])
     return mergeStates(profileState, {

--- a/packages/bsky/src/util.ts
+++ b/packages/bsky/src/util.ts
@@ -1,21 +1,25 @@
+import { parseList } from 'structured-headers'
+
 export type ParsedLabelers = {
   dids: string[]
   redact: Set<string>
 }
 
-export const parseLabelerHeader = (header: string): ParsedLabelers => {
-  const labelers = header.split(',').map((part) => part.trim())
+export const parseLabelerHeader = (
+  header: string | undefined,
+): ParsedLabelers | null => {
+  if (!header) return null
   const labelerDids = new Set<string>()
   const redactDids = new Set<string>()
-  for (const labeler of labelers) {
-    if (labeler.length === 0) {
-      continue
+  const parsed = parseList(header)
+  for (const item of parsed) {
+    const did = item[0].toString()
+    if (!did) {
+      return null
     }
-    const parts = labeler.split(';')
-    const did = parts[0].trim()
     labelerDids.add(did)
-    const rest = parts.slice(1).map((part) => part.trim())
-    if (rest.includes('redact')) {
+    const redact = item[1].get('redact')?.valueOf()
+    if (redact === true) {
       redactDids.add(did)
     }
   }

--- a/packages/bsky/src/util.ts
+++ b/packages/bsky/src/util.ts
@@ -31,3 +31,10 @@ export const defaultLabelerHeader = (dids: string[]): ParsedLabelers => {
     redact: new Set(dids),
   }
 }
+
+export const formatLabelerHeader = (parsed: ParsedLabelers): string => {
+  const parts = parsed.dids.map((did) =>
+    parsed.redact.has(did) ? `${did};redact` : did,
+  )
+  return parts.join(',')
+}

--- a/packages/bsky/src/util.ts
+++ b/packages/bsky/src/util.ts
@@ -1,0 +1,33 @@
+export type ParsedLabelers = {
+  dids: string[]
+  redact: Set<string>
+}
+
+export const parseLabelerHeader = (header: string): ParsedLabelers => {
+  const labelers = header.split(',').map((part) => part.trim())
+  const labelerDids = new Set<string>()
+  const redactDids = new Set<string>()
+  for (const labeler of labelers) {
+    if (labeler.length === 0) {
+      continue
+    }
+    const parts = labeler.split(';')
+    const did = parts[0].trim()
+    labelerDids.add(did)
+    const rest = parts.slice(1).map((part) => part.trim())
+    if (rest.includes('redact')) {
+      redactDids.add(did)
+    }
+  }
+  return {
+    dids: [...labelerDids],
+    redact: redactDids,
+  }
+}
+
+export const defaultLabelerHeader = (dids: string[]): ParsedLabelers => {
+  return {
+    dids,
+    redact: new Set(dids),
+  }
+}

--- a/packages/bsky/tests/label-hydration.test.ts
+++ b/packages/bsky/tests/label-hydration.test.ts
@@ -61,11 +61,17 @@ describe('label hydration', () => {
   it('hydrates labels based on a supplied labeler header', async () => {
     const res = await pdsAgent.api.app.bsky.actor.getProfile(
       { actor: carol },
-      { headers: { ...sc.getHeaders(bob), 'atproto-labelers': alice } },
+      {
+        headers: {
+          ...sc.getHeaders(bob),
+          'atproto-accept-labelers': `${alice};redact`,
+        },
+      },
     )
     expect(res.data.labels?.length).toBe(1)
     expect(res.data.labels?.[0].src).toBe(alice)
     expect(res.data.labels?.[0].val).toBe('spam')
+    expect(res.headers['atproto-content-labelers']).toEqual(`${alice};redact`)
   })
 
   it('hydrates labels based on multiple a supplied labelers', async () => {
@@ -74,7 +80,7 @@ describe('label hydration', () => {
       {
         headers: {
           ...sc.getHeaders(bob),
-          'atproto-labelers': `${alice},${bob}, ${labelerDid}`,
+          'atproto-accept-labelers': `${alice},${bob};redact, ${labelerDid}`,
         },
       },
     )
@@ -86,6 +92,10 @@ describe('label hydration', () => {
     expect(res.data.labels?.find((l) => l.src === labelerDid)?.val).toEqual(
       'misleading',
     )
+    const labelerHeaderDids = res.headers['atproto-content-labelers'].split(',')
+    expect(labelerHeaderDids.sort()).toEqual(
+      [alice, `${bob};redact`, labelerDid].sort(),
+    )
   })
 
   it('defaults to service labels when no labeler header is provided', async () => {
@@ -96,5 +106,8 @@ describe('label hydration', () => {
     expect(res.data.labels?.length).toBe(1)
     expect(res.data.labels?.[0].src).toBe(labelerDid)
     expect(res.data.labels?.[0].val).toBe('misleading')
+    expect(res.headers['atproto-content-labelers']).toEqual(
+      `${labelerDid};redact`,
+    )
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
+      structured-headers:
+        specifier: ^1.0.1
+        version: 1.0.1
       typed-emitter:
         specifier: ^2.1.0
         version: 2.1.0
@@ -11320,6 +11323,11 @@ packages:
     dependencies:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
+
+  /structured-headers@1.0.1:
+    resolution: {integrity: sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==}
+    engines: {node: '>= 14', npm: '>=6'}
+    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}


### PR DESCRIPTION
Updated semantics for atproto labelers headers

```
# on requests
atproto-accept-labelers: did:web:mod.bsky.app;redact, did:plc:abc123, did:plc:xyz789

# on responses
atproto-content-labelers: did:web:mod.bsky.app;redact, did:plc:abc123, did:plc:xyz789
```