### PR TITLE
Fix run-dev-env-logged command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ run-dev-env: ## Run a "development environment" shell
 
 .PHONY: run-dev-env-logged
 run-dev-env-logged: ## Run a "development environment" shell (with logging)
-	LOG_ENABLED=true cd packages/dev-env; NODE_ENV=development pnpm run start | pnpm exec pino-pretty
+	cd packages/dev-env; LOG_ENABLED=true NODE_ENV=development pnpm run start | pnpm exec pino-pretty
 
 .PHONY: codegen
 codegen: ## Re-generate packages from lexicon/ files


### PR DESCRIPTION
Noticed logging wasn't actually working.

Another suggestion: add `| tee logs.txt` so they're easier to browse. Idk about y'all but my tmux setup only persists like 2k lines lol.