### PR TITLE
More explicit error messages when uploading corrupt images

### DIFF
--- a/packages/pds/src/image/index.ts
+++ b/packages/pds/src/image/index.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
 import sharp from 'sharp'
 import { errHasMsg } from '@atproto/common'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export async function maybeGetInfo(
   stream: Readable,
@@ -15,10 +16,12 @@ export async function maybeGetInfo(
     ])
     metadata = result
   } catch (err) {
+    // If the buffer doesn't have any identifiable image in it, return null
     if (errHasMsg(err, 'Input buffer contains unsupported image format')) {
       return null
     }
-    throw err
+    // Otherwise, the buffer has a corrupt image in it
+    throw new InvalidRequestError("Image detected but content is unparsable")
   }
   const { size, height, width, format } = metadata
   if (


### PR DESCRIPTION
Fixes #3151 

Uploading an attachment using `com.atproto.repo.uploadBlob` will fail with a 500 Internal Server Error if the contents of the upload has the signature of an image (as determined by sharp via ImageMagick) but is not fully parsable as the corresponding image type.

While it is possible to handle such uploads by silencing this error, this PR errs on the side of caution and continues to reject corrupted images but with a more explicit error. It seems to me that the risk of allowing people to upload malformed images outweighs the benefit of more flexible uploads. I can change the code to silently accept such uploads though if that is desirable instead.