### PR TITLE
Remove SDK enforcement of max labelers (NOTE: still enforced server side)

### DIFF
--- a/.changeset/good-taxis-move.md
+++ b/.changeset/good-taxis-move.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Remove client-side enforcement of labeler limits

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -21,7 +21,6 @@ import {
 } from './types'
 import { BSKY_LABELER_DID } from './const'
 
-const MAX_LABELERS = 10
 const REFRESH_SESSION = 'com.atproto.server.refreshSession'
 
 /**
@@ -284,7 +283,7 @@ export class AtpAgent {
 
     reqHeaders = {
       ...reqHeaders,
-      [labelerHeaderName]: labelerHeaders.slice(0, MAX_LABELERS).join(', '),
+      [labelerHeaderName]: labelerHeaders.join(', '),
     }
 
     return reqHeaders


### PR DESCRIPTION
Removes the enforcement of a labeler limit in the client SDK so that it's easier to tune this behavior in the future.

There are still limits which may be enforced on the server. I believe we're bumping it to 25.