### PR TITLE
Privileged app passwords

### DIFF
--- a/.changeset/plenty-dolphins-shop.md
+++ b/.changeset/plenty-dolphins-shop.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Add privileged app password auth scope

--- a/lexicons/com/atproto/server/createAppPassword.json
+++ b/lexicons/com/atproto/server/createAppPassword.json
@@ -37,7 +37,8 @@
       "properties": {
         "name": { "type": "string" },
         "password": { "type": "string" },
-        "createdAt": { "type": "string", "format": "datetime" }
+        "createdAt": { "type": "string", "format": "datetime" },
+        "privileged": { "type": "boolean" }
       }
     }
   }

--- a/lexicons/com/atproto/server/createAppPassword.json
+++ b/lexicons/com/atproto/server/createAppPassword.json
@@ -14,6 +14,10 @@
             "name": {
               "type": "string",
               "description": "A short name for the App Password, to help distinguish them."
+            },
+            "privileged": {
+              "type": "boolean",
+              "description": "If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients."
             }
           }
         }

--- a/lexicons/com/atproto/server/listAppPasswords.json
+++ b/lexicons/com/atproto/server/listAppPasswords.json
@@ -25,7 +25,8 @@
       "required": ["name", "createdAt"],
       "properties": {
         "name": { "type": "string" },
-        "createdAt": { "type": "string", "format": "datetime" }
+        "createdAt": { "type": "string", "format": "datetime" },
+        "privileged": { "type": "boolean" }
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2087,6 +2087,9 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          privileged: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -2052,6 +2052,11 @@ export const schemaDict = {
                 description:
                   'A short name for the App Password, to help distinguish them.',
               },
+              privileged: {
+                type: 'boolean',
+                description:
+                  "If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients.",
+              },
             },
           },
         },
