### PR TITLE
Appview: fix takendown blocklist application on `actor.getProfile`

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfile.ts
@@ -60,7 +60,9 @@ const hydration = async (input: {
   const { ctx, params, skeleton } = input
   return ctx.hydrator.hydrateProfilesDetailed(
     [skeleton.did],
-    params.hydrateCtx.copy({ includeTakedowns: true }),
+    params.hydrateCtx.copy({
+      includeActorTakedowns: true,
+    }),
   )
 }
 

--- a/packages/bsky/src/auth-verifier.ts
+++ b/packages/bsky/src/auth-verifier.ts
@@ -18,14 +18,7 @@ import {
   unpackIdentityKeys,
 } from './data-plane'
 import { GetIdentityByDidResponse } from './proto/bsky_pb'
-import {
-  extractMultikey,
-  extractPrefixedBytes,
-  hasPrefix,
-  parseDidKey,
-  SECP256K1_DID_PREFIX,
-  SECP256K1_JWT_ALG,
-} from '@atproto/crypto'
+import { parseDidKey, SECP256K1_JWT_ALG } from '@atproto/crypto'
 
 type ReqCtx = {
   req: express.Request

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -65,6 +65,7 @@ export class HydrateCtx {
   labelers = this.vals.labelers
   viewer = this.vals.viewer !== null ? serviceRefToDid(this.vals.viewer) : null
   includeTakedowns = this.vals.includeTakedowns
+  includeActorTakedowns = this.vals.includeActorTakedowns
   include3pBlocks = this.vals.include3pBlocks
   constructor(private vals: HydrateCtxVals) {}
   copy<V extends Partial<HydrateCtxVals>>(vals?: V): HydrateCtx & V {
@@ -76,6 +77,7 @@ export type HydrateCtxVals = {
   labelers: ParsedLabelers
   viewer: string | null
   includeTakedowns?: boolean
+  includeActorTakedowns?: boolean
   include3pBlocks?: boolean
 }
 
@@ -179,12 +181,13 @@ export class Hydrator {
     dids: string[],
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
+    const includeTakedowns = ctx.includeTakedowns || ctx.includeActorTakedowns
     const [actors, labels, profileViewersState] = await Promise.all([
-      this.actor.getActors(dids, ctx.includeTakedowns),
+      this.actor.getActors(dids, includeTakedowns),
       this.label.getLabelsForSubjects(labelSubjectsForDid(dids), ctx.labelers),
       this.hydrateProfileViewers(dids, ctx),
     ])
-    if (!ctx.includeTakedowns) {
+    if (!includeTakedowns) {
       actionTakedownLabels(dids, actors, labels)
     }
     return mergeStates(profileViewersState ?? {}, {


### PR DESCRIPTION
Takendown blocklists were taking effect on `actor.getProfile`, but properly not taking effect other places in the app.  This ensures the behavior is consistent on `actor.getProfile`.