### PR TITLE
Adding "mime" (3.x) types as a devDependency to fix type checking

### DIFF
--- a/packages/internal/rollup-plugin-bundle-manifest/package.json
+++ b/packages/internal/rollup-plugin-bundle-manifest/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "mime": "^3.0.0"
+    "mime": "^4.0.4"
   },
   "peerDependencies": {
     "rollup": "^4.0.0"

--- a/packages/internal/rollup-plugin-bundle-manifest/package.json
+++ b/packages/internal/rollup-plugin-bundle-manifest/package.json
@@ -24,12 +24,13 @@
     }
   },
   "dependencies": {
-    "mime": "^4.0.4"
+    "mime": "^3.0.0"
   },
   "peerDependencies": {
     "rollup": "^4.0.0"
   },
   "devDependencies": {
+    "@types/mime": "^3.0.0",
     "rollup": "^4.10.0",
     "typescript": "^5.6.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,9 +671,12 @@ importers:
   packages/internal/rollup-plugin-bundle-manifest:
     dependencies:
       mime:
-        specifier: ^4.0.4
-        version: 4.0.4
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
+      '@types/mime':
+        specifier: ^3.0.0
+        version: 3.0.1
       rollup:
         specifier: ^4.10.0
         version: 4.18.0
@@ -10716,9 +10719,9 @@ packages:
     hasBin: true
     dev: true
 
-  /mime@4.0.4:
-    resolution: {integrity: sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==}
-    engines: {node: '>=16'}
+  /mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,8 +671,8 @@ importers:
   packages/internal/rollup-plugin-bundle-manifest:
     dependencies:
       mime:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^4.0.4
+        version: 4.0.4
     devDependencies:
       rollup:
         specifier: ^4.10.0
@@ -10716,9 +10716,9 @@ packages:
     hasBin: true
     dev: true
 
-  /mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
+  /mime@4.0.4:
+    resolution: {integrity: sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==}
+    engines: {node: '>=16'}
     hasBin: true
     dev: false
 


### PR DESCRIPTION
Fixes: #3132

Note: I tried to go to 4.x because the types are there by default, but that caused issues with module bundling that I do not think is simple to fix.

This adds the types for 3.x to the devDependencies and updates the PNPM lockfile.