### PR TITLE
Revise repo write validation for unknown Lexicons

### DIFF
--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -18,8 +18,7 @@
             },
             "validate": {
               "type": "boolean",
-              "default": true,
-              "description": "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations."
+              "description": "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons."
             },
             "writes": {
               "type": "array",
@@ -33,6 +32,23 @@
               "type": "string",
               "description": "If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.",
               "format": "cid"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [],
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "union",
+                "refs": ["#createResult", "#updateResult", "#deleteResult"],
+                "closed": true
+              }
             }
           }
         }
@@ -72,6 +88,35 @@
         "collection": { "type": "string", "format": "nsid" },
         "rkey": { "type": "string" }
       }
+    },
+    "createResult": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "validationStatus": {
+          "type": "string",
+          "knownValues": ["valid", "unknown"]
+        }
+      }
+    },
+    "updateResult": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "validationStatus": {
+          "type": "string",
+          "knownValues": ["valid", "unknown"]
+        }
+      }
+    },
+    "deleteResult": {
+      "type": "object",
+      "required": [],
+      "properties": {}
     }
   }
 }

--- a/lexicons/com/atproto/repo/createRecord.json
+++ b/lexicons/com/atproto/repo/createRecord.json
@@ -28,8 +28,7 @@
             },
             "validate": {
               "type": "boolean",
-              "default": true,
-              "description": "Can be set to 'false' to skip Lexicon schema validation of record data."
+              "description": "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons."
             },
             "record": {
               "type": "unknown",
@@ -50,7 +49,11 @@
           "required": ["uri", "cid"],
           "properties": {
             "uri": { "type": "string", "format": "at-uri" },
-            "cid": { "type": "string", "format": "cid" }
+            "cid": { "type": "string", "format": "cid" },
+            "validationStatus": {
+              "type": "string",
+              "knownValues": ["valid", "unknown"]
+            }
           }
         }
       },

--- a/lexicons/com/atproto/repo/putRecord.json
+++ b/lexicons/com/atproto/repo/putRecord.json
@@ -29,8 +29,7 @@
             },
             "validate": {
               "type": "boolean",
-              "default": true,
-              "description": "Can be set to 'false' to skip Lexicon schema validation of record data."
+              "description": "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons."
             },
             "record": {
               "type": "unknown",
@@ -56,7 +55,11 @@
           "required": ["uri", "cid"],
           "properties": {
             "uri": { "type": "string", "format": "at-uri" },
-            "cid": { "type": "string", "format": "cid" }
+            "cid": { "type": "string", "format": "cid" },
+            "validationStatus": {
+              "type": "string",
+              "knownValues": ["valid", "unknown"]
+            }
           }
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1254,9 +1254,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               writes: {
                 type: 'array',
@@ -1275,6 +1274,27 @@ export const schemaDict = {
                 description:
                   'If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.',
                 format: 'cid',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              results: {
+                type: 'array',
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.applyWrites#createResult',
+                    'lex:com.atproto.repo.applyWrites#updateResult',
+                    'lex:com.atproto.repo.applyWrites#deleteResult',
+                  ],
+                  closed: true,
+                },
               },
             },
           },
@@ -1336,6 +1356,47 @@ export const schemaDict = {
           },
         },
       },
+      createResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      updateResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      deleteResult: {
+        type: 'object',
+        required: [],
+        properties: {},
+      },
     },
   },
   ComAtprotoRepoCreateRecord: {
@@ -1370,9 +1431,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1400,6 +1460,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },
@@ -1778,9 +1842,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1814,6 +1877,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },

--- a/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
+++ b/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
@@ -12,11 +12,16 @@ export interface QueryParams {}
 export interface InputSchema {
   /** The handle or DID of the repo (aka, current account). */
   repo: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data, for all operations. */
+  /** Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons. */
   validate?: boolean
   writes: (Create | Update | Delete)[]
   /** If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations. */
   swapCommit?: string
+  [k: string]: unknown
+}
+
+export interface OutputSchema {
+  results?: (CreateResult | UpdateResult | DeleteResult)[]
   [k: string]: unknown
 }
 
