### PR TITLE
Set CORS max-age header

### DIFF
--- a/.changeset/twelve-monkeys-switch.md
+++ b/.changeset/twelve-monkeys-switch.md
@@ -1,0 +1,7 @@
+---
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/pds": patch
+---
+
+Set max-age CORS header to max practical value

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -7,6 +7,7 @@ import cors from 'cors'
 import compression from 'compression'
 import AtpAgent from '@atproto/api'
 import { IdResolver } from '@atproto/identity'
+import { DAY, SECOND } from '@atproto/common'
 import API, { health, wellKnown, blobResolver } from './api'
 import * as error from './error'
 import { loggerMiddleware } from './logger'
@@ -48,7 +49,7 @@ export class BskyAppView {
   }): BskyAppView {
     const { config, signingKey } = opts
     const app = express()
-    app.use(cors())
+    app.use(cors({ maxAge: DAY / SECOND }))
     app.use(loggerMiddleware)
     app.use(compression())
 

--- a/packages/ozone/src/index.ts
+++ b/packages/ozone/src/index.ts
@@ -5,6 +5,7 @@ import events from 'events'
 import { createHttpTerminator, HttpTerminator } from 'http-terminator'
 import cors from 'cors'
 import compression from 'compression'
+import { DAY, SECOND } from '@atproto/common'
 import API, { health, wellKnown } from './api'
 import * as error from './error'
 import { dbLogger, loggerMiddleware } from './logger'
@@ -38,7 +39,7 @@ export class OzoneService {
   ): Promise<OzoneService> {
     const app = express()
     app.set('trust proxy', true)
-    app.use(cors())
+    app.use(cors({ maxAge: DAY / SECOND }))
     app.use(loggerMiddleware)
     app.use(compression())
 

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -9,7 +9,7 @@ import cors from 'cors'
 import http from 'http'
 import events from 'events'
 import { Options as XrpcServerOptions } from '@atproto/xrpc-server'
-import { DAY, HOUR, MINUTE } from '@atproto/common'
+import { DAY, HOUR, MINUTE, SECOND } from '@atproto/common'
 import API from './api'
 import * as basicRoutes from './basic-routes'
 import * as wellKnown from './well-known'
@@ -54,7 +54,7 @@ export class PDS {
   ): Promise<PDS> {
     const app = express()
     app.set('trust proxy', true)
-    app.use(cors())
+    app.use(cors({ maxAge: DAY / SECOND }))
     app.use(loggerMiddleware)
     app.use(compression())
 


### PR DESCRIPTION
This sets the CORS max-age header to the maximum practical value on pds, ozone, and bsky.  Should significantly reduce the number of preflights web users encounter.  Kudos to @matthieusieben for calling this out.