### PR TITLE
Allow 3p labelers to query appview account infos

### DIFF
--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -5,18 +5,25 @@ import { INVALID_HANDLE } from '@atproto/syntax'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.admin.getAccountInfos({
-    auth: ctx.authVerifier.roleOrModService,
-    handler: async ({ params }) => {
+    auth: ctx.authVerifier.optionalStandardOrRole,
+    handler: async ({ params, auth }) => {
       const { dids } = params
+      const { canViewTakedowns } = ctx.authVerifier.parseCreds(auth)
+
       const actors = await ctx.hydrator.actor.getActors(dids, true)
 
       const infos = mapDefined(dids, (did) => {
         const info = actors.get(did)
         if (!info) return
+        if (info.takedownRef && !canViewTakedowns) return
+        const profileRecord =
+          !info.profileTakedownRef || canViewTakedowns
+            ? info.profile
+            : undefined
         return {
           did,
           handle: info.handle ?? INVALID_HANDLE,
-          relatedRecords: info.profile ? [info.profile] : undefined,
+          relatedRecords: profileRecord ? [profileRecord] : undefined,
           indexedAt: (info.sortedAt ?? new Date(0)).toISOString(),
         }
       })


### PR DESCRIPTION
This is a route for bulk resolving handles & profile records. We currently have it behind moderation auth, but instead we put it behind standard auth with a special moderation check for viewing takedowns (just like `getProfile`)