### PR TITLE
Return `ThreadgateView` on response from `getPostThread`

### DIFF
--- a/.changeset/plenty-turtles-shop.md
+++ b/.changeset/plenty-turtles-shop.md
@@ -1,0 +1,6 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+---
+
+Add `threadgate: ThreadgateView` to response from `getPostThread`

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -43,7 +43,8 @@
                 "app.bsky.feed.defs#notFoundPost",
                 "app.bsky.feed.defs#blockedPost"
               ]
-            }
+            },
+            "threadgate": { "type": "ref", "ref": "app.bsky.feed.defs#threadgateView" }
           }
         }
       },

--- a/lexicons/app/bsky/feed/getPostThread.json
+++ b/lexicons/app/bsky/feed/getPostThread.json
@@ -44,7 +44,10 @@
                 "app.bsky.feed.defs#blockedPost"
               ]
             },
-            "threadgate": { "type": "ref", "ref": "app.bsky.feed.defs#threadgateView" }
+            "threadgate": {
+              "type": "ref",
+              "ref": "app.bsky.feed.defs#threadgateView"
+            }
           }
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6251,6 +6251,10 @@ export const schemaDict = {
                   'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
+              threadgate: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.defs#threadgateView',
+              },
             },
           },
         },

--- a/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getPostThread.ts
@@ -25,6 +25,7 @@ export interface OutputSchema {
     | AppBskyFeedDefs.NotFoundPost
     | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
+  threadgate?: AppBskyFeedDefs.ThreadgateView
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -115,14 +115,12 @@ const presentation = (
     // @TODO technically this could be returned as a NotFoundPost based on lexicon
     throw new InvalidRequestError(`Post not found: ${params.uri}`, 'NotFound')
   }
-  let threadgate: OutputSchema['threadgate']
-  if (isThreadViewPost(thread) && isPostRecord(thread.post.record)) {
-    const rootUri = thread.post.record.reply?.root?.uri || thread.post.uri
-    threadgate = ctx.views.threadgate(
-      postUriToThreadgateUri(rootUri),
-      hydration,
-    )
-  }
+  const rootUri =
+    hydration.posts?.get(params.uri)?.record.reply?.root.uri ?? params.uri
+  const threadgate = ctx.views.threadgate(
+    postUriToThreadgateUri(rootUri),
+    hydration,
+  )
   return { thread, threadgate }
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -111,18 +111,17 @@ const presentation = (
     height: params.parentHeight,
     depth: params.depth,
   })
-
-  let rootUri: string | undefined = undefined
-  if (isThreadViewPost(thread) && isPostRecord(thread.post.record)) {
-    rootUri = thread.post.record.reply?.root?.uri || thread.post.uri
-  }
-  const threadgate = rootUri
-    ? ctx.views.threadgate(postUriToThreadgateUri(rootUri), hydration)
-    : undefined
-
   if (isNotFoundPost(thread)) {
     // @TODO technically this could be returned as a NotFoundPost based on lexicon
     throw new InvalidRequestError(`Post not found: ${params.uri}`, 'NotFound')
+  }
+  let threadgate: OutputSchema['threadgate']
+  if (isThreadViewPost(thread) && isPostRecord(thread.post.record)) {
+    const rootUri = thread.post.record.reply?.root?.uri || thread.post.uri
+    threadgate = ctx.views.threadgate(
+      postUriToThreadgateUri(rootUri),
+      hydration,
+    )
   }
   return { thread, threadgate }
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6251,6 +6251,10 @@ export const schemaDict = {
                   'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
+              threadgate: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.defs#threadgateView',
+              },
             },
           },
         },

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -26,6 +26,7 @@ export interface OutputSchema {
     | AppBskyFeedDefs.NotFoundPost
     | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
+  threadgate?: AppBskyFeedDefs.ThreadgateView
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6251,6 +6251,10 @@ export const schemaDict = {
                   'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
+              threadgate: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.defs#threadgateView',
+              },
             },
           },
         },

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -26,6 +26,7 @@ export interface OutputSchema {
     | AppBskyFeedDefs.NotFoundPost
     | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
+  threadgate?: AppBskyFeedDefs.ThreadgateView
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6251,6 +6251,10 @@ export const schemaDict = {
                   'lex:app.bsky.feed.defs#blockedPost',
                 ],
               },
+              threadgate: {
+                type: 'ref',
+                ref: 'lex:app.bsky.feed.defs#threadgateView',
+              },
             },
           },
         },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -26,6 +26,7 @@ export interface OutputSchema {
     | AppBskyFeedDefs.NotFoundPost
     | AppBskyFeedDefs.BlockedPost
     | { $type: string; [k: string]: unknown }
+  threadgate?: AppBskyFeedDefs.ThreadgateView
   [k: string]: unknown
 }
 


### PR DESCRIPTION
Adds `threadgate: ThreadgateView` on the response from `getPostThread`.

The reason for this is: we need the threadgate record on thread views in the client in order to sort replies. We can't reliably get this from the root `PostView` bc that post could have been deleted, or detached via a block. We may also not have it due to the default `height` of 80 posts.

However, when constructing a feed response, we always load the threadgate, and we have a reference to the root post of the thread on the `ReplyRef`. So this PR checks if there's a threadgate hydrated for this root post, and returns it if so.