### PR TITLE
Provide a ponyfill for CustomEvent

### DIFF
--- a/.changeset/hot-cows-scream.md
+++ b/.changeset/hot-cows-scream.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-client": patch
+---
+
+Add CustomEvent ponyfill for enviroments that don't provide it


### PR DESCRIPTION
Node < 20 requires a runtime flag to make `CustomEvent` globally available (`--experimental-global-customevent`).

This change uses a local implementation of `CustomEvent` if a global one is not available.

The choice was made to use a local ponyfill instead of a polyfill in `oauth-client-node` for the following reasons:

- Defining a global variable can have side effects
- The ponyfill might be useful in other environments that do not have a `CustomEvent` implementation globally available.
- The footprint on the minified output is only a few bytes
