### PR TITLE
Change max length of names to 64 graphemes

### DIFF
--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -8,7 +8,12 @@
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
         "cid": { "type": "string", "format": "cid" },
-        "name": { "type": "string", "maxLength": 64, "minLength": 1 },
+        "name": {
+          "type": "string",
+          "maxGraphemes": 64,
+          "maxLength": 640,
+          "minLength": 1
+        },
         "purpose": { "type": "ref", "ref": "#listPurpose" },
         "avatar": { "type": "string", "format": "uri" },
         "listItemCount": { "type": "integer", "minimum": 0 },
@@ -27,7 +32,12 @@
         "uri": { "type": "string", "format": "at-uri" },
         "cid": { "type": "string", "format": "cid" },
         "creator": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" },
-        "name": { "type": "string", "maxLength": 64, "minLength": 1 },
+        "name": {
+          "type": "string",
+          "maxGraphemes": 6,
+          "maxLength": 640,
+          "minLength": 1
+        },
         "purpose": { "type": "ref", "ref": "#listPurpose" },
         "description": {
           "type": "string",

--- a/lexicons/app/bsky/graph/list.json
+++ b/lexicons/app/bsky/graph/list.json
@@ -17,7 +17,8 @@
           },
           "name": {
             "type": "string",
-            "maxLength": 64,
+            "maxGraphemes": 64,
+            "maxLength": 640,
             "minLength": 1,
             "description": "Display name for list; can not be empty."
           },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -7839,7 +7839,8 @@ export const schemaDict = {
             },
             name: {
               type: 'string',
-              maxLength: 64,
+              maxGraphemes: 64,
+              maxLength: 640,
               minLength: 1,
               description: 'Display name for list; can not be empty.',
             },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6844,7 +6844,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 64,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {
@@ -6894,7 +6895,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 6,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -7839,7 +7839,8 @@ export const schemaDict = {
             },
             name: {
               type: 'string',
-              maxLength: 64,
+              maxGraphemes: 64,
+              maxLength: 640,
               minLength: 1,
               description: 'Display name for list; can not be empty.',
             },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6844,7 +6844,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 64,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {
@@ -6894,7 +6895,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 6,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -7839,7 +7839,8 @@ export const schemaDict = {
             },
             name: {
               type: 'string',
-              maxLength: 64,
+              maxGraphemes: 64,
+              maxLength: 640,
               minLength: 1,
               description: 'Display name for list; can not be empty.',
             },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6844,7 +6844,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 64,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {
@@ -6894,7 +6895,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 6,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -7839,7 +7839,8 @@ export const schemaDict = {
             },
             name: {
               type: 'string',
-              maxLength: 64,
+              maxGraphemes: 64,
+              maxLength: 640,
               minLength: 1,
               description: 'Display name for list; can not be empty.',
             },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6844,7 +6844,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 64,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {
@@ -6894,7 +6895,8 @@ export const schemaDict = {
           },
           name: {
             type: 'string',
-            maxLength: 64,
+            maxGraphemes: 6,
+            maxLength: 640,
             minLength: 1,
           },
           purpose: {


### PR DESCRIPTION
## Why

Something that got surfaced by starter packs is that lists currently allow only 64 _utf-8 bytes_, not 64 graphemes. This is extremely restrictive, especially for foreign languages which use non-roman alphabets. For example, just adding the world `hello` to a list name (i.e. `こんにちは`) takes up 15 bytes.

I think bumping this to what I suspect is the intended max limit should be okay, since any previously created list should already be compliant with this.
