### PR TITLE
lexicons: add more search parameters

### DIFF
--- a/lexicons/app/bsky/actor/searchActors.json
+++ b/lexicons/app/bsky/actor/searchActors.json
@@ -16,6 +16,11 @@
             "type": "string",
             "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
           },
+          "account": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/actor/searchActors.json
+++ b/lexicons/app/bsky/actor/searchActors.json
@@ -16,11 +16,6 @@
             "type": "string",
             "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
           },
-          "viewer": {
-            "type": "string",
-            "format": "did",
-            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."
-          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/actor/searchActors.json
+++ b/lexicons/app/bsky/actor/searchActors.json
@@ -16,7 +16,7 @@
             "type": "string",
             "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
           },
-          "account": {
+          "viewer": {
             "type": "string",
             "format": "did",
             "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."

--- a/lexicons/app/bsky/actor/searchActorsTypeahead.json
+++ b/lexicons/app/bsky/actor/searchActorsTypeahead.json
@@ -16,7 +16,7 @@
             "type": "string",
             "description": "Search query prefix; not a full query string."
           },
-          "account": {
+          "viewer": {
             "type": "string",
             "format": "did",
             "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."

--- a/lexicons/app/bsky/actor/searchActorsTypeahead.json
+++ b/lexicons/app/bsky/actor/searchActorsTypeahead.json
@@ -16,6 +16,11 @@
             "type": "string",
             "description": "Search query prefix; not a full query string."
           },
+          "account": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -27,7 +27,7 @@
           "until": {
             "type": "string",
             "format": "datetime",
-            "description": "Filter results for posts before the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
           },
           "mentions": {
             "type": "string",

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -16,7 +16,8 @@
           "sort": {
             "type": "string",
             "knownValues": ["top", "latest"],
-            "description": "Specifies the ranking order of results. Default behavior is 'latest'."
+            "default": "latest",
+            "description": "Specifies the ranking order of results."
           },
           "since": {
             "type": "string",
@@ -52,6 +53,12 @@
             "type": "string",
             "format": "language",
             "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
+          },
+          "tag": {
+            "type": "string",
+            "maxLength": 640,
+            "maxGraphemes": 64,
+            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix."
           },
           "limit": {
             "type": "integer",

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -52,10 +52,13 @@
             "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
           },
           "tag": {
-            "type": "string",
-            "maxLength": 640,
-            "maxGraphemes": 64,
-            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix."
+            "type": "array",
+            "items": {
+                "type": "string",
+                "maxLength": 640,
+                "maxGraphemes": 64
+            },
+            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching."
           },
           "limit": {
             "type": "integer",

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -13,6 +13,46 @@
             "type": "string",
             "description": "Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
           },
+          "sort": {
+            "type": "string",
+            "knownValues": ["top", "latest"],
+            "description": "Specifies the ranking order of results. Default behavior is 'latest'."
+          },
+          "since": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+          },
+          "until": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Filter results for posts before the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+          },
+          "mentions": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions."
+          },
+          "author": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "Filter to posts by the given account. Handles are resolved to DID before query-time."
+          },
+          "lang": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts in the given language. Expected to be based on post language field, though server may override language detection."
+          },
+          "domain": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization."
+          },
+          "url": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -54,9 +54,9 @@
           "tag": {
             "type": "array",
             "items": {
-                "type": "string",
-                "maxLength": 640,
-                "maxGraphemes": 64
+              "type": "string",
+              "maxLength": 640,
+              "maxGraphemes": 64
             },
             "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching."
           },

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -46,12 +46,11 @@
           },
           "domain": {
             "type": "string",
-            "format": "language",
             "description": "Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization."
           },
           "url": {
             "type": "string",
-            "format": "language",
+            "format": "uri",
             "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
           },
           "tag": {

--- a/lexicons/app/bsky/feed/searchPosts.json
+++ b/lexicons/app/bsky/feed/searchPosts.json
@@ -21,13 +21,11 @@
           },
           "since": {
             "type": "string",
-            "format": "datetime",
-            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD)."
           },
           "until": {
             "type": "string",
-            "format": "datetime",
-            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD)."
           },
           "mentions": {
             "type": "string",

--- a/lexicons/app/bsky/unspecced/searchActorsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchActorsSkeleton.json
@@ -13,6 +13,11 @@
             "type": "string",
             "description": "Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax."
           },
+          "account": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."
+          },
           "typeahead": {
             "type": "boolean",
             "description": "If true, acts as fast/simple 'typeahead' query."

--- a/lexicons/app/bsky/unspecced/searchActorsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchActorsSkeleton.json
@@ -13,7 +13,7 @@
             "type": "string",
             "description": "Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax."
           },
