### PR TITLE
Scope put prefs by AuthScope

### DIFF
--- a/packages/pds/src/actor-store/preference/reader.ts
+++ b/packages/pds/src/actor-store/preference/reader.ts
@@ -1,9 +1,14 @@
+import { AuthScope } from '../../auth-verifier'
 import { ActorDb } from '../db'
+import { prefInScope } from './util'
 
 export class PreferenceReader {
   constructor(public db: ActorDb) {}
 
-  async getPreferences(namespace?: string): Promise<AccountPreference[]> {
+  async getPreferences(
+    namespace: string,
+    scope: AuthScope,
+  ): Promise<AccountPreference[]> {
     const prefsRes = await this.db.db
       .selectFrom('account_pref')
       .orderBy('id')
@@ -11,6 +16,7 @@ export class PreferenceReader {
       .execute()
     return prefsRes
       .filter((pref) => !namespace || prefMatchNamespace(namespace, pref.name))
+      .filter((pref) => prefInScope(scope, pref.name))
       .map((pref) => JSON.parse(pref.valueJson))
   }
 }

--- a/packages/pds/src/actor-store/preference/util.ts
+++ b/packages/pds/src/actor-store/preference/util.ts
@@ -1,0 +1,8 @@
+import { AuthScope } from '../../auth-verifier'
+
+const FULL_ACCESS_ONLY_PREFS = ['app.bsky.actor.defs#personalDetailsPref']
+
+export const prefInScope = (scope: AuthScope, prefType: string) => {
+  if (scope === AuthScope.Access) return true
+  return !FULL_ACCESS_ONLY_PREFS.includes(prefType)
+}

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -1,6 +1,5 @@
 import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
-import { AuthScope } from '../../../../auth-verifier'
 
 export default function (server: Server, ctx: AppContext) {
   if (!ctx.cfg.bskyAppView) return
@@ -8,15 +7,9 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.accessStandard(),
     handler: async ({ auth }) => {
       const requester = auth.credentials.did
-      let preferences = await ctx.actorStore.read(requester, (store) =>
-        store.pref.getPreferences('app.bsky'),
+      const preferences = await ctx.actorStore.read(requester, (store) =>
+        store.pref.getPreferences('app.bsky', auth.credentials.scope),
       )
-      if (auth.credentials.scope !== AuthScope.Access) {
-        // filter out personal details for app passwords
-        preferences = preferences.filter(
-          (pref) => pref.$type !== 'app.bsky.actor.defs#personalDetailsPref',
-        )
-      }
       return {
         encoding: 'application/json',
         body: { preferences },

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -19,7 +19,11 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
       await ctx.actorStore.transact(requester, async (actorTxn) => {
-        await actorTxn.pref.putPreferences(checkedPreferences, 'app.bsky')
+        await actorTxn.pref.putPreferences(
+          checkedPreferences,
+          'app.bsky',
+          auth.credentials.scope,
+        )
       })
     },
   })


### PR DESCRIPTION
We don't let app passwords read `personalDetailsPref`. This prevents app passwords from writing or deleting the preferences as well

Closes https://github.com/bluesky-social/atproto/issues/2555