### PR TITLE
Parse URLs after sentence dot correctly

### DIFF
--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,6 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 export const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+  /(^|\s|\(|\b)((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(?!\.https?:\/\/)(\.[a-z0-9]+)+)[\S]*))/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -32,6 +32,8 @@ describe('detectFacets', () => {
     'start middle https://end.com/foo/bar?baz=bux#hash',
     'https://newline1.com\nhttps://newline2.com',
     '👨‍👩‍👧‍👧 https://middle.com 👨‍👩‍👧‍👧',
+    'Check this out.https://afterdot.com',
+    'Check this out!https://afterdot.com',
 
     'start middle.com end',
     'start middle.com/foo/bar end',
@@ -122,6 +124,8 @@ describe('detectFacets', () => {
       ['https://newline2.com', 'https://newline2.com'],
     ],
     [['👨‍👩‍👧‍👧 '], ['https://middle.com', 'https://middle.com'], [' 👨‍👩‍👧‍👧']],
+    [['Check this out.'], ['https://afterdot.com', 'https://afterdot.com']],
+    [['Check this out!'], ['https://afterdot.com', 'https://afterdot.com']],
 
     [['start '], ['middle.com', 'https://middle.com'], [' end']],
     [


### PR DESCRIPTION
This is simply a copy of https://github.com/bluesky-social/atproto/pull/913 merged into the current main branch.
All credit should go to the author (@KevSlashNull) and the approver (@dholms).

I noticed that this one is:
A. Still a bug.
B. The oldest non-draft PR (1.5 years old).
C. Already approved.
D. Needing a merge.

Can we get it merged in?

-----
# Original PR description


This fixes the parsing of URLs that are prefixed by a dot (.), i.e. when the user forgot a space between the end of a sentence and a link.

I noticed the problem [in this post](https://staging.bsky.app/profile/phillewis.bsky.social/post/3juec5butr62x) where the link should be clickable.

![image](https://github.com/user-attachments/assets/645e563b-e080-456f-a921-a04a71dd0f3d)

The fix is done by preventing the second alternative capture group from having a domain end in .https:// (which would be an invalid domain anyway), since that would capture out.https in the example message Check this out.https://afterdot.com.