### PR TITLE
:bug: Fix auth level check for protected tags

### DIFF
--- a/packages/ozone/src/api/moderation/emitEvent.ts
+++ b/packages/ozone/src/api/moderation/emitEvent.ts
@@ -99,49 +99,7 @@ const handleModerationEvent = async ({
       )
 
       if (protectedTags) {
-        status.tags.forEach((tag) => {
-          if (!Object.hasOwn(protectedTags, tag)) return
-          if (
-            protectedTags[tag]['moderators'] &&
-            !protectedTags[tag]['moderators'].includes(createdBy)
-          ) {
-            throw new InvalidRequestError(
-              `Not allowed to action on protected tag: ${tag}`,
-            )
-          }
-          if (protectedTags[tag]['roles']) {
-            if (
-              auth.credentials.isAdmin &&
-              !protectedTags[tag]['roles'].includes(
-                'tools.ozone.team.defs#roleAdmin',
-              )
-            ) {
-              throw new InvalidRequestError(
-                `Not allowed to action on protected tag: ${tag}`,
-              )
-            }
-            if (
-              auth.credentials.isModerator &&
-              !protectedTags[tag]['roles'].includes(
-                'tools.ozone.team.defs#roleModerator',
-              )
-            ) {
-              throw new InvalidRequestError(
-                `Not allowed to action on protected tag: ${tag}`,
-              )
-            }
-            if (
-              auth.credentials.isTriage &&
-              !protectedTags[tag]['roles'].includes(
-                'tools.ozone.team.defs#roleTriage',
-              )
-            ) {
-              throw new InvalidRequestError(
-                `Not allowed to action on protected tag: ${tag}`,
-              )
-            }
-          }
-        })
+        assertProtectedTagAction(protectedTags, status.tags, createdBy, auth)
       }
     }
 
@@ -288,6 +246,68 @@ export default function (server: Server, ctx: AppContext) {
         body: moderationEvent,
       }
     },
+  })
+}
+
+const assertProtectedTagAction = (
+  protectedTags: ProtectedTagSetting,
+  subjectTags: string[],
+  actionAuthor: string,
+  auth: ModeratorOutput | AdminTokenOutput,
+) => {
+  subjectTags.forEach((tag) => {
+    if (!Object.hasOwn(protectedTags, tag)) return
+    if (
+      protectedTags[tag]['moderators'] &&
+      !protectedTags[tag]['moderators'].includes(actionAuthor)
+    ) {
+      throw new InvalidRequestError(
+        `Not allowed to action on protected tag: ${tag}`,
+      )
+    }
+
+    if (protectedTags[tag]['roles']) {
+      if (auth.credentials.isAdmin) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleAdmin',
+          )
+        ) {
+          return
+        }
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+
+      if (auth.credentials.isModerator) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleModerator',
+          )
+        ) {
+          return
+        }
+
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+
+      if (auth.credentials.isTriage) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleTriage',
+          )
+        ) {
+          return
+        }
+
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+    }
   })
 }
 

--- a/packages/ozone/tests/protected-tags.test.ts
+++ b/packages/ozone/tests/protected-tags.test.ts
@@ -145,6 +145,22 @@ describe('protected-tags', () => {
           },
         }),
       ).rejects.toThrow(/Can not manage tag vip/gi)
+
+      // Verify that since admins are configured to manage this tag, admin actions go through
+      const removeTag = await modClient.emitEvent(
+        {
+          subject: {
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: sc.dids.bob,
+          },
+          event: {
+            $type: 'tools.ozone.moderation.defs#modEventTakedown',
+          },
+        },
+        'admin',
+      )
+
+      expect(removeTag.id).toBeTruthy()
     })
     it('only allows configured moderators to add/remove protected tags', async () => {
       await modClient.upsertSettingOption({


### PR DESCRIPTION
due to how auth object is set up, for each level of access, all lower level access is also enabled. so when each level of role check passes, lower level access can be assumed to pass.
this PR fixes the redundant role check and refactors the tag level check into a separate function.