### PR TITLE
lex: deprecate getRecord commit param

### DIFF
--- a/lexicons/com/atproto/sync/getRecord.json
+++ b/lexicons/com/atproto/sync/getRecord.json
@@ -19,7 +19,7 @@
           "commit": {
             "type": "string",
             "format": "cid",
-            "description": "An optional past commit CID."
+            "description": "DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit"
           }
         }
       },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3052,7 +3052,8 @@ export const schemaDict = {
             commit: {
               type: 'string',
               format: 'cid',
-              description: 'An optional past commit CID.',
+              description:
+                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -15,7 +15,7 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** An optional past commit CID. */
+  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
   commit?: string
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3052,7 +3052,8 @@ export const schemaDict = {
             commit: {
               type: 'string',
               format: 'cid',
-              description: 'An optional past commit CID.',
+              description:
+                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -15,7 +15,7 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** An optional past commit CID. */
+  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
   commit?: string
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3052,7 +3052,8 @@ export const schemaDict = {
             commit: {
               type: 'string',
               format: 'cid',
-              description: 'An optional past commit CID.',
+              description:
+                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -15,7 +15,7 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** An optional past commit CID. */
+  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
   commit?: string
 }
 


### PR DESCRIPTION
This is a low-stakes description-only change.

TBH, we could and will probably just entirely delete this parameter, but loudly marking it as deprecated is an easy first step.