### PR TITLE
Social proof blocks

### DIFF
--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -36,11 +36,13 @@ import {
 } from './label'
 import {
   HydrationMap,
-  Merges,
   RecordInfo,
   ItemRef,
   didFromUri,
   urisByCollection,
+  mergeMaps,
+  mergeNestedMaps,
+  mergeManyMaps,
 } from './util'
 import {
   FeedGenAggs,
@@ -1064,25 +1066,15 @@ export const mergeStates = (
     labelerAggs: mergeMaps(stateA.labelerAggs, stateB.labelerAggs),
     labelerViewers: mergeMaps(stateA.labelerViewers, stateB.labelerViewers),
     knownFollowers: mergeMaps(stateA.knownFollowers, stateB.knownFollowers),
-    bidirectionalBlocks: mergeMaps(
+    bidirectionalBlocks: mergeNestedMaps(
       stateA.bidirectionalBlocks,
       stateB.bidirectionalBlocks,
     ),
   }
 }
 
-const mergeMaps = <M extends Merges>(mapA?: M, mapB?: M): M | undefined => {
-  if (!mapA) return mapB
-  if (!mapB) return mapA
-  return mapA.merge(mapB)
-}
-
 const mergeManyStates = (...states: HydrationState[]) => {
   return states.reduce(mergeStates, {} as HydrationState)
-}
-
-const mergeManyMaps = <T>(...maps: HydrationMap<T>[]) => {
-  return maps.reduce(mergeMaps, undefined as HydrationMap<T> | undefined)
 }
 
 const actionTakedownLabels = <T>(

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -766,10 +766,10 @@ export class Hydrator {
     const blocks = await this.graph.getBidirectionalBlocks(pairs)
     const result = new HydrationMap<HydrationMap<boolean>>()
 
-    for (const [did] of didMap) {
+    for (const [did, targetDids] of didMap) {
       const followBlocks = new HydrationMap<boolean>()
 
-      for (const followerDid of didMap.get(did)!) {
+      for (const followerDid of targetDids) {
         followBlocks.set(followerDid, blocks.isBlocked(did, followerDid))
       }
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -754,27 +754,24 @@ export class Hydrator {
   }
 
   async hydrateBidirectionalBlocks(
-    didMap: Map<string, string[]>,
+    didMap: Map<string, string[]>, // DID -> DID[]
   ): Promise<BidirectionalBlocks> {
     const pairs: RelationshipPair[] = []
-
-    for (const [target, constituents] of didMap) {
-      for (const follower of constituents) {
-        pairs.push([target, follower])
+    for (const [source, targets] of didMap) {
+      for (const target of targets) {
+        pairs.push([source, target])
       }
     }
 
-    const blocks = await this.graph.getBidirectionalBlocks(pairs)
     const result = new HydrationMap<HydrationMap<boolean>>()
+    const blocks = await this.graph.getBidirectionalBlocks(pairs)
 
-    for (const [did, targetDids] of didMap) {
+    for (const [source, targets] of didMap) {
       const didBlocks = new HydrationMap<boolean>()
-
-      for (const targetDid of targetDids) {
-        didBlocks.set(targetDid, blocks.isBlocked(did, targetDid))
+      for (const target of targets) {
+        didBlocks.set(target, blocks.isBlocked(source, target))
       }
-
-      result.set(did, didBlocks)
+      result.set(source, didBlocks)
     }
 
     return result

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -235,7 +235,7 @@ export class Hydrator {
     const [state, profileAggs, bidirectionalBlocks] = await Promise.all([
       this.hydrateProfiles(allDids, ctx),
       this.actor.getProfileAggregates(dids),
-      this.hydrationBidirectionalBlocks(followBlocksShape),
+      this.hydrateBidirectionalBlocks(followBlocksShape),
     ])
     const starterPackUriSet = new Set<string>()
     state.actors?.forEach((actor) => {
@@ -752,14 +752,14 @@ export class Hydrator {
     return { follows, followBlocks }
   }
 
-  async hydrationBidirectionalBlocks(
+  async hydrateBidirectionalBlocks(
     didMap: Map<string, string[]>,
   ): Promise<BidirectionalBlocks> {
     const pairs: RelationshipPair[] = []
 
-    for (const [uri, followers] of didMap) {
-      for (const follower of followers) {
-        pairs.push([didFromUri(uri), follower])
+    for (const [target, constituents] of didMap) {
+      for (const follower of constituents) {
+        pairs.push([target, follower])
       }
     }
 

--- a/packages/bsky/src/hydration/util.ts
+++ b/packages/bsky/src/hydration/util.ts
@@ -25,6 +25,34 @@ export type RecordInfo<T> = {
   takedownRef: string | undefined
 }
 
+export const mergeMaps = <V, M extends HydrationMap<V>>(
+  mapA?: M,
+  mapB?: M,
+): M | undefined => {
+  if (!mapA) return mapB
+  if (!mapB) return mapA
+  return mapA.merge(mapB)
+}
+
+export const mergeNestedMaps = <V, M extends HydrationMap<HydrationMap<V>>>(
+  mapA?: M,
+  mapB?: M,
+): M | undefined => {
+  if (!mapA) return mapB
+  if (!mapB) return mapA
+
+  for (const [key, map] of mapB) {
+    const merged = mergeMaps(mapA.get(key) ?? undefined, map ?? undefined)
+    mapA.set(key, merged ?? null)
+  }
+
+  return mapA
+}
+
+export const mergeManyMaps = <T>(...maps: HydrationMap<T>[]) => {
+  return maps.reduce(mergeMaps, undefined as HydrationMap<T> | undefined)
+}
+
 export type ItemRef = { uri: string; cid?: string }
 
 export const parseRecord = <T>(

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -115,7 +115,7 @@ export class Views {
     if (!baseView) return
     const knownFollowersSkeleton = state.knownFollowers?.get(did)
     const knownFollowers = knownFollowersSkeleton
-      ? this.knownFollowers(knownFollowersSkeleton, state)
+      ? this.knownFollowers(knownFollowersSkeleton, state, did)
       : undefined
     const profileAggs = state.profileAggs?.get(did)
     return {
@@ -240,9 +240,14 @@ export class Views {
   knownFollowers(
     knownFollowers: Required<HydratorProfileViewerState>['knownFollowers'],
     state: HydrationState,
+    targetDid: string,
   ) {
+    const blocks = state.bidirectionalBlocks?.get(targetDid)
     const followers = mapDefined(knownFollowers.followers, (did) => {
       if (this.viewerBlockExists(did, state)) {
+        return undefined
+      }
+      if (blocks && blocks.get(did) === true) {
         return undefined
       }
       return this.profileBasic(did, state)

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -2,7 +2,6 @@ import { AtUri, INVALID_HANDLE, normalizeDatetimeAlways } from '@atproto/syntax'
 import { mapDefined } from '@atproto/common'
 import { ImageUriBuilder } from '../image/uri'
 import { HydrationState } from '../hydration/hydrator'
-import { ProfileViewerState as HydratorProfileViewerState } from '../hydration/actor'
 import { ids } from '../lexicon/lexicons'
 import {
   ProfileViewDetailed,
@@ -113,10 +112,7 @@ export class Views {
     if (!actor) return
     const baseView = this.profile(did, state)
     if (!baseView) return
-    const knownFollowersSkeleton = state.knownFollowers?.get(did)
-    const knownFollowers = knownFollowersSkeleton
-      ? this.knownFollowers(knownFollowersSkeleton, state, did)
-      : undefined
+    const knownFollowers = this.knownFollowers(did, state)
     const profileAggs = state.profileAggs?.get(did)
     return {
       ...baseView,
@@ -221,10 +217,7 @@ export class Views {
     if (!actor) return
     const baseView = this.profile(did, state)
     if (!baseView) return
-    const knownFollowersSkeleton = state.knownFollowers?.get(did)
-    const knownFollowers = knownFollowersSkeleton
-      ? this.knownFollowers(knownFollowersSkeleton, state, did)
-      : undefined
+    const knownFollowers = this.knownFollowers(did, state)
     return {
       ...baseView,
       viewer: baseView.viewer
@@ -260,24 +253,22 @@ export class Views {
     }
   }
 
-  knownFollowers(
-    knownFollowers: Required<HydratorProfileViewerState>['knownFollowers'],
-    state: HydrationState,
-    targetDid: string,
-  ) {
-    const blocks = state.bidirectionalBlocks?.get(targetDid)
-    const followers = mapDefined(knownFollowers.followers, (did) => {
-      if (this.viewerBlockExists(did, state)) {
+  knownFollowers(did: string, state: HydrationState) {
+    const knownFollowers = state.knownFollowers?.get(did)
+    if (!knownFollowers) return
+    const blocks = state.bidirectionalBlocks?.get(did)
+    const followers = mapDefined(knownFollowers.followers, (followerDid) => {
+      if (this.viewerBlockExists(followerDid, state)) {
         return undefined
       }
-      if (blocks && blocks.get(did) === true) {
+      if (blocks?.get(followerDid) === true) {
         return undefined
       }
-      if (this.actorIsNoHosted(did, state)) {
+      if (this.actorIsNoHosted(followerDid, state)) {
         // @TODO only needed right now to work around getProfile's { includeTakedowns: true }
         return undefined
       }
-      return this.profileBasic(did, state)
+      return this.profileBasic(followerDid, state)
     })
     return { count: knownFollowers.count, followers }
   }

--- a/packages/bsky/tests/hydration/util.test.ts
+++ b/packages/bsky/tests/hydration/util.test.ts
@@ -1,0 +1,82 @@
+import {
+  HydrationMap,
+  mergeMaps,
+  mergeManyMaps,
+  mergeNestedMaps,
+} from '../../src/hydration/util'
+
+const mapToObj = (map: HydrationMap<any>) => {
+  const obj: Record<string, any> = {}
+  for (const [key, value] of map) {
+    obj[key] = value
+  }
+  return obj
+}
+
+describe('hydration util', () => {
+  it(`mergeMaps: merges two maps`, () => {
+    const compare = new HydrationMap<string>()
+    compare.set('a', 'a')
+    compare.set('b', 'b')
+
+    const a = new HydrationMap<string>().set('a', 'a')
+    const b = new HydrationMap<string>().set('b', 'b')
+    const merged = mergeMaps(a, b)
+
+    expect(mapToObj(merged!)).toEqual(mapToObj(compare))
+  })
+
+  it(`mergeManyMaps: merges three maps`, () => {
+    const compare = new HydrationMap<string>()
+    compare.set('a', 'a')
+    compare.set('b', 'b')
+    compare.set('c', 'c')
+
+    const a = new HydrationMap<string>().set('a', 'a')
+    const b = new HydrationMap<string>().set('b', 'b')
+    const c = new HydrationMap<string>().set('c', 'c')
+    const merged = mergeManyMaps(a, b, c)
+
+    expect(mapToObj(merged!)).toEqual(mapToObj(compare))
+  })
+
+  it(`mergeNestedMaps: merges two nested maps`, () => {
+    const compare = new HydrationMap<HydrationMap<string>>()
+    const compareA = new HydrationMap<string>().set('a', 'a')
+    const compareB = new HydrationMap<string>().set('b', 'b')
+    compare.set('a', compareA)
+    compare.set('b', compareB)
+
+    const a = new HydrationMap<HydrationMap<string>>().set(
+      'a',
+      new HydrationMap<string>().set('a', 'a'),
+    )
+    const b = new HydrationMap<HydrationMap<string>>().set(
+      'b',
+      new HydrationMap<string>().set('b', 'b'),
+    )
+    const merged = mergeNestedMaps(a, b)
+
+    expect(mapToObj(merged!)).toEqual(mapToObj(compare))
+  })
+
+  it(`mergeNestedMaps: merges two nested maps with common keys`, () => {
+    const compare = new HydrationMap<HydrationMap<boolean>>()
+    const compareA = new HydrationMap<boolean>()
+    compareA.set('b', true)
+    compareA.set('c', true)
+    compare.set('a', compareA)
+
+    const a = new HydrationMap<HydrationMap<boolean>>().set(
+      'a',
+      new HydrationMap<boolean>().set('b', true),
+    )
+    const b = new HydrationMap<HydrationMap<boolean>>().set(
+      'a',
+      new HydrationMap<boolean>().set('c', true),
+    )
+    const merged = mergeNestedMaps(a, b)
+
+    expect(mapToObj(merged!)).toEqual(mapToObj(compare))
+  })
+})

--- a/packages/bsky/tests/seed/known-followers.ts
+++ b/packages/bsky/tests/seed/known-followers.ts
@@ -41,6 +41,17 @@ const users = {
   sp_block_sub: createUser('sp-block-sub'),
   sp_block_res_1: createUser('sp-block-res-1'),
   sp_block_view: createUser('sp-block-view'),
+
+  /*
+   * Mix of known followers and blocks.
+   */
+  mix_sub_1: createUser('mix-sub-1'),
+  mix_sub_2: createUser('mix-sub-2'),
+  mix_sub_3: createUser('mix-sub-3'),
+  mix_res: createUser('mix-res'),
+  mix_fp_block_res: createUser('mix-fp-block-res'),
+  mix_sp_block_res: createUser('mix-sp-block-res'),
+  mix_view: createUser('mix-view'),
 }
 
 export async function knownFollowersSeed(
@@ -58,6 +69,14 @@ export async function knownFollowersSeed(
   await sc.createAccount('sp_block_res_1', users.sp_block_res_1)
   await sc.createAccount('sp_block_view', users.sp_block_view)
 
+  await sc.createAccount('mix_sub_1', users.mix_sub_1)
+  await sc.createAccount('mix_sub_2', users.mix_sub_2)
+  await sc.createAccount('mix_sub_3', users.mix_sub_3)
+  await sc.createAccount('mix_res', users.mix_res)
+  await sc.createAccount('mix_fp_block_res', users.mix_fp_block_res)
+  await sc.createAccount('mix_sp_block_res', users.mix_sp_block_res)
+  await sc.createAccount('mix_view', users.mix_view)
+
   const dids = sc.dids
 
   await sc.follow(dids.base_res_1, dids.base_sub)
@@ -68,6 +87,19 @@ export async function knownFollowersSeed(
 
   await sc.follow(dids.sp_block_res_1, dids.sp_block_sub)
   await sc.follow(dids.sp_block_view, dids.sp_block_res_1)
+
+  await sc.follow(dids.mix_res, dids.mix_sub_1)
+  await sc.follow(dids.mix_res, dids.mix_sub_2)
+  await sc.follow(dids.mix_res, dids.mix_sub_3)
+  await sc.follow(dids.mix_fp_block_res, dids.mix_sub_1)
+  await sc.follow(dids.mix_fp_block_res, dids.mix_sub_2)
+  await sc.follow(dids.mix_fp_block_res, dids.mix_sub_3)
+  await sc.follow(dids.mix_sp_block_res, dids.mix_sub_1)
+  await sc.follow(dids.mix_sp_block_res, dids.mix_sub_2)
+  await sc.follow(dids.mix_sp_block_res, dids.mix_sub_3)
+  await sc.follow(dids.mix_view, dids.mix_res)
+  await sc.follow(dids.mix_view, dids.mix_fp_block_res)
+  await sc.follow(dids.mix_view, dids.mix_sp_block_res)
 
   await sc.network.processAll()
 

--- a/packages/bsky/tests/seed/known-followers.ts
+++ b/packages/bsky/tests/seed/known-followers.ts
@@ -1,0 +1,78 @@
+import { TestNetwork, SeedClient, TestNetworkNoAppView } from '@atproto/dev-env'
+
+export type User = {
+  email: string
+  handle: string
+  password: string
+  displayName: string
+  description: string
+  selfLabels: undefined
+}
+
+function createUser(name: string): User {
+  return {
+    email: `${name}@test.com`,
+    handle: `${name}.test`,
+    password: `${name}-pass`,
+    displayName: name,
+    description: `hi im ${name} label_me`,
+    selfLabels: undefined,
+  }
+}
+
+const users = {
+  /*
+   * Base test. One known follower.
+   */
+  base_sub: createUser('base-sub'),
+  base_res_1: createUser('base-res-1'),
+  base_view: createUser('base-view'),
+
+  /*
+   * First-part block of a single known follower.
+   */
+  fp_block_sub: createUser('fp-block-sub'),
+  fp_block_res_1: createUser('fp-block-res-1'),
+  fp_block_view: createUser('fp-block-view'),
+
+  /*
+   * Second-party block of a single known follower.
+   */
+  sp_block_sub: createUser('sp-block-sub'),
+  sp_block_res_1: createUser('sp-block-res-1'),
+  sp_block_view: createUser('sp-block-view'),
+}
+
+export async function knownFollowersSeed(
+  sc: SeedClient<TestNetwork | TestNetworkNoAppView>,
+) {
+  await sc.createAccount('base_sub', users.base_sub)
+  await sc.createAccount('base_res_1', users.base_res_1)
+  await sc.createAccount('base_view', users.base_view)
+
+  await sc.createAccount('fp_block_sub', users.fp_block_sub)
+  await sc.createAccount('fp_block_res_1', users.fp_block_res_1)
+  await sc.createAccount('fp_block_view', users.fp_block_view)
+
+  await sc.createAccount('sp_block_sub', users.sp_block_sub)
+  await sc.createAccount('sp_block_res_1', users.sp_block_res_1)
+  await sc.createAccount('sp_block_view', users.sp_block_view)
+
+  const dids = sc.dids
+
+  await sc.follow(dids.base_res_1, dids.base_sub)
+  await sc.follow(dids.base_view, dids.base_res_1)
+
+  await sc.follow(dids.fp_block_res_1, dids.fp_block_sub)
+  await sc.follow(dids.fp_block_view, dids.fp_block_res_1)
+
+  await sc.follow(dids.sp_block_res_1, dids.sp_block_sub)
+  await sc.follow(dids.sp_block_view, dids.sp_block_res_1)
+
+  await sc.network.processAll()
+
+  return {
+    users,
+    seedClient: sc,
+  }
+}

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -598,7 +598,7 @@ describe('pds views with blocking', () => {
     expect(combined).toEqual(full.data.blocks)
   })
 
-  it('returns knownFollowers with 1st-order blocks filtered', async () => {
+  it('returns knownFollowers with blocks filtered', async () => {
     const carolForAlice = await agent.api.app.bsky.actor.getProfile(
       { actor: bob },
       { headers: await network.serviceHeaders(alice) },
@@ -607,38 +607,5 @@ describe('pds views with blocking', () => {
     const knownFollowers = carolForAlice.data.viewer?.knownFollowers
     expect(knownFollowers?.count).toBe(1)
     expect(knownFollowers?.followers).toHaveLength(0)
-  })
-
-  it('returns knownFollowers with 2nd-order blocks filtered', async () => {
-    await sc.follow(carol, dan)
-    await sc.follow(dan, carol)
-    danBlockCarol = await pdsAgent.api.app.bsky.graph.block.create(
-      { repo: dan },
-      { createdAt: new Date().toISOString(), subject: carol },
-      sc.getHeaders(dan),
-    )
-    await network.processAll()
-
-    const result = await agent.api.app.bsky.actor.getProfile(
-      { actor: carol },
-      { headers: await network.serviceHeaders(alice) },
-    )
-
-    const knownFollowers = result.data.viewer?.knownFollowers
-    expect(knownFollowers?.count).toBe(2)
-    expect(knownFollowers?.followers).toHaveLength(1)
-  })
-
-  it('returns knownFollowers with 2nd-order blocks filtered from getProfiles', async () => {
-    const result = await agent.api.app.bsky.actor.getProfiles(
-      { actors: [carol] },
-      { headers: await network.serviceHeaders(alice) },
-    )
-
-    expect(result.data.profiles).toHaveLength(1)
-    const profile = result.data.profiles[0]
-    const knownFollowers = profile.viewer?.knownFollowers
-    expect(knownFollowers?.count).toBe(2)
-    expect(knownFollowers?.followers).toHaveLength(1)
   })
 })

--- a/packages/bsky/tests/views/known-followers.test.ts
+++ b/packages/bsky/tests/views/known-followers.test.ts
@@ -1,0 +1,110 @@
+import { TestNetwork, SeedClient, basicSeed } from '@atproto/dev-env'
+import AtpAgent from '@atproto/api'
+
+describe('known followers aka social proof', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let pdsAgent: AtpAgent
+  let sc: SeedClient
+
+  let alice: string
+  let bob: string
+  let carol: string
+  let dan: string
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_block',
+    })
+    agent = network.bsky.getClient()
+    pdsAgent = network.pds.getClient()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+    alice = sc.dids.alice
+    bob = sc.dids.bob
+    carol = sc.dids.carol
+    dan = sc.dids.dan
+    // add follows to ensure blocks work even w follows
+    await sc.follow(carol, dan)
+    await sc.follow(dan, carol)
+    // dan blocks carol
+    await pdsAgent.api.app.bsky.graph.block.create(
+      { repo: dan },
+      { createdAt: new Date().toISOString(), subject: carol },
+      sc.getHeaders(dan),
+    )
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('does not return knownFollowers for basic profile views', async () => {
+    const { data } = await agent.api.app.bsky.graph.getFollows(
+      { actor: carol },
+      { headers: await network.serviceHeaders(alice) },
+    )
+    const follow = data.follows[0]
+
+    expect(follow.viewer?.knownFollowers).toBeFalsy()
+  })
+
+  it('returns knownFollowers viewer data', async () => {
+    const { data } = await agent.api.app.bsky.actor.getProfile(
+      { actor: bob },
+      { headers: await network.serviceHeaders(alice) },
+    )
+
+    const knownFollowers = data.viewer?.knownFollowers
+    expect(knownFollowers?.count).toBe(1)
+    expect(knownFollowers?.followers).toHaveLength(1)
+    expect(knownFollowers?.followers[0].handle).toBe('dan.test')
+  })
+
+  it('getKnownFollowers works', async () => {
+    const { data } = await agent.api.app.bsky.graph.getKnownFollowers(
+      { actor: bob },
+      { headers: await network.serviceHeaders(alice) },
+    )
+
+    expect(data.subject.did).toBe(bob)
+    expect(data.followers.length).toBe(1)
+    expect(data.followers[0].handle).toBe('dan.test')
+  })
+
+  it('returns knownFollowers with 1st-order blocks filtered', async () => {
+    const { data } = await agent.api.app.bsky.actor.getProfile(
+      { actor: alice },
+      { headers: await network.serviceHeaders(dan) },
+    )
+
+    const knownFollowers = data.viewer?.knownFollowers
+    expect(knownFollowers?.count).toBe(2)
+    expect(knownFollowers?.followers).toHaveLength(1)
+  })
+
+  it('returns knownFollowers with 2nd-order blocks filtered', async () => {
+    const result = await agent.api.app.bsky.actor.getProfile(
+      { actor: carol },
+      { headers: await network.serviceHeaders(alice) },
+    )
+
+    const knownFollowers = result.data.viewer?.knownFollowers
+    expect(knownFollowers?.count).toBe(2)
+    expect(knownFollowers?.followers).toHaveLength(1)
+  })
+
+  it('returns knownFollowers with 2nd-order blocks filtered from getProfiles', async () => {
+    const result = await agent.api.app.bsky.actor.getProfiles(
+      { actors: [carol] },
+      { headers: await network.serviceHeaders(alice) },
+    )
+
+    expect(result.data.profiles).toHaveLength(1)
+    const profile = result.data.profiles[0]
+    const knownFollowers = profile.viewer?.knownFollowers
+    expect(knownFollowers?.count).toBe(2)
+    expect(knownFollowers?.followers).toHaveLength(1)
+  })
+})

--- a/packages/bsky/tests/views/known-followers.test.ts
+++ b/packages/bsky/tests/views/known-followers.test.ts
@@ -20,23 +20,30 @@ describe('known followers (social proof)', () => {
     seedClient = network.getSeedClient()
 
     await knownFollowersSeed(seedClient)
+
     dids = seedClient.dids
 
-    // first-party block — fp_block_view blocks fp_block_res_1
+    /*
+     * First-party block
+     */
     await pdsAgent.api.app.bsky.graph.block.create(
       { repo: dids.fp_block_view },
       { createdAt: new Date().toISOString(), subject: dids.fp_block_res_1 },
       seedClient.getHeaders(dids.fp_block_view),
     )
 
-    // second-party block — sp_block_sub blocks sp_block_res_1
+    /*
+     * Second-party block
+     */
     await pdsAgent.api.app.bsky.graph.block.create(
       { repo: dids.sp_block_sub },
       { createdAt: new Date().toISOString(), subject: dids.sp_block_res_1 },
       seedClient.getHeaders(dids.sp_block_sub),
     )
 
-    // mix of blocks and non
+    /*
+     * Mix of blocks and non
+     */
     await pdsAgent.api.app.bsky.graph.block.create(
       { repo: dids.mix_view },
       { createdAt: new Date().toISOString(), subject: dids.mix_fp_block_res },

--- a/packages/bsky/tests/views/profile.test.ts
+++ b/packages/bsky/tests/views/profile.test.ts
@@ -14,7 +14,6 @@ describe('pds profile views', () => {
   let alice: string
   let bob: string
   let dan: string
-  let carol: string
 
   beforeAll(async () => {
     network = await TestNetwork.create({
@@ -28,7 +27,6 @@ describe('pds profile views', () => {
     alice = sc.dids.alice
     bob = sc.dids.bob
     dan = sc.dids.dan
-    carol = sc.dids.carol
   })
 
   afterAll(async () => {
@@ -76,39 +74,6 @@ describe('pds profile views', () => {
     )
 
     expect(forSnapshot(danForBob.data)).toMatchSnapshot()
-  })
-
-  it('returns knownFollowers viewer data', async () => {
-    const carolForAlice = await agent.api.app.bsky.actor.getProfile(
-      { actor: carol },
-      { headers: await network.serviceHeaders(alice) },
-    )
-
-    const knownFollowers = carolForAlice.data.viewer?.knownFollowers
-    expect(knownFollowers?.count).toBe(1)
-    expect(knownFollowers?.followers).toHaveLength(1)
-    expect(knownFollowers?.followers[0].handle).toBe('bob.test')
-  })
-
-  it('does not return knownFollowers for basic profile views', async () => {
-    const { data } = await agent.api.app.bsky.graph.getFollows(
-      { actor: carol },
-      { headers: await network.serviceHeaders(alice) },
-    )
-    const follow = data.follows[0]
-
-    expect(follow.viewer?.knownFollowers).toBeFalsy()
-  })
-
-  it('getKnownFollowers works', async () => {
-    const { data } = await agent.api.app.bsky.graph.getKnownFollowers(
-      { actor: carol },
-      { headers: await network.serviceHeaders(alice) },
-    )
-
-    expect(data.subject.did).toBe(carol)
-    expect(data.followers.length).toBe(1)
-    expect(data.followers[0].handle).toBe('bob.test')
   })
 
   it('fetches multiple profiles', async () => {

--- a/packages/bsky/tests/views/profile.test.ts
+++ b/packages/bsky/tests/views/profile.test.ts
@@ -29,6 +29,13 @@ describe('pds profile views', () => {
     bob = sc.dids.bob
     dan = sc.dids.dan
     carol = sc.dids.carol
+
+    await pdsAgent.api.app.bsky.graph.block.create(
+      { repo: carol },
+      { createdAt: new Date().toISOString(), subject: bob },
+      sc.getHeaders(carol),
+    )
+    await network.processAll()
   })
 
   afterAll(async () => {

--- a/packages/bsky/tests/views/profile.test.ts
+++ b/packages/bsky/tests/views/profile.test.ts
@@ -29,13 +29,6 @@ describe('pds profile views', () => {
     bob = sc.dids.bob
     dan = sc.dids.dan
     carol = sc.dids.carol
-
-    await pdsAgent.api.app.bsky.graph.block.create(
-      { repo: carol },
-      { createdAt: new Date().toISOString(), subject: bob },
-      sc.getHeaders(carol),
-    )
-    await network.processAll()
   })
 
   afterAll(async () => {


### PR DESCRIPTION
This PR ensures that if I follow Daniel, and Daniel follows Devin, but Devin blocks Daniel, when I view Devin's profile I do not see Daniel as part of `knownFollowers`.

I also extracted some utils and added a few tests + added a new seed specifically for `knownFollowers` testing to handle these 2nd-party blocks more clearly/easily.