### PR TITLE
fix(crypto): Add KeypairOptions for fix tests

### DIFF
--- a/packages/crypto/src/p256/keypair.ts
+++ b/packages/crypto/src/p256/keypair.ts
@@ -12,6 +12,7 @@ import { Keypair } from '../types'
 
 export type P256KeypairOptions = {
   exportable: boolean
+  isCompressed: boolean
 }
 
 export class P256Keypair implements Keypair {
@@ -21,16 +22,18 @@ export class P256Keypair implements Keypair {
   constructor(
     private privateKey: Uint8Array,
     private exportable: boolean,
+    isCompressed: boolean,
   ) {
-    this.publicKey = p256.getPublicKey(privateKey)
+    this.publicKey = p256.getPublicKey(privateKey, isCompressed)
   }
 
   static async create(
     opts?: Partial<P256KeypairOptions>,
   ): Promise<P256Keypair> {
     const { exportable = false } = opts || {}
+    const { isCompressed = true } = opts || {}
     const privKey = p256.utils.randomPrivateKey()
-    return new P256Keypair(privKey, exportable)
+    return new P256Keypair(privKey, exportable, isCompressed)
   }
 
   static async import(
@@ -38,9 +41,10 @@ export class P256Keypair implements Keypair {
     opts?: Partial<P256KeypairOptions>,
   ): Promise<P256Keypair> {
     const { exportable = false } = opts || {}
+    const { isCompressed = true } = opts || {}
     const privKeyBytes =
       typeof privKey === 'string' ? ui8FromString(privKey, 'hex') : privKey
-    return new P256Keypair(privKeyBytes, exportable)
+    return new P256Keypair(privKeyBytes, exportable, isCompressed)
   }
 
   publicKeyBytes(): Uint8Array {

--- a/packages/crypto/src/secp256k1/keypair.ts
+++ b/packages/crypto/src/secp256k1/keypair.ts
@@ -12,6 +12,7 @@ import { Keypair } from '../types'
 
 export type Secp256k1KeypairOptions = {
   exportable: boolean
+  isCompressed: boolean
 }
 
 export class Secp256k1Keypair implements Keypair {
@@ -21,16 +22,18 @@ export class Secp256k1Keypair implements Keypair {
   constructor(
     private privateKey: Uint8Array,
     private exportable: boolean,
+    isCompressed: boolean,
   ) {
-    this.publicKey = k256.getPublicKey(privateKey)
+    this.publicKey = k256.getPublicKey(privateKey, isCompressed)
   }
 
   static async create(
     opts?: Partial<Secp256k1KeypairOptions>,
   ): Promise<Secp256k1Keypair> {
     const { exportable = false } = opts || {}
+    const { isCompressed = true } = opts || {}
     const privKey = k256.utils.randomPrivateKey()
-    return new Secp256k1Keypair(privKey, exportable)
+    return new Secp256k1Keypair(privKey, exportable, isCompressed)
   }
 
   static async import(
@@ -38,9 +41,10 @@ export class Secp256k1Keypair implements Keypair {
     opts?: Partial<Secp256k1KeypairOptions>,
   ): Promise<Secp256k1Keypair> {
     const { exportable = false } = opts || {}
+    const { isCompressed = true } = opts || {}
     const privKeyBytes =
       typeof privKey === 'string' ? ui8FromString(privKey, 'hex') : privKey
-    return new Secp256k1Keypair(privKeyBytes, exportable)
+    return new Secp256k1Keypair(privKeyBytes, exportable, isCompressed)
   }
 
   publicKeyBytes(): Uint8Array {

--- a/packages/crypto/tests/did.test.ts
+++ b/packages/crypto/tests/did.test.ts
@@ -13,12 +13,16 @@ describe('secp256k1 did:key', () => {
 
   it('converts between bytes and did', async () => {
     for (const vector of secpTestVectors) {
-      const keypair = await Secp256k1Keypair.import(vector.seed)
+      const keypair = await Secp256k1Keypair.import(vector.seed, {
+        isCompressed: false,
+      })
       const didKey = did.formatDidKey('ES256K', keypair.publicKeyBytes())
       expect(didKey).toEqual(vector.id)
       const { jwtAlg, keyBytes } = did.parseDidKey(didKey)
       expect(jwtAlg).toBe('ES256K')
-      expect(uint8arrays.equals(keyBytes, keypair.publicKeyBytes())).toBeTruthy
+      expect(
+        uint8arrays.equals(keyBytes, keypair.publicKeyBytes()),
+      ).toBeTruthy()
     }
   })
 })
@@ -36,12 +40,16 @@ describe('P-256 did:key', () => {
   it('converts between bytes and did', async () => {
     for (const vector of p256TestVectors) {
       const bytes = uint8arrays.fromString(vector.privateKeyBase58, 'base58btc')
-      const keypair = await P256Keypair.import(bytes)
+      const keypair = await P256Keypair.import(bytes, {
+        isCompressed: false,
+      })
       const didKey = did.formatDidKey('ES256', keypair.publicKeyBytes())
       expect(didKey).toEqual(vector.id)
       const { jwtAlg, keyBytes } = did.parseDidKey(didKey)
       expect(jwtAlg).toBe('ES256')
-      expect(uint8arrays.equals(keyBytes, keypair.publicKeyBytes())).toBeTruthy
+      expect(
+        uint8arrays.equals(keyBytes, keypair.publicKeyBytes()),
+      ).toBeTruthy()
     }
   })
 })


### PR DESCRIPTION
I found that only `.toBeTruthy` is written (no parentheses) and not tested in `crypto/tests/did.test.ts`: it seems to be the only two places in this repository.
After adding the parentheses and running the test, the test failed. This seems to be because `did.parseDidKey` calls `decompressPubkey` and returns 65-byte keyBytes, while `getPublicKey` in `@noble/curves` generates 33-byte compressed signatures by default.
https://github.com/paulmillr/noble-curves?tab=readme-ov-file#upgrading

If the intended behavior is for `parseDidKey` to return a decompressed version, then the publicKey to be compared in the test needs to be generated with `isCompressed: false`. So, I modified it to add an argument in each plugins.