### PR TITLE
✨ Add ozone proxy for getLikes and getRepostedBy

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -20,9 +20,13 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getLikes({
     auth: ctx.authVerifier.standardOptional,
     handler: async ({ params, auth, req }) => {
-      const viewer = auth.credentials.iss
+      const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
       const result = await getLikes({ ...params, hydrateCtx }, ctx)
 
       return {

--- a/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
@@ -23,9 +23,13 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.getRepostedBy({
     auth: ctx.authVerifier.standardOptional,
     handler: async ({ params, auth, req }) => {
-      const viewer = auth.credentials.iss
+      const { viewer, includeTakedowns } = ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        includeTakedowns,
+      })
       const result = await getRepostedBy({ ...params, hydrateCtx }, ctx)
 
       return {

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -673,7 +673,7 @@ export class Hydrator {
   //     - list basic
   async hydrateReposts(uris: string[], ctx: HydrateCtx) {
     const [reposts, profileState] = await Promise.all([
-      this.feed.getReposts(uris),
+      this.feed.getReposts(uris, ctx.includeTakedowns),
       this.hydrateProfiles(uris.map(didFromUri), ctx),
     ])
     return mergeStates(profileState, { reposts, ctx })

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -661,7 +661,7 @@ export class Hydrator {
   //     - list basic
   async hydrateLikes(uris: string[], ctx: HydrateCtx): Promise<HydrationState> {
     const [likes, profileState] = await Promise.all([
-      this.feed.getLikes(uris),
+      this.feed.getLikes(uris, ctx.includeTakedowns),
       this.hydrateProfiles(uris.map(didFromUri), ctx),
     ])
     return mergeStates(profileState, { likes, ctx })

--- a/packages/dev-env/src/seed/basic.ts
+++ b/packages/dev-env/src/seed/basic.ts
@@ -103,6 +103,7 @@ export default async (
   await sc.like(dan, sc.posts[alice][1].ref)
   await sc.like(alice, sc.posts[carol][0].ref, createdAtMicroseconds())
   await sc.like(bob, sc.posts[carol][0].ref, createdAtTimezone())
+  await sc.block(bob, carol)
 
   const replyImg = await sc.uploadFile(
     bob,

--- a/packages/dev-env/src/seed/basic.ts
+++ b/packages/dev-env/src/seed/basic.ts
@@ -103,7 +103,6 @@ export default async (
   await sc.like(dan, sc.posts[alice][1].ref)
   await sc.like(alice, sc.posts[carol][0].ref, createdAtMicroseconds())
   await sc.like(bob, sc.posts[carol][0].ref, createdAtTimezone())
-  await sc.block(bob, carol)
 
   const replyImg = await sc.uploadFile(
     bob,

--- a/packages/ozone/src/api/proxied.ts
+++ b/packages/ozone/src/api/proxied.ts
@@ -201,4 +201,18 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+
+  server.app.bsky.feed.getLikes({
+    auth: ctx.authVerifier.moderator,
+    handler: async (request) => {
+      const res = await ctx.appviewAgent.api.app.bsky.feed.getLikes(
+        request.params,
+        await ctx.appviewAuth(),
+      )
+      return {
+        encoding: 'application/json',
+        body: res.data,
+      }
+    },
+  })
 }

--- a/packages/ozone/src/api/proxied.ts
+++ b/packages/ozone/src/api/proxied.ts
@@ -215,4 +215,18 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+
+  server.app.bsky.feed.getRepostedBy({
+    auth: ctx.authVerifier.moderator,
+    handler: async (request) => {
+      const res = await ctx.appviewAgent.api.app.bsky.feed.getRepostedBy(
+        request.params,
+        await ctx.appviewAuth(),
+      )
+      return {
+        encoding: 'application/json',
+        body: res.data,
+      }
+    },
+  })
 }


### PR DESCRIPTION
This helps mod view the likers and reposters of posts from within ozone. Especially helpful for takendown content.