### PR TITLE
Add quote gate props to postgate

### DIFF
--- a/lexicons/app/bsky/feed/postgate.json
+++ b/lexicons/app/bsky/feed/postgate.json
@@ -25,12 +25,17 @@
             },
             "description": "List of detached quote post URIs."
           },
-          "quotePostRules": {
+          "quotepostRules": {
             "type": "array",
             "maxLength": 5,
             "items": {
               "type": "union",
-              "refs": ["#disableRule", "#mentionRule", "#followingRule", "#listRule"]
+              "refs": [
+                "#disableRule",
+                "#mentionRule",
+                "#followingRule",
+                "#listRule"
+              ]
             }
           }
         }

--- a/lexicons/app/bsky/feed/postgate.json
+++ b/lexicons/app/bsky/feed/postgate.json
@@ -39,29 +39,29 @@
             }
           }
         }
-      },
-      "disableRule": {
-        "type": "object",
-        "description": "Disable quoteposts entirely.",
-        "properties": {}
-      },
-      "mentionRule": {
-        "type": "object",
-        "description": "Allow quoteposts from actors mentioned in your post.",
-        "properties": {}
-      },
-      "followingRule": {
-        "type": "object",
-        "description": "Allow quoteposts from actors you follow.",
-        "properties": {}
-      },
-      "listRule": {
-        "type": "object",
-        "description": "Allow quoteposts from actors on a list.",
-        "required": ["list"],
-        "properties": {
-          "list": { "type": "string", "format": "at-uri" }
-        }
+      }
+    },
+    "disableRule": {
+      "type": "object",
+      "description": "Disable quoteposts entirely.",
+      "properties": {}
+    },
+    "mentionRule": {
+      "type": "object",
+      "description": "Allow quoteposts from actors mentioned in your post.",
+      "properties": {}
+    },
+    "followingRule": {
+      "type": "object",
+      "description": "Allow quoteposts from actors you follow.",
+      "properties": {}
+    },
+    "listRule": {
+      "type": "object",
+      "description": "Allow quoteposts from actors on a list.",
+      "required": ["list"],
+      "properties": {
+        "list": { "type": "string", "format": "at-uri" }
       }
     }
   }

--- a/lexicons/app/bsky/feed/postgate.json
+++ b/lexicons/app/bsky/feed/postgate.json
@@ -24,7 +24,38 @@
               "format": "at-uri"
             },
             "description": "List of detached quote post URIs."
+          },
+          "quotePostRules": {
+            "type": "array",
+            "maxLength": 5,
+            "items": {
+              "type": "union",
+              "refs": ["#disableRule", "#mentionRule", "#followingRule", "#listRule"]
+            }
           }
+        }
+      },
+      "disableRule": {
+        "type": "object",
+        "description": "Disable quoteposts entirely.",
+        "properties": {}
+      },
+      "mentionRule": {
+        "type": "object",
+        "description": "Allow quoteposts from actors mentioned in your post.",
+        "properties": {}
+      },
+      "followingRule": {
+        "type": "object",
+        "description": "Allow quoteposts from actors you follow.",
+        "properties": {}
+      },
+      "listRule": {
+        "type": "object",
+        "description": "Allow quoteposts from actors on a list.",
+        "required": ["list"],
+        "properties": {
+          "list": { "type": "string", "format": "at-uri" }
         }
       }
     }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6624,6 +6624,45 @@ export const schemaDict = {
               },
               description: 'List of detached quote post URIs.',
             },
