### PR TITLE
:bug: Fix appealed param's usage

### DIFF
--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -703,7 +703,7 @@ export class ModerationService {
     cursor?: string
     limit?: number
     takendown?: boolean
-    appealed?: boolean | null
+    appealed?: boolean
     reviewedBefore?: string
     reviewState?: ModerationSubjectStatusRow['reviewState']
     reviewedAfter?: string
@@ -769,7 +769,7 @@ export class ModerationService {
 
     if (appealed !== undefined) {
       builder =
-        appealed === null
+        appealed === false
           ? builder.where('appealed', 'is', null)
           : builder.where('appealed', '=', appealed)
     }


### PR DESCRIPTION
Since the appealed param is sent via GET request, expecting it to be null is not reliable so this fix expects it to be either boolean or undefined. This allows the callers to either see only appeals or no appeals or make the response indifferent of appealed status.