### PR TITLE
Add `primaryAlgoPrefs` lex and `setPrimaryAlgorithm` method

### DIFF
--- a/.changeset/bright-actors-shout.md
+++ b/.changeset/bright-actors-shout.md
@@ -2,4 +2,4 @@
 "@atproto/api": patch
 ---
 
-Adds `homeAlgoPref` lexicons and related method to `BskyAgent`
+Adds `primaryAlgoPref` lexicons and `setPrimaryAlgorithm` method to `BskyAgent`

--- a/.changeset/bright-actors-shout.md
+++ b/.changeset/bright-actors-shout.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Adds `homeAlgoPref` lexicons and related method to `BskyAgent`

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -128,7 +128,7 @@
           "#interestsPref",
           "#mutedWordsPref",
           "#hiddenPostsPref",
-          "#homeAlgoPref"
+          "#primaryAlgoPref"
         ]
       }
     },
@@ -188,7 +188,7 @@
         }
       }
     },
-    "homeAlgoPref": {
+    "primaryAlgoPref": {
       "type": "object",
       "properties": {
         "enabled": {

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -127,7 +127,8 @@
           "#threadViewPref",
           "#interestsPref",
           "#mutedWordsPref",
-          "#hiddenPostsPref"
+          "#hiddenPostsPref",
+          "#homeAlgoPref"
         ]
       }
     },
@@ -184,6 +185,19 @@
           "type": "string",
           "format": "datetime",
           "description": "The birth date of account owner."
+        }
+      }
+    },
+    "homeAlgoPref": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
         }
       }
     },

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -190,7 +190,6 @@
     },
     "homeAlgoPref": {
       "type": "object",
-      "required": ["enabled"],
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -12,6 +12,7 @@ import {
   BskyFeedViewPreference,
   BskyThreadViewPreference,
   BskyInterestsPreference,
+  BskyHomeAlgoPreference,
 } from './types'
 import {
   InterpretedLabelValueDefinition,
@@ -890,6 +891,33 @@ export class BskyAgent extends AtpAgent {
 
   async unhidePost(postUri: string) {
     await updateHiddenPost(this, postUri, 'unhide')
+  }
+
+  async setHomeAlgoPref(pref: Partial<BskyHomeAlgoPreference>) {
+    await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
+      const existing = prefs.findLast(
+        (pref) =>
+          AppBskyActorDefs.isHomeAlgoPref(pref) &&
+          AppBskyActorDefs.validateHomeAlgoPref(pref).success,
+      )
+
+      let next: BskyHomeAlgoPreference = { enabled: undefined }
+
+      if (existing && AppBskyActorDefs.isHomeAlgoPref(existing)) {
+        next = { ...existing }
+      }
+
+      if (pref.enabled !== undefined) {
+        next.enabled = pref.enabled
+      }
+      if (pref.uri) {
+        next.uri = pref.uri
+      }
+
+      return prefs
+        .filter((p) => !AppBskyActorDefs.isHomeAlgoPref(p))
+        .concat([{ ...next, $type: 'app.bsky.actor.defs#homeAlgoPref' }])
+    })
   }
 }
 

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -382,6 +382,9 @@ export class BskyAgent extends AtpAgent {
       interests: {
         tags: [],
       },
+      homeAlgo: {
+        enabled: undefined,
+      },
     }
     const res = await this.app.bsky.actor.getPreferences({})
     const labelPrefs: AppBskyActorDefs.ContentLabelPref[] = []
