### PR TITLE
lexicons: add missing ozone Tag event type to unions

### DIFF
--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -30,7 +30,8 @@
             "#modEventUnmuteReporter",
             "#modEventEmail",
             "#modEventResolveAppeal",
-            "#modEventDivert"
+            "#modEventDivert",
+            "#modEventTag"
           ]
         },
         "subject": {
@@ -76,7 +77,8 @@
             "#modEventUnmuteReporter",
             "#modEventEmail",
             "#modEventResolveAppeal",
-            "#modEventDivert"
+            "#modEventDivert",
+            "#modEventTag"
           ]
         },
         "subject": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10114,6 +10114,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {
@@ -10177,6 +10178,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -29,6 +29,7 @@ export interface ModEventView {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | ComAtprotoAdminDefs.RepoRef
@@ -72,6 +73,7 @@ export interface ModEventViewDetail {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | RepoView

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -10114,6 +10114,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {
@@ -10177,6 +10178,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -29,6 +29,7 @@ export interface ModEventView {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | ComAtprotoAdminDefs.RepoRef
@@ -72,6 +73,7 @@ export interface ModEventViewDetail {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | RepoView

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -10114,6 +10114,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {
@@ -10177,6 +10178,7 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#modEventEmail',
               'lex:tools.ozone.moderation.defs#modEventResolveAppeal',
               'lex:tools.ozone.moderation.defs#modEventDivert',
+              'lex:tools.ozone.moderation.defs#modEventTag',
             ],
           },
           subject: {

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -29,6 +29,7 @@ export interface ModEventView {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | ComAtprotoAdminDefs.RepoRef
@@ -72,6 +73,7 @@ export interface ModEventViewDetail {
     | ModEventEmail
     | ModEventResolveAppeal
     | ModEventDivert
+    | ModEventTag
     | { $type: string; [k: string]: unknown }
   subject:
     | RepoView


### PR DESCRIPTION
A bit unfortunate that these need to be manually edited.

Might also be good to consistently sort the union lists so it is visually easier to notice differences; didn't want to bite off a larger codegen in this PR though.