### PR TITLE
Validate profile records for views

### DIFF
--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -5,7 +5,6 @@ import {
   HydrationMap,
   RecordInfo,
   parseRecord,
-  parseRecordBytes,
   parseString,
   safeTakedownRef,
 } from './util'
@@ -116,18 +115,19 @@ export class ActorHydrator {
       ) {
         return acc.set(did, null)
       }
-      const profile =
-        includeTakedowns || !actor.profile?.takenDown
-          ? actor.profile
-          : undefined
+
+      const profile = actor.profile
+        ? parseRecord<ProfileRecord>(actor.profile, includeTakedowns)
+        : undefined
+
       return acc.set(did, {
         did,
         handle: parseString(actor.handle),
-        profile: parseRecordBytes<ProfileRecord>(profile?.record),
+        profile: profile?.record,
         profileCid: profile?.cid,
-        profileTakedownRef: safeTakedownRef(profile),
-        sortedAt: profile?.sortedAt?.toDate(),
-        indexedAt: profile?.indexedAt?.toDate(),
+        profileTakedownRef: profile?.takedownRef,
+        sortedAt: profile?.sortedAt,
+        indexedAt: profile?.indexedAt,
         takedownRef: safeTakedownRef(actor),
         isLabeler: actor.labeler ?? false,
         allowIncomingChatsFrom: actor.allowIncomingChatsFrom || undefined,


### PR DESCRIPTION
Correctly validate profile records so that we don't serve the client broken views. 

Note: this is what we do for all other record types, I think we just didn't do it for profiles because they're wrapped in the actor type and are structured a bit differently