### PR TITLE
Fix getActorLikes documentation to reflect auth required

### DIFF
--- a/lexicons/app/bsky/feed/getActorLikes.json
+++ b/lexicons/app/bsky/feed/getActorLikes.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Get a list of posts liked by an actor. Does not require auth.",
+      "description": "Get a list of posts liked by an actor. Requires auth, actor must be the requesting account.",
       "parameters": {
         "type": "params",
         "required": ["actor"],


### PR DESCRIPTION
You can only view your own likes and this fixes the documentation to note that auth is required and that the actor must be the requesting account

https://github.com/bluesky-social/atproto/pull/1440#issuecomment-1700193127

It looks like `getActorLikes` got marked as "Does not require auth" when it does require auth.