### PR TITLE
:sparkles: Optionally ack all open subjects from the author with takedown event

### DIFF
--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -210,6 +210,10 @@
         "durationInHours": {
           "type": "integer",
           "description": "Indicates how long the takedown should be in effect before automatically expiring."
+        },
+        "acknowledgeAllSubjectsOfAccount": {
+          "type": "boolean",
+          "description": "Set to true if all subjects authored by the account should be resolved."
         }
       }
     },

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -211,7 +211,7 @@
           "type": "integer",
           "description": "Indicates how long the takedown should be in effect before automatically expiring."
         },
-        "acknowledgeAllSubjectsOfAccount": {
+        "acknowledgeAccountSubjects": {
           "type": "boolean",
           "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
         }

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -213,7 +213,7 @@
         },
         "acknowledgeAllSubjectsOfAccount": {
           "type": "boolean",
-          "description": "Set to true if all subjects authored by the account should be resolved."
+          "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
         }
       }
     },

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -8,15 +8,14 @@
       "parameters": {
         "type": "params",
         "properties": {
-          "forAccount": {
-            "type": "string",
-            "format": "did",
-            "description": "All subjects belonging to this account will be returned. If provided, this will take priority over 'subject' parameter."
+          "includeAllUserRecords": {
+            "type": "boolean",
+            "description": "All subjects belonging to the account specified in the 'subject' param will be returned."
           },
           "subject": {
             "type": "string",
             "format": "uri",
-            "description": "The subject to get the status for. If provided along with 'forAccount', this will be ignored."
+            "description": "The subject to get the status for."
           },
           "comment": {
             "type": "string",
@@ -69,18 +68,12 @@
           "sortField": {
             "type": "string",
             "default": "lastReportedAt",
-            "enum": [
-              "lastReviewedAt",
-              "lastReportedAt"
-            ]
+            "enum": ["lastReviewedAt", "lastReportedAt"]
           },
           "sortDirection": {
             "type": "string",
             "default": "desc",
-            "enum": [
-              "asc",
-              "desc"
-            ]
+            "enum": ["asc", "desc"]
           },
           "takendown": {
             "type": "boolean",
@@ -117,9 +110,7 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": [
-            "subjectStatuses"
-          ],
+          "required": ["subjectStatuses"],
           "properties": {
             "cursor": {
               "type": "string"

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -8,8 +8,16 @@
       "parameters": {
         "type": "params",
         "properties": {
-          "forAccount": { "type": "string", "format": "did" },
-          "subject": { "type": "string", "format": "uri" },
+          "forAccount": {
+            "type": "string",
+            "format": "did",
+            "description": "All subjects belonging to this account will be returned. If provided, this will take priority over 'subject' parameter."
+          },
+          "subject": {
+            "type": "string",
+            "format": "uri",
+            "description": "The subject to get the status for. If provided along with 'forAccount', this will be ignored."
+          },
           "comment": {
             "type": "string",
             "description": "Search subjects by keyword from comments"
@@ -48,7 +56,10 @@
           },
           "ignoreSubjects": {
             "type": "array",
-            "items": { "type": "string", "format": "uri" }
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           },
           "lastReviewedBy": {
             "type": "string",
@@ -58,12 +69,18 @@
           "sortField": {
             "type": "string",
             "default": "lastReportedAt",
-            "enum": ["lastReviewedAt", "lastReportedAt"]
+            "enum": [
+              "lastReviewedAt",
+              "lastReportedAt"
+            ]
           },
           "sortDirection": {
             "type": "string",
             "default": "desc",
-            "enum": ["asc", "desc"]
+            "enum": [
+              "asc",
+              "desc"
+            ]
           },
           "takendown": {
             "type": "boolean",
@@ -81,22 +98,32 @@
           },
           "tags": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           },
           "excludeTags": {
             "type": "array",
-            "items": { "type": "string" }
+            "items": {
+              "type": "string"
+            }
           },
-          "cursor": { "type": "string" }
+          "cursor": {
+            "type": "string"
+          }
         }
       },
       "output": {
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["subjectStatuses"],
+          "required": [
+            "subjectStatuses"
+          ],
           "properties": {
-            "cursor": { "type": "string" },
+            "cursor": {
+              "type": "string"
+            },
             "subjectStatuses": {
               "type": "array",
               "items": {

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -8,6 +8,7 @@
       "parameters": {
         "type": "params",
         "properties": {
+          "forAccount": { "type": "string", "format": "did" },
           "subject": { "type": "string", "format": "uri" },
           "comment": {
             "type": "string",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10923,7 +10923,7 @@ export const schemaDict = {
           acknowledgeAllSubjectsOfAccount: {
             type: 'boolean',
             description:
-              'Set to true if all subjects authored by the account should be resolved.',
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
         },
       },
@@ -11736,13 +11736,15 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            forAccount: {
-              type: 'string',
-              format: 'did',
+            includeAllUserRecords: {
+              type: 'boolean',
+              description:
+                "All subjects belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
               format: 'uri',
+              description: 'The subject to get the status for.',
             },
             comment: {
               type: 'string',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10920,7 +10920,7 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
-          acknowledgeAllSubjectsOfAccount: {
+          acknowledgeAccountSubjects: {
             type: 'boolean',
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10920,6 +10920,11 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
+          acknowledgeAllSubjectsOfAccount: {
+            type: 'boolean',
+            description:
+              'Set to true if all subjects authored by the account should be resolved.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -11731,6 +11736,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            forAccount: {
+              type: 'string',
+              format: 'did',
+            },
             subject: {
               type: 'string',
               format: 'uri',

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -163,7 +163,7 @@ export interface ModEventTakedown {
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
-  acknowledgeAllSubjectsOfAccount?: boolean
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -162,6 +162,8 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
+  /** Set to true if all subjects authored by the account should be resolved. */
+  acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -162,7 +162,7 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
-  /** Set to true if all subjects authored by the account should be resolved. */
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  forAccount?: string
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -9,7 +9,9 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  forAccount?: string
+  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  includeAllUserRecords?: boolean
+  /** The subject to get the status for. */
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string

--- a/packages/dev-env/src/moderator-client.ts
+++ b/packages/dev-env/src/moderator-client.ts
@@ -119,15 +119,17 @@ export class ModeratorClient {
       subject: TakeActionInput['subject']
       subjectBlobCids?: TakeActionInput['subjectBlobCids']
       durationInHours?: number
+      acknowledgeAllSubjectsOfAccount?: boolean
       reason?: string
     },
     role?: ModLevel,
   ) {
-    const { durationInHours, ...rest } = opts
+    const { durationInHours, acknowledgeAllSubjectsOfAccount, ...rest } = opts
     return this.emitEvent(
       {
         event: {
           $type: 'tools.ozone.moderation.defs#modEventTakedown',
+          acknowledgeAllSubjectsOfAccount,
           durationInHours,
         },
         ...rest,

--- a/packages/dev-env/src/moderator-client.ts
+++ b/packages/dev-env/src/moderator-client.ts
@@ -119,17 +119,17 @@ export class ModeratorClient {
       subject: TakeActionInput['subject']
       subjectBlobCids?: TakeActionInput['subjectBlobCids']
       durationInHours?: number
-      acknowledgeAllSubjectsOfAccount?: boolean
+      acknowledgeAccountSubjects?: boolean
       reason?: string
     },
     role?: ModLevel,
   ) {
-    const { durationInHours, acknowledgeAllSubjectsOfAccount, ...rest } = opts
+    const { durationInHours, acknowledgeAccountSubjects, ...rest } = opts
     return this.emitEvent(
       {
         event: {
           $type: 'tools.ozone.moderation.defs#modEventTakedown',
-          acknowledgeAllSubjectsOfAccount,
+          acknowledgeAccountSubjects,
           durationInHours,
         },
         ...rest,

--- a/packages/ozone/src/api/moderation/emitEvent.ts
+++ b/packages/ozone/src/api/moderation/emitEvent.ts
@@ -162,7 +162,7 @@ const handleModerationEvent = async ({
       }
     }
 
-    if (isTakedownEvent && result.event.meta?.acknowledgeAllSubjectsOfAccount) {
+    if (isTakedownEvent && result.event.meta?.acknowledgeAccountSubjects) {
       await moderationTxn.resolveSubjectsForAccount(subject.did, createdBy)
     }
 

--- a/packages/ozone/src/api/moderation/emitEvent.ts
+++ b/packages/ozone/src/api/moderation/emitEvent.ts
@@ -162,6 +162,10 @@ const handleModerationEvent = async ({
       }
     }
 
+    if (isTakedownEvent && result.event.meta?.acknowledgeAllSubjectsOfAccount) {
+      await moderationTxn.resolveSubjectsForAccount(subject.did, createdBy)
+    }
+
     if (isLabelEvent) {
       await moderationTxn.formatAndCreateLabels(
         result.event.subjectUri ?? result.event.subjectDid,

--- a/packages/ozone/src/api/moderation/queryStatuses.ts
+++ b/packages/ozone/src/api/moderation/queryStatuses.ts
@@ -7,6 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.modOrAdminToken,
     handler: async ({ params }) => {
       const {
+        forAccount,
         subject,
         takendown,
         appealed,
@@ -30,6 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       const modService = ctx.modService(db)
       const results = await modService.getSubjectStatuses({
         reviewState: getReviewState(reviewState),
+        forAccount,
         subject,
         takendown,
         appealed,

--- a/packages/ozone/src/api/moderation/queryStatuses.ts
+++ b/packages/ozone/src/api/moderation/queryStatuses.ts
@@ -7,7 +7,7 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.modOrAdminToken,
     handler: async ({ params }) => {
       const {
-        forAccount,
+        includeAllUserRecords,
         subject,
         takendown,
         appealed,
@@ -31,7 +31,7 @@ export default function (server: Server, ctx: AppContext) {
       const modService = ctx.modService(db)
       const results = await modService.getSubjectStatuses({
         reviewState: getReviewState(reviewState),
-        forAccount,
+        includeAllUserRecords,
         subject,
         takendown,
         appealed,

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -10923,7 +10923,7 @@ export const schemaDict = {
           acknowledgeAllSubjectsOfAccount: {
             type: 'boolean',
             description:
-              'Set to true if all subjects authored by the account should be resolved.',
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
         },
       },
@@ -11736,13 +11736,15 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            forAccount: {
-              type: 'string',
-              format: 'did',
+            includeAllUserRecords: {
+              type: 'boolean',
+              description:
+                "All subjects belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
               format: 'uri',
+              description: 'The subject to get the status for.',
             },
             comment: {
               type: 'string',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -10920,7 +10920,7 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
-          acknowledgeAllSubjectsOfAccount: {
+          acknowledgeAccountSubjects: {
             type: 'boolean',
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -10920,6 +10920,11 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
+          acknowledgeAllSubjectsOfAccount: {
+            type: 'boolean',
+            description:
+              'Set to true if all subjects authored by the account should be resolved.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -11731,6 +11736,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            forAccount: {
+              type: 'string',
+              format: 'did',
+            },
             subject: {
               type: 'string',
               format: 'uri',

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -163,7 +163,7 @@ export interface ModEventTakedown {
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
-  acknowledgeAllSubjectsOfAccount?: boolean
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -162,6 +162,8 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
+  /** Set to true if all subjects authored by the account should be resolved. */
+  acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -162,7 +162,7 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
-  /** Set to true if all subjects authored by the account should be resolved. */
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,7 +10,9 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  forAccount?: string
+  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  includeAllUserRecords?: boolean
+  /** The subject to get the status for. */
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,6 +10,7 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  forAccount?: string
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -368,8 +368,8 @@ export class ModerationService {
       }
     }
 
-    if (isModEventTakedown(event) && event.acknowledgeAllSubjectsOfAccount) {
-      meta.acknowledgeAllSubjectsOfAccount = true
+    if (isModEventTakedown(event) && event.acknowledgeAccountSubjects) {
+      meta.acknowledgeAccountSubjects = true
     }
 
     // Keep trace of reports that came in while the reporter was in muted stated

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -3,7 +3,7 @@ import { Insertable, sql } from 'kysely'
 import { CID } from 'multiformats/cid'
 import { AtUri, INVALID_HANDLE } from '@atproto/syntax'
 import { InvalidRequestError } from '@atproto/xrpc-server'
-import { addHoursToDate } from '@atproto/common'
+import { addHoursToDate, chunkArray } from '@atproto/common'
 import { Keypair } from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
 import { AtpAgent } from '@atproto/api'
@@ -18,6 +18,8 @@ import {
   isModEventTakedown,
   isModEventEmail,
   isModEventTag,
+  REVIEWESCALATED,
+  REVIEWOPEN,
 } from '../lexicon/types/tools/ozone/moderation/defs'
 import { RepoRef, RepoBlobRef } from '../lexicon/types/com/atproto/admin/defs'
 import {
@@ -279,6 +281,52 @@ export class ModerationService {
     return await builder.execute()
   }
 
+  async resolveSubjectsForAccount(did: string, createdBy: string) {
+    const subjectsToBeResolved = await this.db.db
+      .selectFrom('moderation_subject_status')
+      .where('did', '=', did)
+      .where('recordPath', '!=', '')
+      .where('reviewState', 'in', [REVIEWESCALATED, REVIEWOPEN])
+      .selectAll()
+      .execute()
+
+    if (subjectsToBeResolved.length === 0) {
+      return
+    }
+
+    // Process subjects in chunks of 100 since each of these will trigger multiple db queries
+    for (const subjects of chunkArray(subjectsToBeResolved, 100)) {
+      await Promise.all(
+        subjects.map(async (subject) => {
+          const eventData = {
+            createdBy,
+            subject: subjectFromStatusRow(subject),
+          }
+          // For consistency's sake, when acknowledging appealed subjects, we should first resolve the appeal
+          if (subject.appealed) {
+            await this.logEvent({
+              event: {
+                $type: 'tools.ozone.moderation.defs#modEventResolveAppeal',
+                comment:
+                  '[AUTO_RESOLVE_FOR_TAKENDOWN_ACCOUNT]: Automatically resolving all appealed content for a takendown account',
+              },
+              ...eventData,
+            })
+          }
+
+          await this.logEvent({
+            event: {
+              $type: 'tools.ozone.moderation.defs#modEventAcknowledge',
+              comment:
+                '[AUTO_RESOLVE_FOR_TAKENDOWN_ACCOUNT]: Automatically resolving all reported content for a takendown account',
+            },
+            ...eventData,
+          })
+        }),
+      )
+    }
+  }
+
   async logEvent(info: {
     event: ModEventType
     subject: ModSubject
@@ -318,6 +366,10 @@ export class ModerationService {
       if (event.content) {
         meta.content = event.content
       }
+    }
+
+    if (isModEventTakedown(event) && event.acknowledgeAllSubjectsOfAccount) {
+      meta.acknowledgeAllSubjectsOfAccount = true
     }
 
     // Keep trace of reports that came in while the reporter was in muted stated
@@ -677,6 +729,7 @@ export class ModerationService {
   }
 
   async getSubjectStatuses({
+    forAccount,
     cursor,
     limit = 50,
     takendown,
@@ -696,6 +749,7 @@ export class ModerationService {
     tags,
     excludeTags,
   }: {
+    forAccount?: string
     cursor?: string
     limit?: number
     takendown?: boolean
@@ -727,6 +781,8 @@ export class ModerationService {
             ? qb.where('recordPath', '=', subjectInfo.recordPath)
             : qb.where('recordPath', '=', ''),
         )
+    } else if (forAccount) {
+      builder = builder.where('moderation_subject_status.did', '=', forAccount)
     }
 
     if (ignoreSubjects?.length) {

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -772,7 +772,9 @@ export class ModerationService {
     let builder = this.db.db.selectFrom('moderation_subject_status').selectAll()
     const { ref } = this.db.db.dynamic
 
-    if (subject) {
+    if (forAccount) {
+      builder = builder.where('moderation_subject_status.did', '=', forAccount)
+    } else if (subject) {
       const subjectInfo = getStatusIdentifierFromSubject(subject)
       builder = builder
         .where('moderation_subject_status.did', '=', subjectInfo.did)
@@ -781,8 +783,6 @@ export class ModerationService {
             ? qb.where('recordPath', '=', subjectInfo.recordPath)
             : qb.where('recordPath', '=', ''),
         )
-    } else if (forAccount) {
-      builder = builder.where('moderation_subject_status.did', '=', forAccount)
     }
 
     if (ignoreSubjects?.length) {

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -122,6 +122,17 @@ export class ModerationViews {
       }
     }
 
+    if (
+      event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
+      event.meta?.acknowledgeAllSubjectsOfAccount
+    ) {
+      eventView.event = {
+        ...eventView.event,
+        acknowledgeAllSubjectsOfAccount:
+          event.meta?.acknowledgeAllSubjectsOfAccount,
+      }
+    }
+
     if (event.action === 'tools.ozone.moderation.defs#modEventLabel') {
       eventView.event = {
         ...eventView.event,

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -124,12 +124,11 @@ export class ModerationViews {
 
     if (
       event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
-      event.meta?.acknowledgeAllSubjectsOfAccount
+      event.meta?.acknowledgeAccountSubjects
     ) {
       eventView.event = {
         ...eventView.event,
-        acknowledgeAllSubjectsOfAccount:
-          event.meta?.acknowledgeAllSubjectsOfAccount,
+        acknowledgeAccountSubjects: event.meta?.acknowledgeAccountSubjects,
       }
     }
 

--- a/packages/ozone/tests/ack-all-subjects-of-account.test.ts
+++ b/packages/ozone/tests/ack-all-subjects-of-account.test.ts
@@ -87,7 +87,7 @@ describe('moderation', () => {
 
     await modClient.performTakedown({
       subject: repoSubject(sc.dids.bob),
-      acknowledgeAllSubjectsOfAccount: true,
+      acknowledgeAccountSubjects: true,
     })
 
     const { subjectStatuses: statusesAfter } = await modClient.queryStatuses({

--- a/packages/ozone/tests/ack-all-subjects-of-account.test.ts
+++ b/packages/ozone/tests/ack-all-subjects-of-account.test.ts
@@ -1,31 +1,22 @@
 import {
   TestNetwork,
   TestOzone,
-  ImageRef,
   RecordRef,
   SeedClient,
   basicSeed,
   ModeratorClient,
 } from '@atproto/dev-env'
-import { AtpAgent, ToolsOzoneModerationEmitEvent } from '@atproto/api'
-import { AtUri } from '@atproto/syntax'
-import { forSnapshot } from './_util'
+import { AtpAgent } from '@atproto/api'
 import {
   REASONAPPEAL,
-  REASONMISLEADING,
   REASONOTHER,
   REASONSPAM,
 } from '../src/lexicon/types/com/atproto/moderation/defs'
 import {
-  ModEventLabel,
   REVIEWCLOSED,
   REVIEWESCALATED,
   REVIEWOPEN,
 } from '../src/lexicon/types/tools/ozone/moderation/defs'
-import { EventReverser } from '../src'
-import { ImageInvalidator } from '../src/image-invalidator'
-import { TAKEDOWN_LABEL } from '../src/mod-service'
-import { ids } from '../src/lexicon/lexicons'
 
 describe('moderation', () => {
   let network: TestNetwork

--- a/packages/ozone/tests/ack-all-subjects-of-account.test.ts
+++ b/packages/ozone/tests/ack-all-subjects-of-account.test.ts
@@ -1,0 +1,134 @@
+import {
+  TestNetwork,
+  TestOzone,
+  ImageRef,
+  RecordRef,
+  SeedClient,
+  basicSeed,
+  ModeratorClient,
+} from '@atproto/dev-env'
+import { AtpAgent, ToolsOzoneModerationEmitEvent } from '@atproto/api'
+import { AtUri } from '@atproto/syntax'
+import { forSnapshot } from './_util'
+import {
+  REASONAPPEAL,
+  REASONMISLEADING,
+  REASONOTHER,
+  REASONSPAM,
+} from '../src/lexicon/types/com/atproto/moderation/defs'
+import {
+  ModEventLabel,
+  REVIEWCLOSED,
+  REVIEWESCALATED,
+  REVIEWOPEN,
+} from '../src/lexicon/types/tools/ozone/moderation/defs'
+import { EventReverser } from '../src'
+import { ImageInvalidator } from '../src/image-invalidator'
+import { TAKEDOWN_LABEL } from '../src/mod-service'
+import { ids } from '../src/lexicon/lexicons'
+
+describe('moderation', () => {
+  let network: TestNetwork
+  let ozone: TestOzone
+  let agent: AtpAgent
+  let bskyAgent: AtpAgent
+  let pdsAgent: AtpAgent
+  let sc: SeedClient
+  let modClient: ModeratorClient
+
+  const repoSubject = (did: string) => ({
+    $type: 'com.atproto.admin.defs#repoRef',
+    did,
+  })
+
+  const recordSubject = (ref: RecordRef) => ({
+    $type: 'com.atproto.repo.strongRef',
+    uri: ref.uriStr,
+    cid: ref.cidStr,
+  })
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_ack_all_subjects_of_account',
+    })
+    ozone = network.ozone
+    agent = network.ozone.getClient()
+    bskyAgent = network.bsky.getClient()
+    pdsAgent = network.pds.getClient()
+    sc = network.getSeedClient()
+    modClient = network.ozone.getModClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('acknowledges all open/escalated review subjects.', async () => {
+    const postOne = sc.posts[sc.dids.bob][0].ref
+    const postTwo = sc.posts[sc.dids.bob][1].ref
+    await Promise.all([
+      sc.createReport({
+        reasonType: REASONSPAM,
+        subject: repoSubject(sc.dids.bob),
+        reportedBy: sc.dids.alice,
+      }),
+      sc.createReport({
+        reasonType: REASONOTHER,
+        reason: 'defamation',
+        subject: recordSubject(postOne),
+        reportedBy: sc.dids.carol,
+      }),
+      sc.createReport({
+        reasonType: REASONOTHER,
+        reason: 'defamation',
+        subject: recordSubject(postTwo),
+        reportedBy: sc.dids.carol,
+      }),
+    ])
+
+    await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventReport',
+        reportType: REASONAPPEAL,
+      },
+      subject: recordSubject(postTwo),
+    })
+
+    const { subjectStatuses: statusesBefore } = await modClient.queryStatuses({
+      forAccount: sc.dids.bob,
+    })
+
+    await modClient.performTakedown({
+      subject: repoSubject(sc.dids.bob),
+      acknowledgeAllSubjectsOfAccount: true,
+    })
+
+    const { subjectStatuses: statusesAfter } = await modClient.queryStatuses({
+      forAccount: sc.dids.bob,
+    })
+
+    statusesBefore.forEach((item) => {
+      if (item.subject.uri === postOne.uriStr) {
+        expect(item.reviewState).toBe(REVIEWOPEN)
+      } else if (item.subject.uri === postTwo.uriStr) {
+        expect(item.reviewState).toBe(REVIEWESCALATED)
+        expect(item.appealed).toBe(true)
+      } else if (!item.subject.uri && item.subject.did === sc.dids.bob) {
+        expect(item.reviewState).toBe(REVIEWOPEN)
+      }
+    })
+
+    statusesAfter.forEach((item) => {
+      if (item.subject.uri === postOne.uriStr) {
+        expect(item.reviewState).toBe(REVIEWCLOSED)
+      } else if (item.subject.uri === postTwo.uriStr) {
+        expect(item.reviewState).toBe(REVIEWCLOSED)
+        expect(item.appealed).toBe(false)
+      } else if (!item.subject.uri && item.subject.did === sc.dids.bob) {
+        expect(item.reviewState).toBe(REVIEWCLOSED)
+      }
+    })
+  })
+})

--- a/packages/ozone/tests/ack-all-subjects-of-account.test.ts
+++ b/packages/ozone/tests/ack-all-subjects-of-account.test.ts
@@ -1,12 +1,10 @@
 import {
   TestNetwork,
-  TestOzone,
   RecordRef,
   SeedClient,
   basicSeed,
   ModeratorClient,
 } from '@atproto/dev-env'
-import { AtpAgent } from '@atproto/api'
 import {
   REASONAPPEAL,
   REASONOTHER,
@@ -20,10 +18,6 @@ import {
 
 describe('moderation', () => {
   let network: TestNetwork
-  let ozone: TestOzone
-  let agent: AtpAgent
-  let bskyAgent: AtpAgent
-  let pdsAgent: AtpAgent
   let sc: SeedClient
   let modClient: ModeratorClient
 
@@ -42,10 +36,6 @@ describe('moderation', () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'ozone_ack_all_subjects_of_account',
     })
-    ozone = network.ozone
-    agent = network.ozone.getClient()
-    bskyAgent = network.bsky.getClient()
-    pdsAgent = network.pds.getClient()
     sc = network.getSeedClient()
     modClient = network.ozone.getModClient()
     await basicSeed(sc)
@@ -88,7 +78,8 @@ describe('moderation', () => {
     })
 
     const { subjectStatuses: statusesBefore } = await modClient.queryStatuses({
-      forAccount: sc.dids.bob,
+      subject: sc.dids.bob,
+      includeAllUserRecords: true,
     })
 
     await modClient.performTakedown({
@@ -97,7 +88,8 @@ describe('moderation', () => {
     })
 
     const { subjectStatuses: statusesAfter } = await modClient.queryStatuses({
-      forAccount: sc.dids.bob,
+      subject: sc.dids.bob,
+      includeAllUserRecords: true,
     })
 
     statusesBefore.forEach((item) => {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -10923,7 +10923,7 @@ export const schemaDict = {
           acknowledgeAllSubjectsOfAccount: {
             type: 'boolean',
             description:
-              'Set to true if all subjects authored by the account should be resolved.',
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
         },
       },
@@ -11736,13 +11736,15 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
-            forAccount: {
-              type: 'string',
-              format: 'did',
+            includeAllUserRecords: {
+              type: 'boolean',
+              description:
+                "All subjects belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
               format: 'uri',
+              description: 'The subject to get the status for.',
             },
             comment: {
               type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -10920,7 +10920,7 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
-          acknowledgeAllSubjectsOfAccount: {
+          acknowledgeAccountSubjects: {
             type: 'boolean',
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -10920,6 +10920,11 @@ export const schemaDict = {
             description:
               'Indicates how long the takedown should be in effect before automatically expiring.',
           },
+          acknowledgeAllSubjectsOfAccount: {
+            type: 'boolean',
+            description:
+              'Set to true if all subjects authored by the account should be resolved.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -11731,6 +11736,10 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            forAccount: {
+              type: 'string',
+              format: 'did',
+            },
             subject: {
               type: 'string',
               format: 'uri',

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -163,7 +163,7 @@ export interface ModEventTakedown {
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
-  acknowledgeAllSubjectsOfAccount?: boolean
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -162,6 +162,8 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
+  /** Set to true if all subjects authored by the account should be resolved. */
+  acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -162,7 +162,7 @@ export interface ModEventTakedown {
   comment?: string
   /** Indicates how long the takedown should be in effect before automatically expiring. */
   durationInHours?: number
-  /** Set to true if all subjects authored by the account should be resolved. */
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAllSubjectsOfAccount?: boolean
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,7 +10,9 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  forAccount?: string
+  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  includeAllUserRecords?: boolean
+  /** The subject to get the status for. */
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,6 +10,7 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  forAccount?: string
   subject?: string
   /** Search subjects by keyword from comments */
   comment?: string


### PR DESCRIPTION
This PR adds a `acknowledgeAllSubjectsOfAccount` flag to takedown event which allows moderators to acknowledge all subjects in reviewOpen/reviewEscalated/Appealed state from the account being takendown.

This helps clean up moderation queue of unnecessary subjects that won't require individual reviews if the author's account is already taken down permanently.

An additional but unrelated feature in this PR is a `forAccount` param in `tools.ozone.moderation.queryStatuses` which allows moderators to view all subject statuses for a specific account.