### PR TITLE
PDS: handle S3 upload timeout more gracefully

### DIFF
--- a/packages/aws/src/s3.ts
+++ b/packages/aws/src/s3.ts
@@ -71,7 +71,11 @@ export class S3BlobStore implements BlobStore {
       // @ts-ignore native implementation fine in node >=15
       abortController,
     })
-    await upload.done().finally(() => clearTimeout(timeout))
+    try {
+      await upload.done()
+    } finally {
+      clearTimeout(timeout)
+    }
     return key
   }
 
@@ -108,7 +112,11 @@ export class S3BlobStore implements BlobStore {
       // @ts-ignore native implementation fine in node >=15
       abortController,
     })
-    await upload.done().finally(() => clearTimeout(timeout))
+    try {
+      await upload.done()
+    } finally {
+      clearTimeout(timeout)
+    }
   }
 
   async quarantine(cid: CID): Promise<void> {

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -55,6 +55,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     blobstoreCfg = {
       provider: 's3',
       bucket: env.blobstoreS3Bucket,
+      uploadTimeoutMs: env.blobstoreS3UploadTimeoutMs || 20000,
       region: env.blobstoreS3Region,
       endpoint: env.blobstoreS3Endpoint,
       forcePathStyle: env.blobstoreS3ForcePathStyle,
@@ -305,6 +306,7 @@ export type S3BlobstoreConfig = {
   region?: string
   endpoint?: string
   forcePathStyle?: boolean
+  uploadTimeoutMs?: number
   credentials?: {
     accessKeyId: string
     secretAccessKey: string

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -33,6 +33,7 @@ export const readEnv = (): ServerEnvironment => {
     blobstoreS3ForcePathStyle: envBool('PDS_BLOBSTORE_S3_FORCE_PATH_STYLE'),
     blobstoreS3AccessKeyId: envStr('PDS_BLOBSTORE_S3_ACCESS_KEY_ID'),
     blobstoreS3SecretAccessKey: envStr('PDS_BLOBSTORE_S3_SECRET_ACCESS_KEY'),
+    blobstoreS3UploadTimeoutMs: envInt('PDS_BLOBSTORE_S3_UPLOAD_TIMEOUT_MS'),
     // disk
     blobstoreDiskLocation: envStr('PDS_BLOBSTORE_DISK_LOCATION'),
     blobstoreDiskTmpLocation: envStr('PDS_BLOBSTORE_DISK_TMP_LOCATION'),
@@ -143,6 +144,7 @@ export type ServerEnvironment = {
   blobstoreS3ForcePathStyle?: boolean
   blobstoreS3AccessKeyId?: string
   blobstoreS3SecretAccessKey?: string
+  blobstoreS3UploadTimeoutMs?: number
 
   // identity
   didPlcUrl?: string

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -107,6 +107,7 @@ export class AppContext {
             endpoint: cfg.blobstore.endpoint,
             forcePathStyle: cfg.blobstore.forcePathStyle,
             credentials: cfg.blobstore.credentials,
+            uploadTimeoutMs: cfg.blobstore.uploadTimeoutMs,
           })
         : DiskBlobStore.creator(
             cfg.blobstore.location,


### PR DESCRIPTION
This makes upload timeouts to S3 handled a bit more consistently, and surfaces them to the user in a more legible way.
 - Support a config on `S3BlobStore` for upload timeouts.
 - Apply  `S3BlobStore` timeouts to  both `putTemp()` and `putPermanent()`.
 - Clear upload timeouts more reliably (e.g. in cases where upload fails for some reason other that the timeout).
 - Add PDS config `PDS_BLOBSTORE_S3_UPLOAD_TIMEOUT_MS`, defaulting to `20000`.  The previous timeout was 10sec which was too short in enough cases that it was worth increasing to 20sec.
 - Surface better error to user when `repo.uploadBlob` endpoint fails due to a timeout.
