### PR TITLE
Use uppercase 2fa codes in email templates

### DIFF
--- a/packages/oauth/oauth-client/README.md
+++ b/packages/oauth/oauth-client/README.md
@@ -61,7 +61,10 @@ const client = new OAuthClient({
       throw new TypeError(`Unsupported algorithm: ${algorithm.name}`)
     },
 
-    requestLock: <T>(name: string, fn: () => T | PromiseLike<T>): Promise<T> => {
+    requestLock: <T>(
+      name: string,
+      fn: () => T | PromiseLike<T>,
+    ): Promise<T> => {
       // This function is used to prevent concurrent refreshes of the same
       // credentials. It is important to ensure that only one refresh is done at
       // a time to prevent the sessions from being revoked.
@@ -74,13 +77,16 @@ const client = new OAuthClient({
       declare const locks: Map<string, Promise<void>>
 
       const current = locks.get(name) || Promise.resolve()
-      const next = current.then(fn).catch(() => {}).finally(() => {
-        if (locks.get(name) === next) locks.delete(name)
-      })
+      const next = current
+        .then(fn)
+        .catch(() => {})
+        .finally(() => {
+          if (locks.get(name) === next) locks.delete(name)
+        })
 
       locks.set(name, next)
       return next
-    }
+    },
   },
 
   stateStore: {

--- a/packages/pds/src/mailer/templates/confirm-email.hbs
+++ b/packages/pds/src/mailer/templates/confirm-email.hbs
@@ -68,7 +68,7 @@
                       style="font-size:16px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 24%, 34.2%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px;padding-bottom:12px;padding-right:32px"
                     >To confirm this email for your account, please enter the
                       code below in the app.</p><code
-                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:lowercase"
+                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:uppercase"
                     >{{token}}</code>
                     <p
                       style="font-size:14px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 20%, 53%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px"

--- a/packages/pds/src/mailer/templates/delete-account.hbs
+++ b/packages/pds/src/mailer/templates/delete-account.hbs
@@ -71,7 +71,7 @@
                         account,</span>
                       <!-- -->please enter the code below in the app along with
                       your password.</p><code
-                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:lowercase"
+                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:uppercase"
                     >{{token}}</code>
                     <p
                       style="font-size:14px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 20%, 53%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px;padding-right:32px"

--- a/packages/pds/src/mailer/templates/plc-operation.hbs
+++ b/packages/pds/src/mailer/templates/plc-operation.hbs
@@ -68,7 +68,7 @@
                       style="font-size:16px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 24%, 34.2%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px;padding-bottom:12px"
                     >We received a request to update your PLC identity. Your
                       confirmation code is:</p><code
-                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:lowercase"
+                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:uppercase"
                     >{{token}}</code>
                     <p
                       style="font-size:14px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 20%, 53%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px"

--- a/packages/pds/src/mailer/templates/reset-password.hbs
+++ b/packages/pds/src/mailer/templates/reset-password.hbs
@@ -70,7 +70,7 @@
                       <span
                         style="color:hsl(211, 99%, 53%)"
                       >@<!-- -->{{handle}}<!-- -->.</span></p><code
-                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:lowercase"
+                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:uppercase"
                     >{{token}}</code>
                     <p
                       style="font-size:14px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 20%, 53%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px"

--- a/packages/pds/src/mailer/templates/update-email.hbs
+++ b/packages/pds/src/mailer/templates/update-email.hbs
@@ -69,7 +69,7 @@
                       style="font-size:16px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 24%, 34.2%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px;padding-bottom:12px;padding-right:32px"
                     >To update the email for your account, enter the code below
                       in the app along with your new email.</p><code
-                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:lowercase"
+                      style="display:block;padding:16px;border-radius:8px;border-width:1px;border-style:solid;background-color:hsl(211, 20%, 95.3%);border-color:hsl(211, 20%, 85.89999999999999%);font-size:14px;letter-spacing:0.25px;font-family:monospace;text-transform:uppercase"
                     >{{token}}</code>
                     <p
                       style="font-size:14px;line-height:1.4;margin:0px 0px;letter-spacing:0.25px;color:hsl(211, 20%, 53%);font-family:-apple-system, BlinkMacSystemFont, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif;padding-top:12px"


### PR DESCRIPTION
Ensures codes are uppercased, since that's what our app expects. We could also loosen those regexes to allow lowercase i.e. `[A-z]` but let's just stick to the script.

Fixes #2825 and https://github.com/bluesky-social/social-app/issues/5448