### PR TITLE
Run test env with `updateSnapshot`

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -22,7 +22,7 @@
     "start": "node --enable-source-maps dist/bin.js",
     "test": "../dev-infra/with-test-redis-and-db.sh jest",
     "test:log": "tail -50 test.log | pino-pretty",
-    "test:updateSnapshot": "jest --updateSnapshot",
+    "test:updateSnapshot": "../dev-infra/with-test-redis-and-db.sh jest --updateSnapshot",
     "migration:create": "ts-node ./bin/migration-create.ts",
     "buf:gen": "buf generate ../bsync/proto && buf generate ./proto"
   },

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -25,7 +25,7 @@
     "test:sqlite": "jest",
     "test:sqlite-only": "jest --testPathIgnorePatterns /tests/proxied/*",
     "test:log": "tail -50 test.log | pino-pretty",
-    "test:updateSnapshot": "jest --updateSnapshot",
+    "test:updateSnapshot": "../dev-infra/with-test-redis-and-db.sh jest --updateSnapshot",
     "migration:create": "ts-node ./bin/migration-create.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Small thing that bothers me every time I need to do this, would be nice for the `updateSnapshot` script to run with the test env, unless there's a reason for us not to.