### PR TITLE
Enforce feed limit before hydration

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -245,20 +245,14 @@ const skeletonFromFeedGen = async (
   }
 
   const { feed: feedSkele, ...skele } = skeleton
-  // Limit again in case the feedgen does not respect the limit.
-  // Leave some margin in case filtering removes more items.
-  const limitMargin = Math.ceil(params.limit * 0.3)
-
-  const feedItems = feedSkele
-    .slice(0, params.limit + limitMargin)
-    .map((item) => ({
-      post: { uri: item.post },
-      repost:
-        typeof item.reason?.repost === 'string'
-          ? { uri: item.reason.repost }
-          : undefined,
-      feedContext: item.feedContext,
-    }))
+  const feedItems = feedSkele.slice(0, params.limit).map((item) => ({
+    post: { uri: item.post },
+    repost:
+      typeof item.reason?.repost === 'string'
+        ? { uri: item.reason.repost }
+        : undefined,
+    feedContext: item.feedContext,
+  }))
 
   return { ...skele, resHeaders, feedItems }
 }

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -129,13 +129,14 @@ const noBlocksOrMutes = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
       !bam.ancestorAuthorBlocked
     )
   })
+
   return skeleton
 }
 
 const presentation = (
   inputs: PresentationFnInput<Context, Params, Skeleton>,
 ) => {
-  const { ctx, params, skeleton, hydration } = inputs
+  const { ctx, skeleton, hydration } = inputs
   const feed = mapDefined(skeleton.items, (item) => {
     const post = ctx.views.feedViewPost(item, hydration)
     if (!post) return
@@ -143,7 +144,7 @@ const presentation = (
       ...post,
       feedContext: item.feedContext,
     }
-  }).slice(0, params.limit)
+  })
   return {
     feed,
     cursor: skeleton.cursor,
@@ -211,6 +212,7 @@ const skeletonFromFeedGen = async (
     const result = await agent.api.app.bsky.feed.getFeedSkeleton(
       {
         feed: params.feed,
+        // The feedgen is not guaranteed to honor the limit, but we try it.
         limit: params.limit,
         cursor: params.cursor,
       },
@@ -243,14 +245,20 @@ const skeletonFromFeedGen = async (
   }
 
   const { feed: feedSkele, ...skele } = skeleton
-  const feedItems = feedSkele.map((item) => ({
-    post: { uri: item.post },
-    repost:
-      typeof item.reason?.repost === 'string'
-        ? { uri: item.reason.repost }
-        : undefined,
-    feedContext: item.feedContext,
-  }))
+  // Limit again in case the feedgen does not respect the limit.
+  // Leave some margin in case filtering removes more items.
+  const limitMargin = Math.ceil(params.limit * 0.3)
+
+  const feedItems = feedSkele
+    .slice(0, params.limit + limitMargin)
+    .map((item) => ({
+      post: { uri: item.post },
+      repost:
+        typeof item.reason?.repost === 'string'
+          ? { uri: item.reason.repost }
+          : undefined,
+      feedContext: item.feedContext,
+    }))
 
   return { ...skele, resHeaders, feedItems }
 }


### PR DESCRIPTION
We passed the limit in the feedgen call, but since they are not guaranteed to honor it, we were subject to hydrating a large number of posts if the feedgen didn't respect pagination. We were applying the limit again in the presentation, but hydration had already happened at that point.

Now we apply the limit + some margin right after fetching from the feedgen. The margin is added because some posts might be removed during filtering, so we should usually still have enough to fill a page even after filtering.

If the feed gen misbehaves (returning way more posts than the limit) and filtering doesn't remove enough of them, our pages will be larger than the limit. I figure it is better to return the page with more items in this case to keep the last result in sync with the cursor returned.

I wanted to add a test for this but it felt a bit complicated to do rn.