### PR TITLE
Use default Statsig export

### DIFF
--- a/packages/bsky/src/feature-gates.ts
+++ b/packages/bsky/src/feature-gates.ts
@@ -1,4 +1,4 @@
-import { Statsig, StatsigUser } from 'statsig-node'
+import Statsig, { StatsigUser } from 'statsig-node'
 import { sha256Hex } from '@atproto/crypto'
 
 import { featureGatesLogger } from './logger'


### PR DESCRIPTION
We were getting errors like `Cannot read properties of undefined (reading 'initialize')`. I was able to repro this locally using `localMode` settings. When using the default export, the error went away.