### PR TITLE
Introduce `StrictKeyOmit`

### DIFF
--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -312,7 +312,7 @@ function genRecordCls(file: SourceFile, nsid: string, lexRecord: LexRecord) {
     })
     method.addParameter({
       name: 'params',
-      type: `Omit<${toTitleCase(ATP_METHODS.list)}.QueryParams, "collection">`,
+      type: `StrictKeyOmit<${toTitleCase(ATP_METHODS.list)}.QueryParams, "collection">`,
     })
     method.setBodyText(
       [
@@ -330,7 +330,7 @@ function genRecordCls(file: SourceFile, nsid: string, lexRecord: LexRecord) {
     })
     method.addParameter({
       name: 'params',
-      type: `Omit<${toTitleCase(ATP_METHODS.get)}.QueryParams, "collection">`,
+      type: `StrictKeyOmit<${toTitleCase(ATP_METHODS.get)}.QueryParams, "collection">`,
     })
     method.setBodyText(
       [
@@ -348,7 +348,7 @@ function genRecordCls(file: SourceFile, nsid: string, lexRecord: LexRecord) {
     })
     method.addParameter({
       name: 'params',
-      type: `Omit<${toTitleCase(
+      type: `StrictKeyOmit<${toTitleCase(
         ATP_METHODS.create,
       )}.InputSchema, "collection" | "record">`,
     })
@@ -380,7 +380,7 @@ function genRecordCls(file: SourceFile, nsid: string, lexRecord: LexRecord) {
   //   })
   //   method.addParameter({
   //     name: 'params',
-  //     type: `Omit<${toTitleCase(ATP_METHODS.put)}.InputSchema, "collection" | "record">`,
+  //     type: `StrictKeyOmit<${toTitleCase(ATP_METHODS.put)}.InputSchema, "collection" | "record">`,
   //   })
   //   method.addParameter({
   //     name: 'record',
@@ -407,7 +407,7 @@ function genRecordCls(file: SourceFile, nsid: string, lexRecord: LexRecord) {
     })
     method.addParameter({
       name: 'params',
-      type: `Omit<${toTitleCase(
+      type: `StrictKeyOmit<${toTitleCase(
         ATP_METHODS.delete,
       )}.InputSchema, "collection">`,
     })
@@ -444,6 +444,7 @@ const lexiconTs = (project, lexicons: Lexicons, lexiconDoc: LexiconDoc) =>
         xrpcImport.addNamedImports([
           { name: 'HeadersMap' },
           { name: 'XRPCError' },
+          { name: 'StrictKeyOmit' },
         ])
       }
       //= import {ValidationResult, BlobRef} from '@atproto/lexicon'

--- a/packages/xrpc/src/types.ts
+++ b/packages/xrpc/src/types.ts
@@ -188,3 +188,17 @@ export class XRPCInvalidResponseError extends XRPCError {
     )
   }
 }
+
+type IsLiteralKey<K extends PropertyKey> = {
+  string: string extends K ? 0 : 1
+  number: number extends K ? 0 : 1
+  symbol: symbol extends K ? 0 : 1
+}[K extends string ? 'string' : K extends number ? 'number' : 'symbol']
+
+type LiteralKey<T> = keyof {
+  [K in keyof T as IsLiteralKey<K> extends 1 ? K : never]: K
+}
+
+export type StrictKeyOmit<T, K extends LiteralKey<T>> = {
+  [K2 in keyof T as K2 extends K ? never : K2]: T[K2]
+}


### PR DESCRIPTION
fixes https://github.com/bluesky-social/atproto/issues/2952

I couldn't run `codegen` script for some reason so I didn't regenerate the output yet. I end up with:
```
> @atproto/api@0.13.15 codegen /Code/atproto/packages/api
> node ./scripts/generate-code.mjs && lex gen-api --yes ./src/client ../../lexicons/com/atproto/*/* ../../lexicons/app/bsky/*/* ../../lexicons/chat/bsky/*/* ../../lexicons/tools/ozone/*/*

flex: can't open gen-api
```

This improves type safety by omitting only the desired literal keys when index signatures are present (leaving the index signatures in place!). You can see this in action in this [TS playground](https://www.typescriptlang.org/play/?ts=5.6.3#code/JYOwLgpgTgZghgYwgAgJIgA4FcwGUEAWEAtnMgN4BQyyA9AFT3IAqRyBcIAJgDYoD2UZABFUw5PxjIwbKBAz9kACjgBrOABpkCLFDnhkiBPyzgAlADpk9WtWRyFALmQBnMFFABzANx2GTVhQAOVwxCSkZFDljKC5tfh4+BDBgfhArGztjRIhk1JBnNw8QHz9GFjYAJVzBOIBpCABPDNsaKFUmgH5C9y9fGn9kAGFOZAAjFBcIMGlFAHJ4Him52ddVYAxkABkIAA9gYxBXQhIyADc4HmAuOBS08Psa2OQbsE1kOfcsCBWwRTkAI5YYByZDAMBaQTIPhwM4oUxTGZ-ZAXK6vAQgHiNZAwKGqED8ADuRx2+0OLhadlR11uEG6434CQgnH6dHKgUeMTi4KmPBgVgAslg3PFwHBQIZkAASMCNDAoGDACA8LiUtpPLjOcgAX1ZgyG-GIGDgoM4cRchLgm0J4II0jYGDkZ1SwvixGI4PG2KGYjVrktGAN7vB9KKfTsAG1VD1ip4ALrOUz4okgXzayiUPYKKBIuUoIa6fRgaouLA8GYAXmQAHkPWAADx+Wg0FstgB6nTs6GweBOpA0dgARNFaoPkAAfZDD+T8QeUAB8vkosvlaBcW3B0EuDUa9bqyD2kG4LmQAAUoPx5TnGjv58gq1QaGGSjGvAfdkeuCf951kAAGZBnAARlZEAsGICYoGcMCIOgd9P2-ZBfwA4DWRcRoIISQoMLGBJ4IgY9kB-f9AOQEDKG1CN90PAiv1cXoSiQqdn08MdnGoj9aJPGDIKYwceOgNjmJwhJBzjJcVxQDdICgbcmnrZg7yrDpGkkChI33CUVLU5hDBPVB103WSeB3Pc7xowigKY-doIgOEoATIi0yXLNBFzVdcF6ZId1rcEFK0DiEO2Iy5N3RSlPUmgqIAJjBI5tKkXS4G-WKLLo4iQDsuD2OixzmBi8SKJc3Zs3clBz0vfgpi4Esy0rZBPI8byml8hsm1bVsOy7TAcHwIh+yHEdYjHSdpwUOdF0oIA)