### PR TITLE
Ozone: add sort idx to moderation_subject_status

### DIFF
--- a/packages/ozone/src/db/migrations/20241205T203713695Z-subject-status-sort-idxs.ts
+++ b/packages/ozone/src/db/migrations/20241205T203713695Z-subject-status-sort-idxs.ts
@@ -1,0 +1,16 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const ref = db.dynamic.ref
+  sql`CREATE INDEX moderation_subject_status_sort_idx ON ${ref('moderation_subject_status')} (${ref('lastReportedAt')} DESC NULLS LAST, ${ref('id')} DESC NULLS LAST);`.execute(
+    db,
+  )
+  sql`CREATE INDEX moderation_subject_status_unreviewed_sort_idx ON ${ref('moderation_subject_status')} (${ref('lastReportedAt')} DESC NULLS LAST, ${ref('id')} DESC NULLS LAST); WHERE ${ref('reviewState')} = 'tools.ozone.moderation.defs#reviewNone';`.execute(
+    db,
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  db.schema.dropIndex('moderation_subject_status_sort_idx').execute()
+  db.schema.dropIndex('moderation_subject_status_unreviewed_sort_idx').execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -17,3 +17,4 @@ export * as _20241001T205730722Z from './20241001T205730722Z-subject-status-revi
 export * as _20241008T205730722Z from './20241008T205730722Z-sets'
 export * as _20241018T205730722Z from './20241018T205730722Z-setting'
 export * as _20241026T205730722Z from './20241026T205730722Z-add-hosting-status-to-subject-status'
+export * as _20241205T203713695Z from './20241205T203713695Z-subject-status-sort-idxs'


### PR DESCRIPTION
Adding a couple of artisanal hand-crafted indexes to `moderation_subject_status` to support some of our more expensive paginated queries