### PR TITLE
Export `AtpAgentOptions` type from @atproto/api

### DIFF
--- a/.changeset/purple-fishes-search.md
+++ b/.changeset/purple-fishes-search.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Export AtpAgentOptions type to better support extending AtpAgent.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -24,7 +24,7 @@ export * from './mocker'
 export { LABELS, DEFAULT_LABEL_SETTINGS } from './moderation/const/labels'
 export { Agent } from './agent'
 
-export { AtpAgent } from './atp-agent'
+export { AtpAgent, type AtpAgentOptions } from './atp-agent'
 export { BskyAgent } from './bsky-agent'
 
 /** @deprecated */


### PR DESCRIPTION
This gives us proper support for extending `AtpAgent`, as described in the changelog for v0.13.0.