### PR TITLE
Add `savedFeedsPrefV2` and new methods

### DIFF
--- a/.changeset/five-planes-know.md
+++ b/.changeset/five-planes-know.md
@@ -1,0 +1,7 @@
+---
+"@atproto/api": patch
+---
+
+Introduces V2 of saved feeds preferences. V2 and v1 prefs are incompatible. v1
+methods and preference objects are retained for backwards compatability, but are
+considered deprecated. Developers should immediately migrate to v2 interfaces.

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -122,6 +122,7 @@
           "#adultContentPref",
           "#contentLabelPref",
           "#savedFeedsPref",
+          "#savedFeedsPrefV2",
           "#personalDetailsPref",
           "#feedViewPref",
           "#threadViewPref",
@@ -151,6 +152,38 @@
         "visibility": {
           "type": "string",
           "knownValues": ["ignore", "show", "warn", "hide"]
+        }
+      }
+    },
+    "savedFeed": {
+      "type": "object",
+      "required": ["id", "type", "value", "pinned"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "knownValues": ["feed", "list", "timeline"]
+        },
+        "value": {
+          "type": "string"
+        },
+        "pinned": {
+          "type": "boolean"
+        }
+      }
+    },
+    "savedFeedsPrefV2": {
+      "type": "object",
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "app.bsky.actor.defs#savedFeed"
+          }
         }
       }
     },

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -652,7 +652,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `addSavedFeeds` or `updatedSavedFeed`
+   * @deprecated use `addSavedFeeds` or `updatedSavedFeeds`
    */
   async addPinnedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({
@@ -662,7 +662,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `updateSavedFeed` or `removeSavedFeeds`
+   * @deprecated use `updateSavedFeeds` or `removeSavedFeeds`
    */
   async removePinnedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -658,7 +658,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `addSavedFeeds` or `updatedSavedFeeds`
+   * @deprecated use `addSavedFeeds` or `updateSavedFeeds`
    */
   async addPinnedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -629,7 +629,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `addSavedFeedV2`
+   * @deprecated use `addSavedFeeds`
    */
   async addSavedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({
@@ -639,7 +639,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `removeSavedFeedV2`
+   * @deprecated use `removeSavedFeeds`
    */
   async removeSavedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({
@@ -649,7 +649,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `addSavedFeedV2` or `updatedSavedFeed`
+   * @deprecated use `addSavedFeeds` or `updatedSavedFeed`
    */
   async addPinnedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({
@@ -659,7 +659,7 @@ export class BskyAgent extends AtpAgent {
   }
 
   /**
-   * @deprecated use `updatedPinnedFeed`
+   * @deprecated use `updateSavedFeed` or `removeSavedFeeds`
    */
   async removePinnedFeed(v: string) {
     return updateFeedPreferences(this, (saved: string[], pinned: string[]) => ({

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -508,9 +508,12 @@ export class BskyAgent extends AtpAgent {
 
         // use pinned as source of truth for feed order
         for (const uri of pinned) {
+          const type = getSavedFeedType(uri)
+          // only want supported types
+          if (type === 'unknown') continue
           uniqueMigratedSavedFeeds.set(uri, {
             id: TID.nextStr(),
-            type: getSavedFeedType(uri),
+            type,
             value: uri,
             pinned: true,
           })
@@ -518,9 +521,12 @@ export class BskyAgent extends AtpAgent {
 
         for (const uri of saved) {
           if (!uniqueMigratedSavedFeeds.has(uri)) {
+            const type = getSavedFeedType(uri)
+            // only want supported types
+            if (type === 'unknown') continue
             uniqueMigratedSavedFeeds.set(uri, {
               id: TID.nextStr(),
-              type: getSavedFeedType(uri),
+              type,
               value: uri,
               pinned: false,
             })

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -598,20 +598,6 @@ export class BskyAgent extends AtpAgent {
     ])
   }
 
-  async addSavedFeedV2(
-    savedFeed: Pick<AppBskyActorDefs.SavedFeed, 'type' | 'value' | 'pinned'>,
-  ) {
-    const toSave: AppBskyActorDefs.SavedFeed = {
-      ...savedFeed,
-      id: TID.nextStr(),
-    }
-    validateSavedFeed(toSave)
-    return updateSavedFeedsV2Preferences(this, (savedFeeds) => [
-      ...savedFeeds,
-      toSave,
-    ])
-  }
-
   async addSavedFeeds(
     savedFeeds: Pick<AppBskyActorDefs.SavedFeed, 'type' | 'value' | 'pinned'>[],
   ) {
@@ -626,9 +612,9 @@ export class BskyAgent extends AtpAgent {
     ])
   }
 
-  async removeSavedFeedV2(id: string) {
+  async removeSavedFeeds(ids: string[]) {
     return updateSavedFeedsV2Preferences(this, (savedFeeds) => [
-      ...savedFeeds.filter((feed) => feed.id !== id),
+      ...savedFeeds.filter((feed) => !ids.find((id) => feed.id === id)),
     ])
   }
 

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -570,7 +570,13 @@ export class BskyAgent extends AtpAgent {
   async setSavedFeedsV2(savedFeeds: AppBskyActorDefs.SavedFeed[]) {
     savedFeeds.forEach(validateSavedFeed)
     const uniqueSavedFeeds = new Map<string, AppBskyActorDefs.SavedFeed>()
-    savedFeeds.forEach((feed) => uniqueSavedFeeds.set(feed.id, feed))
+    savedFeeds.forEach((feed) => {
+      // remove and re-insert to preserve order
+      if (uniqueSavedFeeds.has(feed.id)) {
+        uniqueSavedFeeds.delete(feed.id)
+      }
+      uniqueSavedFeeds.set(feed.id, feed)
+    })
     return updateSavedFeedsV2Preferences(this, () =>
       Array.from(uniqueSavedFeeds.values()),
     )

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -499,10 +499,10 @@ export class BskyAgent extends AtpAgent {
         > = new Map()
 
         // insert Following feed first
-        uniqueMigratedSavedFeeds.set('home', {
+        uniqueMigratedSavedFeeds.set('timeline', {
           id: TID.nextStr(),
           type: 'timeline',
-          value: 'home',
+          value: 'following',
           pinned: true,
         })
 
@@ -539,7 +539,7 @@ export class BskyAgent extends AtpAgent {
           {
             id: TID.nextStr(),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ]

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -1091,6 +1091,11 @@ async function updateFeedPreferences(
       }
     }
 
+    // enforce ordering, pinned then saved
+    const pinned = existingV2Pref.items.filter((i) => i.pinned)
+    const saved = existingV2Pref.items.filter((i) => !i.pinned)
+    existingV2Pref.items = pinned.concat(saved)
+
     let updatedPrefs = prefs
       .filter((pref) => !AppBskyActorDefs.isSavedFeedsPrefV2(pref))
       .concat(existingV2Pref)

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -612,6 +612,20 @@ export class BskyAgent extends AtpAgent {
     ])
   }
 
+  async addSavedFeeds(
+    savedFeeds: Pick<AppBskyActorDefs.SavedFeed, 'type' | 'value' | 'pinned'>[],
+  ) {
+    const toSave: AppBskyActorDefs.SavedFeed[] = savedFeeds.map((f) => ({
+      ...f,
+      id: TID.nextStr(),
+    }))
+    toSave.forEach(validateSavedFeed)
+    return updateSavedFeedsV2Preferences(this, (savedFeeds) => [
+      ...savedFeeds,
+      ...toSave,
+    ])
+  }
+
   async removeSavedFeedV2(id: string) {
     return updateSavedFeedsV2Preferences(this, (savedFeeds) => [
       ...savedFeeds.filter((feed) => feed.id !== id),

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3822,6 +3822,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#savedFeedsPrefV2',
             'lex:app.bsky.actor.defs#personalDetailsPref',
             'lex:app.bsky.actor.defs#feedViewPref',
             'lex:app.bsky.actor.defs#threadViewPref',
@@ -3857,6 +3858,38 @@ export const schemaDict = {
           visibility: {
             type: 'string',
             knownValues: ['ignore', 'show', 'warn', 'hide'],
+          },
+        },
+      },
+      savedFeed: {
+        type: 'object',
+        required: ['id', 'type', 'value', 'pinned'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          type: {
+            type: 'string',
+            knownValues: ['feed', 'list', 'timeline'],
+          },
+          value: {
+            type: 'string',
+          },
+          pinned: {
+            type: 'boolean',
+          },
+        },
+      },
+      savedFeedsPrefV2: {
+        type: 'object',
+        required: ['items'],
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#savedFeed',
+            },
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -132,6 +132,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | SavedFeedsPrefV2
   | PersonalDetailsPref
   | FeedViewPref
   | ThreadViewPref
@@ -176,6 +177,43 @@ export function isContentLabelPref(v: unknown): v is ContentLabelPref {
 
 export function validateContentLabelPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#contentLabelPref', v)
+}
+
+export interface SavedFeed {
+  id: string
+  type: 'feed' | 'list' | 'timeline' | (string & {})
+  value: string
+  pinned: boolean
+  [k: string]: unknown
+}
+
+export function isSavedFeed(v: unknown): v is SavedFeed {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeed'
+  )
+}
+
+export function validateSavedFeed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeed', v)
+}
+
+export interface SavedFeedsPrefV2 {
+  items: SavedFeed[]
+  [k: string]: unknown
+}
+
+export function isSavedFeedsPrefV2(v: unknown): v is SavedFeedsPrefV2 {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeedsPrefV2'
+  )
+}
+
+export function validateSavedFeedsPrefV2(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeedsPrefV2', v)
 }
 
 export interface SavedFeedsPref {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -112,10 +112,14 @@ export interface BskyInterestsPreference {
  * Bluesky preferences
  */
 export interface BskyPreferences {
+  /**
+   * @deprecated use `savedFeeds`
+   */
   feeds: {
     saved?: string[]
     pinned?: string[]
   }
+  savedFeeds: AppBskyActorDefs.SavedFeed[]
   feedViewPrefs: Record<string, BskyFeedViewPreference>
   threadViewPrefs: BskyThreadViewPreference
   moderationPrefs: ModerationPrefs

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,4 +1,5 @@
 import { AtUri } from '@atproto/syntax'
+import { TID } from '@atproto/common-web'
 
 import { AppBskyActorDefs } from './client'
 
@@ -56,6 +57,8 @@ export function getSavedFeedType(
 }
 
 export function validateSavedFeed(savedFeed: AppBskyActorDefs.SavedFeed) {
+  new TID(savedFeed.id)
+
   const uri = new AtUri(savedFeed.value)
   const isFeed = uri.collection === 'app.bsky.feed.generator'
   const isList = uri.collection === 'app.bsky.graph.list'

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -59,18 +59,20 @@ export function getSavedFeedType(
 export function validateSavedFeed(savedFeed: AppBskyActorDefs.SavedFeed) {
   new TID(savedFeed.id)
 
-  const uri = new AtUri(savedFeed.value)
-  const isFeed = uri.collection === 'app.bsky.feed.generator'
-  const isList = uri.collection === 'app.bsky.graph.list'
+  if (['feed', 'list'].includes(savedFeed.type)) {
+    const uri = new AtUri(savedFeed.value)
+    const isFeed = uri.collection === 'app.bsky.feed.generator'
+    const isList = uri.collection === 'app.bsky.graph.list'
 
-  if (savedFeed.type === 'feed' && !isFeed) {
-    throw new Error(
-      `Saved feed of type 'feed' must be a feed, got ${uri.collection}`,
-    )
-  }
-  if (savedFeed.type === 'list' && !isList) {
-    throw new Error(
-      `Saved feed of type 'list' must be a list, got ${uri.collection}`,
-    )
+    if (savedFeed.type === 'feed' && !isFeed) {
+      throw new Error(
+        `Saved feed of type 'feed' must be a feed, got ${uri.collection}`,
+      )
+    }
+    if (savedFeed.type === 'list' && !isList) {
+      throw new Error(
+        `Saved feed of type 'list' must be a list, got ${uri.collection}`,
+      )
+    }
   }
 }

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -9,7 +9,9 @@ export function sanitizeMutedWordValue(value: string) {
     .replace(/[\r\n\u00AD\u2060\u200D\u200C\u200B]+/, '')
 }
 
-export function savedFeedsV2ToV1(savedFeeds: AppBskyActorDefs.SavedFeed[]): {
+export function savedFeedsToUriArrays(
+  savedFeeds: AppBskyActorDefs.SavedFeed[],
+): {
   pinned: string[]
   saved: string[]
 } {
@@ -49,18 +51,6 @@ export function getSavedFeedType(
       return 'list'
     default:
       return 'unknown'
-  }
-}
-
-export function uriToSavedFeed(
-  uri: string,
-  partialSavedFeed: Partial<AppBskyActorDefs.SavedFeed>,
-): AppBskyActorDefs.SavedFeed {
-  return {
-    pinned: false,
-    ...partialSavedFeed,
-    type: getSavedFeedType(uri),
-    value: uri,
   }
 }
 

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -21,6 +21,8 @@ export function savedFeedsToUriArrays(
   for (const feed of savedFeeds) {
     if (feed.pinned) {
       pinned.push(feed.value)
+      // saved in v1 includes pinned
+      saved.push(feed.value)
     } else {
       saved.push(feed.value)
     }
@@ -28,8 +30,7 @@ export function savedFeedsToUriArrays(
 
   return {
     pinned,
-    // saved is a concatenation of pinned and saved in v1
-    saved: pinned.concat(saved),
+    saved,
   }
 }
 

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,6 +1,82 @@
+import { AtUri } from '@atproto/syntax'
+
+import { AppBskyActorDefs } from './client'
+
 export function sanitizeMutedWordValue(value: string) {
   return value
     .trim()
     .replace(/^#(?!\ufe0f)/, '')
     .replace(/[\r\n\u00AD\u2060\u200D\u200C\u200B]+/, '')
+}
+
+export function savedFeedsV2ToV1(savedFeeds: AppBskyActorDefs.SavedFeed[]): {
+  pinned: string[]
+  saved: string[]
+} {
+  const pinned: string[] = []
+  const saved: string[] = []
+
+  for (const feed of savedFeeds) {
+    if (feed.pinned) {
+      pinned.push(feed.value)
+    } else {
+      saved.push(feed.value)
+    }
+  }
+
+  return {
+    pinned,
+    // saved is a concatenation of pinned and saved in v1
+    saved: pinned.concat(saved),
+  }
+}
+
+/**
+ * Get the type of a saved feed, used by deprecated methods for backwards
+ * compat. Should not be used moving forward. *Invalid URIs will throw.*
+ *
+ * @param uri - The AT URI of the saved feed
+ */
+export function getSavedFeedType(
+  uri: string,
+): AppBskyActorDefs.SavedFeed['type'] {
+  const urip = new AtUri(uri)
+
+  switch (urip.collection) {
+    case 'app.bsky.feed.generator':
+      return 'feed'
+    case 'app.bsky.graph.list':
+      return 'list'
+    default:
+      return 'unknown'
+  }
+}
+
+export function uriToSavedFeed(
+  uri: string,
+  partialSavedFeed: Partial<AppBskyActorDefs.SavedFeed>,
+): AppBskyActorDefs.SavedFeed {
+  return {
+    pinned: false,
+    ...partialSavedFeed,
+    type: getSavedFeedType(uri),
+    value: uri,
+  }
+}
+
+export function validateSavedFeed(savedFeed: AppBskyActorDefs.SavedFeed) {
+  const uri = new AtUri(savedFeed.value)
+  const isFeed = uri.collection === 'app.bsky.feed.generator'
+  const isList = uri.collection === 'app.bsky.graph.list'
+
+  if (savedFeed.type === 'feed' && !isFeed) {
+    throw new Error(
+      `Saved feed of type 'feed' must be a feed, got ${uri.collection}`,
+    )
+  }
+  if (savedFeed.type === 'list' && !isList) {
+    throw new Error(
+      `Saved feed of type 'list' must be a list, got ${uri.collection}`,
+    )
+  }
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -2078,7 +2078,7 @@ describe('agent', () => {
         })
       })
 
-      describe(`setSavedFeedsV2`, () => {
+      describe(`overwriteSavedFeeds`, () => {
         it(`dedupes by id, takes last, preserves order based on last found`, async () => {
           const a = {
             id: TID.nextStr(),
@@ -2092,7 +2092,7 @@ describe('agent', () => {
             value: feedUri(),
             pinned: true,
           }
-          await agent.setSavedFeedsV2([a, b, a])
+          await agent.overwriteSavedFeeds([a, b, a])
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([b, a])
         })
@@ -2103,7 +2103,7 @@ describe('agent', () => {
           const c = feedUri()
           const d = feedUri()
 
-          await agent.setSavedFeedsV2([
+          await agent.overwriteSavedFeeds([
             {
               id: TID.nextStr(),
               type: 'timeline',
@@ -2162,7 +2162,7 @@ describe('agent', () => {
         })
       })
 
-      describe(`updateSavedFeed`, () => {
+      describe(`updateSavedFeeds`, () => {
         it(`updates affect order, saved last, new pins last`, async () => {
           const a = {
             id: TID.nextStr(),
@@ -2183,11 +2183,13 @@ describe('agent', () => {
             pinned: true,
           }
 
-          await agent.setSavedFeedsV2([a, b, c])
-          await agent.updateSavedFeed({
-            ...b,
-            pinned: false,
-          })
+          await agent.overwriteSavedFeeds([a, b, c])
+          await agent.updateSavedFeeds([
+            {
+              ...b,
+              pinned: false,
+            },
+          ])
 
           const prefs1 = await agent.getPreferences()
           expect(prefs1.savedFeeds).toStrictEqual([
@@ -2199,10 +2201,12 @@ describe('agent', () => {
             },
           ])
 
-          await agent.updateSavedFeed({
-            ...b,
-            pinned: true,
-          })
+          await agent.updateSavedFeeds([
+            {
+              ...b,
+              pinned: true,
+            },
+          ])
 
           const prefs2 = await agent.getPreferences()
           expect(prefs2.savedFeeds).toStrictEqual([a, c, b])
@@ -2215,14 +2219,62 @@ describe('agent', () => {
             value: feedUri(),
             pinned: true,
           }
-          await agent.setSavedFeedsV2([a])
-          await agent.updateSavedFeed({
-            ...a,
-            pinned: false,
-            id: TID.nextStr(),
-          })
+          await agent.overwriteSavedFeeds([a])
+          await agent.updateSavedFeeds([
+            {
+              ...a,
+              pinned: false,
+              id: TID.nextStr(),
+            },
+          ])
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([a])
+        })
+
+        it(`updates multiple`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          const b = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          const c = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+
+          await agent.overwriteSavedFeeds([a, b, c])
+          await agent.updateSavedFeeds([
+            {
+              ...b,
+              pinned: true,
+            },
+            {
+              ...c,
+              pinned: true,
+            },
+          ])
+
+          const prefs1 = await agent.getPreferences()
+          expect(prefs1.savedFeeds).toStrictEqual([
+            {
+              ...b,
+              pinned: true,
+            },
+            {
+              ...c,
+              pinned: true,
+            },
+            a,
+          ])
         })
       })
     })

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1916,14 +1916,14 @@ describe('agent', () => {
         })
       })
 
-      describe(`addSavedFeedV2`, () => {
+      describe(`addSavedFeeds`, () => {
         it('works', async () => {
           const feed = {
             type: 'feed',
             value: feedUri(),
             pinned: false,
           }
-          await agent.addSavedFeedV2(feed)
+          await agent.addSavedFeeds([feed])
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([
             {
@@ -1936,31 +1936,37 @@ describe('agent', () => {
         it('throws if feed is specified and list provided', async () => {
           const list = listUri()
           await expect(() =>
-            agent.addSavedFeedV2({
-              type: 'feed',
-              value: list,
-              pinned: true,
-            }),
+            agent.addSavedFeeds([
+              {
+                type: 'feed',
+                value: list,
+                pinned: true,
+              },
+            ]),
           ).rejects.toThrow()
         })
 
         it('throws if list is specified and feed provided', async () => {
           const feed = feedUri()
           await expect(() =>
-            agent.addSavedFeedV2({
-              type: 'list',
-              value: feed,
-              pinned: true,
-            }),
+            agent.addSavedFeeds([
+              {
+                type: 'list',
+                value: feed,
+                pinned: true,
+              },
+            ]),
           ).rejects.toThrow()
         })
 
         it(`timeline`, async () => {
-          const feeds = await agent.addSavedFeedV2({
-            type: 'timeline',
-            value: 'home',
-            pinned: true,
-          })
+          const feeds = await agent.addSavedFeeds([
+            {
+              type: 'timeline',
+              value: 'home',
+              pinned: true,
+            },
+          ])
           const prefs = await agent.getPreferences()
           expect(
             prefs.savedFeeds.filter((f) => f.type === 'timeline'),
@@ -1973,8 +1979,8 @@ describe('agent', () => {
             value: feedUri(),
             pinned: false,
           }
-          await agent.addSavedFeedV2(feed)
-          await agent.addSavedFeedV2(feed)
+          await agent.addSavedFeeds([feed])
+          await agent.addSavedFeeds([feed])
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([
             {
@@ -1987,17 +1993,86 @@ describe('agent', () => {
             },
           ])
         })
+
+        it(`adds multiple`, async () => {
+          const a = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          await agent.addSavedFeeds([a, b])
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            {
+              ...a,
+              id: expect.any(String),
+            },
+            {
+              ...b,
+              id: expect.any(String),
+            },
+          ])
+        })
+
+        it(`appends multiple`, async () => {
+          const a = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          const c = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const d = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          await agent.addSavedFeeds([a, b])
+          await agent.addSavedFeeds([c, d])
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            {
+              ...a,
+              id: expect.any(String),
+            },
+            {
+              ...c,
+              id: expect.any(String),
+            },
+            {
+              ...b,
+              id: expect.any(String),
+            },
+            {
+              ...d,
+              id: expect.any(String),
+            },
+          ])
+        })
       })
 
-      describe(`removeSavedFeedV2`, () => {
+      describe(`removeSavedFeeds`, () => {
         it('works', async () => {
           const feed = {
             type: 'feed',
             value: feedUri(),
             pinned: true,
           }
-          const savedFeeds = await agent.addSavedFeedV2(feed)
-          await agent.removeSavedFeedV2(savedFeeds[0].id)
+          const savedFeeds = await agent.addSavedFeeds([feed])
+          await agent.removeSavedFeeds([savedFeeds[0].id])
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([])
         })
@@ -2150,77 +2225,6 @@ describe('agent', () => {
           expect(prefs.savedFeeds).toStrictEqual([a])
         })
       })
-
-      describe('addSavedFeeds', () => {
-        it(`adds multiple`, async () => {
-          const a = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          const b = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: false,
-          }
-          await agent.addSavedFeeds([a, b])
-          const prefs = await agent.getPreferences()
-          expect(prefs.savedFeeds).toStrictEqual([
-            {
-              ...a,
-              id: expect.any(String),
-            },
-            {
-              ...b,
-              id: expect.any(String),
-            },
-          ])
-        })
-
-        it(`appends multiple`, async () => {
-          const a = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          const b = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: false,
-          }
-          const c = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          const d = {
-            type: 'feed',
-            value: feedUri(),
-            pinned: false,
-          }
-          await agent.addSavedFeeds([a, b])
-          await agent.addSavedFeeds([c, d])
-          const prefs = await agent.getPreferences()
-          expect(prefs.savedFeeds).toStrictEqual([
-            {
-              ...a,
-              id: expect.any(String),
-            },
-            {
-              ...c,
-              id: expect.any(String),
-            },
-            {
-              ...b,
-              id: expect.any(String),
-            },
-            {
-              ...d,
-              id: expect.any(String),
-            },
-          ])
-        })
-      })
     })
 
     describe(`saved feeds v2: migration scenarios`, () => {
@@ -2249,7 +2253,7 @@ describe('agent', () => {
           value: feedUri(),
           pinned: false,
         }
-        await agent.addSavedFeedV2(feed)
+        await agent.addSavedFeeds([feed])
         const prefs = await agent.getPreferences()
         expect(prefs.savedFeeds).toStrictEqual([
           {
@@ -2266,7 +2270,7 @@ describe('agent', () => {
           value: feedUri(),
           pinned: false,
         }
-        await agent.addSavedFeedV2(feed)
+        await agent.addSavedFeeds([feed])
         const prefs = await agent.getPreferences()
         expect(prefs.savedFeeds).toStrictEqual([
           {
@@ -2304,11 +2308,13 @@ describe('agent', () => {
         const a = feedUri()
         // migration happens
         await agent.getPreferences()
-        await agent.addSavedFeedV2({
-          type: 'feed',
-          value: a,
-          pinned: false,
-        })
+        await agent.addSavedFeeds([
+          {
+            type: 'feed',
+            value: a,
+            pinned: false,
+          },
+        ])
         const prefs = await agent.getPreferences()
         expect(prefs.savedFeeds).toStrictEqual([
           {
@@ -2449,11 +2455,13 @@ describe('agent', () => {
         await agent.getPreferences()
 
         // new write to v2, c is saved
-        await agent.addSavedFeedV2({
-          type: 'feed',
-          value: c,
-          pinned: false,
-        })
+        await agent.addSavedFeeds([
+          {
+            type: 'feed',
+            value: c,
+            pinned: false,
+          },
+        ])
 
         // v2 write wrote to v1 also
         const res1 = await agent.app.bsky.actor.getPreferences()
@@ -2480,11 +2488,13 @@ describe('agent', () => {
         })
 
         // another new write to v2, pins e
-        await agent.addSavedFeedV2({
-          type: 'feed',
-          value: e,
-          pinned: true,
-        })
+        await agent.addSavedFeeds([
+          {
+            type: 'feed',
+            value: e,
+            pinned: true,
+          },
+        ])
 
         const res4 = await agent.app.bsky.actor.getPreferences()
         const v1Pref4 = res4.data.preferences.find((p) =>

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -2150,6 +2150,77 @@ describe('agent', () => {
           expect(prefs.savedFeeds).toStrictEqual([a])
         })
       })
+
+      describe('addSavedFeeds', () => {
+        it(`adds multiple`, async () => {
+          const a = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          await agent.addSavedFeeds([a, b])
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            {
+              ...a,
+              id: expect.any(String),
+            },
+            {
+              ...b,
+              id: expect.any(String),
+            },
+          ])
+        })
+
+        it(`appends multiple`, async () => {
+          const a = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          const c = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const d = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          await agent.addSavedFeeds([a, b])
+          await agent.addSavedFeeds([c, d])
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            {
+              ...a,
+              id: expect.any(String),
+            },
+            {
+              ...c,
+              id: expect.any(String),
+            },
+            {
+              ...b,
+              id: expect.any(String),
+            },
+            {
+              ...d,
+              id: expect.any(String),
+            },
+          ])
+        })
+      })
     })
 
     describe(`saved feeds v2: migration scenarios`, () => {

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1990,7 +1990,7 @@ describe('agent', () => {
       })
 
       describe(`removeSavedFeedV2`, () => {
-        it('removeSavedFeedV2: feed, pinned', async () => {
+        it('works', async () => {
           const feed = {
             type: 'feed',
             value: feedUri(),
@@ -2088,61 +2088,7 @@ describe('agent', () => {
       })
 
       describe(`updateSavedFeed`, () => {
-        it(`updates in situ and preserves order`, async () => {
-          const a = {
-            id: TID.nextStr(),
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          const b = {
-            id: TID.nextStr(),
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          const c = {
-            id: TID.nextStr(),
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          await agent.setSavedFeedsV2([a, b, c])
-          await agent.updateSavedFeed({
-            ...b,
-            pinned: false,
-          })
-          const prefs = await agent.getPreferences()
-          expect(prefs.savedFeeds).toStrictEqual([
-            a,
-            c,
-            {
-              ...b,
-              pinned: false,
-            },
-          ])
-        })
-
-        it(`cannot override original id`, async () => {
-          const a = {
-            id: TID.nextStr(),
-            type: 'feed',
-            value: feedUri(),
-            pinned: true,
-          }
-          await agent.setSavedFeedsV2([a])
-          await agent.updateSavedFeed({
-            ...a,
-            pinned: false,
-            id: TID.nextStr(),
-          })
-          const prefs = await agent.getPreferences()
-          expect(prefs.savedFeeds).toStrictEqual([a])
-        })
-      })
-
-      describe(`misc`, () => {
-        it(`sorts by pinned, appends new pins to end`, async () => {
+        it(`updates affect order, saved last, new pins last`, async () => {
           const a = {
             id: TID.nextStr(),
             type: 'feed',
@@ -2185,6 +2131,23 @@ describe('agent', () => {
 
           const prefs2 = await agent.getPreferences()
           expect(prefs2.savedFeeds).toStrictEqual([a, c, b])
+        })
+
+        it(`cannot override original id`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          await agent.setSavedFeedsV2([a])
+          await agent.updateSavedFeed({
+            ...a,
+            pinned: false,
+            id: TID.nextStr(),
+          })
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([a])
         })
       })
     })

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -2115,11 +2115,11 @@ describe('agent', () => {
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([
             a,
+            c,
             {
               ...b,
               pinned: false,
             },
-            c,
           ])
         })
 
@@ -2138,6 +2138,53 @@ describe('agent', () => {
           })
           const prefs = await agent.getPreferences()
           expect(prefs.savedFeeds).toStrictEqual([a])
+        })
+      })
+
+      describe(`misc`, () => {
+        it(`sorts by pinned, appends new pins to end`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const c = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+
+          await agent.setSavedFeedsV2([a, b, c])
+          await agent.updateSavedFeed({
+            ...b,
+            pinned: false,
+          })
+
+          const prefs1 = await agent.getPreferences()
+          expect(prefs1.savedFeeds).toStrictEqual([
+            a,
+            c,
+            {
+              ...b,
+              pinned: false,
+            },
+          ])
+
+          await agent.updateSavedFeed({
+            ...b,
+            pinned: true,
+          })
+
+          const prefs2 = await agent.getPreferences()
+          expect(prefs2.savedFeeds).toStrictEqual([a, c, b])
         })
       })
     })
@@ -2427,8 +2474,8 @@ describe('agent', () => {
           },
           { id: expect.any(String), type: 'feed', value: a, pinned: true },
           { id: expect.any(String), type: 'feed', value: b, pinned: true },
-          { id: expect.any(String), type: 'feed', value: c, pinned: false },
           { id: expect.any(String), type: 'feed', value: e, pinned: true },
+          { id: expect.any(String), type: 'feed', value: c, pinned: false },
         ])
       })
     })

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -1,4 +1,5 @@
 import { TestNetworkNoAppView } from '@atproto/dev-env'
+import { TID } from '@atproto/common-web'
 import {
   BskyAgent,
   ComAtprotoRepoPutRecord,
@@ -237,9 +238,10 @@ describe('agent', () => {
       }))
 
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: ['home'], saved: ['home'] },
+        feeds: { pinned: undefined, saved: undefined },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
@@ -273,9 +275,10 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(true)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: ['home'], saved: ['home'] },
+        feeds: { pinned: undefined, saved: undefined },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
@@ -309,9 +312,10 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(false)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: ['home'], saved: ['home'] },
+        feeds: { pinned: undefined, saved: undefined },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
@@ -345,9 +349,10 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('misinfo', 'hide')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: ['home'], saved: ['home'] },
+        feeds: { pinned: undefined, saved: undefined },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
@@ -381,9 +386,10 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('spam', 'ignore')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: ['home'], saved: ['home'] },
+        feeds: { pinned: undefined, saved: undefined },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
@@ -423,19 +429,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: false,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
-          },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: [],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -471,19 +473,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -519,19 +517,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: false,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
-          },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: [],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -567,14 +561,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -610,19 +605,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -658,29 +649,18 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
-          },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
           pinned: [
-            'home',
             'at://bob.com/app.bsky.feed.generator/fake',
             'at://bob.com/app.bsky.feed.generator/fake2',
           ],
           saved: [
-            'home',
             'at://bob.com/app.bsky.feed.generator/fake',
             'at://bob.com/app.bsky.feed.generator/fake2',
           ],
@@ -719,19 +699,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -767,19 +743,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -815,19 +787,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -863,19 +831,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -911,19 +875,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -966,19 +926,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1021,19 +977,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1076,19 +1028,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
           },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
-          },
         ],
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1247,14 +1195,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             type: 'timeline',
             value: 'home',
             pinned: true,
           },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         },
         moderationPrefs: {
           adultContentEnabled: true,
@@ -1299,14 +1248,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             type: 'timeline',
             value: 'home',
             pinned: true,
           },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1351,14 +1301,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             type: 'timeline',
             value: 'home',
             pinned: true,
           },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1404,14 +1355,15 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            id: expect.any(String),
             type: 'timeline',
             value: 'home',
             pinned: true,
           },
         ],
         feeds: {
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1452,19 +1404,15 @@ describe('agent', () => {
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
-          },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         moderationPrefs: {
@@ -1506,19 +1454,15 @@ describe('agent', () => {
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
-          },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         moderationPrefs: {
@@ -1571,19 +1515,15 @@ describe('agent', () => {
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
-          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
         savedFeeds: [
           {
+            id: expect.any(String),
             pinned: true,
             type: 'timeline',
             value: 'home',
-          },
-          {
-            pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         moderationPrefs: {
@@ -1656,14 +1596,10 @@ describe('agent', () => {
             $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
             items: [
               {
+                id: expect.any(String),
                 pinned: true,
                 type: 'timeline',
                 value: 'home',
-              },
-              {
-                pinned: true,
-                type: 'feed',
-                value: 'at://bob.com/app.bsky.feed.generator/fake',
               },
             ],
           },
@@ -1974,179 +1910,235 @@ describe('agent', () => {
         })
       })
 
-      it('upsertSavedFeed: feed, unpinned', async () => {
-        const feed = feedUri()
-        await agent.upsertSavedFeed({
-          type: 'feed',
-          value: feed,
-          pinned: false,
+      beforeEach(async () => {
+        await agent.app.bsky.actor.putPreferences({
+          preferences: [],
         })
-        const prefs = await agent.getPreferences()
-        expect(prefs.feeds.saved).toContain(feed)
-        expect(prefs.feeds.pinned).not.toContain(feed)
       })
 
-      it('upsertSavedFeed: feed, pinned', async () => {
-        const feed = feedUri()
-        await agent.upsertSavedFeed({
-          type: 'feed',
-          value: feed,
-          pinned: true,
-        })
-        const prefs = await agent.getPreferences()
-        // also in saved, backwards compat
-        expect(prefs.feeds.saved).toContain(feed)
-        expect(prefs.feeds.pinned).toContain(feed)
-      })
-
-      it('upsertSavedFeed: throws if feed is specified and list provided', async () => {
-        const list = listUri()
-        expect(() =>
-          agent.upsertSavedFeed({
+      describe(`addSavedFeedV2`, () => {
+        it('works', async () => {
+          const feed = {
             type: 'feed',
-            value: list,
-            pinned: true,
-          }),
-        ).rejects.toThrow()
-      })
-
-      it('upsertSavedFeed: throws if list is specified and feed provided', async () => {
-        const feed = feedUri()
-        expect(() =>
-          agent.upsertSavedFeed({
-            type: 'list',
-            value: feed,
-            pinned: true,
-          }),
-        ).rejects.toThrow()
-      })
-
-      it('deleteSavedFeed: feed, pinned', async () => {
-        const feed = feedUri()
-        await agent.upsertSavedFeed({
-          type: 'feed',
-          value: feed,
-          pinned: true,
-        })
-        await agent.deleteSavedFeed({
-          type: 'feed',
-          value: feed,
-          pinned: true,
-        })
-        const prefs = await agent.getPreferences()
-        expect(prefs.feeds.saved).not.toContain(feed)
-      })
-
-      it(`updateSavedFeeds: dedupes, takes last`, async () => {
-        const a = feedUri()
-        const b = feedUri()
-        await agent.updateSavedFeeds([
-          {
-            type: 'feed',
-            value: a,
-            pinned: true,
-          },
-          {
-            type: 'feed',
-            value: a,
+            value: feedUri(),
             pinned: false,
-          },
-          {
-            type: 'feed',
-            value: b,
-            pinned: true,
-          },
-        ])
-        const prefs = await agent.getPreferences()
-        expect(prefs.feeds.saved).toContain(a)
-        expect(prefs.feeds.saved).toContain(b)
-        expect(prefs.feeds.pinned).not.toContain(a)
-        expect(prefs.feeds.pinned).toContain(b)
-      })
-
-      it(`upsertSavedFeed: timeline`, async () => {
-        await agent.upsertSavedFeed({
-          type: 'timeline',
-          value: 'home',
-          pinned: true,
-        })
-        const prefs = await agent.getPreferences()
-        expect(
-          prefs.savedFeeds.find((f) => f.type === 'timeline'),
-        ).toStrictEqual({
-          type: 'timeline',
-          value: 'home',
-          pinned: true,
-        })
-      })
-
-      it(`updateSavedFeeds: preserves order`, async () => {
-        const a = feedUri()
-        const b = feedUri()
-        const c = feedUri()
-        const d = feedUri()
-
-        await agent.updateSavedFeeds([
-          {
-            type: 'timeline',
-            value: a,
-            pinned: true,
-          },
-          {
-            type: 'feed',
-            value: b,
-            pinned: false,
-          },
-          {
-            type: 'feed',
-            value: c,
-            pinned: true,
-          },
-          {
-            type: 'feed',
-            value: d,
-            pinned: false,
-          },
-        ])
-
-        const { savedFeeds, feeds } = await agent.getPreferences()
-        expect(JSON.stringify(savedFeeds.filter((f) => f.pinned))).toEqual(
-          JSON.stringify([
+          }
+          await agent.addSavedFeedV2(feed)
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
             {
+              ...feed,
+              id: expect.any(String),
+            },
+          ])
+        })
+
+        it('throws if feed is specified and list provided', async () => {
+          const list = listUri()
+          await expect(() =>
+            agent.addSavedFeedV2({
+              type: 'feed',
+              value: list,
+              pinned: true,
+            }),
+          ).rejects.toThrow()
+        })
+
+        it('throws if list is specified and feed provided', async () => {
+          const feed = feedUri()
+          await expect(() =>
+            agent.addSavedFeedV2({
+              type: 'list',
+              value: feed,
+              pinned: true,
+            }),
+          ).rejects.toThrow()
+        })
+
+        it(`timeline`, async () => {
+          const feeds = await agent.addSavedFeedV2({
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          })
+          const prefs = await agent.getPreferences()
+          expect(
+            prefs.savedFeeds.filter((f) => f.type === 'timeline'),
+          ).toStrictEqual(feeds)
+        })
+
+        it(`allows duplicates`, async () => {
+          const feed = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: false,
+          }
+          await agent.addSavedFeedV2(feed)
+          await agent.addSavedFeedV2(feed)
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            {
+              ...feed,
+              id: expect.any(String),
+            },
+            {
+              ...feed,
+              id: expect.any(String),
+            },
+          ])
+        })
+      })
+
+      describe(`removeSavedFeedV2`, () => {
+        it('removeSavedFeedV2: feed, pinned', async () => {
+          const feed = {
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const savedFeeds = await agent.addSavedFeedV2(feed)
+          await agent.removeSavedFeedV2(savedFeeds[0].id)
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([])
+        })
+      })
+
+      describe(`setSavedFeedsV2`, () => {
+        it(`dedupes by id, takes last`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          await agent.setSavedFeedsV2([a, a, b])
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([a, b])
+        })
+
+        it(`preserves order`, async () => {
+          const a = feedUri()
+          const b = feedUri()
+          const c = feedUri()
+          const d = feedUri()
+
+          await agent.setSavedFeedsV2([
+            {
+              id: TID.nextStr(),
               type: 'timeline',
               value: a,
               pinned: true,
             },
             {
-              type: 'feed',
-              value: c,
-              pinned: true,
-            },
-          ]),
-        )
-        expect(JSON.stringify(feeds.pinned)).toEqual(JSON.stringify([a, c]))
-        expect(JSON.stringify(savedFeeds.filter((f) => !f.pinned))).toEqual(
-          JSON.stringify([
-            {
+              id: TID.nextStr(),
               type: 'feed',
               value: b,
               pinned: false,
             },
             {
+              id: TID.nextStr(),
+              type: 'feed',
+              value: c,
+              pinned: true,
+            },
+            {
+              id: TID.nextStr(),
               type: 'feed',
               value: d,
               pinned: false,
             },
-          ]),
-        )
-        expect(JSON.stringify(feeds.saved)).toEqual(JSON.stringify([a, b, c, d]))
+          ])
+
+          const { savedFeeds } = await agent.getPreferences()
+          expect(savedFeeds.filter((f) => f.pinned)).toStrictEqual([
+            {
+              id: expect.any(String),
+              type: 'timeline',
+              value: a,
+              pinned: true,
+            },
+            {
+              id: expect.any(String),
+              type: 'feed',
+              value: c,
+              pinned: true,
+            },
+          ])
+          expect(savedFeeds.filter((f) => !f.pinned)).toEqual([
+            {
+              id: expect.any(String),
+              type: 'feed',
+              value: b,
+              pinned: false,
+            },
+            {
+              id: expect.any(String),
+              type: 'feed',
+              value: d,
+              pinned: false,
+            },
+          ])
+        })
       })
 
-      /*
-       * Old methods can't handle `timeline` or types other than `feed` or
-       * `list`
-       */
-      it(`deprecated methods write only to v1`, async () => {
+      describe(`updateSavedFeed`, () => {
+        it(`updates in situ and preserves order`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const b = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          const c = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          await agent.setSavedFeedsV2([a, b, c])
+          await agent.updateSavedFeed({
+            ...b,
+            pinned: false,
+          })
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([
+            a,
+            {
+              ...b,
+              pinned: false,
+            },
+            c,
+          ])
+        })
+
+        it(`cannot override original id`, async () => {
+          const a = {
+            id: TID.nextStr(),
+            type: 'feed',
+            value: feedUri(),
+            pinned: true,
+          }
+          await agent.setSavedFeedsV2([a])
+          await agent.updateSavedFeed({
+            ...a,
+            pinned: false,
+            id: TID.nextStr(),
+          })
+          const prefs = await agent.getPreferences()
+          expect(prefs.savedFeeds).toStrictEqual([a])
+        })
       })
     })
 
@@ -2170,86 +2162,137 @@ describe('agent', () => {
         })
       })
 
-      // fresh account OR an old account with no v1 prefs to migrate from
-      it(`migrates on startup for new/old users`, async () => {
+      it('CRUD action before migration, no timeline inserted', async () => {
+        const feed = {
+          type: 'feed',
+          value: feedUri(),
+          pinned: false,
+        }
+        await agent.addSavedFeedV2(feed)
         const prefs = await agent.getPreferences()
-
-        expect(prefs.feeds).toStrictEqual({
-          saved: ['home'],
-          pinned: ['home'],
-        })
         expect(prefs.savedFeeds).toStrictEqual([
           {
-            type: 'timeline',
-            value: 'home',
-            pinned: true,
-          }
+            ...feed,
+            id: expect.any(String),
+          },
         ])
       })
 
-      it(`migrates pinned & saved feed`, async () => {
+      it('CRUD action AFTER migration, timeline was inserted', async () => {
+        await agent.getPreferences()
+        const feed = {
+          type: 'feed',
+          value: feedUri(),
+          pinned: false,
+        }
+        await agent.addSavedFeedV2(feed)
+        const prefs = await agent.getPreferences()
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+          {
+            ...feed,
+            id: expect.any(String),
+          },
+        ])
+      })
+
+      // fresh account OR an old account with no v1 prefs to migrate from
+      it(`brand new user, v1 remains undefined`, async () => {
+        const prefs = await agent.getPreferences()
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ])
+        // no v1 prefs to populate from
+        expect(prefs.feeds).toStrictEqual({
+          saved: undefined,
+          pinned: undefined,
+        })
+      })
+
+      it(`brand new user, v2 does not write to v1`, async () => {
+        const a = feedUri()
+        // migration happens
+        await agent.getPreferences()
+        await agent.addSavedFeedV2({
+          type: 'feed',
+          value: a,
+          pinned: false,
+        })
+        const prefs = await agent.getPreferences()
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+          {
+            id: expect.any(String),
+            type: 'feed',
+            value: a,
+            pinned: false,
+          },
+        ])
+        // no v1 prefs to populate from
+        expect(prefs.feeds).toStrictEqual({
+          saved: undefined,
+          pinned: undefined,
+        })
+      })
+
+      it(`existing user with v1 prefs, migrates`, async () => {
         const one = feedUri()
+        const two = feedUri()
         await agent.app.bsky.actor.putPreferences({
           preferences: [
             {
               $type: 'app.bsky.actor.defs#savedFeedsPref',
               pinned: [one],
-              saved: [one],
+              saved: [one, two],
             },
           ],
         })
         const prefs = await agent.getPreferences()
 
+        // deprecated interface receives what it normally would
         expect(prefs.feeds).toStrictEqual({
-          saved: ['home', one],
-          pinned: ['home', one],
+          pinned: [one],
+          saved: [one, two],
         })
+        // new interface gets new timeline + old pinned feed
         expect(prefs.savedFeeds).toStrictEqual([
           {
+            id: expect.any(String),
             type: 'timeline',
             value: 'home',
             pinned: true,
           },
           {
+            id: expect.any(String),
             type: 'feed',
             value: one,
-            pinned: true,
-          }
-        ])
-      })
-
-      it(`migrates saved feed`, async () => {
-        const one = feedUri()
-        await agent.app.bsky.actor.putPreferences({
-          preferences: [
-            {
-              $type: 'app.bsky.actor.defs#savedFeedsPref',
-              pinned: [],
-              saved: [one],
-            },
-          ],
-        })
-        const prefs = await agent.getPreferences()
-
-        expect(prefs.feeds).toStrictEqual({
-          saved: ['home', one],
-          pinned: ['home'],
-        })
-        expect(prefs.savedFeeds).toStrictEqual([
-          {
-            type: 'timeline',
-            value: 'home',
             pinned: true,
           },
           {
+            id: expect.any(String),
             type: 'feed',
-            value: one,
+            value: two,
             pinned: false,
-          }
+          },
         ])
       })
 
-      it('squashes duplicates', async () => {
+      it('squashes duplicates during migration', async () => {
         const one = feedUri()
         const two = feedUri()
         await agent.app.bsky.actor.putPreferences({
@@ -2270,9 +2313,17 @@ describe('agent', () => {
         // performs migration
         const prefs = await agent.getPreferences()
         expect(prefs.feeds).toStrictEqual({
-          pinned: ['home'],
-          saved: ['home'],
+          pinned: [],
+          saved: [],
         })
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ])
 
         const res = await agent.app.bsky.actor.getPreferences()
         expect(res.data.preferences).toStrictEqual([
@@ -2280,6 +2331,7 @@ describe('agent', () => {
             $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
             items: [
               {
+                id: expect.any(String),
                 type: 'timeline',
                 value: 'home',
                 pinned: true,
@@ -2294,7 +2346,7 @@ describe('agent', () => {
         ])
       })
 
-      it('writes to v2 persist to v1, writes to v1 (from v1 client) persist to v1 but not to v2', async () => {
+      it('v2 writes persist to v1, not the inverse', async () => {
         const a = feedUri()
         const b = feedUri()
         const c = feedUri()
@@ -2312,10 +2364,11 @@ describe('agent', () => {
         })
 
         // client updates, migrates to v2
+        // a and b are both pinned
         await agent.getPreferences()
 
-        // new write to v2
-        await agent.upsertSavedFeed({
+        // new write to v2, c is saved
+        await agent.addSavedFeedV2({
           type: 'feed',
           value: c,
           pinned: false,
@@ -2332,20 +2385,8 @@ describe('agent', () => {
           saved: [a, b, c],
         })
 
-        // v1 write occurs
-        const res2 = await agent.app.bsky.actor.getPreferences()
-        await agent.app.bsky.actor.putPreferences({
-          preferences: [
-            ...res2.data.preferences.filter(
-              (p) => !AppBskyActorDefs.isSavedFeedsPref(p),
-            ),
-            {
-              $type: 'app.bsky.actor.defs#savedFeedsPref',
-              pinned: [a, b],
-              saved: [a, b, c, d],
-            },
-          ],
-        })
+        // v1 write occurs, d is added but not to v2
+        await agent.addSavedFeed(d)
 
         const res3 = await agent.app.bsky.actor.getPreferences()
         const v1Pref3 = res3.data.preferences.find((p) =>
@@ -2356,15 +2397,9 @@ describe('agent', () => {
           pinned: [a, b],
           saved: [a, b, c, d],
         })
-        // v2 reads, not updated with v1 write
-        const prefs = await agent.getPreferences()
-        expect(prefs.feeds).toStrictEqual({
-          pinned: ['home', a, b],
-          saved: ['home', a, b, c],
-        })
 
-        // another new write to v2
-        await agent.upsertSavedFeed({
+        // another new write to v2, pins e
+        await agent.addSavedFeedV2({
           type: 'feed',
           value: e,
           pinned: true,
@@ -2374,17 +2409,29 @@ describe('agent', () => {
         const v1Pref4 = res4.data.preferences.find((p) =>
           AppBskyActorDefs.isSavedFeedsPref(p),
         )
+        // v1 pref got v2 write
         expect(v1Pref4).toStrictEqual({
           $type: 'app.bsky.actor.defs#savedFeedsPref',
           pinned: [a, b, e],
           saved: [a, b, c, d, e],
         })
+
+        const final = await agent.getPreferences()
+        // d not here bc it was written with v1
+        expect(final.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+          { id: expect.any(String), type: 'feed', value: a, pinned: true },
+          { id: expect.any(String), type: 'feed', value: b, pinned: true },
+          { id: expect.any(String), type: 'feed', value: c, pinned: false },
+          { id: expect.any(String), type: 'feed', value: e, pinned: true },
+        ])
       })
     })
-
-    // TODO
-    // [ ] updating timeline is based on uri, will duplicate
-    // [ ] should v1 methods write to v2
 
     // end
   })

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -2574,6 +2574,28 @@ describe('agent', () => {
           { id: expect.any(String), type: 'feed', value: c, pinned: false },
         ])
       })
+
+      it(`filters out invalid values in v1 prefs`, async () => {
+        // v1 prefs must be valid AtUris, but they could be any type in theory
+        await agent.app.bsky.actor.putPreferences({
+          preferences: [
+            {
+              $type: 'app.bsky.actor.defs#savedFeedsPref',
+              pinned: ['at://did:plc:fake/app.bsky.graph.follow/fake'],
+              saved: ['at://did:plc:fake/app.bsky.graph.follow/fake'],
+            },
+          ],
+        })
+        const prefs = await agent.getPreferences()
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            id: expect.any(String),
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ])
+      })
     })
 
     // end

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -2004,7 +2004,7 @@ describe('agent', () => {
       })
 
       describe(`setSavedFeedsV2`, () => {
-        it(`dedupes by id, takes last`, async () => {
+        it(`dedupes by id, takes last, preserves order based on last found`, async () => {
           const a = {
             id: TID.nextStr(),
             type: 'feed',
@@ -2017,9 +2017,9 @@ describe('agent', () => {
             value: feedUri(),
             pinned: true,
           }
-          await agent.setSavedFeedsV2([a, a, b])
+          await agent.setSavedFeedsV2([a, b, a])
           const prefs = await agent.getPreferences()
-          expect(prefs.savedFeeds).toStrictEqual([a, b])
+          expect(prefs.savedFeeds).toStrictEqual([b, a])
         })
 
         it(`preserves order`, async () => {

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -6,6 +6,11 @@ import {
   AppBskyActorProfile,
   DEFAULT_LABEL_SETTINGS,
 } from '../src'
+import {
+  savedFeedsToUriArrays,
+  getSavedFeedType,
+  validateSavedFeed,
+} from '../src/util'
 import { AppBskyActorDefs } from '../dist'
 
 describe('agent', () => {
@@ -244,7 +249,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -281,7 +286,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -318,7 +323,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -355,7 +360,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -392,7 +397,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -432,7 +437,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -476,7 +481,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -520,7 +525,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -564,7 +569,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -608,7 +613,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -652,7 +657,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -702,7 +707,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -746,7 +751,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -790,7 +795,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -834,7 +839,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -878,7 +883,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -929,7 +934,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -980,7 +985,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -1031,7 +1036,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         feeds: {
@@ -1197,7 +1202,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ],
@@ -1250,7 +1255,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ],
@@ -1303,7 +1308,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ],
@@ -1357,7 +1362,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ],
@@ -1412,7 +1417,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -1462,7 +1467,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -1523,7 +1528,7 @@ describe('agent', () => {
             id: expect.any(String),
             pinned: true,
             type: 'timeline',
-            value: 'home',
+            value: 'following',
           },
         ],
         moderationPrefs: {
@@ -1599,7 +1604,7 @@ describe('agent', () => {
                 id: expect.any(String),
                 pinned: true,
                 type: 'timeline',
-                value: 'home',
+                value: 'following',
               },
             ],
           },
@@ -1963,7 +1968,7 @@ describe('agent', () => {
           const feeds = await agent.addSavedFeeds([
             {
               type: 'timeline',
-              value: 'home',
+              value: 'following',
               pinned: true,
             },
           ])
@@ -2277,6 +2282,96 @@ describe('agent', () => {
           ])
         })
       })
+
+      describe(`utils`, () => {
+        describe(`savedFeedsToUriArrays`, () => {
+          const { saved, pinned } = savedFeedsToUriArrays([
+            {
+              id: '',
+              type: 'feed',
+              value: 'a',
+              pinned: true,
+            },
+            {
+              id: '',
+              type: 'feed',
+              value: 'b',
+              pinned: false,
+            },
+            {
+              id: '',
+              type: 'feed',
+              value: 'c',
+              pinned: true,
+            },
+          ])
+          expect(saved).toStrictEqual(['a', 'b', 'c'])
+          expect(pinned).toStrictEqual(['a', 'c'])
+        })
+
+        describe(`getSavedFeedType`, () => {
+          it(`works`, () => {
+            expect(getSavedFeedType('foo')).toBe('unknown')
+            expect(getSavedFeedType(feedUri())).toBe('feed')
+            expect(getSavedFeedType(listUri())).toBe('list')
+            expect(
+              getSavedFeedType('at://did:plc:fake/app.bsky.graph.follow/fake'),
+            ).toBe('unknown')
+          })
+        })
+
+        describe(`validateSavedFeed`, () => {
+          it(`throws if invalid TID`, () => {
+            // really only checks length at time of writing
+            expect(() =>
+              validateSavedFeed({
+                id: 'a',
+                type: 'feed',
+                value: feedUri(),
+                pinned: false,
+              }),
+            ).toThrow()
+          })
+
+          it(`throws if mismatched types`, () => {
+            expect(() =>
+              validateSavedFeed({
+                id: TID.nextStr(),
+                type: 'list',
+                value: feedUri(),
+                pinned: false,
+              }),
+            ).toThrow()
+            expect(() =>
+              validateSavedFeed({
+                id: TID.nextStr(),
+                type: 'feed',
+                value: listUri(),
+                pinned: false,
+              }),
+            ).toThrow()
+          })
+
+          it(`ignores values it can't validate`, () => {
+            expect(() =>
+              validateSavedFeed({
+                id: TID.nextStr(),
+                type: 'timeline',
+                value: 'following',
+                pinned: false,
+              }),
+            ).not.toThrow()
+            expect(() =>
+              validateSavedFeed({
+                id: TID.nextStr(),
+                type: 'unknown',
+                value: 'could be @nyt4!ng',
+                pinned: false,
+              }),
+            ).not.toThrow()
+          })
+        })
+      })
     })
 
     describe(`saved feeds v2: migration scenarios`, () => {
@@ -2328,7 +2423,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
           {
@@ -2345,7 +2440,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ])
@@ -2372,7 +2467,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
           {
@@ -2413,7 +2508,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
           {
@@ -2459,7 +2554,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ])
@@ -2472,7 +2567,7 @@ describe('agent', () => {
               {
                 id: expect.any(String),
                 type: 'timeline',
-                value: 'home',
+                value: 'following',
                 pinned: true,
               },
             ],
@@ -2565,7 +2660,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
           { id: expect.any(String), type: 'feed', value: a, pinned: true },
@@ -2591,7 +2686,7 @@ describe('agent', () => {
           {
             id: expect.any(String),
             type: 'timeline',
-            value: 'home',
+            value: 'following',
             pinned: true,
           },
         ])

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -237,8 +237,14 @@ describe('agent', () => {
       }))
 
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: undefined, saved: undefined },
-        savedFeeds: [],
+        feeds: { pinned: ['home'], saved: ['home'] },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -267,8 +273,14 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(true)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: undefined, saved: undefined },
-        savedFeeds: [],
+        feeds: { pinned: ['home'], saved: ['home'] },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: true,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -297,8 +309,14 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(false)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: undefined, saved: undefined },
-        savedFeeds: [],
+        feeds: { pinned: ['home'], saved: ['home'] },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -327,8 +345,14 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('misinfo', 'hide')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: undefined, saved: undefined },
-        savedFeeds: [],
+        feeds: { pinned: ['home'], saved: ['home'] },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: { ...DEFAULT_LABEL_SETTINGS, misinfo: 'hide' },
@@ -357,8 +381,14 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('spam', 'ignore')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        feeds: { pinned: undefined, saved: undefined },
-        savedFeeds: [],
+        feeds: { pinned: ['home'], saved: ['home'] },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: {
@@ -393,14 +423,19 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
             pinned: false,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         feeds: {
-          pinned: [],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['home'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -437,13 +472,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -479,14 +519,19 @@ describe('agent', () => {
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         savedFeeds: [
           {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
             pinned: false,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         feeds: {
-          pinned: [],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['home'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -520,10 +565,16 @@ describe('agent', () => {
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        savedFeeds: [],
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+        ],
         feeds: {
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -560,13 +611,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -603,23 +659,30 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
-            type: 'feed',
-            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+            type: 'timeline',
+            value: 'home',
           },
           {
             pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
         ],
         feeds: {
           pinned: [
-            'at://bob.com/app.bsky.feed.generator/fake2',
+            'home',
             'at://bob.com/app.bsky.feed.generator/fake',
+            'at://bob.com/app.bsky.feed.generator/fake2',
           ],
           saved: [
-            'at://bob.com/app.bsky.feed.generator/fake2',
+            'home',
             'at://bob.com/app.bsky.feed.generator/fake',
+            'at://bob.com/app.bsky.feed.generator/fake2',
           ],
         },
         moderationPrefs: {
@@ -657,13 +720,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -700,13 +768,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -743,13 +816,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -786,13 +864,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -829,13 +912,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -879,13 +967,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -929,13 +1022,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -979,13 +1077,18 @@ describe('agent', () => {
         savedFeeds: [
           {
             pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
+          {
+            pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake2',
           },
         ],
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake2'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1142,10 +1245,16 @@ describe('agent', () => {
         ],
       })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        savedFeeds: [],
+        savedFeeds: [
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ],
         feeds: {
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         },
         moderationPrefs: {
           adultContentEnabled: true,
@@ -1188,10 +1297,16 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(false)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        savedFeeds: [],
+        savedFeeds: [
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ],
         feeds: {
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1234,10 +1349,16 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('porn', 'ignore')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        savedFeeds: [],
+        savedFeeds: [
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ],
         feeds: {
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1281,10 +1402,16 @@ describe('agent', () => {
 
       await agent.removeLabeler('did:plc:other')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
-        savedFeeds: [],
+        savedFeeds: [
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+        ],
         feeds: {
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         },
         moderationPrefs: {
           adultContentEnabled: false,
@@ -1325,10 +1452,15 @@ describe('agent', () => {
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
         },
         savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
           {
             pinned: true,
             type: 'feed',
@@ -1373,17 +1505,22 @@ describe('agent', () => {
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+        },
         savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
           {
             pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
-        feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
-        },
         moderationPrefs: {
           adultContentEnabled: false,
           labels: {
@@ -1433,17 +1570,22 @@ describe('agent', () => {
       })
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        feeds: {
+          pinned: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+          saved: ['home', 'at://bob.com/app.bsky.feed.generator/fake'],
+        },
         savedFeeds: [
+          {
+            pinned: true,
+            type: 'timeline',
+            value: 'home',
+          },
           {
             pinned: true,
             type: 'feed',
             value: 'at://bob.com/app.bsky.feed.generator/fake',
           },
         ],
-        feeds: {
-          pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
-          saved: ['at://bob.com/app.bsky.feed.generator/fake'],
-        },
         moderationPrefs: {
           adultContentEnabled: false,
           labels: {
@@ -1513,6 +1655,11 @@ describe('agent', () => {
           {
             $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
             items: [
+              {
+                pinned: true,
+                type: 'timeline',
+                value: 'home',
+              },
               {
                 pinned: true,
                 type: 'feed',
@@ -1916,6 +2063,91 @@ describe('agent', () => {
         expect(prefs.feeds.pinned).not.toContain(a)
         expect(prefs.feeds.pinned).toContain(b)
       })
+
+      it(`upsertSavedFeed: timeline`, async () => {
+        await agent.upsertSavedFeed({
+          type: 'timeline',
+          value: 'home',
+          pinned: true,
+        })
+        const prefs = await agent.getPreferences()
+        expect(
+          prefs.savedFeeds.find((f) => f.type === 'timeline'),
+        ).toStrictEqual({
+          type: 'timeline',
+          value: 'home',
+          pinned: true,
+        })
+      })
+
+      it(`updateSavedFeeds: preserves order`, async () => {
+        const a = feedUri()
+        const b = feedUri()
+        const c = feedUri()
+        const d = feedUri()
+
+        await agent.updateSavedFeeds([
+          {
+            type: 'timeline',
+            value: a,
+            pinned: true,
+          },
+          {
+            type: 'feed',
+            value: b,
+            pinned: false,
+          },
+          {
+            type: 'feed',
+            value: c,
+            pinned: true,
+          },
+          {
+            type: 'feed',
+            value: d,
+            pinned: false,
+          },
+        ])
+
+        const { savedFeeds, feeds } = await agent.getPreferences()
+        expect(JSON.stringify(savedFeeds.filter((f) => f.pinned))).toEqual(
+          JSON.stringify([
+            {
+              type: 'timeline',
+              value: a,
+              pinned: true,
+            },
+            {
+              type: 'feed',
+              value: c,
+              pinned: true,
+            },
+          ]),
+        )
+        expect(JSON.stringify(feeds.pinned)).toEqual(JSON.stringify([a, c]))
+        expect(JSON.stringify(savedFeeds.filter((f) => !f.pinned))).toEqual(
+          JSON.stringify([
+            {
+              type: 'feed',
+              value: b,
+              pinned: false,
+            },
+            {
+              type: 'feed',
+              value: d,
+              pinned: false,
+            },
+          ]),
+        )
+        expect(JSON.stringify(feeds.saved)).toEqual(JSON.stringify([a, b, c, d]))
+      })
+
+      /*
+       * Old methods can't handle `timeline` or types other than `feed` or
+       * `list`
+       */
+      it(`deprecated methods write only to v1`, async () => {
+      })
     })
 
     describe(`saved feeds v2: migration scenarios`, () => {
@@ -1936,6 +2168,85 @@ describe('agent', () => {
         await agent.app.bsky.actor.putPreferences({
           preferences: [],
         })
+      })
+
+      // fresh account OR an old account with no v1 prefs to migrate from
+      it(`migrates on startup for new/old users`, async () => {
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.feeds).toStrictEqual({
+          saved: ['home'],
+          pinned: ['home'],
+        })
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          }
+        ])
+      })
+
+      it(`migrates pinned & saved feed`, async () => {
+        const one = feedUri()
+        await agent.app.bsky.actor.putPreferences({
+          preferences: [
+            {
+              $type: 'app.bsky.actor.defs#savedFeedsPref',
+              pinned: [one],
+              saved: [one],
+            },
+          ],
+        })
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.feeds).toStrictEqual({
+          saved: ['home', one],
+          pinned: ['home', one],
+        })
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+          {
+            type: 'feed',
+            value: one,
+            pinned: true,
+          }
+        ])
+      })
+
+      it(`migrates saved feed`, async () => {
+        const one = feedUri()
+        await agent.app.bsky.actor.putPreferences({
+          preferences: [
+            {
+              $type: 'app.bsky.actor.defs#savedFeedsPref',
+              pinned: [],
+              saved: [one],
+            },
+          ],
+        })
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.feeds).toStrictEqual({
+          saved: ['home', one],
+          pinned: ['home'],
+        })
+        expect(prefs.savedFeeds).toStrictEqual([
+          {
+            type: 'timeline',
+            value: 'home',
+            pinned: true,
+          },
+          {
+            type: 'feed',
+            value: one,
+            pinned: false,
+          }
+        ])
       })
 
       it('squashes duplicates', async () => {
@@ -1959,15 +2270,21 @@ describe('agent', () => {
         // performs migration
         const prefs = await agent.getPreferences()
         expect(prefs.feeds).toStrictEqual({
-          pinned: [],
-          saved: [],
+          pinned: ['home'],
+          saved: ['home'],
         })
 
         const res = await agent.app.bsky.actor.getPreferences()
         expect(res.data.preferences).toStrictEqual([
           {
             $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
-            items: [],
+            items: [
+              {
+                type: 'timeline',
+                value: 'home',
+                pinned: true,
+              },
+            ],
           },
           {
             $type: 'app.bsky.actor.defs#savedFeedsPref',
@@ -1977,7 +2294,7 @@ describe('agent', () => {
         ])
       })
 
-      it('writes to v2 persist to v1, writes to v1 persist but not to v2', async () => {
+      it('writes to v2 persist to v1, writes to v1 (from v1 client) persist to v1 but not to v2', async () => {
         const a = feedUri()
         const b = feedUri()
         const c = feedUri()
@@ -2042,8 +2359,8 @@ describe('agent', () => {
         // v2 reads, not updated with v1 write
         const prefs = await agent.getPreferences()
         expect(prefs.feeds).toStrictEqual({
-          pinned: [a, b],
-          saved: [a, b, c],
+          pinned: ['home', a, b],
+          saved: ['home', a, b, c],
         })
 
         // another new write to v2
@@ -2064,6 +2381,10 @@ describe('agent', () => {
         })
       })
     })
+
+    // TODO
+    // [ ] updating timeline is based on uri, will duplicate
+    // [ ] should v1 methods write to v2
 
     // end
   })

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -238,6 +238,7 @@ describe('agent', () => {
 
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: { pinned: undefined, saved: undefined },
+        savedFeeds: [],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -267,6 +268,7 @@ describe('agent', () => {
       await agent.setAdultContentEnabled(true)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: { pinned: undefined, saved: undefined },
+        savedFeeds: [],
         moderationPrefs: {
           adultContentEnabled: true,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -296,6 +298,7 @@ describe('agent', () => {
       await agent.setAdultContentEnabled(false)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: { pinned: undefined, saved: undefined },
+        savedFeeds: [],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: DEFAULT_LABEL_SETTINGS,
@@ -325,6 +328,7 @@ describe('agent', () => {
       await agent.setContentLabelPref('misinfo', 'hide')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: { pinned: undefined, saved: undefined },
+        savedFeeds: [],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: { ...DEFAULT_LABEL_SETTINGS, misinfo: 'hide' },
@@ -354,6 +358,7 @@ describe('agent', () => {
       await agent.setContentLabelPref('spam', 'ignore')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: { pinned: undefined, saved: undefined },
+        savedFeeds: [],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: {
@@ -386,6 +391,13 @@ describe('agent', () => {
 
       await agent.addSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: false,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: [],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -422,6 +434,13 @@ describe('agent', () => {
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -458,6 +477,13 @@ describe('agent', () => {
 
       await agent.removePinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: false,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: [],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -494,6 +520,7 @@ describe('agent', () => {
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [],
         feeds: {
           pinned: [],
           saved: [],
@@ -530,6 +557,13 @@ describe('agent', () => {
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -566,6 +600,18 @@ describe('agent', () => {
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake2')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: [
             'at://bob.com/app.bsky.feed.generator/fake2',
@@ -608,6 +654,13 @@ describe('agent', () => {
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -644,6 +697,13 @@ describe('agent', () => {
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -680,6 +740,13 @@ describe('agent', () => {
 
       await agent.setFeedViewPrefs('home', { hideReplies: true })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -716,6 +783,13 @@ describe('agent', () => {
 
       await agent.setFeedViewPrefs('home', { hideReplies: false })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -752,6 +826,13 @@ describe('agent', () => {
 
       await agent.setFeedViewPrefs('other', { hideReplies: true })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -795,6 +876,13 @@ describe('agent', () => {
 
       await agent.setThreadViewPrefs({ sort: 'random' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -838,6 +926,13 @@ describe('agent', () => {
 
       await agent.setThreadViewPrefs({ sort: 'oldest' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -881,6 +976,13 @@ describe('agent', () => {
 
       await agent.setInterestsPref({ tags: ['foo', 'bar'] })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake2',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake2'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake2'],
@@ -1040,6 +1142,7 @@ describe('agent', () => {
         ],
       })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [],
         feeds: {
           pinned: [],
           saved: [],
@@ -1085,6 +1188,7 @@ describe('agent', () => {
 
       await agent.setAdultContentEnabled(false)
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [],
         feeds: {
           pinned: [],
           saved: [],
@@ -1130,6 +1234,7 @@ describe('agent', () => {
 
       await agent.setContentLabelPref('porn', 'ignore')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [],
         feeds: {
           pinned: [],
           saved: [],
@@ -1176,6 +1281,7 @@ describe('agent', () => {
 
       await agent.removeLabeler('did:plc:other')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [],
         feeds: {
           pinned: [],
           saved: [],
@@ -1222,6 +1328,13 @@ describe('agent', () => {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
         },
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         moderationPrefs: {
           adultContentEnabled: false,
           labels: {
@@ -1260,6 +1373,13 @@ describe('agent', () => {
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -1313,6 +1433,13 @@ describe('agent', () => {
       })
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
+        savedFeeds: [
+          {
+            pinned: true,
+            type: 'feed',
+            value: 'at://bob.com/app.bsky.feed.generator/fake',
+          },
+        ],
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
           saved: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -1685,7 +1812,7 @@ describe('agent', () => {
       })
     })
 
-    describe(`savedFeedsPrefV2`, () => {
+    describe(`saved feeds v2`, () => {
       let agent: BskyAgent
       let i = 0
       const feedUri = () => `at://bob.com/app.bsky.feed.generator/${i++}`
@@ -1791,7 +1918,7 @@ describe('agent', () => {
       })
     })
 
-    describe(`savedFeedsPrefV2 migration scenarios`, () => {
+    describe(`saved feeds v2: migration scenarios`, () => {
       let agent: BskyAgent
       let i = 0
       const feedUri = () => `at://bob.com/app.bsky.feed.generator/${i++}`
@@ -1887,9 +2014,6 @@ describe('agent', () => {
           pinned: [a, b],
           saved: [a, b, c],
         })
-        // const temp = await agent.app.bsky.actor.getPreferences()
-        // console.log(JSON.stringify(temp.data.preferences, null, '  '))
-        // return
 
         // v1 write occurs
         const res2 = await agent.app.bsky.actor.getPreferences()

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -53,6 +53,7 @@ describe('agent', () => {
         pinned: undefined,
         saved: undefined,
       },
+      savedFeeds: expect.any(Array),
       interests: { tags: [] },
       moderationPrefs: {
         adultContentEnabled: false,
@@ -98,6 +99,7 @@ describe('agent', () => {
     expect(agent.labelersHeader).toStrictEqual(['did:plc:other'])
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
+      savedFeeds: expect.any(Array),
       interests: { tags: [] },
       moderationPrefs: {
         adultContentEnabled: false,
@@ -133,6 +135,7 @@ describe('agent', () => {
     expect(agent.labelersHeader).toStrictEqual([])
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
+      savedFeeds: expect.any(Array),
       interests: { tags: [] },
       moderationPrefs: {
         adultContentEnabled: false,
@@ -177,6 +180,7 @@ describe('agent', () => {
 
     await expect(agent.getPreferences()).resolves.toStrictEqual({
       feeds: { pinned: undefined, saved: undefined },
+      savedFeeds: expect.any(Array),
       interests: { tags: [] },
       moderationPrefs: {
         adultContentEnabled: false,

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3822,6 +3822,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#savedFeedsPrefV2',
             'lex:app.bsky.actor.defs#personalDetailsPref',
             'lex:app.bsky.actor.defs#feedViewPref',
             'lex:app.bsky.actor.defs#threadViewPref',
@@ -3857,6 +3858,38 @@ export const schemaDict = {
           visibility: {
             type: 'string',
             knownValues: ['ignore', 'show', 'warn', 'hide'],
+          },
+        },
+      },
+      savedFeed: {
+        type: 'object',
+        required: ['id', 'type', 'value', 'pinned'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          type: {
+            type: 'string',
+            knownValues: ['feed', 'list', 'timeline'],
+          },
+          value: {
+            type: 'string',
+          },
+          pinned: {
+            type: 'boolean',
+          },
+        },
+      },
+      savedFeedsPrefV2: {
+        type: 'object',
+        required: ['items'],
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#savedFeed',
+            },
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -132,6 +132,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | SavedFeedsPrefV2
   | PersonalDetailsPref
   | FeedViewPref
   | ThreadViewPref
@@ -176,6 +177,43 @@ export function isContentLabelPref(v: unknown): v is ContentLabelPref {
 
 export function validateContentLabelPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#contentLabelPref', v)
+}
+
+export interface SavedFeed {
+  id: string
+  type: 'feed' | 'list' | 'timeline' | (string & {})
+  value: string
+  pinned: boolean
+  [k: string]: unknown
+}
+
+export function isSavedFeed(v: unknown): v is SavedFeed {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeed'
+  )
+}
+
+export function validateSavedFeed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeed', v)
+}
+
+export interface SavedFeedsPrefV2 {
+  items: SavedFeed[]
+  [k: string]: unknown
+}
+
+export function isSavedFeedsPrefV2(v: unknown): v is SavedFeedsPrefV2 {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeedsPrefV2'
+  )
+}
+
+export function validateSavedFeedsPrefV2(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeedsPrefV2', v)
 }
 
 export interface SavedFeedsPref {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3822,6 +3822,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#savedFeedsPrefV2',
             'lex:app.bsky.actor.defs#personalDetailsPref',
             'lex:app.bsky.actor.defs#feedViewPref',
             'lex:app.bsky.actor.defs#threadViewPref',
@@ -3857,6 +3858,38 @@ export const schemaDict = {
           visibility: {
             type: 'string',
             knownValues: ['ignore', 'show', 'warn', 'hide'],
+          },
+        },
+      },
+      savedFeed: {
+        type: 'object',
+        required: ['id', 'type', 'value', 'pinned'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          type: {
+            type: 'string',
+            knownValues: ['feed', 'list', 'timeline'],
+          },
+          value: {
+            type: 'string',
+          },
+          pinned: {
+            type: 'boolean',
+          },
+        },
+      },
+      savedFeedsPrefV2: {
+        type: 'object',
+        required: ['items'],
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#savedFeed',
+            },
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -132,6 +132,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | SavedFeedsPrefV2
   | PersonalDetailsPref
   | FeedViewPref
   | ThreadViewPref
@@ -176,6 +177,43 @@ export function isContentLabelPref(v: unknown): v is ContentLabelPref {
 
 export function validateContentLabelPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#contentLabelPref', v)
+}
+
+export interface SavedFeed {
+  id: string
+  type: 'feed' | 'list' | 'timeline' | (string & {})
+  value: string
+  pinned: boolean
+  [k: string]: unknown
+}
+
+export function isSavedFeed(v: unknown): v is SavedFeed {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeed'
+  )
+}
+
+export function validateSavedFeed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeed', v)
+}
+
+export interface SavedFeedsPrefV2 {
+  items: SavedFeed[]
+  [k: string]: unknown
+}
+
+export function isSavedFeedsPrefV2(v: unknown): v is SavedFeedsPrefV2 {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeedsPrefV2'
+  )
+}
+
+export function validateSavedFeedsPrefV2(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeedsPrefV2', v)
 }
 
 export interface SavedFeedsPref {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3822,6 +3822,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#adultContentPref',
             'lex:app.bsky.actor.defs#contentLabelPref',
             'lex:app.bsky.actor.defs#savedFeedsPref',
+            'lex:app.bsky.actor.defs#savedFeedsPrefV2',
             'lex:app.bsky.actor.defs#personalDetailsPref',
             'lex:app.bsky.actor.defs#feedViewPref',
             'lex:app.bsky.actor.defs#threadViewPref',
@@ -3857,6 +3858,38 @@ export const schemaDict = {
           visibility: {
             type: 'string',
             knownValues: ['ignore', 'show', 'warn', 'hide'],
+          },
+        },
+      },
+      savedFeed: {
+        type: 'object',
+        required: ['id', 'type', 'value', 'pinned'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          type: {
+            type: 'string',
+            knownValues: ['feed', 'list', 'timeline'],
+          },
+          value: {
+            type: 'string',
+          },
+          pinned: {
+            type: 'boolean',
+          },
+        },
+      },
+      savedFeedsPrefV2: {
+        type: 'object',
+        required: ['items'],
+        properties: {
+          items: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#savedFeed',
+            },
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -132,6 +132,7 @@ export type Preferences = (
   | AdultContentPref
   | ContentLabelPref
   | SavedFeedsPref
+  | SavedFeedsPrefV2
   | PersonalDetailsPref
   | FeedViewPref
   | ThreadViewPref
@@ -176,6 +177,43 @@ export function isContentLabelPref(v: unknown): v is ContentLabelPref {
 
 export function validateContentLabelPref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#contentLabelPref', v)
+}
+
+export interface SavedFeed {
+  id: string
+  type: 'feed' | 'list' | 'timeline' | (string & {})
+  value: string
+  pinned: boolean
+  [k: string]: unknown
+}
+
+export function isSavedFeed(v: unknown): v is SavedFeed {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeed'
+  )
+}
+
+export function validateSavedFeed(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeed', v)
+}
+
+export interface SavedFeedsPrefV2 {
+  items: SavedFeed[]
+  [k: string]: unknown
+}
+
+export function isSavedFeedsPrefV2(v: unknown): v is SavedFeedsPrefV2 {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#savedFeedsPrefV2'
+  )
+}
+
+export function validateSavedFeedsPrefV2(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#savedFeedsPrefV2', v)
 }
 
 export interface SavedFeedsPref {


### PR DESCRIPTION
I explored a different approach in #2411, but after implementing in the app, we decided that introducing a new UX pattern (primary algo) wasn't the right move.

So we fell back on the original plan: a movable following feed. This PR does that.

To do so, we needed some new preference that would be unset on the first read only, so that we could migrate the following feed into the user's saved feeds array. I could have done this using something as simple as `isFeedsMigrated` or `timelineIndex` (from previous work here), but I decided to do a full v2 revision for a few reasons:
- the following feed isn't an `AtUri`, and v1 prefs enforced that formatting
- I wanted to treat the following feed as much like any other feed as possible e.g. not manually inject it on the client side, or have to manually factor it in when re-ordering pins
- it seemed like a good idea to combine `saved` and `pinned` into a single array to avoid redundancy
- moving to objects should allow for extension in the future e.g. saved searches 👀 
- avoid any backwards compatibility issues

The V2 pref look like this:
```typescript
type SavedFeed = {
  id: TID
  type: 'feed' | 'list' | 'timeline' // or 'unknown' if we can't detect it
  value: string // the URI or other value to store
  pinned: boolean
}

type Preferences = {
  ...,
  savedFeeds: SavedFeed[]
}
```

### Migration
The v2 prefs are first written upon first request to `getPreferences`. It checks for v1 prefs, and if they exist, it migrates them to v2 objects. If they don't exist, it means it's a new user or it's an _old user who's never edited their feeds_.

In either case, a saved feed of type `timeline` is then added in as the first saved feed. The new array of objects then is saved to `savedFeeds`, added to the response, and returned as the response to `getPreferences`.

Since v2 prefs now exist, this migration won't be run again.

Note: If the user's preferences are wiped, then it will run again but it will be as if the user is brand new e.g. they'll just have `timeline` as their only saved feed. If _only_ v2 prefs are wiped... then it will run again and migrate v1 prefs to v2.

### Backwards compat
Old clients can continue to write to v1 prefs without issue. New clients that use the now-deprecated methods will continue to write to v1 prefs without issue. In both cases, the now-deprecated `preferences.feeds` object will be populated via v1 prefs.

New clients that write to v2 prefs _will also write to v1 prefs if they exist._ This double write will ignore any saved feeds of types other than `feed` or `list` since only those two are supported by v1 e.g. `timeline` will never be encountered by an older client (which could break).

Writes to v1 prefs _do not affect v2 prefs_ in any way. This means that saved feeds can diverge if a user uses both old and new clients. This is because v1 only supports feeds/lists, and the design of `setSavedFeeds` allows for a complete overwrite of prefs without support for other saved feed types like `timeline`.

### New methods
For added utility, and to avoid naming collisions with v1 methods, v2 methods all accept arrays of `SavedFeed`s and are named plural-ly.
- `setSavedFeeds` => `overwriteSavedFeeds`
- `addSavedFeed` => `addSavedFeeds`
- `removeSavedFeed` => `removeSavedFeeds`
- `addPinnedFeed` => `addSavedFeeds` or `updateSavedFeeds`
- `removePinnedFeed` => `updateSavedFeeds` or `removeSavedFeeds`

Notes:
- `updateSavedFeeds` is net-new, uses the `id` to match, and only updates `pinned`.
- `overwriteSavedFeeds` is less commonly used and potentially destructive, so I opted for an explicit name to avoid errant usages
- duplicated saved feeds are technically possible in v2, but since we assign them `TID`s, we can remove them individually as well.
- ordering is still based on insertion order, and feeds are sorted on-write into `[...pinned, ...saved]` to retain correct ordering.