### PR TITLE
Appview: support alternate audiences on standard auth

### DIFF
--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -7,6 +7,7 @@ export interface ServerConfigValues {
   port?: number
   publicUrl?: string
   serverDid: string
+  alternateAudienceDids: string[]
   // external services
   dataplaneUrls: string[]
   dataplaneHttpVersion?: '1.1' | '2'
@@ -48,6 +49,9 @@ export class ServerConfig {
     const envPort = parseInt(process.env.BSKY_PORT || '', 10)
     const port = isNaN(envPort) ? 2584 : envPort
     const didPlcUrl = process.env.BSKY_DID_PLC_URL || 'http://localhost:2582'
+    const alternateAudienceDids = process.env.BSKY_ALT_AUDIENCE_DIDS
+      ? process.env.BSKY_ALT_AUDIENCE_DIDS.split(',')
+      : []
     const handleResolveNameservers = process.env.BSKY_HANDLE_RESOLVE_NAMESERVERS
       ? process.env.BSKY_HANDLE_RESOLVE_NAMESERVERS.split(',')
       : []
@@ -104,6 +108,7 @@ export class ServerConfig {
       port,
       publicUrl,
       serverDid,
+      alternateAudienceDids,
       dataplaneUrls,
       dataplaneHttpVersion,
       dataplaneIgnoreBadTls,
@@ -162,6 +167,10 @@ export class ServerConfig {
 
   get serverDid() {
     return this.cfg.serverDid
+  }
+
+  get alternateAudienceDids() {
+    return this.cfg.alternateAudienceDids
   }
 
   get dataplaneUrls() {

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -110,6 +110,7 @@ export class BskyAppView {
 
     const authVerifier = new AuthVerifier(dataplane, {
       ownDid: config.serverDid,
+      alternateAudienceDids: config.alternateAudienceDids,
       modServiceDid: config.modServiceDid,
       adminPasses: config.adminPasswords,
     })

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -58,6 +58,7 @@ export class TestBsky {
       didPlcUrl: cfg.plcUrl,
       publicUrl: 'https://bsky.public.url',
       serverDid,
+      alternateAudienceDids: [],
       dataplaneUrls: [`http://localhost:${dataplanePort}`],
       dataplaneHttpVersion: '1.1',
       bsyncUrl: `http://localhost:${bsyncPort}`,


### PR DESCRIPTION
This will allow trusted supporting services to make service requests to the appview on behalf of users.  I expect in the future we'll have a more explicit form of delegation/attenuation which would support the same use case.