### PR TITLE
Handle empty bodies in lexicon validation

### DIFF
--- a/.changeset/afraid-mirrors-smoke.md
+++ b/.changeset/afraid-mirrors-smoke.md
@@ -1,0 +1,6 @@
+---
+"@atproto/lexicon": patch
+"@atproto/xrpc": patch
+---
+
+handle empty bodies in lexicon validation

--- a/packages/lexicon/src/validation.ts
+++ b/packages/lexicon/src/validation.ts
@@ -27,7 +27,7 @@ export function assertValidXrpcParams(
   value: unknown,
 ) {
   if (def.parameters) {
-    const res = params(lexicons, 'Params', def.parameters, value)
+    const res = params(lexicons, 'Params', def.parameters, value ?? {})
     if (!res.success) throw res.error
     return res.value
   }
@@ -40,7 +40,13 @@ export function assertValidXrpcInput(
 ) {
   if (def.input?.schema) {
     // loop: all input schema definitions
-    return assertValidOneOf(lexicons, 'Input', def.input.schema, value, true)
+    return assertValidOneOf(
+      lexicons,
+      'Input',
+      def.input.schema,
+      value ?? {},
+      true,
+    )
   }
 }
 
@@ -51,7 +57,13 @@ export function assertValidXrpcOutput(
 ) {
   if (def.output?.schema) {
     // loop: all output schema definitions
-    return assertValidOneOf(lexicons, 'Output', def.output.schema, value, true)
+    return assertValidOneOf(
+      lexicons,
+      'Output',
+      def.output.schema,
+      value ?? {},
+      true,
+    )
   }
 }
 

--- a/packages/xrpc/src/util.ts
+++ b/packages/xrpc/src/util.ts
@@ -1,5 +1,6 @@
 import {
   jsonStringToLex,
+  LexValue,
   LexXrpcProcedure,
   LexXrpcQuery,
   stringifyLex,
@@ -357,7 +358,7 @@ function iterableToReadableStream(
 export function httpResponseBodyParse(
   mimeType: string | null,
   data: ArrayBuffer | undefined,
-): any {
+): LexValue {
   try {
     if (mimeType) {
       if (mimeType.includes('application/json')) {
@@ -369,7 +370,11 @@ export function httpResponseBodyParse(
       }
     }
     if (data instanceof ArrayBuffer) {
-      return new Uint8Array(data)
+      if (data.byteLength === 0) {
+        return undefined
+      } else {
+        return new Uint8Array(data)
+      }
     }
     return data
   } catch (cause) {


### PR DESCRIPTION
There's a weird edge case in lexicon validation around a schema moving from having _no_ output schema to having an output schema with all optional properties. This is allowed in Lexicon. And it actually works with the current code but not for the reasons we expect.

The existing code will parse the body as an empty array and then treat it as an object and do lexicon checks against it as if it is the parsed JSON of the response.

Instead, we parse an empty body with no content type as `undefined`, and then in the higher level lexicon assertions (for validating output/input/params), pass instead pass the `undefined` through as an empty JSON object.