### PR TITLE
api: Always apply self labels even if post is your own, downgrade `hide` moderation preference to `blur` when the post is your own

### DIFF
--- a/.changeset/clever-trainers-own.md
+++ b/.changeset/clever-trainers-own.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Modify label-handling on user's own content to still apply blurring

--- a/packages/api/tests/moderation-behaviors.test.ts
+++ b/packages/api/tests/moderation-behaviors.test.ts
@@ -536,14 +536,26 @@ const SCENARIOS: SuiteScenarios = {
     subject: 'profile',
     author: 'self',
     labels: { account: ['!hide'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      displayName: ['blur'],
+      profileList: ['blur'],
+      profileView: ['blur'],
+      contentList: ['blur'],
+      contentView: ['blur'],
+    },
   },
   'Self-profile: !hide on profile': {
     cfg: 'none',
     subject: 'profile',
     author: 'self',
     labels: { profile: ['!hide'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      displayName: ['blur'],
+    },
   },
 
   "Self-post: Imperative label ('!hide') on post": {
@@ -553,6 +565,7 @@ const SCENARIOS: SuiteScenarios = {
     labels: { post: ['!hide'] },
     behaviors: {
       contentView: ['blur'],
+      contentList: ['blur'],
     },
   },
   "Self-post: Imperative label ('!hide') on author profile": {
@@ -560,14 +573,24 @@ const SCENARIOS: SuiteScenarios = {
     subject: 'post',
     author: 'self',
     labels: { profile: ['!hide'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      displayName: ['blur'],
+    },
   },
   "Self-post: Imperative label ('!hide') on author account": {
     cfg: 'none',
     subject: 'post',
     author: 'self',
     labels: { account: ['!hide'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      displayName: ['blur'],
+      contentList: ['blur'],
+      contentView: ['blur'],
+    },
   },
 
   "Self-post: Imperative label ('!warn') on post": {
@@ -577,6 +600,7 @@ const SCENARIOS: SuiteScenarios = {
     labels: { post: ['!warn'] },
     behaviors: {
       contentView: ['blur'],
+      contentList: ['blur'],
     },
   },
   "Self-post: Imperative label ('!warn') on author profile": {
@@ -584,14 +608,23 @@ const SCENARIOS: SuiteScenarios = {
     subject: 'post',
     author: 'self',
     labels: { profile: ['!warn'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      displayName: ['blur'],
+    },
   },
   "Self-post: Imperative label ('!warn') on author account": {
     cfg: 'none',
     subject: 'post',
     author: 'self',
     labels: { account: ['!warn'] },
-    behaviors: {},
+    behaviors: {
+      avatar: ['blur'],
+      banner: ['blur'],
+      contentList: ['blur'],
+      contentView: ['blur'],
+    },
   },
 
   'Mute/block: Blocking user': {

--- a/packages/api/tests/moderation-behaviors.test.ts
+++ b/packages/api/tests/moderation-behaviors.test.ts
@@ -551,7 +551,9 @@ const SCENARIOS: SuiteScenarios = {
     subject: 'post',
     author: 'self',
     labels: { post: ['!hide'] },
-    behaviors: {},
+    behaviors: {
+      contentView: ['blur'],
+    },
   },
   "Self-post: Imperative label ('!hide') on author profile": {
     cfg: 'none',
@@ -573,7 +575,9 @@ const SCENARIOS: SuiteScenarios = {
     subject: 'post',
     author: 'self',
     labels: { post: ['!warn'] },
-    behaviors: {},
+    behaviors: {
+      contentView: ['blur'],
+    },
   },
   "Self-post: Imperative label ('!warn') on author profile": {
     cfg: 'none',


### PR DESCRIPTION
Fixes: https://github.com/bluesky-social/social-app/issues/3871

## Why

This is one part of adjusting the difficulty in seeing whether your post is actually labeled or not whenever you apply a self label to the post. Take this scenario:

- You post an image and add the self-label `nudity`
- The post gets upgraded to the `porn` label immediately. To the user, this Bluesky upgraded label appears to be _their_ self label
- If the user realizes that the label was upgraded, they appeal the upgrade
- Bluesky moderation accepts the appeal, and downgrades it back to `nudity`
- To the poster, the UI makes it look like _all_ labels were removed from their post, even though they were not.

Another, simpler scenario where this is problematic:

- You post an image and add the self-label `nudity`
- Your moderation preferences are set to blur nudity
- The posts that you labeled as `nudity` on your timeline are _not_ blurred, while other people's are. This in some ways defeats the purpose of being able to "blur" NSFW content.

This also allows for showing the "X labels have been placed on this content" even for self-labels so that there can be less confusion about what is going on for the user. https://github.com/bluesky-social/social-app/pull/3874

## How

Instead of returning a default `ModerationUI` whenever the post is yours, we should always check for labels when the c context is `contentView` or `contentMedia`. In those cases, we should also downgrade the `hide` setting to `warn` so the user still sees their post.

## Test Plan

Make a post and self label it as something like nudity. Toggle the various settings and check your following feed for the post.


https://github.com/bluesky-social/atproto/assets/153161762/5fc9f111-85af-4527-bed0-161b7760ede3

