### PR TITLE
Remove non-standard *_endpoint_auth_method

### DIFF
--- a/.changeset/cool-moose-argue.md
+++ b/.changeset/cool-moose-argue.md
@@ -1,0 +1,6 @@
+---
+"@atproto/oauth-provider": patch
+"@atproto/oauth-client": patch
+---
+
+The non-standard `introspection_endpoint_auth_method`, and `introspection_endpoint_auth_signing_alg` client metadata properties were removed. The client's `token_endpoint_auth_method`, and `token_endpoint_auth_signing_alg` properties are now used as the only indication of how a client must authenticate at the introspection endpoint.

--- a/.changeset/eight-poems-pump.md
+++ b/.changeset/eight-poems-pump.md
@@ -1,0 +1,6 @@
+---
+"@atproto/oauth-provider": patch
+"@atproto/oauth-client": patch
+---
+
+The non-standard `revocation_endpoint_auth_method`, and `revocation_endpoint_auth_signing_alg` client metadata properties were removed. The client's `token_endpoint_auth_method`, and `token_endpoint_auth_signing_alg` properties are now used as the only indication of how a client must authenticate at the revocation endpoint.

--- a/.changeset/hungry-queens-walk.md
+++ b/.changeset/hungry-queens-walk.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-types": patch
+---
+
+Avoid code duplication in the definition of OAuthEndpointName

