### PR TITLE
Add specced takedown labels

### DIFF
--- a/packages/ozone/src/api/label/fetchLabels.ts
+++ b/packages/ozone/src/api/label/fetchLabels.ts
@@ -1,30 +1,18 @@
 import { Server } from '../../lexicon'
 import AppContext from '../../context'
-import {
-  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-  UNSPECCED_TAKEDOWN_LABEL,
-} from '../../mod-service/types'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.temp.fetchLabels({
     auth: ctx.authVerifier.standardOptionalOrAdminToken,
-    handler: async ({ auth, params }) => {
+    handler: async ({ params }) => {
       const { limit } = params
       const since =
         params.since !== undefined ? new Date(params.since).toISOString() : ''
-      const includeUnspeccedTakedowns =
-        auth.credentials.type === 'none' ? false : auth.credentials.isAdmin
       const labelRes = await ctx.db.db
         .selectFrom('label')
         .selectAll()
         .orderBy('label.cts', 'asc')
         .where('cts', '>', since)
-        .if(!includeUnspeccedTakedowns, (q) =>
-          q.where('label.val', 'not in', [
-            UNSPECCED_TAKEDOWN_LABEL,
-            UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-          ]),
-        )
         .limit(limit)
         .execute()
 

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -506,10 +506,18 @@ export class ModerationService {
       })
       .returning('id')
       .execute()
-    const existingLabels = await this.views.labelRows(subject.did)
-    const existingVals = existingLabels.map((row) => row.val)
+
+    const existingTakedownLabels = await this.db.db
+      .selectFrom('label')
+      .where('label.uri', '=', subject.did)
+      .where('label.val', 'in', [TAKEDOWN_LABEL, SUSPEND_LABEL])
+      .where('neg', '=', false)
+      .selectAll()
+      .execute()
+
+    const takedownVals = existingTakedownLabels.map((row) => row.val)
     await this.formatAndCreateLabels(subject.did, null, {
-      negate: existingVals,
+      negate: takedownVals,
     })
 
     this.db.onCommit(() => {

--- a/packages/ozone/src/mod-service/types.ts
+++ b/packages/ozone/src/mod-service/types.ts
@@ -31,7 +31,3 @@ export type ModEventType =
   | ToolsOzoneModerationDefs.ModEventMute
   | ToolsOzoneModerationDefs.ModEventReverseTakedown
   | ToolsOzoneModerationDefs.ModEventTag
-
-export const UNSPECCED_TAKEDOWN_LABEL = '!unspecced-takedown'
-
-export const UNSPECCED_TAKEDOWN_BLOBS_LABEL = '!unspecced-takedown-blobs'

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -408,17 +408,13 @@ export class ModerationViews {
     })
   }
 
-  async labelRows(subject: string, includeNeg?: boolean): Promise<LabelRow[]> {
-    return this.db.db
+  async labels(subject: string, includeNeg?: boolean): Promise<Label[]> {
+    const res = await this.db.db
       .selectFrom('label')
       .where('label.uri', '=', subject)
       .if(!includeNeg, (qb) => qb.where('neg', '=', false))
       .selectAll()
       .execute()
-  }
-
-  async labels(subject: string, includeNeg?: boolean): Promise<Label[]> {
-    const res = await this.labelRows(subject, includeNeg)
     return Promise.all(res.map((l) => this.formatLabelAndEnsureSig(l)))
   }
 

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -408,13 +408,17 @@ export class ModerationViews {
     })
   }
 
-  async labels(subject: string, includeNeg?: boolean): Promise<Label[]> {
-    const res = await this.db.db
+  async labelRows(subject: string, includeNeg?: boolean): Promise<LabelRow[]> {
+    return this.db.db
       .selectFrom('label')
       .where('label.uri', '=', subject)
       .if(!includeNeg, (qb) => qb.where('neg', '=', false))
       .selectAll()
       .execute()
+  }
+
+  async labels(subject: string, includeNeg?: boolean): Promise<Label[]> {
+    const res = await this.labelRows(subject, includeNeg)
     return Promise.all(res.map((l) => this.formatLabelAndEnsureSig(l)))
   }
 

--- a/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-record.test.ts.snap
@@ -16,7 +16,7 @@ Object {
       },
       "src": "user(2)",
       "uri": "record(0)",
-      "val": "!unspecced-takedown",
+      "val": "!takedown",
       "ver": 1,
     },
     Object {
@@ -117,7 +117,7 @@ Object {
       },
       "src": "user(2)",
       "uri": "record(0)",
-      "val": "!unspecced-takedown",
+      "val": "!takedown",
       "ver": 1,
     },
     Object {

--- a/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/get-repo.test.ts.snap
@@ -17,7 +17,7 @@ Object {
       },
       "src": "user(2)",
       "uri": "user(0)",
-      "val": "!unspecced-takedown",
+      "val": "!takedown",
       "ver": 1,
     },
   ],

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -1,5 +1,6 @@
 import {
   TestNetwork,
+  TestOzone,
   ImageRef,
   RecordRef,
   SeedClient,
@@ -20,12 +21,8 @@ import {
   REVIEWESCALATED,
 } from '../src/lexicon/types/tools/ozone/moderation/defs'
 import { EventReverser } from '../src'
-import { TestOzone } from '@atproto/dev-env/src/ozone'
 import { ImageInvalidator } from '../src/image-invalidator'
-import {
-  UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-  UNSPECCED_TAKEDOWN_LABEL,
-} from '../src/mod-service/types'
+import { TAKEDOWN_LABEL, SUSPEND_LABEL } from '../src/mod-service'
 
 describe('moderation', () => {
   let network: TestNetwork
@@ -542,10 +539,7 @@ describe('moderation', () => {
       )
       expect(bskyRes1.data.takedown?.applied).toBe(true)
 
-      const takedownLabel1 = await getLabel(
-        sc.dids.bob,
-        UNSPECCED_TAKEDOWN_LABEL,
-      )
+      const takedownLabel1 = await getLabel(sc.dids.bob, TAKEDOWN_LABEL)
       expect(takedownLabel1).toBeDefined()
 
       // cleanup
@@ -570,52 +564,7 @@ describe('moderation', () => {
       )
       expect(bskyRes2.data.takedown?.applied).toBe(false)
 
-      const takedownLabel2 = await getLabel(
-        sc.dids.bob,
-        UNSPECCED_TAKEDOWN_LABEL,
-      )
-      expect(takedownLabel2).toBeUndefined()
-    })
-
-    it('fans out record takedowns', async () => {
-      const post = sc.posts[sc.dids.bob][0].ref
-      const uri = post.uriStr
-      await modClient.performTakedown({
-        subject: recordSubject(post),
-      })
-      await ozone.processAll()
-
-      const pdsRes1 = await pdsAgent.api.com.atproto.admin.getSubjectStatus(
-        { uri },
-        { headers: network.pds.adminAuthHeaders() },
-      )
-      expect(pdsRes1.data.takedown?.applied).toBe(true)
-
-      const bskyRes1 = await bskyAgent.api.com.atproto.admin.getSubjectStatus(
-        { uri },
-        { headers: network.bsky.adminAuthHeaders() },
-      )
-      expect(bskyRes1.data.takedown?.applied).toBe(true)
-
-      const takedownLabel1 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
-      expect(takedownLabel1).toBeDefined()
-
-      // cleanup
-      await modClient.performReverseTakedown({ subject: recordSubject(post) })
-      await ozone.processAll()
-
-      const pdsRes2 = await pdsAgent.api.com.atproto.admin.getSubjectStatus(
-        { uri },
-        { headers: network.pds.adminAuthHeaders() },
-      )
-      expect(pdsRes2.data.takedown?.applied).toBe(false)
-      const bskyRes2 = await bskyAgent.api.com.atproto.admin.getSubjectStatus(
-        { uri },
-        { headers: network.bsky.adminAuthHeaders() },
-      )
-      expect(bskyRes2.data.takedown?.applied).toBe(false)
-
-      const takedownLabel2 = await getLabel(uri, UNSPECCED_TAKEDOWN_LABEL)
+      const takedownLabel2 = await getLabel(sc.dids.bob, TAKEDOWN_LABEL)
       expect(takedownLabel2).toBeUndefined()
     })
 
@@ -711,22 +660,6 @@ describe('moderation', () => {
             '[SCHEDULED_REVERSAL] Reverting action as originally scheduled',
         },
       })
-    })
-
-    it('serves label when authed', async () => {
-      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
-        {},
-      )
-      expect(unauthed.labels.map((l) => l.val)).not.toContain(
-        UNSPECCED_TAKEDOWN_LABEL,
-      )
-      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
-        {},
-        { headers: network.bsky.adminAuthHeaders() },
-      )
-      expect(authed.labels.map((l) => l.val)).toContain(
-        UNSPECCED_TAKEDOWN_LABEL,
-      )
     })
 
     async function emitLabelEvent(
@@ -860,14 +793,6 @@ describe('moderation', () => {
       expect(res.data.takedown?.applied).toBe(true)
     })
 
-    it('creates a takedown blobs label', async () => {
-      const label = await getLabel(
-        post.ref.uriStr,
-        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-      )
-      expect(label).toBeDefined()
-    })
-
     it('restores blob when action is reversed.', async () => {
       await modClient.performReverseTakedown({
         subject: recordSubject(post.ref),
@@ -897,30 +822,6 @@ describe('moderation', () => {
         { headers: network.pds.adminAuthHeaders() },
       )
       expect(res.data.takedown?.applied).toBe(false)
-    })
-
-    it('serves label when authed', async () => {
-      const { data: unauthed } = await agent.api.com.atproto.temp.fetchLabels(
-        {},
-      )
-      expect(unauthed.labels.map((l) => l.val)).not.toContain(
-        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-      )
-      const { data: authed } = await agent.api.com.atproto.temp.fetchLabels(
-        {},
-        { headers: network.bsky.adminAuthHeaders() },
-      )
-      expect(authed.labels.map((l) => l.val)).toContain(
-        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-      )
-    })
-
-    it('negates takedown blobs label on reversal', async () => {
-      const label = await getLabel(
-        post.ref.uriStr,
-        UNSPECCED_TAKEDOWN_BLOBS_LABEL,
-      )
-      expect(label).toBeUndefined()
     })
   })
 })

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../src/lexicon/types/tools/ozone/moderation/defs'
 import { EventReverser } from '../src'
 import { ImageInvalidator } from '../src/image-invalidator'
-import { TAKEDOWN_LABEL, SUSPEND_LABEL } from '../src/mod-service'
+import { TAKEDOWN_LABEL } from '../src/mod-service'
 
 describe('moderation', () => {
   let network: TestNetwork


### PR DESCRIPTION
- remove current unspecced takedown labels
- emit `!takedown` labels for records & repos and `!suspend` labels for repos when applicable
- no longer push out record takedown events (as these are to be actioned with `!takedown` labels)

Note: pair this with a database migration that adjusts existing unspecced takedowns to specced takedown labels