### PR TITLE
remove deprecated sync fields

### DIFF
--- a/.changeset/orange-chairs-act.md
+++ b/.changeset/orange-chairs-act.md
@@ -1,0 +1,6 @@
+---
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+remove some deprecated fields from com.atproto Lexicons

--- a/lexicons/com/atproto/repo/listRecords.json
+++ b/lexicons/com/atproto/repo/listRecords.json
@@ -27,14 +27,6 @@
             "description": "The number of records to return."
           },
           "cursor": { "type": "string" },
-          "rkeyStart": {
-            "type": "string",
-            "description": "DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)"
-          },
-          "rkeyEnd": {
-            "type": "string",
-            "description": "DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)"
-          },
           "reverse": {
             "type": "boolean",
             "description": "Flag to reverse the order of the returned records."

--- a/lexicons/com/atproto/sync/getRecord.json
+++ b/lexicons/com/atproto/sync/getRecord.json
@@ -19,11 +19,6 @@
             "type": "string",
             "description": "Record Key",
             "format": "record-key"
-          },
-          "commit": {
-            "type": "string",
-            "format": "cid",
-            "description": "DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit"
           }
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1855,16 +1855,6 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
-            rkeyStart: {
-              type: 'string',
-              description:
-                'DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)',
-            },
-            rkeyEnd: {
-              type: 'string',
-              description:
-                'DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)',
-            },
             reverse: {
               type: 'boolean',
               description: 'Flag to reverse the order of the returned records.',
@@ -3404,12 +3394,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Record Key',
               format: 'record-key',
-            },
-            commit: {
-              type: 'string',
-              format: 'cid',
-              description:
-                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/api/src/client/types/com/atproto/repo/listRecords.ts
+++ b/packages/api/src/client/types/com/atproto/repo/listRecords.ts
@@ -19,10 +19,6 @@ export interface QueryParams {
   /** The number of records to return. */
   limit?: number
   cursor?: string
-  /** DEPRECATED: The lowest sort-ordered rkey to start from (exclusive) */
-  rkeyStart?: string
-  /** DEPRECATED: The highest sort-ordered rkey to stop at (exclusive) */
-  rkeyEnd?: string
   /** Flag to reverse the order of the returned records. */
   reverse?: boolean
 }

--- a/packages/api/src/client/types/com/atproto/sync/getRecord.ts
+++ b/packages/api/src/client/types/com/atproto/sync/getRecord.ts
@@ -17,8 +17,6 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
-  commit?: string
 }
 
 export type InputSchema = undefined

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -1855,16 +1855,6 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
-            rkeyStart: {
-              type: 'string',
-              description:
-                'DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)',
-            },
-            rkeyEnd: {
-              type: 'string',
-              description:
-                'DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)',
-            },
             reverse: {
               type: 'boolean',
               description: 'Flag to reverse the order of the returned records.',
@@ -3404,12 +3394,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Record Key',
               format: 'record-key',
-            },
-            commit: {
-              type: 'string',
-              format: 'cid',
-              description:
-                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -20,10 +20,6 @@ export interface QueryParams {
   /** The number of records to return. */
   limit: number
   cursor?: string
-  /** DEPRECATED: The lowest sort-ordered rkey to start from (exclusive) */
-  rkeyStart?: string
-  /** DEPRECATED: The highest sort-ordered rkey to stop at (exclusive) */
-  rkeyEnd?: string
   /** Flag to reverse the order of the returned records. */
   reverse?: boolean
 }

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -19,8 +19,6 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
-  commit?: string
 }
 
 export type InputSchema = undefined

--- a/packages/pds/src/api/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/api/com/atproto/repo/listRecords.ts
@@ -5,15 +5,7 @@ import { Server } from '../../../../lexicon'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.listRecords(async ({ params }) => {
-    const {
-      repo,
-      collection,
-      limit = 50,
-      cursor,
-      rkeyStart,
-      rkeyEnd,
-      reverse = false,
-    } = params
+    const { repo, collection, limit = 50, cursor, reverse = false } = params
 
     const did = await ctx.accountManager.getDidForActor(repo)
     if (!did) {
@@ -26,8 +18,6 @@ export default function (server: Server, ctx: AppContext) {
         limit,
         reverse,
         cursor,
-        rkeyStart,
-        rkeyEnd,
       }),
     )
 

--- a/packages/pds/src/api/com/atproto/sync/getRecord.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRecord.ts
@@ -25,9 +25,7 @@ export default function (server: Server, ctx: AppContext) {
       let carStream: stream.Readable
       try {
         const storage = new SqlRepoReader(actorDb)
-        const commit = params.commit
-          ? CID.parse(params.commit)
-          : await storage.getRoot()
+        const commit = await storage.getRoot()
 
         if (!commit) {
           throw new InvalidRequestError(`Could not find repo for DID: ${did}`)

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1855,16 +1855,6 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
-            rkeyStart: {
-              type: 'string',
-              description:
-                'DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)',
-            },
-            rkeyEnd: {
-              type: 'string',
-              description:
-                'DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)',
-            },
             reverse: {
               type: 'boolean',
               description: 'Flag to reverse the order of the returned records.',
@@ -3404,12 +3394,6 @@ export const schemaDict = {
               type: 'string',
               description: 'Record Key',
               format: 'record-key',
-            },
-            commit: {
-              type: 'string',
-              format: 'cid',
-              description:
-                'DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit',
             },
           },
         },

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -20,10 +20,6 @@ export interface QueryParams {
   /** The number of records to return. */
   limit: number
   cursor?: string
-  /** DEPRECATED: The lowest sort-ordered rkey to start from (exclusive) */
-  rkeyStart?: string
-  /** DEPRECATED: The highest sort-ordered rkey to stop at (exclusive) */
-  rkeyEnd?: string
   /** Flag to reverse the order of the returned records. */
   reverse?: boolean
 }

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -19,8 +19,6 @@ export interface QueryParams {
   collection: string
   /** Record Key */
   rkey: string
-  /** DEPRECATED: referenced a repo commit by CID, and retrieved record as of that commit */
-  commit?: string
 }
 
 export type InputSchema = undefined


### PR DESCRIPTION
Part of splitting up https://github.com/bluesky-social/atproto/pull/2376 in to smaller chunks for easier merging.

These have been marked deprecated for a long time.

Removes from client and API-side at the same time. These are fairly low-level and not used by, eg, the app.