### PR TITLE
fix(crypto): fix error message of `bytesToMultibase`

### DIFF
--- a/packages/crypto/src/multibase.ts
+++ b/packages/crypto/src/multibase.ts
@@ -48,6 +48,6 @@ export const bytesToMultibase = (
     case 'base64urlpad':
       return 'U' + uint8arrays.toString(mb, encoding)
     default:
-      throw new Error(`Unsupported multibase: :${mb}`)
+      throw new Error(`Unsupported multibase: :${encoding}`)
   }
 }


### PR DESCRIPTION
The error message was printing the `Uint8Array` instead of the name of the unsupported encoding.