### PR TITLE
Support alternate did methods in update handle

### DIFF
--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -54,7 +54,7 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       if (!account) {
-        if (requester.startsWith('did:plc')) {
+        if (requester.startsWith('did:plc:')) {
           await ctx.plcClient.updateHandle(
             requester,
             ctx.plcRotationKey,

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -74,7 +74,7 @@ export default function (server: Server, ctx: AppContext) {
         await ctx.accountManager.updateHandle(requester, handle)
       } else {
         // if we found an account with matching handle, check if it is the same as requester
-        // is so, error. if not, then just emit an identity event
+        // if so emit an identity event, otherwise error.
         if (account.did !== requester) {
           throw new InvalidRequestError(`Handle already taken: ${handle}`)
         }

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -61,8 +61,10 @@ export default function (server: Server, ctx: AppContext) {
             handle,
           )
         } else {
-          const resolved =
-            await ctx.idResolver.did.resolveAtprotoData(requester)
+          const resolved = await ctx.idResolver.did.resolveAtprotoData(
+            requester,
+            true,
+          )
           if (resolved.handle !== handle) {
             throw new InvalidRequestError(
               'DID is not properly configured for handle',

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -53,13 +53,29 @@ export default function (server: Server, ctx: AppContext) {
         includeDeactivated: true,
       })
 
-      if (account) {
+      if (!account) {
+        if (requester.startsWith('did:plc')) {
+          await ctx.plcClient.updateHandle(
+            requester,
+            ctx.plcRotationKey,
+            handle,
+          )
+        } else {
+          const resolved =
+            await ctx.idResolver.did.resolveAtprotoData(requester)
+          if (resolved.handle !== handle) {
+            throw new InvalidRequestError(
+              'DID is not properly configured for handle',
+            )
+          }
+        }
+        await ctx.accountManager.updateHandle(requester, handle)
+      } else {
+        // if we found an account with matching handle, check if it is the same as requester
+        // is so, error. if not, then just emit an identity event
         if (account.did !== requester) {
           throw new InvalidRequestError(`Handle already taken: ${handle}`)
         }
-      } else {
-        await ctx.plcClient.updateHandle(requester, ctx.plcRotationKey, handle)
-        await ctx.accountManager.updateHandle(requester, handle)
       }
 
       try {


### PR DESCRIPTION
If a user's DID is not did:plc, then resolve the DID to ensure that they set their handle correctly & track handle update