### PR TITLE
replace graphemer by unicode-segmenter

### DIFF
--- a/packages/common-web/package.json
+++ b/packages/common-web/package.json
@@ -19,9 +19,9 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
-    "graphemer": "^1.4.0",
     "multiformats": "^9.9.0",
     "uint8arrays": "3.0.0",
+    "unicode-segmenter": "^0.7.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/common-web/src/strings.ts
+++ b/packages/common-web/src/strings.ts
@@ -1,4 +1,4 @@
-import Graphemer from 'graphemer'
+import { countGrapheme } from 'unicode-segmenter/grapheme';
 import * as ui8 from 'uint8arrays'
 
 // counts the number of bytes in a utf8 string
@@ -8,8 +8,7 @@ export const utf8Len = (str: string): number => {
 
 // counts the number of graphemes (user-displayed characters) in a string
 export const graphemeLen = (str: string): number => {
-  const splitter = new Graphemer()
-  return splitter.countGraphemes(str)
+  return countGrapheme(str)
 }
 
 export const utf8ToB64Url = (utf8: string): string => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,15 +360,15 @@ importers:
 
   packages/common-web:
     dependencies:
-      graphemer:
-        specifier: ^1.4.0
-        version: 1.4.0
       multiformats:
         specifier: ^9.9.0
         version: 9.9.0
       uint8arrays:
         specifier: 3.0.0
         version: 3.0.0
+      unicode-segmenter:
+        specifier: ^0.7.0
+        version: 0.7.0
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -7517,6 +7517,7 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
 
   /handlebars@4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
@@ -10784,6 +10785,10 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.0
+
+  /unicode-segmenter@0.7.0:
+    resolution: {integrity: sha512-GgySw5Xcmz0rVL3WOsVFk9mdXPUWsgxulVrZQUcQq4HZNY5r2z8OPnTRAX+Y0GwRXPX+BuDa399PnIy6fqh8og==}
+    dev: false
 
   /unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}


### PR DESCRIPTION
I made a Unicode library that is much smaller and faster than graphemer. Check it out: https://github.com/cometkim/unicode-segmenter?tab=readme-ov-file#unicode-segmentergrapheme-vs

It ensures compliance with the latest Unicode data by performing tests and fuzzing against the `Intl.Segmenter` API.