### PR TITLE
Fix optimistic getPostThread for URIs with handle

### DIFF
--- a/.changeset/funny-queens-lick.md
+++ b/.changeset/funny-queens-lick.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Fix getPostThread optimistic handling for URIs with handle


### PR DESCRIPTION
Previously, `getPostThread` read-after-write handling was not taking `at://<handle>/...` URIs into account. This resulted in the PDS returning 404 for post thread query whenever relay is lagging, which resulted in a confusing UX in the app (the post would show up but clicking into it would show 404). This should fix that.

## Test Plan

See two additions to tests. One of those worked before, the other one failed. Now both work.