### PR TITLE
getSuggestionsSkeleton lexicon

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -114,13 +114,6 @@
         "followedBy": { "type": "string", "format": "at-uri" }
       }
     },
-    "skeletonActor": {
-      "type": "object",
-      "required": ["did"],
-      "properties": {
-        "did": { "type": "string", "format": "did" }
-      }
-    },
     "preferences": {
       "type": "array",
       "items": {

--- a/lexicons/app/bsky/unspecced/getSuggestionsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getSuggestionsSkeleton.json
@@ -33,7 +33,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#skeletonActor"
+                "ref": "app.bsky.unspecced.defs#skeletonSearchActor"
               }
             }
           }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3799,16 +3799,6 @@ export const schemaDict = {
           },
         },
       },
-      skeletonActor: {
-        type: 'object',
-        required: ['did'],
-        properties: {
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-        },
-      },
       preferences: {
         type: 'array',
         items: {
@@ -7900,7 +7890,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#skeletonActor',
+                  ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
               },
             },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -128,23 +128,6 @@ export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
 }
 
-export interface SkeletonActor {
-  did: string
-  [k: string]: unknown
-}
-
-export function isSkeletonActor(v: unknown): v is SkeletonActor {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#skeletonActor'
-  )
-}
-
-export function validateSkeletonActor(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#skeletonActor', v)
-}
-
 export type Preferences = (
   | AdultContentPref
   | ContentLabelPref

--- a/packages/api/src/client/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -6,7 +6,7 @@ import { ValidationResult, BlobRef } from '@atproto/lexicon'
 import { isObj, hasProp } from '../../../../util'
 import { lexicons } from '../../../../lexicons'
 import { CID } from 'multiformats/cid'
-import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyUnspeccedDefs from './defs'
 
 export interface QueryParams {
   /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
@@ -19,7 +19,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.SkeletonActor[]
+  actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3799,16 +3799,6 @@ export const schemaDict = {
           },
         },
       },
-      skeletonActor: {
-        type: 'object',
-        required: ['did'],
-        properties: {
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-        },
-      },
       preferences: {
         type: 'array',
         items: {
@@ -7900,7 +7890,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#skeletonActor',
+                  ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
               },
             },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -128,23 +128,6 @@ export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
 }
 
-export interface SkeletonActor {
-  did: string
-  [k: string]: unknown
-}
-
-export function isSkeletonActor(v: unknown): v is SkeletonActor {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#skeletonActor'
-  )
-}
-
-export function validateSkeletonActor(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#skeletonActor', v)
-}
-
 export type Preferences = (
   | AdultContentPref
   | ContentLabelPref

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -7,7 +7,7 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyUnspeccedDefs from './defs'
 
 export interface QueryParams {
   /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
@@ -20,7 +20,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.SkeletonActor[]
+  actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3799,16 +3799,6 @@ export const schemaDict = {
           },
         },
       },
-      skeletonActor: {
-        type: 'object',
-        required: ['did'],
-        properties: {
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-        },
-      },
       preferences: {
         type: 'array',
         items: {
@@ -7900,7 +7890,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#skeletonActor',
+                  ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
               },
             },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -128,23 +128,6 @@ export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
 }
 
-export interface SkeletonActor {
-  did: string
-  [k: string]: unknown
-}
-
-export function isSkeletonActor(v: unknown): v is SkeletonActor {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#skeletonActor'
-  )
-}
-
-export function validateSkeletonActor(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#skeletonActor', v)
-}
-
 export type Preferences = (
   | AdultContentPref
   | ContentLabelPref

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -7,7 +7,7 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyUnspeccedDefs from './defs'
 
 export interface QueryParams {
   /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
@@ -20,7 +20,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.SkeletonActor[]
+  actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3799,16 +3799,6 @@ export const schemaDict = {
           },
         },
       },
-      skeletonActor: {
-        type: 'object',
-        required: ['did'],
-        properties: {
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-        },
-      },
       preferences: {
         type: 'array',
         items: {
@@ -7900,7 +7890,7 @@ export const schemaDict = {
                 type: 'array',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.actor.defs#skeletonActor',
+                  ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
               },
             },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -128,23 +128,6 @@ export function validateViewerState(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#viewerState', v)
 }
 
-export interface SkeletonActor {
-  did: string
-  [k: string]: unknown
-}
-
-export function isSkeletonActor(v: unknown): v is SkeletonActor {
-  return (
-    isObj(v) &&
-    hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#skeletonActor'
-  )
-}
-
-export function validateSkeletonActor(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#skeletonActor', v)
-}
-
 export type Preferences = (
   | AdultContentPref
   | ContentLabelPref

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -7,7 +7,7 @@ import { lexicons } from '../../../../lexicons'
 import { isObj, hasProp } from '../../../../util'
 import { CID } from 'multiformats/cid'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import * as AppBskyActorDefs from '../actor/defs'
+import * as AppBskyUnspeccedDefs from './defs'
 
 export interface QueryParams {
   /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
@@ -20,7 +20,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   cursor?: string
-  actors: AppBskyActorDefs.SkeletonActor[]
+  actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
   [k: string]: unknown
 }
 


### PR DESCRIPTION
Adds a schema for `getSuggestionsSkeleton`

Return values are of type `app.bsky.actor.defs#skeletonActor` which is just a wrapper object around `did` but leaves us room to add some annotations in the future if we need to