### PR TITLE
Bump json size limit on pds

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -63,7 +63,7 @@ export class PDS {
     const xrpcOpts: XrpcServerOptions = {
       validateResponse: false,
       payload: {
-        jsonLimit: 100 * 1024, // 100kb
+        jsonLimit: 150 * 1024, // 150kb
         textLimit: 100 * 1024, // 100kb
         blobLimit: cfg.service.blobUploadLimit,
       },

--- a/packages/pds/tests/server.test.ts
+++ b/packages/pds/tests/server.test.ts
@@ -64,7 +64,7 @@ describe('server', () => {
       await axios.post(
         `${network.pds.url}/xrpc/com.atproto.repo.createRecord`,
         {
-          data: 'x'.repeat(100 * 1024), // 100kb
+          data: 'x'.repeat(150 * 1024), // 150kb
         },
         { headers: sc.getHeaders(alice) },
       )
@@ -89,7 +89,7 @@ describe('server', () => {
       text: 'blahblabh',
       createdAt: new Date().toISOString(),
     }
-    for (let i = 0; i < 150; i++) {
+    for (let i = 0; i < 100; i++) {
       record[randomStr(8, 'base32')] = randomStr(32, 'base32')
     }
     const createRes = await agent.com.atproto.repo.createRecord(


### PR DESCRIPTION
Simple fix that bumps json size limit on pds from 100kb -> 150kb

In the future we should:
- make size limits configurable generally (like blobs)
- make size limits configurable by route