### PR TITLE
PDS: fix account deactivation when behind entryway by using entryway auth

### DIFF
--- a/packages/pds/src/api/com/atproto/server/deactivateAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/deactivateAccount.ts
@@ -1,23 +1,16 @@
-import assert from 'node:assert'
-
 import AppContext from '../../../../context'
 import { Server } from '../../../../lexicon'
-import { ids } from '../../../../lexicon/lexicons'
+import { authPassthru } from '../../../proxy'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.server.deactivateAccount({
     auth: ctx.authVerifier.accessFull(),
-    handler: async ({ auth, input }) => {
+    handler: async ({ req, auth, input }) => {
       // in the case of entryway, the full flow is deactivateAccount (PDS) -> deactivateAccount (Entryway) -> updateSubjectStatus(PDS)
       if (ctx.entrywayAgent) {
-        assert(ctx.cfg.entryway)
         await ctx.entrywayAgent.com.atproto.server.deactivateAccount(
           input.body,
-          await ctx.serviceAuthHeaders(
-            auth.credentials.did,
-            ctx.cfg.entryway.did,
-            ids.ComAtprotoServerDeactivateAccount,
-          ),
+          authPassthru(req),
         )
         return
       }


### PR DESCRIPTION
Addresses an issue where a user attempts to deactivate their account after their signing key has changed in an account migration.  The problem is that the user's signing key changes, and then their old PDS becomes unable to perform service auth on their behalf.  This breaks the flow on PDSes that are a behind an entryway service (e.g. bsky.social), since service auth was used between the old PDS and its entryway service.

Resolves #3149 