### PR TITLE
lexicons: use 'tid' and 'record-key' formats in sync+repo lexicons

### DIFF
--- a/.changeset/perfect-jars-act.md
+++ b/.changeset/perfect-jars-act.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+set 'tid' and 'record-key' formats on com.atproto.sync and com.atproto.repo lexicons

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -18,7 +18,8 @@
             },
             "validate": {
               "type": "boolean",
-              "description": "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons."
+              "default": true,
+              "description": "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations."
             },
             "writes": {
               "type": "array",
@@ -70,7 +71,7 @@
       "required": ["collection", "value"],
       "properties": {
         "collection": { "type": "string", "format": "nsid" },
-        "rkey": { "type": "string", "maxLength": 512 },
+        "rkey": { "type": "string", "maxLength": 512, "format": "record-key" },
         "value": { "type": "unknown" }
       }
     },
@@ -80,7 +81,7 @@
       "required": ["collection", "rkey", "value"],
       "properties": {
         "collection": { "type": "string", "format": "nsid" },
-        "rkey": { "type": "string" },
+        "rkey": { "type": "string", "format": "record-key" },
         "value": { "type": "unknown" }
       }
     },
@@ -90,7 +91,7 @@
       "required": ["collection", "rkey"],
       "properties": {
         "collection": { "type": "string", "format": "nsid" },
-        "rkey": { "type": "string" }
+        "rkey": { "type": "string", "format": "record-key" }
       }
     },
     "createResult": {

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -71,7 +71,12 @@
       "required": ["collection", "value"],
       "properties": {
         "collection": { "type": "string", "format": "nsid" },
-        "rkey": { "type": "string", "format": "record-key" },
+        "rkey": {
+          "type": "string",
+          "maxLength": 512,
+          "format": "record-key",
+          "description": "NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility."
+        },
         "value": { "type": "unknown" }
       }
     },

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -18,8 +18,7 @@
             },
             "validate": {
               "type": "boolean",
-              "default": true,
-              "description": "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations."
+              "description": "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons."
             },
             "writes": {
               "type": "array",

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -71,7 +71,7 @@
       "required": ["collection", "value"],
       "properties": {
         "collection": { "type": "string", "format": "nsid" },
-        "rkey": { "type": "string", "maxLength": 512, "format": "record-key" },
+        "rkey": { "type": "string", "format": "record-key" },
         "value": { "type": "unknown" }
       }
     },

--- a/lexicons/com/atproto/repo/createRecord.json
+++ b/lexicons/com/atproto/repo/createRecord.json
@@ -23,6 +23,7 @@
             },
             "rkey": {
               "type": "string",
+              "format": "record-key",
               "description": "The Record Key.",
               "maxLength": 512
             },

--- a/lexicons/com/atproto/repo/defs.json
+++ b/lexicons/com/atproto/repo/defs.json
@@ -7,7 +7,7 @@
       "required": ["cid", "rev"],
       "properties": {
         "cid": { "type": "string", "format": "cid" },
-        "rev": { "type": "string" }
+        "rev": { "type": "string", "format": "tid" }
       }
     }
   }

--- a/lexicons/com/atproto/repo/deleteRecord.json
+++ b/lexicons/com/atproto/repo/deleteRecord.json
@@ -23,6 +23,7 @@
             },
             "rkey": {
               "type": "string",
+              "format": "record-key",
               "description": "The Record Key."
             },
             "swapRecord": {

--- a/lexicons/com/atproto/repo/getRecord.json
+++ b/lexicons/com/atproto/repo/getRecord.json
@@ -19,7 +19,11 @@
             "format": "nsid",
             "description": "The NSID of the record collection."
           },
-          "rkey": { "type": "string", "description": "The Record Key." },
+          "rkey": {
+            "type": "string",
+            "description": "The Record Key.",
+            "format": "record-key"
+          },
           "cid": {
             "type": "string",
             "format": "cid",

--- a/lexicons/com/atproto/repo/putRecord.json
+++ b/lexicons/com/atproto/repo/putRecord.json
@@ -24,6 +24,7 @@
             },
             "rkey": {
               "type": "string",
+              "format": "record-key",
               "description": "The Record Key.",
               "maxLength": 512
             },

--- a/lexicons/com/atproto/sync/getLatestCommit.json
+++ b/lexicons/com/atproto/sync/getLatestCommit.json
@@ -23,7 +23,7 @@
           "required": ["cid", "rev"],
           "properties": {
             "cid": { "type": "string", "format": "cid" },
-            "rev": { "type": "string" }
+            "rev": { "type": "string", "format": "tid" }
           }
         }
       },

--- a/lexicons/com/atproto/sync/getRecord.json
+++ b/lexicons/com/atproto/sync/getRecord.json
@@ -15,7 +15,11 @@
             "description": "The DID of the repo."
           },
           "collection": { "type": "string", "format": "nsid" },
