### PR TITLE
Replace "Javascript" with "JavaScript"

### DIFF
--- a/lexicons/app/bsky/richtext/facet.json
+++ b/lexicons/app/bsky/richtext/facet.json
@@ -40,7 +40,7 @@
     },
     "byteSlice": {
       "type": "object",
-      "description": "Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.",
+      "description": "Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.",
       "required": ["byteStart", "byteEnd"],
       "properties": {
         "byteStart": { "type": "integer", "minimum": 0 },

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -194,7 +194,7 @@ if (AppBskyFeedPost.isRecord(post)) {
 
 Some records (ie posts) use the `app.bsky.richtext` lexicon. At the moment richtext is only used for links and mentions, but it will be extended over time to include bold, italic, and so on.
 
-ℹ️ It is **strongly** recommended to use this package's `RichText` library. Javascript encodes strings in utf16 while the protocol (and most other programming environments) use utf8. Converting between the two is challenging, but `RichText` handles that for you.
+ℹ️ It is **strongly** recommended to use this package's `RichText` library. JavaScript encodes strings in utf16 while the protocol (and most other programming environments) use utf8. Converting between the two is challenging, but `RichText` handles that for you.
 
 ```typescript
 import { RichText } from '@atproto/api'

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -9114,7 +9114,7 @@ export const schemaDict = {
       byteSlice: {
         type: 'object',
         description:
-          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
+          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
         required: ['byteStart', 'byteEnd'],
         properties: {
           byteStart: {

--- a/packages/api/src/client/types/app/bsky/richtext/facet.ts
+++ b/packages/api/src/client/types/app/bsky/richtext/facet.ts
@@ -78,7 +78,7 @@ export function validateTag(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#tag', v)
 }
 
-/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
+/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
 export interface ByteSlice {
   byteStart: number
   byteEnd: number

--- a/packages/api/src/rich-text/unicode.ts
+++ b/packages/api/src/rich-text/unicode.ts
@@ -1,5 +1,5 @@
 /**
- * Javascript uses utf16-encoded strings while most environments and specs
+ * JavaScript uses utf16-encoded strings while most environments and specs
  * have standardized around utf8 (including JSON).
  *
  * After some lengthy debated we decided that richtext facets need to use

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -9114,7 +9114,7 @@ export const schemaDict = {
       byteSlice: {
         type: 'object',
         description:
-          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
+          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
         required: ['byteStart', 'byteEnd'],
         properties: {
           byteStart: {

--- a/packages/bsky/src/lexicon/types/app/bsky/richtext/facet.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/richtext/facet.ts
@@ -78,7 +78,7 @@ export function validateTag(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#tag', v)
 }
 
-/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
+/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
 export interface ByteSlice {
   byteStart: number
   byteEnd: number

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -9114,7 +9114,7 @@ export const schemaDict = {
       byteSlice: {
         type: 'object',
         description:
-          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
+          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
         required: ['byteStart', 'byteEnd'],
         properties: {
           byteStart: {

--- a/packages/ozone/src/lexicon/types/app/bsky/richtext/facet.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/richtext/facet.ts
@@ -78,7 +78,7 @@ export function validateTag(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#tag', v)
 }
 
-/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
+/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
 export interface ByteSlice {
   byteStart: number
   byteEnd: number

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -9114,7 +9114,7 @@ export const schemaDict = {
       byteSlice: {
         type: 'object',
         description:
-          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
+          'Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.',
         required: ['byteStart', 'byteEnd'],
         properties: {
           byteStart: {

--- a/packages/pds/src/lexicon/types/app/bsky/richtext/facet.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/richtext/facet.ts
@@ -78,7 +78,7 @@ export function validateTag(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.richtext.facet#tag', v)
 }
 
-/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
+/** Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like JavaScript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets. */
 export interface ByteSlice {
   byteStart: number
   byteEnd: number


### PR DESCRIPTION
This just bugged me, sorry...

Goes with https://github.com/bluesky-social/bsky-docs/pull/223