### PR TITLE
Appview: support new post search params, viewer context in search

### DIFF
--- a/.changeset/tiny-hornets-vanish.md
+++ b/.changeset/tiny-hornets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Support for upcoming post search params

--- a/lexicons/app/bsky/actor/searchActorsTypeahead.json
+++ b/lexicons/app/bsky/actor/searchActorsTypeahead.json
@@ -16,11 +16,6 @@
             "type": "string",
             "description": "Search query prefix; not a full query string."
           },
-          "viewer": {
-            "type": "string",
-            "format": "did",
-            "description": "DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking."
-          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4307,12 +4307,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
-            viewer: {
-              type: 'string',
-              format: 'did',
-              description:
-                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
-            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -13,8 +13,6 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
-  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
-  viewer?: string
   limit?: number
 }
 

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -57,6 +57,7 @@ const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
         q: term,
         cursor: params.cursor,
         limit: params.limit,
+        viewer: params.hydrateCtx.viewer ?? undefined,
       })
     return {
       dids: res.actors.map(({ did }) => did),

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -56,6 +56,7 @@ const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
         typeahead: true,
         q: term,
         limit: params.limit,
+        viewer: params.hydrateCtx.viewer ?? undefined,
       })
     return {
       dids: res.actors.map(({ did }) => did),

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -50,6 +50,16 @@ const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
         q: params.q,
         cursor: params.cursor,
         limit: params.limit,
+        author: params.author,
+        domain: params.domain,
+        lang: params.lang,
+        mentions: params.mentions,
+        since: params.since,
+        sort: params.sort,
+        tag: params.tag,
+        until: params.until,
+        url: params.url,
+        viewer: params.hydrateCtx.viewer ?? undefined,
       })
     return {
       posts: res.posts.map(({ uri }) => uri),

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4307,12 +4307,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
-            viewer: {
-              type: 'string',
-              format: 'did',
-              description:
-                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
-            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,8 +14,6 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
-  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
-  viewer?: string
   limit: number
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4307,12 +4307,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
-            viewer: {
-              type: 'string',
-              format: 'did',
-              description:
-                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
-            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,8 +14,6 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
-  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
-  viewer?: string
   limit: number
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4307,12 +4307,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
             },
-            viewer: {
-              type: 'string',
-              format: 'did',
-              description:
-                'DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.',
-            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -14,8 +14,6 @@ export interface QueryParams {
   term?: string
   /** Search query prefix; not a full query string. */
   q?: string
-  /** DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking. */
-  viewer?: string
   limit: number
 }
 


### PR DESCRIPTION
Three changes here in followup to #2396:
 - removes the unreleased `viewer` parameter from `app.bsky.actor.searchActorsTypeahead`.
 - passes through upcoming post search parameters to search service.
 - passes through viewer context to search service.