-          "rkey": { "type": "string", "description": "Record Key" },
+          "rkey": {
+            "type": "string",
+            "description": "Record Key",
+            "format": "record-key"
+          },
           "commit": {
             "type": "string",
             "format": "cid",

--- a/lexicons/com/atproto/sync/getRepo.json
+++ b/lexicons/com/atproto/sync/getRepo.json
@@ -16,6 +16,7 @@
           },
           "since": {
             "type": "string",
+            "format": "tid",
             "description": "The revision ('rev') of the repo to create a diff from."
           }
         }

--- a/lexicons/com/atproto/sync/getRepoStatus.json
+++ b/lexicons/com/atproto/sync/getRepoStatus.json
@@ -31,6 +31,7 @@
             },
             "rev": {
               "type": "string",
+              "format": "tid",
               "description": "Optional field, the current rev of the repo, if active=true"
             }
           }

--- a/lexicons/com/atproto/sync/listBlobs.json
+++ b/lexicons/com/atproto/sync/listBlobs.json
@@ -16,6 +16,7 @@
           },
           "since": {
             "type": "string",
+            "format": "tid",
             "description": "Optional revision of the repo to list blobs since."
           },
           "limit": {

--- a/lexicons/com/atproto/sync/listRepos.json
+++ b/lexicons/com/atproto/sync/listRepos.json
@@ -42,7 +42,7 @@
           "format": "cid",
           "description": "Current repo commit CID"
         },
-        "rev": { "type": "string" },
+        "rev": { "type": "string", "format": "tid" },
         "active": { "type": "boolean" },
         "status": {
           "type": "string",

--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -78,10 +78,12 @@
         },
         "rev": {
           "type": "string",
+          "format": "tid",
           "description": "The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event."
         },
         "since": {
           "type": "string",
+          "format": "tid",
           "description": "The rev of the last emitted commit from this repo (if any)."
         },
         "blocks": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1371,6 +1371,9 @@ export const schemaDict = {
           rkey: {
             type: 'string',
             maxLength: 512,
+            format: 'record-key',
+            description:
+              'NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility.',
           },
           value: {
             type: 'unknown',
@@ -1388,6 +1391,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
           value: {
             type: 'unknown',
@@ -1405,6 +1409,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
         },
       },
@@ -1478,6 +1483,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -1548,6 +1554,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
         },
       },
@@ -1580,6 +1587,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
               },
               swapRecord: {
@@ -1705,6 +1713,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'The Record Key.',
+              format: 'record-key',
             },
             cid: {
               type: 'string',
@@ -1929,6 +1938,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -3347,6 +3357,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
               },
             },
           },
@@ -3392,6 +3403,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'Record Key',
+              format: 'record-key',
             },
             commit: {
               type: 'string',
@@ -3443,6 +3455,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description:
                 "The revision ('rev') of the repo to create a diff from.",
             },
@@ -3508,6 +3521,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
                 description:
                   'Optional field, the current rev of the repo, if active=true',
               },
@@ -3541,6 +3555,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description: 'Optional revision of the repo to list blobs since.',
             },
             limit: {
@@ -3647,6 +3662,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
           active: {
             type: 'boolean',
@@ -3862,11 +3878,13 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event.',
           },
           since: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the last emitted commit from this repo (if any).',
           },

--- a/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
+++ b/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
@@ -64,6 +64,7 @@ export function toKnownErr(e: any) {
 export interface Create {
   $type?: 'com.atproto.repo.applyWrites#create'
   collection: string
+  /** NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility. */
   rkey?: string
   value: { [_ in string]: unknown }
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -1371,6 +1371,9 @@ export const schemaDict = {
           rkey: {
             type: 'string',
             maxLength: 512,
+            format: 'record-key',
+            description:
+              'NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility.',
           },
           value: {
             type: 'unknown',
@@ -1388,6 +1391,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
           value: {
             type: 'unknown',
@@ -1405,6 +1409,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
         },
       },
@@ -1478,6 +1483,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -1548,6 +1554,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
         },
       },
@@ -1580,6 +1587,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
               },
               swapRecord: {
@@ -1705,6 +1713,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'The Record Key.',
+              format: 'record-key',
             },
             cid: {
               type: 'string',
@@ -1929,6 +1938,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -3347,6 +3357,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
               },
             },
           },
@@ -3392,6 +3403,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'Record Key',
+              format: 'record-key',
             },
             commit: {
               type: 'string',
@@ -3443,6 +3455,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description:
                 "The revision ('rev') of the repo to create a diff from.",
             },
@@ -3508,6 +3521,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
                 description:
                   'Optional field, the current rev of the repo, if active=true',
               },
