### PR TITLE
Clean up PLC op submission

### DIFF
--- a/packages/pds/tests/plc-operations.test.ts
+++ b/packages/pds/tests/plc-operations.test.ts
@@ -223,4 +223,16 @@ describe('plc operations', () => {
     const didData = await ctx.plcClient.getDocumentData(alice)
     expect(didData.rotationKeys).toEqual([sampleKey, ctx.plcRotationKey.did()])
   })
+
+  it('emits an identity event after a valid operation', async () => {
+    const lastEvt = await ctx.sequencer.db.db
+      .selectFrom('repo_seq')
+      .selectAll()
+      .orderBy('repo_seq.seq', 'desc')
+      .limit(1)
+      .executeTakeFirst()
+    assert(lastEvt)
+    expect(lastEvt.did).toBe(alice)
+    expect(lastEvt.eventType).toBe('identity')
+  })
 })


### PR DESCRIPTION
Set of fixes for PLC op submission:
- check against entryway plc rotation key when running PDS in entryway mode
- emit an `#identity` event on firehose after submitting operation
- bust DID cache for requester after submitting operation

Closes https://github.com/bluesky-social/atproto/issues/2265