### PR TITLE
OAuth: Enable to configure scope via query parameter for loopback client metadata

### DIFF
--- a/packages/oauth/oauth-provider/src/request/request-manager.ts
+++ b/packages/oauth/oauth-provider/src/request/request-manager.ts
@@ -119,7 +119,7 @@ export class RequestManager {
     // > server MUST include the scope response parameter in the token response
     // > (Section 3.2.3) to inform the client of the actual scope granted.
 
-    const cScopes = client.metadata.scope?.split(' ').filter(Boolean)
+    const cScopes = (client.metadata.scope || '').split(' ').filter(Boolean)
     const sScopes = this.metadata.scopes_supported
 
     const scopes = new Set(
@@ -141,8 +141,7 @@ export class RequestManager {
     }
 
     for (const scope of scopes) {
-      // Loopback clients do not define any scope in their metadata
-      if (cScopes && !cScopes.includes(scope)) {
+      if (!cScopes.includes(scope)) {
         throw new InvalidParametersError(
           parameters,
           `Scope "${scope}" is not registered for this client`,

--- a/packages/oauth/oauth-types/src/atproto-loopback-client-metadata.ts
+++ b/packages/oauth/oauth-types/src/atproto-loopback-client-metadata.ts
@@ -12,11 +12,12 @@ export function atprotoLoopbackClientMetadata(
   const { origin, pathname, searchParams } = parseOAuthClientIdUrl(clientId)
 
   for (const name of searchParams.keys()) {
-    if (name !== 'redirect_uri') {
+    if (name !== 'redirect_uri' && name !== 'scope') {
       throw new TypeError(`Invalid query parameter ${name} in client ID`)
     }
   }
   const redirectUris = searchParams.getAll('redirect_uri')
+  const scope = searchParams.get('scope')
 
   return {
     client_id: clientId,
@@ -29,6 +30,7 @@ export function atprotoLoopbackClientMetadata(
           (ip) =>
             Object.assign(new URL(pathname, origin), { hostname: ip }).href,
         )) as [string, ...string[]],
+    scope: scope || 'atproto',
     token_endpoint_auth_method: 'none',
     application_type: 'native',
     dpop_bound_access_tokens: true,


### PR DESCRIPTION
The draft OAuth Spec says that for localhost clients, the `scope` "can be configured via query parameter in the `client_id` URL", and "Default is `atproto`”, but this was not the case.
https://github.com/bluesky-social/atproto-website/blob/bnewbold/spec-oauth/content/specs/auth.md#localhost-client-development
So I implemented it to work as per the spec.