### PR TITLE
Add fast path for UTF8 length counting

### DIFF
--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -197,9 +197,14 @@ export function string(
     }
   }
 
+  // Lazily calculated and reused between checks.
+  let cachedUtf8Len: number | undefined
+  let cachedGraphemeLen: number | undefined
+
   // maxLength
   if (typeof def.maxLength === 'number') {
-    if (utf8Len(value) > def.maxLength) {
+    const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
+    if (len > def.maxLength) {
       return {
         success: false,
         error: new ValidationError(
@@ -211,7 +216,8 @@ export function string(
 
   // minLength
   if (typeof def.minLength === 'number') {
-    if (utf8Len(value) < def.minLength) {
+    const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
+    if (len < def.minLength) {
       return {
         success: false,
         error: new ValidationError(
@@ -223,7 +229,8 @@ export function string(
 
   // maxGraphemes
   if (typeof def.maxGraphemes === 'number') {
-    if (graphemeLen(value) > def.maxGraphemes) {
+    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+    if (len > def.maxGraphemes) {
       return {
         success: false,
         error: new ValidationError(
@@ -235,7 +242,8 @@ export function string(
 
   // minGraphemes
   if (typeof def.minGraphemes === 'number') {
-    if (graphemeLen(value) < def.minGraphemes) {
+    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+    if (len < def.minGraphemes) {
       return {
         success: false,
         error: new ValidationError(

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -229,26 +229,44 @@ export function string(
 
   // maxGraphemes
   if (typeof def.maxGraphemes === 'number') {
-    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
-    if (len > def.maxGraphemes) {
-      return {
-        success: false,
-        error: new ValidationError(
-          `${path} must not be longer than ${def.maxGraphemes} graphemes`,
-        ),
+    if (value.length <= def.maxGraphemes) {
+      // If the JavaScript string length is within the maximum limit,
+      // its grapheme length (which <= .length) will also be within.
+      // Skip validation.
+    } else {
+      const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+      if (len > def.maxGraphemes) {
+        return {
+          success: false,
+          error: new ValidationError(
+            `${path} must not be longer than ${def.maxGraphemes} graphemes`,
+          ),
+        }
       }
     }
   }
 
   // minGraphemes
   if (typeof def.minGraphemes === 'number') {
-    const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
-    if (len < def.minGraphemes) {
+    if (value.length < def.minGraphemes) {
+      // If the JavaScript string length is below the minimal limit,
+      // its grapheme length (which <= .length) will also be below.
+      // Fail early.
       return {
         success: false,
         error: new ValidationError(
           `${path} must not be shorter than ${def.minGraphemes} graphemes`,
         ),
+      }
+    } else {
+      const len = cachedGraphemeLen ?? (cachedGraphemeLen = graphemeLen(value))
+      if (len < def.minGraphemes) {
+        return {
+          success: false,
+          error: new ValidationError(
+            `${path} must not be shorter than ${def.minGraphemes} graphemes`,
+          ),
+        }
       }
     }
   }

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -203,19 +203,36 @@ export function string(
 
   // maxLength
   if (typeof def.maxLength === 'number') {
-    const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
-    if (len > def.maxLength) {
-      return {
-        success: false,
-        error: new ValidationError(
-          `${path} must not be longer than ${def.maxLength} characters`,
-        ),
+    if (value.length * 3 <= def.maxLength) {
+      // If the JavaScript string length * 3 is within the maximum limit,
+      // its UTF8 length (which <= .length * 3) will also be within.
+      // Skip validation.
+    } else {
+      const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
+      if (len > def.maxLength) {
+        return {
+          success: false,
+          error: new ValidationError(
+            `${path} must not be longer than ${def.maxLength} characters`,
+          ),
+        }
       }
     }
   }
 
   // minLength
   if (typeof def.minLength === 'number') {
+    if (value.length * 3 < def.minLength) {
+      // If the JavaScript string length * 3 is below the maximum limit,
+      // its UTF8 length (which <= .length * 3) will also be below.
+      // Fail early.
+      return {
+        success: false,
+        error: new ValidationError(
+          `${path} must not be shorter than ${def.minLength} characters`,
+        ),
+      }
+    }
     const len = cachedUtf8Len ?? (cachedUtf8Len = utf8Len(value))
     if (len < def.minLength) {
       return {

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -592,20 +592,97 @@ describe('Record validation', () => {
   })
 
   it('Applies grapheme string length constraint', () => {
-    lex.assertValidRecord('com.example.stringLengthGrapheme', {
-      $type: 'com.example.stringLengthGrapheme',
-      string: '12👨‍👩‍👧‍👧',
-    })
+    // Shorter than two graphemes
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '',
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '\u0301\u0301\u0301', // Three combining acute accents
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a',
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a\u0301\u0301\u0301\u0301', // 'á́́́' ('a' with four combining acute accents)
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '5\uFE0F', // '5️' with emoji presentation
+      }),
+    ).toThrow('Record/string must not be shorter than 2 graphemes')
     expect(() =>
       lex.assertValidRecord('com.example.stringLengthGrapheme', {
         $type: 'com.example.stringLengthGrapheme',
         string: '👨‍👩‍👧‍👧',
       }),
     ).toThrow('Record/string must not be shorter than 2 graphemes')
+
+    // Two to four graphemes
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'ab',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b', // 'áb' with combining accent
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b\u0301', // 'áb́'
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: '😀😀',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: '12👨‍👩‍👧‍👧',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'abcd',
+    })
+    lex.assertValidRecord('com.example.stringLengthGrapheme', {
+      $type: 'com.example.stringLengthGrapheme',
+      string: 'a\u0301b\u0301c\u0301d\u0301', // 'áb́ćd́'
+    })
+
+    // Longer than four graphemes
     expect(() =>
       lex.assertValidRecord('com.example.stringLengthGrapheme', {
         $type: 'com.example.stringLengthGrapheme',
-        string: '12345',
+        string: 'abcde',
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'a\u0301b\u0301c\u0301d\u0301e\u0301', // 'áb́ćd́é'
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: '😀😀😀😀😀',
+      }),
+    ).toThrow('Record/string must not be longer than 4 graphemes')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLengthGrapheme', {
+        $type: 'com.example.stringLengthGrapheme',
+        string: 'ab😀de',
       }),
     ).toThrow('Record/string must not be longer than 4 graphemes')
   })

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -567,26 +567,106 @@ describe('Record validation', () => {
   })
 
   it('Applies string length constraint', () => {
-    lex.assertValidRecord('com.example.stringLength', {
-      $type: 'com.example.stringLength',
-      string: '123',
-    })
+    // Shorter than two UTF8 characters
     expect(() =>
       lex.assertValidRecord('com.example.stringLength', {
         $type: 'com.example.stringLength',
-        string: '1',
+        string: '',
       }),
     ).toThrow('Record/string must not be shorter than 2 characters')
     expect(() =>
       lex.assertValidRecord('com.example.stringLength', {
         $type: 'com.example.stringLength',
-        string: '12345',
+        string: 'a',
+      }),
+    ).toThrow('Record/string must not be shorter than 2 characters')
+
+    // Two to four UTF8 characters
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'ab',
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: '\u0301', // Combining acute accent (2 bytes)
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'a\u0301', // 'a' + combining acute accent (1 + 2 bytes = 3 bytes)
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'aé', // 'a' (1 byte) + 'é' (2 bytes) = 3 bytes
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'abc',
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: '一', // CJK character (3 bytes)
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: '\uD83D', // Unpaired high surrogate (3 bytes)
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'abcd',
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'éé', // 'é' + 'é' (2 + 2 bytes = 4 bytes)
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: 'aaé', // 1 + 1 + 2 = 4 bytes
+    })
+    lex.assertValidRecord('com.example.stringLength', {
+      $type: 'com.example.stringLength',
+      string: '👋', // 4 bytes
+    })
+
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: 'abcde',
       }),
     ).toThrow('Record/string must not be longer than 4 characters')
     expect(() =>
       lex.assertValidRecord('com.example.stringLength', {
         $type: 'com.example.stringLength',
-        string: '👨‍👩‍👧‍👧',
+        string: 'a\u0301\u0301', // 1 + (2 * 2) = 5 bytes
+      }),
+    ).toThrow('Record/string must not be longer than 4 characters')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: '\uD83D\uD83D', // Two unpaired high surrogates (3 * 2 = 6 bytes)
+      }),
+    ).toThrow('Record/string must not be longer than 4 characters')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: 'ééé', // 2 + 2 + 2 bytes = 6 bytes
+      }),
+    ).toThrow('Record/string must not be longer than 4 characters')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: '👋a', // 4 + 1 bytes = 5 bytes
+      }),
+    ).toThrow('Record/string must not be longer than 4 characters')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: '👨👨', // 4 + 4 = 8 bytes
+      }),
+    ).toThrow('Record/string must not be longer than 4 characters')
+    expect(() =>
+      lex.assertValidRecord('com.example.stringLength', {
+        $type: 'com.example.stringLength',
+        string: '👨‍👩‍👧‍👧', // 4 emojis × 4 bytes + 3 ZWJs × 3 bytes = 25 bytes
       }),
     ).toThrow('Record/string must not be longer than 4 characters')
   })


### PR DESCRIPTION
## Stacked on https://github.com/bluesky-social/atproto/pull/2817

## Commits

- https://github.com/bluesky-social/atproto/commit/e3dabaf9bb0960b9b290dfd9f10d68a6c930997e
- https://github.com/bluesky-social/atproto/commit/9337c2b122b0626e7565634e56747fba49f84003?w=1

## What


Similar to https://github.com/bluesky-social/atproto/pull/2817, I'm trying to avoid calling into `TextEncoder().encode(str).byteLength` for every string. After this change, I basically don't hit it in the app at all — the fast path always lets me out early.

The fast pass itself is pretty general. The idea is that `.length` counts UTF-16 code units, and each UTF-16 code unit corresponds to at most 3 bytes in UTF-8 encoding. So we can safely use `value.length * 3` as an upper bound on what `utf8Len(value)` could possibly be. If this upper bound is below the `minLength`, the same is true for `utf8Len`. If this upper bound is within `maxLength`, the same is true for `utf8Len`. This generalizes to the `''` case with `minLength = 1` too.

Why `* 3`?

- Codepoints fit into a single UTF-16 code unit become 1 to 3 bytes in UTF-8. (Worst case is 3x.)
- Codepoints that need two UTF-16 code units become 4 bytes in UTF-8. (Worst case is 2x.)

So `.length * 3` should always give us a valid upper bound. But this needs a look from an expert.

I've added some test cases.