@@ -30,6 +35,7 @@ export interface CallOptions {
 export interface Response {
   success: boolean
   headers: HeadersMap
+  data: OutputSchema
 }
 
 export class InvalidSwapError extends XRPCError {
@@ -103,4 +109,58 @@ export function isDelete(v: unknown): v is Delete {
 
 export function validateDelete(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.repo.applyWrites#delete', v)
+}
+
+export interface CreateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isCreateResult(v: unknown): v is CreateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#createResult'
+  )
+}
+
+export function validateCreateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#createResult', v)
+}
+
+export interface UpdateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isUpdateResult(v: unknown): v is UpdateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#updateResult'
+  )
+}
+
+export function validateUpdateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#updateResult', v)
+}
+
+export interface DeleteResult {
+  [k: string]: unknown
+}
+
+export function isDeleteResult(v: unknown): v is DeleteResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#deleteResult'
+  )
+}
+
+export function validateDeleteResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#deleteResult', v)
 }

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -16,7 +16,7 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey?: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
   validate?: boolean
   /** The record itself. Must contain a $type field. */
   record: {}
@@ -28,6 +28,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/com/atproto/repo/putRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/putRecord.ts
@@ -16,7 +16,7 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
   validate?: boolean
   /** The record to write. */
   record: {}
@@ -30,6 +30,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -1254,9 +1254,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               writes: {
                 type: 'array',
@@ -1275,6 +1274,27 @@ export const schemaDict = {
                 description:
                   'If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.',
                 format: 'cid',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              results: {
+                type: 'array',
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.applyWrites#createResult',
+                    'lex:com.atproto.repo.applyWrites#updateResult',
+                    'lex:com.atproto.repo.applyWrites#deleteResult',
+                  ],
+                  closed: true,
+                },
               },
             },
           },
@@ -1336,6 +1356,47 @@ export const schemaDict = {
           },
         },
       },
+      createResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      updateResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      deleteResult: {
+        type: 'object',
+        required: [],
+        properties: {},
+      },
     },
   },
   ComAtprotoRepoCreateRecord: {
@@ -1370,9 +1431,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1400,6 +1460,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },
@@ -1778,9 +1842,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1814,6 +1877,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -13,11 +13,16 @@ export interface QueryParams {}
 export interface InputSchema {
   /** The handle or DID of the repo (aka, current account). */
   repo: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data, for all operations. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   writes: (Create | Update | Delete)[]
   /** If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations. */
   swapCommit?: string
+  [k: string]: unknown
+}
+
+export interface OutputSchema {
+  results?: (CreateResult | UpdateResult | DeleteResult)[]
   [k: string]: unknown
 }
 
@@ -26,13 +31,19 @@ export interface HandlerInput {
   body: InputSchema
 }
 
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
 export interface HandlerError {
   status: number
   message?: string
   error?: 'InvalidSwap'
 }
 
-export type HandlerOutput = HandlerError | void
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough
 export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   auth: HA
   params: QueryParams
@@ -101,4 +112,58 @@ export function isDelete(v: unknown): v is Delete {
 
 export function validateDelete(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.repo.applyWrites#delete', v)
+}
+
+export interface CreateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isCreateResult(v: unknown): v is CreateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#createResult'
+  )
+}
+
+export function validateCreateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#createResult', v)
+}
+
+export interface UpdateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isUpdateResult(v: unknown): v is UpdateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#updateResult'
+  )
+}
+
+export function validateUpdateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#updateResult', v)
+}
+
+export interface DeleteResult {
+  [k: string]: unknown
+}
+
+export function isDeleteResult(v: unknown): v is DeleteResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#deleteResult'
+  )
+}
+
+export function validateDeleteResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#deleteResult', v)
 }

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey?: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record itself. Must contain a $type field. */
   record: {}
   /** Compare and swap with the previous commit by CID. */
@@ -29,6 +29,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record to write. */
   record: {}
   /** Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation */
@@ -31,6 +31,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -1254,9 +1254,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               writes: {
                 type: 'array',
@@ -1275,6 +1274,27 @@ export const schemaDict = {
                 description:
                   'If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.',
                 format: 'cid',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              results: {
+                type: 'array',
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.applyWrites#createResult',
+                    'lex:com.atproto.repo.applyWrites#updateResult',
+                    'lex:com.atproto.repo.applyWrites#deleteResult',
+                  ],
+                  closed: true,
+                },
               },
             },
           },
