### PR TITLE
Update legacy blob refs in profile records

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -2,6 +2,7 @@ import { CID } from 'multiformats/cid'
 import { AtUri } from '@atproto/syntax'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { CommitData } from '@atproto/repo'
+import { BlobRef } from '@atproto/lexicon'
 import { Server } from '../../../../lexicon'
 import { prepareUpdate, prepareCreate } from '../../../../repo'
 import AppContext from '../../../../context'
@@ -12,6 +13,9 @@ import {
   PreparedCreate,
   PreparedUpdate,
 } from '../../../../repo'
+import { ids } from '../../../../lexicon/lexicons'
+import { Record as ProfileRecord } from '../../../../lexicon/types/app/bsky/actor/profile'
+import { ActorStoreTransactor } from '../../../../actor-store'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.putRecord({
@@ -61,6 +65,14 @@ export default function (server: Server, ctx: AppContext) {
         did,
         async (actorTxn) => {
           const current = await actorTxn.record.getRecord(uri, null, true)
+          const isUpdate = current !== null
+
+          // @TODO temporaray hack for legacy blob refs in profiles - remove after migrating legacy blobs
+          if (isUpdate && collection === ids.AppBskyActorProfile) {
+            console.log('HERE')
+            await updateProfileLegacyBlobRef(actorTxn, record)
+            // console.log(record.avatar?.original)
+          }
           const writeInfo = {
             did,
             collection,
@@ -72,7 +84,7 @@ export default function (server: Server, ctx: AppContext) {
 
           let write: PreparedCreate | PreparedUpdate
           try {
-            write = current
+            write = isUpdate
               ? await prepareUpdate(writeInfo)
               : await prepareCreate(writeInfo)
           } catch (err) {
@@ -121,4 +133,27 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+// WARNING: mutates object
+const updateProfileLegacyBlobRef = async (
+  actorStore: ActorStoreTransactor,
+  record: ProfileRecord,
+) => {
+  if (record.avatar && !record.avatar.original['$type']) {
+    const blob = await actorStore.repo.blob.getBlobMetadata(record.avatar.ref)
+    record.avatar = new BlobRef(
+      record.avatar.ref,
+      record.avatar.mimeType,
+      blob.size,
+    )
+  }
+  if (record.banner && !record.banner.original['$type']) {
+    const blob = await actorStore.repo.blob.getBlobMetadata(record.banner.ref)
+    record.banner = new BlobRef(
+      record.banner.ref,
+      record.banner.mimeType,
+      blob.size,
+    )
+  }
 }

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -69,9 +69,7 @@ export default function (server: Server, ctx: AppContext) {
 
           // @TODO temporaray hack for legacy blob refs in profiles - remove after migrating legacy blobs
           if (isUpdate && collection === ids.AppBskyActorProfile) {
-            console.log('HERE')
             await updateProfileLegacyBlobRef(actorTxn, record)
-            // console.log(record.avatar?.original)
           }
           const writeInfo = {
             did,

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -517,6 +517,36 @@ describe('crud operations', () => {
         description: 'Dog lover',
       })
     })
+
+    // @TODO remove after migrating legacy blobs
+    it('updates a legacy blob ref when updating profile', async () => {
+      const { repo } = bobAgent.api.com.atproto
+      const file = await fs.readFile(
+        '../dev-env/src/seed/img/key-portrait-small.jpg',
+      )
+      const uploadedRes = await repo.uploadBlob(file, {
+        encoding: 'image/jpeg',
+      })
+
+      await repo.putRecord({
+        ...profilePath,
+        repo: bob.did,
+        record: {
+          displayName: 'Robert',
+          avatar: BlobRef.fromJsonRef({
+            mimeType: uploadedRes.data.blob.mimeType,
+            cid: uploadedRes.data.blob.ref.toString(),
+          }),
+        },
+      })
+
+      const got = await repo.getRecord({
+        ...profilePath,
+        repo: bob.did,
+      })
+      const gotAvatar = got.data.value['avatar'] as BlobRef
+      expect(gotAvatar.original).toEqual(uploadedRes.data.blob.original)
+    })
   })
 
   // Validation


### PR DESCRIPTION
This is a relatively crude/ham-fisted fix intended to help with the fact that some accounts still have legacy blob refs in their profile records which is preventing them from updating their profile record.

Ended up landing this in `putRecord` instead of the `prepareWrite` functions because we need access to the actor store to find the `size` of the blob. We only implement it in `putRecord` when updating specifically a profile record in order to both reduce the number of checks we're required to do, but also because this issue is mostly isolated to historical profile records.

This is a stopgap until we have time to run a proper migration that updates all legacy blob refs.