### PR TITLE
Filter out invalid facets in RichText

### DIFF
--- a/.changeset/swift-sheep-confess.md
+++ b/.changeset/swift-sheep-confess.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Fix handling of invalid facets in RichText

--- a/packages/api/src/rich-text/rich-text.ts
+++ b/packages/api/src/rich-text/rich-text.ts
@@ -169,7 +169,7 @@ export class RichText {
       this.facets = entitiesToFacets(this.unicodeText, props.entities)
     }
     if (this.facets) {
-      this.facets.sort(facetSort)
+      this.facets = this.facets.filter(facetFilter).sort(facetSort)
     }
     if (opts?.cleanNewlines) {
       sanitizeRichText(this, { cleanNewlines: true }).copyInto(this)
@@ -378,7 +378,11 @@ export class RichText {
   }
 }
 
-const facetSort = (a, b) => a.index.byteStart - b.index.byteStart
+const facetSort = (a: Facet, b: Facet) => a.index.byteStart - b.index.byteStart
+
+const facetFilter = (facet: Facet) =>
+  // discard negative-length facets. zero-length facets are valid
+  facet.index.byteStart <= facet.index.byteEnd
 
 function entitiesToFacets(text: UnicodeString, entities: Entity[]): Facet[] {
   const facets: Facet[] = []

--- a/packages/api/tests/rich-text.test.ts
+++ b/packages/api/tests/rich-text.test.ts
@@ -658,4 +658,69 @@ describe('RichText#segments', () => {
       },
     ])
   })
+
+  it("doesn't duplicate text when funky facets are present", () => {
+    const funky = {
+      facets: [
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+        {
+          features: [],
+          index: {
+            byteEnd: 0,
+            byteStart: 300,
+          },
+        },
+      ],
+      text: ':3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 ',
+    }
+    const input = new RichText(funky)
+
+    let output = ''
+    for (const segment of input.segments()) {
+      output += segment.text
+    }
+
+    expect(output).toEqual(funky.text)
+  })
 })

--- a/packages/api/tests/rich-text.test.ts
+++ b/packages/api/tests/rich-text.test.ts
@@ -660,25 +660,46 @@ describe('RichText#segments', () => {
   })
 
   it("doesn't duplicate text when negative-length facets are present", () => {
-    const funky = {
+    const input = {
       text: 'hello world',
       facets: [
+        // invalid zero-length
+        {
+          features: [],
+          index: {
+            byteStart: 6,
+            byteEnd: 0,
+          },
+        },
+        // valid normal facet
+        {
+          features: [],
+          index: {
+            byteEnd: 11,
+            byteStart: 6,
+          },
+        },
+        // valid zero-length
         {
           features: [],
           index: {
             byteEnd: 0,
-            byteStart: 6,
+            byteStart: 0,
           },
         },
       ],
     }
-    const input = new RichText(funky)
+
+    const rt = new RichText(input)
 
     let output = ''
-    for (const segment of input.segments()) {
+    for (const segment of rt.segments()) {
       output += segment.text
     }
 
-    expect(output).toEqual(funky.text)
+    expect(output).toEqual(input.text)
+
+    // invalid one should have been removed
+    expect(rt.facets?.length).toEqual(2)
   })
 })

--- a/packages/api/tests/rich-text.test.ts
+++ b/packages/api/tests/rich-text.test.ts
@@ -659,60 +659,18 @@ describe('RichText#segments', () => {
     ])
   })
 
-  it("doesn't duplicate text when funky facets are present", () => {
+  it("doesn't duplicate text when negative-length facets are present", () => {
     const funky = {
+      text: 'hello world',
       facets: [
         {
           features: [],
           index: {
             byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
-          },
-        },
-        {
-          features: [],
-          index: {
-            byteEnd: 0,
-            byteStart: 300,
+            byteStart: 6,
           },
         },
       ],
-      text: ':3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 :3 ',
     }
     const input = new RichText(funky)
 


### PR DESCRIPTION
Negative-length facets cause text to be duplicated for whatever reason. Fixed by filtering out facets where `byteStart` is larger than `byteEnd`. Zero-length facets are still allowed.

A new test case was added to catch this:

![Screenshot 2024-10-31 at 17 45 17](https://github.com/user-attachments/assets/1ef7c7dc-ccd4-4d24-9952-deeeb23eb900)
