### PR TITLE
:zap: Add composite index on reviewState and lastReportedAt columns

### DIFF
--- a/packages/ozone/src/db/migrations/20241202T211332580Z-last-reported-at-index.ts
+++ b/packages/ozone/src/db/migrations/20241202T211332580Z-last-reported-at-index.ts
@@ -1,0 +1,23 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex('moderation_subject_status_review_state_last_reported_idx')
+    .on('moderation_subject_status')
+    .columns(['reviewState', 'lastReportedAt'])
+    .execute()
+  await db.schema
+    .dropIndex('moderation_subject_status_review_state_idx')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex('moderation_subject_status_review_state_idx')
+    .on('moderation_subject_status')
+    .column('reviewState')
+    .execute()
+  await db.schema
+    .dropIndex('moderation_subject_status_review_state_last_reported_idx')
+    .execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -17,3 +17,4 @@ export * as _20241001T205730722Z from './20241001T205730722Z-subject-status-revi
 export * as _20241008T205730722Z from './20241008T205730722Z-sets'
 export * as _20241018T205730722Z from './20241018T205730722Z-setting'
 export * as _20241026T205730722Z from './20241026T205730722Z-add-hosting-status-to-subject-status'
+export * as _20241202T211332580Z from './20241202T211332580Z-last-reported-at-index'


### PR DESCRIPTION
Dropping the index on `reviewState` column in favor of a composite index on `reviewState` and `lastReportedAt` columns since the `lastReportedAt` column is used as cursor and is present in almost all queries on the `moderation_subject_status` table.