### PR TITLE
Fix: correctly detect blocked QPs when moderating posts

### DIFF
--- a/.changeset/quiet-papayas-accept.md
+++ b/.changeset/quiet-papayas-accept.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Fix: correctly detected blocked quote-posts when moderating posts


### PR DESCRIPTION
The current `moderatePost()` function isnt checking quote posts for `#viewBlocked` responses, which is causing it to not correctly filter posts that quote blocked users. This PR fixes that.