### PR TITLE
Lexicon: support for post embeds on chat messages

### DIFF
--- a/.changeset/big-birds-drum.md
+++ b/.changeset/big-birds-drum.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Support for post embeds in chat lexicons

--- a/lexicons/chat/bsky/convo/defs.json
+++ b/lexicons/chat/bsky/convo/defs.json
@@ -49,7 +49,7 @@
         },
         "embed": {
           "type": "union",
-          "refs": ["app.bsky.embed.record"]
+          "refs": ["app.bsky.embed.record#view"]
         },
         "sender": { "type": "ref", "ref": "#messageViewSender" },
         "sentAt": { "type": "string", "format": "datetime" }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8379,7 +8379,7 @@ export const schemaDict = {
           },
           embed: {
             type: 'union',
-            refs: ['lex:app.bsky.embed.record'],
+            refs: ['lex:app.bsky.embed.record#view'],
           },
           sender: {
             type: 'ref',

--- a/packages/api/src/client/types/chat/bsky/convo/defs.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/defs.ts
@@ -54,7 +54,7 @@ export interface MessageView {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
-  embed?: AppBskyEmbedRecord.Main | { $type: string; [k: string]: unknown }
+  embed?: AppBskyEmbedRecord.View | { $type: string; [k: string]: unknown }
   sender: MessageViewSender
   sentAt: string
   [k: string]: unknown

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8379,7 +8379,7 @@ export const schemaDict = {
           },
           embed: {
             type: 'union',
-            refs: ['lex:app.bsky.embed.record'],
+            refs: ['lex:app.bsky.embed.record#view'],
           },
           sender: {
             type: 'ref',

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -54,7 +54,7 @@ export interface MessageView {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
-  embed?: AppBskyEmbedRecord.Main | { $type: string; [k: string]: unknown }
+  embed?: AppBskyEmbedRecord.View | { $type: string; [k: string]: unknown }
   sender: MessageViewSender
   sentAt: string
   [k: string]: unknown

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8379,7 +8379,7 @@ export const schemaDict = {
           },
           embed: {
             type: 'union',
-            refs: ['lex:app.bsky.embed.record'],
+            refs: ['lex:app.bsky.embed.record#view'],
           },
           sender: {
             type: 'ref',

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -54,7 +54,7 @@ export interface MessageView {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
-  embed?: AppBskyEmbedRecord.Main | { $type: string; [k: string]: unknown }
+  embed?: AppBskyEmbedRecord.View | { $type: string; [k: string]: unknown }
   sender: MessageViewSender
   sentAt: string
   [k: string]: unknown

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8379,7 +8379,7 @@ export const schemaDict = {
           },
           embed: {
             type: 'union',
-            refs: ['lex:app.bsky.embed.record'],
+            refs: ['lex:app.bsky.embed.record#view'],
           },
           sender: {
             type: 'ref',

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -54,7 +54,7 @@ export interface MessageView {
   text: string
   /** Annotations of text (mentions, URLs, hashtags, etc) */
   facets?: AppBskyRichtextFacet.Main[]
-  embed?: AppBskyEmbedRecord.Main | { $type: string; [k: string]: unknown }
+  embed?: AppBskyEmbedRecord.View | { $type: string; [k: string]: unknown }
   sender: MessageViewSender
   sentAt: string
   [k: string]: unknown


### PR DESCRIPTION
Minor lexicon update to reflect that embeds on chat messages may be record embed views (specifically for post records).