@@ -464,6 +467,12 @@ export class BskyAgent extends AtpAgent {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { $type, ...v } = pref
         prefs.moderationPrefs.hiddenPosts = v.items
+      } else if (
+        AppBskyActorDefs.isHomeAlgoPref(pref) &&
+        AppBskyActorDefs.validateHomeAlgoPref(pref).success
+      ) {
+        prefs.homeAlgo.enabled = pref.enabled
+        prefs.homeAlgo.uri = pref.uri
       }
     }
 

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -12,7 +12,6 @@ import {
   BskyFeedViewPreference,
   BskyThreadViewPreference,
   BskyInterestsPreference,
-  BskyHomeAlgoPreference,
 } from './types'
 import {
   InterpretedLabelValueDefinition,
@@ -383,7 +382,7 @@ export class BskyAgent extends AtpAgent {
       interests: {
         tags: [],
       },
-      homeAlgo: {
+      primaryAlgorithm: {
         enabled: undefined,
       },
     }
@@ -469,11 +468,11 @@ export class BskyAgent extends AtpAgent {
         const { $type, ...v } = pref
         prefs.moderationPrefs.hiddenPosts = v.items
       } else if (
-        AppBskyActorDefs.isHomeAlgoPref(pref) &&
-        AppBskyActorDefs.validateHomeAlgoPref(pref).success
+        AppBskyActorDefs.isPrimaryAlgoPref(pref) &&
+        AppBskyActorDefs.validatePrimaryAlgoPref(pref).success
       ) {
-        prefs.homeAlgo.enabled = pref.enabled
-        prefs.homeAlgo.uri = pref.uri
+        prefs.primaryAlgorithm.enabled = pref.enabled
+        prefs.primaryAlgorithm.uri = pref.uri
       }
     }
 
@@ -893,19 +892,19 @@ export class BskyAgent extends AtpAgent {
     await updateHiddenPost(this, postUri, 'unhide')
   }
 
-  async setHomeAlgoPref(pref: Partial<BskyHomeAlgoPreference>) {
+  async setPrimaryAlgorithm(pref: Partial<AppBskyActorDefs.PrimaryAlgoPref>) {
     const newPrefs = await updatePreferences(
       this,
       (prefs: AppBskyActorDefs.Preferences) => {
         const existing = prefs.findLast(
           (pref) =>
-            AppBskyActorDefs.isHomeAlgoPref(pref) &&
-            AppBskyActorDefs.validateHomeAlgoPref(pref).success,
+            AppBskyActorDefs.isPrimaryAlgoPref(pref) &&
+            AppBskyActorDefs.validatePrimaryAlgoPref(pref).success,
         )
 
-        let next: BskyHomeAlgoPreference = { enabled: undefined }
+        let next: AppBskyActorDefs.PrimaryAlgoPref = { enabled: undefined }
 
-        if (existing && AppBskyActorDefs.isHomeAlgoPref(existing)) {
+        if (existing && AppBskyActorDefs.isPrimaryAlgoPref(existing)) {
           next = { ...existing }
         }
 
@@ -917,19 +916,22 @@ export class BskyAgent extends AtpAgent {
         }
 
         return prefs
-          .filter((p) => !AppBskyActorDefs.isHomeAlgoPref(p))
-          .concat([{ ...next, $type: 'app.bsky.actor.defs#homeAlgoPref' }])
+          .filter((p) => !AppBskyActorDefs.isPrimaryAlgoPref(p))
+          .concat([{ ...next, $type: 'app.bsky.actor.defs#primaryAlgoPref' }])
       },
     )
 
-    const homeAlgoPref = newPrefs.findLast(
+    const primaryAlgorithm = newPrefs.findLast(
       (pref) =>
-        AppBskyActorDefs.isHomeAlgoPref(pref) &&
-        AppBskyActorDefs.validateHomeAlgoPref(pref).success,
+        AppBskyActorDefs.isPrimaryAlgoPref(pref) &&
+        AppBskyActorDefs.validatePrimaryAlgoPref(pref).success,
     )
 
-    if (homeAlgoPref && AppBskyActorDefs.isHomeAlgoPref(homeAlgoPref)) {
-      const { enabled, uri } = homeAlgoPref
+    if (
+      primaryAlgorithm &&
+      AppBskyActorDefs.isPrimaryAlgoPref(primaryAlgorithm)
+    ) {
+      const { enabled, uri } = primaryAlgorithm
       if (enabled && uri) {
         await this.removeSavedFeed(uri)
       }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3813,7 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
-            'lex:app.bsky.actor.defs#homeAlgoPref',
+            'lex:app.bsky.actor.defs#primaryAlgoPref',
           ],
         },
       },
@@ -3879,7 +3879,7 @@ export const schemaDict = {
           },
         },
       },
-      homeAlgoPref: {
+      primaryAlgoPref: {
         type: 'object',
         properties: {
           enabled: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3881,7 +3881,6 @@ export const schemaDict = {
       },
       homeAlgoPref: {
         type: 'object',
-        required: ['enabled'],
         properties: {
           enabled: {
             type: 'boolean',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3813,6 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#homeAlgoPref',
           ],
         },
       },
@@ -3875,6 +3876,19 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
             description: 'The birth date of account owner.',
+          },
+        },
+      },
+      homeAlgoPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -138,7 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
-  | HomeAlgoPref
+  | PrimaryAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -216,22 +216,22 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
 }
 
-export interface HomeAlgoPref {
+export interface PrimaryAlgoPref {
   enabled?: boolean
   uri?: string
   [k: string]: unknown
 }
 
-export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+export function isPrimaryAlgoPref(v: unknown): v is PrimaryAlgoPref {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+    v.$type === 'app.bsky.actor.defs#primaryAlgoPref'
   )
 }
 
-export function validateHomeAlgoPref(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
+export function validatePrimaryAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#primaryAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -138,6 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | HomeAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -213,6 +214,24 @@ export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
 
 export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}
+
+export interface HomeAlgoPref {
+  enabled: boolean
+  uri?: string
+  [k: string]: unknown
+}
+
+export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+  )
+}
+
+export function validateHomeAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -217,7 +217,7 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
 }
 
 export interface HomeAlgoPref {
-  enabled: boolean
+  enabled?: boolean
   uri?: string
   [k: string]: unknown
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -107,7 +107,7 @@ export interface BskyInterestsPreference {
 }
 
 export interface BskyHomeAlgoPreference {
-  enabled: boolean | undefined
+  enabled?: boolean
   uri?: string
   [key: string]: any
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -106,12 +106,6 @@ export interface BskyInterestsPreference {
   [key: string]: any
 }
 
-export interface BskyHomeAlgoPreference {
-  enabled?: boolean
-  uri?: string
-  [key: string]: any
-}
-
 /**
  * Bluesky preferences
  */
@@ -125,5 +119,5 @@ export interface BskyPreferences {
   moderationPrefs: ModerationPrefs
   birthDate: Date | undefined
   interests: BskyInterestsPreference
-  homeAlgo: BskyHomeAlgoPreference
+  primaryAlgorithm: AppBskyActorDefs.PrimaryAlgoPref
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -106,6 +106,12 @@ export interface BskyInterestsPreference {
   [key: string]: any
 }
 
+export interface HomeAlgo {
+  enabled: boolean | undefined
+  uri?: string
+  [key: string]: any
+}
+
 /**
  * Bluesky preferences
  */
@@ -119,4 +125,5 @@ export interface BskyPreferences {
   moderationPrefs: ModerationPrefs
   birthDate: Date | undefined
   interests: BskyInterestsPreference
+  homeAlgo: HomeAlgo
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -106,7 +106,7 @@ export interface BskyInterestsPreference {
   [key: string]: any
 }
 
-export interface HomeAlgo {
+export interface BskyHomeAlgoPreference {
   enabled: boolean | undefined
   uri?: string
   [key: string]: any
@@ -125,5 +125,5 @@ export interface BskyPreferences {
   moderationPrefs: ModerationPrefs
   birthDate: Date | undefined
   interests: BskyInterestsPreference
-  homeAlgo: HomeAlgo
+  homeAlgo: BskyHomeAlgoPreference
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -4,7 +4,7 @@ import {
   ComAtprotoRepoPutRecord,
   AppBskyActorProfile,
   DEFAULT_LABEL_SETTINGS,
-} from '..'
+} from '../src'
 
 describe('agent', () => {
   let network: TestNetworkNoAppView
@@ -1764,11 +1764,39 @@ describe('agent', () => {
         })
       })
 
-      it('getPreferences', async () => {
+      it('returns defaults', async () => {
         const prefs = await agent.getPreferences()
         expect('enabled' in prefs.homeAlgo).toBe(true)
+        expect('uri' in prefs.homeAlgo).toBe(false)
         expect(prefs.homeAlgo.enabled).toBe(undefined)
         expect(prefs.homeAlgo.uri).toBe(undefined)
+      })
+
+      it(`setHomeAlgoPref: enable with URI`, async () => {
+        await agent.setHomeAlgoPref({ enabled: true, uri: 'at://did:plc:fake' })
+        const prefs = await agent.getPreferences()
+        expect(prefs.homeAlgo.enabled).toBe(true)
+        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+      })
+
+      it(`setHomeAlgoPref: disable, retain URI`, async () => {
+        await agent.setHomeAlgoPref({ enabled: false })
+        const prefs = await agent.getPreferences()
+        expect(prefs.homeAlgo.enabled).toBe(false)
+        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+      })
+
+      it(`setHomeAlgoPref: cannot unset URI`, async () => {
+        await agent.setHomeAlgoPref({ uri: undefined })
+        const prefs = await agent.getPreferences()
+        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+      })
+
+      it(`setHomeAlgoPref: cannot unset enabled, only boolean`, async () => {
+        await agent.setHomeAlgoPref({ enabled: undefined })
+        const prefs = await agent.getPreferences()
+        // last valid value still set
+        expect(prefs.homeAlgo.enabled).toBe(false)
       })
     })
 

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1829,6 +1829,26 @@ describe('agent', () => {
           uri: 'at://bob.com/app.bsky.feed.generator/fake',
         })
       })
+
+      it(`setPrimaryAlgorithm: does not unset pinned feed if disabled`, async () => {
+        // we aim to guard against this in the client, but it's possible in 3p apps
+        await agent.setPrimaryAlgorithm({
+          enabled: true,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+        await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
+        await agent.setPrimaryAlgorithm({
+          enabled: false,
+        })
+        const prefs = await agent.getPreferences()
+        expect(prefs.feeds.pinned).toStrictEqual([
+          'at://bob.com/app.bsky.feed.generator/fake',
+        ])
+        expect(prefs.primaryAlgorithm).toStrictEqual({
+          enabled: false,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+      })
     })
 
     // end

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -261,6 +261,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setAdultContentEnabled(true)
@@ -289,6 +292,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -319,6 +325,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setContentLabelPref('misinfo', 'hide')
@@ -347,6 +356,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -380,6 +392,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -417,6 +432,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -452,6 +470,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -489,6 +510,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -525,6 +549,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -560,6 +587,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -603,6 +633,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -638,6 +671,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -675,6 +711,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: true })
@@ -711,6 +750,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: false })
@@ -746,6 +788,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -790,6 +835,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setThreadViewPrefs({ sort: 'random' })
@@ -832,6 +880,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -876,6 +927,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setInterestsPref({ tags: ['foo', 'bar'] })
@@ -918,6 +972,9 @@ describe('agent', () => {
         },
         interests: {
           tags: ['foo', 'bar'],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
     })
@@ -1080,6 +1137,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setAdultContentEnabled(false)
@@ -1124,6 +1184,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -1171,6 +1234,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.removeLabeler('did:plc:other')
@@ -1212,6 +1278,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -1255,6 +1324,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        homeAlgo: {
+          enabled: undefined,
+        },
       })
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
@@ -1296,6 +1368,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -1349,6 +1424,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        homeAlgo: {
+          enabled: undefined,
         },
       })
 