@@ -3541,6 +3555,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description: 'Optional revision of the repo to list blobs since.',
             },
             limit: {
@@ -3647,6 +3662,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
           active: {
             type: 'boolean',
@@ -3862,11 +3878,13 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event.',
           },
           since: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the last emitted commit from this repo (if any).',
           },

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -68,6 +68,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface Create {
   $type?: 'com.atproto.repo.applyWrites#create'
   collection: string
+  /** NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility. */
   rkey?: string
   value: { [_ in string]: unknown }
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -1371,6 +1371,9 @@ export const schemaDict = {
           rkey: {
             type: 'string',
             maxLength: 512,
+            format: 'record-key',
+            description:
+              'NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility.',
           },
           value: {
             type: 'unknown',
@@ -1388,6 +1391,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
           value: {
             type: 'unknown',
@@ -1405,6 +1409,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
         },
       },
@@ -1478,6 +1483,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -1548,6 +1554,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
         },
       },
@@ -1580,6 +1587,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
               },
               swapRecord: {
@@ -1705,6 +1713,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'The Record Key.',
+              format: 'record-key',
             },
             cid: {
               type: 'string',
@@ -1929,6 +1938,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -3347,6 +3357,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
               },
             },
           },
@@ -3392,6 +3403,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'Record Key',
+              format: 'record-key',
             },
             commit: {
               type: 'string',
@@ -3443,6 +3455,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description:
                 "The revision ('rev') of the repo to create a diff from.",
             },
@@ -3508,6 +3521,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
                 description:
                   'Optional field, the current rev of the repo, if active=true',
               },
@@ -3541,6 +3555,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description: 'Optional revision of the repo to list blobs since.',
             },
             limit: {
@@ -3647,6 +3662,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
           active: {
             type: 'boolean',
@@ -3862,11 +3878,13 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event.',
           },
           since: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the last emitted commit from this repo (if any).',
           },

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -68,6 +68,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface Create {
   $type?: 'com.atproto.repo.applyWrites#create'
   collection: string
+  /** NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility. */
   rkey?: string
   value: { [_ in string]: unknown }
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1371,6 +1371,9 @@ export const schemaDict = {
           rkey: {
             type: 'string',
             maxLength: 512,
+            format: 'record-key',
+            description:
+              'NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility.',
           },
           value: {
             type: 'unknown',
@@ -1388,6 +1391,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
           value: {
             type: 'unknown',
@@ -1405,6 +1409,7 @@ export const schemaDict = {
           },
           rkey: {
             type: 'string',
+            format: 'record-key',
           },
         },
       },
@@ -1478,6 +1483,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -1548,6 +1554,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
         },
       },
@@ -1580,6 +1587,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
               },
               swapRecord: {
@@ -1705,6 +1713,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'The Record Key.',
+              format: 'record-key',
             },
             cid: {
               type: 'string',
@@ -1929,6 +1938,7 @@ export const schemaDict = {
               },
               rkey: {
                 type: 'string',
+                format: 'record-key',
                 description: 'The Record Key.',
                 maxLength: 512,
               },
@@ -3347,6 +3357,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
               },
             },
           },
@@ -3392,6 +3403,7 @@ export const schemaDict = {
             rkey: {
               type: 'string',
               description: 'Record Key',
+              format: 'record-key',
             },
             commit: {
               type: 'string',
@@ -3443,6 +3455,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description:
                 "The revision ('rev') of the repo to create a diff from.",
             },
@@ -3508,6 +3521,7 @@ export const schemaDict = {
               },
               rev: {
                 type: 'string',
+                format: 'tid',
                 description:
                   'Optional field, the current rev of the repo, if active=true',
               },
@@ -3541,6 +3555,7 @@ export const schemaDict = {
             },
             since: {
               type: 'string',
+              format: 'tid',
               description: 'Optional revision of the repo to list blobs since.',
             },
             limit: {
@@ -3647,6 +3662,7 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
           },
           active: {
             type: 'boolean',
@@ -3862,11 +3878,13 @@ export const schemaDict = {
           },
           rev: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event.',
           },
           since: {
             type: 'string',
+            format: 'tid',
             description:
               'The rev of the last emitted commit from this repo (if any).',
           },

--- a/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -68,6 +68,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface Create {
   $type?: 'com.atproto.repo.applyWrites#create'
   collection: string
+  /** NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility. */
   rkey?: string
   value: { [_ in string]: unknown }
 }

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -611,7 +611,7 @@ describe('crud operations', () => {
         },
         rkey: '..',
       }),
-    ).rejects.toThrow('record key can not be "." or ".."')
+    ).rejects.toThrow('Input/rkey must be a valid Record Key')
   })
 
   it('validates the record on write', async () => {


### PR DESCRIPTION
Depends on: https://github.com/bluesky-social/atproto/pull/2377

~We'd probably want to hold off on actually merging this until we've done some dev comms and let the specs and library support PRs sink in.~

Needs codegen.