### PR TITLE
Bugfixes for generic proxy rate limiting

### DIFF
--- a/packages/xrpc-server/tests/rate-limiter.test.ts
+++ b/packages/xrpc-server/tests/rate-limiter.test.ts
@@ -97,7 +97,7 @@ const LEXICONS: LexiconDoc[] = [
   },
   {
     lexicon: 1,
-    id: 'io.example.nonExistant',
+    id: 'io.example.nonExistent',
     defs: {
       main: {
         type: 'query',
@@ -246,7 +246,7 @@ describe('Parameters', () => {
   })
 
   it('applies global limits to xrpc catchall', async () => {
-    const makeCall = () => client.call('io.example.nonExistant')
+    const makeCall = () => client.call('io.example.nonExistent')
     await expect(makeCall()).rejects.toThrow('Rate Limit Exceeded')
   })
 

--- a/packages/xrpc-server/tests/rate-limiter.test.ts
+++ b/packages/xrpc-server/tests/rate-limiter.test.ts
@@ -95,6 +95,18 @@ const LEXICONS: LexiconDoc[] = [
       },
     },
   },
+  {
+    lexicon: 1,
+    id: 'io.example.nonExistant',
+    defs: {
+      main: {
+        type: 'query',
+        output: {
+          encoding: 'application/json',
+        },
+      },
+    },
+  },
 ]
 
 describe('Parameters', () => {
@@ -231,6 +243,11 @@ describe('Parameters', () => {
       calls.push(makeCall())
     }
     await expect(Promise.all(calls)).rejects.toThrow('Rate Limit Exceeded')
+  })
+
+  it('applies global limits to xrpc catchall', async () => {
+    const makeCall = () => client.call('io.example.nonExistant')
+    await expect(makeCall()).rejects.toThrow('Rate Limit Exceeded')
   })
 
   it('can bypass rate limits', async () => {


### PR DESCRIPTION
Two fixes:
- better error handling. Specifically the limit consume fn _returns_ an error rather than throwing so we need to handle that correctly
- fix the scope on the consume function