### PR TITLE
[docs] add caveat about oauth-client-browser requiring https client_id

### DIFF
--- a/packages/oauth/oauth-client-browser/README.md
+++ b/packages/oauth/oauth-client-browser/README.md
@@ -81,6 +81,11 @@ of doing this:
    })
    ```
 
+> [!TIP]
+>
+> HTTPS is required for the client_id URL. Only loopback addresses may use HTTP, as described in
+> [using in development](#using-in-development-localhost)
+
 If performances are important to you, it is recommended to burn the metadata
 into the script. Server side rendering techniques can also be used to inject the
 metadata into the script at runtime.


### PR DESCRIPTION
## What changed

This PR adds a caveat that your `client_id` must be an HTTPS url if it is not a loopback address

## Why

In setting up a new repository while following this guide, I found that [this code](https://github.com/bluesky-social/atproto/blob/0dff6123ff5f9232aa2f7645078fb9fb365e7a3a/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts#L89) requires that any `http:` address must be a loopback configuration.

I ran into this because Github Pages isn't set up with HTTPS by default and that's what I was deploying on. Once I switched, it worked as expected.

