### PR TITLE
Lexicon: misc fixes to chat lexicons

### DIFF
--- a/.changeset/heavy-pears-sip.md
+++ b/.changeset/heavy-pears-sip.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Misc tweaks and fixes to chat lexicons

--- a/lexicons/chat/bsky/convo/defs.json
+++ b/lexicons/chat/bsky/convo/defs.json
@@ -4,17 +4,17 @@
   "defs": {
     "messageRef": {
       "type": "object",
-      "required": ["did", "messageId"],
+      "required": ["did", "messageId", "convoId"],
       "properties": {
         "did": { "type": "string", "format": "did" },
+        "convoId": { "type": "string" },
         "messageId": { "type": "string" }
       }
     },
-    "message": {
+    "messageInput": {
       "type": "object",
       "required": ["text"],
       "properties": {
-        "id": { "type": "string" },
         "text": {
           "type": "string",
           "maxLength": 10000,

--- a/lexicons/chat/bsky/convo/sendMessage.json
+++ b/lexicons/chat/bsky/convo/sendMessage.json
@@ -13,7 +13,7 @@
             "convoId": { "type": "string" },
             "message": {
               "type": "ref",
-              "ref": "chat.bsky.convo.defs#message"
+              "ref": "chat.bsky.convo.defs#messageInput"
             }
           }
         }

--- a/lexicons/chat/bsky/convo/sendMessageBatch.json
+++ b/lexicons/chat/bsky/convo/sendMessageBatch.json
@@ -12,6 +12,7 @@
           "properties": {
             "items": {
               "type": "array",
+              "maxLength": 100,
               "items": {
                 "type": "ref",
                 "ref": "#batchItem"
@@ -44,7 +45,7 @@
         "convoId": { "type": "string" },
         "message": {
           "type": "ref",
-          "ref": "chat.bsky.convo.defs#message"
+          "ref": "chat.bsky.convo.defs#messageInput"
         }
       }
     }

--- a/lexicons/chat/bsky/moderation/getMessageContext.json
+++ b/lexicons/chat/bsky/moderation/getMessageContext.json
@@ -8,6 +8,10 @@
         "type": "params",
         "required": ["messageId"],
         "properties": {
+          "convoId": {
+            "type": "string",
+            "description": "Conversation that the message is from. NOTE: this field will eventually be required."
+          },
           "messageId": { "type": "string" },
           "before": { "type": "integer", "default": 5 },
           "after": { "type": "integer", "default": 5 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8306,24 +8306,24 @@ export const schemaDict = {
     defs: {
       messageRef: {
         type: 'object',
-        required: ['did', 'messageId'],
+        required: ['did', 'messageId', 'convoId'],
         properties: {
           did: {
             type: 'string',
             format: 'did',
+          },
+          convoId: {
+            type: 'string',
           },
           messageId: {
             type: 'string',
           },
         },
       },
-      message: {
+      messageInput: {
         type: 'object',
         required: ['text'],
         properties: {
-          id: {
-            type: 'string',
-          },
           text: {
             type: 'string',
             maxLength: 10000,
@@ -8825,7 +8825,7 @@ export const schemaDict = {
               },
               message: {
                 type: 'ref',
-                ref: 'lex:chat.bsky.convo.defs#message',
+                ref: 'lex:chat.bsky.convo.defs#messageInput',
               },
             },
           },
@@ -8854,6 +8854,7 @@ export const schemaDict = {
             properties: {
               items: {
                 type: 'array',
+                maxLength: 100,
                 items: {
                   type: 'ref',
                   ref: 'lex:chat.bsky.convo.sendMessageBatch#batchItem',
@@ -8888,7 +8889,7 @@ export const schemaDict = {
           },
           message: {
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#message',
+            ref: 'lex:chat.bsky.convo.defs#messageInput',
           },
         },
       },
@@ -9038,6 +9039,11 @@ export const schemaDict = {
           type: 'params',
           required: ['messageId'],
           properties: {
+            convoId: {
+              type: 'string',
+              description:
+                'Conversation that the message is from. NOTE: this field will eventually be required.',
+            },
             messageId: {
               type: 'string',
             },

--- a/packages/api/src/client/types/chat/bsky/convo/defs.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/defs.ts
@@ -11,6 +11,7 @@ import * as ChatBskyActorDefs from '../actor/defs'
 
 export interface MessageRef {
   did: string
+  convoId: string
   messageId: string
   [k: string]: unknown
 }
@@ -27,8 +28,7 @@ export function validateMessageRef(v: unknown): ValidationResult {
   return lexicons.validate('chat.bsky.convo.defs#messageRef', v)
 }
 
-export interface Message {
-  id?: string
+export interface MessageInput {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
@@ -36,16 +36,16 @@ export interface Message {
   [k: string]: unknown
 }
 
-export function isMessage(v: unknown): v is Message {
+export function isMessageInput(v: unknown): v is MessageInput {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'chat.bsky.convo.defs#message'
+    v.$type === 'chat.bsky.convo.defs#messageInput'
   )
 }
 
-export function validateMessage(v: unknown): ValidationResult {
-  return lexicons.validate('chat.bsky.convo.defs#message', v)
+export function validateMessageInput(v: unknown): ValidationResult {
+  return lexicons.validate('chat.bsky.convo.defs#messageInput', v)
 }
 
 export interface MessageView {

--- a/packages/api/src/client/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/sendMessage.ts
@@ -12,7 +12,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/sendMessageBatch.ts
@@ -40,7 +40,7 @@ export function toKnownErr(e: any) {
 
 export interface BatchItem {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/api/src/client/types/chat/bsky/moderation/getMessageContext.ts
@@ -9,6 +9,8 @@ import { CID } from 'multiformats/cid'
 import * as ChatBskyConvoDefs from '../convo/defs'
 
 export interface QueryParams {
+  /** Conversation that the message is from. NOTE: this field will eventually be required. */
+  convoId?: string
   messageId: string
   before?: number
   after?: number

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8306,24 +8306,24 @@ export const schemaDict = {
     defs: {
       messageRef: {
         type: 'object',
-        required: ['did', 'messageId'],
+        required: ['did', 'messageId', 'convoId'],
         properties: {
           did: {
             type: 'string',
             format: 'did',
+          },
+          convoId: {
+            type: 'string',
           },
           messageId: {
             type: 'string',
           },
         },
       },
-      message: {
+      messageInput: {
         type: 'object',
         required: ['text'],
         properties: {
-          id: {
-            type: 'string',
-          },
           text: {
             type: 'string',
             maxLength: 10000,
@@ -8825,7 +8825,7 @@ export const schemaDict = {
               },
               message: {
                 type: 'ref',
-                ref: 'lex:chat.bsky.convo.defs#message',
+                ref: 'lex:chat.bsky.convo.defs#messageInput',
               },
             },
           },
@@ -8854,6 +8854,7 @@ export const schemaDict = {
             properties: {
               items: {
                 type: 'array',
+                maxLength: 100,
                 items: {
                   type: 'ref',
                   ref: 'lex:chat.bsky.convo.sendMessageBatch#batchItem',
@@ -8888,7 +8889,7 @@ export const schemaDict = {
           },
           message: {
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#message',
+            ref: 'lex:chat.bsky.convo.defs#messageInput',
           },
         },
       },
@@ -9038,6 +9039,11 @@ export const schemaDict = {
           type: 'params',
           required: ['messageId'],
           properties: {
+            convoId: {
+              type: 'string',
+              description:
+                'Conversation that the message is from. NOTE: this field will eventually be required.',
+            },
             messageId: {
               type: 'string',
             },

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -11,6 +11,7 @@ import * as ChatBskyActorDefs from '../actor/defs'
 
 export interface MessageRef {
   did: string
+  convoId: string
   messageId: string
   [k: string]: unknown
 }
@@ -27,8 +28,7 @@ export function validateMessageRef(v: unknown): ValidationResult {
   return lexicons.validate('chat.bsky.convo.defs#messageRef', v)
 }
 
-export interface Message {
-  id?: string
+export interface MessageInput {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
@@ -36,16 +36,16 @@ export interface Message {
   [k: string]: unknown
 }
 
-export function isMessage(v: unknown): v is Message {
+export function isMessageInput(v: unknown): v is MessageInput {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'chat.bsky.convo.defs#message'
+    v.$type === 'chat.bsky.convo.defs#messageInput'
   )
 }
 
-export function validateMessage(v: unknown): ValidationResult {
-  return lexicons.validate('chat.bsky.convo.defs#message', v)
+export function validateMessageInput(v: unknown): ValidationResult {
+  return lexicons.validate('chat.bsky.convo.defs#messageInput', v)
 }
 
 export interface MessageView {

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -13,7 +13,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -51,7 +51,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 
 export interface BatchItem {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -10,6 +10,8 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ChatBskyConvoDefs from '../convo/defs'
 
 export interface QueryParams {
+  /** Conversation that the message is from. NOTE: this field will eventually be required. */
+  convoId?: string
   messageId: string
   before: number
   after: number

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8306,24 +8306,24 @@ export const schemaDict = {
     defs: {
       messageRef: {
         type: 'object',
-        required: ['did', 'messageId'],
+        required: ['did', 'messageId', 'convoId'],
         properties: {
           did: {
             type: 'string',
             format: 'did',
+          },
+          convoId: {
+            type: 'string',
           },
           messageId: {
             type: 'string',
           },
         },
       },
-      message: {
+      messageInput: {
         type: 'object',
         required: ['text'],
         properties: {
-          id: {
-            type: 'string',
-          },
           text: {
             type: 'string',
             maxLength: 10000,
@@ -8825,7 +8825,7 @@ export const schemaDict = {
               },
               message: {
                 type: 'ref',
-                ref: 'lex:chat.bsky.convo.defs#message',
+                ref: 'lex:chat.bsky.convo.defs#messageInput',
               },
             },
           },
@@ -8854,6 +8854,7 @@ export const schemaDict = {
             properties: {
               items: {
                 type: 'array',
+                maxLength: 100,
                 items: {
                   type: 'ref',
                   ref: 'lex:chat.bsky.convo.sendMessageBatch#batchItem',
@@ -8888,7 +8889,7 @@ export const schemaDict = {
           },
           message: {
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#message',
+            ref: 'lex:chat.bsky.convo.defs#messageInput',
           },
         },
       },
@@ -9038,6 +9039,11 @@ export const schemaDict = {
           type: 'params',
           required: ['messageId'],
           properties: {
+            convoId: {
+              type: 'string',
+              description:
+                'Conversation that the message is from. NOTE: this field will eventually be required.',
+            },
             messageId: {
               type: 'string',
             },

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -11,6 +11,7 @@ import * as ChatBskyActorDefs from '../actor/defs'
 
 export interface MessageRef {
   did: string
+  convoId: string
   messageId: string
   [k: string]: unknown
 }
@@ -27,8 +28,7 @@ export function validateMessageRef(v: unknown): ValidationResult {
   return lexicons.validate('chat.bsky.convo.defs#messageRef', v)
 }
 
-export interface Message {
-  id?: string
+export interface MessageInput {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
@@ -36,16 +36,16 @@ export interface Message {
   [k: string]: unknown
 }
 
-export function isMessage(v: unknown): v is Message {
+export function isMessageInput(v: unknown): v is MessageInput {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'chat.bsky.convo.defs#message'
+    v.$type === 'chat.bsky.convo.defs#messageInput'
   )
 }
 
-export function validateMessage(v: unknown): ValidationResult {
-  return lexicons.validate('chat.bsky.convo.defs#message', v)
+export function validateMessageInput(v: unknown): ValidationResult {
+  return lexicons.validate('chat.bsky.convo.defs#messageInput', v)
 }
 
 export interface MessageView {

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -13,7 +13,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -51,7 +51,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 
 export interface BatchItem {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -10,6 +10,8 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ChatBskyConvoDefs from '../convo/defs'
 
 export interface QueryParams {
+  /** Conversation that the message is from. NOTE: this field will eventually be required. */
+  convoId?: string
   messageId: string
   before: number
   after: number

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -18,7 +18,6 @@ import {
   isModEventTakedown,
   isModEventEmail,
   isModEventTag,
-  isModEventUnmute,
 } from '../lexicon/types/tools/ozone/moderation/defs'
 import { RepoRef, RepoBlobRef } from '../lexicon/types/com/atproto/admin/defs'
 import {
@@ -335,7 +334,7 @@ export class ModerationService {
         durationInHours: event.durationInHours
           ? Number(event.durationInHours)
           : null,
-        meta,
+        meta: Object.assign(meta, subjectInfo.meta),
         expiresAt:
           (isModEventTakedown(event) || isModEventMute(event)) &&
           event.durationInHours

--- a/packages/ozone/tests/__snapshots__/moderation.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/moderation.test.ts.snap
@@ -9,6 +9,7 @@ Array [
     "reportedBy": "user(0)",
     "subject": Object {
       "$type": "chat.bsky.convo.defs#messageRef",
+      "convoId": "testconvoid1",
       "did": "user(1)",
       "messageId": "testmessageid1",
     },
@@ -21,6 +22,7 @@ Array [
     "reportedBy": "user(1)",
     "subject": Object {
       "$type": "chat.bsky.convo.defs#messageRef",
+      "convoId": "testconvoid2",
       "did": "user(1)",
       "messageId": "testmessageid2",
     },

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -160,6 +160,7 @@ describe('moderation', () => {
           $type: 'chat.bsky.convo.defs#messageRef',
           did: sc.dids.carol,
           messageId: messageId1,
+          convoId: 'testconvoid1',
         },
       })
       const reportB = await sc.createReport({
@@ -170,6 +171,7 @@ describe('moderation', () => {
           $type: 'chat.bsky.convo.defs#messageRef',
           did: sc.dids.carol,
           messageId: messageId2,
+          convoId: 'testconvoid2',
         },
       })
       expect(forSnapshot([reportA, reportB])).toMatchSnapshot()

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8306,24 +8306,24 @@ export const schemaDict = {
     defs: {
       messageRef: {
         type: 'object',
-        required: ['did', 'messageId'],
+        required: ['did', 'messageId', 'convoId'],
         properties: {
           did: {
             type: 'string',
             format: 'did',
+          },
+          convoId: {
+            type: 'string',
           },
           messageId: {
             type: 'string',
           },
         },
       },
-      message: {
+      messageInput: {
         type: 'object',
         required: ['text'],
         properties: {
-          id: {
-            type: 'string',
-          },
           text: {
             type: 'string',
             maxLength: 10000,
@@ -8825,7 +8825,7 @@ export const schemaDict = {
               },
               message: {
                 type: 'ref',
-                ref: 'lex:chat.bsky.convo.defs#message',
+                ref: 'lex:chat.bsky.convo.defs#messageInput',
               },
             },
           },
@@ -8854,6 +8854,7 @@ export const schemaDict = {
             properties: {
               items: {
                 type: 'array',
+                maxLength: 100,
                 items: {
                   type: 'ref',
                   ref: 'lex:chat.bsky.convo.sendMessageBatch#batchItem',
@@ -8888,7 +8889,7 @@ export const schemaDict = {
           },
           message: {
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#message',
+            ref: 'lex:chat.bsky.convo.defs#messageInput',
           },
         },
       },
@@ -9038,6 +9039,11 @@ export const schemaDict = {
           type: 'params',
           required: ['messageId'],
           properties: {
+            convoId: {
+              type: 'string',
+              description:
+                'Conversation that the message is from. NOTE: this field will eventually be required.',
+            },
             messageId: {
               type: 'string',
             },

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -11,6 +11,7 @@ import * as ChatBskyActorDefs from '../actor/defs'
 
 export interface MessageRef {
   did: string
+  convoId: string
   messageId: string
   [k: string]: unknown
 }
@@ -27,8 +28,7 @@ export function validateMessageRef(v: unknown): ValidationResult {
   return lexicons.validate('chat.bsky.convo.defs#messageRef', v)
 }
 
-export interface Message {
-  id?: string
+export interface MessageInput {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
@@ -36,16 +36,16 @@ export interface Message {
   [k: string]: unknown
 }
 
-export function isMessage(v: unknown): v is Message {
+export function isMessageInput(v: unknown): v is MessageInput {
   return (
     isObj(v) &&
     hasProp(v, '$type') &&
-    v.$type === 'chat.bsky.convo.defs#message'
+    v.$type === 'chat.bsky.convo.defs#messageInput'
   )
 }
 
-export function validateMessage(v: unknown): ValidationResult {
-  return lexicons.validate('chat.bsky.convo.defs#message', v)
+export function validateMessageInput(v: unknown): ValidationResult {
+  return lexicons.validate('chat.bsky.convo.defs#messageInput', v)
 }
 
 export interface MessageView {

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -13,7 +13,7 @@ export interface QueryParams {}
 
 export interface InputSchema {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -51,7 +51,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 
 export interface BatchItem {
   convoId: string
-  message: ChatBskyConvoDefs.Message
+  message: ChatBskyConvoDefs.MessageInput
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -10,6 +10,8 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ChatBskyConvoDefs from '../convo/defs'
 
 export interface QueryParams {
+  /** Conversation that the message is from. NOTE: this field will eventually be required. */
+  convoId?: string
   messageId: string
   before: number
   after: number


### PR DESCRIPTION
A few small `chat.bsky` lexicon tweaks in here:
 - Add temporarily optional `convoId` to `getMessageContext`.  Looking to be consistent about always qualifying `messageId` within a given `convoId`.
 - Rename `#message` to `#messageInput` and remove its optional `id` field.
 - Add a limit to the number of messages in `sendMessageBatch`.
 - Add required `convoId` to `#messageRef` used by ozone, make requisite ozone changes.