### PR TITLE
Add new preference and api for bsky app state; also put preference updates within transactional lock regions

### DIFF
--- a/.changeset/strange-camels-float.md
+++ b/.changeset/strange-camels-float.md
@@ -1,0 +1,8 @@
+---
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Added bsky app state preference and improved protections against race conditions in preferences sdk

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -394,15 +394,27 @@
       }
     },
     "bskyAppStatePref": {
-      "description": "A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this.",
+      "description": "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.",
       "type": "object",
       "properties": {
-        "dismissedNudges": {
-          "description": "An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again.",
+        "activeProgressGuide": {
+          "type": "ref",
+          "ref": "#bskyAppProgressGuide"
+        },
+        "queuedNudges": {
+          "description": "An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.",
           "type": "array",
           "maxLength": 1000,
-          "items": {"type": "string", "maxLength": 100}
+          "items": { "type": "string", "maxLength": 100 }
         }
+      }
+    },
+    "bskyAppProgressGuide": {
+      "description": "If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress.",
+      "type": "object",
+      "required": ["guide"],
+      "properties": {
+        "guide": { "type": "string", "maxLength": 100 }
       }
     }
   }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -168,7 +168,8 @@
           "#threadViewPref",
           "#interestsPref",
           "#mutedWordsPref",
-          "#hiddenPostsPref"
+          "#hiddenPostsPref",
+          "#bskyAppStatePref"
         ]
       }
     },
@@ -389,6 +390,18 @@
         "did": {
           "type": "string",
           "format": "did"
+        }
+      }
+    },
+    "bskyAppStatePref": {
+      "description": "A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this.",
+      "type": "object",
+      "properties": {
+        "dismissedNudges": {
+          "description": "An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again.",
+          "type": "array",
+          "maxLength": 1000,
+          "items": {"type": "string", "maxLength": 100}
         }
       }
     }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,6 +26,7 @@
     "@atproto/lexicon": "workspace:^",
     "@atproto/syntax": "workspace:^",
     "@atproto/xrpc": "workspace:^",
+    "await-lock": "^2.2.2",
     "multiformats": "^9.9.0",
     "tlds": "^1.234.0"
   },

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -1044,7 +1044,7 @@ export class BskyAgent extends AtpAgent {
     await updateHiddenPost(this, postUri, 'unhide')
   }
 
