### PR TITLE
Lex-cli prettier changes changeset

### DIFF
--- a/.changeset/odd-guests-repair.md
+++ b/.changeset/odd-guests-repair.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lex-cli": patch
+---
+
+Fix use of prettier.format for codegen


### PR DESCRIPTION
Adding a changeset in order to publish the updates to our use of the `prettier` package here: https://github.com/bluesky-social/atproto/pull/2393

Running into this myself while working on an example app. Most notably two issues:
- prettier is not listed as a dependency of `@atproto/lex-cli` and therefore doesn't get installed
- we're not `await`ing `prettier.format` which is causing every codegenned file to just read `[object Promise]`