### PR TITLE
Appview: fix uri used to place threadgate in getPostThread response

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getPostThread.ts
@@ -113,10 +113,14 @@ const presentation = (
   })
   if (isNotFoundPost(thread)) {
     // @TODO technically this could be returned as a NotFoundPost based on lexicon
-    throw new InvalidRequestError(`Post not found: ${params.uri}`, 'NotFound')
+    throw new InvalidRequestError(
+      `Post not found: ${skeleton.anchor}`,
+      'NotFound',
+    )
   }
   const rootUri =
-    hydration.posts?.get(params.uri)?.record.reply?.root.uri ?? params.uri
+    hydration.posts?.get(skeleton.anchor)?.record.reply?.root.uri ??
+    skeleton.anchor
   const threadgate = ctx.views.threadgate(
     postUriToThreadgateUri(rootUri),
     hydration,


### PR DESCRIPTION
The issue here was that `params.uri` is the "unresolved" thread anchor URI, which may contain a handle as the authority.  By switching to `skeleton.anchor` we use the fully resolved URI instead.