@@ -1336,6 +1356,47 @@ export const schemaDict = {
           },
         },
       },
+      createResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      updateResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      deleteResult: {
+        type: 'object',
+        required: [],
+        properties: {},
+      },
     },
   },
   ComAtprotoRepoCreateRecord: {
@@ -1370,9 +1431,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1400,6 +1460,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },
@@ -1778,9 +1842,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1814,6 +1877,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -13,11 +13,16 @@ export interface QueryParams {}
 export interface InputSchema {
   /** The handle or DID of the repo (aka, current account). */
   repo: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data, for all operations. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   writes: (Create | Update | Delete)[]
   /** If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations. */
   swapCommit?: string
+  [k: string]: unknown
+}
+
+export interface OutputSchema {
+  results?: (CreateResult | UpdateResult | DeleteResult)[]
   [k: string]: unknown
 }
 
@@ -26,13 +31,19 @@ export interface HandlerInput {
   body: InputSchema
 }
 
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
 export interface HandlerError {
   status: number
   message?: string
   error?: 'InvalidSwap'
 }
 
-export type HandlerOutput = HandlerError | void
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough
 export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   auth: HA
   params: QueryParams
@@ -101,4 +112,58 @@ export function isDelete(v: unknown): v is Delete {
 
 export function validateDelete(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.repo.applyWrites#delete', v)
+}
+
+export interface CreateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isCreateResult(v: unknown): v is CreateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#createResult'
+  )
+}
+
+export function validateCreateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#createResult', v)
+}
+
+export interface UpdateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isUpdateResult(v: unknown): v is UpdateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#updateResult'
+  )
+}
+
+export function validateUpdateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#updateResult', v)
+}
+
+export interface DeleteResult {
+  [k: string]: unknown
+}
+
+export function isDeleteResult(v: unknown): v is DeleteResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#deleteResult'
+  )
+}
+
+export function validateDeleteResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#deleteResult', v)
 }

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey?: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record itself. Must contain a $type field. */
   record: {}
   /** Compare and swap with the previous commit by CID. */
@@ -29,6 +29,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record to write. */
   record: {}
   /** Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation */
@@ -31,6 +31,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -68,12 +68,13 @@ export default function (server: Server, ctx: AppContext) {
       const { commit, writes } = await ctx.actorStore.transact(
         did,
         async (actorTxn) => {
-          const backlinkConflicts = validate
-            ? await actorTxn.record.getBacklinkConflicts(
-                write.uri,
-                write.record,
-              )
-            : []
+          const backlinkConflicts =
+            validate !== false
+              ? await actorTxn.record.getBacklinkConflicts(
+                  write.uri,
+                  write.record,
+                )
+              : []
           const backlinkDeletions = backlinkConflicts.map((uri) =>
             prepareDelete({
               did: uri.hostname,
@@ -102,7 +103,11 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: { uri: write.uri.toString(), cid: write.cid.toString() },
+        body: {
+          uri: write.uri.toString(),
+          cid: write.cid.toString(),
+          validationStatus: write.validationStatus,
+        },
       }
     },
   })

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -130,6 +130,7 @@ export default function (server: Server, ctx: AppContext) {
         body: {
           uri: write.uri.toString(),
           cid: write.cid.toString(),
+          validationStatus: write.validationStatus,
         },
       }
     },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1254,9 +1254,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data, for all operations.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               writes: {
                 type: 'array',
@@ -1275,6 +1274,27 @@ export const schemaDict = {
                 description:
                   'If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.',
                 format: 'cid',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              results: {
+                type: 'array',
+                items: {
+                  type: 'union',
+                  refs: [
+                    'lex:com.atproto.repo.applyWrites#createResult',
+                    'lex:com.atproto.repo.applyWrites#updateResult',
+                    'lex:com.atproto.repo.applyWrites#deleteResult',
+                  ],
+                  closed: true,
+                },
               },
             },
           },
@@ -1336,6 +1356,47 @@ export const schemaDict = {
           },
         },
       },