-          "account": {
+          "viewer": {
             "type": "string",
             "format": "did",
             "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -27,7 +27,7 @@
           "until": {
             "type": "string",
             "format": "datetime",
-            "description": "Filter results for posts before the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
           },
           "mentions": {
             "type": "string",

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -52,10 +52,13 @@
             "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
           },
           "tag": {
-            "type": "string",
-            "maxLength": 640,
-            "maxGraphemes": 64,
-            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix."
+            "type": "array",
+            "items": {
+                "type": "string",
+                "maxLength": 640,
+                "maxGraphemes": 64
+            },
+            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching."
           },
           "limit": {
             "type": "integer",

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -13,6 +13,46 @@
             "type": "string",
             "description": "Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
           },
+          "sort": {
+            "type": "string",
+            "knownValues": ["top", "latest"],
+            "description": "Specifies the ranking order of results. Default behavior is 'latest'."
+          },
+          "since": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+          },
+          "until": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Filter results for posts before the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+          },
+          "mentions": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions."
+          },
+          "author": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "Filter to posts by the given account. Handles are resolved to DID before query-time."
+          },
+          "lang": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts in the given language. Expected to be based on post language field, though server may override language detection."
+          },
+          "domain": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization."
+          },
+          "url": {
+            "type": "string",
+            "format": "language",
+            "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -60,6 +60,11 @@
             },
             "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching."
           },
