### PR TITLE
✨ Optionally ack all open subjects from the author with acknowledge event

### DIFF
--- a/.changeset/new-poems-scream.md
+++ b/.changeset/new-poems-scream.md
@@ -1,0 +1,6 @@
+---
+"@atproto/ozone": patch
+"@atproto/api": patch
+---
+
+Allow moderators to optionally acknowledge all open subjects of an account when acknowledging account level reports

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -300,7 +300,11 @@
     "modEventAcknowledge": {
       "type": "object",
       "properties": {
-        "comment": { "type": "string" }
+        "comment": { "type": "string" },
+        "acknowledgeAccountSubjects": {
+          "type": "boolean",
+          "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
+        }
       }
     },
     "modEventEscalate": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -11310,6 +11310,11 @@ export const schemaDict = {
           comment: {
             type: 'string',
           },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
         },
       },
       modEventEscalate: {
@@ -13489,8 +13494,9 @@ export const schemaDict = {
       },
     },
   },
-}
-export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
+} as const satisfies Record<string, LexiconDoc>
+
+export const schemas = Object.values(schemaDict)
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -300,6 +300,8 @@ export function validateModEventLabel(v: unknown): ValidationResult {
 
 export interface ModEventAcknowledge {
   comment?: string
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -10728,8 +10728,9 @@ export const schemaDict = {
       },
     },
   },
-}
-export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
+} as const satisfies Record<string, LexiconDoc>
+
+export const schemas = Object.values(schemaDict)
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -11310,6 +11310,11 @@ export const schemaDict = {
           comment: {
             type: 'string',
           },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
         },
       },
       modEventEscalate: {
@@ -13489,8 +13494,9 @@ export const schemaDict = {
       },
     },
   },
-}
-export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
+} as const satisfies Record<string, LexiconDoc>
+
+export const schemas = Object.values(schemaDict)
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -300,6 +300,8 @@ export function validateModEventLabel(v: unknown): ValidationResult {
 
 export interface ModEventAcknowledge {
   comment?: string
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -127,12 +127,13 @@ export class ModerationViews {
     }
 
     if (
-      event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
+      (event.action === 'tools.ozone.moderation.defs#modEventTakedown' ||
+        event.action === 'tools.ozone.moderation.defs#modEventAcknowledge') &&
       event.meta?.acknowledgeAccountSubjects
     ) {
       eventView.event = {
         ...eventView.event,
-        acknowledgeAccountSubjects: event.meta?.acknowledgeAccountSubjects,
+        acknowledgeAccountSubjects: event.meta.acknowledgeAccountSubjects,
       }
     }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -11310,6 +11310,11 @@ export const schemaDict = {
           comment: {
             type: 'string',
           },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
         },
       },
       modEventEscalate: {
@@ -13489,8 +13494,9 @@ export const schemaDict = {
       },
     },
   },
-}
-export const schemas: LexiconDoc[] = Object.values(schemaDict) as LexiconDoc[]
+} as const satisfies Record<string, LexiconDoc>
+
+export const schemas = Object.values(schemaDict)
 export const lexicons: Lexicons = new Lexicons(schemas)
 export const ids = {
   ComAtprotoAdminDefs: 'com.atproto.admin.defs',

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -300,6 +300,8 @@ export function validateModEventLabel(v: unknown): ValidationResult {
 
 export interface ModEventAcknowledge {
   comment?: string
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
   [k: string]: unknown
 }
 


### PR DESCRIPTION
This PR brings the same flag as takedown event from here https://github.com/bluesky-social/atproto/pull/2793 for the acknowledge event. This helps clean up moderation queue of unnecessary subjects that won't require individual reviews if the author's account is being acked.