### PR TITLE
Appview: retry dataplane requests on abort

### DIFF
--- a/packages/bsky/src/data-plane/client.ts
+++ b/packages/bsky/src/data-plane/client.ts
@@ -34,7 +34,10 @@ export const createDataPlaneClient = (
         try {
           return await client.lib[method.localName](...args)
         } catch (err) {
-          if (err instanceof ConnectError && err.code === Code.Unavailable) {
+          if (
+            err instanceof ConnectError &&
+            (err.code === Code.Unavailable || err.code === Code.Aborted)
+          ) {
             tries++
             error = err
             remainingClients = getRemainingClients(remainingClients, client)


### PR DESCRIPTION
In the appview we properly retry requests when the dataplane is partially offline, but have been failing to retry in-flight requests that have been aborted.