### PR TITLE
PDS - inspect bearer tokens

### DIFF
--- a/.changeset/curvy-jeans-dream.md
+++ b/.changeset/curvy-jeans-dream.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Inspect bearer auth token on uploadBlob

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -249,11 +249,14 @@ export class AuthVerifier {
   accessOrUserServiceAuth =
     (opts: Partial<AccessOpts> = {}) =>
     async (ctx: ReqCtx): Promise<UserServiceAuthOutput | AccessOutput> => {
-      try {
-        return await this.accessStandard(opts)(ctx)
-      } catch {
-        return await this.userServiceAuth(ctx)
+      const token = bearerTokenFromReq(ctx.req)
+      if (token) {
+        const payload = jose.decodeJwt(token)
+        if (payload['lxm']) {
+          return this.userServiceAuth(ctx)
+        }
       }
+      return this.accessStandard(opts)(ctx)
     }
 
   modService = async (ctx: ReqCtx): Promise<ModServiceOutput> => {


### PR DESCRIPTION
Inspect bearer tokens to check if they are access tokens or service auth tokens so that we can report the correct error.

We use the presence of the `lxm` claim to determine if they are service auth tokens.