+      createResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      updateResult: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          cid: {
+            type: 'string',
+            format: 'cid',
+          },
+          validationStatus: {
+            type: 'string',
+            knownValues: ['valid', 'unknown'],
+          },
+        },
+      },
+      deleteResult: {
+        type: 'object',
+        required: [],
+        properties: {},
+      },
     },
   },
   ComAtprotoRepoCreateRecord: {
@@ -1370,9 +1431,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1400,6 +1460,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },
@@ -1778,9 +1842,8 @@ export const schemaDict = {
               },
               validate: {
                 type: 'boolean',
-                default: true,
                 description:
-                  "Can be set to 'false' to skip Lexicon schema validation of record data.",
+                  "Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.",
               },
               record: {
                 type: 'unknown',
@@ -1814,6 +1877,10 @@ export const schemaDict = {
               cid: {
                 type: 'string',
                 format: 'cid',
+              },
+              validationStatus: {
+                type: 'string',
+                knownValues: ['valid', 'unknown'],
               },
             },
           },

--- a/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -13,11 +13,16 @@ export interface QueryParams {}
 export interface InputSchema {
   /** The handle or DID of the repo (aka, current account). */
   repo: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data, for all operations. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   writes: (Create | Update | Delete)[]
   /** If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations. */
   swapCommit?: string
+  [k: string]: unknown
+}
+
+export interface OutputSchema {
+  results?: (CreateResult | UpdateResult | DeleteResult)[]
   [k: string]: unknown
 }
 
@@ -26,13 +31,19 @@ export interface HandlerInput {
   body: InputSchema
 }
 
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
 export interface HandlerError {
   status: number
   message?: string
   error?: 'InvalidSwap'
 }
 
-export type HandlerOutput = HandlerError | void
+export type HandlerOutput = HandlerError | HandlerSuccess | HandlerPipeThrough
 export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   auth: HA
   params: QueryParams
@@ -101,4 +112,58 @@ export function isDelete(v: unknown): v is Delete {
 
 export function validateDelete(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.repo.applyWrites#delete', v)
+}
+
+export interface CreateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isCreateResult(v: unknown): v is CreateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#createResult'
+  )
+}
+
+export function validateCreateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#createResult', v)
+}
+
+export interface UpdateResult {
+  uri: string
+  cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
+  [k: string]: unknown
+}
+
+export function isUpdateResult(v: unknown): v is UpdateResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#updateResult'
+  )
+}
+
+export function validateUpdateResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#updateResult', v)
+}
+
+export interface DeleteResult {
+  [k: string]: unknown
+}
+
+export function isDeleteResult(v: unknown): v is DeleteResult {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.repo.applyWrites#deleteResult'
+  )
+}
+
+export function validateDeleteResult(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.repo.applyWrites#deleteResult', v)
 }

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey?: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record itself. Must contain a $type field. */
   record: {}
   /** Compare and swap with the previous commit by CID. */
