### PR TITLE
`PDS_BSKY_APP_VIEW_ENDPOINT` is now `PDS_BSKY_APP_VIEW_URL`

### DIFF
--- a/packages/pds/example.env
+++ b/packages/pds/example.env
@@ -20,7 +20,7 @@ PDS_ADMIN_PASSWORD="admin-pass"
 
 # Environment - example is for live network
 PDS_DID_PLC_URL="https://plc.directory"
-PDS_BSKY_APP_VIEW_ENDPOINT="https://api.bsky.app"
+PDS_BSKY_APP_VIEW_URL="https://api.bsky.app"
 PDS_BSKY_APP_VIEW_DID="did:web:api.bsky.app"
 PDS_CRAWLERS="https://bsky.network"
 


### PR DESCRIPTION
This has changed about a year ago, but this example was missed.

Fixes: d664b51c6490ebed3557c002ad912cfa828aef56