### PR TITLE
Appview: ensure hydration context tracks viewer did and not full service ref

### DIFF
--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -55,7 +55,7 @@ import { ParsedLabelers } from '../util'
 
 export class HydrateCtx {
   labelers = this.vals.labelers
-  viewer = this.vals.viewer
+  viewer = this.vals.viewer !== null ? serviceRefToDid(this.vals.viewer) : null
   includeTakedowns = this.vals.includeTakedowns
   constructor(private vals: HydrateCtxVals) {}
   copy<V extends Partial<HydrateCtxVals>>(vals?: V): HydrateCtx & V {
@@ -683,6 +683,12 @@ export class Hydrator {
       includeTakedowns: vals.includeTakedowns,
     })
   }
+}
+
+// service refs may look like "did:plc:example#service_id". we want to extract the did part "did:plc:example".
+const serviceRefToDid = (serviceRef: string) => {
+  const idx = serviceRef.indexOf('#')
+  return idx !== -1 ? serviceRef.slice(0, idx) : serviceRef
 }
 
 const listUrisFromProfileViewer = (item: ProfileViewerState | null) => {


### PR DESCRIPTION
Service refs (e.g. `did:plc:example#service_id`) were getting preserved into the hydration and dataplane layer, where we really just want to work with the relevant DIDs (e.g. `did:plc:example`).