### PR TITLE
:sparkles: Add a policy property to takedown events

### DIFF
--- a/.changeset/smooth-steaks-suffer.md
+++ b/.changeset/smooth-steaks-suffer.md
@@ -1,0 +1,7 @@
+---
+"@atproto/dev-env": patch
+"@atproto/ozone": patch
+"@atproto/api": patch
+---
+
+Allow setting policy names with takedown actions and when querying events

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -224,6 +224,10 @@
         "acknowledgeAccountSubjects": {
           "type": "boolean",
           "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
+        },
+        "policy": {
+          "type": "string",
+          "description": "Name/Keyword of the policy that drove the decision."
         }
       }
     },

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -225,9 +225,11 @@
           "type": "boolean",
           "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
         },
-        "policy": {
-          "type": "string",
-          "description": "Name/Keyword of the policy that drove the decision."
+        "policies": {
+          "type": "array",
+          "maxLength": 5,
+          "items": { "type": "string" },
+          "description": "Names/Keywords of the policies that drove the decision."
         }
       }
     },

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -106,6 +106,10 @@
               "type": "string"
             }
           },
+          "policy": {
+            "type": "string",
+            "description": "If specified, only events where the policy matches the given policy are returned"
+          },
           "cursor": {
             "type": "string"
           }

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -106,9 +106,12 @@
               "type": "string"
             }
           },
-          "policy": {
-            "type": "string",
-            "description": "If specified, only events where the policy matches the given policy are returned"
+          "policies": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "If specified, only events where the policy matches the given policy are returned"
+            }
           },
           "cursor": {
             "type": "string"

--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -110,7 +110,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "If specified, only events where the policy matches the given policy are returned"
+              "description": "If specified, only events where the action policies match any of the given policies are returned"
             }
           },
           "cursor": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -11304,9 +11304,14 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
-          policy: {
-            type: 'string',
-            description: 'Name/Keyword of the policy that drove the decision.',
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
           },
         },
       },
@@ -12344,10 +12349,13 @@ export const schemaDict = {
                 type: 'string',
               },
             },