-  async bskyAppDismissNudge(nudge: string) {
+  async bskyAppDismissNudge(nudge: string, isDismissed = true) {
     await updatePreferences(this, (prefs: AppBskyActorDefs.Preferences) => {
       let bskyAppStatePref = prefs.findLast(
         (pref) =>
@@ -1053,11 +1053,20 @@ export class BskyAgent extends AtpAgent {
       )
 
       bskyAppStatePref = bskyAppStatePref || {}
-      if (!Array.isArray(bskyAppStatePref.dismissedNudges)) {
-        bskyAppStatePref.dismissedNudges = [nudge]
+      if (isDismissed) {
+        if (!Array.isArray(bskyAppStatePref.dismissedNudges)) {
+          bskyAppStatePref.dismissedNudges = [nudge]
+        } else {
+          if (!bskyAppStatePref.dismissedNudges.includes(nudge)) {
+            bskyAppStatePref.dismissedNudges.push(nudge)
+          }
+        }
       } else {
-        if (!bskyAppStatePref.dismissedNudges.includes(nudge)) {
-          bskyAppStatePref.dismissedNudges.push(nudge)
+        if (!Array.isArray(bskyAppStatePref.dismissedNudges)) {
+          bskyAppStatePref.dismissedNudges = []
+        } else {
+          bskyAppStatePref.dismissedNudges =
+            bskyAppStatePref.dismissedNudges.filter((v) => v !== nudge)
         }
       }
 

--- a/packages/api/src/bsky-agent.ts
+++ b/packages/api/src/bsky-agent.ts
@@ -395,6 +395,7 @@ export class BskyAgent extends AtpAgent {
       },
       bskyAppState: {
         queuedNudges: [],
+        activeProgressGuide: undefined,
       },
     }
     const res = await this.app.bsky.actor.getPreferences({})

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3343,7 +3343,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'List blob CIDso for an account, since some repo revision. Does not require auth; implemented by PDS.',
+          'List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.',
         parameters: {
           type: 'params',
           required: ['did'],
@@ -4410,18 +4410,34 @@ export const schemaDict = {
       },
       bskyAppStatePref: {
         description:
-          "A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this.",
+          "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.",
         type: 'object',
         properties: {
-          dismissedNudges: {
+          activeProgressGuide: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#bskyAppProgressGuide',
+          },
+          queuedNudges: {
             description:
-              "An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again.",
+              'An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.',
             type: 'array',
             maxLength: 1000,
             items: {
               type: 'string',
               maxLength: 100,
             },
+          },
+        },
+      },
+      bskyAppProgressGuide: {
+        description:
+          'If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress.',
+        type: 'object',
+        required: ['guide'],
+        properties: {
+          guide: {
+            type: 'string',
+            maxLength: 100,
           },
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4166,6 +4166,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#bskyAppStatePref',
           ],
         },
       },
@@ -4404,6 +4405,23 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+        },
+      },
+      bskyAppStatePref: {
+        description:
+          "A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this.",
+        type: 'object',
+        properties: {
+          dismissedNudges: {
+            description:
+              "An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again.",
+            type: 'array',
+            maxLength: 1000,
+            items: {
+              type: 'string',
+              maxLength: 100,
+            },
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -458,10 +458,11 @@ export function validateLabelerPrefItem(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#labelerPrefItem', v)
 }
 
-/** A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this. */
+/** A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this. */
 export interface BskyAppStatePref {
-  /** An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again. */
-  dismissedNudges?: string[]
+  activeProgressGuide?: BskyAppProgressGuide
+  /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
+  queuedNudges?: string[]
   [k: string]: unknown
 }
 
@@ -475,4 +476,22 @@ export function isBskyAppStatePref(v: unknown): v is BskyAppStatePref {
 
 export function validateBskyAppStatePref(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppStatePref', v)
+}
+
+/** If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress. */
+export interface BskyAppProgressGuide {
+  guide: string
+  [k: string]: unknown
+}
+
+export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppProgressGuide'
+  )
+}
+
+export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -184,6 +184,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | BskyAppStatePref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -455,4 +456,23 @@ export function isLabelerPrefItem(v: unknown): v is LabelerPrefItem {
 
 export function validateLabelerPrefItem(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#labelerPrefItem', v)
+}
+
+/** A grab bag of state that's specific to the bsky.app program. Third-party apps probably shouldn't muck with this. */
+export interface BskyAppStatePref {
+  /** An array of tokens which identify nudges (modals, popups) that the user has seen and dismissed, and which therefore don't need to be shown again. */
+  dismissedNudges?: string[]
+  [k: string]: unknown
+}
+
+export function isBskyAppStatePref(v: unknown): v is BskyAppStatePref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppStatePref'
+  )
+}
+
+export function validateBskyAppStatePref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppStatePref', v)
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -127,4 +127,7 @@ export interface BskyPreferences {
   moderationPrefs: ModerationPrefs
   birthDate: Date | undefined
   interests: BskyInterestsPreference
+  bskyAppState: {
+    dismissedNudges: string[]
+  }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -128,6 +128,7 @@ export interface BskyPreferences {
   birthDate: Date | undefined
   interests: BskyInterestsPreference
   bskyAppState: {
-    dismissedNudges: string[]
+    queuedNudges: string[]
+    activeProgressGuide: AppBskyActorDefs.BskyAppProgressGuide | undefined
   }
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -276,6 +276,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setAdultContentEnabled(true)
@@ -312,6 +315,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -350,6 +356,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setContentLabelPref('misinfo', 'hide')
@@ -386,6 +395,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -427,6 +439,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -472,6 +487,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -515,6 +533,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -560,6 +581,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -604,6 +628,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -647,6 +674,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -698,6 +728,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -741,6 +774,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -786,6 +822,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: true })
@@ -830,6 +869,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: false })
@@ -873,6 +915,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -925,6 +970,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setThreadViewPrefs({ sort: 'random' })
@@ -975,6 +1023,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
 
@@ -1027,6 +1078,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: [],
+        },
       })
 
       await agent.setInterestsPref({ tags: ['foo', 'bar'] })
@@ -1077,6 +1131,9 @@ describe('agent', () => {
         },
         interests: {
           tags: ['foo', 'bar'],
+        },
+        bskyAppState: {
+          dismissedNudges: [],
         },
       })
     })
