### PR TITLE
OAuth: fix client-side crash on authorize page

### DIFF
--- a/.changeset/quiet-rice-design.md
+++ b/.changeset/quiet-rice-design.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Fix client-side crash on authorize page

--- a/packages/oauth/oauth-provider/src/assets/app/components/url-viewer.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/url-viewer.tsx
@@ -1,4 +1,4 @@
-import { Component, HTMLAttributes, useMemo } from 'react'
+import { HTMLAttributes, useMemo } from 'react'
 
 export type UrlPartRenderingOptions = {
   faded?: boolean
@@ -28,7 +28,7 @@ export function UrlViewer({
   const urlObj = useMemo(() => new URL(url), [url])
 
   return (
-    <Component as={As} {...attrs}>
+    <As {...attrs}>
       {proto && (
         <UrlPartViewer
           value={`${urlObj.protocol}//`}
@@ -56,7 +56,7 @@ export function UrlViewer({
       {hash && (
         <UrlPartViewer value={urlObj.hash} {...(hash === true ? null : hash)} />
       )}
-    </Component>
+    </As>
   )
 }
 


### PR DESCRIPTION
Fixes a client-side issue when attempting to display the client id during the authorize flow.