### PR TITLE
Slow down get repos

### DIFF
--- a/packages/pds/src/actor-store/repo/sql-repo-reader.ts
+++ b/packages/pds/src/actor-store/repo/sql-repo-reader.ts
@@ -97,9 +97,9 @@ export class SqlRepoReader extends ReadableBlockstore {
       do {
         const res = await this.getBlockRange(since, cursor)
         await writeRows(res)
-        await wait(100) // @NOTE temporary measure to prevent over-writing to buffer. can remove once we refactor car writer to give back pressure on streams
         const lastRow = res.at(-1)
         if (lastRow && lastRow.repoRev) {
+          await wait(100) // @NOTE temporary measure to prevent over-writing to buffer. can remove once we refactor car writer to give back pressure on streams
           cursor = {
             cid: CID.parse(lastRow.cid),
             rev: lastRow.repoRev,

--- a/packages/pds/src/actor-store/repo/sql-repo-reader.ts
+++ b/packages/pds/src/actor-store/repo/sql-repo-reader.ts
@@ -4,7 +4,7 @@ import {
   ReadableBlockstore,
   writeCarStream,
 } from '@atproto/repo'
-import { chunkArray } from '@atproto/common'
+import { chunkArray, wait } from '@atproto/common'
 import { CID } from 'multiformats/cid'
 import { ActorDb } from '../db'
 import { sql } from 'kysely'
@@ -94,11 +94,10 @@ export class SqlRepoReader extends ReadableBlockstore {
         }
       }
       // allow us to write to car while fetching the next page
-      let writePromise: Promise<void> = Promise.resolve()
       do {
         const res = await this.getBlockRange(since, cursor)
-        await writePromise
-        writePromise = writeRows(res)
+        await writeRows(res)
+        await wait(100) // @NOTE temporary measure to prevent over-writing to buffer. can remove once we refactor car writer to give back pressure on streams
         const lastRow = res.at(-1)
         if (lastRow && lastRow.repoRev) {
           cursor = {
@@ -109,8 +108,6 @@ export class SqlRepoReader extends ReadableBlockstore {
           cursor = undefined
         }
       } while (cursor)
-      // ensure we flush the last page of blocks
-      await writePromise
     })
   }
 


### PR DESCRIPTION
Somewhat hacky solution to add a `wait` in `getCarStream` for `sync.getRepo`. Current hypothesis is that we're not correctly applying back pressure to the stream and we're filling up our outgoing buffers