### PR TITLE
PDS support Deno and Bun by expanding Kysely dialect configuration options

### DIFF
--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -44,7 +44,6 @@
     "@atproto/xrpc-server": "workspace:^",
     "@did-plc/lib": "^0.0.4",
     "@hapi/address": "^5.1.1",
-    "better-sqlite3": "^10.0.0",
     "bytes": "^3.1.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/packages/pds/src/account-manager/db/index.ts
+++ b/packages/pds/src/account-manager/db/index.ts
@@ -6,14 +6,14 @@ export * from './schema'
 
 export type AccountDb = Database<DatabaseSchema>
 
-export const getDb = (
+export const getDb = async (
   location: string,
   disableWalAutoCheckpoint = false,
-): AccountDb => {
+): Promise<AccountDb> => {
   const pragmas: Record<string, string> = disableWalAutoCheckpoint
     ? { wal_autocheckpoint: '0' }
     : {}
-  return Database.sqlite(location, { pragmas })
+  return await Database.sqlite(location, { pragmas })
 }
 
 export const getMigrator = (db: AccountDb) => {

--- a/packages/pds/src/actor-store/db/index.ts
+++ b/packages/pds/src/actor-store/db/index.ts
@@ -5,14 +5,14 @@ export * from './schema'
 
 export type ActorDb = Database<DatabaseSchema>
 
-export const getDb = (
+export const getDb = async (
   location: string,
   disableWalAutoCheckpoint = false,
-): ActorDb => {
+): Promise<ActorDb> => {
   const pragmas: Record<string, string> = disableWalAutoCheckpoint
     ? { wal_autocheckpoint: '0' }
     : {}
-  return Database.sqlite(location, { pragmas })
+  return await Database.sqlite(location, { pragmas })
 }
 
 export const getMigrator = (db: Database<DatabaseSchema>) => {

--- a/packages/pds/src/actor-store/index.ts
+++ b/packages/pds/src/actor-store/index.ts
@@ -67,7 +67,7 @@ export class ActorStore {
       throw new InvalidRequestError('Repo not found', 'NotFound')
     }
 
-    const db = getDb(dbLocation, this.cfg.disableWalAutoCheckpoint)
+    const db = await getDb(dbLocation, this.cfg.disableWalAutoCheckpoint)
 
     // run a simple select with retry logic to ensure the db is ready (not in wal recovery mode)
     try {
@@ -142,7 +142,7 @@ export class ActorStore {
     const privKey = await keypair.export()
     await fs.writeFile(keyLocation, privKey)
 
-    const db: ActorDb = getDb(dbLocation, this.cfg.disableWalAutoCheckpoint)
+    const db: ActorDb = await getDb(dbLocation, this.cfg.disableWalAutoCheckpoint)
     try {
       await db.ensureWal()
       const migrator = getMigrator(db)

--- a/packages/pds/src/actor-store/migrate.ts
+++ b/packages/pds/src/actor-store/migrate.ts
@@ -10,7 +10,8 @@ export const forEachActorStore = async (
   const { concurrency = 1 } = opts
 
   const queue = new PQueue({ concurrency })
-  const actorQb = ctx.accountManager.db.db
+  const connection = await ctx.accountManager.getDb()
+  const actorQb = connection.db
     .selectFrom('actor')
     .selectAll()
     .limit(2 * concurrency)

--- a/packages/pds/src/api/com/atproto/admin/getInviteCodes.ts
+++ b/packages/pds/src/api/com/atproto/admin/getInviteCodes.ts
@@ -19,8 +19,8 @@ export default function (server: Server, ctx: AppContext) {
         )
       }
       const { sort, limit, cursor } = params
-      const db = ctx.accountManager.db
-      const ref = db.db.dynamic.ref
+      const connection = await ctx.accountManager.getDb()
+      const ref = connection.db.dynamic.ref
       let keyset
       if (sort === 'recent') {
         keyset = new TimeCodeKeyset(ref('createdAt'), ref('code'))
@@ -30,7 +30,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError(`unknown sort method: ${sort}`)
       }
 
-      let builder = selectInviteCodesQb(db)
+      let builder = selectInviteCodesQb(connection)
       builder = paginate(builder, {
         limit,
         cursor,

--- a/packages/pds/src/api/com/atproto/sync/listRepos.ts
+++ b/packages/pds/src/api/com/atproto/sync/listRepos.ts
@@ -7,9 +7,9 @@ import { formatAccountStatus } from '../../../../account-manager'
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.sync.listRepos(async ({ params }) => {
     const { limit, cursor } = params
-    const db = ctx.accountManager.db
-    const { ref } = db.db.dynamic
-    let builder = db.db
+    const connection = await ctx.accountManager.getDb()
+    const { ref } = connection.db.dynamic
+    let builder = connection.db
       .selectFrom('actor')
       .innerJoin('repo_root', 'repo_root.did', 'actor.did')
       .select([

--- a/packages/pds/src/basic-routes.ts
+++ b/packages/pds/src/basic-routes.ts
@@ -22,7 +22,8 @@ export const createRouter = (ctx: AppContext): express.Router => {
   router.get('/xrpc/_health', async function (req, res) {
     const { version } = ctx.cfg.service
     try {
-      await sql`select 1`.execute(ctx.accountManager.db.db)
+      const connection = await ctx.accountManager.getDb()
+      await sql`select 1`.execute(connection.db)
     } catch (err) {
       req.log.error(err, 'failed health check')
       res.status(503).send({ version, error: 'Service Unavailable' })

--- a/packages/pds/src/db/db.ts
+++ b/packages/pds/src/db/db.ts
@@ -10,7 +10,6 @@ import {
   QueryResult,
   UnknownRow,
 } from 'kysely'
-import SqliteDB from 'better-sqlite3'
 import { dbLogger } from '../logger'
 import { retrySqlite } from './util'
 
@@ -24,10 +23,11 @@ export class Database<Schema> {
 
   constructor(public db: Kysely<Schema>) {}
 
-  static sqlite<T>(
+  static async sqlite<T>(
     location: string,
     opts?: { pragmas?: Record<string, string> },
-  ): Database<T> {
+  ): Promise<Database<T>> {
+    const { SqliteDB } = await import('better-sqlite3')
     const sqliteDb = new SqliteDB(location, {
       timeout: 0, // handled by application
     })

--- a/packages/pds/src/did-cache/db/index.ts
+++ b/packages/pds/src/did-cache/db/index.ts
@@ -6,14 +6,14 @@ export * from './schema'
 
 export type DidCacheDb = Database<DidCacheSchema>
 
-export const getDb = (
+export const getDb = async (
   location: string,
   disableWalAutoCheckpoint = false,
-): DidCacheDb => {
+): Promise<DidCacheDb> => {
   const pragmas: Record<string, string> = disableWalAutoCheckpoint
     ? { wal_autocheckpoint: '0', synchronous: 'NORMAL' }
     : { synchronous: 'NORMAL' }
-  return Database.sqlite(location, { pragmas })
+  return await Database.sqlite(location, { pragmas })
 }
 
 export const getMigrator = (db: DidCacheDb) => {

--- a/packages/pds/src/sequencer/db/index.ts
+++ b/packages/pds/src/sequencer/db/index.ts
@@ -6,14 +6,14 @@ export * from './schema'
 
 export type SequencerDb = Database<SequencerDbSchema>
 
-export const getDb = (
+export const getDb = async (
   location: string,
   disableWalAutoCheckpoint = false,
-): SequencerDb => {
+): Promise<SequencerDb> => {
   const pragmas: Record<string, string> = disableWalAutoCheckpoint
     ? { wal_autocheckpoint: '0' }
     : {}
-  return Database.sqlite(location, pragmas)
+  return await Database.sqlite(location, pragmas)
 }
 
 export const getMigrator = (db: Database<SequencerDbSchema>) => {

--- a/services/pds/package.json
+++ b/services/pds/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "@atproto/pds": "workspace:^",
     "@opentelemetry/instrumentation": "^0.45.0",
-    "dd-trace": "^4.18.0",
-    "opentelemetry-plugin-better-sqlite3": "^1.1.0"
+    "dd-trace": "^4.18.0"
   }
 }

--- a/services/pds/tracer.js
+++ b/services/pds/tracer.js
@@ -4,9 +4,9 @@
 
 const { registerInstrumentations } = require('@opentelemetry/instrumentation')
 
-const {
-  BetterSqlite3Instrumentation,
-} = require('opentelemetry-plugin-better-sqlite3')
+// const {
+//   BetterSqlite3Instrumentation,
+// } = require('opentelemetry-plugin-better-sqlite3')
 
 const { TracerProvider } = require('dd-trace') // Only works with commonjs
   .init({ logInjection: true })
@@ -19,7 +19,9 @@ tracer.register()
 
 registerInstrumentations({
   tracerProvider: tracer,
-  instrumentations: [new BetterSqlite3Instrumentation()],
+  instrumentations: [
+    // new BetterSqlite3Instrumentation(),
+  ],
 })
 
 const path = require('path')


### PR DESCRIPTION
Problem Summary:

`better-sqlite3` relies on Node internal native APIs and not general-purpose APIs. This means PDS can _only_ run in Node and _only_ use sqlite and _only_ this one dependency _despite_ the underlying library providing DB support (Kysely) being very flexible. PDS just does not allow you to pass that in very easily at the moment.

Proposed Solution:

- Eliminate explicit better-sqlite3 dependency to support non-Node runtimes.
- Support configuring PDS with more DB dialects, even non-sqlite.
  - [Deno](https://jsr.io/@soapbox/kysely-deno-sqlite)
  - [Bun](https://www.npmjs.com/package/kysely-bun-worker)
  - [Postgres](https://www.npmjs.com/package/kysely-postgres-js)
- Implement a standard fetch API example for PDS

Key changes:

1. [x] Create async accessor functions and refactor references to `this.db` to use `const connection = await this.getDb()`
2. [x] Replace direct dependency on `better-sqlite3` with a dynamic import inside of the static constructor.
3. [x] Refactor instances of "this.db.db" to "connection.db" which is easier to understand.
4. [ ] Solution for replacing `opentelemetry-plugin-better-sqlite3` in the tracer instrumentation configuration. **(needs help)**
5. [ ] Quick start usage of PDS which selects the most appropriate dependency based on operating environment and environmental configuration **(needs help)**
6. [ ] Documentation updates **(needs help)**
7. [ ] Testing **(needs help)**
8. [x] Standard fetch API example (separate - in the pds repo)

Summary:

This PR lays the groundwork in the core of PDS for using an alternative Kysely dialect, which will resolve #2866 

In addition, it enables easily exposing PDS via the standard fetch API (such as `deno serve`, Cloudflare Workers, AWS Lambda, etc.) which can reduce errors for first-time adopters. This will have a companion PR in the PDS repo.

Please let me know your feedback 🦃 