### PR TITLE
Ozone update sig on label overwrite

### DIFF
--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -907,6 +907,9 @@ export class ModerationService {
           id: sql`${excluded('id')}`,
           neg: sql`${excluded('neg')}`,
           cts: sql`${excluded('cts')}`,
+          exp: sql`${excluded('exp')}`,
+          sig: sql`${excluded('sig')}`,
+          signingKeyId: sql`${excluded('signingKeyId')}`,
         }),
       )
       .returningAll()


### PR DESCRIPTION
When overwriting an existing label, we weren't updating the cached sig