### PR TITLE
Remove "exp" from DPoP proofs

### DIFF
--- a/.changeset/itchy-phones-kneel.md
+++ b/.changeset/itchy-phones-kneel.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-client": patch
+---
+
+Remove "exp" from dpop proof

--- a/.changeset/warm-timers-pay.md
+++ b/.changeset/warm-timers-pay.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Do not require "exp" claim in dpop proof

--- a/packages/oauth/oauth-client/src/fetch-dpop.ts
+++ b/packages/oauth/oauth-client/src/fetch-dpop.ts
@@ -158,6 +158,7 @@ async function buildProof(
   const now = Math.floor(Date.now() / 1e3)
 
   return key.createJwt(
+    // https://datatracker.ietf.org/doc/html/rfc9449#section-4.2
     {
       alg,
       typ: 'dpop+jwt',
@@ -166,7 +167,6 @@ async function buildProof(
     {
       iss,
       iat: now,
-      exp: now + 10,
       // Any collision will cause the request to be rejected by the server. no biggie.
       jti: Math.random().toString(36).slice(2),
       htm,

--- a/packages/oauth/oauth-provider/src/dpop/dpop-manager.ts
+++ b/packages/oauth/oauth-provider/src/dpop/dpop-manager.ts
@@ -52,13 +52,12 @@ export class DpopManager {
 
     const { protectedHeader, payload } = await jwtVerify<{
       iat: number
-      exp: number
       jti: string
     }>(proof, EmbeddedJWK, {
       typ: 'dpop+jwt',
       maxTokenAge: 10,
       clockTolerance: DPOP_NONCE_MAX_AGE / 1e3,
-      requiredClaims: ['iat', 'exp', 'jti'],
+      requiredClaims: ['iat', 'jti'],
     }).catch((err) => {
       const message =
         err instanceof JOSEError
@@ -71,7 +70,10 @@ export class DpopManager {
       throw new InvalidDpopProofError('Invalid or missing jti property')
     }
 
-    if (payload.exp - payload.iat > DPOP_NONCE_MAX_AGE / 3 / 1e3) {
+    if (
+      payload.exp == null ||
+      payload.exp - payload.iat > DPOP_NONCE_MAX_AGE / 3 / 1e3
+    ) {
       throw new InvalidDpopProofError('DPoP proof validity too long')
     }
 


### PR DESCRIPTION
DPoP [spec](https://datatracker.ietf.org/doc/html/rfc9449#section-4.2) does not require an `exp` claim in the DPoP proof jwt.

fyi @bnewbold 