### PR TITLE
:sparkles: Add getLists endpoint to proxied routes via ozone

### DIFF
--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -16,11 +16,15 @@ import { clearlyBadCursor, resHeaders } from '../../../util'
 export default function (server: Server, ctx: AppContext) {
   const getLists = createPipeline(skeleton, hydration, noRules, presentation)
   server.app.bsky.graph.getLists({
-    auth: ctx.authVerifier.standardOptional,
+    auth: ctx.authVerifier.optionalStandardOrRole,
     handler: async ({ params, auth, req }) => {
-      const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
       const result = await getLists({ ...params, hydrateCtx }, ctx)
 
       return {

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -224,7 +224,6 @@ export class Hydrator {
       this.label.getLabelsForSubjects(uris, ctx.labelers),
     ])
 
-    // TODO: Check why the takedown label is not coming through here when list has been takendown
     if (!ctx.includeTakedowns) {
       actionTakedownLabels(uris, lists, labels)
     }

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -219,11 +219,12 @@ export class Hydrator {
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
     const [lists, listViewers, labels] = await Promise.all([
-      this.graph.getLists(uris),
+      this.graph.getLists(uris, ctx.includeTakedowns),
       ctx.viewer ? this.graph.getListViewerStates(uris, ctx.viewer) : undefined,
       this.label.getLabelsForSubjects(uris, ctx.labelers),
     ])
 
+    // TODO: Check why the takedown label is not coming through here when list has been takendown
     if (!ctx.includeTakedowns) {
       actionTakedownLabels(uris, lists, labels)
     }

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -1,7 +1,7 @@
 import { AtUri } from '@atproto/syntax'
 import AtpAgent, { COM_ATPROTO_MODERATION } from '@atproto/api'
 import { Database } from '@atproto/bsky'
-import { EXAMPLE_LABELER, TestNetwork } from '../index'
+import { EXAMPLE_LABELER, RecordRef, TestNetwork } from '../index'
 import { postTexts, replyTexts } from './data'
 import labeledImgB64 from './img/labeled-img-b64'
 import blurHashB64 from './img/blur-hash-avatar-b64'
@@ -478,6 +478,44 @@ export async function generateMockSetup(env: TestNetwork) {
       val: 'spam',
       src: res.data.did,
     })
+  }
+
+  // Create lists and add people to the lists
+  {
+    const flowerLovers = await alice.agent.api.app.bsky.graph.list.create(
+      { repo: alice.did },
+      {
+        name: 'Flower Lovers',
+        purpose: 'app.bsky.graph.defs#curatelist',
+        createdAt: new Date().toISOString(),
+        description: 'A list of posts about flowers',
+      },
+    )
+    const labelHaters = await bob.agent.api.app.bsky.graph.list.create(
+      { repo: bob.did },
+      {
+        name: 'Label Haters',
+        purpose: 'app.bsky.graph.defs#modlist',
+        createdAt: new Date().toISOString(),
+        description: 'A list of people who hate labels',
+      },
+    )
+    alice.agent.api.app.bsky.graph.listitem.create(
+      { repo: alice.did },
+      {
+        subject: bob.did,
+        createdAt: new Date().toISOString(),
+        list: new RecordRef(flowerLovers.uri, flowerLovers.cid).uriStr,
+      },
+    )
+    bob.agent.api.app.bsky.graph.listitem.create(
+      { repo: bob.did },
+      {
+        subject: alice.did,
+        createdAt: new Date().toISOString(),
+        list: new RecordRef(labelHaters.uri, labelHaters.cid).uriStr,
+      },
+    )
   }
 }
 

--- a/packages/dev-env/src/mock/index.ts
+++ b/packages/dev-env/src/mock/index.ts
@@ -500,7 +500,7 @@ export async function generateMockSetup(env: TestNetwork) {
         description: 'A list of people who hate labels',
       },
     )
-    alice.agent.api.app.bsky.graph.listitem.create(
+    await alice.agent.api.app.bsky.graph.listitem.create(
       { repo: alice.did },
       {
         subject: bob.did,
@@ -508,7 +508,7 @@ export async function generateMockSetup(env: TestNetwork) {
         list: new RecordRef(flowerLovers.uri, flowerLovers.cid).uriStr,
       },
     )
-    bob.agent.api.app.bsky.graph.listitem.create(
+    await bob.agent.api.app.bsky.graph.listitem.create(
       { repo: bob.did },
       {
         subject: alice.did,

--- a/packages/ozone/src/api/proxied.ts
+++ b/packages/ozone/src/api/proxied.ts
@@ -127,4 +127,18 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+
+  server.app.bsky.graph.getLists({
+    auth: ctx.authVerifier.moderator,
+    handler: async (request) => {
+      const res = await ctx.appviewAgent.api.app.bsky.graph.getLists(
+        request.params,
+        await ctx.appviewAuth(),
+      )
+      return {
+        encoding: 'application/json',
+        body: res.data,
+      }
+    },
+  })
 }

--- a/packages/ozone/tests/get-lists.test.ts
+++ b/packages/ozone/tests/get-lists.test.ts
@@ -6,7 +6,7 @@ import {
   ModeratorClient,
   RecordRef,
 } from '@atproto/dev-env'
-import AtpAgent from '@atproto/api'
+import AtpAgent, { BSKY_LABELER_DID } from '@atproto/api'
 import { TAKEDOWN_LABEL } from '../src/mod-service'
 
 describe('admin get lists', () => {
@@ -34,6 +34,7 @@ describe('admin get lists', () => {
   })
 
   afterAll(async () => {
+    AtpAgent.configure({ appLabelers: [BSKY_LABELER_DID] })
     await network.close()
   })
 
@@ -54,7 +55,7 @@ describe('admin get lists', () => {
     expect(beforeTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
     expect(beforeTakedown.fromAppview.lists[0].uri).toEqual(alicesList.uriStr)
 
-    //     Takedown alice's account
+    // Takedown alice's account
     await modClient.emitEvent({
       event: { $type: 'tools.ozone.moderation.defs#modEventTakedown' },
       subject: {
@@ -70,7 +71,7 @@ describe('admin get lists', () => {
     expect(afterTakedown.fromAppview.lists.length).toBe(0)
     expect(afterTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
 
-    //     Reverse alice's account takedown
+    // Reverse alice's account takedown
     await modClient.emitEvent({
       event: { $type: 'tools.ozone.moderation.defs#modEventReverseTakedown' },
       subject: {

--- a/packages/ozone/tests/get-lists.test.ts
+++ b/packages/ozone/tests/get-lists.test.ts
@@ -9,7 +9,7 @@ import {
 import AtpAgent from '@atproto/api'
 import { TAKEDOWN_LABEL } from '../src/mod-service'
 
-describe('admin get repo view', () => {
+describe('admin get lists', () => {
   let network: TestNetwork
   let ozone: TestOzone
   let agent: AtpAgent

--- a/packages/ozone/tests/get-lists.test.ts
+++ b/packages/ozone/tests/get-lists.test.ts
@@ -1,0 +1,112 @@
+import {
+  SeedClient,
+  TestNetwork,
+  TestOzone,
+  basicSeed,
+  ModeratorClient,
+  RecordRef,
+} from '@atproto/dev-env'
+import AtpAgent from '@atproto/api'
+import { forSnapshot } from './_util'
+import { TAKEDOWN_LABEL } from '../src/mod-service'
+
+describe('admin get repo view', () => {
+  let network: TestNetwork
+  let ozone: TestOzone
+  let agent: AtpAgent
+  let appviewAgent: AtpAgent
+  let sc: SeedClient
+  let modClient: ModeratorClient
+  let alicesList: RecordRef
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_admin_get_lists',
+    })
+    ozone = network.ozone
+    agent = ozone.getClient()
+    appviewAgent = network.bsky.getClient()
+    sc = network.getSeedClient()
+    modClient = ozone.getModClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  beforeAll(async () => {
+    alicesList = await sc.createList(sc.dids.alice, "Alice's List", 'mod')
+  })
+
+  const getAlicesList = async () => {
+    const [{ data: fromOzone }, { data: fromAppview }] = await Promise.all([
+      agent.api.app.bsky.graph.getLists(
+        { actor: sc.dids.alice },
+        { headers: await ozone.modHeaders() },
+      ),
+      appviewAgent.api.app.bsky.graph.getLists({ actor: sc.dids.alice }),
+    ])
+
+    return { fromOzone, fromAppview }
+  }
+
+  it('returns lists from takendown account', async () => {
+    const beforeTakedown = await getAlicesList()
+    expect(beforeTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
+    expect(beforeTakedown.fromAppview.lists[0].uri).toEqual(alicesList.uriStr)
+
+    //     Takedown alice's account
+    await modClient.emitEvent({
+      event: { $type: 'tools.ozone.moderation.defs#modEventTakedown' },
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.alice,
+      },
+    })
+    await network.processAll()
+
+    const afterTakedown = await getAlicesList()
+
+    // Verify that takendown list is shown when queried through ozone but not through appview
+    expect(afterTakedown.fromAppview.lists.length).toBe(0)
+    expect(afterTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
+
+    //     Reverse alice's account takedown
+    await modClient.emitEvent({
+      event: { $type: 'tools.ozone.moderation.defs#modEventReverseTakedown' },
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.alice,
+      },
+    })
+    await network.processAll()
+  })
+
+  //   TODO: This should pass but for some reason, the takendown list is returned by the appview too
+  //   which is not relevant to the change since all that matters is that ozone returns it but would be good to have that fixed too
+  it('returns takendown lists', async () => {
+    const beforeTakedown = await getAlicesList()
+    expect(beforeTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
+    expect(beforeTakedown.fromAppview.lists[0].uri).toEqual(alicesList.uriStr)
+
+    //     Takedown alice's list
+    await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventTakedown',
+      },
+      subject: {
+        $type: 'com.atproto.repo.strongRef',
+        ...alicesList.raw,
+      },
+    })
+    await network.processAll()
+
+    const afterTakedown = await getAlicesList()
+
+    // Verify that takendown list is shown when queried through ozone but not through appview
+    expect(afterTakedown.fromAppview.lists.length).toBe(0)
+    expect(afterTakedown.fromOzone.lists[0].uri).toEqual(alicesList.uriStr)
+  })
+})


### PR DESCRIPTION
This PR allows ozone to proxy `api.app.bsky.graph.getLists` request to appview.
Additionally, it also seeds a couple of lists in the dev-env mock data.