### PR TITLE
Lowercase uri before checking for link

### DIFF
--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -41,7 +41,7 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
     // links
     const re = URL_REGEX
     while ((match = re.exec(text.utf16))) {
-      let uri = match[2]
+      let uri = match[2].toLowerCase()
       if (!uri.startsWith('http')) {
         const domain = match.groups?.domain
         if (!domain || !isValidDomain(domain)) {


### PR DESCRIPTION
The below method will fail for situations like: Https://google.com, cnn.COM even though these strings should be considered as valid urls. 