@@ -1195,6 +1252,14 @@ describe('agent', () => {
             sort: 'newest',
             prioritizeFollowedUsers: false,
           },
+          {
+            $type: 'app.bsky.actor.defs#bskyAppStatePref',
+            dismissedNudges: ['one'],
+          },
+          {
+            $type: 'app.bsky.actor.defs#bskyAppStatePref',
+            dismissedNudges: ['two'],
+          },
         ],
       })
       await expect(agent.getPreferences()).resolves.toStrictEqual({
@@ -1246,6 +1311,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: ['two'],
         },
       })
 
@@ -1299,6 +1367,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: ['two'],
         },
       })
 
@@ -1354,6 +1425,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: ['two'],
+        },
       })
 
       await agent.removeLabeler('did:plc:other')
@@ -1403,6 +1477,9 @@ describe('agent', () => {
         },
         interests: {
           tags: [],
+        },
+        bskyAppState: {
+          dismissedNudges: ['two'],
         },
       })
 
@@ -1454,6 +1531,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: ['two'],
+        },
       })
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
@@ -1504,6 +1584,9 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: ['two'],
+        },
       })
 
       await agent.setFeedViewPrefs('home', {
@@ -1518,6 +1601,7 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
       })
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
+      await agent.bskyAppDismissNudge('three')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -1565,11 +1649,18 @@ describe('agent', () => {
         interests: {
           tags: [],
         },
+        bskyAppState: {
+          dismissedNudges: ['two', 'three'],
+        },
       })
 
       const res = await agent.app.bsky.actor.getPreferences()
       expect(res.data.preferences.sort(byType)).toStrictEqual(
         [
+          {
+            $type: 'app.bsky.actor.defs#bskyAppStatePref',
+            dismissedNudges: ['two', 'three'],
+          },
           {
             $type: 'app.bsky.actor.defs#adultContentPref',
             enabled: false,
@@ -2690,6 +2781,50 @@ describe('agent', () => {
             pinned: true,
           },
         ])
+      })
+    })
+
+    describe('dismissed nudges', () => {
+      let agent: BskyAgent
+
+      beforeAll(async () => {
+        agent = new BskyAgent({ service: network.pds.url })
+        await agent.createAccount({
+          handle: 'user11.test',
+          email: 'user11@test.com',
+          password: 'password',
+        })
+      })
+
+      it('dismissNudge (true)', async () => {
+        await agent.bskyAppDismissNudge('first')
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.dismissedNudges',
+          ['first'],
+        )
+        await agent.bskyAppDismissNudge('first')
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.dismissedNudges',
+          ['first'],
+        )
+        await agent.bskyAppDismissNudge('second')
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.dismissedNudges',
+          ['first', 'second'],
+        )
+      })
+
+      it('dismissNudge (false)', async () => {
+        await agent.bskyAppDismissNudge('first', false)
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.dismissedNudges',
+          ['second'],
+        )
+        await agent.bskyAppDismissNudge('first', false)
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.dismissedNudges',
+          ['second'],
+        )
       })
     })
 

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -277,6 +277,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -317,6 +318,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -357,6 +359,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -397,6 +400,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -441,6 +445,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -488,6 +493,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -535,6 +541,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -582,6 +589,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -629,6 +637,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -676,6 +685,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -729,6 +739,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -776,6 +787,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -823,6 +835,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -870,6 +883,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -917,6 +931,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -971,6 +986,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -1025,6 +1041,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -1079,6 +1096,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -1133,6 +1151,7 @@ describe('agent', () => {
           tags: ['foo', 'bar'],
         },
         bskyAppState: {
+          activeProgressGuide: undefined,
           queuedNudges: [],
         },
       })
@@ -1258,6 +1277,7 @@ describe('agent', () => {
           },
           {
             $type: 'app.bsky.actor.defs#bskyAppStatePref',
+            activeProgressGuide: undefined,
             queuedNudges: ['two'],
           },
         ],

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -277,7 +277,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -317,7 +317,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -357,7 +357,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -397,7 +397,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -441,7 +441,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -488,7 +488,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -535,7 +535,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -582,7 +582,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -629,7 +629,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -676,7 +676,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -729,7 +729,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -776,7 +776,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -823,7 +823,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -870,7 +870,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -917,7 +917,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -971,7 +971,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -1025,7 +1025,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -1079,7 +1079,7 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
 
@@ -1133,7 +1133,7 @@ describe('agent', () => {
           tags: ['foo', 'bar'],
         },
         bskyAppState: {
-          dismissedNudges: [],
+          queuedNudges: [],
         },
       })
     })
