### PR TITLE
Fix handling of too big events

### DIFF
--- a/packages/pds/src/sequencer/events.ts
+++ b/packages/pds/src/sequencer/events.ts
@@ -26,7 +26,11 @@ export const formatSeqCommit = async (
   if (writes.length > 200 || commitData.newBlocks.byteSize > 1000000) {
     tooBig = true
     const justRoot = new BlockMap()
-    justRoot.add(commitData.newBlocks.get(commitData.cid))
+    const commitCid = commitData.cid
+    const commitBlock = commitData.newBlocks.get(commitCid)
+    if (commitBlock) {
+      justRoot.set(commitCid, commitBlock)
+    }
     carSlice = await blocksToCarFile(commitData.cid, justRoot)
   } else {
     tooBig = false


### PR DESCRIPTION
We were using the wrong method on BlockMap here: the async `.add` which serializes & hashes the content instead of the synchronous `.set` since we already know the bytes & cid for the block

Closes https://github.com/bluesky-social/atproto/issues/2893