### PR TITLE
Update README.md to add some missing details in examples

### DIFF
--- a/packages/oauth/oauth-client-node/README.md
+++ b/packages/oauth/oauth-client-node/README.md
@@ -38,9 +38,11 @@ const client = new NodeOAuthClient({
     policy_uri: 'https://my-app.com/policy',
     redirect_uris: ['https://my-app.com/callback'],
     grant_types: ['authorization_code', 'refresh_token'],
+    scope: 'atproto transition:generic',
     response_types: ['code'],
     application_type: 'web',
     token_endpoint_auth_method: 'private_key_jwt',
+    token_endpoint_auth_signing_alg: 'RS256',
     dpop_bound_access_tokens: true,
     jwks_uri: 'https://my-app.com/jwks.json',
   },
@@ -48,9 +50,9 @@ const client = new NodeOAuthClient({
   // Used to authenticate the client to the token endpoint. Will be used to
   // build the jwks object to be exposed on the "jwks_uri" endpoint.
   keyset: await Promise.all([
-    JoseKey.fromImportable(process.env.PRIVATE_KEY_1),
-    JoseKey.fromImportable(process.env.PRIVATE_KEY_2),
-    JoseKey.fromImportable(process.env.PRIVATE_KEY_3),
+    JoseKey.fromImportable(process.env.PRIVATE_KEY_1, 'key1'),
+    JoseKey.fromImportable(process.env.PRIVATE_KEY_2, 'key2'),
+    JoseKey.fromImportable(process.env.PRIVATE_KEY_3, 'key3'),
   ]),
 
   // Interface to store authorization state data (during authorization flows)


### PR DESCRIPTION
I built an [example](https://github.com/kidGodzilla/bsky-oauth-example) and ran into a few small omissions in the examples here, that might make it difficult for a new developer not incredibly familiar with OAuth internals to figure out why their example doesn't work.

My recommended changes to `README.md`:

Each `JoseKey.fromImportable` call requires a key ID (parameter 2). Recommended change:

```
            JoseKey.fromImportable(process.env.PRIVATE_KEY_1, 'key1'),
            JoseKey.fromImportable(process.env.PRIVATE_KEY_2, 'key2'),
            JoseKey.fromImportable(process.env.PRIVATE_KEY_3, 'key3'),
```

Otherwise, it fails silently in testing (localhost) and fails with an error in production (because kid is missing on each key in jwks.json).

---

Scope requires `atproto transition:generic` for the code example that follows, would recommend adding the scope line back in as:

```
scope: 'atproto transition:generic',
```

Otherwise, the example that follows this (login) will not work, transition:generic is required for that.

---

This is required in the example given:

```
token_endpoint_auth_signing_alg: 'RS256',
```

Otherwise an error is thrown. Recommend adding this line.

---

Not included, if you wanted to include it, is a little in-memory store to complete the example.

```js
// Simple In-memory session store (OAuth requirement)
class InMemoryStore {
    constructor() {
        this.storeData = {};
    }

    // stateStore methods
    async set(key, internalState) {
        this.storeData[key] = internalState;
    }

    async get(key) {
        return this.storeData[key] || undefined;
    }

    async del(key) {
        delete this.storeData[key];
    }
}
const stateStore = new InMemoryStore();
const sessionStore = new InMemoryStore();
```

But, I did not include this, you might have an existing library in mind or not want to give an easier option than the redis session store example.

Feel free to add if you think it improves things.