### PR TITLE
pds: support config for email reply-to addresses

### DIFF
--- a/.changeset/slow-brooms-scream.md
+++ b/.changeset/slow-brooms-scream.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Support configuration for email reply-to addresses.

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -150,6 +150,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     emailCfg = {
       smtpUrl: env.emailSmtpUrl,
       fromAddress: env.emailFromAddress,
+      replyToAddress: env.emailReplyToAddress,
     }
   }
 
@@ -165,6 +166,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     moderationEmailCfg = {
       smtpUrl: env.moderationEmailSmtpUrl,
       fromAddress: env.moderationEmailAddress,
+      replyToAddress: env.moderationEmailReplyToAddress,
     }
   }
 
@@ -452,6 +454,7 @@ export type InvitesConfig =
 export type EmailConfig = {
   smtpUrl: string
   fromAddress: string
+  replyToAddress?: string
 }
 
 export type SubscriptionConfig = {

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -73,8 +73,12 @@ export const readEnv = (): ServerEnvironment => {
     // email
     emailSmtpUrl: envStr('PDS_EMAIL_SMTP_URL'),
     emailFromAddress: envStr('PDS_EMAIL_FROM_ADDRESS'),
+    emailReplyToAddress: envStr('PDS_EMAIL_REPLY_TO_ADDRESS'),
     moderationEmailSmtpUrl: envStr('PDS_MODERATION_EMAIL_SMTP_URL'),
     moderationEmailAddress: envStr('PDS_MODERATION_EMAIL_ADDRESS'),
+    moderationEmailReplyToAddress: envStr(
+      'PDS_MODERATION_EMAIL_REPLY_TO_ADDRESS',
+    ),
 
     // subscription
     maxSubscriptionBuffer: envInt('PDS_MAX_SUBSCRIPTION_BUFFER'),
@@ -203,8 +207,10 @@ export type ServerEnvironment = {
   // email
   emailSmtpUrl?: string
   emailFromAddress?: string
+  emailReplyToAddress?: string
   moderationEmailSmtpUrl?: string
   moderationEmailAddress?: string
+  moderationEmailReplyToAddress?: string
 
   // subscription
   maxSubscriptionBuffer?: number

--- a/packages/pds/src/mailer/index.ts
+++ b/packages/pds/src/mailer/index.ts
@@ -70,6 +70,7 @@ export class ServerMailer {
     const res = await this.transporter.sendMail({
       ...mailOpts,
       from: mailOpts.from ?? this.config.email?.fromAddress,
+      replyTo: this.config.email?.replyToAddress,
       html,
     })
     if (!this.config.email?.smtpUrl) {

--- a/packages/pds/src/mailer/moderation.ts
+++ b/packages/pds/src/mailer/moderation.ts
@@ -19,14 +19,12 @@ export class ModerationMailer {
   }
 
   async send({ content }: { content: string }, mailOpts: Mail.Options) {
-    const mail = {
+    const res = await this.transporter.sendMail({
       ...mailOpts,
       html: content,
       from: this.config.moderationEmail?.fromAddress,
-    }
-
-    const res = await this.transporter.sendMail(mail)
-
+      replyTo: this.config.moderationEmail?.replyToAddress,
+    })
     if (!this.config.moderationEmail?.smtpUrl) {
       mailerLogger.debug(
         'Moderation email auth is not configured. Intended to send email:\n' +


### PR DESCRIPTION
The pds can be configured with email reply-to addresses, useful in particular if it should be different from the sender.  The new optional environment variables are:
 - `PDS_EMAIL_REPLY_TO_ADDRESS`
 - `PDS_MODERATION_EMAIL_REPLY_TO_ADDRESS`