### PR TITLE
Remove author blocks from getLikes

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -77,21 +77,7 @@ const hydration = async (inputs: {
     skeleton.likes,
     params.hydrateCtx,
   )
-  const dids = [skeleton.authorDid]
-
-  if (likesState.likes) {
-    for (const like of likesState.likes.values()) {
-      if (like) {
-        dids.push(like.cid)
-      }
-    }
-  }
-  const profileState = await ctx.hydrator.hydrateProfiles(
-    dids,
-    params.hydrateCtx,
-  )
-
-  return mergeStates(likesState, profileState)
+  return likesState
 }
 
 const noBlocks = (input: RulesFnInput<Context, Params, Skeleton>) => {

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -81,8 +81,7 @@ const hydration = async (inputs: {
 }
 
 const noBlocks = (input: RulesFnInput<Context, Params, Skeleton>) => {
-  const { ctx, params, skeleton, hydration } = input
-  const viewer = params.hydrateCtx.viewer
+  const { ctx, skeleton, hydration } = input
 
   skeleton.likes = skeleton.likes.filter((likeUri) => {
     const like = hydration.likes?.get(likeUri)
@@ -90,7 +89,7 @@ const noBlocks = (input: RulesFnInput<Context, Params, Skeleton>) => {
     const likerDid = creatorFromUri(likeUri)
     return (
       !hydration.likeBlocks?.get(likeUri) &&
-      (!viewer || !ctx.views.viewerBlockExists(likerDid, hydration))
+      !ctx.views.viewerBlockExists(likerDid, hydration)
     )
   })
   return skeleton

--- a/packages/bsky/tests/views/likes.test.ts
+++ b/packages/bsky/tests/views/likes.test.ts
@@ -11,6 +11,7 @@ describe('pds like views', () => {
   // account dids, for convenience
   let alice: string
   let bob: string
+  let carol: string
   let frankie: string
 
   beforeAll(async () => {
@@ -29,6 +30,7 @@ describe('pds like views', () => {
 
     alice = sc.dids.alice
     bob = sc.dids.bob
+    carol = sc.dids.carol
     frankie = sc.dids.frankie
   })
 
@@ -117,7 +119,7 @@ describe('pds like views', () => {
     )
   })
 
-  it(`author doesn't see likes by user the author blocked`, async () => {
+  it(`author viewer doesn't see likes by user the author blocked`, async () => {
     await sc.like(frankie, sc.posts[alice][1].ref)
     await network.processAll()
 
@@ -150,13 +152,13 @@ describe('pds like views', () => {
     ])
   })
 
-  it(`non-author doesn't see likes by user the author blocked`, async () => {
+  it(`non-author viewer doesn't see likes by user the author blocked and by user the viewer blocked `, async () => {
     await sc.unblock(alice, frankie)
     await network.processAll()
 
     const beforeBlock = await agent.app.bsky.feed.getLikes(
       { uri: sc.posts[alice][1].ref.uriStr },
-      { headers: await network.serviceHeaders(alice, ids.AppBskyFeedGetLikes) },
+      { headers: await network.serviceHeaders(bob, ids.AppBskyFeedGetLikes) },
     )
 
     expect(beforeBlock.data.likes.map((like) => like.actor.did)).toStrictEqual([
@@ -168,6 +170,7 @@ describe('pds like views', () => {
     ])
 
     await sc.block(alice, frankie)
+    await sc.block(bob, carol)
     await network.processAll()
 
     const afterBlock = await agent.app.bsky.feed.getLikes(
@@ -178,7 +181,6 @@ describe('pds like views', () => {
     expect(afterBlock.data.likes.map((like) => like.actor.did)).toStrictEqual([
       sc.dids.eve,
       sc.dids.dan,
-      sc.dids.carol,
       sc.dids.bob,
     ])
   })


### PR DESCRIPTION
This removes 3rd-party blocks from `getLikes`.

So a viewer seeing the likes in a post will not see the likes by users the viewer blocked and by users the post author blocked.