### PR TITLE
Appview: remove replies to blocked posts from feeds

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -111,7 +111,8 @@ const noBlocksOrMutes = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
       !bam.authorBlocked &&
       !bam.authorMuted &&
       !bam.originatorBlocked &&
-      !bam.originatorMuted
+      !bam.originatorMuted &&
+      !bam.parentAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -86,7 +86,8 @@ const noBlocksOrMutes = (inputs: {
       !bam.authorBlocked &&
       !bam.authorMuted &&
       !bam.originatorBlocked &&
-      !bam.originatorMuted
+      !bam.originatorMuted &&
+      !bam.parentAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -89,7 +89,8 @@ const noBlocksOrMutes = (inputs: {
       !bam.authorBlocked &&
       !bam.authorMuted &&
       !bam.originatorBlocked &&
-      !bam.originatorMuted
+      !bam.originatorMuted &&
+      !bam.parentAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -334,16 +334,23 @@ export class Views {
     originatorBlocked: boolean
     authorMuted: boolean
     authorBlocked: boolean
+    parentAuthorBlocked: boolean
   } {
     const authorDid = creatorFromUri(item.post.uri)
     const originatorDid = item.repost
       ? creatorFromUri(item.repost.uri)
       : authorDid
+    const post = state.posts?.get(item.post.uri)
+    const parentUri = post?.record.reply?.parent.uri
+    const parentAuthorDid = parentUri && creatorFromUri(parentUri)
     return {
       originatorMuted: this.viewerMuteExists(originatorDid, state),
       originatorBlocked: this.viewerBlockExists(originatorDid, state),
       authorMuted: this.viewerMuteExists(authorDid, state),
       authorBlocked: this.viewerBlockExists(authorDid, state),
+      parentAuthorBlocked: parentAuthorDid
+        ? this.viewerBlockExists(parentAuthorDid, state)
+        : false,
     }
   }
 

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -160,8 +160,14 @@ describe('pds views with blocking', () => {
       { limit: 100 },
       { headers: await network.serviceHeaders(carol) },
     )
+
+    // dan's posts don't appear, nor alice's reply to dan.
     expect(
-      resCarol.data.feed.some((post) => post.post.author.did === dan),
+      resCarol.data.feed.some(
+        (post) =>
+          post.post.author.did === dan ||
+          post.reply?.parent.author?.['did'] === dan,
+      ),
     ).toBeFalsy()
 
     const resDan = await agent.api.app.bsky.feed.getTimeline(
@@ -169,7 +175,11 @@ describe('pds views with blocking', () => {
       { headers: await network.serviceHeaders(dan) },
     )
     expect(
-      resDan.data.feed.some((post) => post.post.author.did === carol),
+      resDan.data.feed.some(
+        (post) =>
+          post.post.author.did === carol ||
+          post.reply?.parent.author?.['did'] === carol,
+      ),
     ).toBeFalsy()
   })
 


### PR DESCRIPTION
Remove any replies appearing in a feed or timeline that are in response to a blocked post.  Before we would serve the reply and signal that the parent is blocked using a `#blockedPost`, which remains the behavior on author feeds.