### PR TITLE
:construction: Proposal for ozone config lexicons

### DIFF
--- a/lexicons/tools/ozone/config/createConfig.json
+++ b/lexicons/tools/ozone/config/createConfig.json
@@ -1,0 +1,58 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.config.createConfig",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Create new configuration key-value pairs.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["configs"],
+          "properties": {
+            "configs": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#configItem"
+              },
+              "description": "Array of key-value configurations to be created."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["configurations"],
+          "properties": {
+            "configurations": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.config.defs#configurationView"
+              },
+              "description": "Array of created configuration key-value pairs."
+            }
+          }
+        }
+      }
+    },
+    "configItem": {
+      "type": "object",
+      "required": ["key", "value"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key of the configuration."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the configuration."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/tools/ozone/config/defs.json
+++ b/lexicons/tools/ozone/config/defs.json
@@ -1,0 +1,17 @@
+{
+      "lexicon": 1,
+      "id": "com.atproto.config.defs",
+      "defs": {
+        "configurationView": {
+          "type": "object",
+          "required": ["key", "value", "createdAt", "updatedAt"],
+          "properties": {
+            "key": { "type": "string" },
+            "value": { "type": "string" },
+            "createdAt": { "type": "string", "format": "datetime" },
+            "updatedAt": { "type": "string", "format": "datetime" },
+            "createdBy": { "type": "string", "format": "did" }
+          }
+        }
+      }
+    }

--- a/lexicons/tools/ozone/config/deleteConfig.json
+++ b/lexicons/tools/ozone/config/deleteConfig.json
@@ -1,0 +1,30 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.config.deleteConfig",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Delete all config configuration matching a key or key-value pair. Wildcards can be used for values.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["key"],
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "All config values associated with this key will be removed, unless value is specified."
+            },
+            "value": {
+              "type": "string",
+              "description": "The value of the configuration to be deleted. Wildcards (*) can be used to only remove values that match certain pattern."
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "ConfigNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/tools/ozone/config/listConfig.json
+++ b/lexicons/tools/ozone/config/listConfig.json
@@ -1,0 +1,49 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.config.listConfig",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List configurations, matching a specific key or similar/exact value.",
+      "parameters": {
+        "type": "params",
+        "required": [],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key of the configuration."
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the configuration. Asterisk (*) can be used as a wildcard to match similar values prefixed or suffixed with a certain keyword."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 50,
+            "description": "The number of configuration key-value pairs to return."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "The cursor for pagination."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["configurations"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "configurations": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "com.atproto.config.defs#configurationView" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/tools/ozone/config/updateConfig.json
+++ b/lexicons/tools/ozone/config/updateConfig.json
@@ -1,0 +1,63 @@
+{
+      "lexicon": 1,
+      "id": "com.atproto.config.updateConfig",
+      "defs": {
+        "main": {
+          "type": "procedure",
+          "description": "Update configuration values for given key-value pairs.",
+          "input": {
+            "encoding": "application/json",
+            "schema": {
+              "type": "object",
+              "required": ["updates"],
+              "properties": {
+                "updates": {
+                  "type": "array",
+                  "items": {
+                    "type": "ref",
+                    "ref": "#updateItem"
+                  },
+                  "description": "Array of key-value pairs to be updated."
+                }
+              }
+            }
+          },
+          "output": {
+            "encoding": "application/json",
+            "schema": {
+              "type": "object",
+              "required": ["configurations"],
+              "properties": {
+                "configurations": {
+                  "type": "array",
+                  "items": {
+                    "type": "ref",
+                    "ref": "com.atproto.config.defs#configurationView"
+                  },
+                  "description": "Array of updated configuration key-value pairs."
+                }
+              }
+            }
+          }
+        },
+        "updateItem": {
+          "type": "object",
+          "required": ["key", "currentValue", "newValue"],
+          "properties": {
+            "key": {
+              "type": "string",
+              "description": "The key for which the configuration value(s) will be updated."
+            },
+            "currentValue": {
+              "type": "string",
+              "description": "The current value of the configuration."
+            },
+            "newValue": {
+              "type": "string",
+              "description": "The new value to update the configuration to."
+            }
+          }
+        }
+      }
+    }
+    

--- a/packages/ozone/src/db/migrations/20240607T085607200Z-configuration.ts
+++ b/packages/ozone/src/db/migrations/20240607T085607200Z-configuration.ts
@@ -3,13 +3,12 @@ import { Kysely } from 'kysely'
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .createTable('configuration')
-    .addColumn('id', 'serial', (col) => col.primaryKey())
     .addColumn('key', 'varchar', (col) => col.notNull())
     .addColumn('value', 'varchar', (col) => col.notNull())
     .addColumn('createdAt', 'timestamptz', (col) => col.notNull())
     .addColumn('updatedAt', 'timestamptz', (col) => col.notNull())
     .addColumn('createdBy', 'varchar', (col) => col.notNull())
-    .addUniqueConstraint('configuration_unique_key_value', ['key', 'value'])
+    .addPrimaryKeyConstraint('configuration_pkey', ['key', 'value'])
     .execute()
 }
 

--- a/packages/ozone/src/db/migrations/20240607T085607200Z-configuration.ts
+++ b/packages/ozone/src/db/migrations/20240607T085607200Z-configuration.ts
@@ -1,0 +1,18 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('configuration')
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('key', 'varchar', (col) => col.notNull())
+    .addColumn('value', 'varchar', (col) => col.notNull())
+    .addColumn('createdAt', 'timestamptz', (col) => col.notNull())
+    .addColumn('updatedAt', 'timestamptz', (col) => col.notNull())
+    .addColumn('createdBy', 'varchar', (col) => col.notNull())
+    .addUniqueConstraint('configuration_unique_key_value', ['key', 'value'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('configuration').execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -9,3 +9,4 @@ export * as _20240208T213404429Z from './20240208T213404429Z-add-tags-column-to-
 export * as _20240228T003647759Z from './20240228T003647759Z-add-label-sigs'
 export * as _20240408T192432676Z from './20240408T192432676Z-mute-reporting'
 export * as _20240506T225055595Z from './20240506T225055595Z-message-subject'
+export * as _20240607T085607200Z from './20240607T085607200Z-configuration'


### PR DESCRIPTION
This proposal introduces a new entity `config` which is essentially a list of key value pairs where each key may have one or many values.

A few open questions
1. Updates are tricky. The current proposal does not include updating a key or update values by wildcard.
2. Create and update allows array input but delete only allows key and wildcard value input, do we want array input for deletion too?

One of the primary reasons why I'm in favor of calling this `config` and generalizing this is to facilitate storing shareable config for entire instance, that are currently browser based and as a result, user specific or stored in env var. For instance, our queue config is only stored in the env var of the client build and we could move that to the db under configs where each row with key `queue` would be the config for an individual queue. We also have external labeler config currently [in review](https://github.com/bluesky-social/ozone/pull/93) but ideally, we would want to store these on the server so that all mods using the instance see labels from same external labelers.