### PR TITLE
Ensure RAW returns empty quoteCount

### DIFF
--- a/.changeset/fuzzy-wolves-speak.md
+++ b/.changeset/fuzzy-wolves-speak.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Ensure read-after-write handles `quoteCount` for `getPostThread` responses.

--- a/packages/pds/src/read-after-write/viewer.ts
+++ b/packages/pds/src/read-after-write/viewer.ts
@@ -172,6 +172,7 @@ export class LocalViewer {
       likeCount: 0, // counts presumed to be 0 directly after post creation
       replyCount: 0,
       repostCount: 0,
+      quoteCount: 0,
       author,
       record,
       embed: embed ?? undefined,


### PR DESCRIPTION
Some folks noticed during the outage earlier today that quoteCount wasn't returned on responses for recently made posts, since those responses were served directly by the PDS via RAW and not the App View (bc outage). This was causing some rendering errors.

So this PR ensures that if we fall back to RAW, the response matches what's expected from `getPostThread`. Basically, `quoteCount` should not be `undefined`.