### PR TITLE
fix(api): `hasMutedWord` for facets with multiple features

### DIFF
--- a/.changeset/six-teachers-tie.md
+++ b/.changeset/six-teachers-tie.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Fix `hasMutedWord` for facets with multiple features

--- a/packages/api/src/moderation/mutewords.ts
+++ b/packages/api/src/moderation/mutewords.ts
@@ -38,13 +38,9 @@ export function hasMutedWord({
   const tags = ([] as string[])
     .concat(outlineTags || [])
     .concat(
-      facets
-        ?.filter((facet) => {
-          return facet.features.find((feature) =>
-            AppBskyRichtextFacet.isTag(feature),
-          )
-        })
-        .map((t) => t.features[0].tag as string) || [],
+      (facets || []).flatMap((facet) =>
+        facet.features.filter(AppBskyRichtextFacet.isTag).map((tag) => tag.tag),
+      ),
     )
     .map((t) => t.toLowerCase())
 

--- a/packages/api/tests/moderation-mutewords.test.ts
+++ b/packages/api/tests/moderation-mutewords.test.ts
@@ -680,6 +680,60 @@ describe(`hasMutedWord`, () => {
     })
   })
 
+  describe(`facet with multiple features`, () => {
+    it(`multiple tags`, () => {
+      const match = hasMutedWord({
+        mutedWords: [{ value: 'bad', targets: ['content'] }],
+        text: 'tags',
+        facets: [
+          {
+            features: [
+              {
+                $type: 'app.bsky.richtext.facet#tag',
+                tag: 'good',
+              },
+              {
+                $type: 'app.bsky.richtext.facet#tag',
+                tag: 'bad',
+              },
+            ],
+            index: {
+              byteEnd: 4,
+              byteStart: 0,
+            },
+          },
+        ],
+      })
+      expect(match).toBe(true)
+    })
+
+    it(`other features`, () => {
+      const match = hasMutedWord({
+        mutedWords: [{ value: 'bad', targets: ['content'] }],
+        text: 'test',
+        facets: [
+          {
+            features: [
+              {
+                $type: 'com.example.richtext.facet#other',
+                foo: 'bar',
+              },
+              {
+                $type: 'app.bsky.richtext.facet#tag',
+                tag: 'bad',
+              },
+            ],
+            index: {
+              byteEnd: 4,
+              byteStart: 0,
+            },
+          },
+        ],
+      })
+      expect(match).toBe(true)
+    })
+  })
+
   describe(`doesn't mute own post`, () => {
     it(`does mute if it isn't own post`, () => {
       const res = moderatePost(


### PR DESCRIPTION
The `hasMutedWord` function used in moderation uses the value of the tag in the facets passed as an argument as `tags` for judging. The current implementation was to “add the 0th of the features to the `tags` if a feature corresponding to `isTag` is found”.

This is incorrect, `features` is an array that can contain multiple elements, and those of type `#tag` can be included after the first. The 0th element can be hidden by a tag that is not the target word of the mute, or it can be a completely unrelated type.

Actually, it is possible to create such a post (e.g. https://bsky.app/profile/sugyan.pds.shigepon.net/post/3kukmykhshk2l), and an error will occur if a user with `mutedWords` set tries to view it.

Fixed it so all `#tag` types in `features` are subject to the decision, and added a test.