### PR TITLE
Add check for external media within RecordWithMedia

### DIFF
--- a/.changeset/long-rings-invent.md
+++ b/.changeset/long-rings-invent.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Adds support for muting words within link cards attached to `RecordWithMedia` embeds.

--- a/packages/api/src/moderation/subjects/post.ts
+++ b/packages/api/src/moderation/subjects/post.ts
@@ -321,6 +321,20 @@ function checkMutedWords(
           }
         }
       }
+
+      if (AppBskyEmbedExternal.isView(subject.embed.media)) {
+        const { external } = subject.embed.media
+        if (
+          hasMutedWord({
+            mutedWords,
+            text: external.title + ' ' + external.description,
+            languages: [],
+            actor: embedAuthor,
+          })
+        ) {
+          return true
+        }
+      }
     }
   }
   return false


### PR DESCRIPTION
We had a report a while back that if a link card was attached along with a quoted post, mute words didn't apply to the link card. This fixes that.