### PR TITLE
Improve link detection

### DIFF
--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,6 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 export const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+  /(?:^|\s|\()((https?:\/\/[\S]+)|([a-z0-9-]+(?:\.[a-z0-9-]+)*(?:\.[a-z]{2,}))(\/[\S]*)?)/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**
@@ -9,3 +9,5 @@ export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
  */
 export const TAG_REGEX =
   /(^|\s)[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu
+
+export const END_PUNCTUATION_REGEX = /(?:(?<!\(.*)\))?[.,;]*$/

--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,6 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 export const URL_REGEX =
-  /(?:^|\s|\()((https?:\/\/[\S]+)|([a-z0-9-]+(?:\.[a-z0-9-]+)*(?:\.[a-z]{2,}))(\/[\S]*)?)/gim
+  /(?:^|\s|\()((https?:\/\/[\S]+)|([a-z0-9-]+(?:\.[a-z0-9-]+)*(?:\.[a-z]{2,}))([/?][\S]*)?)/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -44,6 +44,7 @@ describe('detectFacets', () => {
     'a trailing bsky.app: colon',
     'foo example.com" bar',
     "foo example.com' bar",
+    'start example.com?foo=bar end',
 
     'not.. a..url ..here',
     'e.g.',
@@ -168,6 +169,11 @@ describe('detectFacets', () => {
     [['a trailing '], ['bsky.app', 'https://bsky.app'], [': colon']],
     [['foo '], ['example.com', 'https://example.com'], ['" bar']],
     [['foo '], ['example.com', 'https://example.com'], ["' bar"]],
+    [
+      ['start '],
+      ['example.com?foo=bar', 'https://example.com?foo=bar'],
+      [' end'],
+    ],
 
     [['not.. a..url ..here']],
     [['e.g.']],

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -42,6 +42,8 @@ describe('detectFacets', () => {
     'newline1.com\nnewline2.com',
     'a example.com/index.php php link',
     'a trailing bsky.app: colon',
+    'foo example.com" bar',
+    "foo example.com' bar",
 
     'not.. a..url ..here',
     'e.g.',
@@ -164,6 +166,8 @@ describe('detectFacets', () => {
       [' php link'],
     ],
     [['a trailing '], ['bsky.app', 'https://bsky.app'], [': colon']],
+    [['foo '], ['example.com', 'https://example.com'], ['" bar']],
+    [['foo '], ['example.com', 'https://example.com'], ["' bar"]],
 
     [['not.. a..url ..here']],
     [['e.g.']],


### PR DESCRIPTION
Make link detection a lot more stricter

- Prevent `bsky.app'` from being matched, domain has to be succeeded by either `/` or `?`
- Punctuation trimming is more thorough, follows Discord's URL trimming behavior
- Allow `bsky-debug.app` to be matched