@@ -1671,6 +1749,26 @@ describe('agent', () => {
           'moderationPrefs.hiddenPosts',
           [],
         )
+      })
+    })
+
+    describe('home algo prefs', () => {
+      let agent: BskyAgent
+
+      beforeAll(async () => {
+        agent = new BskyAgent({ service: network.pds.url })
+        await agent.createAccount({
+          handle: 'user9.test',
+          email: 'user9@test.com',
+          password: 'password',
+        })
+      })
+
+      it('getPreferences', async () => {
+        const prefs = await agent.getPreferences()
+        expect('enabled' in prefs.homeAlgo).toBe(true)
+        expect(prefs.homeAlgo.enabled).toBe(undefined)
+        expect(prefs.homeAlgo.uri).toBe(undefined)
       })
     })
 

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1798,6 +1798,34 @@ describe('agent', () => {
         // last valid value still set
         expect(prefs.homeAlgo.enabled).toBe(false)
       })
+
+      it(`setHomeAlgoPref: unsets pinned feed`, async () => {
+        await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
+        await agent.setHomeAlgoPref({
+          enabled: true,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+        const prefs = await agent.getPreferences()
+        expect(prefs.feeds.pinned).toStrictEqual([])
+        expect(prefs.homeAlgo).toStrictEqual({
+          enabled: true,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+      })
+
+      it(`setHomeAlgoPref: unsets saved feed`, async () => {
+        await agent.addSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
+        await agent.setHomeAlgoPref({
+          enabled: true,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+        const prefs = await agent.getPreferences()
+        expect(prefs.feeds.saved).toStrictEqual([])
+        expect(prefs.homeAlgo).toStrictEqual({
+          enabled: true,
+          uri: 'at://bob.com/app.bsky.feed.generator/fake',
+        })
+      })
     })
 
     // end

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -4,7 +4,7 @@ import {
   ComAtprotoRepoPutRecord,
   AppBskyActorProfile,
   DEFAULT_LABEL_SETTINGS,
-} from '../src'
+} from '..'
 
 describe('agent', () => {
   let network: TestNetworkNoAppView

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -261,7 +261,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -293,7 +293,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -325,7 +325,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -357,7 +357,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -393,7 +393,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -432,7 +432,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -471,7 +471,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -510,7 +510,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -549,7 +549,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -588,7 +588,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -633,7 +633,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -672,7 +672,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -711,7 +711,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -750,7 +750,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -789,7 +789,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -835,7 +835,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -881,7 +881,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -927,7 +927,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -973,7 +973,7 @@ describe('agent', () => {
         interests: {
           tags: ['foo', 'bar'],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1137,7 +1137,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1185,7 +1185,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1234,7 +1234,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1279,7 +1279,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1324,7 +1324,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1369,7 +1369,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1425,7 +1425,7 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
-        homeAlgo: {
+        primaryAlgorithm: {
           enabled: undefined,
         },
       })
@@ -1752,7 +1752,7 @@ describe('agent', () => {
       })
     })
 
-    describe('home algo prefs', () => {
+    describe('primary algorithm prefs', () => {
       let agent: BskyAgent
 
       beforeAll(async () => {
@@ -1766,62 +1766,65 @@ describe('agent', () => {
 
       it('returns defaults', async () => {
         const prefs = await agent.getPreferences()
-        expect('enabled' in prefs.homeAlgo).toBe(true)
-        expect('uri' in prefs.homeAlgo).toBe(false)
-        expect(prefs.homeAlgo.enabled).toBe(undefined)
-        expect(prefs.homeAlgo.uri).toBe(undefined)
+        expect('enabled' in prefs.primaryAlgorithm).toBe(true)
+        expect('uri' in prefs.primaryAlgorithm).toBe(false)
+        expect(prefs.primaryAlgorithm.enabled).toBe(undefined)
+        expect(prefs.primaryAlgorithm.uri).toBe(undefined)
       })
 
-      it(`setHomeAlgoPref: enable with URI`, async () => {
-        await agent.setHomeAlgoPref({ enabled: true, uri: 'at://did:plc:fake' })
+      it(`setPrimaryAlgorithm: enable with URI`, async () => {
+        await agent.setPrimaryAlgorithm({
+          enabled: true,
+          uri: 'at://did:plc:fake',
+        })
         const prefs = await agent.getPreferences()
-        expect(prefs.homeAlgo.enabled).toBe(true)
-        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+        expect(prefs.primaryAlgorithm.enabled).toBe(true)
+        expect(prefs.primaryAlgorithm.uri).toBe('at://did:plc:fake')
       })
 
-      it(`setHomeAlgoPref: disable, retain URI`, async () => {
-        await agent.setHomeAlgoPref({ enabled: false })
+      it(`setPrimaryAlgorithm: disable, retain URI`, async () => {
+        await agent.setPrimaryAlgorithm({ enabled: false })
         const prefs = await agent.getPreferences()
-        expect(prefs.homeAlgo.enabled).toBe(false)
-        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+        expect(prefs.primaryAlgorithm.enabled).toBe(false)
+        expect(prefs.primaryAlgorithm.uri).toBe('at://did:plc:fake')
       })
 
-      it(`setHomeAlgoPref: cannot unset URI`, async () => {
-        await agent.setHomeAlgoPref({ uri: undefined })
+      it(`setPrimaryAlgorithm: cannot unset URI`, async () => {
+        await agent.setPrimaryAlgorithm({ uri: undefined })
         const prefs = await agent.getPreferences()
-        expect(prefs.homeAlgo.uri).toBe('at://did:plc:fake')
+        expect(prefs.primaryAlgorithm.uri).toBe('at://did:plc:fake')
       })
 
-      it(`setHomeAlgoPref: cannot unset enabled, only boolean`, async () => {
-        await agent.setHomeAlgoPref({ enabled: undefined })
+      it(`setPrimaryAlgorithm: cannot unset enabled, only boolean`, async () => {
+        await agent.setPrimaryAlgorithm({ enabled: undefined })
         const prefs = await agent.getPreferences()
         // last valid value still set
-        expect(prefs.homeAlgo.enabled).toBe(false)
+        expect(prefs.primaryAlgorithm.enabled).toBe(false)
       })
 
-      it(`setHomeAlgoPref: unsets pinned feed`, async () => {
+      it(`setPrimaryAlgorithm: unsets pinned feed`, async () => {
         await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
-        await agent.setHomeAlgoPref({
+        await agent.setPrimaryAlgorithm({
           enabled: true,
           uri: 'at://bob.com/app.bsky.feed.generator/fake',
         })
         const prefs = await agent.getPreferences()
         expect(prefs.feeds.pinned).toStrictEqual([])
-        expect(prefs.homeAlgo).toStrictEqual({
+        expect(prefs.primaryAlgorithm).toStrictEqual({
           enabled: true,
           uri: 'at://bob.com/app.bsky.feed.generator/fake',
         })
       })
 
-      it(`setHomeAlgoPref: unsets saved feed`, async () => {
+      it(`setPrimaryAlgorithm: unsets saved feed`, async () => {
         await agent.addSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
-        await agent.setHomeAlgoPref({
+        await agent.setPrimaryAlgorithm({
           enabled: true,
           uri: 'at://bob.com/app.bsky.feed.generator/fake',
         })
         const prefs = await agent.getPreferences()
         expect(prefs.feeds.saved).toStrictEqual([])
-        expect(prefs.homeAlgo).toStrictEqual({
+        expect(prefs.primaryAlgorithm).toStrictEqual({
           enabled: true,
           uri: 'at://bob.com/app.bsky.feed.generator/fake',
         })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -54,7 +54,7 @@ describe('agent', () => {
         saved: undefined,
       },
       interests: { tags: [] },
-      homeAlgo: { enabled: undefined },
+      primaryAlgorithm: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: {
@@ -100,7 +100,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
-      homeAlgo: { enabled: undefined },
+      primaryAlgorithm: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: DEFAULT_LABEL_SETTINGS,
@@ -136,7 +136,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
-      homeAlgo: { enabled: undefined },
+      primaryAlgorithm: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: DEFAULT_LABEL_SETTINGS,
@@ -181,7 +181,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
-      homeAlgo: { enabled: undefined },
+      primaryAlgorithm: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: { ...DEFAULT_LABEL_SETTINGS, porn: 'ignore', nsfw: 'ignore' },

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -54,6 +54,7 @@ describe('agent', () => {
         saved: undefined,
       },
       interests: { tags: [] },
+      homeAlgo: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: {
@@ -99,6 +100,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
+      homeAlgo: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: DEFAULT_LABEL_SETTINGS,
@@ -134,6 +136,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
+      homeAlgo: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: DEFAULT_LABEL_SETTINGS,
@@ -178,6 +181,7 @@ describe('agent', () => {
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
       interests: { tags: [] },
+      homeAlgo: { enabled: undefined },
       moderationPrefs: {
         adultContentEnabled: false,
         labels: { ...DEFAULT_LABEL_SETTINGS, porn: 'ignore', nsfw: 'ignore' },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3813,7 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
-            'lex:app.bsky.actor.defs#homeAlgoPref',
+            'lex:app.bsky.actor.defs#primaryAlgoPref',
           ],
         },
       },
@@ -3879,7 +3879,7 @@ export const schemaDict = {
           },
         },
       },
-      homeAlgoPref: {
+      primaryAlgoPref: {
         type: 'object',
         properties: {
           enabled: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3881,7 +3881,6 @@ export const schemaDict = {
       },
       homeAlgoPref: {
         type: 'object',
-        required: ['enabled'],
         properties: {
           enabled: {
             type: 'boolean',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3813,6 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#homeAlgoPref',
           ],
         },
       },
@@ -3875,6 +3876,19 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
             description: 'The birth date of account owner.',
+          },
+        },
+      },
+      homeAlgoPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,7 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
-  | HomeAlgoPref
+  | PrimaryAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -216,22 +216,22 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
 }
 
-export interface HomeAlgoPref {
+export interface PrimaryAlgoPref {
   enabled?: boolean
   uri?: string
   [k: string]: unknown
 }
 
-export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+export function isPrimaryAlgoPref(v: unknown): v is PrimaryAlgoPref {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+    v.$type === 'app.bsky.actor.defs#primaryAlgoPref'
   )
 }
 
-export function validateHomeAlgoPref(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
+export function validatePrimaryAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#primaryAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,6 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | HomeAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -213,6 +214,24 @@ export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
 
 export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}
+
+export interface HomeAlgoPref {
+  enabled: boolean
+  uri?: string
+  [k: string]: unknown
+}
+
+export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+  )
+}
+
+export function validateHomeAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -217,7 +217,7 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
 }
 
 export interface HomeAlgoPref {
-  enabled: boolean
+  enabled?: boolean
   uri?: string
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3813,7 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
-            'lex:app.bsky.actor.defs#homeAlgoPref',
+            'lex:app.bsky.actor.defs#primaryAlgoPref',
           ],
         },
       },
@@ -3879,7 +3879,7 @@ export const schemaDict = {
           },
         },
       },
-      homeAlgoPref: {
+      primaryAlgoPref: {
         type: 'object',
         properties: {
           enabled: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3881,7 +3881,6 @@ export const schemaDict = {
       },
       homeAlgoPref: {
         type: 'object',
-        required: ['enabled'],
         properties: {
           enabled: {
             type: 'boolean',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3813,6 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#homeAlgoPref',
           ],
         },
       },
@@ -3875,6 +3876,19 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
             description: 'The birth date of account owner.',
+          },
+        },
+      },
+      homeAlgoPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,7 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
-  | HomeAlgoPref
+  | PrimaryAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -216,22 +216,22 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
 }
 
-export interface HomeAlgoPref {
+export interface PrimaryAlgoPref {
   enabled?: boolean
   uri?: string
   [k: string]: unknown
 }
 
-export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+export function isPrimaryAlgoPref(v: unknown): v is PrimaryAlgoPref {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+    v.$type === 'app.bsky.actor.defs#primaryAlgoPref'
   )
 }
 
-export function validateHomeAlgoPref(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
+export function validatePrimaryAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#primaryAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,6 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | HomeAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -213,6 +214,24 @@ export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
 
 export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}
+
+export interface HomeAlgoPref {
+  enabled: boolean
+  uri?: string
+  [k: string]: unknown
+}
+
+export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+  )
+}
+
+export function validateHomeAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -217,7 +217,7 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
 }
 
 export interface HomeAlgoPref {
-  enabled: boolean
+  enabled?: boolean
   uri?: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3813,7 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
-            'lex:app.bsky.actor.defs#homeAlgoPref',
+            'lex:app.bsky.actor.defs#primaryAlgoPref',
           ],
         },
       },
@@ -3879,7 +3879,7 @@ export const schemaDict = {
           },
         },
       },
-      homeAlgoPref: {
+      primaryAlgoPref: {
         type: 'object',
         properties: {
           enabled: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3881,7 +3881,6 @@ export const schemaDict = {
       },
       homeAlgoPref: {
         type: 'object',
-        required: ['enabled'],
         properties: {
           enabled: {
             type: 'boolean',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3813,6 +3813,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#homeAlgoPref',
           ],
         },
       },
@@ -3875,6 +3876,19 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
             description: 'The birth date of account owner.',
+          },
+        },
+      },
+      homeAlgoPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+          uri: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,7 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
-  | HomeAlgoPref
+  | PrimaryAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -216,22 +216,22 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
 }
 
-export interface HomeAlgoPref {
+export interface PrimaryAlgoPref {
   enabled?: boolean
   uri?: string
   [k: string]: unknown
 }
 
-export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+export function isPrimaryAlgoPref(v: unknown): v is PrimaryAlgoPref {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+    v.$type === 'app.bsky.actor.defs#primaryAlgoPref'
   )
 }
 
-export function validateHomeAlgoPref(v: unknown): ValidationResult {
-  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
+export function validatePrimaryAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#primaryAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -138,6 +138,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | HomeAlgoPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -213,6 +214,24 @@ export function isPersonalDetailsPref(v: unknown): v is PersonalDetailsPref {
 
 export function validatePersonalDetailsPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#personalDetailsPref', v)
+}
+
+export interface HomeAlgoPref {
+  enabled: boolean
+  uri?: string
+  [k: string]: unknown
+}
+
+export function isHomeAlgoPref(v: unknown): v is HomeAlgoPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#homeAlgoPref'
+  )
+}
+
+export function validateHomeAlgoPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#homeAlgoPref', v)
 }
 
 export interface FeedViewPref {

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -217,7 +217,7 @@ export function validatePersonalDetailsPref(v: unknown): ValidationResult {
 }
 
 export interface HomeAlgoPref {
-  enabled: boolean
+  enabled?: boolean
   uri?: string
   [k: string]: unknown
 }


### PR DESCRIPTION
Adds `primaryAlgoPref` to preferences, and adds a method `setPrimaryAlgorithm({ enabled: boolean, uri: string })` to `BskyAgent`. See tests for usage.

Notes:
- if `enabled` is `undefined` we know the user has no interacted with this pref, which is an ability I want to retain, lmk if any issues with the optionality of this prop — I guarded against this value being set back to `undefined` once set to a boolean
- when a feed is set as the primary algo, it's removed from saved/pinned feeds to avoid confusion