### PR TITLE
Default to unencoded responses

### DIFF
--- a/.changeset/dirty-foxes-bow.md
+++ b/.changeset/dirty-foxes-bow.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Allow defaulting to unencoded responses when proxying client requests that do not specify accept-encoding

--- a/.changeset/happy-islands-wash.md
+++ b/.changeset/happy-islands-wash.md
@@ -1,0 +1,5 @@
+---
+"@atproto/common": patch
+---
+
+Allow contentEncoding to be an array for consistency with typing of headers

--- a/packages/common-web/src/util.ts
+++ b/packages/common-web/src/util.ts
@@ -21,7 +21,7 @@ export function omit<
   rejectedKeys: readonly K[],
 ): T extends undefined ? undefined : T extends null ? null : Omit<T, K>
 export function omit(
-  src: Record<string, unknown>,
+  src: undefined | null | Record<string, unknown>,
   rejectedKeys: readonly string[],
 ): undefined | null | Record<string, unknown> {
   // Hot path

--- a/packages/common-web/src/util.ts
+++ b/packages/common-web/src/util.ts
@@ -10,47 +10,33 @@ export const noUndefinedVals = <T>(
 }
 
 /**
- * Creates a copy of the object with the specified keys omitted. If the object
- * is `undefined`, it returns `undefined`. If the object did not have any of the
- * keys to omit, it returns the same object.
+ * Returns a shallow copy of the object without the specified keys. If the input
+ * is nullish, it returns the input.
  */
 export function omit<
-  T extends undefined | Record<string, unknown>,
+  T extends undefined | null | Record<string, unknown>,
   K extends keyof NonNullable<T>,
->(obj: T, keys: readonly K[]): T extends undefined ? undefined : Omit<T, K>
+>(
+  object: T,
+  rejectedKeys: readonly K[],
+): T extends undefined ? undefined : T extends null ? null : Omit<T, K>
 export function omit(
-  obj: Record<string, unknown>,
-  keys: readonly string[],
-): undefined | Record<string, unknown> {
+  src: Record<string, unknown>,
+  rejectedKeys: readonly string[],
+): undefined | null | Record<string, unknown> {
   // Hot path
-  if (obj) {
-    const objKeys = Object.keys(obj)
-    for (let i = 0; i < objKeys.length; i++) {
-      // If the key at position i must be excluded
-      if (keys.includes(keys[i])) {
-        // Create a copy
-        const newObj = {}
 
-        // Copy all the keys already visited (that did not have to be excluded),
-        // without re-checking if they need to be excluded.
-        for (let j = 0; j < i; j++) {
-          const key = objKeys[j]
-          newObj[key] = obj[key]
-        }
+  if (!src) return src
 
-        // Copy all the remaining keys, excluding the ones that need to be
-        // excluded.
-        for (let j = i + 1; j < objKeys.length; j++) {
-          const key = objKeys[j]
-          if (!keys.includes(key)) newObj[key] = obj[key]
-        }
-
-        return newObj
-      }
+  const dst = {}
+  const srcKeys = Object.keys(src)
+  for (let i = 0; i < srcKeys.length; i++) {
+    const key = srcKeys[i]
+    if (!rejectedKeys.includes(key)) {
+      dst[key] = src[key]
     }
   }
-
-  return obj
+  return dst
 }
 
 export const jitter = (maxMs: number) => {

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -88,15 +88,15 @@ export class MaxSizeChecker extends Transform {
 
 export function decodeStream(
   stream: Readable,
-  contentEncoding?: string,
+  contentEncoding?: string | string[],
 ): Readable
 export function decodeStream(
   stream: AsyncIterable<Uint8Array>,
-  contentEncoding?: string,
+  contentEncoding?: string | string[],
 ): AsyncIterable<Uint8Array> | Readable
 export function decodeStream(
   stream: Readable | AsyncIterable<Uint8Array>,
-  contentEncoding?: string,
+  contentEncoding?: string | string[],
 ): Readable | AsyncIterable<Uint8Array> {
   const decoders = createDecoders(contentEncoding)
   if (decoders.length === 0) return stream
@@ -107,8 +107,12 @@ export function decodeStream(
  * Create a series of decoding streams based on the content-encoding header. The
  * resulting streams should be piped together to decode the content.
  */
-export function createDecoders(contentEncoding?: string): Duplex[] {
+export function createDecoders(contentEncoding?: string | string[]): Duplex[] {
   const decoders: Duplex[] = []
+
+  if (Array.isArray(contentEncoding)) {
+    throw new TypeError('content-encoding must be a comma separated string')
+  }
 
   if (contentEncoding) {
     const encodings = contentEncoding.split(',')

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -246,6 +246,8 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     headersTimeout: env.proxyHeadersTimeout ?? 10e3,
     bodyTimeout: env.proxyBodyTimeout ?? 30e3,
     maxResponseSize: env.proxyMaxResponseSize ?? 10 * 1024 * 1024, // 10mb
+    decodeResponses: env.proxyDecodeResponses ?? false,
+    preferUncompressed: env.proxyPreferUncompressed ?? false,
   }
 
   const oauthCfg: ServerConfig['oauth'] = entrywayCfg
@@ -413,6 +415,21 @@ export type ProxyConfig = {
   headersTimeout: number
   bodyTimeout: number
   maxResponseSize: number
+
+  /**
+   * If true, the PDS will decode proxied responses to clients not specifying an
+   * "accept-encoding" header.
+   */
+  decodeResponses: boolean
+
+  /**
+   * When {@link ProxyConfig.decodeResponses} is true, the PDS will
+   * decode proxied responses to clients not specifying an "accept-encoding"
+   * header. In order to do this, it can either ask upstream servers to send
+   * uncompressed responses, or it can decode the response itself. The former
+   * saves CPU time on the PDS, at the cost of bandwidth.
+   */
+  preferUncompressed: boolean
 }
 
 export type OAuthConfig = {

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -246,7 +246,6 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     headersTimeout: env.proxyHeadersTimeout ?? 10e3,
     bodyTimeout: env.proxyBodyTimeout ?? 30e3,
     maxResponseSize: env.proxyMaxResponseSize ?? 10 * 1024 * 1024, // 10mb
-    decodeResponses: env.proxyDecodeResponses ?? true,
     preferCompressed: env.proxyPreferCompressed ?? false,
   }
 
@@ -415,12 +414,6 @@ export type ProxyConfig = {
   headersTimeout: number
   bodyTimeout: number
   maxResponseSize: number
-
-  /**
-   * If true, the PDS will decode proxied responses to clients not specifying an
-   * "accept-encoding" header.
-   */
-  decodeResponses: boolean
 
   /**
    * When {@link ProxyConfig.decodeResponses} is true, the PDS will

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -416,9 +416,11 @@ export type ProxyConfig = {
   maxResponseSize: number
 
   /**
-   * Prefers compressed responses when proxying requests. Might cause additional
-   * CPU usage on the server (since the payload will need to decompressed when
-   * the client does not specify an "accept-encoding"), but can save bandwidth.
+   * When proxying requests that might get intercepted (for read-after-write) we
+   * negotiate the encoding based on the client's preferences. We will however
+   * use or own weights in order to be able to better control if the PDS will
+   * need to perform content decoding. This settings allows to prefer compressed
+   * content over uncompressed one.
    */
   preferCompressed: boolean
 }

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -246,8 +246,8 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     headersTimeout: env.proxyHeadersTimeout ?? 10e3,
     bodyTimeout: env.proxyBodyTimeout ?? 30e3,
     maxResponseSize: env.proxyMaxResponseSize ?? 10 * 1024 * 1024, // 10mb
-    decodeResponses: env.proxyDecodeResponses ?? false,
-    preferUncompressed: env.proxyPreferUncompressed ?? false,
+    decodeResponses: env.proxyDecodeResponses ?? true,
+    preferCompressed: env.proxyPreferCompressed ?? false,
   }
 
   const oauthCfg: ServerConfig['oauth'] = entrywayCfg
@@ -429,7 +429,7 @@ export type ProxyConfig = {
    * uncompressed responses, or it can decode the response itself. The former
    * saves CPU time on the PDS, at the cost of bandwidth.
    */
-  preferUncompressed: boolean
+  preferCompressed: boolean
 }
 
 export type OAuthConfig = {

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -416,11 +416,9 @@ export type ProxyConfig = {
   maxResponseSize: number
 
   /**
-   * When {@link ProxyConfig.decodeResponses} is true, the PDS will
-   * decode proxied responses to clients not specifying an "accept-encoding"
-   * header. In order to do this, it can either ask upstream servers to send
-   * uncompressed responses, or it can decode the response itself. The former
-   * saves CPU time on the PDS, at the cost of bandwidth.
+   * Prefers compressed responses when proxying requests. Might cause additional
+   * CPU usage on the server (since the payload will need to decompressed when
+   * the client does not specify an "accept-encoding"), but can save bandwidth.
    */
   preferCompressed: boolean
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -128,7 +128,6 @@ export const readEnv = (): ServerEnvironment => {
     proxyHeadersTimeout: envInt('PDS_PROXY_HEADERS_TIMEOUT'),
     proxyBodyTimeout: envInt('PDS_PROXY_BODY_TIMEOUT'),
     proxyMaxResponseSize: envInt('PDS_PROXY_MAX_RESPONSE_SIZE'),
-    proxyDecodeResponses: envBool('PDS_PROXY_DECODE_RESPONSES'),
     proxyPreferCompressed: envBool('PDS_PROXY_PREFER_COMPRESSED'),
   }
 }
@@ -255,6 +254,5 @@ export type ServerEnvironment = {
   proxyHeadersTimeout?: number
   proxyBodyTimeout?: number
   proxyMaxResponseSize?: number
-  proxyDecodeResponses?: boolean
   proxyPreferCompressed?: boolean
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -128,6 +128,8 @@ export const readEnv = (): ServerEnvironment => {
     proxyHeadersTimeout: envInt('PDS_PROXY_HEADERS_TIMEOUT'),
     proxyBodyTimeout: envInt('PDS_PROXY_BODY_TIMEOUT'),
     proxyMaxResponseSize: envInt('PDS_PROXY_MAX_RESPONSE_SIZE'),
+    proxyDecodeResponses: envBool('PDS_PROXY_DECODE_RESPONSES'),
+    proxyPreferUncompressed: envBool('PDS_PROXY_PREFER_UNCOMPRESSED'),
   }
 }
 
@@ -253,4 +255,6 @@ export type ServerEnvironment = {
   proxyHeadersTimeout?: number
   proxyBodyTimeout?: number
   proxyMaxResponseSize?: number
+  proxyDecodeResponses?: boolean
+  proxyPreferUncompressed?: boolean
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -129,7 +129,7 @@ export const readEnv = (): ServerEnvironment => {
     proxyBodyTimeout: envInt('PDS_PROXY_BODY_TIMEOUT'),
     proxyMaxResponseSize: envInt('PDS_PROXY_MAX_RESPONSE_SIZE'),
     proxyDecodeResponses: envBool('PDS_PROXY_DECODE_RESPONSES'),
-    proxyPreferUncompressed: envBool('PDS_PROXY_PREFER_UNCOMPRESSED'),
+    proxyPreferCompressed: envBool('PDS_PROXY_PREFER_COMPRESSED'),
   }
 }
 
@@ -256,5 +256,5 @@ export type ServerEnvironment = {
   proxyBodyTimeout?: number
   proxyMaxResponseSize?: number
   proxyDecodeResponses?: boolean
-  proxyPreferUncompressed?: boolean
+  proxyPreferCompressed?: boolean
 }

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -63,9 +63,9 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
       const headers: IncomingHttpHeaders = {
         'accept-encoding':
           req.headers['accept-encoding'] ||
-          (ctx.cfg.proxy.preferUncompressed
-            ? 'identity'
-            : formatAccepted(SUPPORTED_ENCODINGS)),
+          (ctx.cfg.proxy.preferCompressed
+            ? formatAccepted(SUPPORTED_ENCODINGS)
+            : 'identity'),
         'accept-language': req.headers['accept-language'],
         'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
         'x-bsky-topics': req.headers['x-bsky-topics'],
@@ -188,7 +188,7 @@ export async function pipethrough(
   // understand.
   const acceptEncoding = negotiateAccept(
     req.headers['accept-encoding'] ||
-      (ctx.cfg.proxy.preferUncompressed ? 'identity' : '*'),
+      (ctx.cfg.proxy.preferCompressed ? '*' : 'identity'),
     SUPPORTED_ENCODINGS,
   )
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -132,7 +132,8 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
             const dec = createDecoders(upstream.headers['content-encoding'])
             if (dec.length) {
               pipeline([...dec, res], (_err: Error | null) => {})
-              res.setHeader('content-encoding', 'identity')
+              res.removeHeader('content-encoding')
+              res.removeHeader('content-length')
               return dec[0]
             }
           } catch {
@@ -241,7 +242,7 @@ export async function pipethrough(
   if (!req.headers['accept-encoding']) {
     return {
       encoding,
-      headers: { ...headers, 'content-encoding': 'identity' },
+      headers: omit(headers, ['content-encoding', 'content-length']),
       stream: decodeStream(upstream.body, upstream.headers['content-encoding']),
     }
   }

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -1,6 +1,7 @@
 import util from 'node:util'
 import assert from 'node:assert'
 import { AtpAgent } from '@atproto/api'
+import { request } from 'undici'
 import { TestNetwork, SeedClient, RecordRef } from '@atproto/dev-env'
 import basicSeed from '../seeds/basic'
 import { ThreadViewPost } from '../../src/lexicon/types/app/bsky/feed/defs'
@@ -265,5 +266,81 @@ describe('proxy read after write', () => {
     expect(lag).toBeDefined()
     const parsed = parseInt(lag)
     expect(parsed > 0).toBe(true)
+  })
+
+  it('negotiates encoding', async () => {
+    const identity = await agent.api.app.bsky.feed.getTimeline(
+      {},
+      { headers: { ...sc.getHeaders(alice), 'accept-encoding': 'identity' } },
+    )
+    expect(identity.headers['content-encoding']).toBeUndefined()
+
+    const gzip = await agent.api.app.bsky.feed.getTimeline(
+      {},
+      {
+        headers: { ...sc.getHeaders(alice), 'accept-encoding': 'gzip, *;q=0' },
+      },
+    )
+    expect(gzip.headers['content-encoding']).toBe('gzip')
+  })
+
+  it('defaults to identity encoding', async () => {
+    // Not using the "agent" because "fetch()" will add "accept-encoding: gzip,
+    // deflate" if not "accept-encoding" header is provided
+    const res = await request(
+      new URL(`/xrpc/app.bsky.feed.getTimeline`, agent.dispatchUrl),
+      {
+        headers: { ...sc.getHeaders(alice) },
+      },
+    )
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-encoding']).toBeUndefined()
+  })
+
+  it('falls back to identity encoding', async () => {
+    const invalid = await agent.api.app.bsky.feed.getTimeline(
+      {},
+      { headers: { ...sc.getHeaders(alice), 'accept-encoding': 'invalid' } },
+    )
+
+    expect(invalid.headers['content-encoding']).toBeUndefined()
+  })
+
+  it('errors when failing to negotiate encoding', async () => {
+    await expect(
+      agent.api.app.bsky.feed.getTimeline(
+        {},
+        {
+          headers: {
+            ...sc.getHeaders(alice),
+            'accept-encoding': 'invalid, *;q=0',
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        status: 406,
+        message: 'this service does not support any of the requested encodings',
+      }),
+    )
+  })
+
+  it('errors on invalid content-encoding format', async () => {
+    await expect(
+      agent.api.app.bsky.feed.getTimeline(
+        {},
+        {
+          headers: {
+            ...sc.getHeaders(alice),
+            'accept-encoding': ';q=1',
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        status: 400,
+        message: 'Invalid accept-encoding: ";q=1"',
+      }),
+    )
   })
 })


### PR DESCRIPTION
This enables PDSs to serve un-compressed responses when the request does not contain `accept-encoding`. This is done by specifying `identity` as preferred `content-encoding` when performing the upstream request. If the upstream server did not respect our priority list, the PDS will decode the response before serving it.

If, at some point we would like to reduce the bandwidth (at the cost of increased CPU usage on both the PDS and AppView(s)), we can set `PDS_PROXY_PREFER_COMPRESSED=true`. This will cause the PDS to ask for compressed responses with higher priority than uncompressed (`identity`) payloads.