### PR TITLE
[Videos] Add attribution and licence fields

### DIFF
--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -26,6 +26,16 @@
         "aspectRatio": {
           "type": "ref",
           "ref": "app.bsky.embed.defs#aspectRatio"
+        },
+        "attribution": {
+          "type": "string",
+          "description": "Attribution for the video, e.g. the creator or source.",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "licenseUri": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -69,7 +69,13 @@
         "aspectRatio": {
           "type": "ref",
           "ref": "app.bsky.embed.defs#aspectRatio"
-        }
+        },
+        "attribution": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "licenseUri": { "type": "string", "format": "uri" }
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5350,6 +5350,15 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
     },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5297,6 +5297,17 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            description:
+              'Attribution for the video, e.g. the creator or source.',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
       caption: {

--- a/packages/api/src/client/types/app/bsky/embed/video.ts
+++ b/packages/api/src/client/types/app/bsky/embed/video.ts
@@ -56,6 +56,8 @@ export interface View {
   thumbnail?: string
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/embed/video.ts
+++ b/packages/api/src/client/types/app/bsky/embed/video.ts
@@ -13,6 +13,9 @@ export interface Main {
   /** Alt text description of the video, for accessibility. */
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  /** Attribution for the video, e.g. the creator or source. */
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5350,6 +5350,15 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
     },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5297,6 +5297,17 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            description:
+              'Attribution for the video, e.g. the creator or source.',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
       caption: {

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
@@ -56,6 +56,8 @@ export interface View {
   thumbnail?: string
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,9 @@ export interface Main {
   /** Alt text description of the video, for accessibility. */
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  /** Attribution for the video, e.g. the creator or source. */
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5350,6 +5350,15 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
     },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5297,6 +5297,17 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            description:
+              'Attribution for the video, e.g. the creator or source.',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
       caption: {

--- a/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
@@ -56,6 +56,8 @@ export interface View {
   thumbnail?: string
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,9 @@ export interface Main {
   /** Alt text description of the video, for accessibility. */
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  /** Attribution for the video, e.g. the creator or source. */
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5350,6 +5350,15 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
     },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5297,6 +5297,17 @@ export const schemaDict = {
             type: 'ref',
             ref: 'lex:app.bsky.embed.defs#aspectRatio',
           },
+          attribution: {
+            type: 'string',
+            description:
+              'Attribution for the video, e.g. the creator or source.',
+            maxGraphemes: 300,
+            maxLength: 3000,
+          },
+          licenseUri: {
+            type: 'string',
+            format: 'uri',
+          },
         },
       },
       caption: {

--- a/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
@@ -56,6 +56,8 @@ export interface View {
   thumbnail?: string
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,9 @@ export interface Main {
   /** Alt text description of the video, for accessibility. */
   alt?: string
   aspectRatio?: AppBskyEmbedDefs.AspectRatio
+  /** Attribution for the video, e.g. the creator or source. */
+  attribution?: string
+  licenseUri?: string
   [k: string]: unknown
 }
 


### PR DESCRIPTION
As discussed, added a freeform `attribution` field and a URI `licenseUri` field to the video embed record