### PR TITLE
:bug: Add divert event to the list of event types

### DIFF
--- a/packages/ozone/src/api/util.ts
+++ b/packages/ozone/src/api/util.ts
@@ -118,4 +118,5 @@ const eventTypes = new Set([
   'tools.ozone.moderation.defs#modEventEmail',
   'tools.ozone.moderation.defs#modEventResolveAppeal',
   'tools.ozone.moderation.defs#modEventTag',
+  'tools.ozone.moderation.defs#modEventDivert',
 ])


### PR DESCRIPTION
This was causing the `queryEvents` endpoint to fail at times.