### PR TITLE
Allow punctuation characters before hashtags

### DIFF
--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -9,4 +9,4 @@ export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
  */
 export const TAG_REGEX =
   // eslint-disable-next-line no-misleading-character-class
-  /(^|\s)[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu
+  /(^|[\s\p{P}])[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -75,7 +75,7 @@ describe('detectFacets', () => {
     ],
     [['@full123-chars.test', 'did:fake:full123-chars.test']],
     [['not@right']],
-    [['@handle.com', 'did:fake:handle.com'], ['!@#$chars']],
+    [['@handle.com', 'did:fake:handle.com'], ['!@'], ['#$chars', '$chars']],
     [
       ['@handle.com', 'did:fake:handle.com'],
       ['\n'],
@@ -348,6 +348,45 @@ describe('detectFacets', () => {
         [{ byteStart: 36, byteEnd: 49 }],
       ],
       ['no match 1?: #1?', [], []],
+      [
+        'match #tag1 #tag2 /#tag3 "#tag4 (#tag5 -#tag6 _#tag7 !#tag8 ?#tag9 @#tag10 ;#tag11 ,#tag12 .#tag13 [#tag14 &#tag15 &#tag16',
+        [
+          'tag1',
+          'tag2',
+          'tag3',
+          'tag4',
+          'tag5',
+          'tag6',
+          'tag7',
+          'tag8',
+          'tag9',
+          'tag10',
+          'tag11',
+          'tag12',
+          'tag13',
+          'tag14',
+          'tag15',
+          'tag16',
+        ],
+        [
+          { byteStart: 6, byteEnd: 11 },
+          { byteStart: 12, byteEnd: 17 },
+          { byteStart: 19, byteEnd: 24 },
+          { byteStart: 26, byteEnd: 31 },
+          { byteStart: 33, byteEnd: 38 },
+          { byteStart: 40, byteEnd: 45 },
+          { byteStart: 47, byteEnd: 52 },
+          { byteStart: 54, byteEnd: 59 },
+          { byteStart: 61, byteEnd: 66 },
+          { byteStart: 68, byteEnd: 74 },
+          { byteStart: 76, byteEnd: 82 },
+          { byteStart: 84, byteEnd: 90 },
+          { byteStart: 92, byteEnd: 98 },
+          { byteStart: 100, byteEnd: 106 },
+          { byteStart: 108, byteEnd: 114 },
+          { byteStart: 116, byteEnd: 122 },
+        ],
+      ],
     ]
 
     it.each(inputs)('%s', async (input, tags, indices) => {
@@ -380,6 +419,7 @@ function segmentToOutput(segment: RichTextSegment): string[] {
       segment.facet?.features.map((f) => {
         if (isMention(f)) return f.did
         if (isLink(f)) return f.uri
+        if (isTag(f)) return f.tag
         return undefined
       })?.[0] || '',
     ]


### PR DESCRIPTION
Users have been reporting issues regarding hashtags presided by punctuation characters. This PR adds to the core tag regex the ability to detect hashtags followed by those characters using the Unicode standard.

Solves #2723 #2466 https://github.com/bluesky-social/social-app/issues/6539