### PR TITLE
remove deprecated search 'term' (use 'q')

### DIFF
--- a/.changeset/tidy-shoes-fail.md
+++ b/.changeset/tidy-shoes-fail.md
@@ -1,0 +1,7 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+remove deprecated search 'term' param

--- a/lexicons/app/bsky/actor/searchActors.json
+++ b/lexicons/app/bsky/actor/searchActors.json
@@ -8,10 +8,6 @@
       "parameters": {
         "type": "params",
         "properties": {
-          "term": {
-            "type": "string",
-            "description": "DEPRECATED: use 'q' instead."
-          },
           "q": {
             "type": "string",
             "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."

--- a/lexicons/app/bsky/actor/searchActorsTypeahead.json
+++ b/lexicons/app/bsky/actor/searchActorsTypeahead.json
@@ -8,10 +8,6 @@
       "parameters": {
         "type": "params",
         "properties": {
-          "term": {
-            "type": "string",
-            "description": "DEPRECATED: use 'q' instead."
-          },
           "q": {
             "type": "string",
             "description": "Search query prefix; not a full query string."

--- a/lexicons/tools/ozone/moderation/searchRepos.json
+++ b/lexicons/tools/ozone/moderation/searchRepos.json
@@ -8,10 +8,6 @@
       "parameters": {
         "type": "params",
         "properties": {
-          "term": {
-            "type": "string",
-            "description": "DEPRECATED: use 'q' instead"
-          },
           "q": { "type": "string" },
           "limit": {
             "type": "integer",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4308,10 +4308,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description:
@@ -4361,10 +4357,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
@@ -10491,10 +10483,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead",
-            },
             q: {
               type: 'string',
             },

--- a/packages/api/src/client/types/app/bsky/actor/searchActors.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActors.ts
@@ -9,8 +9,6 @@ import { CID } from 'multiformats/cid'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q?: string
   limit?: number

--- a/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/api/src/client/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -9,8 +9,6 @@ import { CID } from 'multiformats/cid'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query prefix; not a full query string. */
   q?: string
   limit?: number

--- a/packages/api/src/client/types/tools/ozone/moderation/searchRepos.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/searchRepos.ts
@@ -9,8 +9,6 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead */
-  term?: string
   q?: string
   limit?: number
   cursor?: string

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -45,7 +45,7 @@ export default function (server: Server, ctx: AppContext) {
 
 const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
   const { ctx, params } = inputs
-  const term = params.q ?? params.term ?? ''
+  const term = params.q ?? ''
 
   // @TODO
   // add hits total

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -44,7 +44,7 @@ export default function (server: Server, ctx: AppContext) {
 
 const skeleton = async (inputs: SkeletonFnInput<Context, Params>) => {
   const { ctx, params } = inputs
-  const term = params.q ?? params.term ?? ''
+  const term = params.q ?? ''
 
   // @TODO
   // add typeahead option

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4308,10 +4308,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description:
@@ -4361,10 +4357,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description: 'Search query prefix; not a full query string.',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q?: string
   limit: number

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query prefix; not a full query string. */
   q?: string
   limit: number

--- a/packages/bsky/tests/views/actor-search.test.ts
+++ b/packages/bsky/tests/views/actor-search.test.ts
@@ -49,7 +49,7 @@ describe.skip('pds actor search views', () => {
 
   it('typeahead gives relevant results', async () => {
     const result = await agent.api.app.bsky.actor.searchActorsTypeahead(
-      { term: 'car' },
+      { q: 'car' },
       { headers },
     )
 
@@ -85,9 +85,9 @@ describe.skip('pds actor search views', () => {
     expect(forSnapshot(sorted)).toMatchSnapshot()
   })
 
-  it('typeahead gives empty result set when provided empty term', async () => {
+  it('typeahead gives empty result set when provided empty q', async () => {
     const result = await agent.api.app.bsky.actor.searchActorsTypeahead(
-      { term: '' },
+      { q: '' },
       { headers },
     )
 
@@ -96,14 +96,14 @@ describe.skip('pds actor search views', () => {
 
   it('typeahead applies limit', async () => {
     const full = await agent.api.app.bsky.actor.searchActorsTypeahead(
-      { term: 'p' },
+      { q: 'p' },
       { headers },
     )
 
     expect(full.data.actors.length).toBeGreaterThan(5)
 
     const limited = await agent.api.app.bsky.actor.searchActorsTypeahead(
-      { term: 'p', limit: 5 },
+      { q: 'p', limit: 5 },
       { headers },
     )
 
@@ -125,12 +125,12 @@ describe.skip('pds actor search views', () => {
   it('typeahead gives results unauthed', async () => {
     const { data: authed } =
       await agent.api.app.bsky.actor.searchActorsTypeahead(
-        { term: 'car' },
+        { q: 'car' },
         { headers },
       )
     const { data: unauthed } =
       await agent.api.app.bsky.actor.searchActorsTypeahead({
-        term: 'car',
+        q: 'car',
       })
     expect(unauthed.actors.length).toBeGreaterThan(0)
     expect(unauthed.actors).toEqual(authed.actors.map(stripViewer))
@@ -138,7 +138,7 @@ describe.skip('pds actor search views', () => {
 
   it('search gives relevant results', async () => {
     const result = await agent.api.app.bsky.actor.searchActors(
-      { term: 'car' },
+      { q: 'car' },
       { headers },
     )
 
@@ -174,9 +174,9 @@ describe.skip('pds actor search views', () => {
     expect(forSnapshot(sorted)).toMatchSnapshot()
   })
 
-  it('search gives empty result set when provided empty term', async () => {
+  it('search gives empty result set when provided empty q', async () => {
     const result = await agent.api.app.bsky.actor.searchActors(
-      { term: '' },
+      { q: '' },
       { headers },
     )
 
@@ -187,7 +187,7 @@ describe.skip('pds actor search views', () => {
     const results = (results) => results.flatMap((res) => res.users)
     const paginator = async (cursor?: string) => {
       const res = await agent.api.app.bsky.actor.searchActors(
-        { term: 'p', cursor, limit: 3 },
+        { q: 'p', cursor, limit: 3 },
         { headers },
       )
       return res.data
@@ -199,7 +199,7 @@ describe.skip('pds actor search views', () => {
     )
 
     const full = await agent.api.app.bsky.actor.searchActors(
-      { term: 'p' },
+      { q: 'p' },
       { headers },
     )
 
@@ -217,7 +217,7 @@ describe.skip('pds actor search views', () => {
     // Mostly for sqlite's benefit, since it uses LIKE and these are special characters that will
     // get stripped. This input triggers a special case where there are no "safe" words for sqlite to search on.
     const result = await agent.api.app.bsky.actor.searchActors(
-      { term: ' % _ ' },
+      { q: ' % _ ' },
       { headers },
     )
 
@@ -226,11 +226,11 @@ describe.skip('pds actor search views', () => {
 
   it('search gives results unauthed', async () => {
     const { data: authed } = await agent.api.app.bsky.actor.searchActors(
-      { term: 'car' },
+      { q: 'car' },
       { headers },
     )
     const { data: unauthed } = await agent.api.app.bsky.actor.searchActors({
-      term: 'car',
+      q: 'car',
     })
     expect(unauthed.actors.length).toBeGreaterThan(0)
     expect(unauthed.actors).toEqual(authed.actors.map(stripViewer))
@@ -241,7 +241,7 @@ describe.skip('pds actor search views', () => {
       did: sc.dids['cara-wiegand69.test'],
     })
     const result = await agent.api.app.bsky.actor.searchActorsTypeahead(
-      { term: 'car' },
+      { q: 'car' },
       { headers },
     )
     const handles = result.data.actors.map((u) => u.handle)

--- a/packages/bsky/tests/views/block-lists.test.ts
+++ b/packages/bsky/tests/views/block-lists.test.ts
@@ -277,7 +277,7 @@ describe('pds views with blocking from block lists', () => {
   it('does not return blocked accounts in actor search', async () => {
     const resCarol = await agent.api.app.bsky.actor.searchActors(
       {
-        term: 'dan.test',
+        q: 'dan.test',
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -285,7 +285,7 @@ describe('pds views with blocking from block lists', () => {
 
     const resDan = await agent.api.app.bsky.actor.searchActors(
       {
-        term: 'carol.test',
+        q: 'carol.test',
       },
       { headers: await network.serviceHeaders(dan) },
     )
@@ -295,7 +295,7 @@ describe('pds views with blocking from block lists', () => {
   it('does not return blocked accounts in actor search typeahead', async () => {
     const resCarol = await agent.api.app.bsky.actor.searchActorsTypeahead(
       {
-        term: 'dan.test',
+        q: 'dan.test',
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -303,7 +303,7 @@ describe('pds views with blocking from block lists', () => {
 
     const resDan = await agent.api.app.bsky.actor.searchActorsTypeahead(
       {
-        term: 'carol.test',
+        q: 'carol.test',
       },
       { headers: await network.serviceHeaders(dan) },
     )

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -347,7 +347,7 @@ describe('pds views with blocking', () => {
   it('does not return blocked accounts in actor search', async () => {
     const resCarol = await agent.api.app.bsky.actor.searchActors(
       {
-        term: 'dan.test',
+        q: 'dan.test',
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -355,7 +355,7 @@ describe('pds views with blocking', () => {
 
     const resDan = await agent.api.app.bsky.actor.searchActors(
       {
-        term: 'carol.test',
+        q: 'carol.test',
       },
       { headers: await network.serviceHeaders(dan) },
     )
@@ -365,7 +365,7 @@ describe('pds views with blocking', () => {
   it('does not return blocked accounts in actor search typeahead', async () => {
     const resCarol = await agent.api.app.bsky.actor.searchActorsTypeahead(
       {
-        term: 'dan.test',
+        q: 'dan.test',
       },
       { headers: await network.serviceHeaders(carol) },
     )
@@ -373,7 +373,7 @@ describe('pds views with blocking', () => {
 
     const resDan = await agent.api.app.bsky.actor.searchActorsTypeahead(
       {
-        term: 'carol.test',
+        q: 'carol.test',
       },
       { headers: await network.serviceHeaders(dan) },
     )

--- a/packages/ozone/src/api/moderation/searchRepos.ts
+++ b/packages/ozone/src/api/moderation/searchRepos.ts
@@ -7,9 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.modOrAdminToken,
     handler: async ({ params }) => {
       const modService = ctx.modService(ctx.db)
-
-      // prefer new 'q' query param over deprecated 'term'
-      const query = params.q ?? params.term
+      const query = params.q ?? ''
 
       // special case for did searches - do exact match
       if (query?.startsWith('did:')) {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4308,10 +4308,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description:
@@ -4361,10 +4357,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
@@ -10491,10 +10483,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead",
-            },
             q: {
               type: 'string',
             },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q?: string
   limit: number

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query prefix; not a full query string. */
   q?: string
   limit: number

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead */
-  term?: string
   q?: string
   limit: number
   cursor?: string

--- a/packages/ozone/tests/repo-search.test.ts
+++ b/packages/ozone/tests/repo-search.test.ts
@@ -43,7 +43,7 @@ describe('admin repo search view', () => {
 
   it('gives relevant results', async () => {
     const result = await agent.api.tools.ozone.moderation.searchRepos(
-      { term: 'car' },
+      { q: 'car' },
       { headers },
     )
 
@@ -71,21 +71,21 @@ describe('admin repo search view', () => {
   })
 
   it('finds repo by did', async () => {
-    const term = sc.dids['cara-wiegand69.test']
+    const q = sc.dids['cara-wiegand69.test']
     const res = await agent.api.tools.ozone.moderation.searchRepos(
-      { term },
+      { q },
       { headers },
     )
 
     expect(res.data.repos.length).toEqual(1)
-    expect(res.data.repos[0].did).toEqual(term)
+    expect(res.data.repos[0].did).toEqual(q)
   })
 
-  it('paginates with term', async () => {
+  it('paginates with q', async () => {
     const results = (results) => results.flatMap((res) => res.users)
     const paginator = async (cursor?: string) => {
       const res = await agent.api.tools.ozone.moderation.searchRepos(
-        { term: 'p', cursor, limit: 3 },
+        { q: 'p', cursor, limit: 3 },
         { headers },
       )
       return res.data
@@ -97,7 +97,7 @@ describe('admin repo search view', () => {
     )
 
     const full = await agent.api.tools.ozone.moderation.searchRepos(
-      { term: 'p' },
+      { q: 'p' },
       { headers },
     )
 
@@ -105,7 +105,7 @@ describe('admin repo search view', () => {
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
 
-  it('paginates without term', async () => {
+  it('paginates without q', async () => {
     const results = (results) => results.flatMap((res) => res.repos)
     const paginator = async (cursor?: string) => {
       const res = await agent.api.tools.ozone.moderation.searchRepos(

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4308,10 +4308,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description:
@@ -4361,10 +4357,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead.",
-            },
             q: {
               type: 'string',
               description: 'Search query prefix; not a full query string.',
@@ -10491,10 +10483,6 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            term: {
-              type: 'string',
-              description: "DEPRECATED: use 'q' instead",
-            },
             q: {
               type: 'string',
             },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
   q?: string
   limit: number

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as AppBskyActorDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead. */
-  term?: string
   /** Search query prefix; not a full query string. */
   q?: string
   limit: number

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
@@ -10,8 +10,6 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** DEPRECATED: use 'q' instead */
-  term?: string
   q?: string
   limit: number
   cursor?: string

--- a/packages/pds/tests/proxied/admin.test.ts
+++ b/packages/pds/tests/proxied/admin.test.ts
@@ -184,7 +184,7 @@ describe('proxies admin requests', () => {
 
   it('searches repos.', async () => {
     const { data: result } = await agent.api.tools.ozone.moderation.searchRepos(
-      { term: 'alice' },
+      { q: 'alice' },
       { headers: sc.getHeaders(moderator) },
     )
     expect(forSnapshot(result.repos)).toMatchSnapshot()

--- a/packages/pds/tests/proxied/views.test.ts
+++ b/packages/pds/tests/proxied/views.test.ts
@@ -113,7 +113,7 @@ describe('proxies view requests', () => {
   it('actor.searchActor', async () => {
     const res = await agent.api.app.bsky.actor.searchActors(
       {
-        term: '.test',
+        q: '.test',
       },
       {
         headers: { ...sc.getHeaders(alice) },
@@ -126,7 +126,7 @@ describe('proxies view requests', () => {
     expect(forSnapshot(sortedFull)).toMatchSnapshot()
     const pt1 = await agent.api.app.bsky.actor.searchActors(
       {
-        term: '.test',
+        q: '.test',
         limit: 1,
       },
       {
@@ -135,7 +135,7 @@ describe('proxies view requests', () => {
     )
     const pt2 = await agent.api.app.bsky.actor.searchActors(
       {
-        term: '.test',
+        q: '.test',
         cursor: pt1.data.cursor,
       },
       {
@@ -151,7 +151,7 @@ describe('proxies view requests', () => {
   it('actor.searchActorTypeahead', async () => {
     const res = await agent.api.app.bsky.actor.searchActorsTypeahead(
       {
-        term: '.test',
+        q: '.test',
       },
       {
         headers: { ...sc.getHeaders(alice) },


### PR DESCRIPTION
Another one breaking up https://github.com/bluesky-social/atproto/pull/2376 in to smaller chunks.

In a previous review on the old PR, @dholms that the client hadn't been updated to use `q` instead of `term`. I'm not sure where that is? I can't find use of `term` in `social-app` but maybe i'm not looking correctly.

Looking in the appview logs though, there do seem to be a steady trickle of `terms` queries to the search endpoints from indie devs. I'll need to do some dev comms around this before we merge+deploy.

@foysalit it seems like the Ozone front-end might be using `term` not `q`; would be good to update that.