### PR TITLE
Fix calls from pds containing content-type but no body

### DIFF
--- a/.changeset/wild-beans-dress.md
+++ b/.changeset/wild-beans-dress.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Fix calls from pds containing content-type but no body

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - service-auth-scopes
+      - divy/fix-pds-calls-no-body
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/packages/pds/src/api/com/atproto/server/activateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/activateAccount.ts
@@ -14,7 +14,7 @@ export default function (server: Server, ctx: AppContext) {
       if (ctx.entrywayAgent) {
         await ctx.entrywayAgent.com.atproto.server.activateAccount(
           undefined,
-          authPassthru(req, true),
+          authPassthru(req),
         )
         return
       }

--- a/packages/pds/src/api/com/atproto/server/deleteSession.ts
+++ b/packages/pds/src/api/com/atproto/server/deleteSession.ts
@@ -8,7 +8,7 @@ export default function (server: Server, ctx: AppContext) {
     server.com.atproto.server.deleteSession(async (reqCtx) => {
       await entrywayAgent.com.atproto.server.deleteSession(
         undefined,
-        authPassthru(reqCtx.req, true),
+        authPassthru(reqCtx.req),
       )
     })
   } else {


### PR DESCRIPTION
These bad calls from PDS to entryway were failing within xrpc, which was catching that we were setting a content-type but not sending a body.