@@ -29,6 +29,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -17,8 +17,8 @@ export interface InputSchema {
   collection: string
   /** The Record Key. */
   rkey: string
-  /** Can be set to 'false' to skip Lexicon schema validation of record data. */
-  validate: boolean
+  /** Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons. */
+  validate?: boolean
   /** The record to write. */
   record: {}
   /** Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation */
@@ -31,6 +31,7 @@ export interface InputSchema {
 export interface OutputSchema {
   uri: string
   cid: string
+  validationStatus?: 'valid' | 'unknown' | (string & {})
   [k: string]: unknown
 }
 

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -42,7 +42,7 @@ import { hasExplicitSlur } from '../handle/explicit-slurs'
 
 export const assertValidRecordWithStatus = (
   record: Record<string, unknown>,
-  requireLexicon: boolean,
+  opts: { requireLexicon: boolean },
 ): ValidationStatus => {
   if (typeof record.$type !== 'string') {
     throw new InvalidRecordError('No $type provided')
@@ -52,7 +52,7 @@ export const assertValidRecordWithStatus = (
     assertValidCreatedAt(record)
   } catch (e) {
     if (e instanceof LexiconDefNotFoundError) {
-      if (requireLexicon) {
+      if (opts.requireLexicon) {
         throw new InvalidRecordError(e.message)
       } else {
         return 'unknown'
@@ -112,9 +112,10 @@ export const prepareCreate = async (opts: {
   const record = setCollectionName(collection, opts.record, maybeValidate)
   let validationStatus: ValidationStatus
   if (maybeValidate) {
-    validationStatus = assertValidRecordWithStatus(record, validate === true)
+    validationStatus = assertValidRecordWithStatus(record, {
+      requireLexicon: validate === true,
+    })
   }
-
   const nextRkey = TID.next()
   const rkey = opts.rkey || nextRkey.toString()
   // @TODO: validate against Lexicon record 'key' type, not just overall recordkey syntax
@@ -144,7 +145,9 @@ export const prepareUpdate = async (opts: {
   const record = setCollectionName(collection, opts.record, maybeValidate)
   let validationStatus: ValidationStatus
   if (maybeValidate) {
-    validationStatus = assertValidRecordWithStatus(record, validate === true)
+    validationStatus = assertValidRecordWithStatus(record, {
+      requireLexicon: validate === true,
+    })
   }
   assertNoExplicitSlurs(rkey, record)
   return {

--- a/packages/pds/src/repo/types.ts
+++ b/packages/pds/src/repo/types.ts
@@ -3,6 +3,8 @@ import { AtUri } from '@atproto/syntax'
 import { WriteOpAction } from '@atproto/repo'
 import { RepoRecord } from '@atproto/lexicon'
 
+export type ValidationStatus = 'valid' | 'unknown' | undefined
+
 export type BlobConstraint = {
   accept?: string[]
   maxSize?: number
@@ -21,6 +23,7 @@ export type PreparedCreate = {
   swapCid?: CID | null
   record: RepoRecord
   blobs: PreparedBlobRef[]
+  validationStatus: ValidationStatus
 }
 
 export type PreparedUpdate = {
@@ -30,6 +33,7 @@ export type PreparedUpdate = {
   swapCid?: CID | null
   record: RepoRecord
   blobs: PreparedBlobRef[]
+  validationStatus: ValidationStatus
 }
 
 export type PreparedDelete = {

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -9,7 +9,6 @@ import * as Post from '../src/lexicon/types/app/bsky/feed/post'
 import { forSnapshot, paginateAll } from './_util'
 import AppContext from '../src/context'
 import { ids, lexicons } from '../src/lexicon/lexicons'
-import { text } from 'stream/consumers'
 
 describe('crud operations', () => {
   let network: TestNetworkNoAppView
@@ -580,13 +579,12 @@ describe('crud operations', () => {
 
   it('does not require the schema to be known if not explicitly validating', async () => {
     const prom = await aliceAgent.api.com.atproto.repo.createRecord({
+      // validate not set
       repo: aliceAgent.accountDid,
       collection: 'com.example.foobar',
       record: { $type: 'com.example.foobar' },
     })
-    expect(prom.data).toMatchObject({
-      validationStatus: 'unknown',
-    })
+    expect(prom.data.validationStatus).toBe('unknown')
   })
 
   it('requires the $type to match the schema', async () => {

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -6,9 +6,10 @@ import { TestNetworkNoAppView } from '@atproto/dev-env'
 import { cidForCbor, TID, ui8ToArrayBuffer } from '@atproto/common'
 import { BlobNotFoundError } from '@atproto/repo'
 import * as Post from '../src/lexicon/types/app/bsky/feed/post'
-import { paginateAll } from './_util'
+import { forSnapshot, paginateAll } from './_util'
 import AppContext from '../src/context'
 import { ids, lexicons } from '../src/lexicon/lexicons'
+import { text } from 'stream/consumers'
 
 describe('crud operations', () => {
   let network: TestNetworkNoAppView
@@ -565,8 +566,9 @@ describe('crud operations', () => {
     expect(got.data.value['$type']).toBe(uri.collection)
   })
 
-  it('requires the schema to be known if validating', async () => {
+  it('requires the schema to be known if explicitly validating', async () => {
     const prom = aliceAgent.api.com.atproto.repo.createRecord({
+      validate: true,
       repo: aliceAgent.accountDid,
       collection: 'com.example.foobar',
       record: { $type: 'com.example.foobar' },
@@ -574,6 +576,17 @@ describe('crud operations', () => {
     await expect(prom).rejects.toThrow(
       'Lexicon not found: lex:com.example.foobar',
     )
+  })
+
+  it('does not require the schema to be known if not explicitly validating', async () => {
+    const prom = await aliceAgent.api.com.atproto.repo.createRecord({
+      repo: aliceAgent.accountDid,
+      collection: 'com.example.foobar',
+      record: { $type: 'com.example.foobar' },
+    })
+    expect(prom.data).toMatchObject({
+      validationStatus: 'unknown',
+    })
   })
 
   it('requires the $type to match the schema', async () => {
@@ -637,6 +650,7 @@ describe('crud operations', () => {
   describe('unvalidated writes', () => {
     it('disallows creation of unknown lexicons when validate is set to true', async () => {
       const attempt = aliceAgent.api.com.atproto.repo.createRecord({
+        validate: true,
         repo: aliceAgent.accountDid,
         collection: 'com.example.record',
         record: {
@@ -648,50 +662,155 @@ describe('crud operations', () => {
       )
     })
 
-    it('allows creation of unknown lexicons when validate is set to false', async () => {
-      const res = await aliceAgent.api.com.atproto.repo.createRecord({
+    it('allows creation of unknown lexicons when validate is not set to true', async () => {
+      // validate: default
+      const res1 = await aliceAgent.api.com.atproto.repo.createRecord({
         repo: aliceAgent.accountDid,
         collection: 'com.example.record',
         record: {
-          blah: 'thing',
+          blah: 'thing1',
         },
-        validate: false,
       })
-      const record = await ctx.actorStore.read(aliceAgent.accountDid, (store) =>
-        store.record.getRecord(new AtUri(res.data.uri), res.data.cid),
+      expect(res1.data.validationStatus).toBe('unknown')
+      const record1 = await ctx.actorStore.read(
+        aliceAgent.accountDid,
+        (store) =>
+          store.record.getRecord(new AtUri(res1.data.uri), res1.data.cid),
       )
-      expect(record?.value).toEqual({
+      expect(record1?.value).toEqual({
         $type: 'com.example.record',
-        blah: 'thing',
+        blah: 'thing1',
+      })
+      // validate: false
+      const res2 = await aliceAgent.api.com.atproto.repo.createRecord({
+        validate: false,
+        repo: aliceAgent.accountDid,
+        collection: 'com.example.record',
+        record: {
+          blah: 'thing2',
+        },
+      })
+      expect(res2.data.validationStatus).toBeUndefined()
+      const record2 = await ctx.actorStore.read(
+        aliceAgent.accountDid,
+        (store) =>
+          store.record.getRecord(new AtUri(res2.data.uri), res2.data.cid),
+      )
+      expect(record2?.value).toEqual({
+        $type: 'com.example.record',
+        blah: 'thing2',
       })
     })
 
     it('allows update of unknown lexicons when validate is set to false', async () => {
       const createRes = await aliceAgent.api.com.atproto.repo.createRecord({
+        validate: false,
         repo: aliceAgent.accountDid,
         collection: 'com.example.record',
         record: {
           blah: 'thing',
         },
-        validate: false,
       })
       const uri = new AtUri(createRes.data.uri)
-      const updateRes = await aliceAgent.api.com.atproto.repo.putRecord({
+      // validate: default
+      const updateRes1 = await aliceAgent.api.com.atproto.repo.putRecord({
         repo: aliceAgent.accountDid,
         collection: 'com.example.record',
         rkey: uri.rkey,
         record: {
           blah: 'something else',
         },
-        validate: false,
       })
-      const record = await ctx.actorStore.read(aliceAgent.accountDid, (store) =>
-        store.record.getRecord(uri, updateRes.data.cid),
+      const record1 = await ctx.actorStore.read(
+        aliceAgent.accountDid,
+        (store) => store.record.getRecord(uri, updateRes1.data.cid),
       )
-      expect(record?.value).toEqual({
+      expect(record1?.value).toEqual({
         $type: 'com.example.record',
         blah: 'something else',
       })
+      // validate: false
+      const updateRes2 = await aliceAgent.api.com.atproto.repo.putRecord({
+        validate: false,
+        repo: aliceAgent.accountDid,
+        collection: 'com.example.record',
+        rkey: uri.rkey,
+        record: {
+          blah: 'something else',
+        },
+      })
+      const record2 = await ctx.actorStore.read(
+        aliceAgent.accountDid,
+        (store) => store.record.getRecord(uri, updateRes2.data.cid),
+      )
+      expect(record2?.value).toEqual({
+        $type: 'com.example.record',
+        blah: 'something else',
+      })
+    })
+
+    it('applyWrites returns results with validation status', async () => {
+      const existing1 = await aliceAgent.api.com.atproto.repo.createRecord({
+        validate: false,
+        repo: aliceAgent.accountDid,
+        collection: 'com.example.record',
+        record: {
+          blah: 'thing1',
+        },
+      })
+      const existing2 = await aliceAgent.api.com.atproto.repo.createRecord({
+        validate: false,
+        repo: aliceAgent.accountDid,
+        collection: 'com.example.record',
+        record: {
+          blah: 'thing2',
+        },
+      })
+      const {
+        data: { results },
+      } = await aliceAgent.com.atproto.repo.applyWrites({
+        repo: aliceAgent.accountDid,
+        writes: [
+          {
+            $type: `${ids.ComAtprotoRepoApplyWrites}#create`,
+            action: 'create',
+            collection: ids.AppBskyFeedPost,
+            value: {
+              $type: ids.AppBskyFeedPost,
+              text: '👋',
+              createdAt: new Date().toISOString(),
+            },
+          },
+          {
+            $type: `${ids.ComAtprotoRepoApplyWrites}#update`,
+            action: 'update',
+            collection: 'com.example.record',
+            rkey: new AtUri(existing1.data.uri).rkey,
+            value: {},
+          },
+          {
+            $type: `${ids.ComAtprotoRepoApplyWrites}#delete`,
+            action: 'delete',
+            collection: 'com.example.record',
+            rkey: new AtUri(existing2.data.uri).rkey,
+          },
+        ],
+      })
+      expect(forSnapshot(results)).toEqual([
+        {
+          $type: `${ids.ComAtprotoRepoApplyWrites}#createResult`,
+          cid: 'cids(0)',
+          uri: 'record(0)',
+          validationStatus: 'valid',
+        },
+        {
+          $type: `${ids.ComAtprotoRepoApplyWrites}#updateResult`,
+          cid: 'cids(1)',
+          uri: 'record(1)',
+          validationStatus: 'unknown',
+        },
+        { $type: `${ids.ComAtprotoRepoApplyWrites}#deleteResult` },
+      ])
     })
 
     it('correctly associates images with unknown record types', async () => {


### PR DESCRIPTION
To date when using `com.atproto.repo.{createRecord,putRecord,applyWrites}` to write to a repository, by the default the PDS will reject any writes into a collection with a Lexicon unknown to the PDS.  This behavior is controlled by the `validate` input.  We would like to change this behavior in order to be forward looking into a world where a PDS may have a dynamic set of Lexicons that are either resolved on the fly or otherwise loaded at runtime.

Record validation by the PDS is a driver of coherent/compatible data across the network, but network participants can't rely on all data in the network adhering to a given Lexicon: ultimately each party (e.g. an appview, feed generator, or client app) needs to validate repo records themselves.  So while validation within the PDS is very useful to nudge applications towards writing proper data, it provides no strong guarantee.  Furthermore, a PDS's access to a given Lexicon should not be a bottleneck to users' usage of apps that rely on it.  Otherwise you could easily imagine downtime of a service that serves a given Lexicon cascading into write degradation for all apps making use of it.  Since validation at the PDS provides no strong guarantee, it's not worthwhile to have such a bottleneck.

The proposal here is to a. loosen the requirement that by default the PDS must have a given Lexicon to permit writes, b. report back to the caller whether the PDS was able to perform validation.  More specifically we'll update `com.atproto.repo.{createRecord,putRecord,applyWrites}` such that:
 - the `validate` input no longer has a default (technically a breaking change for PDS implementations).  When `validate` is not set, the PDS will perform validation for any Lexicons available to it and skip validation for any Lexicons unavailable to it.
 - Responses to `createRecord` and `putRecord` include a new optional field `validationStatus` that will be set to `'valid'` if the PDS was able to validate the record and `'unknown'` otherwise.
 - The `applyWrites` method now has a response containing the a list of write results, preserving the order of the `writes` input received.