### PR TITLE
Always include counts on post and profile views

### DIFF
--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -101,9 +101,9 @@ export class Views {
             cidFromBlobJson(actor.profile.banner),
           )
         : undefined,
-      followersCount: profileAggs?.followers,
-      followsCount: profileAggs?.follows,
-      postsCount: profileAggs?.posts,
+      followersCount: profileAggs?.followers ?? 0,
+      followsCount: profileAggs?.follows ?? 0,
+      postsCount: profileAggs?.posts ?? 0,
       associated: {
         lists: profileAggs?.lists,
         feedgens: profileAggs?.feeds,
@@ -296,7 +296,7 @@ export class Views {
       uri,
       cid: labeler.cid.toString(),
       creator,
-      likeCount: aggs?.likes,
+      likeCount: aggs?.likes ?? 0,
       viewer: viewer
         ? {
             like: viewer.like,
@@ -371,7 +371,7 @@ export class Views {
             cidFromBlobJson(feedgen.record.avatar),
           )
         : undefined,
-      likeCount: aggs?.likes,
+      likeCount: aggs?.likes ?? 0,
       labels,
       viewer: viewer
         ? {
@@ -427,9 +427,9 @@ export class Views {
         depth < 2 && post.record.embed
           ? this.embed(uri, post.record.embed, state, depth + 1)
           : undefined,
-      replyCount: aggs?.replies,
-      repostCount: aggs?.reposts,
-      likeCount: aggs?.likes,
+      replyCount: aggs?.replies ?? 0,
+      repostCount: aggs?.reposts ?? 0,
+      likeCount: aggs?.likes ?? 0,
       indexedAt: post.sortedAt.toISOString(),
       viewer: viewer
         ? {

--- a/packages/pds/src/read-after-write/viewer.ts
+++ b/packages/pds/src/read-after-write/viewer.ts
@@ -168,6 +168,9 @@ export class LocalViewer {
     return {
       uri: uri.toString(),
       cid: cid.toString(),
+      likeCount: 0, // counts presumed to be 0 directly after post creation
+      replyCount: 0,
+      repostCount: 0,
       author,
       record,
       embed: embed ?? undefined,
@@ -240,9 +243,7 @@ export class LocalViewer {
     const collection = new AtUri(embed.record.uri).collection
     if (collection === ids.AppBskyFeedPost) {
       const res = await this.appViewAgent.api.app.bsky.feed.getPosts(
-        {
-          uris: [embed.record.uri],
-        },
+        { uris: [embed.record.uri] },
         await this.serviceAuthHeaders(this.did),
       )
       const post = res.data.posts[0]
@@ -259,24 +260,20 @@ export class LocalViewer {
       }
     } else if (collection === ids.AppBskyFeedGenerator) {
       const res = await this.appViewAgent.api.app.bsky.feed.getFeedGenerator(
-        {
-          feed: embed.record.uri,
-        },
+        { feed: embed.record.uri },
         await this.serviceAuthHeaders(this.did),
       )
       return {
-        $type: 'app.bsaky.feed.defs#generatorView',
+        $type: 'app.bsky.feed.defs#generatorView',
         ...res.data.view,
       }
     } else if (collection === ids.AppBskyGraphList) {
       const res = await this.appViewAgent.api.app.bsky.graph.getList(
-        {
-          list: embed.record.uri,
-        },
+        { list: embed.record.uri },
         await this.serviceAuthHeaders(this.did),
       )
       return {
-        $type: 'app.bsaky.graph.defs#listView',
+        $type: 'app.bsky.graph.defs#listView',
         ...res.data.list,
       }
     }


### PR DESCRIPTION
Ensure counts are set in all post and profile views, even when aggregations are missing.  Apply the same to read-after-write logic in the PDS, and tidy some `$type` typos found along the way.