### PR TITLE
Include description in feed search

### DIFF
--- a/packages/bsky/src/data-plane/server/routes/feed-gens.ts
+++ b/packages/bsky/src/data-plane/server/routes/feed-gens.ts
@@ -50,7 +50,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     const query = req.query.trim()
     let builder = db.db
       .selectFrom('feed_generator')
-      .if(!!query, (q) => q.where('displayName', 'ilike', `%${query}%`))
+      .if(!!query, (q) =>
+        q
+          .where('displayName', 'ilike', `%${query}%`)
+          .orWhere('description', 'ilike', `%${query}%`),
+      )
       .selectAll()
     const keyset = new TimeCidKeyset(
       ref('feed_generator.createdAt'),

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -504,7 +504,12 @@ describe('feed generation', () => {
           ),
         },
       )
-      expect(res.data.feeds.map((f) => f.uri)).toEqual([feedUriAll])
+      expect(res.data.feeds.map((f) => f.uri)).toEqual([
+        // first two contain 'all' in description
+        feedUriNeedsAuth,
+        feedUriBadPagination,
+        feedUriAll,
+      ])
     })
 
     it('paginates', async () => {


### PR DESCRIPTION
This includes the description when searching for popular feeds instead of just the display name in the `getPopularFeedGenerators` endpoint.

Our main motivation behind this change is a bit selfish, where right now searching for “furry” in the popular feed yields no list from [@furryli.st](https://bsky.app/profile/furryli.st) despite having the most popular furry feeds across Bluesky.

Our feeds are named as short as possible to be recognizable (with the paws emoji 🐾) but to take up as little space as possible in the user’s feed list.

Some other feeds have similar discoverability problems due to having branded or short names, such as “My Bangers” (by Jaz), “📽️” (by Frances), or “GreenSky” (by Ketan) where the title is obvious but would be easier to discover if the description was included in search.

## Screenshots (current)

The feeds aren’t discoverable even if they’re more than 5x more popular.

| Search | Feeds |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/cd8442e0-c9e6-4457-b443-90597cec5eb8) | ![image](https://github.com/user-attachments/assets/8610c965-5dab-415e-bbba-7019f9e610eb) |