### PR TITLE
doc: fix typos in API docs

### DIFF
--- a/packages/api/OAUTH.md
+++ b/packages/api/OAUTH.md
@@ -1,12 +1,12 @@
 # OAuth Client Quickstart
 
-This document describes how to implement OAuth based authentication in a
+This document describes how to implement OAuth-based authentication in a
 browser-based Single Page App (SPA), to communicate with
 [atproto](https://atproto.com) API services.
 
 ## Prerequisites
 
-- You need a web server - or at the very least a static file server - to host your SPA.
+- You need a web server&ndash;or at the very least a static file server&ndash;to host your SPA.
 
 > [!TIP]
 >
@@ -184,7 +184,7 @@ document.addEventListener('DOMContentLoaded', main)
 
 > [!CAUTION]
 >
-> Using Bluesky-hosted services for handle resolution (eg, the `bsky.social`
+> Using Bluesky-hosted services for handle resolution (e.g., the `bsky.social`
 > endpoint) will leak both user IP addresses and handle identifier to Bluesky,
 > a third party. While Bluesky has a declared privacy policy, both developers
 > and users of applications need to be informed of and aware of the privacy

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -75,7 +75,7 @@ await agent.login({
 })
 ```
 
-#### OAuth based session management
+#### OAuth-based session management
 
 Depending on the environment used by your application, different OAuth clients
 are available:
@@ -85,7 +85,7 @@ are available:
 - [@atproto/oauth-client-node](https://www.npmjs.com/package/@atproto/oauth-client-node): for
   Node.js.
 - [@atproto/oauth-client](https://www.npmjs.com/package/@atproto/oauth-client):
-  Lower lever; compatible with most JS engines.
+  Lower level; compatible with most JS engines.
 
 Every `@atproto/oauth-client-*` implementation has a different way to obtain an
 `OAuthSession` instance that can be used to instantiate an `Agent` (from
@@ -370,4 +370,4 @@ This project is dual-licensed under MIT and Apache 2.0 terms:
 - MIT license ([LICENSE-MIT.txt](https://github.com/bluesky-social/atproto/blob/main/LICENSE-MIT.txt) or http://opensource.org/licenses/MIT)
 - Apache License, Version 2.0, ([LICENSE-APACHE.txt](https://github.com/bluesky-social/atproto/blob/main/LICENSE-APACHE.txt) or http://www.apache.org/licenses/LICENSE-2.0)
 
-Downstream projects and end users may chose either license individually, or both together, at their discretion. The motivation for this dual-licensing is the additional software patent assurance provided by Apache 2.0.
+Downstream projects and end users may choose either license individually, or both together, at their discretion. The motivation for this dual-licensing is the additional software patent assurance provided by Apache 2.0.


### PR DESCRIPTION
Just fixed a few typos I noticed in the API docs.