### PR TITLE
Fix flaky tests surrounding ozone/pds

### DIFF
--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -152,9 +152,9 @@ export class TestNetwork extends TestNetworkNoAppView {
 
   async processAll(timeout?: number) {
     await this.pds.processAll()
+    await this.ozone.processAll()
     await this.processFullSubscription(timeout)
     await this.bsky.sub.background.processAll()
-    await this.ozone.processAll()
   }
 
   async serviceHeaders(did: string, aud?: string) {

--- a/packages/ozone/tests/lang.test.ts
+++ b/packages/ozone/tests/lang.test.ts
@@ -15,7 +15,7 @@ describe('moderation status language tagging', () => {
 
   beforeAll(async () => {
     network = await TestNetwork.create({
-      dbPostgresSchema: 'ozone_blob_divert_test',
+      dbPostgresSchema: 'ozone_lang_test',
       ozone: {
         blobDivertUrl: `https://blob-report.com`,
         blobDivertAdminPassword: 'test-auth-token',


### PR DESCRIPTION
Found a couple small issues that are probably contributing to test flakiness:
 - `network.processAll()` should ensure to process ozone before appview in order for hosting status changes to propagate.
 - minor issue with two tests using same backing pg schema.