+          "viewer": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries."
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -54,9 +54,9 @@
           "tag": {
             "type": "array",
             "items": {
-                "type": "string",
-                "maxLength": 640,
-                "maxGraphemes": 64
+              "type": "string",
+              "maxLength": 640,
+              "maxGraphemes": 64
             },
             "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching."
           },

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -21,13 +21,11 @@
           },
           "since": {
             "type": "string",
-            "format": "datetime",
-            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD)."
           },
           "until": {
             "type": "string",
-            "format": "datetime",
-            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'."
+            "description": "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD)."
           },
           "mentions": {
             "type": "string",

--- a/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/searchPostsSkeleton.json
@@ -16,7 +16,8 @@
           "sort": {
             "type": "string",
             "knownValues": ["top", "latest"],
-            "description": "Specifies the ranking order of results. Default behavior is 'latest'."
+            "default": "latest",
+            "description": "Specifies the ranking order of results."
           },
           "since": {
             "type": "string",
@@ -45,13 +46,18 @@
           },
           "domain": {
             "type": "string",
-            "format": "language",
             "description": "Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization."
           },
           "url": {
             "type": "string",
-            "format": "language",
+            "format": "uri",
             "description": "Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching."
+          },
+          "tag": {
+            "type": "string",
+            "maxLength": 640,
+            "maxGraphemes": 64,
+            "description": "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix."
           },
           "limit": {
             "type": "integer",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4307,6 +4307,12 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6167,6 +6173,61 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
             },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -7852,6 +7913,12 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             typeahead: {
               type: 'boolean',
               description: "If true, acts as fast/simple 'typeahead' query.",
@@ -7916,6 +7983,67 @@ export const schemaDict = {
               type: 'string',
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
+            },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                "DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries.",
             },
             limit: {
               type: 'integer',

--- a/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -13,6 +13,8 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   limit?: number
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/searchPosts.ts
+++ b/packages/api/src/client/types/app/bsky/feed/searchPosts.ts
@@ -11,6 +11,24 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort?: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
   limit?: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/api/src/client/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -11,6 +11,8 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax. */
   q: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   /** If true, acts as fast/simple 'typeahead' query. */
   typeahead?: boolean
   limit?: number

--- a/packages/api/src/client/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -11,6 +11,26 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort?: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries. */
+  viewer?: string
   limit?: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4307,6 +4307,12 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6167,6 +6173,61 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
             },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -7852,6 +7913,12 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             typeahead: {
               type: 'boolean',
               description: "If true, acts as fast/simple 'typeahead' query.",
@@ -7916,6 +7983,67 @@ export const schemaDict = {
               type: 'string',
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
+            },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                "DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries.",
             },
             limit: {
               type: 'integer',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,6 +14,8 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   limit: number
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -12,6 +12,24 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -12,6 +12,8 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax. */
   q: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   /** If true, acts as fast/simple 'typeahead' query. */
   typeahead?: boolean
   limit: number

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -12,6 +12,26 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries. */
+  viewer?: string
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4307,6 +4307,12 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6167,6 +6173,61 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
             },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -7852,6 +7913,12 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             typeahead: {
               type: 'boolean',
               description: "If true, acts as fast/simple 'typeahead' query.",
@@ -7916,6 +7983,67 @@ export const schemaDict = {
               type: 'string',
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
+            },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                "DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries.",
             },
             limit: {
               type: 'integer',

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,6 +14,8 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   limit: number
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -12,6 +12,24 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -12,6 +12,8 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax. */
   q: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   /** If true, acts as fast/simple 'typeahead' query. */
   typeahead?: boolean
   limit: number

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -12,6 +12,26 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries. */
+  viewer?: string
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4307,6 +4307,12 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -6167,6 +6173,61 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
             },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
             limit: {
               type: 'integer',
               minimum: 1,
@@ -7852,6 +7913,12 @@ export const schemaDict = {
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax.',
             },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
+            },
             typeahead: {
               type: 'boolean',
               description: "If true, acts as fast/simple 'typeahead' query.",
@@ -7916,6 +7983,67 @@ export const schemaDict = {
               type: 'string',
               description:
                 'Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.',
+            },
+            sort: {
+              type: 'string',
+              knownValues: ['top', 'latest'],
+              default: 'latest',
+              description: 'Specifies the ranking order of results.',
+            },
+            since: {
+              type: 'string',
+              description:
+                "Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).",
+            },
+            until: {
+              type: 'string',
+              description:
+                "Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).",
+            },
+            mentions: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.',
+            },
+            author: {
+              type: 'string',
+              format: 'at-identifier',
+              description:
+                'Filter to posts by the given account. Handles are resolved to DID before query-time.',
+            },
+            lang: {
+              type: 'string',
+              format: 'language',
+              description:
+                'Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.',
+            },
+            domain: {
+              type: 'string',
+              description:
+                'Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.',
+            },
+            url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.',
+            },
+            tag: {
+              type: 'array',
+              items: {
+                type: 'string',
+                maxLength: 640,
+                maxGraphemes: 64,
+              },
+              description:
+                "Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.",
+            },
+            viewer: {
+              type: 'string',
+              format: 'did',
+              description:
+                "DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries.",
             },
             limit: {
               type: 'integer',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,6 +14,8 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   limit: number
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -12,6 +12,24 @@ import * as AppBskyFeedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -12,6 +12,8 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax. */
   q: string
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
+  viewer?: string
   /** If true, acts as fast/simple 'typeahead' query. */
   typeahead?: boolean
   limit: number

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -12,6 +12,26 @@ import * as AppBskyUnspeccedDefs from './defs'
 export interface QueryParams {
   /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q: string
+  /** Specifies the ranking order of results. */
+  sort: 'top' | 'latest' | (string & {})
+  /** Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+  since?: string
+  /** Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD). */
+  until?: string
+  /** Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions. */
+  mentions?: string
+  /** Filter to posts by the given account. Handles are resolved to DID before query-time. */
+  author?: string
+  /** Filter to posts in the given language. Expected to be based on post language field, though server may override language detection. */
+  lang?: string
+  /** Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization. */
+  domain?: string
+  /** Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching. */
+  url?: string
+  /** Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching. */
+  tag?: string[]
+  /** DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries. */
+  viewer?: string
   limit: number
   /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
   cursor?: string


### PR DESCRIPTION
Let's get agreement on the params/lexicon structure, then might need to hand this off to dan/devin to implement the query param pass-through in the appview typescript code (or I can try to bite that off).

Lexicon style notes:

- using full tokens/refs for things like sort-order felt a bit heavy? on the other hand would feel more lexicon-idiomatic
- I didn't specify `default` even for fields which have a clear default. I don't think we've used default much? and i'm not sure if that would result in the query-param always getting set by client, or only interpreted on backend. I guess writing this now I would lean towards making the defaults explicit
- in theory, more of these params could be arrays instead of single string values. that would help things like bots and analysis tools, but could make queries expensive, and API a bit less ergonomic in languages like golang. would always be easy to add plural version ("langs") in the future? hrm.

There are a couplbut I guess particularly with query params it would make sense.
e additional post search params we might want to add, but might require more palomar work so haven't added yet:

- `adult` (boolean?): whether to filter out posts with adult-content images. kind of redundant with labeler header, but can be more efficient to do this in the search index itself
- `replies` (boolean?): whether to include reply posts, or only top-level posts
- `media` (string?): eg, no-images, only-images, only-video-embed