### PR TITLE
lexicon: add support for TID and record-key string formats

### DIFF
--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -38,6 +38,8 @@ export const lexStringFormat = z.enum([
   'nsid',
   'cid',
   'language',
+  'tid',
+  'record-key',
 ])
 export type LexStringFormat = z.infer<typeof lexStringFormat>
 

--- a/packages/lexicon/src/validators/formats.ts
+++ b/packages/lexicon/src/validators/formats.ts
@@ -6,6 +6,8 @@ import {
   ensureValidHandle,
   ensureValidNsid,
   ensureValidAtUri,
+  ensureValidTid,
+  ensureValidRecordKey,
 } from '@atproto/syntax'
 import { validateLanguage } from '@atproto/common-web'
 
@@ -121,4 +123,30 @@ export function language(path: string, value: string): ValidationResult {
       `${path} must be a well-formed BCP 47 language tag`,
     ),
   }
+}
+
+export function tid(path: string, value: string): ValidationResult {
+  try {
+    ensureValidTid(value)
+  } catch {
+    return {
+      success: false,
+      error: new ValidationError(
+        `${path} must be a valid TID (timestamp identifier)`,
+      ),
+    }
+  }
+  return { success: true, value }
+}
+
+export function recordKey(path: string, value: string): ValidationResult {
+  try {
+    ensureValidRecordKey(value)
+  } catch {
+    return {
+      success: false,
+      error: new ValidationError(`${path} must be a valid Record Key`),
+    }
+  }
+  return { success: true, value }
 }

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -265,6 +265,10 @@ export function string(
         return formats.cid(path, value)
       case 'language':
         return formats.language(path, value)
+      case 'tid':
+        return formats.tid(path, value)
+      case 'record-key':
+        return formats.recordKey(path, value)
     }
   }
 


### PR DESCRIPTION
Pretty simple? Doesn't seem like there is any support needed in `lex-cli`.

Will add the actual formats to lexicons in a separate PR.

See also specs PR: https://github.com/bluesky-social/atproto-website/pull/248