### PR TITLE
lexicon nits: use string format `uri` in more places

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -13,7 +13,7 @@
           "maxGraphemes": 64,
           "maxLength": 640
         },
-        "avatar": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
         "associated": {
           "type": "ref",
           "ref": "#profileAssociated"
@@ -41,7 +41,7 @@
           "maxGraphemes": 256,
           "maxLength": 2560
         },
-        "avatar": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
         "associated": {
           "type": "ref",
           "ref": "#profileAssociated"
@@ -70,8 +70,8 @@
           "maxGraphemes": 256,
           "maxLength": 2560
         },
-        "avatar": { "type": "string" },
-        "banner": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
+        "banner": { "type": "string", "format": "uri" },
         "followersCount": { "type": "integer" },
         "followsCount": { "type": "integer" },
         "postsCount": { "type": "integer" },

--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -44,7 +44,7 @@
         "uri": { "type": "string", "format": "uri" },
         "title": { "type": "string" },
         "description": { "type": "string" },
-        "thumb": { "type": "string" }
+        "thumb": { "type": "string", "format": "uri" }
       }
     }
   }

--- a/lexicons/app/bsky/embed/images.json
+++ b/lexicons/app/bsky/embed/images.json
@@ -56,10 +56,12 @@
       "properties": {
         "thumb": {
           "type": "string",
+          "format": "uri",
           "description": "Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View."
         },
         "fullsize": {
           "type": "string",
+          "format": "uri",
           "description": "Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View."
         },
         "alt": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -135,7 +135,7 @@
           "type": "array",
           "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
         },
-        "avatar": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
         "likeCount": { "type": "integer", "minimum": 0 },
         "labels": {
           "type": "array",

--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -10,7 +10,7 @@
         "cid": { "type": "string", "format": "cid" },
         "name": { "type": "string", "maxLength": 64, "minLength": 1 },
         "purpose": { "type": "ref", "ref": "#listPurpose" },
-        "avatar": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
         "labels": {
           "type": "array",
           "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
@@ -37,7 +37,7 @@
           "type": "array",
           "items": { "type": "ref", "ref": "app.bsky.richtext.facet" }
         },
-        "avatar": { "type": "string" },
+        "avatar": { "type": "string", "format": "uri" },
         "labels": {
           "type": "array",
           "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }

--- a/lexicons/com/atproto/server/describeServer.json
+++ b/lexicons/com/atproto/server/describeServer.json
@@ -45,8 +45,8 @@
     "links": {
       "type": "object",
       "properties": {
-        "privacyPolicy": { "type": "string" },
-        "termsOfService": { "type": "string" }
+        "privacyPolicy": { "type": "string", "format": "uri" },
+        "termsOfService": { "type": "string", "format": "uri" }
       }
     },
     "contact": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2438,9 +2438,11 @@ export const schemaDict = {
         properties: {
           privacyPolicy: {
             type: 'string',
+            format: 'uri',
           },
           termsOfService: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -3621,6 +3623,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3663,6 +3666,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3709,9 +3713,11 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           banner: {
             type: 'string',
+            format: 'uri',
           },
           followersCount: {
             type: 'integer',
@@ -4388,6 +4394,7 @@ export const schemaDict = {
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4468,11 +4475,13 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View.',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View.',
           },
@@ -4886,6 +4895,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           likeCount: {
             type: 'integer',
@@ -6201,6 +6211,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',
@@ -6258,6 +6269,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2438,9 +2438,11 @@ export const schemaDict = {
         properties: {
           privacyPolicy: {
             type: 'string',
+            format: 'uri',
           },
           termsOfService: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -3621,6 +3623,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3663,6 +3666,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3709,9 +3713,11 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           banner: {
             type: 'string',
+            format: 'uri',
           },
           followersCount: {
             type: 'integer',
@@ -4388,6 +4394,7 @@ export const schemaDict = {
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4468,11 +4475,13 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View.',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View.',
           },
@@ -4886,6 +4895,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           likeCount: {
             type: 'integer',
@@ -6201,6 +6211,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',
@@ -6258,6 +6269,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -2438,9 +2438,11 @@ export const schemaDict = {
         properties: {
           privacyPolicy: {
             type: 'string',
+            format: 'uri',
           },
           termsOfService: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -3621,6 +3623,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3663,6 +3666,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3709,9 +3713,11 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           banner: {
             type: 'string',
+            format: 'uri',
           },
           followersCount: {
             type: 'integer',
@@ -4388,6 +4394,7 @@ export const schemaDict = {
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4468,11 +4475,13 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View.',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View.',
           },
@@ -4886,6 +4895,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           likeCount: {
             type: 'integer',
@@ -6201,6 +6211,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',
@@ -6258,6 +6269,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2438,9 +2438,11 @@ export const schemaDict = {
         properties: {
           privacyPolicy: {
             type: 'string',
+            format: 'uri',
           },
           termsOfService: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -3621,6 +3623,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3663,6 +3666,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           associated: {
             type: 'ref',
@@ -3709,9 +3713,11 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           banner: {
             type: 'string',
+            format: 'uri',
           },
           followersCount: {
             type: 'integer',
@@ -4388,6 +4394,7 @@ export const schemaDict = {
           },
           thumb: {
             type: 'string',
+            format: 'uri',
           },
         },
       },
@@ -4468,11 +4475,13 @@ export const schemaDict = {
         properties: {
           thumb: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View.',
           },
           fullsize: {
             type: 'string',
+            format: 'uri',
             description:
               'Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View.',
           },
@@ -4886,6 +4895,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           likeCount: {
             type: 'integer',
@@ -6201,6 +6211,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',
@@ -6258,6 +6269,7 @@ export const schemaDict = {
           },
           avatar: {
             type: 'string',
+            format: 'uri',
           },
           labels: {
             type: 'array',


### PR DESCRIPTION
Mentioned in https://github.com/bluesky-social/atproto/issues/2111

This is technically a Lexicon evolution rules-breaking change, because it is adding a non-optional restriction on an existing field. This is part of final cleanup of existing Lexicons trying to hit all such final "breaking" changes.

In practice, I think this is basically a no-op as we aren't validating `uri` fields against any format or regex in the typescript implementation (I probably will require them to be URIs of some sort in the golang Lexicon validator).

Some of these changes appeared earlier in https://github.com/bluesky-social/atproto/pull/1994, which was mostly about string length limits, and we needed to revert. I'm trying to both be more complete here, and to break up these changes in to more focused chunks.