### PR TITLE
Fix handler typo in EventRunner definition

### DIFF
--- a/packages/sync/src/runner/types.ts
+++ b/packages/sync/src/runner/types.ts
@@ -3,6 +3,6 @@ export interface EventRunner {
   trackEvent(
     did: string,
     seq: number,
-    hanlder: () => Promise<void>,
+    handler: () => Promise<void>,
   ): Promise<void>
 }


### PR DESCRIPTION
This patch fixes a typo in the EventRunner definition in `@atproto/sync`.