### PR TITLE
Fix comment on atp-agent.ts for AtpAgent class

### DIFF
--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -42,11 +42,9 @@ export type AtpAgentOptions = {
  * with a {@link CredentialSession} instead:
  *
  *  ```ts
- *  const session = new CredentialSession({
- *    service: new URL('https://example.com'),
- *  })
- *
+ *  const session = new CredentialSession(new URL('https://example.com'))
  *  const agent = new Agent(session)
+ *  session.login({identifier:handle,password:'string'})
  *  ```
  */
 export class AtpAgent extends Agent {


### PR DESCRIPTION
Fix a wrong suggestion located inside AtpAgent comment, it had a wrong syntax:  
CredentialSession does not take a `{service: URL}`, it simply takes the URL as it's first argument (according to its source code).