### PR TITLE
filter posts with an embed block

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -72,7 +72,8 @@ const noBlocks = (inputs: {
 }) => {
   const { ctx, skeleton, hydration } = inputs
   skeleton.uris = skeleton.uris.filter((uri) => {
-    return !ctx.views.viewerBlockExists(uri, hydration)
+    const embedBlock = hydration.postBlocks?.get(uri)?.embed
+    return !ctx.views.viewerBlockExists(uri, hydration) && !embedBlock
   })
   return skeleton
 }

--- a/packages/bsky/tests/views/quotes.test.ts
+++ b/packages/bsky/tests/views/quotes.test.ts
@@ -106,7 +106,6 @@ describe('pds quote views', () => {
   })
 
   it('does not return post in list when the embed is blocked', async () => {
-    console.log('hi')
     await sc.block(carol, eve)
     await network.processAll()
 

--- a/packages/bsky/tests/views/quotes.test.ts
+++ b/packages/bsky/tests/views/quotes.test.ts
@@ -11,6 +11,7 @@ describe('pds quote views', () => {
   // account dids, for convenience
   let alice: string
   let bob: string
+  let carol: string
   let eve: string
 
   beforeAll(async () => {
@@ -23,6 +24,7 @@ describe('pds quote views', () => {
     await network.processAll()
     alice = sc.dids.alice
     bob = sc.dids.bob
+    carol = sc.dids.carol
     eve = sc.dids.eve
   })
 
@@ -101,5 +103,18 @@ describe('pds quote views', () => {
 
     expect(bobPost.data.posts[0].quoteCount).toEqual(0)
     expect(forSnapshot(bobPost.data)).toMatchSnapshot()
+  })
+
+  it('does not return post in list when the embed is blocked', async () => {
+    console.log('hi')
+    await sc.block(carol, eve)
+    await network.processAll()
+
+    const quotes = await agent.api.app.bsky.feed.getQuotes(
+      { uri: sc.posts[carol][1].ref.uriStr },
+      { headers: await network.serviceHeaders(bob, ids.AppBskyFeedGetQuotes) },
+    )
+
+    expect(quotes.data.posts.length).toBe(0)
   })
 })

--- a/packages/dev-env/src/seed/quotes.ts
+++ b/packages/dev-env/src/seed/quotes.ts
@@ -32,6 +32,9 @@ export default async (sc: SeedClient) => {
     sc.replies[sc.dids.bob][0].ref,
   )
 
+  const carolPost = await sc.post(sc.dids.carol, 'post')
+  await sc.post(sc.dids.eve, 'qUoTe 4', undefined, undefined, carolPost.ref)
+
   const spamPosts: Promise<any>[] = []
   for (let i = 0; i < 5; i++) {
     spamPosts.push(


### PR DESCRIPTION
## Why

Follow up to quote listing. We don't want to show quotes that are made by people the original author has blocked (i.e., where the quoted post would show up as a blocked view in the post).