### PR TITLE
Align OAuth 2FA code handling with social-app

### DIFF
--- a/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
@@ -109,7 +109,7 @@ export function SignInForm({
   secondFactorPattern = '^[A-Z2-7]{5}-[A-Z2-7]{5}$',
   secondFactorFormat = 'XXXXX-XXXXX',
   secondFactorHint = 'Check your $1 email for a login code and enter it here.',
-  secondFactorParseValue = checkAndFormatResetCode,
+  secondFactorParseValue = checkAndFormatEmailOtpCode,
 
   rememberVisible = true,
   rememberDefault = false,
@@ -317,7 +317,7 @@ function parseErrorMessage(err: unknown): string {
   return 'An unknown error occurred'
 }
 
-export function checkAndFormatResetCode(code: string): string | false {
+export function checkAndFormatEmailOtpCode(code: string): string | false {
   const EMAIL_CODE_REGEX = /^[A-Z2-7]{5}-[A-Z2-7]{5}$/
 
   // Trim the reset code

--- a/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
@@ -106,7 +106,7 @@ export function SignInForm({
   secondFactorLabel = 'Confirmation code',
   secondFactorAria = secondFactorLabel,
   secondFactorPlaceholder = secondFactorLabel,
-  secondFactorPattern = '^[A-Z0-9]{5}-[A-Z0-9]{5}$',
+  secondFactorPattern = '^[A-Z2-7]{5}-[A-Z2-7]{5}$',
   secondFactorFormat = 'XXXXX-XXXXX',
   secondFactorHint = 'Check your $1 email for a login code and enter it here.',
   secondFactorParseValue = checkAndFormatResetCode,

--- a/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
@@ -161,7 +161,7 @@ export function SignInForm({
         if (!value) {
           setSecondFactor({
             type: secondFactor.type,
-            hint: `Make sure to matches the format: ${secondFactorFormat}`,
+            hint: `Make sure to match the format: ${secondFactorFormat}`,
           })
           return
         }

--- a/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
@@ -155,7 +155,11 @@ export function SignInForm({
       if (secondFactor) {
         const element = event.currentTarget.secondFactor
         if (!element) throw new Error('Second factor input not found')
-        credentials[secondFactor.type] = element.value
+        let value = element.value
+        if (secondFactor.type === 'emailOtp') {
+          value = value.toUpperCase()
+        }
+        credentials[secondFactor.type] = value
       }
 
       setLoading(true)


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5448

The email OTP code we send is in lowercase for some reason - I'll try and fix that as well, but in social-app it tries some basic corrections on the code in case someone types it by hand. This PR uses the same function that social-app uses, which uppercases it and adds the dash in the middle if it's not present.

> [!NOTE]
> social-app uses the regex `/^[A-Z2-7]{5}-[A-Z2-7]{5}$/`, whereas I found oauth was using the slightly more lax `/^[A-Z0-9]{5}-[A-Z0-9]{5}$/`. I replaced it with social-app's one, I hope that's ok?