### PR TITLE
Add fast path for validating non-required undefined fields

### DIFF
--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -122,6 +122,10 @@ export function object(
       if (value[key] === null && nullableProps.has(key)) {
         continue
       }
+      if (typeof value[key] === 'undefined' && !requiredProps.has(key)) {
+        // Fast path.
+        continue
+      }
       const propDef = def.properties[key]
       const propPath = `${path}/${key}`
       const validated = validateOneOf(lexicons, propPath, propDef, value[key])

--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -122,11 +122,22 @@ export function object(
       if (value[key] === null && nullableProps.has(key)) {
         continue
       }
-      if (typeof value[key] === 'undefined' && !requiredProps.has(key)) {
-        // Fast path.
-        continue
-      }
       const propDef = def.properties[key]
+      if (typeof value[key] === 'undefined' && !requiredProps.has(key)) {
+        // Fast path for non-required undefined props.
+        if (
+          propDef.type === 'integer' ||
+          propDef.type === 'boolean' ||
+          propDef.type === 'string'
+        ) {
+          if (typeof propDef.default === 'undefined') {
+            continue
+          }
+        } else {
+          // Other types have no defaults.
+          continue
+        }
+      }
       const propPath = `${path}/${key}`
       const validated = validateOneOf(lexicons, propPath, propDef, value[key])
       const propValue = validated.success ? validated.value : value[key]


### PR DESCRIPTION
Creating a thousand error objects (as observed [in this post](https://bsky.app/profile/bencollins.bsky.social/post/3kr2kcufdxf2t)) is not good. Let's not do that.

The costs are shown with 6x throttling but can be higher on lower-end Android.

## Before

<img width="640" alt="Screenshot 2024-04-27 at 07 02 55" src="https://github.com/bluesky-social/atproto/assets/810438/6ca502c2-6c0e-42b8-898a-c5a02add7727">

<img width="380" alt="Screenshot 2024-04-27 at 07 04 58" src="https://github.com/bluesky-social/atproto/assets/810438/f085e5d6-e9b3-4dcd-97ae-658b5186c616">

## After

<img width="307" alt="Screenshot 2024-04-27 at 07 06 16" src="https://github.com/bluesky-social/atproto/assets/810438/f3bb26bf-2fa6-40ef-8bf3-8bd1d373d5c9">
