### PR TITLE
Add filter param to listNotifications

### DIFF
--- a/.changeset/stupid-feet-allow.md
+++ b/.changeset/stupid-feet-allow.md
@@ -1,0 +1,8 @@
+---
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Add optional filter param to listNotifications

--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -8,6 +8,12 @@
       "parameters": {
         "type": "params",
         "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Notification types to include in response.",
+            "knownValues": ["all", "mentions"],
+            "default": "all"
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8944,6 +8944,12 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            filter: {
+              type: 'string',
+              description: 'Notification types to include in response.',
+              knownValues: ['all', 'mentions'],
+              default: 'all',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
+++ b/packages/api/src/client/types/app/bsky/notification/listNotifications.ts
@@ -10,6 +10,8 @@ import * as AppBskyActorDefs from '../actor/defs'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface QueryParams {
+  /** Notification types to include in response. */
+  filter?: 'all' | 'mentions' | (string & {})
   limit?: number
   priority?: boolean
   cursor?: string

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8944,6 +8944,12 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            filter: {
+              type: 'string',
+              description: 'Notification types to include in response.',
+              knownValues: ['all', 'mentions'],
+              default: 'all',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -11,6 +11,8 @@ import * as AppBskyActorDefs from '../actor/defs'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface QueryParams {
+  /** Notification types to include in response. */
+  filter: 'all' | 'mentions' | (string & {})
   limit: number
   priority?: boolean
   cursor?: string

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8944,6 +8944,12 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            filter: {
+              type: 'string',
+              description: 'Notification types to include in response.',
+              knownValues: ['all', 'mentions'],
+              default: 'all',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -11,6 +11,8 @@ import * as AppBskyActorDefs from '../actor/defs'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface QueryParams {
+  /** Notification types to include in response. */
+  filter: 'all' | 'mentions' | (string & {})
   limit: number
   priority?: boolean
   cursor?: string

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8944,6 +8944,12 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            filter: {
+              type: 'string',
+              description: 'Notification types to include in response.',
+              knownValues: ['all', 'mentions'],
+              default: 'all',
+            },
             limit: {
               type: 'integer',
               minimum: 1,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -11,6 +11,8 @@ import * as AppBskyActorDefs from '../actor/defs'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 
 export interface QueryParams {
+  /** Notification types to include in response. */
+  filter: 'all' | 'mentions' | (string & {})
   limit: number
   priority?: boolean
   cursor?: string


### PR DESCRIPTION
This is what I imagine I'll need. The `mentions` name is not exactly reflective of the purpose (it'll be *any* text — so replies, quotes, mentions all count). Could maybe call that "posts" idk. But in the UI we'll probably call it Mentions for familiarity.