@@ -1254,11 +1254,11 @@ describe('agent', () => {
           },
           {
             $type: 'app.bsky.actor.defs#bskyAppStatePref',
-            dismissedNudges: ['one'],
+            queuedNudges: ['one'],
           },
           {
             $type: 'app.bsky.actor.defs#bskyAppStatePref',
-            dismissedNudges: ['two'],
+            queuedNudges: ['two'],
           },
         ],
       })
@@ -1313,7 +1313,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1369,7 +1370,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1426,7 +1428,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1479,7 +1482,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1532,7 +1536,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1585,7 +1590,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two'],
         },
       })
 
@@ -1601,7 +1607,7 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
       })
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
-      await agent.bskyAppDismissNudge('three')
+      await agent.bskyAppQueueNudges('three')
       await expect(agent.getPreferences()).resolves.toStrictEqual({
         feeds: {
           pinned: ['at://bob.com/app.bsky.feed.generator/fake'],
@@ -1650,7 +1656,8 @@ describe('agent', () => {
           tags: [],
         },
         bskyAppState: {
-          dismissedNudges: ['two', 'three'],
+          activeProgressGuide: undefined,
+          queuedNudges: ['two', 'three'],
         },
       })
 
@@ -1659,7 +1666,7 @@ describe('agent', () => {
         [
           {
             $type: 'app.bsky.actor.defs#bskyAppStatePref',
-            dismissedNudges: ['two', 'three'],
+            queuedNudges: ['two', 'three'],
           },
           {
             $type: 'app.bsky.actor.defs#adultContentPref',
@@ -2784,7 +2791,7 @@ describe('agent', () => {
       })
     })
 
-    describe('dismissed nudges', () => {
+    describe('queued nudges', () => {
       let agent: BskyAgent
 
       beforeAll(async () => {
@@ -2796,34 +2803,67 @@ describe('agent', () => {
         })
       })
 
-      it('dismissNudge (true)', async () => {
-        await agent.bskyAppDismissNudge('first')
+      it('queueNudges & dismissNudges', async () => {
+        await agent.bskyAppQueueNudges('first')
         await expect(agent.getPreferences()).resolves.toHaveProperty(
-          'bskyAppState.dismissedNudges',
+          'bskyAppState.queuedNudges',
           ['first'],
         )
-        await agent.bskyAppDismissNudge('first')
+        await agent.bskyAppQueueNudges(['second', 'third'])
         await expect(agent.getPreferences()).resolves.toHaveProperty(
-          'bskyAppState.dismissedNudges',
-          ['first'],
+          'bskyAppState.queuedNudges',
+          ['first', 'second', 'third'],
         )
-        await agent.bskyAppDismissNudge('second')
+        await agent.bskyAppDismissNudges('second')
         await expect(agent.getPreferences()).resolves.toHaveProperty(
-          'bskyAppState.dismissedNudges',
-          ['first', 'second'],
+          'bskyAppState.queuedNudges',
+          ['first', 'third'],
+        )
+        await agent.bskyAppDismissNudges(['first', 'third'])
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.queuedNudges',
+          [],
         )
       })
+    })
 
-      it('dismissNudge (false)', async () => {
-        await agent.bskyAppDismissNudge('first', false)
+    describe('guided tours', () => {
+      let agent: BskyAgent
+
+      beforeAll(async () => {
+        agent = new BskyAgent({ service: network.pds.url })
+        await agent.createAccount({
+          handle: 'user12.test',
+          email: 'user12@test.com',
+          password: 'password',
+        })
+      })
+
+      it('setActiveProgressGuide', async () => {
+        await agent.bskyAppSetActiveProgressGuide({
+          guide: 'test-guide',
+          numThings: 0,
+        })
         await expect(agent.getPreferences()).resolves.toHaveProperty(
-          'bskyAppState.dismissedNudges',
-          ['second'],
+          'bskyAppState.activeProgressGuide.guide',
+          'test-guide',
         )
-        await agent.bskyAppDismissNudge('first', false)
+        await agent.bskyAppSetActiveProgressGuide({
+          guide: 'test-guide',
+          numThings: 1,
+        })
         await expect(agent.getPreferences()).resolves.toHaveProperty(
-          'bskyAppState.dismissedNudges',
-          ['second'],
+          'bskyAppState.activeProgressGuide.guide',
+          'test-guide',
+        )
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.activeProgressGuide.numThings',
+          1,
+        )
+        await agent.bskyAppSetActiveProgressGuide(undefined)
+        await expect(agent.getPreferences()).resolves.toHaveProperty(
+          'bskyAppState.activeProgressGuide',
+          undefined,
         )
       })
     })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -83,6 +83,9 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
         sort: 'oldest',
       },
+      bskyAppState: {
+        dismissedNudges: [],
+      },
     })
   })
 
@@ -128,6 +131,9 @@ describe('agent', () => {
         sort: 'oldest',
         prioritizeFollowedUsers: true,
       },
+      bskyAppState: {
+        dismissedNudges: [],
+      },
     })
     expect(agent.labelersHeader).toStrictEqual(['did:plc:other'])
 
@@ -159,6 +165,9 @@ describe('agent', () => {
       threadViewPrefs: {
         sort: 'oldest',
         prioritizeFollowedUsers: true,
+      },
+      bskyAppState: {
+        dismissedNudges: [],
       },
     })
     expect(agent.labelersHeader).toStrictEqual([])
@@ -211,6 +220,9 @@ describe('agent', () => {
       threadViewPrefs: {
         sort: 'oldest',
         prioritizeFollowedUsers: true,
+      },
+      bskyAppState: {
+        dismissedNudges: [],
       },
     })
   })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -84,7 +84,8 @@ describe('agent', () => {
         sort: 'oldest',
       },
       bskyAppState: {
-        dismissedNudges: [],
+        activeProgressGuide: undefined,
+        queuedNudges: [],
       },
     })
   })
