### PR TITLE
Labeler takedowns (alternate)

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfiles.ts
@@ -18,7 +18,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { viewer, labelers }
+      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
 
       const result = await getProfile({ ...params, hydrateCtx }, ctx)
 
@@ -29,7 +29,7 @@ export default function (server: Server, ctx: AppContext) {
         body: result,
         headers: resHeaders({
           repoRev,
-          labelers,
+          labelers: hydrateCtx.labelers,
         }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -25,13 +25,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { viewer, labelers }
+      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
       const result = await getSuggestions({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -28,12 +28,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { viewer, labelers }
+      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
       const results = await searchActors({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',
         body: results,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -26,9 +26,13 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.actor.searchActors({
     auth: ctx.authVerifier.standardOptional,
     handler: async ({ auth, params, req }) => {
-      const viewer = auth.credentials.iss
+      const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        viewer,
+        labelers,
+        includeTakedowns,
+      })
       const results = await searchActors({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -28,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const results = await searchActorsTypeahead(
         { ...params, hydrateCtx },
         ctx,
@@ -36,7 +36,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: results,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
@@ -26,12 +26,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getActorFeeds({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -28,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
       const result = await getActorLikes({ ...params, hydrateCtx }, ctx)
 
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
         body: result,
         headers: resHeaders({
           repoRev,
-          labelers,
+          labelers: hydrateCtx.labelers,
         }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -30,7 +30,11 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer, includeTakedowns }
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
 
       const result = await getAuthorFeed({ ...params, hydrateCtx }, ctx)
 
@@ -41,7 +45,7 @@ export default function (server: Server, ctx: AppContext) {
         body: result,
         headers: resHeaders({
           repoRev,
-          labelers,
+          labelers: hydrateCtx.labelers,
         }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -42,7 +42,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         authorization: req.headers['authorization'],
         'accept-language': req.headers['accept-language'],
@@ -60,7 +60,7 @@ export default function (server: Server, ctx: AppContext) {
         body: result,
         headers: {
           ...(feedResHeaders ?? {}),
-          ...resHeaders({ labelers }),
+          ...resHeaders({ labelers: hydrateCtx.labelers }),
           'server-timing': serverTimingHeader([timerSkele, timerHydr]),
         },
       }

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerator.ts
@@ -17,11 +17,8 @@ export default function (server: Server, ctx: AppContext) {
       const { feed } = params
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-
-      const hydration = await ctx.hydrator.hydrateFeedGens([feed], {
-        viewer,
-        labelers,
-      })
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydration = await ctx.hydrator.hydrateFeedGens([feed], hydrateCtx)
       const feedInfo = hydration.feedgens?.get(feed)
       if (!feedInfo) {
         throw new InvalidRequestError('could not find feed')
@@ -64,7 +61,7 @@ export default function (server: Server, ctx: AppContext) {
           isOnline: true,
           isValid: true,
         },
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeedGenerators.ts
@@ -23,12 +23,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const view = await getFeedGenerators({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',
         body: view,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -21,13 +21,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getLikes({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
       const result = await getListFeed({ ...params, hydrateCtx }, ctx)
 
@@ -35,7 +35,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers, repoRev }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers, repoRev }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -30,7 +30,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req, res }) => {
       const { viewer } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
       let result: OutputSchema
       try {
@@ -50,7 +50,7 @@ export default function (server: Server, ctx: AppContext) {
         body: result,
         headers: resHeaders({
           repoRev,
-          labelers,
+          labelers: hydrateCtx.labelers,
         }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPosts.ts
@@ -19,14 +19,14 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
       const results = await getPosts({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: results,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
@@ -25,13 +25,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getRepostedBy({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
@@ -18,10 +18,8 @@ export default function (server: Server, ctx: AppContext) {
         cursor: params.cursor,
       })
       const uris = suggestedRes.uris
-      const hydration = await ctx.hydrator.hydrateFeedGens(uris, {
-        labelers,
-        viewer,
-      })
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydration = await ctx.hydrator.hydrateFeedGens(uris, hydrateCtx)
       const feedViews = mapDefined(uris, (uri) =>
         ctx.views.feedGenerator(uri, hydration),
       )
@@ -32,7 +30,7 @@ export default function (server: Server, ctx: AppContext) {
           feeds: feedViews,
           cursor: parseString(suggestedRes.cursor),
         },
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -26,16 +26,19 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
-      const result = await getTimeline({ ...params, hydrateCtx }, ctx)
+      const result = await getTimeline(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers, repoRev }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers, repoRev }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -29,12 +29,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const results = await searchPosts({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',
         body: results,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
@@ -20,12 +20,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
-      const result = await getBlocks({ ...params, hydrateCtx }, ctx)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await getBlocks(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
@@ -31,14 +31,18 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer, includeTakedowns }
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
 
       const result = await getFollowers({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollows.ts
@@ -25,7 +25,11 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer, includeTakedowns }
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
 
       // @TODO ensure canViewTakedowns gets threaded through and applied properly
       const result = await getFollows({ ...params, hydrateCtx }, ctx)
@@ -33,7 +37,7 @@ export default function (server: Server, ctx: AppContext) {
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -26,12 +26,12 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getList({ ...params, hydrateCtx }, ctx)
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
@@ -25,12 +25,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
-      const result = await getListBlocks({ ...params, hydrateCtx }, ctx)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await getListBlocks(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
@@ -25,12 +25,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
-      const result = await getListMutes({ ...params, hydrateCtx }, ctx)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await getListMutes(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -20,13 +20,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getLists({ ...params, hydrateCtx }, ctx)
 
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getMutes.ts
@@ -20,12 +20,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
-      const result = await getMutes({ ...params, hydrateCtx }, ctx)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await getMutes(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -26,15 +26,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const result = await getSuggestedFollowsByActor(
-        { ...params, hydrateCtx },
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
         ctx,
       )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/labeler/getServices.ts
+++ b/packages/bsky/src/api/app/bsky/labeler/getServices.ts
@@ -10,11 +10,11 @@ export default function (server: Server, ctx: AppContext) {
       const { dids, detailed } = params
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-
-      const hydration = await ctx.hydrator.hydrateLabelers(dids, {
+      const hydrateCtx = await ctx.hydrator.createContext({
         viewer,
         labelers,
       })
+      const hydration = await ctx.hydrator.hydrateLabelers(dids, hydrateCtx)
 
       const views = mapDefined(dids, (did) => {
         if (detailed) {
@@ -39,7 +39,7 @@ export default function (server: Server, ctx: AppContext) {
         body: {
           views,
         },
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -28,12 +28,15 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { labelers, viewer }
-      const result = await listNotifications({ ...params, hydrateCtx }, ctx)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await listNotifications(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
       return {
         encoding: 'application/json',
         body: result,
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -13,7 +13,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = { viewer, labelers }
+      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
 
       if (clearlyBadCursor(params.cursor)) {
         return {
@@ -53,7 +53,7 @@ export default function (server: Server, ctx: AppContext) {
           feeds: feedViews,
           cursor,
         },
-        headers: resHeaders({ labelers }),
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -53,7 +53,17 @@ import {
 } from './feed'
 import { ParsedLabelers } from '../util'
 
-export type HydrateCtx = {
+export class HydrateCtx {
+  labelers = this.vals.labelers
+  viewer = this.vals.viewer
+  includeTakedowns = this.vals.includeTakedowns
+  constructor(private vals: HydrateCtxVals) {}
+  copy<V extends Partial<HydrateCtxVals>>(vals?: V): HydrateCtx & V {
+    return new HydrateCtx({ ...this.vals, ...vals }) as HydrateCtx & V
+  }
+}
+
+export type HydrateCtxVals = {
   labelers: ParsedLabelers
   viewer: string | null
   includeTakedowns?: boolean
@@ -97,12 +107,17 @@ export class Hydrator {
   feed: FeedHydrator
   graph: GraphHydrator
   label: LabelHydrator
+  serviceLabelers: Set<string>
 
-  constructor(public dataplane: DataPlaneClient) {
+  constructor(
+    public dataplane: DataPlaneClient,
+    serviceLabelers: string[] = [],
+  ) {
     this.actor = new ActorHydrator(dataplane)
     this.feed = new FeedHydrator(dataplane)
     this.graph = new GraphHydrator(dataplane)
     this.label = new LabelHydrator(dataplane)
+    this.serviceLabelers = new Set(serviceLabelers)
   }
 
   // app.bsky.actor.defs#profileView
@@ -636,6 +651,29 @@ export class Hydrator {
         takedownRef: actor.profileTakedownRef,
       }
     }
+  }
+
+  async createContext(vals: HydrateCtxVals) {
+    const labelers = vals.labelers.dids
+    const nonServiceLabelers = labelers.filter(
+      (did) => !this.serviceLabelers.has(did),
+    )
+    const labelerActors = await this.actor.getActors(
+      nonServiceLabelers,
+      vals.includeTakedowns,
+    )
+    const availableDids = labelers.filter(
+      (did) => this.serviceLabelers.has(did) || !!labelerActors.get(did),
+    )
+    const availableLabelers = {
+      dids: availableDids,
+      redact: vals.labelers.redact,
+    }
+    return new HydrateCtx({
+      labelers: availableLabelers,
+      viewer: vals.viewer,
+      includeTakedowns: vals.includeTakedowns,
+    })
   }
 }
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -570,13 +570,14 @@ export class Hydrator {
   ): Promise<HydrationState> {
     const [labelers, labelerAggs, labelerViewers, profileState] =
       await Promise.all([
-        this.label.getLabelers(dids),
+        this.label.getLabelers(dids, ctx.includeTakedowns),
         this.label.getLabelerAggregates(dids),
         ctx.viewer
           ? this.label.getLabelerViewerStates(dids, ctx.viewer)
           : undefined,
-        this.hydrateProfiles(dids.map(didFromUri), ctx),
+        this.hydrateProfiles(dids, ctx),
       ])
+    actionTakedownLabels(dids, labelers, profileState.labels ?? new Labels())
     return mergeStates(profileState, {
       labelers,
       labelerAggs,

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -654,6 +654,7 @@ export class Hydrator {
   }
 
   async createContext(vals: HydrateCtxVals) {
+    // ensures we're only apply labelers that exist and are not taken down
     const labelers = vals.labelers.dids
     const nonServiceLabelers = labelers.filter(
       (did) => !this.serviceLabelers.has(did),

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -77,7 +77,7 @@ export class BskyAppView {
       httpVersion: config.dataplaneHttpVersion,
       rejectUnauthorized: !config.dataplaneIgnoreBadTls,
     })
-    const hydrator = new Hydrator(dataplane)
+    const hydrator = new Hydrator(dataplane, config.labelsFromIssuerDids)
     const views = new Views(imgUriBuilder)
 
     const bsyncClient = createBsyncClient({

--- a/packages/bsky/tests/label-hydration.test.ts
+++ b/packages/bsky/tests/label-hydration.test.ts
@@ -111,16 +111,7 @@ describe('label hydration', () => {
   it('does not hydrate labels from takendown labeler', async () => {
     AtpAgent.configure({ appLabelers: [alice, sc.dids.dan] })
     pdsAgent.configureLabelersHeader([])
-    await agent.api.com.atproto.admin.updateSubjectStatus(
-      {
-        subject: { $type: 'com.atproto.admin.defs#repoRef', did: alice },
-        takedown: { applied: true },
-      },
-      {
-        encoding: 'application/json',
-        headers: network.bsky.adminAuthHeaders(),
-      },
-    )
+    await network.bsky.ctx.dataplane.takedownActor({ did: alice })
     const res = await pdsAgent.api.app.bsky.actor.getProfile(
       { actor: carol },
       { headers: sc.getHeaders(bob) },
@@ -130,16 +121,7 @@ describe('label hydration', () => {
     expect(res.headers['atproto-content-labelers']).toEqual(
       `${sc.dids.dan};redact`, // does not include alice
     )
-    await agent.api.com.atproto.admin.updateSubjectStatus(
-      {
-        subject: { $type: 'com.atproto.admin.defs#repoRef', did: alice },
-        takedown: { applied: false },
-      },
-      {
-        encoding: 'application/json',
-        headers: network.bsky.adminAuthHeaders(),
-      },
-    )
+    await network.bsky.ctx.dataplane.untakedownActor({ did: alice })
   })
 
   it('hydrates labels onto list views.', async () => {

--- a/packages/bsky/tests/label-hydration.test.ts
+++ b/packages/bsky/tests/label-hydration.test.ts
@@ -4,6 +4,7 @@ import axios from 'axios'
 
 describe('label hydration', () => {
   let network: TestNetwork
+  let agent: AtpAgent
   let pdsAgent: AtpAgent
   let sc: SeedClient
 
@@ -16,6 +17,7 @@ describe('label hydration', () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'bsky_label_hydration',
     })
+    agent = network.bsky.getClient()
     pdsAgent = network.pds.getClient()
     sc = network.getSeedClient()
     await basicSeed(sc)
@@ -104,6 +106,40 @@ describe('label hydration', () => {
     expect(labels.map((l) => ({ val: l.val, src: l.src }))).toEqual([
       { src: alice, val: 'spam' },
     ])
+  })
+
+  it('does not hydrate labels from takendown labeler', async () => {
+    AtpAgent.configure({ appLabelers: [alice, sc.dids.dan] })
+    pdsAgent.configureLabelersHeader([])
+    await agent.api.com.atproto.admin.updateSubjectStatus(
+      {
+        subject: { $type: 'com.atproto.admin.defs#repoRef', did: alice },
+        takedown: { applied: true },
+      },
+      {
+        encoding: 'application/json',
+        headers: network.bsky.adminAuthHeaders(),
+      },
+    )
+    const res = await pdsAgent.api.app.bsky.actor.getProfile(
+      { actor: carol },
+      { headers: sc.getHeaders(bob) },
+    )
+    const { labels = [] } = res.data
+    expect(labels.map((l) => ({ val: l.val, src: l.src }))).toEqual([])
+    expect(res.headers['atproto-content-labelers']).toEqual(
+      `${sc.dids.dan};redact`, // does not include alice
+    )
+    await agent.api.com.atproto.admin.updateSubjectStatus(
+      {
+        subject: { $type: 'com.atproto.admin.defs#repoRef', did: alice },
+        takedown: { applied: false },
+      },
+      {
+        encoding: 'application/json',
+        headers: network.bsky.adminAuthHeaders(),
+      },
+    )
   })
 
   it('hydrates labels onto list views.', async () => {

--- a/packages/bsky/tests/label-hydration.test.ts
+++ b/packages/bsky/tests/label-hydration.test.ts
@@ -126,7 +126,7 @@ describe('label hydration', () => {
       { headers: sc.getHeaders(bob) },
     )
     const { labels = [] } = res.data
-    expect(labels.map((l) => ({ val: l.val, src: l.src }))).toEqual([])
+    expect(labels).toEqual([])
     expect(res.headers['atproto-content-labelers']).toEqual(
       `${sc.dids.dan};redact`, // does not include alice
     )

--- a/packages/bsky/tests/views/labeler-service.test.ts
+++ b/packages/bsky/tests/views/labeler-service.test.ts
@@ -136,10 +136,7 @@ describe('labeler service views', () => {
   })
 
   it('blocked by labeler takedown', async () => {
-    await network.bsky.ctx.dataplane.takedownRecord({
-      recordUri: aliceService.uriStr,
-    })
-
+    await network.bsky.ctx.dataplane.takedownActor({ did: alice })
     const res = await agent.api.app.bsky.labeler.getServices(
       { dids: [alice, bob] },
       { headers: await network.serviceHeaders(bob) },
@@ -149,8 +146,6 @@ describe('labeler service views', () => {
     expect(res.data.views[0].creator.did).toEqual(bob)
 
     // Cleanup
-    await network.bsky.ctx.dataplane.untakedownRecord({
-      recordUri: aliceService.uriStr,
-    })
+    await network.bsky.ctx.dataplane.untakedownActor({ did: alice })
   })
 })

--- a/packages/ozone/src/api/moderation/searchRepos.ts
+++ b/packages/ozone/src/api/moderation/searchRepos.ts
@@ -23,7 +23,10 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
-      const res = await ctx.appviewAgent.api.app.bsky.actor.searchActors(params)
+      const res = await ctx.appviewAgent.api.app.bsky.actor.searchActors(
+        params,
+        await ctx.appviewAuth(),
+      )
       const repoMap = await modService.views.repos(
         res.data.actors.map((a) => a.did),
       )

--- a/packages/ozone/tests/repo-search.test.ts
+++ b/packages/ozone/tests/repo-search.test.ts
@@ -38,6 +38,7 @@ describe('admin repo search view', () => {
         did: sc.dids['cara-wiegand69.test'],
       },
     })
+    await network.ozone.processAll()
   })
 
   it('gives relevant results', async () => {


### PR DESCRIPTION
Another option alongside #2316.  I wanted to see what this would look like if we took into account labeler takedowns while building the hydration context rather than during label hydration.  The upsides I'm going for here are a. only perform the takedown checks once, b. improve accuracy of `atproto-content-labelers` response header.