### PR TITLE
PDS contact email address

### DIFF
--- a/lexicons/com/atproto/server/describeServer.json
+++ b/lexicons/com/atproto/server/describeServer.json
@@ -29,6 +29,11 @@
               "description": "URLs of service policy documents.",
               "ref": "#links"
             },
+            "contact": {
+              "type": "ref",
+              "description": "Contact information",
+              "ref": "#contact"
+            },
             "did": {
               "type": "string",
               "format": "did"
@@ -42,6 +47,12 @@
       "properties": {
         "privacyPolicy": { "type": "string" },
         "termsOfService": { "type": "string" }
+      }
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": { "type": "string" }
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2420,6 +2420,11 @@ export const schemaDict = {
                 description: 'URLs of service policy documents.',
                 ref: 'lex:com.atproto.server.describeServer#links',
               },
+              contact: {
+                type: 'ref',
+                description: 'Contact information',
+                ref: 'lex:com.atproto.server.describeServer#contact',
+              },
               did: {
                 type: 'string',
                 format: 'did',
@@ -2435,6 +2440,14 @@ export const schemaDict = {
             type: 'string',
           },
           termsOfService: {
+            type: 'string',
+          },
+        },
+      },
+      contact: {
+        type: 'object',
+        properties: {
+          email: {
             type: 'string',
           },
         },

--- a/packages/api/src/client/types/com/atproto/server/describeServer.ts
+++ b/packages/api/src/client/types/com/atproto/server/describeServer.ts
@@ -19,6 +19,7 @@ export interface OutputSchema {
   /** List of domain suffixes that can be used in account handles. */
   availableUserDomains: string[]
   links?: Links
+  contact?: Contact
   did: string
   [k: string]: unknown
 }
@@ -55,4 +56,21 @@ export function isLinks(v: unknown): v is Links {
 
 export function validateLinks(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.server.describeServer#links', v)
+}
+
+export interface Contact {
+  email?: string
+  [k: string]: unknown
+}
+
+export function isContact(v: unknown): v is Contact {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.describeServer#contact'
+  )
+}
+
+export function validateContact(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.describeServer#contact', v)
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2420,6 +2420,11 @@ export const schemaDict = {
                 description: 'URLs of service policy documents.',
                 ref: 'lex:com.atproto.server.describeServer#links',
               },
+              contact: {
+                type: 'ref',
+                description: 'Contact information',
+                ref: 'lex:com.atproto.server.describeServer#contact',
+              },
               did: {
                 type: 'string',
                 format: 'did',
@@ -2435,6 +2440,14 @@ export const schemaDict = {
             type: 'string',
           },
           termsOfService: {
+            type: 'string',
+          },
+        },
+      },
+      contact: {
+        type: 'object',
+        properties: {
+          email: {
             type: 'string',
           },
         },

--- a/packages/bsky/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -20,6 +20,7 @@ export interface OutputSchema {
   /** List of domain suffixes that can be used in account handles. */
   availableUserDomains: string[]
   links?: Links
+  contact?: Contact
   did: string
   [k: string]: unknown
 }
@@ -65,4 +66,21 @@ export function isLinks(v: unknown): v is Links {
 
 export function validateLinks(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.server.describeServer#links', v)
+}
+
+export interface Contact {
+  email?: string
+  [k: string]: unknown
+}
+
+export function isContact(v: unknown): v is Contact {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.describeServer#contact'
+  )
+}
+
+export function validateContact(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.describeServer#contact', v)
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -2420,6 +2420,11 @@ export const schemaDict = {
                 description: 'URLs of service policy documents.',
                 ref: 'lex:com.atproto.server.describeServer#links',
               },
+              contact: {
+                type: 'ref',
+                description: 'Contact information',
+                ref: 'lex:com.atproto.server.describeServer#contact',
+              },
               did: {
                 type: 'string',
                 format: 'did',
@@ -2435,6 +2440,14 @@ export const schemaDict = {
             type: 'string',
           },
           termsOfService: {
+            type: 'string',
+          },
+        },
+      },
+      contact: {
+        type: 'object',
+        properties: {
+          email: {
             type: 'string',
           },
         },

--- a/packages/ozone/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -20,6 +20,7 @@ export interface OutputSchema {
   /** List of domain suffixes that can be used in account handles. */
   availableUserDomains: string[]
   links?: Links
+  contact?: Contact
   did: string
   [k: string]: unknown
 }
@@ -65,4 +66,21 @@ export function isLinks(v: unknown): v is Links {
 
 export function validateLinks(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.server.describeServer#links', v)
+}
+
+export interface Contact {
+  email?: string
+  [k: string]: unknown
+}
+
+export function isContact(v: unknown): v is Contact {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.describeServer#contact'
+  )
+}
+
+export function validateContact(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.describeServer#contact', v)
 }

--- a/packages/pds/src/api/com/atproto/server/describeServer.ts
+++ b/packages/pds/src/api/com/atproto/server/describeServer.ts
@@ -7,6 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     const inviteCodeRequired = ctx.cfg.invites.required
     const privacyPolicy = ctx.cfg.service.privacyPolicyUrl
     const termsOfService = ctx.cfg.service.termsOfServiceUrl
+    const contactEmailAddress = ctx.cfg.service.contactEmailAddress
 
     return {
       encoding: 'application/json',
@@ -15,6 +16,9 @@ export default function (server: Server, ctx: AppContext) {
         availableUserDomains,
         inviteCodeRequired,
         links: { privacyPolicy, termsOfService },
+        contact: {
+          email: contactEmailAddress,
+        },
       },
     }
   })

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -22,6 +22,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     version: env.version, // default?
     privacyPolicyUrl: env.privacyPolicyUrl,
     termsOfServiceUrl: env.termsOfServiceUrl,
+    contactEmailAddress: env.contactEmailAddress,
     acceptingImports: env.acceptingImports ?? true,
     blobUploadLimit: env.blobUploadLimit ?? 5 * 1024 * 1024, // 5mb
     devMode: env.devMode ?? false,
@@ -281,6 +282,7 @@ export type ServiceConfig = {
   termsOfServiceUrl?: string
   acceptingImports: boolean
   blobUploadLimit: number
+  contactEmailAddress?: string
   devMode: boolean
 }
 

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -9,6 +9,7 @@ export const readEnv = (): ServerEnvironment => {
     version: envStr('PDS_VERSION'),
     privacyPolicyUrl: envStr('PDS_PRIVACY_POLICY_URL'),
     termsOfServiceUrl: envStr('PDS_TERMS_OF_SERVICE_URL'),
+    contactEmailAddress: envStr('PDS_CONTACT_EMAIL_ADDRESS'),
     acceptingImports: envBool('PDS_ACCEPTING_REPO_IMPORTS'),
     blobUploadLimit: envInt('PDS_BLOB_UPLOAD_LIMIT'),
     devMode: envBool('PDS_DEV_MODE'),
@@ -115,6 +116,7 @@ export type ServerEnvironment = {
   version?: string
   privacyPolicyUrl?: string
   termsOfServiceUrl?: string
+  contactEmailAddress?: string
   acceptingImports?: boolean
   blobUploadLimit?: number
   devMode?: boolean

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2420,6 +2420,11 @@ export const schemaDict = {
                 description: 'URLs of service policy documents.',
                 ref: 'lex:com.atproto.server.describeServer#links',
               },
+              contact: {
+                type: 'ref',
+                description: 'Contact information',
+                ref: 'lex:com.atproto.server.describeServer#contact',
+              },
               did: {
                 type: 'string',
                 format: 'did',
@@ -2435,6 +2440,14 @@ export const schemaDict = {
             type: 'string',
           },
           termsOfService: {
+            type: 'string',
+          },
+        },
+      },
+      contact: {
+        type: 'object',
+        properties: {
+          email: {
             type: 'string',
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -20,6 +20,7 @@ export interface OutputSchema {
   /** List of domain suffixes that can be used in account handles. */
   availableUserDomains: string[]
   links?: Links
+  contact?: Contact
   did: string
   [k: string]: unknown
 }
@@ -65,4 +66,21 @@ export function isLinks(v: unknown): v is Links {
 
 export function validateLinks(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.server.describeServer#links', v)
+}
+
+export interface Contact {
+  email?: string
+  [k: string]: unknown
+}
+
+export function isContact(v: unknown): v is Contact {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.server.describeServer#contact'
+  )
+}
+
+export function validateContact(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.server.describeServer#contact', v)
 }

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -26,6 +26,7 @@ describe('account', () => {
     network = await TestNetworkNoAppView.create({
       dbPostgresSchema: 'account',
       pds: {
+        contactEmailAddress: 'abuse@example.com',
         termsOfServiceUrl: 'https://example.com/tos',
         privacyPolicyUrl: 'https://example.com/privacy-policy',
       },
@@ -58,6 +59,7 @@ describe('account', () => {
       'https://example.com/privacy-policy',
     )
     expect(res.data.links?.termsOfService).toBe('https://example.com/tos')
+    expect(res.data.contact?.email).toBe('abuse@example.com')
   })
 
   it('fails on invalid handles', async () => {


### PR DESCRIPTION
Allow PDS operators to configure their server with a public contact email address, e.g. for receiving abuse reports.