@@ -2628,6 +2633,9 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          privileged: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
@@ -48,6 +48,7 @@ export interface AppPassword {
   name: string
   password: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
+++ b/packages/api/src/client/types/com/atproto/server/createAppPassword.ts
@@ -12,6 +12,8 @@ export interface QueryParams {}
 export interface InputSchema {
   /** A short name for the App Password, to help distinguish them. */
   name: string
+  /** If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients. */
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/api/src/client/types/com/atproto/server/listAppPasswords.ts
@@ -42,6 +42,7 @@ export function toKnownErr(e: any) {
 export interface AppPassword {
   name: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2087,6 +2087,9 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          privileged: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -2052,6 +2052,11 @@ export const schemaDict = {
                 description:
                   'A short name for the App Password, to help distinguish them.',
               },
+              privileged: {
+                type: 'boolean',
+                description:
+                  "If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients.",
+              },
             },
           },
         },
@@ -2628,6 +2633,9 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          privileged: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -13,6 +13,8 @@ export interface QueryParams {}
 export interface InputSchema {
   /** A short name for the App Password, to help distinguish them. */
   name: string
+  /** If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients. */
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -53,6 +53,7 @@ export interface AppPassword {
   name: string
   password: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -46,6 +46,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface AppPassword {
   name: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -2087,6 +2087,9 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          privileged: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -2052,6 +2052,11 @@ export const schemaDict = {
                 description:
                   'A short name for the App Password, to help distinguish them.',
               },
+              privileged: {
+                type: 'boolean',
+                description:
+                  "If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients.",
+              },
             },
           },
         },
@@ -2628,6 +2633,9 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          privileged: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -13,6 +13,8 @@ export interface QueryParams {}
 export interface InputSchema {
   /** A short name for the App Password, to help distinguish them. */
   name: string
+  /** If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients. */
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -53,6 +53,7 @@ export interface AppPassword {
   name: string
   password: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -46,6 +46,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface AppPassword {
   name: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
+++ b/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
@@ -3,7 +3,7 @@ import { Kysely } from 'kysely'
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .alterTable('app_password')
-    .addColumn('privileged', 'boolean')
+    .addColumn('privileged', 'integer')
     .execute()
 }
 

--- a/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
+++ b/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
@@ -3,7 +3,7 @@ import { Kysely } from 'kysely'
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .alterTable('app_password')
-    .addColumn('privileged', 'integer')
+    .addColumn('privileged', 'integer', (col) => col.notNull().defaultTo(0))
     .execute()
 }
 

--- a/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
+++ b/packages/pds/src/account-manager/db/migrations/003-privileged-app-passwords.ts
@@ -1,0 +1,12 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('app_password')
+    .addColumn('privileged', 'boolean')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('app_password').dropColumn('privileged').execute()
+}

--- a/packages/pds/src/account-manager/db/migrations/index.ts
+++ b/packages/pds/src/account-manager/db/migrations/index.ts
@@ -1,7 +1,9 @@
 import * as mig001 from './001-init'
 import * as mig002 from './002-account-deactivation'
+import * as mig003 from './003-privileged-app-passwords'
 
 export default {
   '001': mig001,
   '002': mig002,
+  '003': mig003,
 }

--- a/packages/pds/src/account-manager/db/schema/app-password.ts
+++ b/packages/pds/src/account-manager/db/schema/app-password.ts
@@ -3,6 +3,7 @@ export interface AppPassword {
   name: string
   passwordScrypt: string
   createdAt: string
+  privileged: boolean | null
 }
 
 export const tableName = 'app_password'

--- a/packages/pds/src/account-manager/db/schema/app-password.ts
+++ b/packages/pds/src/account-manager/db/schema/app-password.ts
@@ -3,7 +3,7 @@ export interface AppPassword {
   name: string
   passwordScrypt: string
   createdAt: string
-  privileged: 0 | 1 | null
+  privileged: 0 | 1
 }
 
 export const tableName = 'app_password'

--- a/packages/pds/src/account-manager/db/schema/app-password.ts
+++ b/packages/pds/src/account-manager/db/schema/app-password.ts
@@ -3,7 +3,7 @@ export interface AppPassword {
   name: string
   passwordScrypt: string
   createdAt: string
-  privileged: boolean | null
+  privileged: 0 | 1 | null
 }
 
 export const tableName = 'app_password'

--- a/packages/pds/src/account-manager/helpers/auth.ts
+++ b/packages/pds/src/account-manager/helpers/auth.ts
@@ -105,7 +105,7 @@ export const storeRefreshToken = async (
 }
 
 export const getRefreshToken = async (db: AccountDb, id: string) => {
-  return db.db
+  const res = await db.db
     .selectFrom('refresh_token')
     .leftJoin(
       'app_password',
@@ -116,6 +116,20 @@ export const getRefreshToken = async (db: AccountDb, id: string) => {
     .selectAll('refresh_token')
     .select('app_password.privileged')
     .executeTakeFirst()
+  if (!res) return null
+  const { did, expiresAt, appPasswordName, nextId, privileged } = res
+  return {
+    id,
+    did,
+    expiresAt,
+    nextId,
+    appPassword: appPasswordName
+      ? {
+          name: appPasswordName,
+          privileged: privileged === 1 ? true : false,
+        }
+      : null,
+  }
 }
 
 export const deleteExpiredRefreshTokens = async (

--- a/packages/pds/src/account-manager/helpers/auth.ts
+++ b/packages/pds/src/account-manager/helpers/auth.ts
@@ -5,6 +5,7 @@ import * as ui8 from 'uint8arrays'
 import * as crypto from '@atproto/crypto'
 import { AuthScope } from '../../auth-verifier'
 import { AccountDb } from '../db'
+import { AppPassDescript } from './password'
 
 export type AuthToken = {
   scope: AuthScope
@@ -87,7 +88,7 @@ export const decodeRefreshToken = (jwt: string) => {
 export const storeRefreshToken = async (
   db: AccountDb,
   payload: RefreshToken,
-  appPasswordName: string | null,
+  appPassword: AppPassDescript | null,
 ) => {
   const [result] = await db.executeWithRetry(
     db.db
@@ -95,7 +96,7 @@ export const storeRefreshToken = async (
       .values({
         id: payload.jti,
         did: payload.sub,
-        appPasswordName,
+        appPasswordName: appPassword?.name,
         expiresAt: new Date(payload.exp * 1000).toISOString(),
       })
       .onConflict((oc) => oc.doNothing()), // E.g. when re-granting during a refresh grace period
@@ -106,8 +107,14 @@ export const storeRefreshToken = async (
 export const getRefreshToken = async (db: AccountDb, id: string) => {
   return db.db
     .selectFrom('refresh_token')
+    .leftJoin(
+      'app_password',
+      'app_password.name',
+      'refresh_token.appPasswordName',
+    )
     .where('id', '=', id)
-    .selectAll()
+    .selectAll('refresh_token')
+    .select('app_password.privileged')
     .executeTakeFirst()
 }
 
@@ -179,6 +186,13 @@ export const revokeAppPasswordRefreshToken = async (
 
 export const getRefreshTokenId = () => {
   return ui8.toString(crypto.randomBytes(32), 'base64')
+}
+
+export const formatScope = (appPassword: AppPassDescript | null): AuthScope => {
+  if (!appPassword) return AuthScope.Access
+  return appPassword.privileged
+    ? AuthScope.AppPassPrivileged
+    : AuthScope.AppPass
 }
 
 export class ConcurrentRefreshError extends Error {}

--- a/packages/pds/src/account-manager/helpers/password.ts
+++ b/packages/pds/src/account-manager/helpers/password.ts
@@ -4,6 +4,11 @@ import * as scrypt from './scrypt'
 import { AccountDb } from '../db'
 import { AppPassword } from '../../lexicon/types/com/atproto/server/createAppPassword'
 
+export type AppPassDescript = {
+  name: string
+  privileged: boolean
+}
+
 export const verifyAccountPassword = async (
   db: AccountDb,
   did: string,
@@ -21,7 +26,7 @@ export const verifyAppPassword = async (
   db: AccountDb,
   did: string,
   password: string,
-): Promise<string | null> => {
+): Promise<AppPassDescript | null> => {
   const passwordScrypt = await scrypt.hashAppPassword(did, password)
   const found = await db.db
     .selectFrom('app_password')
@@ -29,7 +34,11 @@ export const verifyAppPassword = async (
     .where('did', '=', did)
     .where('passwordScrypt', '=', passwordScrypt)
     .executeTakeFirst()
-  return found?.name ?? null
+  if (!found) return null
+  return {
+    name: found.name,
+    privileged: found.privileged ?? false,
+  }
 }
 
 export const updateUserPassword = async (
@@ -51,6 +60,7 @@ export const createAppPassword = async (
   db: AccountDb,
   did: string,
   name: string,
+  privileged: boolean,
 ): Promise<AppPassword> => {
   // create an app password with format:
   // 1234-abcd-5678-efgh
@@ -71,6 +81,7 @@ export const createAppPassword = async (
         name,
         passwordScrypt,
         createdAt: new Date().toISOString(),
+        privileged,
       })
       .returningAll(),
   )
@@ -87,12 +98,17 @@ export const createAppPassword = async (
 export const listAppPasswords = async (
   db: AccountDb,
   did: string,
-): Promise<{ name: string; createdAt: string }[]> => {
-  return db.db
+): Promise<{ name: string; createdAt: string; privileged: boolean }[]> => {
+  const res = await db.db
     .selectFrom('app_password')
-    .select(['name', 'createdAt'])
+    .select(['name', 'createdAt', 'privileged'])
     .where('did', '=', did)
     .execute()
+  return res.map((row) => ({
+    name: row.name,
+    createdAt: row.createdAt,
+    privileged: row.privileged ?? false,
+  }))
 }
 
 export const deleteAppPassword = async (

--- a/packages/pds/src/account-manager/helpers/password.ts
+++ b/packages/pds/src/account-manager/helpers/password.ts
@@ -37,7 +37,7 @@ export const verifyAppPassword = async (
   if (!found) return null
   return {
     name: found.name,
-    privileged: found.privileged ?? false,
+    privileged: found.privileged === 1 ? true : false,
   }
 }
 
@@ -81,7 +81,7 @@ export const createAppPassword = async (
         name,
         passwordScrypt,
         createdAt: new Date().toISOString(),
-        privileged,
+        privileged: privileged ? 1 : 0,
       })
       .returningAll(),
   )
@@ -92,6 +92,7 @@ export const createAppPassword = async (
     name,
     password,
     createdAt: got.createdAt,
+    privileged,
   }
 }
 
@@ -103,11 +104,12 @@ export const listAppPasswords = async (
     .selectFrom('app_password')
     .select(['name', 'createdAt', 'privileged'])
     .where('did', '=', did)
+    .orderBy('createdAt', 'desc')
     .execute()
   return res.map((row) => ({
     name: row.name,
     createdAt: row.createdAt,
-    privileged: row.privileged ?? false,
+    privileged: row.privileged === 1 ? true : false,
   }))
 }
 

--- a/packages/pds/src/account-manager/index.ts
+++ b/packages/pds/src/account-manager/index.ts
@@ -181,10 +181,6 @@ export class AccountManager {
     const token = await auth.getRefreshToken(this.db, id)
     if (!token) return null
 
-    const tokenAppPass = token.appPasswordName
-      ? { name: token.appPasswordName, privileged: token.privileged ?? false }
-      : null
-
     const now = new Date()
 
     // take the chance to tidy all of a user's expired tokens
@@ -212,7 +208,7 @@ export class AccountManager {
       did: token.did,
       jwtKey: this.jwtKey,
       serviceDid: this.serviceDid,
-      scope: auth.formatScope(tokenAppPass),
+      scope: auth.formatScope(token.appPassword),
       jti: nextId,
     })
 
@@ -225,7 +221,7 @@ export class AccountManager {
             expiresAt: expiresAt.toISOString(),
             nextId,
           }),
-          auth.storeRefreshToken(dbTxn, refreshPayload, tokenAppPass),
+          auth.storeRefreshToken(dbTxn, refreshPayload, token.appPassword),
         ]),
       )
     } catch (err) {

--- a/packages/pds/src/api/chat/index.ts
+++ b/packages/pds/src/api/chat/index.ts
@@ -4,85 +4,85 @@ import { pipethrough, pipethroughProcedure } from '../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
   server.chat.bsky.actor.deleteAccount({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: async ({ req, auth }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.actor.exportAccountData({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.deleteMessageForSelf({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.getConvo({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.getConvoForMembers({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.getLog({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.getMessages({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.leaveConvo({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.listConvos({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth }) => {
       return pipethrough(ctx, req, auth.credentials.did)
     },
   })
   server.chat.bsky.convo.muteConvo({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.sendMessage({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.sendMessageBatch({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.unmuteConvo({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },
   })
   server.chat.bsky.convo.updateRead({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: ({ req, auth, input }) => {
       return pipethroughProcedure(ctx, req, auth.credentials.did, input.body)
     },

--- a/packages/pds/src/api/com/atproto/identity/requestPlcOperationSignature.ts
+++ b/packages/pds/src/api/com/atproto/identity/requestPlcOperationSignature.ts
@@ -5,7 +5,7 @@ import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.identity.requestPlcOperationSignature({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth, req }) => {
       if (ctx.entrywayAgent) {
         await ctx.entrywayAgent.com.atproto.identity.requestPlcOperationSignature(

--- a/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
+++ b/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
@@ -7,7 +7,7 @@ import { authPassthru, resultPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.identity.signPlcOperation({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth, input, req }) => {
       if (ctx.entrywayAgent) {
         return resultPassthru(

--- a/packages/pds/src/api/com/atproto/repo/importRepo.ts
+++ b/packages/pds/src/api/com/atproto/repo/importRepo.ts
@@ -17,7 +17,7 @@ import { BlobRef, LexValue, RepoRecord } from '@atproto/lexicon'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.repo.importRepo({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ input, auth }) => {
       const did = auth.credentials.did
       if (!ctx.cfg.service.acceptingImports) {

--- a/packages/pds/src/api/com/atproto/server/activateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/activateAccount.ts
@@ -7,7 +7,7 @@ import { assertValidDidDocumentForService } from './util'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.activateAccount({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth }) => {
       const requester = auth.credentials.did
 

--- a/packages/pds/src/api/com/atproto/server/createAppPassword.ts
+++ b/packages/pds/src/api/com/atproto/server/createAppPassword.ts
@@ -21,6 +21,7 @@ export default function (server: Server, ctx: AppContext) {
         name,
         input.body.privileged ?? false,
       )
+
       return {
         encoding: 'application/json',
         body: appPassword,

--- a/packages/pds/src/api/com/atproto/server/createAppPassword.ts
+++ b/packages/pds/src/api/com/atproto/server/createAppPassword.ts
@@ -4,7 +4,7 @@ import { authPassthru, resultPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.createAppPassword({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth, input, req }) => {
       if (ctx.entrywayAgent) {
         return resultPassthru(
@@ -19,6 +19,7 @@ export default function (server: Server, ctx: AppContext) {
       const appPassword = await ctx.accountManager.createAppPassword(
         auth.credentials.did,
         name,
+        input.body.privileged ?? false,
       )
       return {
         encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/server/createSession.ts
+++ b/packages/pds/src/api/com/atproto/server/createSession.ts
@@ -6,6 +6,7 @@ import { softDeleted } from '../../../../db/util'
 import { Server } from '../../../../lexicon'
 import { didDocForSession } from './util'
 import { authPassthru, resultPassthru } from '../../../proxy'
+import { AppPassDescript } from '../../../../account-manager/helpers/password'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.createSession({
@@ -48,17 +49,17 @@ export default function (server: Server, ctx: AppContext) {
         throw new AuthRequiredError('Invalid identifier or password')
       }
 
-      let appPasswordName: string | null = null
+      let appPassword: AppPassDescript | null = null
       const validAccountPass = await ctx.accountManager.verifyAccountPassword(
         user.did,
         password,
       )
       if (!validAccountPass) {
-        appPasswordName = await ctx.accountManager.verifyAppPassword(
+        appPassword = await ctx.accountManager.verifyAppPassword(
           user.did,
           password,
         )
-        if (appPasswordName === null) {
+        if (appPassword === null) {
           throw new AuthRequiredError('Invalid identifier or password')
         }
       }
@@ -71,7 +72,7 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const [{ accessJwt, refreshJwt }, didDoc] = await Promise.all([
-        ctx.accountManager.createSession(user.did, appPasswordName),
+        ctx.accountManager.createSession(user.did, appPassword),
         didDocForSession(ctx, user.did),
       ])
 

--- a/packages/pds/src/api/com/atproto/server/deactivateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deactivateAccount.ts
@@ -3,7 +3,7 @@ import AppContext from '../../../../context'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.deactivateAccount({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
       await ctx.accountManager.deactivateAccount(

--- a/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/server/getAccountInviteCodes.ts
@@ -7,7 +7,7 @@ import { authPassthru, resultPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.getAccountInviteCodes({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ params, auth, req }) => {
       if (ctx.entrywayAgent) {
         return resultPassthru(

--- a/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
@@ -4,7 +4,7 @@ import { Server } from '../../../../lexicon'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.getServiceAuth({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ params, auth }) => {
       const did = auth.credentials.did
       const keypair = await ctx.actorStore.keypair(did)

--- a/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
@@ -4,7 +4,7 @@ import { Server } from '../../../../lexicon'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.getServiceAuth({
-    auth: ctx.authVerifier.accessFull,
+    auth: ctx.authVerifier.accessAppPassPrivileged,
     handler: async ({ params, auth }) => {
       const did = auth.credentials.did
       const keypair = await ctx.actorStore.keypair(did)

--- a/packages/pds/src/api/com/atproto/server/updateEmail.ts
+++ b/packages/pds/src/api/com/atproto/server/updateEmail.ts
@@ -7,7 +7,7 @@ import { UserAlreadyExistsError } from '../../../../account-manager/helpers/acco
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.updateEmail({
-    auth: ctx.authVerifier.accessNotAppPassword,
+    auth: ctx.authVerifier.accessFull,
     handler: async ({ auth, input, req }) => {
       const did = auth.credentials.did
       const { token, email } = input.body

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -23,6 +23,7 @@ export enum AuthScope {
   Access = 'com.atproto.access',
   Refresh = 'com.atproto.refresh',
   AppPass = 'com.atproto.appPass',
+  AppPassPrivileged = 'com.atproto.appPassPrivileged',
   Deactivated = 'com.atproto.deactivated',
 }
 
@@ -117,6 +118,7 @@ export class AuthVerifier {
   access = (ctx: ReqCtx): Promise<AccessOutput> => {
     return this.validateAccessToken(ctx.req, [
       AuthScope.Access,
+      AuthScope.AppPassPrivileged,
       AuthScope.AppPass,
     ])
   }
@@ -124,6 +126,7 @@ export class AuthVerifier {
   accessCheckTakedown = async (ctx: ReqCtx): Promise<AccessOutput> => {
     const result = await this.validateAccessToken(ctx.req, [
       AuthScope.Access,
+      AuthScope.AppPassPrivileged,
       AuthScope.AppPass,
     ])
     const found = await this.accountManager.getAccount(result.credentials.did, {
@@ -142,14 +145,22 @@ export class AuthVerifier {
     return result
   }
 
-  accessNotAppPassword = (ctx: ReqCtx): Promise<AccessOutput> => {
+  accessFull = (ctx: ReqCtx): Promise<AccessOutput> => {
     return this.validateAccessToken(ctx.req, [AuthScope.Access])
+  }
+
+  accessAppPassPrivileged = (ctx: ReqCtx): Promise<AccessOutput> => {
+    return this.validateAccessToken(ctx.req, [
+      AuthScope.Access,
+      AuthScope.AppPassPrivileged,
+    ])
   }
 
   accessDeactived = (ctx: ReqCtx): Promise<AccessOutput> => {
     return this.validateAccessToken(ctx.req, [
       AuthScope.Access,
       AuthScope.AppPass,
+      AuthScope.AppPassPrivileged,
       AuthScope.Deactivated,
     ])
   }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2087,6 +2087,9 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          privileged: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -2052,6 +2052,11 @@ export const schemaDict = {
                 description:
                   'A short name for the App Password, to help distinguish them.',
               },
+              privileged: {
+                type: 'boolean',
+                description:
+                  "If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients.",
+              },
             },
           },
         },
@@ -2628,6 +2633,9 @@ export const schemaDict = {
           createdAt: {
             type: 'string',
             format: 'datetime',
+          },
+          privileged: {
+            type: 'boolean',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -13,6 +13,8 @@ export interface QueryParams {}
 export interface InputSchema {
   /** A short name for the App Password, to help distinguish them. */
   name: string
+  /** If an app password has 'privileged' access to possibly sensitive account state. Meant for use with trusted clients. */
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -53,6 +53,7 @@ export interface AppPassword {
   name: string
   password: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -46,6 +46,7 @@ export type Handler<HA extends HandlerAuth = never> = (
 export interface AppPassword {
   name: string
   createdAt: string
+  privileged?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/tests/app-passwords.test.ts
+++ b/packages/pds/tests/app-passwords.test.ts
@@ -6,6 +6,7 @@ describe('app_passwords', () => {
   let network: TestNetworkNoAppView
   let accntAgent: AtpAgent
   let appAgent: AtpAgent
+  let priviAgent: AtpAgent
 
   beforeAll(async () => {
     network = await TestNetworkNoAppView.create({
@@ -13,6 +14,7 @@ describe('app_passwords', () => {
     })
     accntAgent = network.pds.getClient()
     appAgent = network.pds.getClient()
+    priviAgent = network.pds.getClient()
 
     await accntAgent.createAccount({
       handle: 'alice.test',
@@ -26,26 +28,46 @@ describe('app_passwords', () => {
   })
 
   let appPass: string
+  let privilegedAppPass: string
 
   it('creates an app-specific password', async () => {
     const res = await accntAgent.api.com.atproto.server.createAppPassword({
       name: 'test-pass',
     })
     expect(res.data.name).toBe('test-pass')
+    expect(res.data.privileged).toBe(false)
     appPass = res.data.password
   })
 
+  it('creates a privileged app-specific password', async () => {
+    const res = await accntAgent.api.com.atproto.server.createAppPassword({
+      name: 'privi-pass',
+      privileged: true,
+    })
+    expect(res.data.name).toBe('privi-pass')
+    expect(res.data.privileged).toBe(true)
+    privilegedAppPass = res.data.password
+  })
+
   it('creates a session with an app-specific password', async () => {
-    const res = await appAgent.login({
+    const res1 = await appAgent.login({
       identifier: 'alice.test',
       password: appPass,
     })
-    expect(res.data.did).toEqual(accntAgent.session?.did)
+    expect(res1.data.did).toEqual(accntAgent.session?.did)
+    const res2 = await priviAgent.login({
+      identifier: 'alice.test',
+      password: privilegedAppPass,
+    })
+    expect(res2.data.did).toEqual(accntAgent.session?.did)
   })
 
   it('creates an access token for an app with a restricted scope', () => {
     const decoded = jose.decodeJwt(appAgent.session?.accessJwt ?? '')
     expect(decoded?.scope).toEqual('com.atproto.appPass')
+
+    const decodedPrivi = jose.decodeJwt(priviAgent.session?.accessJwt ?? '')
+    expect(decodedPrivi?.scope).toEqual('com.atproto.appPassPrivileged')
   })
 
   it('allows actions to be performed from app', async () => {
@@ -58,13 +80,39 @@ describe('app_passwords', () => {
         createdAt: new Date().toISOString(),
       },
     )
+    await priviAgent.api.app.bsky.feed.post.create(
+      {
+        repo: priviAgent.session?.did,
+      },
+      {
+        text: 'testing again',
+        createdAt: new Date().toISOString(),
+      },
+    )
   })
 
-  it('restricts certain actions', async () => {
-    const attempt = appAgent.api.com.atproto.server.createAppPassword({
+  it('restricts full access actions', async () => {
+    const attempt1 = appAgent.api.com.atproto.server.createAppPassword({
       name: 'another-one',
     })
+    await expect(attempt1).rejects.toThrow('Bad token scope')
+    const attempt2 = priviAgent.api.com.atproto.server.createAppPassword({
+      name: 'another-one',
+    })
+    await expect(attempt2).rejects.toThrow('Bad token scope')
+  })
+
+  it('restricts privileged app password actions', async () => {
+    const attempt = appAgent.api.com.atproto.server.getServiceAuth({
+      aud: 'did:example:test',
+    })
     await expect(attempt).rejects.toThrow('Bad token scope')
+  })
+
+  it('allows privileged actions with a privileged app password', async () => {
+    await priviAgent.api.com.atproto.server.getServiceAuth({
+      aud: 'did:example:test',
+    })
   })
 
   it('persists scope across refreshes', async () => {
@@ -90,7 +138,51 @@ describe('app_passwords', () => {
       },
     )
 
-    const attempt = appAgent.api.com.atproto.server.createAppPassword(
+    const priviAttempt = appAgent.api.com.atproto.server.getServiceAuth({
+      aud: 'did:example:test',
+    })
+    await expect(priviAttempt).rejects.toThrow('Bad token scope')
+
+    const fullAttempt = appAgent.api.com.atproto.server.createAppPassword(
+      {
+        name: 'another-one',
+      },
+      {
+        encoding: 'application/json',
+        headers: { authorization: `Bearer ${session.data.accessJwt}` },
+      },
+    )
+    await expect(fullAttempt).rejects.toThrow('Bad token scope')
+  })
+
+  it('persists privileged scope across refreshes', async () => {
+    const session = await priviAgent.api.com.atproto.server.refreshSession(
+      undefined,
+      {
+        headers: {
+          authorization: `Bearer ${priviAgent.session?.refreshJwt}`,
+        },
+      },
+    )
+
+    await priviAgent.api.app.bsky.feed.post.create(
+      {
+        repo: priviAgent.session?.did,
+      },
+      {
+        text: 'Testing testing',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        authorization: `Bearer ${session.data.accessJwt}`,
+      },
+    )
+
+    await priviAgent.api.com.atproto.server.getServiceAuth({
+      aud: 'did:example:test',
+    })
+
+    const attempt = priviAgent.api.com.atproto.server.createAppPassword(
       {
         name: 'another-one',
       },
@@ -104,8 +196,11 @@ describe('app_passwords', () => {
 
   it('lists available app-specific passwords', async () => {
     const res = await appAgent.api.com.atproto.server.listAppPasswords()
-    expect(res.data.passwords.length).toBe(1)
-    expect(res.data.passwords[0].name).toEqual('test-pass')
+    expect(res.data.passwords.length).toBe(2)
+    expect(res.data.passwords[0].name).toEqual('privi-pass')
+    expect(res.data.passwords[0].privileged).toEqual(true)
+    expect(res.data.passwords[1].name).toEqual('test-pass')
+    expect(res.data.passwords[1].privileged).toEqual(false)
   })
 
   it('revokes an app-specific password', async () => {

--- a/packages/pds/tests/app-passwords.test.ts
+++ b/packages/pds/tests/app-passwords.test.ts
@@ -125,6 +125,7 @@ describe('app_passwords', () => {
       },
     )
 
+    // allows any access auth
     await appAgent.api.app.bsky.feed.post.create(
       {
         repo: appAgent.session?.did,
@@ -138,11 +139,13 @@ describe('app_passwords', () => {
       },
     )
 
+    // allows privileged app passwords or higher
     const priviAttempt = appAgent.api.com.atproto.server.getServiceAuth({
       aud: 'did:example:test',
     })
     await expect(priviAttempt).rejects.toThrow('Bad token scope')
 
+    // allows only full access auth
     const fullAttempt = appAgent.api.com.atproto.server.createAppPassword(
       {
         name: 'another-one',
@@ -165,6 +168,7 @@ describe('app_passwords', () => {
       },
     )
 
+    // allows any access auth
     await priviAgent.api.app.bsky.feed.post.create(
       {
         repo: priviAgent.session?.did,
@@ -178,10 +182,12 @@ describe('app_passwords', () => {
       },
     )
 
+    // allows privileged app passwords or higher
     await priviAgent.api.com.atproto.server.getServiceAuth({
       aud: 'did:example:test',
     })
 
+    // allows only full access auth
     const attempt = priviAgent.api.com.atproto.server.createAppPassword(
       {
         name: 'another-one',


### PR DESCRIPTION
Adds in a notion of a "privileged" app password which has greater access than a normal app password - for instance to sensitive account state such as chats - but still less access than a full access token.