### PR TITLE
Appview: add grandparent author to reply ref, ensure no replies to blocked grandparent in feeds

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -68,6 +68,11 @@
         "parent": {
           "type": "union",
           "refs": ["#postView", "#notFoundPost", "#blockedPost"]
+        },
+        "parentReplyAuthor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileViewBasic",
+          "description": "When parent is a reply to another post, this is the author of that post."
         }
       }
     },

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -69,7 +69,7 @@
           "type": "union",
           "refs": ["#postView", "#notFoundPost", "#blockedPost"]
         },
-        "parentReplyAuthor": {
+        "grandparentAuthor": {
           "type": "ref",
           "ref": "app.bsky.actor.defs#profileViewBasic",
           "description": "When parent is a reply to another post, this is the author of that post."

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4833,7 +4833,7 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
-          parentReplyAuthor: {
+          grandparentAuthor: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#profileViewBasic',
             description:

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4833,6 +4833,12 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
+          parentReplyAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+            description:
+              'When parent is a reply to another post, this is the author of that post.',
+          },
         },
       },
       reasonRepost: {
@@ -9164,7 +9170,6 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#modEventMuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventUnmuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventReverseTakedown',
-                  'lex:tools.ozone.moderation.defs#modEventUnmute',
                   'lex:tools.ozone.moderation.defs#modEventEmail',
                   'lex:tools.ozone.moderation.defs#modEventTag',
                 ],

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -97,7 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
-  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
+  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -97,6 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
+  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/emitEvent.ts
@@ -25,7 +25,6 @@ export interface InputSchema {
     | ToolsOzoneModerationDefs.ModEventMuteReporter
     | ToolsOzoneModerationDefs.ModEventUnmuteReporter
     | ToolsOzoneModerationDefs.ModEventReverseTakedown
-    | ToolsOzoneModerationDefs.ModEventUnmute
     | ToolsOzoneModerationDefs.ModEventEmail
     | ToolsOzoneModerationDefs.ModEventTag
     | { $type: string; [k: string]: unknown }

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -115,7 +115,7 @@ const noBlocksOrMutes = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
       !bam.authorMuted &&
       !bam.originatorBlocked &&
       !bam.originatorMuted &&
-      !bam.parentAuthorBlocked
+      !bam.ancestorAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -87,7 +87,7 @@ const noBlocksOrMutes = (inputs: {
       !bam.authorMuted &&
       !bam.originatorBlocked &&
       !bam.originatorMuted &&
-      !bam.parentAuthorBlocked
+      !bam.ancestorAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -90,7 +90,7 @@ const noBlocksOrMutes = (inputs: {
       !bam.authorMuted &&
       !bam.originatorBlocked &&
       !bam.originatorMuted &&
-      !bam.parentAuthorBlocked
+      !bam.ancestorAuthorBlocked
     )
   })
   return skeleton

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -395,7 +395,7 @@ export class Hydrator {
   }
 
   // app.bsky.feed.defs#feedViewPost
-  // - post (+ replies)
+  // - post (+ replies w/ reply parent author)
   //   - profile
   //     - list basic
   //   - list
@@ -413,22 +413,46 @@ export class Hydrator {
     items: FeedItem[],
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
-    const postUris = items.map((item) => item.post.uri)
-    const repostUris = mapDefined(items, (item) => item.repost?.uri)
-    const [posts, reposts, repostProfileState] = await Promise.all([
-      this.feed.getPosts(postUris, ctx.includeTakedowns),
-      this.feed.getReposts(repostUris, ctx.includeTakedowns),
-      this.hydrateProfiles(repostUris.map(didFromUri), ctx),
-    ])
+    // get posts, collect reply refs
+    const posts = await this.feed.getPosts(
+      items.map((item) => item.post.uri),
+      ctx.includeTakedowns,
+    )
+    const rootUris: string[] = []
+    const parentUris: string[] = []
     const postAndReplyRefs: ItemRef[] = []
     posts.forEach((post, uri) => {
       if (!post) return
       postAndReplyRefs.push({ uri, cid: post.cid })
       if (post.record.reply) {
+        rootUris.push(post.record.reply.root.uri)
+        parentUris.push(post.record.reply.parent.uri)
         postAndReplyRefs.push(post.record.reply.root, post.record.reply.parent)
       }
     })
-    const postState = await this.hydratePosts(postAndReplyRefs, ctx, { posts })
+    // get replies, collect reply parent authors
+    const replies = await this.feed.getPosts(
+      [...rootUris, ...parentUris],
+      ctx.includeTakedowns,
+    )
+    const replyParentAuthors: string[] = []
+    parentUris.forEach((uri) => {
+      const parent = replies.get(uri)
+      if (!parent?.record.reply) return
+      replyParentAuthors.push(didFromUri(parent.record.reply.parent.uri))
+    })
+    // hydrate state for all posts, reposts, authors of reposts + reply parent authors
+    const repostUris = mapDefined(items, (item) => item.repost?.uri)
+    const [postState, repostProfileState, reposts] = await Promise.all([
+      this.hydratePosts(postAndReplyRefs, ctx, {
+        posts: posts.merge(replies), // avoids refetches of posts
+      }),
+      this.hydrateProfiles(
+        [...repostUris.map(didFromUri), ...replyParentAuthors],
+        ctx,
+      ),
+      this.feed.getReposts(repostUris, ctx.includeTakedowns),
+    ])
     return mergeManyStates(postState, repostProfileState, {
       reposts,
       ctx,

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4833,7 +4833,7 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
-          parentReplyAuthor: {
+          grandparentAuthor: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#profileViewBasic',
             description:

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4833,6 +4833,12 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
+          parentReplyAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+            description:
+              'When parent is a reply to another post, this is the author of that post.',
+          },
         },
       },
       reasonRepost: {

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,7 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
-  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
+  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,6 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
+  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -16,10 +16,12 @@ import {
   NotFoundPost,
   PostView,
   ReasonRepost,
+  ReplyRef,
   ThreadViewPost,
   ThreadgateView,
   isPostView,
 } from '../lexicon/types/app/bsky/feed/defs'
+import { isRecord as isPostRecord } from '../lexicon/types/app/bsky/feed/post'
 import { ListView, ListViewBasic } from '../lexicon/types/app/bsky/graph/defs'
 import { creatorFromUri, parseThreadGate, cidFromBlobJson } from './util'
 import { isListRule } from '../lexicon/types/app/bsky/feed/threadgate'
@@ -477,7 +479,7 @@ export class Views {
     }
   }
 
-  replyRef(uri: string, state: HydrationState) {
+  replyRef(uri: string, state: HydrationState): ReplyRef | undefined {
     const postRecord = state.posts?.get(uri.toString())?.record
     if (!postRecord?.reply) return
     let root = this.maybePost(postRecord.reply.root.uri, state)
@@ -489,7 +491,18 @@ export class Views {
         root = parent
       }
     }
-    return root && parent ? { root, parent } : undefined
+    let grandparentAuthor: ProfileViewBasic | undefined
+    if (isPostRecord(parent.record) && parent.record.reply) {
+      grandparentAuthor = this.profileBasic(
+        creatorFromUri(parent.record.reply.parent.uri),
+        state,
+      )
+    }
+    return {
+      root,
+      parent,
+      grandparentAuthor,
+    }
   }
 
   maybePost(uri: string, state: HydrationState): MaybePostView {

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -336,7 +336,7 @@ export class Views {
     originatorBlocked: boolean
     authorMuted: boolean
     authorBlocked: boolean
-    parentAuthorBlocked: boolean
+    ancestorAuthorBlocked: boolean
   } {
     const authorDid = creatorFromUri(item.post.uri)
     const originatorDid = item.repost
@@ -345,14 +345,19 @@ export class Views {
     const post = state.posts?.get(item.post.uri)
     const parentUri = post?.record.reply?.parent.uri
     const parentAuthorDid = parentUri && creatorFromUri(parentUri)
+    const parent = parentUri ? state.posts?.get(parentUri) : undefined
+    const grandparentUri = parent?.record.reply?.parent.uri
+    const grandparentAuthorDid =
+      grandparentUri && creatorFromUri(grandparentUri)
     return {
       originatorMuted: this.viewerMuteExists(originatorDid, state),
       originatorBlocked: this.viewerBlockExists(originatorDid, state),
       authorMuted: this.viewerMuteExists(authorDid, state),
       authorBlocked: this.viewerBlockExists(authorDid, state),
-      parentAuthorBlocked: parentAuthorDid
-        ? this.viewerBlockExists(parentAuthorDid, state)
-        : false,
+      ancestorAuthorBlocked:
+        (!!parentAuthorDid && this.viewerBlockExists(parentAuthorDid, state)) ||
+        (!!grandparentAuthorDid &&
+          this.viewerBlockExists(grandparentAuthorDid, state)),
     }
   }
 

--- a/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
@@ -86,6 +86,15 @@ Array [
           "viewer": Object {},
         },
         "reply": Object {
+          "grandparentAuthor": Object {
+            "did": "user(0)",
+            "handle": "alice.test",
+            "labels": Array [],
+            "viewer": Object {
+              "blockedBy": false,
+              "muted": false,
+            },
+          },
           "parent": Object {
             "$type": "app.bsky.feed.defs#postView",
             "author": Object {
@@ -165,15 +174,6 @@ Array [
             "repostCount": 0,
             "uri": "record(3)",
             "viewer": Object {},
-          },
-          "grandparentAuthor": Object {
-            "did": "user(0)",
-            "handle": "alice.test",
-            "labels": Array [],
-            "viewer": Object {
-              "blockedBy": false,
-              "muted": false,
-            },
           },
           "root": Object {
             "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
@@ -166,6 +166,15 @@ Array [
             "uri": "record(3)",
             "viewer": Object {},
           },
+          "grandparentAuthor": Object {
+            "did": "user(0)",
+            "handle": "alice.test",
+            "labels": Array [],
+            "viewer": Object {
+              "blockedBy": false,
+              "muted": false,
+            },
+          },
           "root": Object {
             "$type": "app.bsky.feed.defs#postView",
             "author": Object {

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -55,6 +55,32 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -134,32 +160,6 @@ Array [
         "repostCount": 0,
         "uri": "record(3)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -1220,6 +1220,33 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1298,33 +1325,6 @@ Array [
         "repostCount": 0,
         "uri": "record(4)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(2)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(2)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(1)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -1683,6 +1683,34 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(2)",
+          "following": "record(1)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1761,34 +1789,6 @@ Array [
         "repostCount": 0,
         "uri": "record(5)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(3)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(3)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(2)",
-          "following": "record(1)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -135,6 +135,32 @@ Array [
         "uri": "record(3)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1273,6 +1299,33 @@ Array [
         "uri": "record(4)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1708,6 +1761,34 @@ Array [
         "repostCount": 0,
         "uri": "record(5)",
         "viewer": Object {},
+      },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(2)",
+          "following": "record(1)",
+          "muted": false,
+        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
@@ -193,12 +193,50 @@ Object {
         },
         "text": "alice replies to dan",
       },
-      "replyCount": 0,
+      "replyCount": 1,
       "repostCount": 0,
       "uri": "record(0)",
       "viewer": Object {},
     },
-    "replies": Array [],
+    "replies": Array [
+      Object {
+        "$type": "app.bsky.feed.defs#threadViewPost",
+        "post": Object {
+          "author": Object {
+            "did": "user(3)",
+            "handle": "carol.test",
+            "labels": Array [],
+            "viewer": Object {
+              "blockedBy": false,
+              "muted": false,
+            },
+          },
+          "cid": "cids(4)",
+          "indexedAt": "1970-01-01T00:00:00.000Z",
+          "labels": Array [],
+          "likeCount": 0,
+          "record": Object {
+            "$type": "app.bsky.feed.post",
+            "createdAt": "1970-01-01T00:00:00.000Z",
+            "reply": Object {
+              "parent": Object {
+                "cid": "cids(0)",
+                "uri": "record(0)",
+              },
+              "root": Object {
+                "cid": "cids(3)",
+                "uri": "record(4)",
+              },
+            },
+            "text": "carol replies to alice's reply to dan",
+          },
+          "replyCount": 0,
+          "repostCount": 0,
+          "uri": "record(5)",
+          "viewer": Object {},
+        },
+      },
+    ],
   },
 }
 `;

--- a/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
@@ -57,6 +57,34 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(2)",
+          "following": "record(1)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -135,34 +163,6 @@ Array [
         "repostCount": 0,
         "uri": "record(5)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(3)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(3)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(2)",
-          "following": "record(1)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
@@ -136,6 +136,34 @@ Array [
         "uri": "record(5)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(3)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(2)",
+          "following": "record(1)",
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -1457,6 +1457,32 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1536,32 +1562,6 @@ Array [
         "repostCount": 0,
         "uri": "record(3)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -1915,6 +1915,32 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1994,32 +2020,6 @@ Array [
         "repostCount": 0,
         "uri": "record(3)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(1)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -3311,6 +3311,34 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(7)",
+          "following": "record(6)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -3388,34 +3416,6 @@ Array [
         "repostCount": 0,
         "uri": "record(10)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(7)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(1)",
-            "uri": "record(8)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(7)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(1)",
-            "uri": "record(8)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(7)",
-          "following": "record(6)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -4516,6 +4516,34 @@ Array [
       "viewer": Object {},
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(7)",
+          "following": "record(6)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -4594,34 +4622,6 @@ Array [
         "repostCount": 0,
         "uri": "record(10)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
-        "did": "user(1)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(7)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(1)",
-            "uri": "record(8)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(7)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(1)",
-            "uri": "record(8)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(7)",
-          "following": "record(6)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -5296,6 +5296,33 @@ Array [
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
     "reply": Object {
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
+      },
       "parent": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -5374,33 +5401,6 @@ Array [
         "repostCount": 0,
         "uri": "record(4)",
         "viewer": Object {},
-      },
-      "grandparentAuthor": Object {
-        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
-        "did": "user(0)",
-        "displayName": "ali",
-        "handle": "alice.test",
-        "labels": Array [
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(2)",
-            "val": "self-label-a",
-          },
-          Object {
-            "cid": "cids(2)",
-            "cts": "1970-01-01T00:00:00.000Z",
-            "src": "user(0)",
-            "uri": "record(2)",
-            "val": "self-label-b",
-          },
-        ],
-        "viewer": Object {
-          "blockedBy": false,
-          "followedBy": "record(1)",
-          "muted": false,
-        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -1537,6 +1537,32 @@ Array [
         "uri": "record(3)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -1968,6 +1994,32 @@ Array [
         "repostCount": 0,
         "uri": "record(3)",
         "viewer": Object {},
+      },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(1)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "muted": false,
+        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
@@ -3337,6 +3389,34 @@ Array [
         "uri": "record(10)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(7)",
+          "following": "record(6)",
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -4515,6 +4595,34 @@ Array [
         "uri": "record(10)",
         "viewer": Object {},
       },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(6)/cids(5)@jpeg",
+        "did": "user(1)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(7)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(1)",
+            "uri": "record(8)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(7)",
+          "following": "record(6)",
+          "muted": false,
+        },
+      },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",
         "author": Object {
@@ -5266,6 +5374,33 @@ Array [
         "repostCount": 0,
         "uri": "record(4)",
         "viewer": Object {},
+      },
+      "grandparentAuthor": Object {
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+        "did": "user(0)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(2)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(0)",
+            "uri": "record(2)",
+            "val": "self-label-b",
+          },
+        ],
+        "viewer": Object {
+          "blockedBy": false,
+          "followedBy": "record(1)",
+          "muted": false,
+        },
       },
       "root": Object {
         "$type": "app.bsky.feed.defs#postView",

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -1,6 +1,11 @@
 import AtpAgent, { AtUri } from '@atproto/api'
 import { TestNetwork, SeedClient, authorFeedSeed } from '@atproto/dev-env'
-import { forSnapshot, paginateAll, stripViewerFromPost } from '../_util'
+import {
+  forSnapshot,
+  paginateAll,
+  stripViewer,
+  stripViewerFromPost,
+} from '../_util'
 import { ReplyRef, isRecord } from '../../src/lexicon/types/app/bsky/feed/post'
 import { isView as isEmbedRecordWithMedia } from '../../src/lexicon/types/app/bsky/embed/recordWithMedia'
 import { isView as isImageEmbed } from '../../src/lexicon/types/app/bsky/embed/images'
@@ -132,6 +137,9 @@ describe('pds author feed views', () => {
           result.reply = {
             parent: stripViewerFromPost(item.reply.parent),
             root: stripViewerFromPost(item.reply.root),
+            grandparentAuthor:
+              item.reply.grandparentAuthor &&
+              stripViewer(item.reply.grandparentAuthor),
           }
         }
         return result

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -37,6 +37,12 @@ describe('pds views with blocking', () => {
       sc.posts[dan][0].ref,
       'alice replies to dan',
     )
+    const _carolReplyToAliceReplyToDan = await sc.reply(
+      carol,
+      sc.posts[dan][0].ref,
+      aliceReplyToDan.ref,
+      "carol replies to alice's reply to dan",
+    )
     carolReplyToDan = await sc.reply(
       carol,
       sc.posts[dan][0].ref,
@@ -161,12 +167,13 @@ describe('pds views with blocking', () => {
       { headers: await network.serviceHeaders(carol) },
     )
 
-    // dan's posts don't appear, nor alice's reply to dan.
+    // dan's posts don't appear, nor alice's reply to dan, nor carol's reply to alice (which was a reply to dan)
     expect(
       resCarol.data.feed.some(
         (post) =>
           post.post.author.did === dan ||
-          post.reply?.parent.author?.['did'] === dan,
+          post.reply?.parent.author?.['did'] === dan ||
+          post.reply?.grandparentAuthor?.did === dan,
       ),
     ).toBeFalsy()
 
@@ -178,7 +185,8 @@ describe('pds views with blocking', () => {
       resDan.data.feed.some(
         (post) =>
           post.post.author.did === carol ||
-          post.reply?.parent.author?.['did'] === carol,
+          post.reply?.parent.author?.['did'] === carol ||
+          post.reply?.grandparentAuthor?.did === carol,
       ),
     ).toBeFalsy()
   })

--- a/packages/bsky/tests/views/list-feed.test.ts
+++ b/packages/bsky/tests/views/list-feed.test.ts
@@ -1,6 +1,11 @@
 import AtpAgent from '@atproto/api'
 import { TestNetwork, SeedClient, RecordRef, basicSeed } from '@atproto/dev-env'
-import { forSnapshot, paginateAll, stripViewerFromPost } from '../_util'
+import {
+  forSnapshot,
+  paginateAll,
+  stripViewer,
+  stripViewerFromPost,
+} from '../_util'
 
 describe('list feed views', () => {
   let network: TestNetwork
@@ -94,6 +99,9 @@ describe('list feed views', () => {
           result.reply = {
             parent: stripViewerFromPost(item.reply.parent),
             root: stripViewerFromPost(item.reply.root),
+            grandparentAuthor:
+              item.reply.grandparentAuthor &&
+              stripViewer(item.reply.grandparentAuthor),
           }
         }
         return result

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4833,7 +4833,7 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
-          parentReplyAuthor: {
+          grandparentAuthor: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#profileViewBasic',
             description:

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4833,6 +4833,12 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
+          parentReplyAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+            description:
+              'When parent is a reply to another post, this is the author of that post.',
+          },
         },
       },
       reasonRepost: {
@@ -9164,7 +9170,6 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#modEventMuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventUnmuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventReverseTakedown',
-                  'lex:tools.ozone.moderation.defs#modEventUnmute',
                   'lex:tools.ozone.moderation.defs#modEventEmail',
                   'lex:tools.ozone.moderation.defs#modEventTag',
                 ],

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,7 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
-  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
+  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,6 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
+  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -26,7 +26,6 @@ export interface InputSchema {
     | ToolsOzoneModerationDefs.ModEventMuteReporter
     | ToolsOzoneModerationDefs.ModEventUnmuteReporter
     | ToolsOzoneModerationDefs.ModEventReverseTakedown
-    | ToolsOzoneModerationDefs.ModEventUnmute
     | ToolsOzoneModerationDefs.ModEventEmail
     | ToolsOzoneModerationDefs.ModEventTag
     | { $type: string; [k: string]: unknown }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4833,7 +4833,7 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
-          parentReplyAuthor: {
+          grandparentAuthor: {
             type: 'ref',
             ref: 'lex:app.bsky.actor.defs#profileViewBasic',
             description:

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4833,6 +4833,12 @@ export const schemaDict = {
               'lex:app.bsky.feed.defs#blockedPost',
             ],
           },
+          parentReplyAuthor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileViewBasic',
+            description:
+              'When parent is a reply to another post, this is the author of that post.',
+          },
         },
       },
       reasonRepost: {
@@ -9164,7 +9170,6 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#modEventMuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventUnmuteReporter',
                   'lex:tools.ozone.moderation.defs#modEventReverseTakedown',
-                  'lex:tools.ozone.moderation.defs#modEventUnmute',
                   'lex:tools.ozone.moderation.defs#modEventEmail',
                   'lex:tools.ozone.moderation.defs#modEventTag',
                 ],

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,7 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
-  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
+  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -97,6 +97,7 @@ export interface ReplyRef {
     | NotFoundPost
     | BlockedPost
     | { $type: string; [k: string]: unknown }
+  parentReplyAuthor?: AppBskyActorDefs.ProfileViewBasic
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -26,7 +26,6 @@ export interface InputSchema {
     | ToolsOzoneModerationDefs.ModEventMuteReporter
     | ToolsOzoneModerationDefs.ModEventUnmuteReporter
     | ToolsOzoneModerationDefs.ModEventReverseTakedown
-    | ToolsOzoneModerationDefs.ModEventUnmute
     | ToolsOzoneModerationDefs.ModEventEmail
     | ToolsOzoneModerationDefs.ModEventTag
     | { $type: string; [k: string]: unknown }

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -737,6 +737,32 @@ Object {
         "viewer": Object {},
       },
       "reply": Object {
+        "grandparentAuthor": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
@@ -1595,6 +1621,32 @@ Object {
         "indexedAt": "1970-01-01T00:00:00.000Z",
       },
       "reply": Object {
+        "grandparentAuthor": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {
@@ -2010,6 +2062,32 @@ Object {
         "viewer": Object {},
       },
       "reply": Object {
+        "grandparentAuthor": Object {
+          "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+          "did": "user(0)",
+          "displayName": "ali",
+          "handle": "alice.test",
+          "labels": Array [
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-a",
+            },
+            Object {
+              "cid": "cids(2)",
+              "cts": "1970-01-01T00:00:00.000Z",
+              "src": "user(0)",
+              "uri": "record(1)",
+              "val": "self-label-b",
+            },
+          ],
+          "viewer": Object {
+            "blockedBy": false,
+            "muted": false,
+          },
+        },
         "parent": Object {
           "$type": "app.bsky.feed.defs#postView",
           "author": Object {


### PR DESCRIPTION
Two changes here:
 - introduces a new field on feed items `item.reply.grandparentAuthor` which contains a basic profile for the grandparent (i.e. parent's parent) reply of a post.
 - ensures that in feed settings (e.g. timeline), posts whose reply grandparent author is blocked do not appear.  This essentially applies the block rule to `item.reply.parent` that #2430 applied to `item.post`, if that makes sense.

Replaces #2229.