@@ -132,7 +133,8 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {
-        dismissedNudges: [],
+        activeProgressGuide: undefined,
+        queuedNudges: [],
       },
     })
     expect(agent.labelersHeader).toStrictEqual(['did:plc:other'])
@@ -167,7 +169,8 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {
-        dismissedNudges: [],
+        activeProgressGuide: undefined,
+        queuedNudges: [],
       },
     })
     expect(agent.labelersHeader).toStrictEqual([])
@@ -222,7 +225,8 @@ describe('agent', () => {
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {
-        dismissedNudges: [],
+        activeProgressGuide: undefined,
+        queuedNudges: [],
       },
     })
   })

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3343,7 +3343,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'List blob CIDso for an account, since some repo revision. Does not require auth; implemented by PDS.',
+          'List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.',
         parameters: {
           type: 'params',
           required: ['did'],
@@ -4166,6 +4166,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#bskyAppStatePref',
           ],
         },
       },
@@ -4404,6 +4405,39 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+        },
+      },
+      bskyAppStatePref: {
+        description:
+          "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.",
+        type: 'object',
+        properties: {
+          activeProgressGuide: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#bskyAppProgressGuide',
+          },
+          queuedNudges: {
+            description:
+              'An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.',
+            type: 'array',
+            maxLength: 1000,
+            items: {
+              type: 'string',
+              maxLength: 100,
+            },
+          },
+        },
+      },
+      bskyAppProgressGuide: {
+        description:
+          'If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress.',
+        type: 'object',
+        required: ['guide'],
+        properties: {
+          guide: {
+            type: 'string',
+            maxLength: 100,
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -184,6 +184,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | BskyAppStatePref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -455,4 +456,42 @@ export function isLabelerPrefItem(v: unknown): v is LabelerPrefItem {
 
 export function validateLabelerPrefItem(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#labelerPrefItem', v)
+}
+
+/** A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this. */
+export interface BskyAppStatePref {
+  activeProgressGuide?: BskyAppProgressGuide
+  /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
+  queuedNudges?: string[]
+  [k: string]: unknown
+}
+
+export function isBskyAppStatePref(v: unknown): v is BskyAppStatePref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppStatePref'
+  )
+}
+
+export function validateBskyAppStatePref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppStatePref', v)
+}
+
+/** If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress. */
+export interface BskyAppProgressGuide {
+  guide: string
+  [k: string]: unknown
+}
+
+export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppProgressGuide'
+  )
+}
+
+export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3343,7 +3343,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'List blob CIDso for an account, since some repo revision. Does not require auth; implemented by PDS.',
+          'List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.',
         parameters: {
           type: 'params',
           required: ['did'],
@@ -4166,6 +4166,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#bskyAppStatePref',
           ],
         },
       },