-            policy: {
-              type: 'string',
-              description:
-                'If specified, only events where the policy matches the given policy are returned',
+            policies: {
+              type: 'array',
+              items: {
+                type: 'string',
+                description:
+                  'If specified, only events where the policy matches the given policy are returned',
+              },
             },
             cursor: {
               type: 'string',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -11304,6 +11304,10 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
+          policy: {
+            type: 'string',
+            description: 'Name/Keyword of the policy that drove the decision.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -12339,6 +12343,11 @@ export const schemaDict = {
               items: {
                 type: 'string',
               },
+            },
+            policy: {
+              type: 'string',
+              description:
+                'If specified, only events where the policy matches the given policy are returned',
             },
             cursor: {
               type: 'string',

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -174,8 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
-  /** Name/Keyword of the policy that drove the decision. */
-  policy?: string
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -174,6 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
+  /** Name/Keyword of the policy that drove the decision. */
+  policy?: string
   [k: string]: unknown
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -39,6 +39,8 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
+  /** If specified, only events where the policy matches the given policy are returned */
+  policy?: string
   cursor?: string
 }
 

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -39,8 +39,7 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
-  /** If specified, only events where the policy matches the given policy are returned */
-  policy?: string
+  policies?: string[]
   cursor?: string
 }
 

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -2177,13 +2177,13 @@ export class ChatBskyModerationNS {
 
 type SharedRateLimitOpts<T> = {
   name: string
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type RouteRateLimitOpts<T> = {
   durationMs: number
   points: number
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type HandlerOpts = { blobLimit?: number }

--- a/packages/dev-env/src/moderator-client.ts
+++ b/packages/dev-env/src/moderator-client.ts
@@ -123,16 +123,19 @@ export class ModeratorClient {
       durationInHours?: number
       acknowledgeAccountSubjects?: boolean
       reason?: string
+      policy?: string
     },
     role?: ModLevel,
   ) {
-    const { durationInHours, acknowledgeAccountSubjects, ...rest } = opts
+    const { durationInHours, acknowledgeAccountSubjects, policy, ...rest } =
+      opts
     return this.emitEvent(
       {
         event: {
           $type: 'tools.ozone.moderation.defs#modEventTakedown',
           acknowledgeAccountSubjects,
           durationInHours,
+          policy,
         },
         ...rest,
       },

--- a/packages/dev-env/src/moderator-client.ts
+++ b/packages/dev-env/src/moderator-client.ts
@@ -123,11 +123,11 @@ export class ModeratorClient {
       durationInHours?: number
       acknowledgeAccountSubjects?: boolean
       reason?: string
-      policy?: string
+      policies?: string[]
     },
     role?: ModLevel,
   ) {
-    const { durationInHours, acknowledgeAccountSubjects, policy, ...rest } =
+    const { durationInHours, acknowledgeAccountSubjects, policies, ...rest } =
       opts
     return this.emitEvent(
       {
@@ -135,7 +135,7 @@ export class ModeratorClient {
           $type: 'tools.ozone.moderation.defs#modEventTakedown',
           acknowledgeAccountSubjects,
           durationInHours,
-          policy,
+          policies,
         },
         ...rest,
       },

--- a/packages/ozone/src/api/moderation/queryEvents.ts
+++ b/packages/ozone/src/api/moderation/queryEvents.ts
@@ -25,7 +25,7 @@ export default function (server: Server, ctx: AppContext) {
         reportTypes,
         collections = [],
         subjectType,
-        policy,
+        policies,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -48,7 +48,7 @@ export default function (server: Server, ctx: AppContext) {
         reportTypes,
         collections,
         subjectType,
-        policy,
+        policies,
       })
       return {
         encoding: 'application/json',

--- a/packages/ozone/src/api/moderation/queryEvents.ts
+++ b/packages/ozone/src/api/moderation/queryEvents.ts
@@ -25,6 +25,7 @@ export default function (server: Server, ctx: AppContext) {
         reportTypes,
         collections = [],
         subjectType,
+        policy,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -47,6 +48,7 @@ export default function (server: Server, ctx: AppContext) {
         reportTypes,
         collections,
         subjectType,
+        policy,
       })
       return {
         encoding: 'application/json',

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -2638,13 +2638,13 @@ export class ToolsOzoneTeamNS {
 
 type SharedRateLimitOpts<T> = {
   name: string
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type RouteRateLimitOpts<T> = {
   durationMs: number
   points: number
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type HandlerOpts = { blobLimit?: number }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -11304,9 +11304,14 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
-          policy: {
-            type: 'string',
-            description: 'Name/Keyword of the policy that drove the decision.',
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
           },
         },
       },
@@ -12344,10 +12349,13 @@ export const schemaDict = {
                 type: 'string',
               },
             },
-            policy: {
-              type: 'string',
-              description:
-                'If specified, only events where the policy matches the given policy are returned',
+            policies: {
+              type: 'array',
+              items: {
+                type: 'string',
+                description:
+                  'If specified, only events where the policy matches the given policy are returned',
+              },
             },
             cursor: {
               type: 'string',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -11304,6 +11304,10 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
+          policy: {
+            type: 'string',
+            description: 'Name/Keyword of the policy that drove the decision.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -12339,6 +12343,11 @@ export const schemaDict = {
               items: {
                 type: 'string',
               },
+            },
+            policy: {
+              type: 'string',
+              description:
+                'If specified, only events where the policy matches the given policy are returned',
             },
             cursor: {
               type: 'string',

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -174,8 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
-  /** Name/Keyword of the policy that drove the decision. */
-  policy?: string
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -174,6 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
+  /** Name/Keyword of the policy that drove the decision. */
+  policy?: string
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -40,8 +40,7 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
-  /** If specified, only events where the policy matches the given policy are returned */
-  policy?: string
+  policies?: string[]
   cursor?: string
 }
 

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -40,6 +40,8 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
+  /** If specified, only events where the policy matches the given policy are returned */
+  policy?: string
   cursor?: string
 }
 

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -445,8 +445,8 @@ export class ModerationService {
       meta.acknowledgeAccountSubjects = true
     }
 
-    if (isModEventTakedown(event) && event.policies) {
-      meta.policies = event.policies?.join(' ')
+    if (isModEventTakedown(event) && event.policies?.length) {
+      meta.policies = event.policies.join(',')
     }
 
     // Keep trace of reports that came in while the reporter was in muted stated

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -152,6 +152,7 @@ export class ModerationService {
     reportTypes?: string[]
     collections: string[]
     subjectType?: string
+    policy?: string
   }): Promise<{ cursor?: string; events: ModerationEventRow[] }> {
     const {
       subject,
@@ -172,6 +173,7 @@ export class ModerationService {
       reportTypes,
       collections,
       subjectType,
+      policy,
     } = opts
     const { ref } = this.db.db.dynamic
     let builder = this.db.db.selectFrom('moderation_event').selectAll()
@@ -263,6 +265,9 @@ export class ModerationService {
     }
     if (reportTypes?.length) {
       builder = builder.where(sql`meta->>'reportType'`, 'in', reportTypes)
+    }
+    if (policy) {
+      builder = builder.where(sql`meta->>'policy'`, '=', policy)
     }
 
     const keyset = new TimeIdKeyset(
@@ -433,6 +438,10 @@ export class ModerationService {
       event.acknowledgeAccountSubjects
     ) {
       meta.acknowledgeAccountSubjects = true
+    }
+
+    if (isModEventTakedown(event) && event.policy) {
+      meta.policy = event.policy
     }
 
     // Keep trace of reports that came in while the reporter was in muted stated

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -139,11 +139,12 @@ export class ModerationViews {
 
     if (
       event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
-      typeof event.meta?.policies === 'string'
+      typeof event.meta?.policies === 'string' &&
+      event.meta.policies.length > 0
     ) {
       eventView.event = {
         ...eventView.event,
-        policies: event.meta.policies.split(' '),
+        policies: event.meta.policies.split(','),
       }
     }
 

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -137,6 +137,16 @@ export class ModerationViews {
       }
     }
 
+    if (
+      event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
+      event.meta?.policy
+    ) {
+      eventView.event = {
+        ...eventView.event,
+        policy: event.meta.policy,
+      }
+    }
+
     if (event.action === 'tools.ozone.moderation.defs#modEventLabel') {
       eventView.event = {
         ...eventView.event,

--- a/packages/ozone/src/mod-service/views.ts
+++ b/packages/ozone/src/mod-service/views.ts
@@ -139,11 +139,11 @@ export class ModerationViews {
 
     if (
       event.action === 'tools.ozone.moderation.defs#modEventTakedown' &&
-      event.meta?.policy
+      typeof event.meta?.policies === 'string'
     ) {
       eventView.event = {
         ...eventView.event,
-        policy: event.meta.policy,
+        policies: event.meta.policies.split(' '),
       }
     }
 

--- a/packages/ozone/src/setting/constants.ts
+++ b/packages/ozone/src/setting/constants.ts
@@ -1,1 +1,2 @@
 export const ProtectedTagSettingKey = 'tools.ozone.setting.protectedTags'
+export const PolicyListSettingKey = 'tools.ozone.setting.policyList'

--- a/packages/ozone/tests/takedown.test.ts
+++ b/packages/ozone/tests/takedown.test.ts
@@ -1,0 +1,64 @@
+import {
+  TestNetwork,
+  TestOzone,
+  SeedClient,
+  basicSeed,
+  ModeratorClient,
+} from '@atproto/dev-env'
+import { AtpAgent } from '@atproto/api'
+
+describe('moderation', () => {
+  let network: TestNetwork
+  let ozone: TestOzone
+  let agent: AtpAgent
+  let bskyAgent: AtpAgent
+  let pdsAgent: AtpAgent
+  let sc: SeedClient
+  let modClient: ModeratorClient
+
+  const repoSubject = (did: string) => ({
+    $type: 'com.atproto.admin.defs#repoRef',
+    did,
+  })
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_takedown',
+    })
+    ozone = network.ozone
+    agent = network.ozone.getClient()
+    bskyAgent = network.bsky.getClient()
+    pdsAgent = network.pds.getClient()
+    sc = network.getSeedClient()
+    modClient = network.ozone.getModClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('allows specifying policy for takedown actions.', async () => {
+    await modClient.performTakedown({
+      subject: repoSubject(sc.dids.bob),
+      policy: 'trolling',
+    })
+
+    // Verify that that the takedown even exposes the policy specified for it
+    const { events } = await modClient.queryEvents({
+      subject: sc.dids.bob,
+      types: ['tools.ozone.moderation.defs#modEventTakedown'],
+    })
+
+    expect(events[0].event.policy).toEqual('trolling')
+
+    // Verify that event stream can be filtered by policy
+    const { events: filteredEvents } = await modClient.queryEvents({
+      subject: sc.dids.bob,
+      policy: 'trolling',
+    })
+
+    expect(filteredEvents[0].subject.did).toEqual(sc.dids.bob)
+  })
+})

--- a/packages/ozone/tests/takedown.test.ts
+++ b/packages/ozone/tests/takedown.test.ts
@@ -42,7 +42,7 @@ describe('moderation', () => {
   it('allows specifying policy for takedown actions.', async () => {
     await modClient.performTakedown({
       subject: repoSubject(sc.dids.bob),
-      policy: 'trolling',
+      policies: ['trolling'],
     })
 
     // Verify that that the takedown even exposes the policy specified for it
@@ -51,12 +51,12 @@ describe('moderation', () => {
       types: ['tools.ozone.moderation.defs#modEventTakedown'],
     })
 
-    expect(events[0].event.policy).toEqual('trolling')
+    expect(events[0].event.policies?.[0]).toEqual('trolling')
 
     // Verify that event stream can be filtered by policy
     const { events: filteredEvents } = await modClient.queryEvents({
       subject: sc.dids.bob,
-      policy: 'trolling',
+      policies: ['trolling'],
     })
 
     expect(filteredEvents[0].subject.did).toEqual(sc.dids.bob)

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -2638,13 +2638,13 @@ export class ToolsOzoneTeamNS {
 
 type SharedRateLimitOpts<T> = {
   name: string
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type RouteRateLimitOpts<T> = {
   durationMs: number
   points: number
-  calcKey?: (ctx: T) => string
+  calcKey?: (ctx: T) => string | null
   calcPoints?: (ctx: T) => number
 }
 type HandlerOpts = { blobLimit?: number }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -11304,9 +11304,14 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
-          policy: {
-            type: 'string',
-            description: 'Name/Keyword of the policy that drove the decision.',
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
           },
         },
       },
@@ -12344,10 +12349,13 @@ export const schemaDict = {
                 type: 'string',
               },
             },
-            policy: {
-              type: 'string',
-              description:
-                'If specified, only events where the policy matches the given policy are returned',
+            policies: {
+              type: 'array',
+              items: {
+                type: 'string',
+                description:
+                  'If specified, only events where the policy matches the given policy are returned',
+              },
             },
             cursor: {
               type: 'string',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -11304,6 +11304,10 @@ export const schemaDict = {
             description:
               'If true, all other reports on content authored by this account will be resolved (acknowledged).',
           },
+          policy: {
+            type: 'string',
+            description: 'Name/Keyword of the policy that drove the decision.',
+          },
         },
       },
       modEventReverseTakedown: {
@@ -12339,6 +12343,11 @@ export const schemaDict = {
               items: {
                 type: 'string',
               },
+            },
+            policy: {
+              type: 'string',
+              description:
+                'If specified, only events where the policy matches the given policy are returned',
             },
             cursor: {
               type: 'string',

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -174,8 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
-  /** Name/Keyword of the policy that drove the decision. */
-  policy?: string
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -174,6 +174,8 @@ export interface ModEventTakedown {
   durationInHours?: number
   /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
   acknowledgeAccountSubjects?: boolean
+  /** Name/Keyword of the policy that drove the decision. */
+  policy?: string
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -40,8 +40,7 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
-  /** If specified, only events where the policy matches the given policy are returned */
-  policy?: string
+  policies?: string[]
   cursor?: string
 }
 

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -40,6 +40,8 @@ export interface QueryParams {
   /** If specified, only events where all of these tags were removed are returned */
   removedTags?: string[]
   reportTypes?: string[]
+  /** If specified, only events where the policy matches the given policy are returned */
+  policy?: string
   cursor?: string
 }
 


### PR DESCRIPTION
This PR adds an optional `policy` property to all takedown events that allows an arbitrary string value and allows moderators to query for all takedowns by specifying a `policy` param through th `queryEvents` endpoint.