### PR TITLE
Appview: add chat details to profile views, chronological likes

### DIFF
--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -98,6 +98,14 @@ message GetProfileRecordsResponse {
   repeated Record records = 1;
 }
 
+message GetActorChatDeclarationRecordsRequest {
+  repeated string uris = 1;
+}
+
+message GetActorChatDeclarationRecordsResponse {
+  repeated Record records = 1;
+}
+
 message GetRepostRecordsRequest {
   repeated string uris = 1;
 }
@@ -120,6 +128,13 @@ message GetLabelerRecordsRequest {
 
 message GetLabelerRecordsResponse {
   repeated Record records = 1;
+}
+
+message GetAllLabelersRequest {}
+
+message GetAllLabelersResponse {
+  repeated string uris = 1;
+  repeated Record records = 2;
 }
 
 
@@ -183,6 +198,17 @@ message GetLikesBySubjectRequest {
 }
 
 message GetLikesBySubjectResponse {
+  repeated string uris = 1;
+  string cursor = 2;
+}
+
+message GetLikesBySubjectSortedRequest {
+  RecordRef subject = 1;
+  int32 limit = 2;
+  string cursor = 3;
+}
+
+message GetLikesBySubjectSortedResponse {
   repeated string uris = 1;
   string cursor = 2;
 }
@@ -307,6 +333,7 @@ message ActorInfo {
   string takedown_ref = 5;
   google.protobuf.Timestamp tombstoned_at = 6;
   bool labeler = 7;
+  string allow_incoming_chats_from = 8;
 }
 
 message GetActorsResponse {
@@ -358,12 +385,20 @@ message RelationshipPair {
   string b = 2;
 }
 
+message BlockExistence {
+  string blocked_by = 1;
+  string blocking = 2;
+  string blocked_by_list = 3;
+  string blocking_by_list = 4;
+}
+
 message GetBlockExistenceRequest {
   repeated RelationshipPair pairs = 1;
 }
 
 message GetBlockExistenceResponse {
   repeated bool exists = 1;
+  repeated BlockExistence blocks = 2;
 }
 
 
@@ -931,6 +966,17 @@ message GetRecordTakedownResponse {
 }
 
 
+// Polo-backed Graph Endpoints
+
+// GetFollowsFollowing gets the list of DIDs that the actor follows that also follow the target
+message GetFollowsFollowingRequest {
+  string actor_did = 1;
+  string target_did = 2;
+}
+message GetFollowsFollowingResponse {
+  repeated string dids = 1;
+}
+
 // Ping
 message PingRequest {}
 message PingResponse {}
@@ -953,6 +999,7 @@ service Service {
   rpc GetListRecords(GetListRecordsRequest) returns (GetListRecordsResponse);
   rpc GetPostRecords(GetPostRecordsRequest) returns (GetPostRecordsResponse);
   rpc GetProfileRecords(GetProfileRecordsRequest) returns (GetProfileRecordsResponse);
+  rpc GetActorChatDeclarationRecords(GetActorChatDeclarationRecordsRequest) returns (GetActorChatDeclarationRecordsResponse);
   rpc GetRepostRecords(GetRepostRecordsRequest) returns (GetRepostRecordsResponse);
   rpc GetThreadGateRecords(GetThreadGateRecordsRequest) returns (GetThreadGateRecordsResponse);
   rpc GetLabelerRecords(GetLabelerRecordsRequest) returns (GetLabelerRecordsResponse);
@@ -964,6 +1011,7 @@ service Service {
 
   // Likes
   rpc GetLikesBySubject(GetLikesBySubjectRequest) returns (GetLikesBySubjectResponse);
+  rpc GetLikesBySubjectSorted(GetLikesBySubjectSortedRequest) returns (GetLikesBySubjectSortedResponse);
   rpc GetLikesByActorAndSubjects(GetLikesByActorAndSubjectsRequest) returns (GetLikesByActorAndSubjectsResponse);
   rpc GetActorLikes(GetActorLikesRequest) returns (GetActorLikesResponse);
 
@@ -1041,6 +1089,7 @@ service Service {
 
   // Labels
   rpc GetLabels(GetLabelsRequest) returns (GetLabelsResponse);
+  rpc GetAllLabelers(GetAllLabelersRequest) returns (GetAllLabelersResponse);
 
   // Sync
   rpc GetLatestRev(GetLatestRevRequest) returns (GetLatestRevResponse);
@@ -1053,6 +1102,9 @@ service Service {
   // Identity
   rpc GetIdentityByDid(GetIdentityByDidRequest) returns (GetIdentityByDidResponse);
   rpc GetIdentityByHandle(GetIdentityByHandleRequest) returns (GetIdentityByHandleResponse);
+
+  // Graph
+  rpc GetFollowsFollowing(GetFollowsFollowingRequest) returns (GetFollowsFollowingResponse);
 
   // Ping
   rpc Ping(PingRequest) returns (PingResponse);
@@ -1083,6 +1135,10 @@ service Service {
   rpc ClearActorMutelistSubscriptions(ClearActorMutelistSubscriptionsRequest) returns (ClearActorMutelistSubscriptionsResponse);
 }
 
+
+//
+// Write Path
+//
 
 message TakedownActorRequest {
   string did = 1;

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -41,7 +41,7 @@ const skeleton = async (inputs: {
   if (clearlyBadCursor(params.cursor)) {
     return { likes: [] }
   }
-  const likesRes = await ctx.hydrator.dataplane.getLikesBySubject({
+  const likesRes = await ctx.hydrator.dataplane.getLikesBySubjectSorted({
     subject: { uri: params.uri, cid: params.cid },
     cursor: params.cursor,
     limit: params.limit,

--- a/packages/bsky/src/data-plane/server/indexing/index.ts
+++ b/packages/bsky/src/data-plane/server/indexing/index.ts
@@ -27,6 +27,7 @@ import * as ListBlock from './plugins/list-block'
 import * as Block from './plugins/block'
 import * as FeedGenerator from './plugins/feed-generator'
 import * as Labeler from './plugins/labeler'
+import * as ChatDeclaration from './plugins/chat-declaration'
 import RecordProcessor from './processor'
 import { subLogger } from '../../../logger'
 import { retryHttp } from '../../../util/retry'
@@ -46,6 +47,7 @@ export class IndexingService {
     block: Block.PluginType
     feedGenerator: FeedGenerator.PluginType
     labeler: Labeler.PluginType
+    chatDeclaration: ChatDeclaration.PluginType
   }
 
   constructor(
@@ -66,6 +68,7 @@ export class IndexingService {
       block: Block.makePlugin(this.db, this.background),
       feedGenerator: FeedGenerator.makePlugin(this.db, this.background),
       labeler: Labeler.makePlugin(this.db, this.background),
+      chatDeclaration: ChatDeclaration.makePlugin(this.db, this.background),
     }
   }
 

--- a/packages/bsky/src/data-plane/server/indexing/plugins/chat-declaration.ts
+++ b/packages/bsky/src/data-plane/server/indexing/plugins/chat-declaration.ts
@@ -1,0 +1,62 @@
+import { AtUri } from '@atproto/syntax'
+import { CID } from 'multiformats/cid'
+import { DatabaseSchema } from '../../db/database-schema'
+import RecordProcessor from '../processor'
+import { Database } from '../../db'
+import { BackgroundQueue } from '../../background'
+
+// @NOTE this indexer is a placeholder to ensure it gets indexed in the generic records table
+
+const lexId = 'chat.bsky.actor.declaration' // @TODO use lexicon constant
+
+const insertFn = async (
+  _db: DatabaseSchema,
+  uri: AtUri,
+  _cid: CID,
+  _obj: unknown,
+  _timestamp: string,
+): Promise<unknown | null> => {
+  if (uri.rkey !== 'self') return null
+  return true
+}
+
+const findDuplicate = async (): Promise<AtUri | null> => {
+  return null
+}
+
+const notifsForInsert = () => {
+  return []
+}
+
+const deleteFn = async (
+  _db: DatabaseSchema,
+  uri: AtUri,
+): Promise<unknown | null> => {
+  if (uri.rkey !== 'self') return null
+  return true
+}
+
+const notifsForDelete = () => {
+  return { notifs: [], toDelete: [] }
+}
+
+export type PluginType = RecordProcessor<unknown, unknown>
+
+export const makePlugin = (
+  db: Database,
+  background: BackgroundQueue,
+): PluginType => {
+  const processor = new RecordProcessor(db, background, {
+    lexId,
+    insertFn,
+    findDuplicate,
+    deleteFn,
+    notifsForInsert,
+    notifsForDelete,
+  })
+  // @TODO use lexicon validation
+  processor.assertValidRecord = () => null
+  return processor
+}
+
+export default makePlugin

--- a/packages/bsky/src/data-plane/server/routes/follows.ts
+++ b/packages/bsky/src/data-plane/server/routes/follows.ts
@@ -92,4 +92,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor: keyset.packFromResult(follows),
     }
   },
+  async getFollowsFollowing() {
+    throw new Error('not implemented')
+  },
 })

--- a/packages/bsky/src/data-plane/server/routes/labels.ts
+++ b/packages/bsky/src/data-plane/server/routes/labels.ts
@@ -43,4 +43,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
     return { labels }
   },
+
+  async getAllLabelers() {
+    throw new Error('not implemented')
+  },
 })

--- a/packages/bsky/src/data-plane/server/routes/likes.ts
+++ b/packages/bsky/src/data-plane/server/routes/likes.ts
@@ -5,7 +5,7 @@ import { TimeCidKeyset, paginate } from '../db/pagination'
 import { keyBy } from '@atproto/common'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
-  async getLikesBySubject(req) {
+  async getLikesBySubjectSorted(req) {
     const { subject, cursor, limit } = req
     const { ref } = db.db.dynamic
 
@@ -32,6 +32,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       uris: likes.map((l) => l.uri),
       cursor: keyset.packFromResult(likes),
     }
+  },
+
+  async getLikesBySubject(_req) {
+    throw new Error('deprecated in favor of getLikesBySubjectSorted')
   },
 
   async getLikesByActorAndSubjects(req) {

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -21,6 +21,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   getRepostRecords: getRecords(db, ids.AppBskyFeedRepost),
   getThreadGateRecords: getRecords(db, ids.AppBskyFeedThreadgate),
   getLabelerRecords: getRecords(db, ids.AppBskyLabelerService),
+  getActorChatDeclarationRecords: getRecords(db, 'chat.bsky.actor.declaration'),
 })
 
 export const getRecords =

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -669,6 +669,7 @@ export class Hydrator {
         (await this.label.getLabelers([did], includeTakedowns)).get(did) ??
         undefined
       )
+      // @TODO use lexicon constant
     } else if (collection === 'chat.bsky.actor.declaration') {
       if (parsed.rkey !== 'self') return
       return (

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -669,6 +669,13 @@ export class Hydrator {
         (await this.label.getLabelers([did], includeTakedowns)).get(did) ??
         undefined
       )
+    } else if (collection === 'chat.bsky.actor.declaration') {
+      if (parsed.rkey !== 'self') return
+      return (
+        (await this.actor.getChatDeclarations([uri], includeTakedowns)).get(
+          uri,
+        ) ?? undefined
+      )
     } else if (collection === ids.AppBskyActorProfile) {
       const did = parsed.hostname
       const actor = (await this.actor.getActors([did], includeTakedowns)).get(

--- a/packages/bsky/src/proto/bsky_connect.ts
+++ b/packages/bsky/src/proto/bsky_connect.ts
@@ -16,6 +16,8 @@ import {
   DeleteActorMutelistSubscriptionResponse,
   DeleteActorMuteRequest,
   DeleteActorMuteResponse,
+  GetActorChatDeclarationRecordsRequest,
+  GetActorChatDeclarationRecordsResponse,
   GetActorFeedsRequest,
   GetActorFeedsResponse,
   GetActorFollowsActorsRequest,
@@ -34,6 +36,8 @@ import {
   GetActorsResponse,
   GetActorTakedownRequest,
   GetActorTakedownResponse,
+  GetAllLabelersRequest,
+  GetAllLabelersResponse,
   GetAuthorFeedRequest,
   GetAuthorFeedResponse,
   GetBidirectionalBlockRequest,
@@ -64,6 +68,8 @@ import {
   GetFollowersResponse,
   GetFollowRecordsRequest,
   GetFollowRecordsResponse,
+  GetFollowsFollowingRequest,
+  GetFollowsFollowingResponse,
   GetFollowsRequest,
   GetFollowsResponse,
   GetFollowSuggestionsRequest,
@@ -86,6 +92,8 @@ import {
   GetLikesByActorAndSubjectsResponse,
   GetLikesBySubjectRequest,
   GetLikesBySubjectResponse,
+  GetLikesBySubjectSortedRequest,
+  GetLikesBySubjectSortedResponse,
   GetListBlockRecordsRequest,
   GetListBlockRecordsResponse,
   GetListCountRequest,
@@ -257,6 +265,15 @@ export const Service = {
       kind: MethodKind.Unary,
     },
     /**
+     * @generated from rpc bsky.Service.GetActorChatDeclarationRecords
+     */
+    getActorChatDeclarationRecords: {
+      name: 'GetActorChatDeclarationRecords',
+      I: GetActorChatDeclarationRecordsRequest,
+      O: GetActorChatDeclarationRecordsResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
      * @generated from rpc bsky.Service.GetRepostRecords
      */
     getRepostRecords: {
@@ -321,6 +338,15 @@ export const Service = {
       name: 'GetLikesBySubject',
       I: GetLikesBySubjectRequest,
       O: GetLikesBySubjectResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc bsky.Service.GetLikesBySubjectSorted
+     */
+    getLikesBySubjectSorted: {
+      name: 'GetLikesBySubjectSorted',
+      I: GetLikesBySubjectSortedRequest,
+      O: GetLikesBySubjectSortedResponse,
       kind: MethodKind.Unary,
     },
     /**
@@ -745,6 +771,15 @@ export const Service = {
       kind: MethodKind.Unary,
     },
     /**
+     * @generated from rpc bsky.Service.GetAllLabelers
+     */
+    getAllLabelers: {
+      name: 'GetAllLabelers',
+      I: GetAllLabelersRequest,
+      O: GetAllLabelersResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
      * Sync
      *
      * @generated from rpc bsky.Service.GetLatestRev
@@ -802,6 +837,17 @@ export const Service = {
       name: 'GetIdentityByHandle',
       I: GetIdentityByHandleRequest,
       O: GetIdentityByHandleResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Graph
+     *
+     * @generated from rpc bsky.Service.GetFollowsFollowing
+     */
+    getFollowsFollowing: {
+      name: 'GetFollowsFollowing',
+      I: GetFollowsFollowingRequest,
+      O: GetFollowsFollowingResponse,
       kind: MethodKind.Unary,
     },
     /**

--- a/packages/bsky/src/proto/bsky_pb.ts
+++ b/packages/bsky/src/proto/bsky_pb.ts
@@ -1240,6 +1240,140 @@ export class GetProfileRecordsResponse extends Message<GetProfileRecordsResponse
 }
 
 /**
+ * @generated from message bsky.GetActorChatDeclarationRecordsRequest
+ */
+export class GetActorChatDeclarationRecordsRequest extends Message<GetActorChatDeclarationRecordsRequest> {
+  /**
+   * @generated from field: repeated string uris = 1;
+   */
+  uris: string[] = []
+
+  constructor(data?: PartialMessage<GetActorChatDeclarationRecordsRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetActorChatDeclarationRecordsRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    {
+      no: 1,
+      name: 'uris',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+      repeated: true,
+    },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetActorChatDeclarationRecordsRequest {
+    return new GetActorChatDeclarationRecordsRequest().fromBinary(
+      bytes,
+      options,
+    )
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetActorChatDeclarationRecordsRequest {
+    return new GetActorChatDeclarationRecordsRequest().fromJson(
+      jsonValue,
+      options,
+    )
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetActorChatDeclarationRecordsRequest {
+    return new GetActorChatDeclarationRecordsRequest().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetActorChatDeclarationRecordsRequest
+      | PlainMessage<GetActorChatDeclarationRecordsRequest>
+      | undefined,
+    b:
+      | GetActorChatDeclarationRecordsRequest
+      | PlainMessage<GetActorChatDeclarationRecordsRequest>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetActorChatDeclarationRecordsRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetActorChatDeclarationRecordsResponse
+ */
+export class GetActorChatDeclarationRecordsResponse extends Message<GetActorChatDeclarationRecordsResponse> {
+  /**
+   * @generated from field: repeated bsky.Record records = 1;
+   */
+  records: Record[] = []
+
+  constructor(data?: PartialMessage<GetActorChatDeclarationRecordsResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetActorChatDeclarationRecordsResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'records', kind: 'message', T: Record, repeated: true },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetActorChatDeclarationRecordsResponse {
+    return new GetActorChatDeclarationRecordsResponse().fromBinary(
+      bytes,
+      options,
+    )
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetActorChatDeclarationRecordsResponse {
+    return new GetActorChatDeclarationRecordsResponse().fromJson(
+      jsonValue,
+      options,
+    )
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetActorChatDeclarationRecordsResponse {
+    return new GetActorChatDeclarationRecordsResponse().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetActorChatDeclarationRecordsResponse
+      | PlainMessage<GetActorChatDeclarationRecordsResponse>
+      | undefined,
+    b:
+      | GetActorChatDeclarationRecordsResponse
+      | PlainMessage<GetActorChatDeclarationRecordsResponse>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetActorChatDeclarationRecordsResponse, a, b)
+  }
+}
+
+/**
  * @generated from message bsky.GetRepostRecordsRequest
  */
 export class GetRepostRecordsRequest extends Message<GetRepostRecordsRequest> {
@@ -1587,6 +1721,115 @@ export class GetLabelerRecordsResponse extends Message<GetLabelerRecordsResponse
       | undefined,
   ): boolean {
     return proto3.util.equals(GetLabelerRecordsResponse, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetAllLabelersRequest
+ */
+export class GetAllLabelersRequest extends Message<GetAllLabelersRequest> {
+  constructor(data?: PartialMessage<GetAllLabelersRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetAllLabelersRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetAllLabelersRequest {
+    return new GetAllLabelersRequest().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetAllLabelersRequest {
+    return new GetAllLabelersRequest().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetAllLabelersRequest {
+    return new GetAllLabelersRequest().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a: GetAllLabelersRequest | PlainMessage<GetAllLabelersRequest> | undefined,
+    b: GetAllLabelersRequest | PlainMessage<GetAllLabelersRequest> | undefined,
+  ): boolean {
+    return proto3.util.equals(GetAllLabelersRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetAllLabelersResponse
+ */
+export class GetAllLabelersResponse extends Message<GetAllLabelersResponse> {
+  /**
+   * @generated from field: repeated string uris = 1;
+   */
+  uris: string[] = []
+
+  /**
+   * @generated from field: repeated bsky.Record records = 2;
+   */
+  records: Record[] = []
+
+  constructor(data?: PartialMessage<GetAllLabelersResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetAllLabelersResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    {
+      no: 1,
+      name: 'uris',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+      repeated: true,
+    },
+    { no: 2, name: 'records', kind: 'message', T: Record, repeated: true },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetAllLabelersResponse {
+    return new GetAllLabelersResponse().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetAllLabelersResponse {
+    return new GetAllLabelersResponse().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetAllLabelersResponse {
+    return new GetAllLabelersResponse().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a:
+      | GetAllLabelersResponse
+      | PlainMessage<GetAllLabelersResponse>
+      | undefined,
+    b:
+      | GetAllLabelersResponse
+      | PlainMessage<GetAllLabelersResponse>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetAllLabelersResponse, a, b)
   }
 }
 
@@ -2171,6 +2414,146 @@ export class GetLikesBySubjectResponse extends Message<GetLikesBySubjectResponse
       | undefined,
   ): boolean {
     return proto3.util.equals(GetLikesBySubjectResponse, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetLikesBySubjectSortedRequest
+ */
+export class GetLikesBySubjectSortedRequest extends Message<GetLikesBySubjectSortedRequest> {
+  /**
+   * @generated from field: bsky.RecordRef subject = 1;
+   */
+  subject?: RecordRef
+
+  /**
+   * @generated from field: int32 limit = 2;
+   */
+  limit = 0
+
+  /**
+   * @generated from field: string cursor = 3;
+   */
+  cursor = ''
+
+  constructor(data?: PartialMessage<GetLikesBySubjectSortedRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetLikesBySubjectSortedRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'subject', kind: 'message', T: RecordRef },
+    { no: 2, name: 'limit', kind: 'scalar', T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: 'cursor', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetLikesBySubjectSortedRequest {
+    return new GetLikesBySubjectSortedRequest().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetLikesBySubjectSortedRequest {
+    return new GetLikesBySubjectSortedRequest().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetLikesBySubjectSortedRequest {
+    return new GetLikesBySubjectSortedRequest().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetLikesBySubjectSortedRequest
+      | PlainMessage<GetLikesBySubjectSortedRequest>
+      | undefined,
+    b:
+      | GetLikesBySubjectSortedRequest
+      | PlainMessage<GetLikesBySubjectSortedRequest>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetLikesBySubjectSortedRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetLikesBySubjectSortedResponse
+ */
+export class GetLikesBySubjectSortedResponse extends Message<GetLikesBySubjectSortedResponse> {
+  /**
+   * @generated from field: repeated string uris = 1;
+   */
+  uris: string[] = []
+
+  /**
+   * @generated from field: string cursor = 2;
+   */
+  cursor = ''
+
+  constructor(data?: PartialMessage<GetLikesBySubjectSortedResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetLikesBySubjectSortedResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    {
+      no: 1,
+      name: 'uris',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+      repeated: true,
+    },
+    { no: 2, name: 'cursor', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetLikesBySubjectSortedResponse {
+    return new GetLikesBySubjectSortedResponse().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetLikesBySubjectSortedResponse {
+    return new GetLikesBySubjectSortedResponse().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetLikesBySubjectSortedResponse {
+    return new GetLikesBySubjectSortedResponse().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetLikesBySubjectSortedResponse
+      | PlainMessage<GetLikesBySubjectSortedResponse>
+      | undefined,
+    b:
+      | GetLikesBySubjectSortedResponse
+      | PlainMessage<GetLikesBySubjectSortedResponse>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetLikesBySubjectSortedResponse, a, b)
   }
 }
 
@@ -3372,6 +3755,11 @@ export class ActorInfo extends Message<ActorInfo> {
    */
   labeler = false
 
+  /**
+   * @generated from field: string allow_incoming_chats_from = 8;
+   */
+  allowIncomingChatsFrom = ''
+
   constructor(data?: PartialMessage<ActorInfo>) {
     super()
     proto3.util.initPartial(data, this)
@@ -3392,6 +3780,12 @@ export class ActorInfo extends Message<ActorInfo> {
     },
     { no: 6, name: 'tombstoned_at', kind: 'message', T: Timestamp },
     { no: 7, name: 'labeler', kind: 'scalar', T: 8 /* ScalarType.BOOL */ },
+    {
+      no: 8,
+      name: 'allow_incoming_chats_from',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+    },
   ])
 
   static fromBinary(
@@ -3900,6 +4294,83 @@ export class RelationshipPair extends Message<RelationshipPair> {
 }
 
 /**
+ * @generated from message bsky.BlockExistence
+ */
+export class BlockExistence extends Message<BlockExistence> {
+  /**
+   * @generated from field: string blocked_by = 1;
+   */
+  blockedBy = ''
+
+  /**
+   * @generated from field: string blocking = 2;
+   */
+  blocking = ''
+
+  /**
+   * @generated from field: string blocked_by_list = 3;
+   */
+  blockedByList = ''
+
+  /**
+   * @generated from field: string blocking_by_list = 4;
+   */
+  blockingByList = ''
+
+  constructor(data?: PartialMessage<BlockExistence>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.BlockExistence'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'blocked_by', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: 'blocking', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+    {
+      no: 3,
+      name: 'blocked_by_list',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+    },
+    {
+      no: 4,
+      name: 'blocking_by_list',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+    },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): BlockExistence {
+    return new BlockExistence().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): BlockExistence {
+    return new BlockExistence().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): BlockExistence {
+    return new BlockExistence().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a: BlockExistence | PlainMessage<BlockExistence> | undefined,
+    b: BlockExistence | PlainMessage<BlockExistence> | undefined,
+  ): boolean {
+    return proto3.util.equals(BlockExistence, a, b)
+  }
+}
+
+/**
  * @generated from message bsky.GetBlockExistenceRequest
  */
 export class GetBlockExistenceRequest extends Message<GetBlockExistenceRequest> {
@@ -3969,6 +4440,11 @@ export class GetBlockExistenceResponse extends Message<GetBlockExistenceResponse
    */
   exists: boolean[] = []
 
+  /**
+   * @generated from field: repeated bsky.BlockExistence blocks = 2;
+   */
+  blocks: BlockExistence[] = []
+
   constructor(data?: PartialMessage<GetBlockExistenceResponse>) {
     super()
     proto3.util.initPartial(data, this)
@@ -3982,6 +4458,13 @@ export class GetBlockExistenceResponse extends Message<GetBlockExistenceResponse
       name: 'exists',
       kind: 'scalar',
       T: 8 /* ScalarType.BOOL */,
+      repeated: true,
+    },
+    {
+      no: 2,
+      name: 'blocks',
+      kind: 'message',
+      T: BlockExistence,
       repeated: true,
     },
   ])
@@ -9311,6 +9794,130 @@ export class GetRecordTakedownResponse extends Message<GetRecordTakedownResponse
       | undefined,
   ): boolean {
     return proto3.util.equals(GetRecordTakedownResponse, a, b)
+  }
+}
+
+/**
+ * GetFollowsFollowing gets the list of DIDs that the actor follows that also follow the target
+ *
+ * @generated from message bsky.GetFollowsFollowingRequest
+ */
+export class GetFollowsFollowingRequest extends Message<GetFollowsFollowingRequest> {
+  /**
+   * @generated from field: string actor_did = 1;
+   */
+  actorDid = ''
+
+  /**
+   * @generated from field: string target_did = 2;
+   */
+  targetDid = ''
+
+  constructor(data?: PartialMessage<GetFollowsFollowingRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetFollowsFollowingRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'actor_did', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: 'target_did', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetFollowsFollowingRequest {
+    return new GetFollowsFollowingRequest().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetFollowsFollowingRequest {
+    return new GetFollowsFollowingRequest().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetFollowsFollowingRequest {
+    return new GetFollowsFollowingRequest().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a:
+      | GetFollowsFollowingRequest
+      | PlainMessage<GetFollowsFollowingRequest>
+      | undefined,
+    b:
+      | GetFollowsFollowingRequest
+      | PlainMessage<GetFollowsFollowingRequest>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetFollowsFollowingRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetFollowsFollowingResponse
+ */
+export class GetFollowsFollowingResponse extends Message<GetFollowsFollowingResponse> {
+  /**
+   * @generated from field: repeated string dids = 1;
+   */
+  dids: string[] = []
+
+  constructor(data?: PartialMessage<GetFollowsFollowingResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetFollowsFollowingResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    {
+      no: 1,
+      name: 'dids',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+      repeated: true,
+    },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetFollowsFollowingResponse {
+    return new GetFollowsFollowingResponse().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetFollowsFollowingResponse {
+    return new GetFollowsFollowingResponse().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetFollowsFollowingResponse {
+    return new GetFollowsFollowingResponse().fromJsonString(jsonString, options)
+  }
+
+  static equals(
+    a:
+      | GetFollowsFollowingResponse
+      | PlainMessage<GetFollowsFollowingResponse>
+      | undefined,
+    b:
+      | GetFollowsFollowingResponse
+      | PlainMessage<GetFollowsFollowingResponse>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetFollowsFollowingResponse, a, b)
   }
 }
 

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -110,7 +110,11 @@ export class Views {
       associated: {
         lists: profileAggs?.lists,
         feedgens: profileAggs?.feeds,
-        labeler: actor?.isLabeler,
+        labeler: actor.isLabeler,
+        // @TODO apply default chat policy?
+        chat: actor.allowIncomingChatsFrom
+          ? { allowIncoming: actor.allowIncomingChatsFrom }
+          : undefined,
       },
     }
   }
@@ -160,7 +164,16 @@ export class Views {
         : undefined,
       // associated.feedgens and associated.lists info not necessarily included
       // on profile and profile-basic views, but should be on profile-detailed.
-      associated: actor?.isLabeler ? { labeler: true } : undefined,
+      associated:
+        actor.isLabeler || actor.allowIncomingChatsFrom
+          ? {
+              labeler: actor.isLabeler ? true : undefined,
+              // @TODO apply default chat policy?
+              chat: actor.allowIncomingChatsFrom
+                ? { allowIncoming: actor.allowIncomingChatsFrom }
+                : undefined,
+            }
+          : undefined,
       viewer: this.profileViewer(did, state),
       labels,
     }

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -685,6 +685,11 @@ Array [
     "feedContext": "item-5",
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(6)",
         "handle": "dan.test",
         "labels": Array [],

--- a/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
@@ -219,6 +219,11 @@ Array [
             "record": Object {
               "$type": "app.bsky.embed.record#viewRecord",
               "author": Object {
+                "associated": Object {
+                  "chat": Object {
+                    "allowIncoming": "none",
+                  },
+                },
                 "did": "user(3)",
                 "handle": "dan.test",
                 "labels": Array [],
@@ -432,6 +437,11 @@ Array [
     "cursor": "0000000000000__bafycid",
     "follows": Array [
       Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(3)",
         "handle": "dan.test",
         "labels": Array [],
@@ -633,6 +643,9 @@ Object {
 exports[`indexing indexes profiles. 1`] = `
 Object {
   "associated": Object {
+    "chat": Object {
+      "allowIncoming": "none",
+    },
     "feedgens": 0,
     "labeler": false,
     "lists": 0,
@@ -655,6 +668,9 @@ Object {
 exports[`indexing indexes profiles. 2`] = `
 Object {
   "associated": Object {
+    "chat": Object {
+      "allowIncoming": "none",
+    },
     "feedgens": 0,
     "labeler": false,
     "lists": 0,
@@ -677,6 +693,9 @@ Object {
 exports[`indexing indexes profiles. 3`] = `
 Object {
   "associated": Object {
+    "chat": Object {
+      "allowIncoming": "none",
+    },
     "feedgens": 0,
     "labeler": false,
     "lists": 0,

--- a/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/author-feed.test.ts.snap
@@ -239,6 +239,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(4)",
             "handle": "dan.test",
             "labels": Array [],
@@ -727,6 +732,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(0)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1209,6 +1219,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1423,6 +1438,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1437,6 +1457,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1600,6 +1625,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1874,6 +1904,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(4)",
             "handle": "dan.test",
             "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
@@ -38,6 +38,11 @@ Object {
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(2)",
             "handle": "dan.test",
             "labels": Array [],
@@ -473,6 +478,11 @@ Object {
   "items": Array [
     Object {
       "subject": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/blocks.test.ts.snap
@@ -38,6 +38,11 @@ Object {
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(2)",
             "handle": "dan.test",
             "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
@@ -19,6 +19,11 @@ Object {
     },
     Object {
       "actor": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(1)",
         "handle": "dan.test",
         "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/list-feed.test.ts.snap
@@ -422,6 +422,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(4)",
             "handle": "dan.test",
             "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
@@ -480,6 +480,11 @@ Object {
   "items": Array [
     Object {
       "subject": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
@@ -4,6 +4,11 @@ exports[`notification views fetches notifications omitting mentions and replies 
 Array [
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -31,6 +36,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -58,6 +68,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -367,6 +382,11 @@ exports[`notification views fetches notifications without a last-seen 1`] = `
 Array [
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -394,6 +414,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -421,6 +446,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],
@@ -465,6 +495,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(0)",
       "handle": "dan.test",
       "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/posts.test.ts.snap
@@ -251,6 +251,11 @@ Array [
   },
   Object {
     "author": Object {
+      "associated": Object {
+        "chat": Object {
+          "allowIncoming": "none",
+        },
+      },
       "did": "user(6)",
       "handle": "dan.test",
       "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/profile.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/profile.test.ts.snap
@@ -81,6 +81,9 @@ Array [
   },
   Object {
     "associated": Object {
+      "chat": Object {
+        "allowIncoming": "none",
+      },
       "feedgens": 0,
       "labeler": false,
       "lists": 0,
@@ -144,6 +147,9 @@ Object {
 exports[`pds profile views fetches other's profile, without a follow 1`] = `
 Object {
   "associated": Object {
+    "chat": Object {
+      "allowIncoming": "none",
+    },
     "feedgens": 0,
     "labeler": false,
     "lists": 0,

--- a/packages/bsky/tests/views/__snapshots__/reposts.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/reposts.test.ts.snap
@@ -12,6 +12,11 @@ Array [
     },
   },
   Object {
+    "associated": Object {
+      "chat": Object {
+        "allowIncoming": "none",
+      },
+    },
     "did": "user(1)",
     "handle": "dan.test",
     "labels": Array [],
@@ -62,6 +67,11 @@ Array [
     },
   },
   Object {
+    "associated": Object {
+      "chat": Object {
+        "allowIncoming": "none",
+      },
+    },
     "did": "user(1)",
     "handle": "dan.test",
     "labels": Array [],

--- a/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/timeline.test.ts.snap
@@ -57,6 +57,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -163,6 +168,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -311,6 +321,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(2)",
             "handle": "dan.test",
             "labels": Array [],
@@ -440,6 +455,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -496,6 +516,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -639,6 +664,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -745,6 +775,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1125,6 +1160,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1445,6 +1485,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1652,6 +1697,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -1667,6 +1717,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -2390,6 +2445,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(2)",
             "handle": "dan.test",
             "labels": Array [],
@@ -2614,6 +2674,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -2797,6 +2862,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -3065,6 +3135,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(0)",
         "handle": "dan.test",
         "labels": Array [],
@@ -3805,6 +3880,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(0)",
             "handle": "dan.test",
             "labels": Array [],
@@ -4270,6 +4350,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(0)",
         "handle": "dan.test",
         "labels": Array [],
@@ -4837,6 +4922,11 @@ Array [
         "record": Object {
           "$type": "app.bsky.embed.record#viewRecord",
           "author": Object {
+            "associated": Object {
+              "chat": Object {
+                "allowIncoming": "none",
+              },
+            },
             "did": "user(0)",
             "handle": "dan.test",
             "labels": Array [],
@@ -5285,6 +5375,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -5499,6 +5594,11 @@ Array [
     "reason": Object {
       "$type": "app.bsky.feed.defs#reasonRepost",
       "by": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -5716,6 +5816,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],
@@ -5895,6 +6000,11 @@ Array [
   Object {
     "post": Object {
       "author": Object {
+        "associated": Object {
+          "chat": Object {
+            "allowIncoming": "none",
+          },
+        },
         "did": "user(2)",
         "handle": "dan.test",
         "labels": Array [],

--- a/packages/dev-env/src/seed/users.ts
+++ b/packages/dev-env/src/seed/users.ts
@@ -19,6 +19,23 @@ export default async (sc: SeedClient) => {
     users.bob.selfLabels,
   )
 
+  await sc.agent.api.com.atproto.repo.putRecord(
+    {
+      repo: sc.dids.dan,
+      collection: 'chat.bsky.actor.declaration',
+      rkey: 'self',
+      validate: false,
+      record: {
+        $type: 'chat.bsky.actor.declaration',
+        allowIncoming: 'none',
+      },
+    },
+    {
+      encoding: 'application/json',
+      headers: sc.getHeaders(sc.dids.dan),
+    },
+  )
+
   return sc
 }
 


### PR DESCRIPTION
Updating the appview dataplane protobufs with support for chat details and time-sorted likers.
 - Add `profile.associated.chat.allowIncoming` to profile views.
 - Update `getLikes` to be ordered reverse-chronologically.