### PR TITLE
Filter out reference lists from `getLists`

### DIFF
--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -66,7 +66,7 @@ const presentation = (
   const { listUris, cursor } = skeleton
   const lists = mapDefined(listUris, (uri) => {
     return ctx.views.list(uri, hydration)
-  })
+  }).filter((list) => list.purpose !== 'app.bsky.graph.defs#referencelist')
   return { lists, cursor }
 }
 

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -1,12 +1,13 @@
 import { mapDefined } from '@atproto/common'
 import { Server } from '../../../../lexicon'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/graph/getLists'
+import { REFERENCELIST } from '../../../../lexicon/types/app/bsky/graph/defs'
 import AppContext from '../../../../context'
 import {
   createPipeline,
   HydrationFnInput,
-  noRules,
   PresentationFnInput,
+  RulesFnInput,
   SkeletonFnInput,
 } from '../../../../pipeline'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
@@ -14,7 +15,12 @@ import { Views } from '../../../../views'
 import { clearlyBadCursor, resHeaders } from '../../../util'
 
 export default function (server: Server, ctx: AppContext) {
-  const getLists = createPipeline(skeleton, hydration, noRules, presentation)
+  const getLists = createPipeline(
+    skeleton,
+    hydration,
+    noReferenceLists,
+    presentation,
+  )
   server.app.bsky.graph.getLists({
     auth: ctx.authVerifier.optionalStandardOrRole,
     handler: async ({ params, auth, req }) => {
@@ -59,6 +65,17 @@ const hydration = async (
   return ctx.hydrator.hydrateLists(listUris, params.hydrateCtx)
 }
 
+const noReferenceLists = (
+  input: RulesFnInput<Context, Params, SkeletonState>,
+) => {
+  const { skeleton, hydration } = input
+  skeleton.listUris = skeleton.listUris.filter((uri) => {
+    const list = hydration.lists?.get(uri)
+    return list?.record.purpose !== REFERENCELIST
+  })
+  return skeleton
+}
+
 const presentation = (
   input: PresentationFnInput<Context, Params, SkeletonState>,
 ) => {
@@ -66,7 +83,7 @@ const presentation = (
   const { listUris, cursor } = skeleton
   const lists = mapDefined(listUris, (uri) => {
     return ctx.views.list(uri, hydration)
-  }).filter((list) => list.purpose !== 'app.bsky.graph.defs#referencelist')
+  })
   return { lists, cursor }
 }
 

--- a/packages/bsky/tests/views/__snapshots__/lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/lists.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bsky actor likes feed views does not include reference lists in getActorLists 1`] = `
+Array [
+  Object {
+    "cid": "cids(0)",
+    "creator": Object {
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(1)/cids(1)@jpeg",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "description": "its me!",
+      "did": "user(0)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "src": "user(0)",
+          "uri": "record(1)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(2)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "src": "user(0)",
+          "uri": "record(1)",
+          "val": "self-label-b",
+        },
+      ],
+    },
+    "description": "",
+    "descriptionFacets": Array [],
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 0,
+    "name": "cool curate list!",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(0)",
+  },
+]
+`;

--- a/packages/bsky/tests/views/lists.test.ts
+++ b/packages/bsky/tests/views/lists.test.ts
@@ -1,0 +1,62 @@
+import AtpAgent from '@atproto/api'
+import { TestNetwork, SeedClient, basicSeed } from '@atproto/dev-env'
+import { forSnapshot } from '../_util'
+
+describe('bsky actor likes feed views', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let pdsAgent: AtpAgent
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_actor_lists',
+    })
+    agent = network.bsky.getClient()
+    pdsAgent = network.pds.getClient()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('does not include reference lists in getActorLists', async () => {
+    await pdsAgent.api.app.bsky.graph.list.create(
+      {
+        repo: sc.dids.alice,
+      },
+      {
+        name: 'awesome starter pack list!',
+        description: '',
+        descriptionFacets: [],
+        avatar: undefined,
+        createdAt: new Date().toISOString(),
+        purpose: 'app.bsky.graph.defs#referencelist',
+      },
+      sc.getHeaders(sc.dids.alice),
+    )
+    await pdsAgent.api.app.bsky.graph.list.create(
+      {
+        repo: sc.dids.alice,
+      },
+      {
+        name: 'cool curate list!',
+        description: '',
+        descriptionFacets: [],
+        avatar: undefined,
+        createdAt: new Date().toISOString(),
+        purpose: 'app.bsky.graph.defs#curatelist',
+      },
+      sc.getHeaders(sc.dids.alice),
+    )
+    await network.processAll()
+    const view = await agent.api.app.bsky.graph.getLists({
+      actor: sc.dids.alice,
+    })
+    expect(view.data.lists.length).toBe(1)
+    expect(forSnapshot(view.data.lists)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
These lists are not used for anything other than little tools for starter packs. They shouldn't show up in responses for `getLists`. Our client is already filtering them out, but this will ensure other clients don't need to implement that logic themselves.