@@ -4404,6 +4405,39 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+        },
+      },
+      bskyAppStatePref: {
+        description:
+          "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.",
+        type: 'object',
+        properties: {
+          activeProgressGuide: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#bskyAppProgressGuide',
+          },
+          queuedNudges: {
+            description:
+              'An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.',
+            type: 'array',
+            maxLength: 1000,
+            items: {
+              type: 'string',
+              maxLength: 100,
+            },
+          },
+        },
+      },
+      bskyAppProgressGuide: {
+        description:
+          'If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress.',
+        type: 'object',
+        required: ['guide'],
+        properties: {
+          guide: {
+            type: 'string',
+            maxLength: 100,
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -184,6 +184,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | BskyAppStatePref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -455,4 +456,42 @@ export function isLabelerPrefItem(v: unknown): v is LabelerPrefItem {
 
 export function validateLabelerPrefItem(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#labelerPrefItem', v)
+}
+
+/** A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this. */
+export interface BskyAppStatePref {
+  activeProgressGuide?: BskyAppProgressGuide
+  /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
+  queuedNudges?: string[]
+  [k: string]: unknown
+}
+
+export function isBskyAppStatePref(v: unknown): v is BskyAppStatePref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppStatePref'
+  )
+}
+
+export function validateBskyAppStatePref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppStatePref', v)
+}
+
+/** If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress. */
+export interface BskyAppProgressGuide {
+  guide: string
+  [k: string]: unknown
+}
+
+export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppProgressGuide'
+  )
+}
+
+export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3343,7 +3343,7 @@ export const schemaDict = {
       main: {
         type: 'query',
         description:
-          'List blob CIDso for an account, since some repo revision. Does not require auth; implemented by PDS.',
+          'List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.',
         parameters: {
           type: 'params',
           required: ['did'],
@@ -4166,6 +4166,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#interestsPref',
             'lex:app.bsky.actor.defs#mutedWordsPref',
             'lex:app.bsky.actor.defs#hiddenPostsPref',
+            'lex:app.bsky.actor.defs#bskyAppStatePref',
           ],
         },
       },
@@ -4404,6 +4405,39 @@ export const schemaDict = {
           did: {
             type: 'string',
             format: 'did',
+          },
+        },
+      },
+      bskyAppStatePref: {
+        description:
+          "A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.",
+        type: 'object',
+        properties: {
+          activeProgressGuide: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#bskyAppProgressGuide',
+          },
+          queuedNudges: {
+            description:
+              'An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user.',
+            type: 'array',
+            maxLength: 1000,
+            items: {
+              type: 'string',
+              maxLength: 100,
+            },
+          },
+        },
+      },
+      bskyAppProgressGuide: {
+        description:
+          'If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress.',
+        type: 'object',
+        required: ['guide'],
+        properties: {
+          guide: {
+            type: 'string',
+            maxLength: 100,
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -184,6 +184,7 @@ export type Preferences = (
   | InterestsPref
   | MutedWordsPref
   | HiddenPostsPref
+  | BskyAppStatePref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -455,4 +456,42 @@ export function isLabelerPrefItem(v: unknown): v is LabelerPrefItem {
 
 export function validateLabelerPrefItem(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#labelerPrefItem', v)
+}
+
+/** A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this. */
+export interface BskyAppStatePref {
+  activeProgressGuide?: BskyAppProgressGuide
+  /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
+  queuedNudges?: string[]
+  [k: string]: unknown
+}
+
+export function isBskyAppStatePref(v: unknown): v is BskyAppStatePref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppStatePref'
+  )
+}
+
+export function validateBskyAppStatePref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppStatePref', v)
+}
+
+/** If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress. */
+export interface BskyAppProgressGuide {
+  guide: string
+  [k: string]: unknown
+}
+
+export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#bskyAppProgressGuide'
+  )
+}
+
+export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@atproto/xrpc':
         specifier: workspace:^
         version: link:../xrpc
+      await-lock:
+        specifier: ^2.2.2
+        version: 2.2.2
       multiformats:
         specifier: ^9.9.0
         version: 9.9.0
@@ -6487,6 +6490,10 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+    dev: false
 
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}


### PR DESCRIPTION
- Adds `#bskyAppStatePref` preference
- Adds `bskyAppQueueNudges(nudges: string|string[])`
- Adds `bskyAppDismissNudges(nudges: string|string[])`
- Adds `bskyAppSetActiveProgressGuide(guide: {guide: string, ...})`
- Wraps `updatePreferences` in a lock region to avoid transaction clobbering in the future

To be used by the bsky app to track nudges that the user can dismiss (things like "Introducing DMs!") and to run progress guides. Not meant to be used by other clients, so explicitly namespaced with `bksyApp` within the API.