### PR TITLE
Appview: add associated.labeler info to all profile views

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -14,6 +14,10 @@
           "maxLength": 640
         },
         "avatar": { "type": "string" },
+        "associated": {
+          "type": "ref",
+          "ref": "#profileAssociated"
+        },
         "viewer": { "type": "ref", "ref": "#viewerState" },
         "labels": {
           "type": "array",
@@ -38,6 +42,10 @@
           "maxLength": 2560
         },
         "avatar": { "type": "string" },
+        "associated": {
+          "type": "ref",
+          "ref": "#profileAssociated"
+        },
         "indexedAt": { "type": "string", "format": "datetime" },
         "viewer": { "type": "ref", "ref": "#viewerState" },
         "labels": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3622,6 +3622,10 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
+          },
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
@@ -3659,6 +3663,10 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
           },
           indexedAt: {
             type: 'string',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -13,6 +13,7 @@ export interface ProfileViewBasic {
   handle: string
   displayName?: string
   avatar?: string
+  associated?: ProfileAssociated
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
@@ -36,6 +37,7 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
+  associated?: ProfileAssociated
   indexedAt?: string
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3622,6 +3622,10 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
+          },
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
@@ -3659,6 +3663,10 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
           },
           indexedAt: {
             type: 'string',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -13,6 +13,7 @@ export interface ProfileViewBasic {
   handle: string
   displayName?: string
   avatar?: string
+  associated?: ProfileAssociated
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
@@ -36,6 +37,7 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
+  associated?: ProfileAssociated
   indexedAt?: string
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -155,6 +155,9 @@ export class Views {
             cidFromBlobJson(actor.profile.avatar),
           )
         : undefined,
+      // associated.feedgens and associated.lists info not necessarily included
+      // on profile and profile-basic views, but should be on profile-detailed.
+      associated: actor?.isLabeler ? { labeler: true } : undefined,
       viewer: this.profileViewer(did, state),
       labels,
     }

--- a/packages/bsky/tests/views/__snapshots__/labeler-service.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/labeler-service.test.ts.snap
@@ -7,6 +7,9 @@ Object {
       "$type": "app.bsky.labeler.defs#labelerView",
       "cid": "cids(0)",
       "creator": Object {
+        "associated": Object {
+          "labeler": true,
+        },
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
         "description": "its me!",
         "did": "user(0)",
@@ -48,6 +51,9 @@ Object {
       "$type": "app.bsky.labeler.defs#labelerView",
       "cid": "cids(3)",
       "creator": Object {
+        "associated": Object {
+          "labeler": true,
+        },
         "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1)@jpeg",
         "description": "hi im bob label_me",
         "did": "user(2)",
@@ -77,6 +83,9 @@ Object {
       "$type": "app.bsky.labeler.defs#labelerViewDetailed",
       "cid": "cids(0)",
       "creator": Object {
+        "associated": Object {
+          "labeler": true,
+        },
         "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
         "description": "its me!",
         "did": "user(0)",
@@ -126,6 +135,9 @@ Object {
       "$type": "app.bsky.labeler.defs#labelerViewDetailed",
       "cid": "cids(3)",
       "creator": Object {
+        "associated": Object {
+          "labeler": true,
+        },
         "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(1)@jpeg",
         "description": "hi im bob label_me",
         "did": "user(2)",

--- a/packages/bsky/tests/views/labeler-service.test.ts
+++ b/packages/bsky/tests/views/labeler-service.test.ts
@@ -135,6 +135,15 @@ describe('labeler service views', () => {
     )
   })
 
+  it('renders profile as labeler in non-detailed profile views', async () => {
+    const { data: res } = await agent.api.app.bsky.actor.searchActors(
+      { q: sc.accounts[alice].handle },
+      { headers: await network.serviceHeaders(bob) },
+    )
+    expect(res.actors.length).toBe(1)
+    expect(res.actors[0].associated?.labeler).toBe(true)
+  })
+
   it('blocked by labeler takedown', async () => {
     await network.bsky.ctx.dataplane.takedownActor({ did: alice })
     const res = await agent.api.app.bsky.labeler.getServices(

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -36,7 +36,7 @@
     "axios": "^0.27.2",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "get-port": "^6.1.2",
+    "get-port": "^5.1.1",
     "multiformats": "^9.9.0",
     "uint8arrays": "3.0.0"
   }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3622,6 +3622,10 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
+          },
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
@@ -3659,6 +3663,10 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
           },
           indexedAt: {
             type: 'string',

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -13,6 +13,7 @@ export interface ProfileViewBasic {
   handle: string
   displayName?: string
   avatar?: string
+  associated?: ProfileAssociated
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
@@ -36,6 +37,7 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
+  associated?: ProfileAssociated
   indexedAt?: string
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3622,6 +3622,10 @@ export const schemaDict = {
           avatar: {
             type: 'string',
           },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
+          },
           viewer: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#viewerState',
@@ -3659,6 +3663,10 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+          },
+          associated: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileAssociated',
           },
           indexedAt: {
             type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -13,6 +13,7 @@ export interface ProfileViewBasic {
   handle: string
   displayName?: string
   avatar?: string
+  associated?: ProfileAssociated
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]
   [k: string]: unknown
@@ -36,6 +37,7 @@ export interface ProfileView {
   displayName?: string
   description?: string
   avatar?: string
+  associated?: ProfileAssociated
   indexedAt?: string
   viewer?: ViewerState
   labels?: ComAtprotoLabelDefs.Label[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,8 +453,8 @@ importers:
         specifier: ^4.18.2
         version: 4.18.2
       get-port:
-        specifier: ^6.1.2
-        version: 6.1.2
+        specifier: ^5.1.1
+        version: 5.1.1
       multiformats:
         specifier: ^9.9.0
         version: 9.9.0
@@ -8273,9 +8273,15 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
+  /get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
+    dev: false
+
   /get-port@6.1.2:
     resolution: {integrity: sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
 
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}


### PR DESCRIPTION
Adds the `associated` property to profile and profile-basic views, bringing them in line with profile-detailed views.  In practice only the `associated.labeler` property need be set on these views when the profile is for a labeler.  On profile-detailed views you may find additional info within `associated` related to feeds and lists.