### PR TITLE
OAuth: Fix for multiple `redirect_uris`

### DIFF
--- a/packages/oauth/oauth-client/src/oauth-client.ts
+++ b/packages/oauth/oauth-client/src/oauth-client.ts
@@ -273,6 +273,7 @@ export class OAuthClient extends CustomEventTarget<OAuthClientEventMap> {
       dpopKey,
       verifier: pkce.verifier,
       appState: options?.state,
+      redirectUri,
     })
 
     const parameters = {
@@ -424,7 +425,11 @@ export class OAuthClient extends CustomEventTarget<OAuthClientEventMap> {
         )
       }
 
-      const tokenSet = await server.exchangeCode(codeParam, stateData.verifier)
+      const tokenSet = await server.exchangeCode(
+        codeParam,
+        stateData.redirectUri,
+        stateData.verifier,
+      )
       try {
         await this.sessionGetter.setStored(tokenSet.sub, {
           dpopKey: stateData.dpopKey,

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -69,10 +69,14 @@ export class OAuthServerAgent {
     }
   }
 
-  async exchangeCode(code: string, verifier?: string): Promise<TokenSet> {
+  async exchangeCode(
+    code: string,
+    redirectUri: string,
+    verifier?: string,
+  ): Promise<TokenSet> {
     const tokenResponse = await this.request('token', {
       grant_type: 'authorization_code',
-      redirect_uri: this.clientMetadata.redirect_uris[0]!,
+      redirect_uri: redirectUri,
       code,
       code_verifier: verifier,
     })

--- a/packages/oauth/oauth-client/src/state-store.ts
+++ b/packages/oauth/oauth-client/src/state-store.ts
@@ -6,6 +6,7 @@ export type InternalStateData = {
   dpopKey: Key
   verifier?: string
   appState?: string
+  redirectUri: string
 }
 
 export type StateStore = SimpleStore<string, InternalStateData>


### PR DESCRIPTION
In the client metadata, multiple `redirect_uri` can be specified,

```typescript
const clientMetadata: OAuthClientMetadata = {
  client_id: "https://oauth.example.com/client.json",
  response_types: ["code"],
  grant_types: ["authorization_code"],
  redirect_uris: [
    "https://oauth.example.com/callback1",
    "https://oauth.example.com/callback2",
  ],
};
```

Any value contained in the `redirect_uris` can be used in the `options` of the `OAuthClient.authorize()` method.

```typescript
const client = new OAuthClient({
  clientMetadata,
  responseMode: "query",

  ...

});
const authorization_url = await client.authorize(input, {
  scope: "atproto",
  redirect_uri: "https://oauth.example.com/callback2",
});
```
However, even in the above case, the current implementation automatically selects and sends `this.clientMetadata.redirect_uris[0]` in the token request, so even if the redirected params are correctly obtained,  `exchangeCode()` returns the following error.

```json
{"error": "invalid_grant", "error_description": "This code was issued for another redirect_uri"}
```

Actually, the `callback()` method does not receive the redirect_uri, so I think the only way to get the value of the `redirect_uri` used in the PAR is through `stateStore`.
