### PR TITLE
Ozone: temporary workaround for message refs on createReport

### DIFF
--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -338,15 +338,21 @@ export class ModerationViews {
     labelers?: ParsedLabelers,
   ): Promise<Label[]> {
     if (!labelers?.dids.length && !labelers?.redact.size) return []
-
-    const {
-      data: { labels },
-    } = await this.appviewAgent.api.com.atproto.label.queryLabels({
-      uriPatterns: subjects,
-      sources: labelers.dids,
-    })
-
-    return labels
+    try {
+      const {
+        data: { labels },
+      } = await this.appviewAgent.api.com.atproto.label.queryLabels({
+        uriPatterns: subjects,
+        sources: labelers.dids,
+      })
+      return labels
+    } catch (err) {
+      httpLogger.error(
+        { err, subjects, labelers },
+        'failed to resolve labels from appview',
+      )
+      return []
+    }
   }
 
   formatReport(report: ModerationEventRowWithHandle): ReportOutput {

--- a/packages/ozone/tests/__snapshots__/moderation.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/moderation.test.ts.snap
@@ -22,7 +22,7 @@ Array [
     "reportedBy": "user(1)",
     "subject": Object {
       "$type": "chat.bsky.convo.defs#messageRef",
-      "convoId": "testconvoid2",
+      "convoId": "",
       "did": "user(1)",
       "messageId": "testmessageid2",
     },

--- a/packages/ozone/tests/moderation.test.ts
+++ b/packages/ozone/tests/moderation.test.ts
@@ -171,7 +171,7 @@ describe('moderation', () => {
           $type: 'chat.bsky.convo.defs#messageRef',
           did: sc.dids.carol,
           messageId: messageId2,
-          convoId: 'testconvoid2',
+          // @TODO convoId intentionally missing, restore once this behavior is deprecated
         },
       })
       expect(forSnapshot([reportA, reportB])).toMatchSnapshot()


### PR DESCRIPTION
The app currently does not send `convoId` with reported chat messages, as is required by the `#messageRef` lexicon, likely an artifact of the old version of the chat lexicons.  This introduces a workaround so that the field is temporarily optional, which we'll use until the vast majority of clients start sending `convoId`.  Also added a defensive try/catch around ozone's call to the appview for labels, so that we would not deny service if labels are unavailable for any reason.