### PR TITLE
NUX API

### DIFF
--- a/.changeset/selfish-ads-itch.md
+++ b/.changeset/selfish-ads-itch.md
@@ -1,0 +1,7 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Add NUX API

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -442,9 +442,12 @@
     "nux": {
       "type": "object",
       "description": "A new user experiences (NUX) storage object",
-      "required": ["name", "completed"],
+      "required": ["id", "completed"],
       "properties": {
-        "name": { "type": "string" },
+        "id": {
+          "type": "string",
+          "maxLength": 100
+        },
         "completed": {
           "type": "boolean",
           "default": false

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -442,9 +442,8 @@
     "nux": {
       "type": "object",
       "description": "A new user experiences (NUX) storage object",
-      "required": ["id", "name", "completed"],
+      "required": ["name", "completed"],
       "properties": {
-        "id": { "type": "string" },
         "name": { "type": "string" },
         "completed": {
           "type": "boolean",

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -419,6 +419,15 @@
           "type": "array",
           "maxLength": 1000,
           "items": { "type": "string", "maxLength": 100 }
+        },
+        "nuxs": {
+          "description": "Storage for NUXs the user has encountered.",
+          "type": "array",
+          "maxLength": 100,
+          "items": {
+            "type": "ref",
+            "ref": "app.bsky.actor.defs#nux"
+          }
         }
       }
     },
@@ -428,6 +437,30 @@
       "required": ["guide"],
       "properties": {
         "guide": { "type": "string", "maxLength": 100 }
+      }
+    },
+    "nux": {
+      "type": "object",
+      "description": "A new user experiences (NUX) storage object",
+      "required": ["id", "name", "completed"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "completed": {
+          "type": "boolean",
+          "default": false
+        },
+        "data": {
+          "description": "Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.",
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The date and time at which the NUX will expire and should be considered completed."
+        }
       }
     }
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,8 @@
     "@atproto/xrpc": "workspace:^",
     "await-lock": "^2.2.2",
     "multiformats": "^9.9.0",
-    "tlds": "^1.234.0"
+    "tlds": "^1.234.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@atproto/lex-cli": "workspace:^",

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -1380,7 +1380,7 @@ export class Agent extends XrpcClient {
   /**
    * Insert or update a NUX in user prefs
    */
-  async upsertNux(
+  async bskyAppUpsertNux(
     nux: Nux & {
       id?: Nux['id']
     },
@@ -1432,9 +1432,9 @@ export class Agent extends XrpcClient {
   }
 
   /**
-   * Remove a NUX from user preferences.
+   * Removes NUXs from user preferences.
    */
-  async removeNuxs(nuxs: Nux[]) {
+  async bskyAppRemoveNuxs(nuxs: Nux[]) {
     await this.updatePreferences((prefs: AppBskyActorDefs.Preferences) => {
       let bskyAppStatePref: AppBskyActorDefs.BskyAppStatePref = prefs.findLast(
         (pref) =>

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -1438,16 +1438,9 @@ export class Agent extends XrpcClient {
       )
 
       bskyAppStatePref = bskyAppStatePref || {}
-      bskyAppStatePref.nuxs = bskyAppStatePref.nuxs || []
-
-      for (const id of ids) {
-        const index = bskyAppStatePref.nuxs.findIndex((n) => {
-          return n.id === id
-        })
-        if (index !== -1) {
-          bskyAppStatePref.nuxs.splice(index, 1)
-        }
-      }
+      bskyAppStatePref.nuxs = (bskyAppStatePref.nuxs || []).filter((nux) => {
+        return !ids.includes(nux.id)
+      })
 
       return prefs
         .filter((p) => !AppBskyActorDefs.isBskyAppStatePref(p))

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -1394,15 +1394,14 @@ export class Agent extends XrpcClient {
       bskyAppStatePref.nuxs = bskyAppStatePref.nuxs || []
 
       const existing = bskyAppStatePref.nuxs?.find((n) => {
-        return n.name === nux.name
+        return n.id === nux.id
       })
 
       let next: AppBskyActorDefs.Nux
 
       if (existing) {
         next = {
-          // name does not update
-          name: existing.name,
+          id: existing.id,
           completed: nux.completed,
           data: nux.data,
           expiresAt: nux.expiresAt,
@@ -1413,7 +1412,7 @@ export class Agent extends XrpcClient {
 
       // remove duplicates and append
       bskyAppStatePref.nuxs = bskyAppStatePref.nuxs
-        .filter((n) => n.name !== nux.name)
+        .filter((n) => n.id !== nux.id)
         .concat(next)
 
       return prefs
@@ -1430,7 +1429,7 @@ export class Agent extends XrpcClient {
   /**
    * Removes NUXs from user preferences.
    */
-  async bskyAppRemoveNuxs(nuxs: Nux[]) {
+  async bskyAppRemoveNuxs(ids: string[]) {
     await this.updatePreferences((prefs: AppBskyActorDefs.Preferences) => {
       let bskyAppStatePref: AppBskyActorDefs.BskyAppStatePref = prefs.findLast(
         (pref) =>
@@ -1441,9 +1440,9 @@ export class Agent extends XrpcClient {
       bskyAppStatePref = bskyAppStatePref || {}
       bskyAppStatePref.nuxs = bskyAppStatePref.nuxs || []
 
-      for (const nux of nuxs) {
+      for (const id of ids) {
         const index = bskyAppStatePref.nuxs.findIndex((n) => {
-          return n.name === nux.name
+          return n.id === id
         })
         if (index !== -1) {
           bskyAppStatePref.nuxs.splice(index, 1)

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4598,10 +4598,11 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['name', 'completed'],
+        required: ['id', 'completed'],
         properties: {
-          name: {
+          id: {
             type: 'string',
+            maxLength: 100,
           },
           completed: {
             type: 'boolean',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4572,6 +4572,15 @@ export const schemaDict = {
               maxLength: 100,
             },
           },
+          nuxs: {
+            description: 'Storage for NUXs the user has encountered.',
+            type: 'array',
+            maxLength: 100,
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#nux',
+            },
+          },
         },
       },
       bskyAppProgressGuide: {
@@ -4583,6 +4592,36 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      nux: {
+        type: 'object',
+        description: 'A new user experiences (NUX) storage object',
+        required: ['id', 'name', 'completed'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          completed: {
+            type: 'boolean',
+            default: false,
+          },
+          data: {
+            description:
+              'Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.',
+            type: 'string',
+            maxLength: 3000,
+            maxGraphemes: 300,
+          },
+          expiresAt: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'The date and time at which the NUX will expire and should be considered completed.',
           },
         },
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4598,11 +4598,8 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['id', 'name', 'completed'],
+        required: ['name', 'completed'],
         properties: {
-          id: {
-            type: 'string',
-          },
           name: {
             type: 'string',
           },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -469,6 +469,8 @@ export interface BskyAppStatePref {
   activeProgressGuide?: BskyAppProgressGuide
   /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
   queuedNudges?: string[]
+  /** Storage for NUXs the user has encountered. */
+  nuxs?: Nux[]
   [k: string]: unknown
 }
 
@@ -500,4 +502,26 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+/** A new user experiences (NUX) storage object */
+export interface Nux {
+  id: string
+  name: string
+  completed: boolean
+  /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
+  data?: string
+  /** The date and time at which the NUX will expire and should be considered completed. */
+  expiresAt?: string
+  [k: string]: unknown
+}
+
+export function isNux(v: unknown): v is Nux {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#nux'
+  )
+}
+
+export function validateNux(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#nux', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -506,7 +506,7 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  name: string
+  id: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
   data?: string

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -506,7 +506,6 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  id: string
   name: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -106,5 +106,6 @@ export interface BskyPreferences {
   bskyAppState: {
     queuedNudges: string[]
     activeProgressGuide: AppBskyActorDefs.BskyAppProgressGuide | undefined
+    nuxs: AppBskyActorDefs.Nux[]
   }
 }

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -97,13 +97,13 @@ export const asDid = (value: string): Did => {
   throw new TypeError(`Invalid DID: ${value}`)
 }
 
-export const NuxSchema = zod.object({
+export const nuxSchema = zod.object({
   name: zod.string(),
   completed: zod.boolean(),
   data: zod.string().optional(),
   expiresAt: zod.string().optional(),
-})
+}).strict()
 
 export function validateNux(nux: Nux) {
-  NuxSchema.parse(nux)
+  nuxSchema.parse(nux)
 }

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -97,12 +97,14 @@ export const asDid = (value: string): Did => {
   throw new TypeError(`Invalid DID: ${value}`)
 }
 
-export const nuxSchema = zod.object({
-  name: zod.string(),
-  completed: zod.boolean(),
-  data: zod.string().optional(),
-  expiresAt: zod.string().optional(),
-}).strict()
+export const nuxSchema = zod
+  .object({
+    id: zod.string().max(64),
+    completed: zod.boolean(),
+    data: zod.string().max(300).optional(),
+    expiresAt: zod.string().datetime().optional(),
+  })
+  .strict()
 
 export function validateNux(nux: Nux) {
   nuxSchema.parse(nux)

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -98,17 +98,12 @@ export const asDid = (value: string): Did => {
 }
 
 export const NuxSchema = zod.object({
-  id: zod.string().optional(),
   name: zod.string(),
   completed: zod.boolean(),
   data: zod.string().optional(),
   expiresAt: zod.string().optional(),
 })
 
-export function validateNux(
-  nux: Nux & {
-    id?: Nux['id']
-  },
-) {
+export function validateNux(nux: Nux) {
   NuxSchema.parse(nux)
 }

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,6 +1,8 @@
 import { AtUri } from '@atproto/syntax'
 import { TID } from '@atproto/common-web'
+import zod from 'zod'
 
+import { Nux } from './client/types/app/bsky/actor/defs'
 import { AppBskyActorDefs } from './client'
 
 export function sanitizeMutedWordValue(value: string) {
@@ -93,4 +95,20 @@ export const isDid = (str: unknown): str is Did =>
 export const asDid = (value: string): Did => {
   if (isDid(value)) return value
   throw new TypeError(`Invalid DID: ${value}`)
+}
+
+export const NuxSchema = zod.object({
+  id: zod.string().optional(),
+  name: zod.string(),
+  completed: zod.boolean(),
+  data: zod.string().optional(),
+  expiresAt: zod.string().optional(),
+})
+
+export function validateNux(
+  nux: Nux & {
+    id?: Nux['id']
+  },
+) {
+  NuxSchema.parse(nux)
 }

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -276,6 +276,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -317,6 +318,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -358,6 +360,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -399,6 +402,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -444,6 +448,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -492,6 +497,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -540,6 +546,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -588,6 +595,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -636,6 +644,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -684,6 +693,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -738,6 +748,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -786,6 +797,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -834,6 +846,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -882,6 +895,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -930,6 +944,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -985,6 +1000,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -1040,6 +1056,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -1095,6 +1112,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
 
@@ -1150,6 +1168,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: [],
+          nuxs: [],
         },
       })
     })
@@ -1332,6 +1351,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1389,6 +1409,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1447,6 +1468,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1501,6 +1523,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1555,6 +1578,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1609,6 +1633,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
+          nuxs: [],
         },
       })
 
@@ -1675,6 +1700,7 @@ describe('agent', () => {
         bskyAppState: {
           activeProgressGuide: undefined,
           queuedNudges: ['two', 'three'],
+          nuxs: [],
         },
       })
 
@@ -3243,6 +3269,71 @@ describe('agent', () => {
           'bskyAppState.activeProgressGuide',
           undefined,
         )
+      })
+    })
+
+    describe('nuxs', () => {
+      let agent: BskyAgent
+
+      const nux = {
+        name: 'a',
+        completed: false,
+        data: '{}',
+        expiresAt: new Date(Date.now() + 6e3).toISOString(),
+      }
+
+      beforeAll(async () => {
+        agent = new BskyAgent({ service: network.pds.url })
+
+        await agent.createAccount({
+          handle: 'nuxs.test',
+          email: 'nuxs@test.com',
+          password: 'password',
+        })
+      })
+
+      it('bskyAppUpsertNux', async () => {
+        // never duplicates
+        await agent.bskyAppUpsertNux(nux)
+        await agent.bskyAppUpsertNux(nux)
+        await agent.bskyAppUpsertNux(nux)
+
+        const prefs = await agent.getPreferences()
+        const nuxs = prefs.bskyAppState.nuxs
+
+        expect(nuxs.length).toEqual(1)
+        expect(nuxs.find((n) => n.name === nux.name)).toEqual(nux)
+      })
+
+      it('bskyAppUpsertNux completed', async () => {
+        // never duplicates
+        await agent.bskyAppUpsertNux({
+          ...nux,
+          completed: true,
+        })
+
+        const prefs = await agent.getPreferences()
+        const nuxs = prefs.bskyAppState.nuxs
+
+        expect(nuxs.length).toEqual(1)
+        expect(nuxs.find((n) => n.name === nux.name)?.completed).toEqual(true)
+      })
+
+      it('bskyAppRemoveNuxs', async () => {
+        await agent.bskyAppRemoveNuxs([nux])
+
+        const prefs = await agent.getPreferences()
+        const nuxs = prefs.bskyAppState.nuxs
+
+        expect(nuxs.length).toEqual(0)
+      })
+
+      it('bskyAppUpsertNux validates nux', async () => {
+        // @ts-expect-error
+        expect(() => agent.bskyAppUpsertNux({ id: 'a' })).rejects.toThrow()
+        expect(() =>
+          agent.bskyAppUpsertNux({ name: 'a', completed: false, foo: 'bar' }),
+        ).rejects.toThrow()
       })
     })
 

--- a/packages/api/tests/bsky-agent.test.ts
+++ b/packages/api/tests/bsky-agent.test.ts
@@ -3276,7 +3276,7 @@ describe('agent', () => {
       let agent: BskyAgent
 
       const nux = {
-        name: 'a',
+        id: 'a',
         completed: false,
         data: '{}',
         expiresAt: new Date(Date.now() + 6e3).toISOString(),
@@ -3302,7 +3302,7 @@ describe('agent', () => {
         const nuxs = prefs.bskyAppState.nuxs
 
         expect(nuxs.length).toEqual(1)
-        expect(nuxs.find((n) => n.name === nux.name)).toEqual(nux)
+        expect(nuxs.find((n) => n.id === nux.id)).toEqual(nux)
       })
 
       it('bskyAppUpsertNux completed', async () => {
@@ -3316,11 +3316,11 @@ describe('agent', () => {
         const nuxs = prefs.bskyAppState.nuxs
 
         expect(nuxs.length).toEqual(1)
-        expect(nuxs.find((n) => n.name === nux.name)?.completed).toEqual(true)
+        expect(nuxs.find((n) => n.id === nux.id)?.completed).toEqual(true)
       })
 
       it('bskyAppRemoveNuxs', async () => {
-        await agent.bskyAppRemoveNuxs([nux])
+        await agent.bskyAppRemoveNuxs([nux.id])
 
         const prefs = await agent.getPreferences()
         const nuxs = prefs.bskyAppState.nuxs
@@ -3330,9 +3330,9 @@ describe('agent', () => {
 
       it('bskyAppUpsertNux validates nux', async () => {
         // @ts-expect-error
-        expect(() => agent.bskyAppUpsertNux({ id: 'a' })).rejects.toThrow()
+        expect(() => agent.bskyAppUpsertNux({ name: 'a' })).rejects.toThrow()
         expect(() =>
-          agent.bskyAppUpsertNux({ name: 'a', completed: false, foo: 'bar' }),
+          agent.bskyAppUpsertNux({ id: 'a', completed: false, foo: 'bar' }),
         ).rejects.toThrow()
       })
     })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -84,6 +84,7 @@ describe('agent', () => {
       bskyAppState: {
         activeProgressGuide: undefined,
         queuedNudges: [],
+        nuxs: [],
       },
     })
   })
@@ -133,6 +134,7 @@ describe('agent', () => {
       bskyAppState: {
         activeProgressGuide: undefined,
         queuedNudges: [],
+        nuxs: [],
       },
     })
     expect(agent.labelers).toStrictEqual(['did:plc:other'])
@@ -167,6 +169,7 @@ describe('agent', () => {
       bskyAppState: {
         activeProgressGuide: undefined,
         queuedNudges: [],
+        nuxs: [],
       },
     })
     expect(agent.labelers).toStrictEqual([])
@@ -223,6 +226,7 @@ describe('agent', () => {
       bskyAppState: {
         activeProgressGuide: undefined,
         queuedNudges: [],
+        nuxs: [],
       },
     })
   })

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4598,10 +4598,11 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['name', 'completed'],
+        required: ['id', 'completed'],
         properties: {
-          name: {
+          id: {
             type: 'string',
+            maxLength: 100,
           },
           completed: {
             type: 'boolean',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4572,6 +4572,15 @@ export const schemaDict = {
               maxLength: 100,
             },
           },
+          nuxs: {
+            description: 'Storage for NUXs the user has encountered.',
+            type: 'array',
+            maxLength: 100,
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#nux',
+            },
+          },
         },
       },
       bskyAppProgressGuide: {
@@ -4583,6 +4592,36 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      nux: {
+        type: 'object',
+        description: 'A new user experiences (NUX) storage object',
+        required: ['id', 'name', 'completed'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          completed: {
+            type: 'boolean',
+            default: false,
+          },
+          data: {
+            description:
+              'Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.',
+            type: 'string',
+            maxLength: 3000,
+            maxGraphemes: 300,
+          },
+          expiresAt: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'The date and time at which the NUX will expire and should be considered completed.',
           },
         },
       },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4598,11 +4598,8 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['id', 'name', 'completed'],
+        required: ['name', 'completed'],
         properties: {
-          id: {
-            type: 'string',
-          },
           name: {
             type: 'string',
           },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -469,6 +469,8 @@ export interface BskyAppStatePref {
   activeProgressGuide?: BskyAppProgressGuide
   /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
   queuedNudges?: string[]
+  /** Storage for NUXs the user has encountered. */
+  nuxs?: Nux[]
   [k: string]: unknown
 }
 
@@ -500,4 +502,26 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+/** A new user experiences (NUX) storage object */
+export interface Nux {
+  id: string
+  name: string
+  completed: boolean
+  /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
+  data?: string
+  /** The date and time at which the NUX will expire and should be considered completed. */
+  expiresAt?: string
+  [k: string]: unknown
+}
+
+export function isNux(v: unknown): v is Nux {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#nux'
+  )
+}
+
+export function validateNux(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#nux', v)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,7 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  name: string
+  id: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
   data?: string

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,6 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  id: string
   name: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4598,10 +4598,11 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['name', 'completed'],
+        required: ['id', 'completed'],
         properties: {
-          name: {
+          id: {
             type: 'string',
+            maxLength: 100,
           },
           completed: {
             type: 'boolean',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4572,6 +4572,15 @@ export const schemaDict = {
               maxLength: 100,
             },
           },
+          nuxs: {
+            description: 'Storage for NUXs the user has encountered.',
+            type: 'array',
+            maxLength: 100,
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#nux',
+            },
+          },
         },
       },
       bskyAppProgressGuide: {
@@ -4583,6 +4592,36 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      nux: {
+        type: 'object',
+        description: 'A new user experiences (NUX) storage object',
+        required: ['id', 'name', 'completed'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          completed: {
+            type: 'boolean',
+            default: false,
+          },
+          data: {
+            description:
+              'Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.',
+            type: 'string',
+            maxLength: 3000,
+            maxGraphemes: 300,
+          },
+          expiresAt: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'The date and time at which the NUX will expire and should be considered completed.',
           },
         },
       },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4598,11 +4598,8 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['id', 'name', 'completed'],
+        required: ['name', 'completed'],
         properties: {
-          id: {
-            type: 'string',
-          },
           name: {
             type: 'string',
           },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -469,6 +469,8 @@ export interface BskyAppStatePref {
   activeProgressGuide?: BskyAppProgressGuide
   /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
   queuedNudges?: string[]
+  /** Storage for NUXs the user has encountered. */
+  nuxs?: Nux[]
   [k: string]: unknown
 }
 
@@ -500,4 +502,26 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+/** A new user experiences (NUX) storage object */
+export interface Nux {
+  id: string
+  name: string
+  completed: boolean
+  /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
+  data?: string
+  /** The date and time at which the NUX will expire and should be considered completed. */
+  expiresAt?: string
+  [k: string]: unknown
+}
+
+export function isNux(v: unknown): v is Nux {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#nux'
+  )
+}
+
+export function validateNux(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#nux', v)
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,7 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  name: string
+  id: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
   data?: string

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,6 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  id: string
   name: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4598,10 +4598,11 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['name', 'completed'],
+        required: ['id', 'completed'],
         properties: {
-          name: {
+          id: {
             type: 'string',
+            maxLength: 100,
           },
           completed: {
             type: 'boolean',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4572,6 +4572,15 @@ export const schemaDict = {
               maxLength: 100,
             },
           },
+          nuxs: {
+            description: 'Storage for NUXs the user has encountered.',
+            type: 'array',
+            maxLength: 100,
+            items: {
+              type: 'ref',
+              ref: 'lex:app.bsky.actor.defs#nux',
+            },
+          },
         },
       },
       bskyAppProgressGuide: {
@@ -4583,6 +4592,36 @@ export const schemaDict = {
           guide: {
             type: 'string',
             maxLength: 100,
+          },
+        },
+      },
+      nux: {
+        type: 'object',
+        description: 'A new user experiences (NUX) storage object',
+        required: ['id', 'name', 'completed'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          completed: {
+            type: 'boolean',
+            default: false,
+          },
+          data: {
+            description:
+              'Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters.',
+            type: 'string',
+            maxLength: 3000,
+            maxGraphemes: 300,
+          },
+          expiresAt: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'The date and time at which the NUX will expire and should be considered completed.',
           },
         },
       },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4598,11 +4598,8 @@ export const schemaDict = {
       nux: {
         type: 'object',
         description: 'A new user experiences (NUX) storage object',
-        required: ['id', 'name', 'completed'],
+        required: ['name', 'completed'],
         properties: {
-          id: {
-            type: 'string',
-          },
           name: {
             type: 'string',
           },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -469,6 +469,8 @@ export interface BskyAppStatePref {
   activeProgressGuide?: BskyAppProgressGuide
   /** An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user. */
   queuedNudges?: string[]
+  /** Storage for NUXs the user has encountered. */
+  nuxs?: Nux[]
   [k: string]: unknown
 }
 
@@ -500,4 +502,26 @@ export function isBskyAppProgressGuide(v: unknown): v is BskyAppProgressGuide {
 
 export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#bskyAppProgressGuide', v)
+}
+
+/** A new user experiences (NUX) storage object */
+export interface Nux {
+  id: string
+  name: string
+  completed: boolean
+  /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
+  data?: string
+  /** The date and time at which the NUX will expire and should be considered completed. */
+  expiresAt?: string
+  [k: string]: unknown
+}
+
+export function isNux(v: unknown): v is Nux {
+  return (
+    isObj(v) && hasProp(v, '$type') && v.$type === 'app.bsky.actor.defs#nux'
+  )
+}
+
+export function validateNux(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#nux', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,7 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  name: string
+  id: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */
   data?: string

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -506,7 +506,6 @@ export function validateBskyAppProgressGuide(v: unknown): ValidationResult {
 
 /** A new user experiences (NUX) storage object */
 export interface Nux {
-  id: string
   name: string
   completed: boolean
   /** Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       tlds:
         specifier: ^1.234.0
         version: 1.234.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@atproto/lex-cli':
         specifier: workspace:^


### PR DESCRIPTION
Adds a generic storage interface for "new user experiences". In the app, these will behave like:
- user loads app and encounters a new experience
- we check this storage interface to see if the user has completed this NUX
  - if `completed === true` we do nothing
- we show the user the NUX
  - we can optionally store data on this NUX also using its `data` attribute
- when NUX is dismissed, we set `completed === true` and data is stored in prefs

The interface of a NUX is as follows:
- `id` a string with a max length of 64 characters, meant to be unique but human readable, this will be defined by the app
- `completed` a boolean, you get the idea
- `expiresAt` optional datetime, if expired, app will treat NUX as completed
- `data` string, max length of 300 chars (matches posts), optional stash of data, app will handle serde

### Validation
NUXs are validated before insertion, and before we even hit the prefs API. No additional properties beyond what is defined are allowed.

### Cleanup
Over time, these will accrue. In the app, we'll need to be judicious about how many NUXs are present for a given user. On a rolling basis, we will need to remove old NUXs as we add new ones. Some time after a NUX is removed from the app, we can remove old `id`s either on app load or on next write. This PR does not specify solutions to this.

### Naming
"New user experiences" as an acronym is NUXs. Not NUXes. `nuxs` does look a little weird, but for consistency I left it like that. NUX is how we've been referring to these internally, but if anyone has a better idea for a name lmk.