### PR TITLE
Add hotness as a default thread sort option

### DIFF
--- a/.changeset/fluffy-otters-study.md
+++ b/.changeset/fluffy-otters-study.md
@@ -1,0 +1,8 @@
+---
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Add hotness as a thread sorting option

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -303,7 +303,7 @@
         "sort": {
           "type": "string",
           "description": "Sorting mode for threads.",
-          "knownValues": ["oldest", "newest", "most-likes", "random"]
+          "knownValues": ["oldest", "newest", "most-likes", "random", "hotness"]
         },
         "prioritizeFollowedUsers": {
           "type": "boolean",

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -57,7 +57,7 @@ const FEED_VIEW_PREF_DEFAULTS = {
 }
 
 const THREAD_VIEW_PREF_DEFAULTS = {
-  sort: 'oldest',
+  sort: 'hotness',
   prioritizeFollowedUsers: true,
 }
 

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4490,7 +4490,13 @@ export const schemaDict = {
           sort: {
             type: 'string',
             description: 'Sorting mode for threads.',
-            knownValues: ['oldest', 'newest', 'most-likes', 'random'],
+            knownValues: [
+              'oldest',
+              'newest',
+              'most-likes',
+              'random',
+              'hotness',
+            ],
           },
           prioritizeFollowedUsers: {
             type: 'boolean',
@@ -13483,9 +13489,8 @@ export const schemaDict = {
       },
     },
   },
-} as const satisfies Record<string, LexiconDoc>
-
-export const schemas = Object.values(schemaDict)
+}
+export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -332,7 +332,13 @@ export function validateFeedViewPref(v: unknown): ValidationResult {
 
 export interface ThreadViewPref {
   /** Sorting mode for threads. */
-  sort?: 'oldest' | 'newest' | 'most-likes' | 'random' | (string & {})
+  sort?:
+    | 'oldest'
+    | 'newest'
+    | 'most-likes'
+    | 'random'
+    | 'hotness'
+    | (string & {})
   /** Show followed users at the top of all replies. */
   prioritizeFollowedUsers?: boolean
   [k: string]: unknown

--- a/packages/api/tests/atp-agent.test.ts
+++ b/packages/api/tests/atp-agent.test.ts
@@ -267,7 +267,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -309,7 +309,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -351,7 +351,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -393,7 +393,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -439,7 +439,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -488,7 +488,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -537,7 +537,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -586,7 +586,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -635,7 +635,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -684,7 +684,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -739,7 +739,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -788,7 +788,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -837,7 +837,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -886,7 +886,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -935,7 +935,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {
@@ -991,7 +991,7 @@ describe('agent', () => {
           },
         },
         threadViewPrefs: {
-          sort: 'oldest',
+          sort: 'hotness',
           prioritizeFollowedUsers: true,
         },
         interests: {

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -79,7 +79,7 @@ describe('agent', () => {
       },
       threadViewPrefs: {
         prioritizeFollowedUsers: true,
-        sort: 'oldest',
+        sort: 'hotness',
       },
       bskyAppState: {
         activeProgressGuide: undefined,
@@ -128,7 +128,7 @@ describe('agent', () => {
         },
       },
       threadViewPrefs: {
-        sort: 'oldest',
+        sort: 'hotness',
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {
@@ -163,7 +163,7 @@ describe('agent', () => {
         },
       },
       threadViewPrefs: {
-        sort: 'oldest',
+        sort: 'hotness',
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {
@@ -220,7 +220,7 @@ describe('agent', () => {
         },
       },
       threadViewPrefs: {
-        sort: 'oldest',
+        sort: 'hotness',
         prioritizeFollowedUsers: true,
       },
       bskyAppState: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4490,7 +4490,13 @@ export const schemaDict = {
           sort: {
             type: 'string',
             description: 'Sorting mode for threads.',
-            knownValues: ['oldest', 'newest', 'most-likes', 'random'],
+            knownValues: [
+              'oldest',
+              'newest',
+              'most-likes',
+              'random',
+              'hotness',
+            ],
           },
           prioritizeFollowedUsers: {
             type: 'boolean',
@@ -10722,9 +10728,8 @@ export const schemaDict = {
       },
     },
   },
-} as const satisfies Record<string, LexiconDoc>
-
-export const schemas = Object.values(schemaDict)
+}
+export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -332,7 +332,13 @@ export function validateFeedViewPref(v: unknown): ValidationResult {
 
 export interface ThreadViewPref {
   /** Sorting mode for threads. */
-  sort?: 'oldest' | 'newest' | 'most-likes' | 'random' | (string & {})
+  sort?:
+    | 'oldest'
+    | 'newest'
+    | 'most-likes'
+    | 'random'
+    | 'hotness'
+    | (string & {})
   /** Show followed users at the top of all replies. */
   prioritizeFollowedUsers?: boolean
   [k: string]: unknown

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4490,7 +4490,13 @@ export const schemaDict = {
           sort: {
             type: 'string',
             description: 'Sorting mode for threads.',
-            knownValues: ['oldest', 'newest', 'most-likes', 'random'],
+            knownValues: [
+              'oldest',
+              'newest',
+              'most-likes',
+              'random',
+              'hotness',
+            ],
           },
           prioritizeFollowedUsers: {
             type: 'boolean',
@@ -13483,9 +13489,8 @@ export const schemaDict = {
       },
     },
   },
-} as const satisfies Record<string, LexiconDoc>
-
-export const schemas = Object.values(schemaDict)
+}
+export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -332,7 +332,13 @@ export function validateFeedViewPref(v: unknown): ValidationResult {
 
 export interface ThreadViewPref {
   /** Sorting mode for threads. */
-  sort?: 'oldest' | 'newest' | 'most-likes' | 'random' | (string & {})
+  sort?:
+    | 'oldest'
+    | 'newest'
+    | 'most-likes'
+    | 'random'
+    | 'hotness'
+    | (string & {})
   /** Show followed users at the top of all replies. */
   prioritizeFollowedUsers?: boolean
   [k: string]: unknown

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4490,7 +4490,13 @@ export const schemaDict = {
           sort: {
             type: 'string',
             description: 'Sorting mode for threads.',
-            knownValues: ['oldest', 'newest', 'most-likes', 'random'],
+            knownValues: [
+              'oldest',
+              'newest',
+              'most-likes',
+              'random',
+              'hotness',
+            ],
           },
           prioritizeFollowedUsers: {
             type: 'boolean',
@@ -13483,9 +13489,8 @@ export const schemaDict = {
       },
     },
   },
-} as const satisfies Record<string, LexiconDoc>
-
-export const schemas = Object.values(schemaDict)
+}
+export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -332,7 +332,13 @@ export function validateFeedViewPref(v: unknown): ValidationResult {
 
 export interface ThreadViewPref {
   /** Sorting mode for threads. */
-  sort?: 'oldest' | 'newest' | 'most-likes' | 'random' | (string & {})
+  sort?:
+    | 'oldest'
+    | 'newest'
+    | 'most-likes'
+    | 'random'
+    | 'hotness'
+    | (string & {})
   /** Show followed users at the top of all replies. */
   prioritizeFollowedUsers?: boolean
   [k: string]: unknown


### PR DESCRIPTION
Adds a new `hotness` thread sort option and changes the agent to return it as a default if not specified. Currently it's up to the client to interpret it, we'll add a simple implementation into the social-app that others can use. In the future, we might want to move that logic to the server but we're not well-prepared for that change right now.