### PR TITLE
Allow `'y'` to be treated as valid to continue in `promptContinue()`

### DIFF
--- a/packages/pds/src/scripts/rebuild-repo.ts
+++ b/packages/pds/src/scripts/rebuild-repo.ts
@@ -133,7 +133,7 @@ const promptContinue = async (): Promise<boolean> => {
     output: process.stdout,
   })
   const answer = await rl.question('Continue? y/n ')
-  return answer === ''
+  return answer === '' || answer === 'y'
 }
 
 type RecordDescript = {


### PR DESCRIPTION
Modify the `promptContinue` function to accept both an empty input and 'y' as valid responses for continuation. Previously `promptContinue` expected an empty string (just hit Return/Enter) and would throw an Error "Abort" if anything else was given. 

This could be confusing when the prompt has _"y/n"_ in the message.

* [`packages/pds/src/scripts/rebuild-repo.ts`](diffhunk://#diff-4da2b06e67071716e7890f950f1d8f87a02743e8ffe9e08b9f0f12b59f27ad51L136-R136): Modified the `promptContinue` function to return `true` if the answer is either an empty string or 'y'.