### PR TITLE
Proposal: Pinned posts definitions

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -92,7 +92,8 @@
       "properties": {
         "lists": { "type": "integer" },
         "feedgens": { "type": "integer" },
-        "labeler": { "type": "boolean" }
+        "labeler": { "type": "boolean" },
+        "pinned": { "type": "integer" }
       }
     },
     "viewerState": {

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -93,7 +93,7 @@
         "lists": { "type": "integer" },
         "feedgens": { "type": "integer" },
         "labeler": { "type": "boolean" },
-        "pinned": { "type": "integer" }
+        "pinnedPosts": { "type": "integer" }
       }
     },
     "viewerState": {

--- a/lexicons/app/bsky/actor/profile.json
+++ b/lexicons/app/bsky/actor/profile.json
@@ -32,6 +32,15 @@
             "accept": ["image/png", "image/jpeg"],
             "maxSize": 1000000
           },
+          "pinnedPosts": {
+            "type": "array",
+            "description": "Array of post URIs that are pinned by the user",
+            "maxLength": 2,
+            "items": {
+              "type": "string",
+              "format": "at-uri"
+            }
+          },
           "labels": {
             "type": "union",
             "description": "Self-label values, specific to the Bluesky application, on the overall account.",

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -40,6 +40,7 @@
       "properties": {
         "repost": { "type": "string", "format": "at-uri" },
         "like": { "type": "string", "format": "at-uri" },
+        "pinned": { "type": "boolean" },
         "replyDisabled": { "type": "boolean" }
       }
     },

--- a/lexicons/app/bsky/feed/getAuthorFeed.json
+++ b/lexicons/app/bsky/feed/getAuthorFeed.json
@@ -24,7 +24,8 @@
               "posts_with_replies",
               "posts_no_replies",
               "posts_with_media",
-              "posts_and_author_threads"
+              "posts_and_author_threads",
+              "pinned_posts"
             ],
             "default": "posts_with_replies"
           }


### PR DESCRIPTION
This pull request proposes the lexicon definitions needed for pinned posts functionality.

The only "hard" part about implementing this is how pinned posts should be retrieved, the rest seems trivial, so I'm compelled to do whatever I can to get this shipped, and will probably ask for help for that bit.

## User-facing

- Up to two posts can be pinned at any given moment
  - I think this is a reasonable choice given Bluesky's 300-char limit, not to mention, this provides separation between what users might want to convey (e.g. about me in the first post, projects in the second)
- Pinned posts doesn't have to be the user's own posts, but it might be worthwhile to restrict it for now

## Technical details

- Posts are pinned by attaching the post's URI to the `pinnedPosts` array in the profile record
  - should it be a strong ref? I think it should if we allow other user's posts to be pinned
  - if it were to be limited to 1, I think I'd still make this an array, more of just because though.
- Pinned posts are retrieved by requesting `filter: pinned` in `getAuthorFeed`
- You can tell if the post is pinned by checking the post's viewer state
  - will doing this check incur a noticeable increase in CPU time needed to hydrate a feed?
- Hydrated profiles returns `associated.pinnedPosts` which provides indication for the amount of pinned posts that clients can expect

<details>
<summary>Archived</summary>

## Problem

This is where the problem begins, how should the pinned posts be retrieved? I see two sides to this, and they're both valid.

1. Including it as part of the author feed means that it's less work for clients to do (with no additional network request), and it would affect older clients as well (just without any indication of it being pinned)
2. Being able to retrieve it separately (and subsequently the option to not include it in the feed response) means that clients gets to experiment with their own ideas as to how they'd like to display the pinned posts, without making assumptions (which I feel is critical)

This is incomplete, I'll write up my thoughts on this shortly with these two points in mind.

</details>