### PR TITLE
Appview: handle out-of-date cursor with feed.getLikes

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -13,6 +13,7 @@ import { Views } from '../../../../views'
 import { parseString } from '../../../../hydration/util'
 import { creatorFromUri } from '../../../../views/util'
 import { clearlyBadCursor, resHeaders } from '../../../util'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export default function (server: Server, ctx: AppContext) {
   const getLikes = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -41,8 +42,12 @@ const skeleton = async (inputs: {
   if (clearlyBadCursor(params.cursor)) {
     return { likes: [] }
   }
-  // @TODO deprecate getLikesBySubject and move to getLikesBySubjectSorted
-  const likesRes = await ctx.hydrator.dataplane.getLikesBySubject({
+  if (looksLikeNonSortedCursor(params.cursor)) {
+    throw new InvalidRequestError(
+      'Cursor appear to be out of date, please try reloading.',
+    )
+  }
+  const likesRes = await ctx.hydrator.dataplane.getLikesBySubjectSorted({
     subject: { uri: params.uri, cid: params.cid },
     cursor: params.cursor,
     limit: params.limit,
@@ -116,4 +121,10 @@ type Params = QueryParams & { hydrateCtx: HydrateCtx }
 type Skeleton = {
   likes: string[]
   cursor?: string
+}
+
+const looksLikeNonSortedCursor = (cursor: string | undefined) => {
+  // the old cursor values used with getLikesBySubject() were dids.
+  // we now use getLikesBySubjectSorted(), whose cursors look like timestamps.
+  return cursor?.startsWith('did:')
 }

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -41,7 +41,8 @@ const skeleton = async (inputs: {
   if (clearlyBadCursor(params.cursor)) {
     return { likes: [] }
   }
-  const likesRes = await ctx.hydrator.dataplane.getLikesBySubjectSorted({
+  // @TODO deprecate getLikesBySubject and move to getLikesBySubjectSorted
+  const likesRes = await ctx.hydrator.dataplane.getLikesBySubject({
     subject: { uri: params.uri, cid: params.cid },
     cursor: params.cursor,
     limit: params.limit,

--- a/packages/bsky/src/data-plane/server/routes/likes.ts
+++ b/packages/bsky/src/data-plane/server/routes/likes.ts
@@ -1,8 +1,9 @@
+import assert from 'node:assert'
+import { keyBy } from '@atproto/common'
 import { ServiceImpl } from '@connectrpc/connect'
 import { Service } from '../../../proto/bsky_connect'
 import { Database } from '../db'
 import { TimeCidKeyset, paginate } from '../db/pagination'
-import { keyBy } from '@atproto/common'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getLikesBySubjectSorted(req) {
@@ -34,8 +35,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     }
   },
 
-  async getLikesBySubject(_req) {
-    throw new Error('deprecated in favor of getLikesBySubjectSorted')
+  // @NOTE deprecated in favor of getLikesBySubjectSorted
+  async getLikesBySubject(req, context) {
+    assert(this.getLikesBySubjectSorted)
+    return this.getLikesBySubjectSorted(req, context)
   },
 
   async getLikesByActorAndSubjects(req) {


### PR DESCRIPTION
Followup to #2471, more useful error message when using an out of date cursor with `getLikes`.