### PR TITLE
Add `isFallback` to `getSuggestedFollowsByActor` method

### DIFF
--- a/lexicons/app/bsky/graph/getSuggestedFollowsByActor.json
+++ b/lexicons/app/bsky/graph/getSuggestedFollowsByActor.json
@@ -24,6 +24,11 @@
                 "type": "ref",
                 "ref": "app.bsky.actor.defs#profileView"
               }
+            },
+            "isFallback": {
+              "type": "boolean",
+              "description": "If true, response has fallen-back to generic results, and is not scoped using relativeToDid",
+              "default": false
             }
           }
         }

--- a/lexicons/app/bsky/unspecced/getSuggestionsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getSuggestionsSkeleton.json
@@ -40,6 +40,11 @@
                 "type": "ref",
                 "ref": "app.bsky.unspecced.defs#skeletonSearchActor"
               }
+            },
+            "relativeToDid": {
+              "type": "string",
+              "format": "did",
+              "description": "DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer."
             }
           }
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8199,6 +8199,12 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
+              isFallback: {
+                type: 'boolean',
+                description:
+                  'If true, response has fallen-back to generic results, and is not scoped using relativeToDid',
+                default: false,
+              },
             },
           },
         },
@@ -9154,6 +9160,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
+              },
+              relativeToDid: {
+                type: 'string',
+                format: 'did',
+                description:
+                  'DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer.',
               },
             },
           },

--- a/packages/api/src/client/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -16,6 +16,8 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   suggestions: AppBskyActorDefs.ProfileView[]
+  /** If true, response has fallen-back to generic results, and is not scoped using relativeToDid */
+  isFallback: boolean
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -22,6 +22,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
+  /** DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer. */
+  relativeToDid?: string
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -71,6 +71,7 @@ const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
         { headers: params.headers },
       )
     return {
+      isFallback: !!res.data.relativeToDid,
       suggestedDids: res.data.actors.map((a) => a.did),
       headers: res.headers,
     }
@@ -80,6 +81,7 @@ const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
       relativeToDid,
     })
     return {
+      isFallback: true,
       suggestedDids: dids,
     }
   }
@@ -113,7 +115,7 @@ const presentation = (
   const suggestions = mapDefined(suggestedDids, (did) =>
     ctx.views.profileDetailed(did, hydration),
   )
-  return { suggestions, headers }
+  return { isFallback: skeleton.isFallback, suggestions, headers }
 }
 
 type Context = {
@@ -129,6 +131,7 @@ type Params = QueryParams & {
 }
 
 type SkeletonState = {
+  isFallback: boolean
   suggestedDids: string[]
   headers?: Record<string, string>
 }

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -71,7 +71,7 @@ const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
         { headers: params.headers },
       )
     return {
-      isFallback: !!res.data.relativeToDid,
+      isFallback: !res.data.relativeToDid,
       suggestedDids: res.data.actors.map((a) => a.did),
       headers: res.headers,
     }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8199,6 +8199,12 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
+              isFallback: {
+                type: 'boolean',
+                description:
+                  'If true, response has fallen-back to generic results, and is not scoped using relativeToDid',
+                default: false,
+              },
             },
           },
         },
@@ -9154,6 +9160,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
+              },
+              relativeToDid: {
+                type: 'string',
+                format: 'did',
+                description:
+                  'DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer.',
               },
             },
           },

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -17,6 +17,8 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   suggestions: AppBskyActorDefs.ProfileView[]
+  /** If true, response has fallen-back to generic results, and is not scoped using relativeToDid */
+  isFallback?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -23,6 +23,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
+  /** DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer. */
+  relativeToDid?: string
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8199,6 +8199,12 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
+              isFallback: {
+                type: 'boolean',
+                description:
+                  'If true, response has fallen-back to generic results, and is not scoped using relativeToDid',
+                default: false,
+              },
             },
           },
         },
@@ -9154,6 +9160,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
+              },
+              relativeToDid: {
+                type: 'string',
+                format: 'did',
+                description:
+                  'DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer.',
               },
             },
           },

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -17,6 +17,8 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   suggestions: AppBskyActorDefs.ProfileView[]
+  /** If true, response has fallen-back to generic results, and is not scoped using relativeToDid */
+  isFallback?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -23,6 +23,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
+  /** DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer. */
+  relativeToDid?: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8199,6 +8199,12 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
+              isFallback: {
+                type: 'boolean',
+                description:
+                  'If true, response has fallen-back to generic results, and is not scoped using relativeToDid',
+                default: false,
+              },
             },
           },
         },
@@ -9154,6 +9160,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.unspecced.defs#skeletonSearchActor',
                 },
+              },
+              relativeToDid: {
+                type: 'string',
+                format: 'did',
+                description:
+                  'DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer.',
               },
             },
           },

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -17,6 +17,8 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   suggestions: AppBskyActorDefs.ProfileView[]
+  /** If true, response has fallen-back to generic results, and is not scoped using relativeToDid */
+  isFallback?: boolean
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -23,6 +23,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   actors: AppBskyUnspeccedDefs.SkeletonSearchActor[]
+  /** DID of the account these suggestions are relative to. If this is returned undefined, suggestions are based on the viewer. */
+  relativeToDid?: string
   [k: string]: unknown
 }
 


### PR DESCRIPTION
We want to know on the client if the results from this endpoint are actually specific to the actor we passed in as `relativeToDid` or not. This endpoint is used on Profile screens and nowhere else.