### PR TITLE
Change default blob upload limit to 50 MiB

### DIFF
--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -25,7 +25,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     termsOfServiceUrl: env.termsOfServiceUrl,
     contactEmailAddress: env.contactEmailAddress,
     acceptingImports: env.acceptingImports ?? true,
-    blobUploadLimit: env.blobUploadLimit ?? 5 * 1024 * 1024, // 5mb
+    blobUploadLimit: env.blobUploadLimit ?? 50 * 1024 * 1024, // 50 MiB
     devMode: env.devMode ?? false,
   }
 


### PR DESCRIPTION
https://github.com/bluesky-social/pds/pull/91 is not the right way to do it, it should be the default. PDSes installed with older version of install script don't get this change and people wonder why they can't upload videos on the PDS.