### PR TITLE
Second pass on no false negs in labels

### DIFF
--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -827,7 +827,6 @@ export class ModerationService {
       uri,
       cid: cid ?? undefined,
       val,
-      neg: false,
       cts: new Date().toISOString(),
     }))
     const toNegate = negate.map((val) => ({

--- a/packages/ozone/src/mod-service/util.ts
+++ b/packages/ozone/src/mod-service/util.ts
@@ -47,7 +47,7 @@ export const signLabel = async (
     uri,
     cid,
     val,
-    neg,
+    neg: neg === true ? true : undefined,
     cts,
     exp,
   }) as Label


### PR DESCRIPTION
Follow up to https://github.com/bluesky-social/atproto/pull/2310

Missed a spot + put in an extra failsafe directly before signing