### PR TITLE
Lexicon: languages on starter pack, feed gen, and labeler records

### DIFF
--- a/lexicons/app/bsky/feed/generator.json
+++ b/lexicons/app/bsky/feed/generator.json
@@ -39,6 +39,12 @@
             "description": "Self-label values",
             "refs": ["com.atproto.label.defs#selfLabels"]
           },
+          "langs": {
+            "type": "array",
+            "description": "Indicates the human language for the intended audiences of the feed generator.",
+            "maxLength": 3,
+            "items": { "type": "string", "format": "language" }
+          },
           "createdAt": { "type": "string", "format": "datetime" }
         }
       }

--- a/lexicons/app/bsky/graph/starterpack.json
+++ b/lexicons/app/bsky/graph/starterpack.json
@@ -36,6 +36,12 @@
             "maxLength": 3,
             "items": { "type": "ref", "ref": "#feedItem" }
           },
+          "langs": {
+            "type": "array",
+            "description": "Indicates the human language for the intended audiences of the starter pack.",
+            "maxLength": 3,
+            "items": { "type": "string", "format": "language" }
+          },
           "createdAt": { "type": "string", "format": "datetime" }
         }
       }

--- a/lexicons/app/bsky/labeler/service.json
+++ b/lexicons/app/bsky/labeler/service.json
@@ -18,6 +18,12 @@
             "type": "union",
             "refs": ["com.atproto.label.defs#selfLabels"]
           },
+          "langs": {
+            "type": "array",
+            "description": "Indicates the human language for the intended audiences of the labeler.",
+            "maxLength": 3,
+            "items": { "type": "string", "format": "language" }
+          },
           "createdAt": { "type": "string", "format": "datetime" }
         }
       }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5956,6 +5956,16 @@ export const schemaDict = {
               description: 'Self-label values',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the feed generator.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8514,6 +8524,16 @@ export const schemaDict = {
                 ref: 'lex:app.bsky.graph.starterpack#feedItem',
               },
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the starter pack.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8784,6 +8804,16 @@ export const schemaDict = {
             labels: {
               type: 'union',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
+            },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the labeler.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
             },
             createdAt: {
               type: 'string',

--- a/packages/api/src/client/types/app/bsky/feed/generator.ts
+++ b/packages/api/src/client/types/app/bsky/feed/generator.ts
@@ -19,6 +19,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the feed generator. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/app/bsky/graph/starterpack.ts
+++ b/packages/api/src/client/types/app/bsky/graph/starterpack.ts
@@ -15,6 +15,8 @@ export interface Record {
   /** Reference (AT-URI) to the list record. */
   list: string
   feeds?: FeedItem[]
+  /** Indicates the human language for the intended audiences of the starter pack. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/app/bsky/labeler/service.ts
+++ b/packages/api/src/client/types/app/bsky/labeler/service.ts
@@ -13,6 +13,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the labeler. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5956,6 +5956,16 @@ export const schemaDict = {
               description: 'Self-label values',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the feed generator.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8514,6 +8524,16 @@ export const schemaDict = {
                 ref: 'lex:app.bsky.graph.starterpack#feedItem',
               },
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the starter pack.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8784,6 +8804,16 @@ export const schemaDict = {
             labels: {
               type: 'union',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
+            },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the labeler.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
             },
             createdAt: {
               type: 'string',

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/generator.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/generator.ts
@@ -19,6 +19,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the feed generator. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/starterpack.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/starterpack.ts
@@ -15,6 +15,8 @@ export interface Record {
   /** Reference (AT-URI) to the list record. */
   list: string
   feeds?: FeedItem[]
+  /** Indicates the human language for the intended audiences of the starter pack. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/labeler/service.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/labeler/service.ts
@@ -13,6 +13,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the labeler. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5956,6 +5956,16 @@ export const schemaDict = {
               description: 'Self-label values',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the feed generator.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8514,6 +8524,16 @@ export const schemaDict = {
                 ref: 'lex:app.bsky.graph.starterpack#feedItem',
               },
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the starter pack.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8784,6 +8804,16 @@ export const schemaDict = {
             labels: {
               type: 'union',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
+            },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the labeler.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
             },
             createdAt: {
               type: 'string',

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/generator.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/generator.ts
@@ -19,6 +19,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the feed generator. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/starterpack.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/starterpack.ts
@@ -15,6 +15,8 @@ export interface Record {
   /** Reference (AT-URI) to the list record. */
   list: string
   feeds?: FeedItem[]
+  /** Indicates the human language for the intended audiences of the starter pack. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/labeler/service.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/labeler/service.ts
@@ -13,6 +13,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the labeler. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5956,6 +5956,16 @@ export const schemaDict = {
               description: 'Self-label values',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the feed generator.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8514,6 +8524,16 @@ export const schemaDict = {
                 ref: 'lex:app.bsky.graph.starterpack#feedItem',
               },
             },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the starter pack.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
+            },
             createdAt: {
               type: 'string',
               format: 'datetime',
@@ -8784,6 +8804,16 @@ export const schemaDict = {
             labels: {
               type: 'union',
               refs: ['lex:com.atproto.label.defs#selfLabels'],
+            },
+            langs: {
+              type: 'array',
+              description:
+                'Indicates the human language for the intended audiences of the labeler.',
+              maxLength: 3,
+              items: {
+                type: 'string',
+                format: 'language',
+              },
             },
             createdAt: {
               type: 'string',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/generator.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/generator.ts
@@ -19,6 +19,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the feed generator. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/app/bsky/graph/starterpack.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/starterpack.ts
@@ -15,6 +15,8 @@ export interface Record {
   /** Reference (AT-URI) to the list record. */
   list: string
   feeds?: FeedItem[]
+  /** Indicates the human language for the intended audiences of the starter pack. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/app/bsky/labeler/service.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/labeler/service.ts
@@ -13,6 +13,8 @@ export interface Record {
   labels?:
     | ComAtprotoLabelDefs.SelfLabels
     | { $type: string; [k: string]: unknown }
+  /** Indicates the human language for the intended audiences of the labeler. */
+  langs?: string[]
   createdAt: string
   [k: string]: unknown
 }


### PR DESCRIPTION
This adds optional `langs` fields on starter pack, feed gen, and labeler records.  This is in line with the `langs` field on post records, and should provide more signal on relevance for discovery mechanisms in the app.