### PR TITLE
:sparkles: Add collection and subjectType filters to queryEvents and queryStatuses

### DIFF
--- a/.changeset/flat-bees-argue.md
+++ b/.changeset/flat-bees-argue.md
@@ -1,0 +1,6 @@
+---
+"@atproto/ozone": patch
+"@atproto/api": patch
+---
+
+Add collections and subjectType filters to ozone's queryEvents and queryStatuses endpoints

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -10,7 +10,9 @@
         "properties": {
           "types": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "The types of events (fully qualified string in the format of tools.ozone.moderation.defs#modEvent<name>) to filter by. If not specified, all events are returned."
           },
           "createdBy": {
@@ -33,11 +35,28 @@
             "format": "datetime",
             "description": "Retrieve events created before a given timestamp"
           },
-          "subject": { "type": "string", "format": "uri" },
+          "subject": {
+            "type": "string",
+            "format": "uri"
+          },
+          "collections": {
+            "type": "array",
+            "maxLength": 20,
+            "description": "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+            "items": {
+              "type": "string",
+              "format": "nsid"
+            }
+          },
+          "subjectType": {
+            "type": "string",
+            "description": "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
+            "knownValues": ["account", "record"]
+          },
           "includeAllUserRecords": {
             "type": "boolean",
             "default": false,
-            "description": "If true, events on all record types (posts, lists, profile etc.) owned by the did are returned"
+            "description": "If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned."
           },
           "limit": {
             "type": "integer",
@@ -55,22 +74,30 @@
           },
           "addedLabels": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "If specified, only events where all of these labels were added are returned"
           },
           "removedLabels": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "If specified, only events where all of these labels were removed are returned"
           },
           "addedTags": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "If specified, only events where all of these tags were added are returned"
           },
           "removedTags": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "If specified, only events where all of these tags were removed are returned"
           },
           "reportTypes": {
@@ -79,7 +106,9 @@
               "type": "string"
             }
           },
