### PR TITLE
Appview: temp fix for bad pinned post values

### DIFF
--- a/packages/bsky/src/util/uris.ts
+++ b/packages/bsky/src/util/uris.ts
@@ -1,6 +1,9 @@
-import assert from 'node:assert'
 import { AtUri } from '@atproto/syntax'
 import { ids } from '../lexicon/lexicons'
+import {
+  validateMain as validateStrongRef,
+  Main as StrongRef,
+} from '../lexicon/types/com/atproto/repo/strongRef'
 
 /**
  * Convert a post URI to a threadgate URI. If the URI is not a valid
@@ -28,4 +31,16 @@ export function postUriToPostgateUri(postUri: string) {
 
 export function uriToDid(uri: string) {
   return new AtUri(uri).hostname
+}
+
+// @TODO temp fix for proliferation of invalid pinned post values
+export function safePinnedPost(value: unknown) {
+  if (!value) {
+    return
+  }
+  const validated = validateStrongRef(value)
+  if (!validated.success) {
+    return
+  }
+  return validated.value as StrongRef
 }

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -35,7 +35,7 @@ import {
   VideoUriBuilder,
   parsePostgate,
 } from './util'
-import { uriToDid as creatorFromUri } from '../util/uris'
+import { uriToDid as creatorFromUri, safePinnedPost } from '../util/uris'
 import { isListRule } from '../lexicon/types/app/bsky/feed/threadgate'
 import { isSelfLabels } from '../lexicon/types/com/atproto/label/defs'
 import {
@@ -170,7 +170,7 @@ export class Views {
       joinedViaStarterPack: actor.profile?.joinedViaStarterPack
         ? this.starterPackBasic(actor.profile.joinedViaStarterPack.uri, state)
         : undefined,
-      pinnedPost: actor.profile?.pinnedPost,
+      pinnedPost: safePinnedPost(actor.profile?.pinnedPost),
     }
   }
 
@@ -1143,7 +1143,7 @@ export class Views {
     if (!state.ctx?.viewer || state.ctx.viewer !== authorDid) return
     const actor = state.actors?.get(authorDid)
     if (!actor) return
-    const pinnedPost = actor.profile?.pinnedPost
+    const pinnedPost = safePinnedPost(actor.profile?.pinnedPost)
     if (!pinnedPost) return undefined
     return pinnedPost.uri === uri
   }


### PR DESCRIPTION
Looks like a client or bug may have been responsible for some bad pinned post values on profiles, causing some responses to be invalid.  This should set things straight while it gets worked out.