### PR TITLE
Fix blocked posts showing up in `getQuotes`

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -2,6 +2,7 @@ import { Server } from '../../../../lexicon'
 import AppContext from '../../../../context'
 import { createPipeline } from '../../../../pipeline'
 import { clearlyBadCursor, resHeaders } from '../../../util'
+import { uriToDid as creatorFromUri } from '../../../../util/uris'
 import {
   HydrateCtx,
   HydrationState,
@@ -72,7 +73,7 @@ const noBlocks = (inputs: {
 }) => {
   const { ctx, skeleton, hydration } = inputs
   skeleton.uris = skeleton.uris.filter((uri) => {
-    const creator = creatorFromUri(item.post.uri)
+    const creator = creatorFromUri(uri)
     const embedBlock = hydration.postBlocks?.get(uri)?.embed
     return !ctx.views.viewerBlockExists(creator, hydration) && !embedBlock
   })

--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -72,8 +72,9 @@ const noBlocks = (inputs: {
 }) => {
   const { ctx, skeleton, hydration } = inputs
   skeleton.uris = skeleton.uris.filter((uri) => {
+    const creator = creatorFromUri(item.post.uri)
     const embedBlock = hydration.postBlocks?.get(uri)?.embed
-    return !ctx.views.viewerBlockExists(uri, hydration) && !embedBlock
+    return !ctx.views.viewerBlockExists(creator, hydration) && !embedBlock
   })
   return skeleton
 }


### PR DESCRIPTION
3rd party blocks are showing up in `getQuotes` due to passing a `uri` rather than a `did` to `viewerBlockExists`. This PR should fix that