+            quotepostRules: {
+              type: 'array',
+              maxLength: 5,
+              items: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.postgate#disableRule',
+                  'lex:app.bsky.feed.postgate#mentionRule',
+                  'lex:app.bsky.feed.postgate#followingRule',
+                  'lex:app.bsky.feed.postgate#listRule',
+                ],
+              },
+            },
+          },
+        },
+      },
+      disableRule: {
+        type: 'object',
+        description: 'Disable quoteposts entirely.',
+        properties: {},
+      },
+      mentionRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors mentioned in your post.',
+        properties: {},
+      },
+      followingRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors you follow.',
+        properties: {},
+      },
+      listRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors on a list.',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/feed/postgate.ts
+++ b/packages/api/src/client/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,13 @@ export interface Record {
   post: string
   /** List of detached quote post URIs. */
   detachedQuotes?: string[]
+  quotepostRules?: (
+    | DisableRule
+    | MentionRule
+    | FollowingRule
+    | ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
   [k: string]: unknown
 }
 
@@ -26,4 +33,73 @@ export function isRecord(v: unknown): v is Record {
 
 export function validateRecord(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.postgate#main', v)
+}
+
+/** Disable quoteposts entirely. */
+export interface DisableRule {
+  [k: string]: unknown
+}
+
+export function isDisableRule(v: unknown): v is DisableRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#disableRule'
+  )
+}
+
+export function validateDisableRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#disableRule', v)
+}
+
+/** Allow quoteposts from actors mentioned in your post. */
+export interface MentionRule {
+  [k: string]: unknown
+}
+
+export function isMentionRule(v: unknown): v is MentionRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#mentionRule'
+  )
+}
+
+export function validateMentionRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#mentionRule', v)
+}
+
+/** Allow quoteposts from actors you follow. */
+export interface FollowingRule {
+  [k: string]: unknown
+}
+
+export function isFollowingRule(v: unknown): v is FollowingRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#followingRule'
+  )
+}
+
+export function validateFollowingRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#followingRule', v)
+}
+
+/** Allow quoteposts from actors on a list. */
+export interface ListRule {
+  list: string
+  [k: string]: unknown
+}
+
+export function isListRule(v: unknown): v is ListRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#listRule'
+  )
+}
+
+export function validateListRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#listRule', v)
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6624,6 +6624,45 @@ export const schemaDict = {
               },
               description: 'List of detached quote post URIs.',
             },
+            quotepostRules: {
+              type: 'array',
+              maxLength: 5,
+              items: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.postgate#disableRule',
+                  'lex:app.bsky.feed.postgate#mentionRule',
+                  'lex:app.bsky.feed.postgate#followingRule',
+                  'lex:app.bsky.feed.postgate#listRule',
+                ],
+              },
+            },
+          },
+        },
+      },
+      disableRule: {
+        type: 'object',
+        description: 'Disable quoteposts entirely.',
+        properties: {},
+      },
+      mentionRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors mentioned in your post.',
+        properties: {},
+      },
+      followingRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors you follow.',
+        properties: {},
+      },
+      listRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors on a list.',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,13 @@ export interface Record {
   post: string
   /** List of detached quote post URIs. */
   detachedQuotes?: string[]
+  quotepostRules?: (
+    | DisableRule
+    | MentionRule
+    | FollowingRule
+    | ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
   [k: string]: unknown
 }
 
@@ -26,4 +33,73 @@ export function isRecord(v: unknown): v is Record {
 
 export function validateRecord(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.postgate#main', v)
+}
+
+/** Disable quoteposts entirely. */
+export interface DisableRule {
+  [k: string]: unknown
+}
+
+export function isDisableRule(v: unknown): v is DisableRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#disableRule'
+  )
+}
+
+export function validateDisableRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#disableRule', v)
+}
+
+/** Allow quoteposts from actors mentioned in your post. */
+export interface MentionRule {
+  [k: string]: unknown
+}
+
+export function isMentionRule(v: unknown): v is MentionRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#mentionRule'
+  )
+}
+
+export function validateMentionRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#mentionRule', v)
+}
+
+/** Allow quoteposts from actors you follow. */
+export interface FollowingRule {
+  [k: string]: unknown
+}
+
+export function isFollowingRule(v: unknown): v is FollowingRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#followingRule'
+  )
+}
+
+export function validateFollowingRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#followingRule', v)
+}
+
+/** Allow quoteposts from actors on a list. */
+export interface ListRule {
+  list: string
+  [k: string]: unknown
+}
+
+export function isListRule(v: unknown): v is ListRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#listRule'
+  )
+}
+
+export function validateListRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#listRule', v)
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6624,6 +6624,45 @@ export const schemaDict = {
               },
               description: 'List of detached quote post URIs.',
             },
+            quotepostRules: {
+              type: 'array',
+              maxLength: 5,
+              items: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.postgate#disableRule',
+                  'lex:app.bsky.feed.postgate#mentionRule',
+                  'lex:app.bsky.feed.postgate#followingRule',
+                  'lex:app.bsky.feed.postgate#listRule',
+                ],
+              },
+            },
+          },
+        },
+      },
+      disableRule: {
+        type: 'object',
+        description: 'Disable quoteposts entirely.',
+        properties: {},
+      },
+      mentionRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors mentioned in your post.',
+        properties: {},
+      },
+      followingRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors you follow.',
+        properties: {},
+      },
+      listRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors on a list.',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,13 @@ export interface Record {
   post: string
   /** List of detached quote post URIs. */
   detachedQuotes?: string[]
