### PR TITLE
Appview: include like/repost/reply counts on post embed

### DIFF
--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -45,6 +45,9 @@
           "type": "array",
           "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
         },
+        "replyCount": { "type": "integer" },
+        "repostCount": { "type": "integer" },
+        "likeCount": { "type": "integer" },
         "embeds": {
           "type": "array",
           "items": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4561,6 +4561,15 @@ export const schemaDict = {
               ref: 'lex:com.atproto.label.defs#label',
             },
           },
+          replyCount: {
+            type: 'integer',
+          },
+          repostCount: {
+            type: 'integer',
+          },
+          likeCount: {
+            type: 'integer',
+          },
           embeds: {
             type: 'array',
             items: {

--- a/packages/api/src/client/types/app/bsky/embed/record.ts
+++ b/packages/api/src/client/types/app/bsky/embed/record.ts
@@ -62,6 +62,9 @@ export interface ViewRecord {
   /** The record data itself. */
   value: {}
   labels?: ComAtprotoLabelDefs.Label[]
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   embeds?: (
     | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -324,7 +324,11 @@ export class Hydrator {
       feedGenState,
       labelerState,
     ] = await Promise.all([
-      this.feed.getPostAggregates(refs),
+      this.feed.getPostAggregates([
+        ...refs,
+        ...postUrisLayer1.map(uriToRef), // supports aggregates on embed #viewRecords
+        ...postUrisLayer2.map(uriToRef),
+      ]),
       ctx.viewer ? this.feed.getPostViewerStates(refs, ctx.viewer) : undefined,
       this.label.getLabelsForSubjects(allPostUris, ctx.labelers),
       this.hydratePostBlocks(posts),
@@ -842,4 +846,8 @@ const actionTakedownLabels = <T>(
       hydrationMap.set(key, null)
     }
   }
+}
+
+const uriToRef = (uri: string): ItemRef => {
+  return { uri }
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4561,6 +4561,15 @@ export const schemaDict = {
               ref: 'lex:com.atproto.label.defs#label',
             },
           },
+          replyCount: {
+            type: 'integer',
+          },
+          repostCount: {
+            type: 'integer',
+          },
+          likeCount: {
+            type: 'integer',
+          },
           embeds: {
             type: 'array',
             items: {

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/record.ts
@@ -62,6 +62,9 @@ export interface ViewRecord {
   /** The record data itself. */
   value: {}
   labels?: ComAtprotoLabelDefs.Label[]
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   embeds?: (
     | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -753,6 +753,9 @@ export class Views {
       author: postView.author,
       value: postView.record,
       labels: postView.labels,
+      likeCount: postView.likeCount,
+      replyCount: postView.replyCount,
+      repostCount: postView.repostCount,
       indexedAt: postView.indexedAt,
       embeds: depth > 1 ? undefined : postView.embed ? [postView.embed] : [],
     }

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -485,6 +485,9 @@ Array [
             "embeds": Array [],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(2)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -740,6 +743,9 @@ Array [
                   "cid": "cids(3)",
                   "indexedAt": "1970-01-01T00:00:00.000Z",
                   "labels": Array [],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(2)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -756,6 +762,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(5)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -948,6 +957,9 @@ Array [
             "embeds": Array [],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(3)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -1232,6 +1244,9 @@ Array [
             "embeds": Array [],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(5)",
             "value": Object {
               "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
@@ -238,6 +238,9 @@ Array [
                     "cid": "cids(8)",
                     "indexedAt": "1970-01-01T00:00:00.000Z",
                     "labels": Array [],
+                    "likeCount": 2,
+                    "replyCount": 0,
+                    "repostCount": 0,
                     "uri": "record(9)",
                     "value": Object {
                       "$type": "app.bsky.feed.post",
@@ -285,6 +288,9 @@ Array [
               ],
               "indexedAt": "1970-01-01T00:00:00.000Z",
               "labels": Array [],
+              "likeCount": 0,
+              "replyCount": 0,
+              "repostCount": 1,
               "uri": "record(7)",
               "value": Object {
                 "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -242,6 +242,9 @@ Array [
                 "cid": "cids(8)",
                 "indexedAt": "1970-01-01T00:00:00.000Z",
                 "labels": Array [],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(9)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -289,6 +292,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(7)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -754,6 +760,9 @@ Array [
                   "cid": "cids(4)",
                   "indexedAt": "1970-01-01T00:00:00.000Z",
                   "labels": Array [],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(2)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -770,6 +779,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(1)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -1042,6 +1054,9 @@ Array [
             "embeds": Array [],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(2)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -1428,6 +1443,9 @@ Array [
                   "cid": "cids(9)",
                   "indexedAt": "1970-01-01T00:00:00.000Z",
                   "labels": Array [],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(11)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -1444,6 +1462,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(10)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -1798,6 +1819,9 @@ Array [
                 "cid": "cids(8)",
                 "indexedAt": "1970-01-01T00:00:00.000Z",
                 "labels": Array [],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(10)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -1845,6 +1869,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(9)",
           "value": Object {
             "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
@@ -66,6 +66,9 @@ Object {
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(3)",
           "value": Object {
             "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
@@ -66,6 +66,9 @@ Object {
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(3)",
           "value": Object {
             "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
@@ -420,6 +420,9 @@ Array [
                 "cid": "cids(8)",
                 "indexedAt": "1970-01-01T00:00:00.000Z",
                 "labels": Array [],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(10)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -467,6 +470,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(9)",
           "value": Object {
             "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
@@ -182,6 +182,9 @@ Array [
           "embeds": Array [],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(3)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -311,6 +314,9 @@ Array [
                 "cid": "cids(4)",
                 "indexedAt": "1970-01-01T00:00:00.000Z",
                 "labels": Array [],
+                "likeCount": 0,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(3)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -327,6 +333,9 @@ Array [
         ],
         "indexedAt": "1970-01-01T00:00:00.000Z",
         "labels": Array [],
+        "likeCount": 2,
+        "replyCount": 0,
+        "repostCount": 0,
         "uri": "record(6)",
         "value": Object {
           "$type": "app.bsky.feed.post",

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -333,6 +333,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(6)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -1205,6 +1208,9 @@ Array [
                 "val": "test-label-3",
               },
             ],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(15)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -1706,6 +1712,9 @@ Array [
                       "val": "test-label-3",
                     },
                   ],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(11)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -1730,6 +1739,9 @@ Array [
               "val": "test-label-3",
             },
           ],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(8)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -2363,6 +2375,9 @@ Array [
                     "val": "test-label-3",
                   },
                 ],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(8)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -2410,6 +2425,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(7)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -2615,6 +2633,9 @@ Array [
                       "val": "test-label-3",
                     },
                   ],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(11)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -2639,6 +2660,9 @@ Array [
               "val": "test-label-3",
             },
           ],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(8)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -2804,6 +2828,9 @@ Array [
                 "val": "test-label-3",
               },
             ],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(11)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -3054,6 +3081,9 @@ Array [
                       "val": "test-label-3",
                     },
                   ],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(4)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -3078,6 +3108,9 @@ Array [
               "val": "test-label-3",
             },
           ],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(2)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -3728,6 +3761,9 @@ Array [
                     "val": "test-label-3",
                   },
                 ],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(2)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -3775,6 +3811,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(0)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -3966,6 +4005,9 @@ Array [
                 "val": "test-label-3",
               },
             ],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(4)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -4215,6 +4257,9 @@ Array [
                       "val": "test-label-3",
                     },
                   ],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(2)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -4239,6 +4284,9 @@ Array [
               "val": "test-label-3",
             },
           ],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(1)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -4715,6 +4763,9 @@ Array [
                     "val": "test-label-3",
                   },
                 ],
+                "likeCount": 2,
+                "replyCount": 0,
+                "repostCount": 0,
                 "uri": "record(1)",
                 "value": Object {
                   "$type": "app.bsky.feed.post",
@@ -4762,6 +4813,9 @@ Array [
           ],
           "indexedAt": "1970-01-01T00:00:00.000Z",
           "labels": Array [],
+          "likeCount": 0,
+          "replyCount": 0,
+          "repostCount": 1,
           "uri": "record(0)",
           "value": Object {
             "$type": "app.bsky.feed.post",
@@ -4925,6 +4979,9 @@ Array [
                 "val": "test-label-3",
               },
             ],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(2)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -5591,6 +5648,9 @@ Array [
                       "val": "test-label-3",
                     },
                   ],
+                  "likeCount": 0,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(12)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -5615,6 +5675,9 @@ Array [
               "val": "test-label-3",
             },
           ],
+          "likeCount": 2,
+          "replyCount": 0,
+          "repostCount": 0,
           "uri": "record(11)",
           "value": Object {
             "$type": "app.bsky.feed.post",

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4561,6 +4561,15 @@ export const schemaDict = {
               ref: 'lex:com.atproto.label.defs#label',
             },
           },
+          replyCount: {
+            type: 'integer',
+          },
+          repostCount: {
+            type: 'integer',
+          },
+          likeCount: {
+            type: 'integer',
+          },
           embeds: {
             type: 'array',
             items: {

--- a/packages/ozone/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/embed/record.ts
@@ -62,6 +62,9 @@ export interface ViewRecord {
   /** The record data itself. */
   value: {}
   labels?: ComAtprotoLabelDefs.Label[]
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   embeds?: (
     | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4561,6 +4561,15 @@ export const schemaDict = {
               ref: 'lex:com.atproto.label.defs#label',
             },
           },
+          replyCount: {
+            type: 'integer',
+          },
+          repostCount: {
+            type: 'integer',
+          },
+          likeCount: {
+            type: 'integer',
+          },
           embeds: {
             type: 'array',
             items: {

--- a/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/record.ts
@@ -62,6 +62,9 @@ export interface ViewRecord {
   /** The record data itself. */
   value: {}
   labels?: ComAtprotoLabelDefs.Label[]
+  replyCount?: number
+  repostCount?: number
+  likeCount?: number
   embeds?: (
     | AppBskyEmbedImages.View
     | AppBskyEmbedExternal.View

--- a/packages/pds/tests/proxied/__snapshots__/feedgen.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/feedgen.test.ts.snap
@@ -113,6 +113,9 @@ Object {
               "embeds": Array [],
               "indexedAt": "1970-01-01T00:00:00.000Z",
               "labels": Array [],
+              "likeCount": 0,
+              "replyCount": 0,
+              "repostCount": 0,
               "uri": "record(5)",
               "value": Object {
                 "$type": "app.bsky.feed.post",

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -1040,6 +1040,9 @@ Object {
                   "cid": "cids(8)",
                   "indexedAt": "1970-01-01T00:00:00.000Z",
                   "labels": Array [],
+                  "likeCount": 2,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(9)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -1087,6 +1090,9 @@ Object {
             ],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 1,
             "uri": "record(7)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -1392,6 +1398,9 @@ Object {
             "embeds": Array [],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(0)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -1804,6 +1813,9 @@ Object {
                     "cid": "cids(9)",
                     "indexedAt": "1970-01-01T00:00:00.000Z",
                     "labels": Array [],
+                    "likeCount": 0,
+                    "replyCount": 0,
+                    "repostCount": 0,
                     "uri": "record(11)",
                     "value": Object {
                       "$type": "app.bsky.feed.post",
@@ -1820,6 +1832,9 @@ Object {
             ],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 2,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(8)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -2422,6 +2437,9 @@ Object {
                   "cid": "cids(7)",
                   "indexedAt": "1970-01-01T00:00:00.000Z",
                   "labels": Array [],
+                  "likeCount": 2,
+                  "replyCount": 0,
+                  "repostCount": 0,
                   "uri": "record(8)",
                   "value": Object {
                     "$type": "app.bsky.feed.post",
@@ -2469,6 +2487,9 @@ Object {
             ],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 0,
+            "replyCount": 0,
+            "repostCount": 1,
             "uri": "record(7)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -2665,6 +2686,9 @@ Object {
                     "cid": "cids(9)",
                     "indexedAt": "1970-01-01T00:00:00.000Z",
                     "labels": Array [],
+                    "likeCount": 0,
+                    "replyCount": 0,
+                    "repostCount": 0,
                     "uri": "record(11)",
                     "value": Object {
                       "$type": "app.bsky.feed.post",
@@ -2681,6 +2705,9 @@ Object {
             ],
             "indexedAt": "1970-01-01T00:00:00.000Z",
             "labels": Array [],
+            "likeCount": 2,
+            "replyCount": 0,
+            "repostCount": 0,
             "uri": "record(8)",
             "value": Object {
               "$type": "app.bsky.feed.post",
@@ -2845,6 +2872,9 @@ Object {
               "embeds": Array [],
               "indexedAt": "1970-01-01T00:00:00.000Z",
               "labels": Array [],
+              "likeCount": 0,
+              "replyCount": 0,
+              "repostCount": 0,
               "uri": "record(11)",
               "value": Object {
                 "$type": "app.bsky.feed.post",


### PR DESCRIPTION
This adds the `likeCount`, `repostCount`, `replyCount` fields to the `#viewRecord` embed type.  We may continue to cater the `#viewRecord` lexicon to post embeds, bringing it more in line with list, feedgen, and labeler embed views.