### PR TITLE
:sparkles: Allow querying events by multiple keywords using OR condition

### DIFF
--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -70,7 +70,7 @@
           },
           "comment": {
             "type": "string",
-            "description": "If specified, only events with comments containing the keyword are returned"
+            "description": "If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition."
           },
           "addedLabels": {
             "type": "array",

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -70,7 +70,7 @@
           },
           "comment": {
             "type": "string",
-            "description": "If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition."
+            "description": "If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition."
           },
           "addedLabels": {
             "type": "array",

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -70,7 +70,7 @@
           },
           "comment": {
             "type": "string",
-            "description": "If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition."
+            "description": "If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition."
           },
           "addedLabels": {
             "type": "array",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned',
+                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -28,7 +28,7 @@ export interface QueryParams {
   limit?: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -28,7 +28,7 @@ export interface QueryParams {
   limit?: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -28,7 +28,7 @@ export interface QueryParams {
   limit?: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned */
+  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned',
+                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned */
+  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -233,8 +233,8 @@ export class ModerationService {
           })
           return qb
         })
-      } else {
-        builder = builder.where('comment', 'ilike', `%${comment}%`)
+      } else if (keywords.length === 1) {
+        builder = builder.where('comment', 'ilike', `%${keywords[0]}%`)
       }
     }
     if (hasComment) {

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -222,8 +222,19 @@ export class ModerationService {
     if (createdBefore) {
       builder = builder.where('createdAt', '<=', createdBefore)
     }
+
     if (comment) {
-      builder = builder.where('comment', 'ilike', `%${comment}%`)
+      const keywords = comment.split('|')
+      if (keywords.length > 1) {
+        builder = builder.where((qb) => {
+          keywords.forEach((keyword) => {
+            qb = qb.orWhere('comment', 'ilike', `%${keyword}%`)
+          })
+          return qb
+        })
+      } else {
+        builder = builder.where('comment', 'ilike', `%${comment}%`)
+      }
     }
     if (hasComment) {
       builder = builder.where('comment', 'is not', null)

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -224,7 +224,8 @@ export class ModerationService {
     }
 
     if (comment) {
-      const keywords = comment.split('|')
+      // the input may end in || in which case, there may be item in the array which is just '' and we want to ignore those
+      const keywords = comment.split('||').filter((keyword) => !!keyword.trim())
       if (keywords.length > 1) {
         builder = builder.where((qb) => {
           keywords.forEach((keyword) => {

--- a/packages/ozone/tests/__snapshots__/moderation-events.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/moderation-events.test.ts.snap
@@ -197,3 +197,44 @@ Array [
   },
 ]
 `;
+
+exports[`moderation-events query events returns events matching multiple keywords in comment 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "rainy days feel lazy",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 16,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "november rain",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 15,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+]
+`;

--- a/packages/ozone/tests/__snapshots__/moderation-events.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/moderation-events.test.ts.snap
@@ -238,3 +238,85 @@ Array [
   },
 ]
 `;
+
+exports[`moderation-events query events returns events matching multiple keywords in comment 2`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "rainy days feel lazy",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 16,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "november rain",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 15,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+]
+`;
+
+exports[`moderation-events query events returns events matching multiple keywords in comment 3`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "rainy days feel lazy",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 16,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "creatorHandle": "bob.test",
+    "event": Object {
+      "$type": "tools.ozone.moderation.defs#modEventReport",
+      "comment": "november rain",
+      "isReporterMuted": false,
+      "reportType": "com.atproto.moderation.defs#reasonSpam",
+    },
+    "id": 15,
+    "subject": Object {
+      "$type": "com.atproto.admin.defs#repoRef",
+      "did": "user(0)",
+    },
+    "subjectBlobCids": Array [],
+    "subjectHandle": "alice.test",
+  },
+]
+`;

--- a/packages/ozone/tests/moderation-events.test.ts
+++ b/packages/ozone/tests/moderation-events.test.ts
@@ -245,7 +245,7 @@ describe('moderation-events', () => {
       })
       const eventsMatchingBothKeywords = await modClient.queryEvents({
         hasComment: true,
-        comment: 'november|lazy',
+        comment: 'november||lazy',
       })
 
       expect(forSnapshot(eventsMatchingBothKeywords.events)).toMatchSnapshot()

--- a/packages/ozone/tests/moderation-events.test.ts
+++ b/packages/ozone/tests/moderation-events.test.ts
@@ -224,6 +224,33 @@ describe('moderation-events', () => {
       expect(eventsWithComment.events.length).toEqual(10)
     })
 
+    it('returns events matching multiple keywords in comment', async () => {
+      await sc.createReport({
+        reasonType: REASONSPAM,
+        reason: 'november rain',
+        subject: {
+          $type: 'com.atproto.admin.defs#repoRef',
+          did: sc.dids.alice,
+        },
+        reportedBy: sc.dids.bob,
+      })
+      await sc.createReport({
+        reasonType: REASONSPAM,
+        reason: 'rainy days feel lazy',
+        subject: {
+          $type: 'com.atproto.admin.defs#repoRef',
+          did: sc.dids.alice,
+        },
+        reportedBy: sc.dids.bob,
+      })
+      const eventsMatchingBothKeywords = await modClient.queryEvents({
+        hasComment: true,
+        comment: 'november|lazy',
+      })
+
+      expect(forSnapshot(eventsMatchingBothKeywords.events)).toMatchSnapshot()
+    })
+
     it('returns events matching filter params for labels', async () => {
       const [negatedLabelEvent, createdLabelEvent] = await Promise.all([
         modClient.emitEvent({

--- a/packages/ozone/tests/moderation-events.test.ts
+++ b/packages/ozone/tests/moderation-events.test.ts
@@ -243,12 +243,25 @@ describe('moderation-events', () => {
         },
         reportedBy: sc.dids.bob,
       })
-      const eventsMatchingBothKeywords = await modClient.queryEvents({
-        hasComment: true,
-        comment: 'november||lazy',
-      })
+      const [eventsMatchingBothKeywords, unusedTrailingSeparator, extraSpaces] =
+        await Promise.all([
+          modClient.queryEvents({
+            hasComment: true,
+            comment: 'november||lazy',
+          }),
+          modClient.queryEvents({
+            hasComment: true,
+            comment: 'november||lazy||',
+          }),
+          modClient.queryEvents({
+            hasComment: true,
+            comment: '||november||lazy||  ',
+          }),
+        ])
 
       expect(forSnapshot(eventsMatchingBothKeywords.events)).toMatchSnapshot()
+      expect(forSnapshot(unusedTrailingSeparator.events)).toMatchSnapshot()
+      expect(forSnapshot(extraSpaces.events)).toMatchSnapshot()
     })
 
     it('returns events matching filter params for labels', async () => {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
+                'If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12212,7 +12212,7 @@ export const schemaDict = {
             comment: {
               type: 'string',
               description:
-                'If specified, only events with comments containing the keyword are returned',
+                'If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition.',
             },
             addedLabels: {
               type: 'array',

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply || separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
+  /** If specified, only events with comments containing the keyword are returned. Apply | separator to use multiple keywords and match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -29,7 +29,7 @@ export interface QueryParams {
   limit: number
   /** If true, only events with comments are returned */
   hasComment?: boolean
-  /** If specified, only events with comments containing the keyword are returned */
+  /** If specified, only events with comments containing the keyword are returned. Use | to use multiple keywords in to match using OR condition. */
   comment?: string
   /** If specified, only events where all of these labels were added are returned */
   addedLabels?: string[]


### PR DESCRIPTION
This PR adds a special character `||` in the comment param for `tools.ozone.moderation.queryEvents` endpoint which allows moderators to query events with certain keywords that are used with the `OR` operator.