### PR TITLE
Lexicons: email auth factor

### DIFF
--- a/.changeset/afraid-starfishes-sneeze.md
+++ b/.changeset/afraid-starfishes-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Support for email auth factor lexicons

--- a/lexicons/com/atproto/server/createSession.json
+++ b/lexicons/com/atproto/server/createSession.json
@@ -15,7 +15,8 @@
               "type": "string",
               "description": "Handle or other identifier supported by the server for the authenticating user."
             },
-            "password": { "type": "string" }
+            "password": { "type": "string" },
+            "authFactorToken": { "type": "string" }
           }
         }
       },
@@ -31,11 +32,15 @@
             "did": { "type": "string", "format": "did" },
             "didDoc": { "type": "unknown" },
             "email": { "type": "string" },
-            "emailConfirmed": { "type": "boolean" }
+            "emailConfirmed": { "type": "boolean" },
+            "emailAuthFactor": { "type": "boolean" }
           }
         }
       },
-      "errors": [{ "name": "AccountTakedown" }]
+      "errors": [
+        { "name": "AccountTakedown" },
+        { "name": "AuthFactorTokenRequired" }
+      ]
     }
   }
 }

--- a/lexicons/com/atproto/server/getSession.json
+++ b/lexicons/com/atproto/server/getSession.json
@@ -15,6 +15,7 @@
             "did": { "type": "string", "format": "did" },
             "email": { "type": "string" },
             "emailConfirmed": { "type": "boolean" },
+            "emailAuthFactor": { "type": "boolean" },
             "didDoc": { "type": "unknown" }
           }
         }

--- a/lexicons/com/atproto/server/updateEmail.json
+++ b/lexicons/com/atproto/server/updateEmail.json
@@ -12,6 +12,7 @@
           "required": ["email"],
           "properties": {
             "email": { "type": "string" },
+            "emailAuthFactor": { "type": "boolean" },
             "token": {
               "type": "string",
               "description": "Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed."

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2209,6 +2209,9 @@ export const schemaDict = {
               password: {
                 type: 'string',
               },
+              authFactorToken: {
+                type: 'string',
+              },
             },
           },
         },
@@ -2241,12 +2244,18 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
             },
           },
         },
         errors: [
           {
             name: 'AccountTakedown',
+          },
+          {
+            name: 'AuthFactorTokenRequired',
           },
         ],
       },
@@ -2568,6 +2577,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
               didDoc: {
                 type: 'unknown',
               },
@@ -2836,6 +2848,9 @@ export const schemaDict = {
             properties: {
               email: {
                 type: 'string',
+              },
+              emailAuthFactor: {
+                type: 'boolean',
               },
               token: {
                 type: 'string',

--- a/packages/api/src/client/types/com/atproto/server/createSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/createSession.ts
@@ -13,6 +13,7 @@ export interface InputSchema {
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier: string
   password: string
+  authFactorToken?: string
   [k: string]: unknown
 }
 
@@ -24,6 +25,7 @@ export interface OutputSchema {
   didDoc?: {}
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   [k: string]: unknown
 }
 
@@ -45,9 +47,17 @@ export class AccountTakedownError extends XRPCError {
   }
 }
 
+export class AuthFactorTokenRequiredError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers)
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
     if (e.error === 'AccountTakedown') return new AccountTakedownError(e)
+    if (e.error === 'AuthFactorTokenRequired')
+      return new AuthFactorTokenRequiredError(e)
   }
   return e
 }

--- a/packages/api/src/client/types/com/atproto/server/getSession.ts
+++ b/packages/api/src/client/types/com/atproto/server/getSession.ts
@@ -16,6 +16,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   didDoc?: {}
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/com/atproto/server/updateEmail.ts
+++ b/packages/api/src/client/types/com/atproto/server/updateEmail.ts
@@ -11,6 +11,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   email: string
+  emailAuthFactor?: boolean
   /** Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed. */
   token?: string
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2209,6 +2209,9 @@ export const schemaDict = {
               password: {
                 type: 'string',
               },
+              authFactorToken: {
+                type: 'string',
+              },
             },
           },
         },
@@ -2241,12 +2244,18 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
             },
           },
         },
         errors: [
           {
             name: 'AccountTakedown',
+          },
+          {
+            name: 'AuthFactorTokenRequired',
           },
         ],
       },
@@ -2568,6 +2577,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
               didDoc: {
                 type: 'unknown',
               },
