### PR TITLE
Allow for optional charset in PAR content-type header

### DIFF
--- a/packages/oauth/oauth-provider/src/lib/http/parser.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/parser.ts
@@ -38,7 +38,9 @@ export const parsers = [
   {
     name: 'urlencoded',
     test: (type: string): type is 'application/x-www-form-urlencoded' => {
-      return type === 'application/x-www-form-urlencoded'
+      return /^application\/x-www-form-urlencoded(?:;\s*charset=utf-8)?$/i.test(
+        type,
+      )
     },
     parse: (buffer: Buffer): Partial<Record<string, string>> => {
       try {


### PR DESCRIPTION
Note: I haven't actually tested this fixes things with my setup, but I'm pretty sure it will!

I'm using [oauth4webapi](https://github.com/panva/oauth4webapi) to implement atproto oauth, you can see my code for the PAR request here: https://github.com/likeandscribe/unravel/blob/b32f709d6221da03b716c19c14ce661445b9b91c/packages/frontpage/lib/auth.ts#L92

When I run this code, i receive an Error 400:

```
{"error":"invalid_request","error_description":"Unsupported content-type"}
```

oauth4webapi's `pushedAuthorizationRequest` sets a Content-Type header that can't be overwritten of `application/x-www-form-urlencoded;charset=UTF-8` (see [here](https://github.com/panva/oauth4webapi/blob/29410d8c1d420588823d72abeeeead1fe23604a6/src/index.ts#L2515)). I believe this fails the parser test in oauth-provider.

I've added a regex to allow for an optional charset on the end of the content-type

## Test plan

Not sure! I'd love some help here as setting up and deploying an entire PDS seemed quite a chore for this tiny change 😅. I couldn't see any tests for this code but happy to add them with guidance.