### PR TITLE
Configurable catchall on xrpc-server

### DIFF
--- a/.changeset/lovely-parrots-talk.md
+++ b/.changeset/lovely-parrots-talk.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Add configurable catchall

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -72,7 +72,10 @@ export class Server {
       this.addLexicons(lexicons)
     }
     this.router.use(this.routes)
-    this.router.use('/xrpc/:methodId', this.catchall.bind(this))
+    this.router.use(
+      '/xrpc/:methodId',
+      opts?.catchall ?? this.catchall.bind(this),
+    )
     this.router.use(errorMiddleware)
     this.router.once('mount', (app: Application) => {
       this.enableStreamingOnListen(app)

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -8,8 +8,15 @@ import {
   ResponseTypeNames,
 } from '@atproto/xrpc'
 
+export type CatchallHandler = (
+  req: express.Request,
+  _res: express.Response,
+  next: express.NextFunction,
+) => unknown
+
 export type Options = {
   validateResponse?: boolean
+  catchall?: CatchallHandler
   payload?: {
     jsonLimit?: number
     blobLimit?: number


### PR DESCRIPTION
Add an option to xrpc-server for configuring the catchall logic for unspecified xrpc endpoints.