### PR TITLE
:sparkles: Apply queue filter on database query when fetching subjects

### DIFF
--- a/.changeset/metal-falcons-fail.md
+++ b/.changeset/metal-falcons-fail.md
@@ -1,0 +1,6 @@
+---
+"@atproto/ozone": patch
+"@atproto/api": patch
+---
+
+Apply ozone queue splitting at the database query level

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -16,6 +16,10 @@
             "type": "integer",
             "description": "Index of the queue to fetch subjects from. Works only when queueCount value is specified."
           },
+          "queueSeed": {
+            "type": "string",
+            "description": "A seeder to shuffle/balance the queue items."
+          },
           "includeAllUserRecords": {
             "type": "boolean",
             "description": "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned."

--- a/lexicons/tools/ozone/moderation/queryStatuses.json
+++ b/lexicons/tools/ozone/moderation/queryStatuses.json
@@ -8,6 +8,14 @@
       "parameters": {
         "type": "params",
         "properties": {
+          "queueCount": {
+            "type": "integer",
+            "description": "Number of queues being used by moderators. Subjects will be split among all queues."
+          },
+          "queueIndex": {
+            "type": "integer",
+            "description": "Index of the queue to fetch subjects from. Works only when queueCount value is specified."
+          },
           "includeAllUserRecords": {
             "type": "boolean",
             "description": "All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned."

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12380,12 +12380,16 @@ export const schemaDict = {
             queueCount: {
               type: 'integer',
               description:
-                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+                'Number of queues being used by moderators. Subjects will be split among all queues.',
             },
             queueIndex: {
               type: 'integer',
               description:
-                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+                'Index of the queue to fetch subjects from. Works only when queueCount value is specified.',
+            },
+            queueSeed: {
+              type: 'string',
+              description: 'A seeder to shuffle/balance the queue items.',
             },
             includeAllUserRecords: {
               type: 'boolean',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -12377,6 +12377,16 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            queueCount: {
+              type: 'integer',
+              description:
+                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+            },
+            queueIndex: {
+              type: 'integer',
+              description:
+                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+            },
             includeAllUserRecords: {
               type: 'boolean',
               description:

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -9,10 +9,12 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  /** Number of queues being used by moderators. Subjects will be split among all queues. */
   queueCount?: number
-  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  /** Index of the queue to fetch subjects from. Works only when queueCount value is specified. */
   queueIndex?: number
+  /** A seeder to shuffle/balance the queue items. */
+  queueSeed?: string
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */

--- a/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryStatuses.ts
@@ -9,6 +9,10 @@ import { CID } from 'multiformats/cid'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  queueCount?: number
+  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  queueIndex?: number
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */

--- a/packages/ozone/src/api/moderation/queryStatuses.ts
+++ b/packages/ozone/src/api/moderation/queryStatuses.ts
@@ -35,6 +35,7 @@ export default function (server: Server, ctx: AppContext) {
         subjectType,
         queueCount,
         queueIndex,
+        queueSeed,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -67,6 +68,7 @@ export default function (server: Server, ctx: AppContext) {
         subjectType,
         queueCount,
         queueIndex,
+        queueSeed,
       })
       const subjectStatuses = results.statuses.map((status) =>
         modService.views.formatSubjectStatus(status),

--- a/packages/ozone/src/api/moderation/queryStatuses.ts
+++ b/packages/ozone/src/api/moderation/queryStatuses.ts
@@ -33,6 +33,8 @@ export default function (server: Server, ctx: AppContext) {
         excludeTags = [],
         collections = [],
         subjectType,
+        queueCount,
+        queueIndex,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -63,6 +65,8 @@ export default function (server: Server, ctx: AppContext) {
         excludeTags,
         collections,
         subjectType,
+        queueCount,
+        queueIndex,
       })
       const subjectStatuses = results.statuses.map((status) =>
         modService.views.formatSubjectStatus(status),

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12380,12 +12380,16 @@ export const schemaDict = {
             queueCount: {
               type: 'integer',
               description:
-                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+                'Number of queues being used by moderators. Subjects will be split among all queues.',
             },
             queueIndex: {
               type: 'integer',
               description:
-                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+                'Index of the queue to fetch subjects from. Works only when queueCount value is specified.',
+            },
+            queueSeed: {
+              type: 'string',
+              description: 'A seeder to shuffle/balance the queue items.',
             },
             includeAllUserRecords: {
               type: 'boolean',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -12377,6 +12377,16 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            queueCount: {
+              type: 'integer',
+              description:
+                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+            },
+            queueIndex: {
+              type: 'integer',
+              description:
+                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+            },
             includeAllUserRecords: {
               type: 'boolean',
               description:

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,10 +10,12 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  /** Number of queues being used by moderators. Subjects will be split among all queues. */
   queueCount?: number
-  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  /** Index of the queue to fetch subjects from. Works only when queueCount value is specified. */
   queueIndex?: number
+  /** A seeder to shuffle/balance the queue items. */
+  queueSeed?: string
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,6 +10,10 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  queueCount?: number
+  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  queueIndex?: number
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -831,6 +831,8 @@ export class ModerationService {
   }
 
   async getSubjectStatuses({
+    queueCount,
+    queueIndex,
     includeAllUserRecords,
     cursor,
     limit = 50,
@@ -858,6 +860,8 @@ export class ModerationService {
     collections,
     subjectType,
   }: {
+    queueCount?: number
+    queueIndex?: number
     includeAllUserRecords?: boolean
     cursor?: string
     limit?: number
@@ -907,6 +911,21 @@ export class ModerationService {
       builder = builder.where('recordPath', '=', '')
     } else if (subjectType === 'record') {
       builder = builder.where('recordPath', '!=', '')
+    }
+
+    // Only fetch items that belongs to the specified queue when specified
+    if (
+      !subject &&
+      queueCount &&
+      queueIndex &&
+      queueCount >= 0 &&
+      queueIndex < queueCount
+    ) {
+      builder = builder.where(
+        sql`ABS(HASHTEXT(did)) % ${queueCount}`,
+        '=',
+        queueIndex,
+      )
     }
 
     // If subjectType is set to 'account' let that take priority and ignore collections filter

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -919,8 +919,9 @@ export class ModerationService {
     if (
       !subject &&
       queueCount &&
-      queueIndex &&
-      queueCount >= 0 &&
+      queueCount > 0 &&
+      queueIndex !== undefined &&
+      queueIndex >= 0 &&
       queueIndex < queueCount
     ) {
       builder = builder.where(

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -833,6 +833,7 @@ export class ModerationService {
   async getSubjectStatuses({
     queueCount,
     queueIndex,
+    queueSeed = '',
     includeAllUserRecords,
     cursor,
     limit = 50,
@@ -862,6 +863,7 @@ export class ModerationService {
   }: {
     queueCount?: number
     queueIndex?: number
+    queueSeed?: string
     includeAllUserRecords?: boolean
     cursor?: string
     limit?: number
@@ -922,7 +924,9 @@ export class ModerationService {
       queueIndex < queueCount
     ) {
       builder = builder.where(
-        sql`ABS(HASHTEXT(did)) % ${queueCount}`,
+        queueSeed
+          ? sql`ABS(HASHTEXT(${queueSeed} || did)) % ${queueCount}`
+          : sql`ABS(HASHTEXT(did)) % ${queueCount}`,
         '=',
         queueIndex,
       )

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12380,12 +12380,16 @@ export const schemaDict = {
             queueCount: {
               type: 'integer',
               description:
-                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+                'Number of queues being used by moderators. Subjects will be split among all queues.',
             },
             queueIndex: {
               type: 'integer',
               description:
-                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+                'Index of the queue to fetch subjects from. Works only when queueCount value is specified.',
+            },
+            queueSeed: {
+              type: 'string',
+              description: 'A seeder to shuffle/balance the queue items.',
             },
             includeAllUserRecords: {
               type: 'boolean',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -12377,6 +12377,16 @@ export const schemaDict = {
         parameters: {
           type: 'params',
           properties: {
+            queueCount: {
+              type: 'integer',
+              description:
+                'The number of subjects to return from the queue. If not specified, all subjects are returned.',
+            },
+            queueIndex: {
+              type: 'integer',
+              description:
+                'The index of the first subject to return from the queue. If not specified, the first subject is returned.',
+            },
             includeAllUserRecords: {
               type: 'boolean',
               description:

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,10 +10,12 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
-  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  /** Number of queues being used by moderators. Subjects will be split among all queues. */
   queueCount?: number
-  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  /** Index of the queue to fetch subjects from. Works only when queueCount value is specified. */
   queueIndex?: number
+  /** A seeder to shuffle/balance the queue items. */
+  queueSeed?: string
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -10,6 +10,10 @@ import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
 import * as ToolsOzoneModerationDefs from './defs'
 
 export interface QueryParams {
+  /** The number of subjects to return from the queue. If not specified, all subjects are returned. */
+  queueCount?: number
+  /** The index of the first subject to return from the queue. If not specified, the first subject is returned. */
+  queueIndex?: number
   /** All subjects, or subjects from given 'collections' param, belonging to the account specified in the 'subject' param will be returned. */
   includeAllUserRecords?: boolean
   /** The subject to get the status for. */


### PR DESCRIPTION
Up until now, we have been doing subject to queue mapping entirely on the client which is super inefficient and results in a LOT of load on the server and the client. This PR simply moves the same client side logic into the DB query.

This is the client side implementation of the queue allocation logic https://github.com/bluesky-social/ozone/blob/main/app/reports/page-content.tsx#L435