### PR TITLE
Fix agent.clone() - copy the pdsUrl config

### DIFF
--- a/.changeset/plenty-poets-reply.md
+++ b/.changeset/plenty-poets-reply.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Fixed an issue that would cause agent clones to drop the PDS URI config.

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -91,6 +91,7 @@ export class AtpAgent {
     inst.labelersHeader = this.labelersHeader
     inst.proxyHeader = this.proxyHeader
     inst.pdsUrl = this.pdsUrl
+    inst.api.xrpc.uri = this.pdsUrl || this.service
   }
 
   withProxy(serviceType: AtprotoServiceType, did: string) {


### PR DESCRIPTION
Missed some copy over