### PR TITLE
Fix inclusion for reposts on author feed w/ posts_and_author_threads

### DIFF
--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -283,7 +283,7 @@ describe('pds author feed views', () => {
       filter: 'posts_and_author_threads',
     })
 
-    expect(eveFeed.feed.length).toEqual(5)
+    expect(eveFeed.feed.length).toEqual(6)
     expect(
       eveFeed.feed.some(({ post }) => {
         const replyByEve =
@@ -305,6 +305,14 @@ describe('pds author feed views', () => {
           (!reply.parent.record.reply ||
             isReplyTo(reply.parent.record.reply, eve))
         return replyToEve && replyToReplyByEve
+      }),
+    ).toBeTruthy()
+    // reposts are preserved
+    expect(
+      eveFeed.feed.some(({ post, reason }) => {
+        const repostOfOther =
+          reason && isRecord(post.record) && post.author.did !== eve
+        return repostOfOther
       }),
     ).toBeTruthy()
   })

--- a/packages/dev-env/src/seed/author-feed.ts
+++ b/packages/dev-env/src/seed/author-feed.ts
@@ -62,7 +62,7 @@ export default async (sc: SeedClient) => {
    * "detached" thread, where one Fred post breaks the continuity.
    */
   await sc.post(eve, evePosts[1])
-  await sc.reply(
+  const fredReply = await sc.reply(
     fred,
     sc.posts[eve][1].ref,
     sc.posts[eve][1].ref,
@@ -80,6 +80,9 @@ export default async (sc: SeedClient) => {
     sc.replies[eve][4].ref,
     eveFredReplies[1],
   )
+
+  // a repost for eve's feed
+  await sc.repost(eve, fredReply.ref)
 
   return sc
 }


### PR DESCRIPTION
In #2347 I introduced a bug, where reposted content was being excluded from author feeds under the `posts_and_author_threads` filter.  This fixes it!