### PR TITLE
Exports lexicon from @atproto/bsky. Fixes #2353.

### DIFF
--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -24,6 +24,7 @@ import { authWithApiKey as bsyncAuth, createBsyncClient } from './bsync'
 import { authWithApiKey as courierAuth, createCourierClient } from './courier'
 
 export * from './data-plane'
+export * from './lexicon';
 export type { ServerConfigValues } from './config'
 export { ServerConfig } from './config'
 export { Database } from './data-plane/server/db'


### PR DESCRIPTION
I haven't been able to run tests locally but I don't imagine this would break anything; the build succeeds if nothing else and I suspect if the export was clobbering an existing namespace (the only thing I can think of that would actually break anything with this), `tsc` would complain.