### PR TITLE
Don't replace first post with pin if limit=1

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -106,13 +106,9 @@ export const skeleton = async (inputs: {
       },
       authorPinned: true,
     }
-    if (params.limit === 1) {
-      items[0] = pinnedItem
-    } else {
-      // filter pinned post from first page only
-      items = items.filter((item) => item.post.uri !== pinnedItem.post.uri)
-      items.unshift(pinnedItem)
-    }
+
+    items = items.filter((item) => item.post.uri !== pinnedItem.post.uri)
+    items.unshift(pinnedItem)
   }
 
   return {


### PR DESCRIPTION
We had weird divergent behaviour if you asked for limit=1 or not where limit=1 would *only* return the pinned post. Since we ask for limit=1 to check to see if there are new posts, we should instead return the pin and the top post here so we can check both