-          "cursor": { "type": "string" }
+          "cursor": {
+            "type": "string"
+          }
         }
       },
       "output": {
@@ -88,7 +117,9 @@
           "type": "object",
           "required": ["events"],
           "properties": {
-            "cursor": { "type": "string" },
+            "cursor": {
+              "type": "string"
+            },
             "events": {
               "type": "array",
               "items": {

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -10,7 +10,7 @@
         "properties": {
           "includeAllUserRecords": {
             "type": "boolean",
-            "description": "All subjects belonging to the account specified in the 'subject' param will be returned."
+            "description": "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned."
           },
           "subject": {
             "type": "string",
@@ -103,6 +103,20 @@
           },
           "cursor": {
             "type": "string"
+          },
+          "collections": {
+            "type": "array",
+            "maxLength": 20,
+            "description": "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+            "items": {
+              "type": "string",
+              "format": "nsid"
+            }
+          },
+          "subjectType": {
+            "type": "string",
+            "description": "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
+            "knownValues": ["account", "record"]
           }
         }
       },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -11809,6 +11809,21 @@ export const schemaDict = {
               type: 'string',
               format: 'uri',
             },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
+            },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
@@ -12004,6 +12019,21 @@ export const schemaDict = {
             },
             cursor: {
               type: 'string',
+            },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
             },
           },
         },

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -19,6 +19,10 @@ export interface QueryParams {
   /** Retrieve events created before a given timestamp */
   createdBefore?: string
   subject?: string
+  /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
   /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
   includeAllUserRecords?: boolean
   limit?: number

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -42,6 +42,10 @@ export interface QueryParams {
   tags?: string[]
   excludeTags?: string[]
   cursor?: string
+  /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/ozone/src/api/moderation/queryEvents.ts
+++ b/packages/ozone/src/api/moderation/queryEvents.ts
@@ -23,6 +23,8 @@ export default function (server: Server, ctx: AppContext) {
         addedTags = [],
         removedTags = [],
         reportTypes,
+        collections = [],
+        subjectType,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -43,6 +45,8 @@ export default function (server: Server, ctx: AppContext) {
         removedLabels,
         removedTags,
         reportTypes,
+        collections,
+        subjectType,
       })
       return {
         encoding: 'application/json',

--- a/packages/ozone/src/api/moderation/queryStatuses.ts
+++ b/packages/ozone/src/api/moderation/queryStatuses.ts
@@ -26,6 +26,8 @@ export default function (server: Server, ctx: AppContext) {
         cursor,
         tags = [],
         excludeTags = [],
+        collections = [],
+        subjectType,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -49,6 +51,8 @@ export default function (server: Server, ctx: AppContext) {
         cursor,
         tags,
         excludeTags,
+        collections,
+        subjectType,
       })
       const subjectStatuses = results.statuses.map((status) =>
         modService.views.formatSubjectStatus(status),

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -11809,6 +11809,21 @@ export const schemaDict = {
               type: 'string',
               format: 'uri',
             },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
+            },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
@@ -12004,6 +12019,21 @@ export const schemaDict = {
             },
             cursor: {
               type: 'string',
+            },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
             },
           },
         },

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -20,6 +20,10 @@ export interface QueryParams {
   /** Retrieve events created before a given timestamp */
   createdBefore?: string
   subject?: string
+  /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
   /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
   includeAllUserRecords: boolean
   limit: number

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -43,6 +43,10 @@ export interface QueryParams {
   tags?: string[]
   excludeTags?: string[]
   cursor?: string
+  /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
 }
 
 export type InputSchema = undefined

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -146,6 +146,8 @@ export class ModerationService {
     addedTags: string[]
     removedTags: string[]
     reportTypes?: string[]
+    collections: string[]
+    subjectType?: string
   }): Promise<{ cursor?: string; events: ModerationEventRow[] }> {
     const {
       subject,
@@ -164,6 +166,8 @@ export class ModerationService {
       addedTags,
       removedTags,
       reportTypes,
+      collections,
+      subjectType,
     } = opts
     const { ref } = this.db.db.dynamic
     let builder = this.db.db.selectFrom('moderation_event').selectAll()
@@ -181,6 +185,24 @@ export class ModerationService {
           .if(!subjectUri, (q) => q.where('subjectUri', 'is', null))
           .if(!!subjectUri, (q) => q.where('subjectUri', '=', subjectUri))
       }
+    } else if (subjectType === 'account') {
+      builder = builder.where('subjectUri', 'is', null)
+    } else if (subjectType === 'record') {
+      builder = builder.where('subjectUri', 'is not', null)
+    }
+
+    // If subjectType is set to 'account' let that take priority and ignore collections filter
+    if (collections.length && subjectType !== 'account') {
+      builder = builder.where('subjectUri', 'is not', null).where((qb) => {
+        collections.forEach((collection, index) => {
+          if (index === 0) {
+            qb = qb.where('subjectUri', 'like', `%/${collection}/%`)
+          } else {
+            qb = qb.orWhere('subjectUri', 'like', `%/${collection}/%`)
+          }
+        })
+        return qb
+      })
     }
 
     if (types.length) {
@@ -748,6 +770,8 @@ export class ModerationService {
     subject,
     tags,
     excludeTags,
+    collections,
+    subjectType,
   }: {
     includeAllUserRecords?: boolean
     cursor?: string
@@ -768,6 +792,8 @@ export class ModerationService {
     sortField: 'lastReviewedAt' | 'lastReportedAt'
     tags: string[]
     excludeTags: string[]
+    collections: string[]
+    subjectType?: string
   }) {
     let builder = this.db.db.selectFrom('moderation_subject_status').selectAll()
     const { ref } = this.db.db.dynamic
@@ -787,11 +813,29 @@ export class ModerationService {
             : qb.where('recordPath', '=', ''),
         )
       }
+    } else if (subjectType === 'account') {
+      builder = builder.where('recordPath', '=', '')
+    } else if (subjectType === 'record') {
+      builder = builder.where('recordPath', '!=', '')
+    }
+
+    // If subjectType is set to 'account' let that take priority and ignore collections filter
+    if (collections.length && subjectType !== 'account') {
+      builder = builder.where('recordPath', '!=', '').where((qb) => {
+        collections.forEach((collection, index) => {
+          if (index === 0) {
+            qb = qb.where('recordPath', 'like', `${collection}/%`)
+          } else {
+            qb = qb.orWhere('recordPath', 'like', `${collection}/%`)
+          }
+        })
+        return qb
+      })
     }
 
     if (ignoreSubjects?.length) {
       builder = builder
-        .where('moderation_subject_status.did', 'not in', ignoreSubjects)
+        .where('did', 'not in', ignoreSubjects)
         .where('recordPath', 'not in', ignoreSubjects)
     }
 

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -194,12 +194,8 @@ export class ModerationService {
     // If subjectType is set to 'account' let that take priority and ignore collections filter
     if (collections.length && subjectType !== 'account') {
       builder = builder.where('subjectUri', 'is not', null).where((qb) => {
-        collections.forEach((collection, index) => {
-          if (index === 0) {
-            qb = qb.where('subjectUri', 'like', `%/${collection}/%`)
-          } else {
-            qb = qb.orWhere('subjectUri', 'like', `%/${collection}/%`)
-          }
+        collections.forEach((collection) => {
+          qb = qb.orWhere('subjectUri', 'like', `%/${collection}/%`)
         })
         return qb
       })
@@ -822,12 +818,8 @@ export class ModerationService {
     // If subjectType is set to 'account' let that take priority and ignore collections filter
     if (collections.length && subjectType !== 'account') {
       builder = builder.where('recordPath', '!=', '').where((qb) => {
-        collections.forEach((collection, index) => {
-          if (index === 0) {
-            qb = qb.where('recordPath', 'like', `${collection}/%`)
-          } else {
-            qb = qb.orWhere('recordPath', 'like', `${collection}/%`)
-          }
+        collections.forEach((collection) => {
+          qb = qb.orWhere('recordPath', 'like', `${collection}/%`)
         })
         return qb
       })

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -11809,6 +11809,21 @@ export const schemaDict = {
               type: 'string',
               format: 'uri',
             },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
+            },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
@@ -12004,6 +12019,21 @@ export const schemaDict = {
             },
             cursor: {
               type: 'string',
+            },
+            collections: {
+              type: 'array',
+              description:
+                "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
+              items: {
+                type: 'string',
+                format: 'nsid',
+              },
+            },
+            subjectType: {
+              type: 'string',
+              description:
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+              knownValues: ['account', 'record'],
             },
           },
         },

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -20,6 +20,10 @@ export interface QueryParams {
   /** Retrieve events created before a given timestamp */
   createdBefore?: string
   subject?: string
+  /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
   /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
   includeAllUserRecords: boolean
   limit: number

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -43,6 +43,10 @@ export interface QueryParams {
   tags?: string[]
   excludeTags?: string[]
   cursor?: string
+  /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
+  collections?: string[]
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  subjectType?: 'account' | 'record' | (string & {})
 }
 
 export type InputSchema = undefined


### PR DESCRIPTION
These new params allows ozone api consumers to only listen for 
- account events or record events
- certain collection events

along with being able to
- process only account queue or record queue
- process queue for certain collections only