### PR TITLE
Add threat signatures to admin view

### DIFF
--- a/lexicons/com/atproto/admin/defs.json
+++ b/lexicons/com/atproto/admin/defs.json
@@ -33,7 +33,14 @@
         "invitesDisabled": { "type": "boolean" },
         "emailConfirmedAt": { "type": "string", "format": "datetime" },
         "inviteNote": { "type": "string" },
-        "deactivatedAt": { "type": "string", "format": "datetime" }
+        "deactivatedAt": { "type": "string", "format": "datetime" },
+        "threatSignatures": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#threatSignature"
+          }
+        }
       }
     },
     "repoRef": {
@@ -50,6 +57,14 @@
         "did": { "type": "string", "format": "did" },
         "cid": { "type": "string", "format": "cid" },
         "recordUri": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "threatSignature": {
+      "type": "object",
+      "required": ["property", "value"],
+      "properties": {
+        "property": { "type": "string" },
+        "value": { "type": "string" }
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -70,6 +70,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          threatSignatures: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.admin.defs#threatSignature',
+            },
+          },
         },
       },
       repoRef: {
@@ -97,6 +104,18 @@ export const schemaDict = {
           recordUri: {
             type: 'string',
             format: 'at-uri',
+          },
+        },
+      },
+      threatSignature: {
+        type: 'object',
+        required: ['property', 'value'],
+        properties: {
+          property: {
+            type: 'string',
+          },
+          value: {
+            type: 'string',
           },
         },
       },
@@ -11811,6 +11830,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -11821,14 +11841,14 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
               description:
-                'If true, events on all record types (posts, lists, profile etc.) owned by the did are returned',
+                "If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned.",
             },
             limit: {
               type: 'integer',
@@ -11923,7 +11943,7 @@ export const schemaDict = {
             includeAllUserRecords: {
               type: 'boolean',
               description:
-                "All subjects belonging to the account specified in the 'subject' param will be returned.",
+                "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
@@ -12022,6 +12042,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -12032,7 +12053,7 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
           },

--- a/packages/api/src/client/types/com/atproto/admin/defs.ts
+++ b/packages/api/src/client/types/com/atproto/admin/defs.ts
@@ -37,6 +37,7 @@ export interface AccountView {
   emailConfirmedAt?: string
   inviteNote?: string
   deactivatedAt?: string
+  threatSignatures?: ThreatSignature[]
   [k: string]: unknown
 }
 
@@ -86,4 +87,22 @@ export function isRepoBlobRef(v: unknown): v is RepoBlobRef {
 
 export function validateRepoBlobRef(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoBlobRef', v)
+}
+
+export interface ThreatSignature {
+  property: string
+  value: string
+  [k: string]: unknown
+}
+
+export function isThreatSignature(v: unknown): v is ThreatSignature {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#threatSignature'
+  )
+}
+
+export function validateThreatSignature(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#threatSignature', v)
 }

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -21,9 +21,9 @@ export interface QueryParams {
   subject?: string
   /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
-  /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
+  /** If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned. */
   includeAllUserRecords?: boolean
   limit?: number
   /** If true, only events with comments are returned */

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -9,7 +9,7 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */
   subject?: string
@@ -44,7 +44,7 @@ export interface QueryParams {
   cursor?: string
   /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -70,6 +70,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          threatSignatures: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.admin.defs#threatSignature',
+            },
+          },
         },
       },
       repoRef: {
@@ -97,6 +104,18 @@ export const schemaDict = {
           recordUri: {
             type: 'string',
             format: 'at-uri',
+          },
+        },
+      },
+      threatSignature: {
+        type: 'object',
+        required: ['property', 'value'],
+        properties: {
+          property: {
+            type: 'string',
+          },
+          value: {
+            type: 'string',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/defs.ts
@@ -37,6 +37,7 @@ export interface AccountView {
   emailConfirmedAt?: string
   inviteNote?: string
   deactivatedAt?: string
+  threatSignatures?: ThreatSignature[]
   [k: string]: unknown
 }
 
@@ -86,4 +87,22 @@ export function isRepoBlobRef(v: unknown): v is RepoBlobRef {
 
 export function validateRepoBlobRef(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoBlobRef', v)
+}
+
+export interface ThreatSignature {
+  property: string
+  value: string
+  [k: string]: unknown
+}
+
+export function isThreatSignature(v: unknown): v is ThreatSignature {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#threatSignature'
+  )
+}
+
+export function validateThreatSignature(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#threatSignature', v)
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -70,6 +70,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          threatSignatures: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.admin.defs#threatSignature',
+            },
+          },
         },
       },
       repoRef: {
@@ -97,6 +104,18 @@ export const schemaDict = {
           recordUri: {
             type: 'string',
             format: 'at-uri',
+          },
+        },
+      },
+      threatSignature: {
+        type: 'object',
+        required: ['property', 'value'],
+        properties: {
+          property: {
+            type: 'string',
+          },
+          value: {
+            type: 'string',
           },
         },
       },
@@ -11811,6 +11830,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -11821,14 +11841,14 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
               description:
