### PR TITLE
Add autoplay to preferences

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -170,7 +170,8 @@
           "#mutedWordsPref",
           "#hiddenPostsPref",
           "#bskyAppStatePref",
-          "#labelersPref"
+          "#labelersPref",
+          "#autoplayPref"
         ]
       }
     },
@@ -428,6 +429,13 @@
       "required": ["guide"],
       "properties": {
         "guide": { "type": "string", "maxLength": 100 }
+      }
+    },
+    "autoplayPref": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean", "default": true }
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4186,6 +4186,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#autoplayPref',
           ],
         },
       },
@@ -4473,6 +4474,16 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      autoplayPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+            default: true,
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -186,6 +186,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | AutoplayPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -500,4 +501,21 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+export interface AutoplayPref {
+  enabled: boolean
+  [k: string]: unknown
+}
+
+export function isAutoplayPref(v: unknown): v is AutoplayPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#autoplayPref'
+  )
+}
+
+export function validateAutoplayPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#autoplayPref', v)
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4186,6 +4186,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#autoplayPref',
           ],
         },
       },
@@ -4473,6 +4474,16 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      autoplayPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+            default: true,
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -186,6 +186,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | AutoplayPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -500,4 +501,21 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+export interface AutoplayPref {
+  enabled: boolean
+  [k: string]: unknown
+}
+
+export function isAutoplayPref(v: unknown): v is AutoplayPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#autoplayPref'
+  )
+}
+
+export function validateAutoplayPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#autoplayPref', v)
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4186,6 +4186,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#autoplayPref',
           ],
         },
       },
@@ -4473,6 +4474,16 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      autoplayPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+            default: true,
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -186,6 +186,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | AutoplayPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -500,4 +501,21 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+export interface AutoplayPref {
+  enabled: boolean
+  [k: string]: unknown
+}
+
+export function isAutoplayPref(v: unknown): v is AutoplayPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#autoplayPref'
+  )
+}
+
+export function validateAutoplayPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#autoplayPref', v)
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4186,6 +4186,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#autoplayPref',
           ],
         },
       },
@@ -4473,6 +4474,16 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      autoplayPref: {
+        type: 'object',
+        required: ['enabled'],
+        properties: {
+          enabled: {
+            type: 'boolean',
+            default: true,
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -186,6 +186,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | AutoplayPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -500,4 +501,21 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+export interface AutoplayPref {
+  enabled: boolean
+  [k: string]: unknown
+}
+
+export function isAutoplayPref(v: unknown): v is AutoplayPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#autoplayPref'
+  )
+}
+
+export function validateAutoplayPref(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#autoplayPref', v)
 }


### PR DESCRIPTION
With video coming, we should migrate the "autoplay" local pref to the server

TO DECIDE: current behaviour defers the initial value to `prefers-reduced-motion` or equivalent. How should this factor into this?