### PR TITLE
lex: limit createReport size

### DIFF
--- a/lexicons/com/atproto/moderation/createReport.json
+++ b/lexicons/com/atproto/moderation/createReport.json
@@ -18,6 +18,8 @@
             },
             "reason": {
               "type": "string",
+              "maxGraphemes": 2000,
+              "maxLength": 20000,
               "description": "Additional context about the content and violation."
             },
             "subject": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1067,6 +1067,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
                 description:
                   'Additional context about the content and violation.',
               },
@@ -3054,7 +3056,8 @@ export const schemaDict = {
             commit: {
               type: 'string',
               format: 'cid',
-              description: 'An optional past commit CID.',
+              description:
+                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/sync/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRecord.ts
@@ -13,7 +13,7 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** An optional past commit CID. */
+  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
   commit?: string
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -1067,6 +1067,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
                 description:
                   'Additional context about the content and violation.',
               },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -1067,6 +1067,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
                 description:
                   'Additional context about the content and violation.',
               },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1067,6 +1067,8 @@ export const schemaDict = {
               },
               reason: {
                 type: 'string',
+                maxGraphemes: 2000,
+                maxLength: 20000,
                 description:
                   'Additional context about the content and violation.',
               },


### PR DESCRIPTION
This has actually be limited on the *output* for a long time, apparently as a mistake/typo when locking down string length fields earlier.

Going with the existing length there (2000 graphemes). 1200 might also be good; a longer description could be a future additional field or out-of-band or something.

Includes codegen. Looks like codegen of a recent branch (of mine) didn't merge cleanly, or I had forgot to include in the PR.