### PR TITLE
Appview: fix lookup for labeler via repo.getRecord

### DIFF
--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -619,8 +619,10 @@ export class Hydrator {
         undefined
       )
     } else if (collection === ids.AppBskyLabelerService) {
+      if (parsed.rkey !== 'self') return
+      const did = parsed.hostname
       return (
-        (await this.label.getLabelers([uri], includeTakedowns)).get(uri) ??
+        (await this.label.getLabelers([did], includeTakedowns)).get(did) ??
         undefined
       )
     } else if (collection === ids.AppBskyActorProfile) {


### PR DESCRIPTION
Just fixing a little issue here affecting the ability to lookup a labeler service record from the appview via `com.atproto.repo.getRecord`.