@@ -2836,6 +2848,9 @@ export const schemaDict = {
             properties: {
               email: {
                 type: 'string',
+              },
+              emailAuthFactor: {
+                type: 'boolean',
               },
               token: {
                 type: 'string',

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createSession.ts
@@ -14,6 +14,7 @@ export interface InputSchema {
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier: string
   password: string
+  authFactorToken?: string
   [k: string]: unknown
 }
 
@@ -25,6 +26,7 @@ export interface OutputSchema {
   didDoc?: {}
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   [k: string]: unknown
 }
 
@@ -42,7 +44,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'AccountTakedown'
+  error?: 'AccountTakedown' | 'AuthFactorTokenRequired'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough

--- a/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
@@ -17,6 +17,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   didDoc?: {}
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -12,6 +12,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   email: string
+  emailAuthFactor?: boolean
   /** Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed. */
   token?: string
   [k: string]: unknown

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -2209,6 +2209,9 @@ export const schemaDict = {
               password: {
                 type: 'string',
               },
+              authFactorToken: {
+                type: 'string',
+              },
             },
           },
         },
@@ -2241,12 +2244,18 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
             },
           },
         },
         errors: [
           {
             name: 'AccountTakedown',
+          },
+          {
+            name: 'AuthFactorTokenRequired',
           },
         ],
       },
@@ -2568,6 +2577,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
               didDoc: {
                 type: 'unknown',
               },
@@ -2836,6 +2848,9 @@ export const schemaDict = {
             properties: {
               email: {
                 type: 'string',
+              },
+              emailAuthFactor: {
+                type: 'boolean',
               },
               token: {
                 type: 'string',

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createSession.ts
@@ -14,6 +14,7 @@ export interface InputSchema {
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier: string
   password: string
+  authFactorToken?: string
   [k: string]: unknown
 }
 
@@ -25,6 +26,7 @@ export interface OutputSchema {
   didDoc?: {}
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   [k: string]: unknown
 }
 
@@ -42,7 +44,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'AccountTakedown'
+  error?: 'AccountTakedown' | 'AuthFactorTokenRequired'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough

--- a/packages/ozone/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/getSession.ts
@@ -17,6 +17,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   didDoc?: {}
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -12,6 +12,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   email: string
+  emailAuthFactor?: boolean
   /** Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed. */
   token?: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2209,6 +2209,9 @@ export const schemaDict = {
               password: {
                 type: 'string',
               },
+              authFactorToken: {
+                type: 'string',
+              },
             },
           },
         },
@@ -2241,12 +2244,18 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
             },
           },
         },
         errors: [
           {
             name: 'AccountTakedown',
+          },
+          {
+            name: 'AuthFactorTokenRequired',
           },
         ],
       },
@@ -2568,6 +2577,9 @@ export const schemaDict = {
               emailConfirmed: {
                 type: 'boolean',
               },
+              emailAuthFactor: {
+                type: 'boolean',
+              },
               didDoc: {
                 type: 'unknown',
               },
@@ -2836,6 +2848,9 @@ export const schemaDict = {
             properties: {
               email: {
                 type: 'string',
+              },
+              emailAuthFactor: {
+                type: 'boolean',
               },
               token: {
                 type: 'string',

--- a/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
@@ -14,6 +14,7 @@ export interface InputSchema {
   /** Handle or other identifier supported by the server for the authenticating user. */
   identifier: string
   password: string
+  authFactorToken?: string
   [k: string]: unknown
 }
 
@@ -25,6 +26,7 @@ export interface OutputSchema {
   didDoc?: {}
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   [k: string]: unknown
 }
 
@@ -42,7 +44,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'AccountTakedown'
+  error?: 'AccountTakedown' | 'AuthFactorTokenRequired'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough

--- a/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
@@ -17,6 +17,7 @@ export interface OutputSchema {
   did: string
   email?: string
   emailConfirmed?: boolean
+  emailAuthFactor?: boolean
   didDoc?: {}
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -12,6 +12,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   email: string
+  emailAuthFactor?: boolean
   /** Requires a token from com.atproto.sever.requestEmailUpdate if the account's email has been confirmed. */
   token?: string
   [k: string]: unknown


### PR DESCRIPTION
This contains lexicons for supporting an email auth factor within the current authentication system.  The PDS will eventually support other factors as a more long-term solution via OAuth (see #1958 #2408).  These lexicons will be used as a stand-in for now, at minimum for use with the entryway service (bsky.social) which will support them.