### PR TITLE
Add PDS_MANUAL_CERTS env set

### DIFF
--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -17,6 +17,7 @@ export const readEnv = (): ServerEnvironment => {
     acceptingImports: envBool('PDS_ACCEPTING_REPO_IMPORTS'),
     blobUploadLimit: envInt('PDS_BLOB_UPLOAD_LIMIT'),
     devMode: envBool('PDS_DEV_MODE'),
+    manualCertSet: new Set(envStr('PDS_MANUAL_CERTS')?.split(',')),
 
     // branding
     brandColor: envStr('PDS_PRIMARY_COLOR'),


### PR DESCRIPTION
**NOTE: Second PR on the PDS side to leverage this can be found here:** https://github.com/bluesky-social/pds/pull/155

## Rationale

PDS administrators may want to leverage caddy for on-demand TLS rather than hack around with nginx or another server. 

## Approach

With the introduction of a PDS_MANUAL_CERTS env property, PDS administrators can add a comma-separated list of subdomains (e.g., j.manes.xyz, portfolio.manes.xyz, work.manes.xyz). 

## Example

I own https://manes.xyz. My handle is james.manes.xyz. I used this domain in the past for a personal landing page at https://j.manes.xyz. I want a cert to exist for j.manes.xyz so that I can properly redirect it or proxy-pass it in the caddy config file without having to replace caddy with nginx or apache. 