### PR TITLE
Tear down docker when tests fail

### DIFF
--- a/packages/dev-infra/_common.sh
+++ b/packages/dev-infra/_common.sh
@@ -156,6 +156,8 @@ main_docker() {
     echo "all services ${services} are already running"
   fi
 
+
+  # do not exit when following commands fail, so we can intercept exit code & tear down docker
   set +e
 
   # setup environment variables and run args

--- a/packages/dev-infra/_common.sh
+++ b/packages/dev-infra/_common.sh
@@ -156,7 +156,6 @@ main_docker() {
     echo "all services ${services} are already running"
   fi
 
-
   # do not exit when following commands fail, so we can intercept exit code & tear down docker
   set +e
 

--- a/packages/dev-infra/_common.sh
+++ b/packages/dev-infra/_common.sh
@@ -156,6 +156,8 @@ main_docker() {
     echo "all services ${services} are already running"
   fi
 
+  set +e
+
   # setup environment variables and run args
   export_env
   "$@"


### PR DESCRIPTION
We refactored dev-infra in https://github.com/bluesky-social/atproto/pull/1825 to allow running tests against a local Postgres without docker. Part of that work was to make the script exit if any command fails.

However, when running with docker, we actually don't want the script to exit if the test command fails. We want to intercept the error code and tear down docker before exiting. We can do this by just adding a `set +e` right before calling the supplied command