### PR TITLE
:sparkles: Add && separator for tags filter param on queryStatuses endpoint

### DIFF
--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -119,7 +119,9 @@
           "tags": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 25,
+              "description": "Items in this array are applied with OR filters. To apply AND filter, put all tags in the same string and separate using && characters"
             }
           },
           "excludeTags": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12498,6 +12498,9 @@ export const schemaDict = {
               type: 'array',
               items: {
                 type: 'string',
+                maxLength: 25,
+                description:
+                  'Items in this array are applied with OR filters. To apply AND filter, put all tags in the same string and separate using && characters',
               },
             },
             excludeTags: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12498,6 +12498,9 @@ export const schemaDict = {
               type: 'array',
               items: {
                 type: 'string',
+                maxLength: 25,
+                description:
+                  'Items in this array are applied with OR filters. To apply AND filter, put all tags in the same string and separate using && characters',
               },
             },
             excludeTags: {

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -824,6 +824,8 @@ export class ModerationService {
       })
       .filter(Boolean)
 
+    if (!conditions.length) return builder
+
     // Combine all conditions with OR
     return builder.where(sql`(${sql.join(conditions, sql` OR `)})`)
   }

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -1,5 +1,5 @@
 import net from 'node:net'
-import { Insertable, sql } from 'kysely'
+import { Insertable, SelectQueryBuilder, sql } from 'kysely'
 import { CID } from 'multiformats/cid'
 import { AtUri, INVALID_HANDLE } from '@atproto/syntax'
 import { InvalidRequestError } from '@atproto/xrpc-server'
@@ -791,6 +791,38 @@ export class ModerationService {
     return result
   }
 
+  applyTagFilter = (
+    builder: SelectQueryBuilder<any, any, any>,
+    tags: string[],
+  ) => {
+    const { ref } = this.db.db.dynamic
+    // Build an array of conditions
+    const conditions = tags.map((tag) => {
+      if (tag.includes('&&')) {
+        // Split by '&&' for AND logic
+        const subTags = tag
+          .split('&&')
+          // Make sure spaces on either sides of '&&' are trimmed
+          .map((subTag) => subTag.trim())
+          // Remove empty strings after trimming is applied
+          .filter(Boolean)
+        return sql`(${sql.join(
+          subTags.map(
+            (subTag) =>
+              sql`${ref('moderation_subject_status.tags')} ? ${subTag}`,
+          ),
+          sql` AND `,
+        )})`
+      } else {
+        // Single tag condition
+        return sql`${ref('moderation_subject_status.tags')} ? ${tag}`
+      }
+    })
+
+    // Combine all conditions with OR
+    return builder.where(sql`(${sql.join(conditions, sql` OR `)})`)
+  }
+
   async getSubjectStatuses({
     includeAllUserRecords,
     cursor,
@@ -958,11 +990,7 @@ export class ModerationService {
     }
 
     if (tags.length) {
-      builder = builder.where(
-        sql`${ref('moderation_subject_status.tags')} ?| array[${sql.join(
-          tags,
-        )}]::TEXT[]`,
-      )
+      builder = this.applyTagFilter(builder, tags)
     }
 
     if (excludeTags.length) {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12498,6 +12498,9 @@ export const schemaDict = {
               type: 'array',
               items: {
                 type: 'string',
+                maxLength: 25,
+                description:
+                  'Items in this array are applied with OR filters. To apply AND filter, put all tags in the same string and separate using && characters',
               },
             },
             excludeTags: {


### PR DESCRIPTION
This PR adds a special separator character in the `tags` filter param array on `tools.ozone.moderation.queryStatuses` endpoint which allows moderators to filter queue items for multiple tags using the AND operator instead of the default OR operator which is applied between different items in the array.

So, currently, there is no way for a moderator to find all subjects that have both `embed:image` and `lang:ja` tags because passing `tags: ['lang:ja', 'embed:image']` will return all items with either of the tags. This PR makes way for us to apply the expected filter using the syntax `tags: ['lang:ja && embed:image']`