### PR TITLE
sign-in-form: enable autocomplete on 2FA code field

### DIFF
--- a/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider/src/assets/app/components/sign-in-form.tsx
@@ -290,7 +290,7 @@ export function SignInForm({
               aria-label={secondFactorAria}
               autoCapitalize="none"
               autoCorrect="off"
-              autoComplete="off"
+              autoComplete="one-time-code"
               spellCheck="false"
               dir="auto"
               enterKeyHint="done"


### PR DESCRIPTION
This should (fingers crossed) work in Safari, at least.