+  quotepostRules?: (
+    | DisableRule
+    | MentionRule
+    | FollowingRule
+    | ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
   [k: string]: unknown
 }
 
@@ -26,4 +33,73 @@ export function isRecord(v: unknown): v is Record {
 
 export function validateRecord(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.postgate#main', v)
+}
+
+/** Disable quoteposts entirely. */
+export interface DisableRule {
+  [k: string]: unknown
+}
+
+export function isDisableRule(v: unknown): v is DisableRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#disableRule'
+  )
+}
+
+export function validateDisableRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#disableRule', v)
+}
+
+/** Allow quoteposts from actors mentioned in your post. */
+export interface MentionRule {
+  [k: string]: unknown
+}
+
+export function isMentionRule(v: unknown): v is MentionRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#mentionRule'
+  )
+}
+
+export function validateMentionRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#mentionRule', v)
+}
+
+/** Allow quoteposts from actors you follow. */
+export interface FollowingRule {
+  [k: string]: unknown
+}
+
+export function isFollowingRule(v: unknown): v is FollowingRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#followingRule'
+  )
+}
+
+export function validateFollowingRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#followingRule', v)
+}
+
+/** Allow quoteposts from actors on a list. */
+export interface ListRule {
+  list: string
+  [k: string]: unknown
+}
+
+export function isListRule(v: unknown): v is ListRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#listRule'
+  )
+}
+
+export function validateListRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#listRule', v)
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6624,6 +6624,45 @@ export const schemaDict = {
               },
               description: 'List of detached quote post URIs.',
             },
+            quotepostRules: {
+              type: 'array',
+              maxLength: 5,
+              items: {
+                type: 'union',
+                refs: [
+                  'lex:app.bsky.feed.postgate#disableRule',
+                  'lex:app.bsky.feed.postgate#mentionRule',
+                  'lex:app.bsky.feed.postgate#followingRule',
+                  'lex:app.bsky.feed.postgate#listRule',
+                ],
+              },
+            },
+          },
+        },
+      },
+      disableRule: {
+        type: 'object',
+        description: 'Disable quoteposts entirely.',
+        properties: {},
+      },
+      mentionRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors mentioned in your post.',
+        properties: {},
+      },
+      followingRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors you follow.',
+        properties: {},
+      },
+      listRule: {
+        type: 'object',
+        description: 'Allow quoteposts from actors on a list.',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'string',
+            format: 'at-uri',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,13 @@ export interface Record {
   post: string
   /** List of detached quote post URIs. */
   detachedQuotes?: string[]
+  quotepostRules?: (
+    | DisableRule
+    | MentionRule
+    | FollowingRule
+    | ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
   [k: string]: unknown
 }
 
@@ -26,4 +33,73 @@ export function isRecord(v: unknown): v is Record {
 
 export function validateRecord(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.feed.postgate#main', v)
+}
+
+/** Disable quoteposts entirely. */
+export interface DisableRule {
+  [k: string]: unknown
+}
+
+export function isDisableRule(v: unknown): v is DisableRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#disableRule'
+  )
+}
+
+export function validateDisableRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#disableRule', v)
+}
+
+/** Allow quoteposts from actors mentioned in your post. */
+export interface MentionRule {
+  [k: string]: unknown
+}
+
+export function isMentionRule(v: unknown): v is MentionRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#mentionRule'
+  )
+}
+
+export function validateMentionRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#mentionRule', v)
+}
+
+/** Allow quoteposts from actors you follow. */
+export interface FollowingRule {
+  [k: string]: unknown
+}
+
+export function isFollowingRule(v: unknown): v is FollowingRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#followingRule'
+  )
+}
+
+export function validateFollowingRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#followingRule', v)
+}
+
+/** Allow quoteposts from actors on a list. */
+export interface ListRule {
+  list: string
+  [k: string]: unknown
+}
+
+export function isListRule(v: unknown): v is ListRule {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.feed.postgate#listRule'
+  )
+}
+
+export function validateListRule(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.feed.postgate#listRule', v)
 }


### PR DESCRIPTION
Adds `quotePostRules[]` array to the `postgate` record. It re-uses the rulesets and naming conventions from `threadgate`. Absence of the `quotePostRules` array denotes the default state where everyone is allowed QP the post.

It also adds an additional rule called `disableRule` so that the disabled state is explicit, as opposed to inferred via an empty `allow` array on `threadgate` records. This makes it easier to maintain this record, now that they contain multiple properties managed separately.