### PR TITLE
Resolve duplicate refs in lexicon of ozone

### DIFF
--- a/lexicons/tools/ozone/moderation/emitEvent.json
+++ b/lexicons/tools/ozone/moderation/emitEvent.json
@@ -21,7 +21,6 @@
                 "tools.ozone.moderation.defs#modEventLabel",
                 "tools.ozone.moderation.defs#modEventReport",
                 "tools.ozone.moderation.defs#modEventMute",
-                "tools.ozone.moderation.defs#modEventUnmute",
                 "tools.ozone.moderation.defs#modEventMuteReporter",
                 "tools.ozone.moderation.defs#modEventUnmuteReporter",
                 "tools.ozone.moderation.defs#modEventReverseTakedown",

--- a/lexicons/tools/ozone/moderation/emitEvent.json
+++ b/lexicons/tools/ozone/moderation/emitEvent.json
@@ -21,10 +21,10 @@
                 "tools.ozone.moderation.defs#modEventLabel",
                 "tools.ozone.moderation.defs#modEventReport",
                 "tools.ozone.moderation.defs#modEventMute",
+                "tools.ozone.moderation.defs#modEventUnmute",
                 "tools.ozone.moderation.defs#modEventMuteReporter",
                 "tools.ozone.moderation.defs#modEventUnmuteReporter",
                 "tools.ozone.moderation.defs#modEventReverseTakedown",
-                "tools.ozone.moderation.defs#modEventUnmute",
                 "tools.ozone.moderation.defs#modEventEmail",
                 "tools.ozone.moderation.defs#modEventTag"
               ]


### PR DESCRIPTION
This PR fixes duplicate ref in the Lexicon of "tools.ozone.moderation.emitEvent".