### PR TITLE
Use blocked and not-found unions in post reply refs

### DIFF
--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -68,6 +68,55 @@ Array [
       },
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
+    "reply": Object {
+      "parent": Object {
+        "$type": "app.bsky.feed.defs#notFoundPost",
+        "notFound": true,
+        "uri": "record(3)",
+      },
+      "root": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(3)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(2)",
+        "viewer": Object {},
+      },
+    },
   },
   Object {
     "post": Object {
@@ -177,6 +226,55 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {},
+    },
+    "reply": Object {
+      "parent": Object {
+        "$type": "app.bsky.feed.defs#notFoundPost",
+        "notFound": true,
+        "uri": "record(3)",
+      },
+      "root": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(3)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(2)",
+        "viewer": Object {},
+      },
     },
   },
   Object {
@@ -549,6 +647,55 @@ Array [
       },
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
+    "reply": Object {
+      "parent": Object {
+        "$type": "app.bsky.feed.defs#notFoundPost",
+        "notFound": true,
+        "uri": "record(3)",
+      },
+      "root": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(3)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(2)",
+        "viewer": Object {},
+      },
+    },
   },
   Object {
     "post": Object {
@@ -658,6 +805,55 @@ Array [
       "repostCount": 1,
       "uri": "record(0)",
       "viewer": Object {},
+    },
+    "reply": Object {
+      "parent": Object {
+        "$type": "app.bsky.feed.defs#notFoundPost",
+        "notFound": true,
+        "uri": "record(3)",
+      },
+      "root": Object {
+        "$type": "app.bsky.feed.defs#postView",
+        "author": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
+        "cid": "cids(3)",
+        "indexedAt": "1970-01-01T00:00:00.000Z",
+        "labels": Array [],
+        "likeCount": 3,
+        "record": Object {
+          "$type": "app.bsky.feed.post",
+          "createdAt": "1970-01-01T00:00:00.000000Z",
+          "text": "again",
+        },
+        "replyCount": 2,
+        "repostCount": 1,
+        "uri": "record(2)",
+        "viewer": Object {},
+      },
     },
   },
   Object {

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -516,6 +516,7 @@ describe('pds views with blocking', () => {
   it('applies third-party blocking rules in feeds.', async () => {
     // alice follows carol and dan, block exists between carol and dan.
     const replyBlockedUri = carolReplyToDan.ref.uriStr
+    const replyBlockedParentUri = sc.posts[dan][0].ref.uriStr
     const embedBlockedUri = sc.posts[dan][1].ref.uriStr
     const { data: timeline } = await agent.api.app.bsky.feed.getTimeline(
       { limit: 100 },
@@ -524,8 +525,16 @@ describe('pds views with blocking', () => {
     const replyBlockedPost = timeline.feed.find(
       (item) => item.post.uri === replyBlockedUri,
     )
-    assert(replyBlockedPost)
-    expect(replyBlockedPost.reply?.parent).toBeUndefined()
+    expect(replyBlockedPost?.reply).toMatchObject({
+      root: {
+        $type: 'app.bsky.feed.defs#blockedPost',
+        uri: replyBlockedParentUri,
+      },
+      parent: {
+        $type: 'app.bsky.feed.defs#blockedPost',
+        uri: replyBlockedParentUri,
+      },
+    })
     const embedBlockedPost = timeline.feed.find(
       (item) => item.post.uri === embedBlockedUri,
     )


### PR DESCRIPTION
Feed item views served from the appview include a `post` and a `reply` field.  The `reply` field contains views for the post's reply root and reply parent.  Historically if the reply root/parent were missing or were blocked posts, we would simply omit the `reply` field entirely.  With this change we will start to include it, and use the `app.bsky.feed.defs#notFoundPost` or `app.bsky.feed.defs#blockedPost` if the root/parent are missing or blocked respectively.  This aligns the implementation with how the feed view lexicons were intended to be used.