### PR TITLE
Add fast path skipping grapheme counting

### DIFF
--- a/.changeset/purple-days-repeat.md
+++ b/.changeset/purple-days-repeat.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lexicon": patch
+---
+
+Add fast path skipping grapheme counting

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -197,9 +197,14 @@ export function string(
     }
   }
 
+  // Lazily calculated and reused between checks.
+  let cachedUtf8Len: number | undefined
+  let cachedGraphemeLen: number | undefined
+
   // maxLength
   if (typeof def.maxLength === 'number') {
-    if (utf8Len(value) > def.maxLength) {
+    const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
+    if (len > def.maxLength) {
       return {
         success: false,
         error: new ValidationError(
@@ -211,7 +216,8 @@ export function string(
 
   // minLength
   if (typeof def.minLength === 'number') {
-    if (utf8Len(value) < def.minLength) {
+    const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
+    if (len < def.minLength) {
       return {
         success: false,
         error: new ValidationError(
@@ -223,7 +229,8 @@ export function string(
 
   // maxGraphemes
   if (typeof def.maxGraphemes === 'number') {
-    if (graphemeLen(value) > def.maxGraphemes) {
+    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+    if (len > def.maxGraphemes) {
       return {
         success: false,
         error: new ValidationError(
@@ -235,7 +242,8 @@ export function string(
 
   // minGraphemes
   if (typeof def.minGraphemes === 'number') {
-    if (graphemeLen(value) < def.minGraphemes) {
+    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+    if (len < def.minGraphemes) {
       return {
         success: false,
         error: new ValidationError(

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -229,26 +229,44 @@ export function string(
 
   // maxGraphemes
   if (typeof def.maxGraphemes === 'number') {
-    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
-    if (len > def.maxGraphemes) {
-      return {
-        success: false,
-        error: new ValidationError(
-          `${path} must not be longer than ${def.maxGraphemes} graphemes`,
-        ),
+    if (value.length <= def.maxGraphemes) {
+      // If the JavaScript string length is within the maximum limit,
+      // its grapheme length (which <= .length) will also be within.
+      // Skip validation.
+    } else {
+      const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+      if (len > def.maxGraphemes) {
+        return {
+          success: false,
+          error: new ValidationError(
+            `${path} must not be longer than ${def.maxGraphemes} graphemes`,
+          ),
+        }
       }
     }
   }
 
   // minGraphemes
   if (typeof def.minGraphemes === 'number') {
-    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
-    if (len < def.minGraphemes) {
+    if (value.length < def.minGraphemes) {
+      // If the JavaScript string length is below the minimal limit,
+      // its grapheme length (which <= .length) will also be below.
+      // Fail early.
       return {
         success: false,
         error: new ValidationError(
           `${path} must not be shorter than ${def.minGraphemes} graphemes`,
         ),
+      }
+    } else {
+      const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+      if (len < def.minGraphemes) {
+        return {
+          success: false,
+          error: new ValidationError(
+            `${path} must not be shorter than ${def.minGraphemes} graphemes`,
+          ),
+        }
       }
     }
   }

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -592,20 +592,97 @@ describe('Record validation', () => {
   })
 
   it('Applies grapheme string length constraint', () => {
-    lex.assertValidRecord('com.example.stringLengthGrapheme', {
-      $type: 'com.example.stringLengthGrapheme',
-      string: '12👨‍👩‍👧‍👧',
-    })
+    // Shorter than two graphemes
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '',
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '\u0301\u0301\u0301', // Three combining acute accents
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a',
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a\u0301\u0301\u0301\u0301', // 'á́́́' ('a' with four combining acute accents)
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '5\uFE0F', // '5️' with emoji presentation
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
     expect(() =>
       lex.assertValidRecord('com.example.stringLengthGrapheme', {
         $type: 'com.example.stringLengthGrapheme',
         string: '👨‍👩‍👧‍👧',
       }),
     ).toThrow('Record/string must not be shorter than 2 graphemes')
+
+    // Two to four graphemes
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'ab',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b', // 'áb' with combining accent
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b\u0301', // 'áb́'
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: '😀😀',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: '12👨‍👩‍👧‍👧',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'abcd',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b\u0301c\u0301d\u0301', // 'áb́ćd́'
+    })
+
+    // Longer than four graphemes
     expect(() =>
       lex.assertValidRecord('com.example.stringLengthGrapheme', {
         $type: 'com.example.stringLengthGrapheme',
-        string: '12345',
+        string: 'abcde',
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a\u0301b\u0301c\u0301d\u0301e\u0301', // 'áb́ćd́é'
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '😀😀😀😀😀',
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'ab😀de',
       }),
     ).toThrow('Record/string must not be longer than 4 graphemes')
   })


### PR DESCRIPTION
Not a huge deal but since we visit this codepath for every single validated string, seems like we'd want to avoid any unnecessary computation here, especially on low-end devices.

I don't know how encodings and grapheme work very well so this needs a close look.

## Commits

- https://github.com/bluesky-social/atproto/pull/2817/commits/0d6b54d09a5674bd689d3b7d7df14d5448a541ec
- https://github.com/bluesky-social/atproto/pull/2817/commits/7b973823bad0759970307d95f278e5cb27c02874
- https://github.com/bluesky-social/atproto/pull/2817/commits/8b0bdcb0c1ebc03dc7118f2135ca8d09eacd0611?w=1

## Before

This was showing up in a profile for switching tabs with 6x throttling. (Note this is a DEV profile so in PROD its % would be higher compared to other things around it.)

<img width="980" alt="Screenshot 2024-09-14 at 16 23 43" src="https://github.com/user-attachments/assets/f8d76b16-3a00-459a-bbb7-9eecd61c4f50">

## After

It doesn't show up.

<img width="659" alt="Screenshot 2024-09-14 at 16 30 34" src="https://github.com/user-attachments/assets/5b21502e-0982-4872-84d8-15e8b92715e8">
