### PR TITLE
Ensure presence of DPoP related response headers

### DIFF
--- a/.changeset/giant-starfishes-fry.md
+++ b/.changeset/giant-starfishes-fry.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Expose the request context for AuthVerifier and StreamAuthVerifier as distinct types

--- a/.changeset/happy-eggs-swim.md
+++ b/.changeset/happy-eggs-swim.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Properly authenticate OAuth requests in catch all handler.

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -21,7 +21,7 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
   return async (req, res, next) => {
     try {
       const { url, aud, nsid } = await formatUrlAndAud(ctx, req)
-      const auth = await accessStandard({ req })
+      const auth = await accessStandard({ req, res })
       if (!auth.credentials.isPrivileged && PRIVILEGED_METHODS.has(nsid)) {
         throw new InvalidRequestError('Bad token method', 'InvalidToken')
       }

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -90,14 +90,22 @@ export type XRPCStreamHandler = (ctx: {
 
 export type AuthOutput = HandlerAuth | HandlerError
 
-export type AuthVerifier = (ctx: {
+export interface AuthVerifierContext {
   req: express.Request
   res: express.Response
-}) => Promise<AuthOutput> | AuthOutput
+}
 
-export type StreamAuthVerifier = (ctx: {
+export type AuthVerifier = (
+  ctx: AuthVerifierContext,
+) => Promise<AuthOutput> | AuthOutput
+
+export interface StreamAuthVerifierContext {
   req: IncomingMessage
-}) => Promise<AuthOutput> | AuthOutput
+}
+
+export type StreamAuthVerifier = (
+  ctx: StreamAuthVerifierContext,
+) => Promise<AuthOutput> | AuthOutput
 
 export type CalcKeyFn = (ctx: XRPCReqContext) => string | null
 export type CalcPointsFn = (ctx: XRPCReqContext) => number


### PR DESCRIPTION
In order to work with DPoP, the `AuthVerifier` class needs to be able to set response headers ([here](https://github.com/bluesky-social/atproto/blob/6da2fa0fa76fefed959fad02859da9c0453e1781/packages/pds/src/auth-verifier.ts#L468-L474) and [here](https://github.com/bluesky-social/atproto/blob/6da2fa0fa76fefed959fad02859da9c0453e1781/packages/pds/src/auth-verifier.ts#L501-L506)).

The current catch all handler does not provide the response object to the verifier context, preventing it from setting the headers.

This PRs ensures that the `AuthVerifier`'s `accessStandard` authentication strategy indeed receives the `res` object.