-                'If true, events on all record types (posts, lists, profile etc.) owned by the did are returned',
+                "If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned.",
             },
             limit: {
               type: 'integer',
@@ -11923,7 +11943,7 @@ export const schemaDict = {
             includeAllUserRecords: {
               type: 'boolean',
               description:
-                "All subjects belonging to the account specified in the 'subject' param will be returned.",
+                "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
@@ -12022,6 +12042,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -12032,7 +12053,7 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
           },

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/defs.ts
@@ -37,6 +37,7 @@ export interface AccountView {
   emailConfirmedAt?: string
   inviteNote?: string
   deactivatedAt?: string
+  threatSignatures?: ThreatSignature[]
   [k: string]: unknown
 }
 
@@ -86,4 +87,22 @@ export function isRepoBlobRef(v: unknown): v is RepoBlobRef {
 
 export function validateRepoBlobRef(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoBlobRef', v)
+}
+
+export interface ThreatSignature {
+  property: string
+  value: string
+  [k: string]: unknown
+}
+
+export function isThreatSignature(v: unknown): v is ThreatSignature {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#threatSignature'
+  )
+}
+
+export function validateThreatSignature(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#threatSignature', v)
 }

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -22,9 +22,9 @@ export interface QueryParams {
   subject?: string
   /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
-  /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
+  /** If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned. */
   includeAllUserRecords: boolean
   limit: number
   /** If true, only events with comments are returned */

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,7 +10,7 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */
   subject?: string
@@ -45,7 +45,7 @@ export interface QueryParams {
   cursor?: string
   /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -70,6 +70,13 @@ export const schemaDict = {
             type: 'string',
             format: 'datetime',
           },
+          threatSignatures: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:com.atproto.admin.defs#threatSignature',
+            },
+          },
         },
       },
       repoRef: {
@@ -97,6 +104,18 @@ export const schemaDict = {
           recordUri: {
             type: 'string',
             format: 'at-uri',
+          },
+        },
+      },
+      threatSignature: {
+        type: 'object',
+        required: ['property', 'value'],
+        properties: {
+          property: {
+            type: 'string',
+          },
+          value: {
+            type: 'string',
           },
         },
       },
@@ -11811,6 +11830,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -11821,14 +11841,14 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
             includeAllUserRecords: {
               type: 'boolean',
               default: false,
               description:
-                'If true, events on all record types (posts, lists, profile etc.) owned by the did are returned',
+                "If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned.",
             },
             limit: {
               type: 'integer',
@@ -11923,7 +11943,7 @@ export const schemaDict = {
             includeAllUserRecords: {
               type: 'boolean',
               description:
-                "All subjects belonging to the account specified in the 'subject' param will be returned.",
+                "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned.",
             },
             subject: {
               type: 'string',
@@ -12022,6 +12042,7 @@ export const schemaDict = {
             },
             collections: {
               type: 'array',
+              maxLength: 20,
               description:
                 "If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored.",
               items: {
@@ -12032,7 +12053,7 @@ export const schemaDict = {
             subjectType: {
               type: 'string',
               description:
-                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored.",
+                "If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored.",
               knownValues: ['account', 'record'],
             },
           },

--- a/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/defs.ts
@@ -37,6 +37,7 @@ export interface AccountView {
   emailConfirmedAt?: string
   inviteNote?: string
   deactivatedAt?: string
+  threatSignatures?: ThreatSignature[]
   [k: string]: unknown
 }
 
@@ -86,4 +87,22 @@ export function isRepoBlobRef(v: unknown): v is RepoBlobRef {
 
 export function validateRepoBlobRef(v: unknown): ValidationResult {
   return lexicons.validate('com.atproto.admin.defs#repoBlobRef', v)
+}
+
+export interface ThreatSignature {
+  property: string
+  value: string
+  [k: string]: unknown
+}
+
+export function isThreatSignature(v: unknown): v is ThreatSignature {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'com.atproto.admin.defs#threatSignature'
+  )
+}
+
+export function validateThreatSignature(v: unknown): ValidationResult {
+  return lexicons.validate('com.atproto.admin.defs#threatSignature', v)
 }

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -22,9 +22,9 @@ export interface QueryParams {
   subject?: string
   /** If specified, only events where the subject belongs to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, only events where the subject is of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
-  /** If true, events on all record types (posts, lists, profile etc.) owned by the did are returned */
+  /** If true, events on all record types (posts, lists, profile etc.) or records from given 'collections' param, owned by the did are returned. */
   includeAllUserRecords: boolean
   limit: number
   /** If true, only events with comments are returned */

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,7 +10,7 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** All subjects belonging to the account specified in the 'subject' param will be returned. */
+  /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */
   subject?: string
@@ -45,7 +45,7 @@ export interface QueryParams {
   cursor?: string
   /** If specified, subjects belonging to the given collections will be returned. When subjectType is set to 'account', this will be ignored. */
   collections?: string[]
-  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. */
+  /** If specified, subjects of the given type (account or record) will be returned. When this is set to 'account' the 'collections' parameter will be ignored. When includeAllUserRecords or subject is set, this will be ignored. */
   subjectType?: 'account' | 'record' | (string & {})
 }
 


### PR DESCRIPTION
This is a relatively freeform field for attaching additional arbitrary threat signatures to a given admin view