--- a/.changeset/modern-pears-camp.md
+++ b/.changeset/modern-pears-camp.md
@@ -1,0 +1,6 @@
+---
+"@atproto/oauth-provider": patch
+"@atproto/oauth-client": patch
+---
+
+The non-standard `pushed_authorization_request_endpoint_auth_method`, and `pushed_authorization_request_endpoint_auth_signing_alg` client metadata properties were removed. The client's `token_endpoint_auth_method`, and `token_endpoint_auth_signing_alg` properties are now used as the only indication of how a client must authenticate at the introspection endpoint.

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -206,12 +206,9 @@ export class OAuthServerAgent {
     payload: OAuthClientIdentification
   }> {
     const methodSupported =
-      this.serverMetadata[`${endpoint}_endpoint_auth_methods_supported`] ||
       this.serverMetadata[`token_endpoint_auth_methods_supported`]
 
-    const method =
-      this.clientMetadata[`${endpoint}_endpoint_auth_method`] ||
-      this.clientMetadata[`token_endpoint_auth_method`]
+    const method = this.clientMetadata[`token_endpoint_auth_method`]
 
     if (
       method === 'private_key_jwt' ||
@@ -224,12 +221,8 @@ export class OAuthServerAgent {
       try {
         const alg =
           this.serverMetadata[
-            `${endpoint}_endpoint_auth_signing_alg_values_supported`
-          ] ??
-          this.serverMetadata[
             `token_endpoint_auth_signing_alg_values_supported`
-          ] ??
-          FALLBACK_ALG
+          ] ?? FALLBACK_ALG
 
         // If jwks is defined, make sure to only sign using a key that exists in
         // the jwks. If jwks_uri is defined, we can't be sure that the key we're

--- a/packages/oauth/oauth-client/src/validate-client-metadata.ts
+++ b/packages/oauth/oauth-client/src/validate-client-metadata.ts
@@ -1,16 +1,10 @@
 import { Keyset } from '@atproto/jwk'
-import {
-  OAUTH_AUTHENTICATED_ENDPOINT_NAMES,
-  OAuthClientMetadataInput,
-} from '@atproto/oauth-types'
+import { OAuthClientMetadataInput } from '@atproto/oauth-types'
 
 import { ClientMetadata, clientMetadataSchema } from './types.js'
 
-// Improve bundle size by using concatenation
-const _ENDPOINT_AUTH_METHOD = '_endpoint_auth_method'
-const _ENDPOINT_AUTH_SIGNING_ALG = '_endpoint_auth_signing_alg'
-
-const TOKEN_ENDPOINT_AUTH_METHOD = `token${_ENDPOINT_AUTH_METHOD}`
+const TOKEN_ENDPOINT_AUTH_METHOD = `token_endpoint_auth_method`
+const TOKEN_ENDPOINT_AUTH_SIGNING_ALG = `token_endpoint_auth_signing_alg`
 
 export function validateClientMetadata(
   input: OAuthClientMetadataInput,
@@ -43,36 +37,33 @@ export function validateClientMetadata(
     throw new TypeError(`client_id must be a valid URL`, { cause })
   }
 
-  if (!metadata[TOKEN_ENDPOINT_AUTH_METHOD]) {
-    throw new TypeError(`${TOKEN_ENDPOINT_AUTH_METHOD} must be provided`)
-  }
-
-  for (const endpointName of OAUTH_AUTHENTICATED_ENDPOINT_NAMES) {
-    const method = metadata[`${endpointName}${_ENDPOINT_AUTH_METHOD}`]
-    switch (method) {
-      case undefined:
-      case 'none':
-        if (metadata[`${endpointName}${_ENDPOINT_AUTH_SIGNING_ALG}`]) {
-          throw new TypeError(
-            `${endpointName}${_ENDPOINT_AUTH_SIGNING_ALG} must not be provided`,
-          )
-        }
-        break
-      case 'private_key_jwt':
-        if (!keyset) {
-          throw new TypeError(`Keyset is required for ${method} method`)
-        }
-        if (!metadata[`${endpointName}${_ENDPOINT_AUTH_SIGNING_ALG}`]) {
-          throw new TypeError(
-            `${endpointName}${_ENDPOINT_AUTH_SIGNING_ALG} must be provided`,
-          )
-        }
-        break
-      default:
+  const method = metadata[TOKEN_ENDPOINT_AUTH_METHOD]
+  switch (method) {
+    case undefined:
+      throw new TypeError(`${TOKEN_ENDPOINT_AUTH_METHOD} must be provided`)
+    case 'none':
+      if (metadata[TOKEN_ENDPOINT_AUTH_SIGNING_ALG]) {
         throw new TypeError(
-          `Invalid "${endpointName}${_ENDPOINT_AUTH_METHOD}" value: ${method}`,
+          `${TOKEN_ENDPOINT_AUTH_SIGNING_ALG} must not be provided when ${TOKEN_ENDPOINT_AUTH_METHOD} is "${method}"`,
         )
-    }
+      }
+      break
+    case 'private_key_jwt':
+      if (!keyset?.size) {
+        throw new TypeError(
+          `A non-empty keyset must be provided when ${TOKEN_ENDPOINT_AUTH_METHOD} is "${method}"`,
+        )
+      }
+      if (!metadata[TOKEN_ENDPOINT_AUTH_SIGNING_ALG]) {
+        throw new TypeError(
+          `${TOKEN_ENDPOINT_AUTH_SIGNING_ALG} must be provided when ${TOKEN_ENDPOINT_AUTH_METHOD} is "${method}"`,
+        )
+      }
+      break
+    default:
+      throw new TypeError(
+        `Invalid "token_endpoint_auth_method" value: ${method}`,
+      )
   }
 
   return metadata

--- a/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
+++ b/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
@@ -127,28 +127,14 @@ export function buildMetadata(
     token_endpoint_auth_signing_alg_values_supported: [...VERIFY_ALGOS],
 
     revocation_endpoint: new URL('/oauth/revoke', issuer).href,
-    revocation_endpoint_auth_methods_supported: [
-      ...Client.AUTH_METHODS_SUPPORTED,
-    ],
-    revocation_endpoint_auth_signing_alg_values_supported: [...VERIFY_ALGOS],
 
     introspection_endpoint: new URL('/oauth/introspect', issuer).href,
-    introspection_endpoint_auth_methods_supported: [
-      ...Client.AUTH_METHODS_SUPPORTED,
-    ],
-    introspection_endpoint_auth_signing_alg_values_supported: [...VERIFY_ALGOS],
 
     userinfo_endpoint: new URL('/oauth/userinfo', issuer).href,
     // end_session_endpoint: new URL('/oauth/logout', issuer).href,
 
     // https://datatracker.ietf.org/doc/html/rfc9126#section-5
     pushed_authorization_request_endpoint: new URL('/oauth/par', issuer).href,
-    pushed_authorization_request_endpoint_auth_methods_supported: [
-      ...Client.AUTH_METHODS_SUPPORTED,
-    ],
-    pushed_authorization_request_endpoint_auth_signing_alg_values_supported: [
-      ...VERIFY_ALGOS,
-    ],
 
     require_pushed_authorization_requests: true,
 

--- a/packages/oauth/oauth-types/src/constants.ts
+++ b/packages/oauth/oauth-types/src/constants.ts
@@ -16,10 +16,3 @@ export const ALLOW_UNSECURE_ORIGINS = (() => {
 
 export const CLIENT_ASSERTION_TYPE_JWT_BEARER =
   'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-
-export const OAUTH_AUTHENTICATED_ENDPOINT_NAMES = [
-  'token',
-  'revocation',
-  'introspection',
-  'pushed_authorization_request',
-] as const

--- a/packages/oauth/oauth-types/src/oauth-authorization-server-metadata.ts
+++ b/packages/oauth/oauth-types/src/oauth-authorization-server-metadata.ts
@@ -44,24 +44,8 @@ export const oauthAuthorizationServerMetadataSchema = z.object({
     .optional(),
 
   revocation_endpoint: z.string().url().optional(),
-  revocation_endpoint_auth_methods_supported: z.array(z.string()).optional(),
-  revocation_endpoint_auth_signing_alg_values_supported: z
-    .array(z.string())
-    .optional(),
-
   introspection_endpoint: z.string().url().optional(),
-  introspection_endpoint_auth_methods_supported: z.array(z.string()).optional(),
-  introspection_endpoint_auth_signing_alg_values_supported: z
-    .array(z.string())
-    .optional(),
-
   pushed_authorization_request_endpoint: z.string().url().optional(),
-  pushed_authorization_request_endpoint_auth_methods_supported: z
-    .array(z.string())
-    .optional(),
-  pushed_authorization_request_endpoint_auth_signing_alg_values_supported: z
-    .array(z.string())
-    .optional(),
 
   require_pushed_authorization_requests: z.boolean().optional(),
 

--- a/packages/oauth/oauth-types/src/oauth-client-metadata.ts
+++ b/packages/oauth/oauth-types/src/oauth-client-metadata.ts
@@ -27,13 +27,6 @@ export const oauthClientMetadataSchema = z.object({
     .default('none')
     .optional(),
   token_endpoint_auth_signing_alg: z.string().optional(),
-  introspection_endpoint_auth_method: oauthEndpointAuthMethod.optional(),
-  introspection_endpoint_auth_signing_alg: z.string().optional(),
-  revocation_endpoint_auth_method: oauthEndpointAuthMethod.optional(),
-  revocation_endpoint_auth_signing_alg: z.string().optional(),
-  pushed_authorization_request_endpoint_auth_method:
-    oauthEndpointAuthMethod.optional(),
-  pushed_authorization_request_endpoint_auth_signing_alg: z.string().optional(),
   userinfo_signed_response_alg: z.string().optional(),
   userinfo_encrypted_response_alg: z.string().optional(),
   jwks_uri: z.string().url().optional(),

--- a/packages/oauth/oauth-types/src/oauth-endpoint-name.ts
+++ b/packages/oauth/oauth-types/src/oauth-endpoint-name.ts
@@ -1,5 +1,8 @@
-export type OAuthEndpointName =
-  | 'token'
-  | 'revocation'
-  | 'introspection'
-  | 'pushed_authorization_request'
+export const OAUTH_ENDPOINT_NAMES = [
+  'token',
+  'revocation',
+  'introspection',
+  'pushed_authorization_request',
+] as const
+
+export type OAuthEndpointName = (typeof OAUTH_ENDPOINT_NAMES)[number]


### PR DESCRIPTION
The use of `<name>_endpoint_auth_method` was inspired by https://github.com/panva/node-oidc-provider. This is however non-standard behavior that was removed in `node-oidc-provider`.

This PR removes that code from our oauth implementation