### PR TITLE
Accept a wider range of content types for DoH API calls.

### DIFF
--- a/packages/internal/handle-resolver/src/atproto-doh-handle-resolver.ts
+++ b/packages/internal/handle-resolver/src/atproto-doh-handle-resolver.ts
@@ -54,7 +54,7 @@ function dohResolveTxtFactory({
           ? await response.text()
           : `Failed to resolve ${hostname}`
         throw new TypeError(message)
-      } else if (contentType !== 'application/dns-json') {
+      } else if (contentType?.match(/application\/(dns-)json/i) == null) {
         throw new TypeError('Unexpected response from DoH server')
       }
 


### PR DESCRIPTION
Currently, the DoH calls fail when using google's DoH API, since it returns "application/json; charset=UTF-8" as its response's content-type. Notice that Alibaba Cloud's DoH returns "application/json". 'application/dns-json' seems to be particular to Cloudflare. 

While there is no agreed upon MIME for JSON schema for DoH, it seems judicious to have this implementation to accept at least the major implementations.