### PR TITLE
Lexicon: Poll, Poll Answer

### DIFF
--- a/lexicons/app/bsky/embed/poll.json
+++ b/lexicons/app/bsky/embed/poll.json
@@ -43,7 +43,7 @@
             "maxGraphemes": 300,
             "description": "The options available for the poll."
           },
-          "minLength": 2,
+          "minLength": 1,
           "maxLength": 4
         }
       }

--- a/lexicons/app/bsky/embed/poll.json
+++ b/lexicons/app/bsky/embed/poll.json
@@ -47,6 +47,29 @@
           "maxLength": 4
         }
       }
+    },
+    "view": {
+      "type": "object",
+      "required": ["question", "options"],
+      "properties": {
+        "question": {
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300,
+          "description": "The question being asked."
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "The options available for the poll."
+          },
+          "minLength": 2,
+          "maxLength": 4
+        }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/embed/poll.json
+++ b/lexicons/app/bsky/embed/poll.json
@@ -20,7 +20,7 @@
             "maxGraphemes": 300,
             "description": "The options available for the poll."
           },
-          "minLength": 2,
+          "minLength": 1,
           "maxLength": 4
         }
       }

--- a/lexicons/app/bsky/embed/poll.json
+++ b/lexicons/app/bsky/embed/poll.json
@@ -1,0 +1,29 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.embed.poll",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["question", "options"],
+      "properties": {
+        "question": {
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300,
+          "description": "The question being asked."
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "The options available for the poll."
+          },
+          "minLength": 2,
+          "maxLength": 4
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/embed/poll.json
+++ b/lexicons/app/bsky/embed/poll.json
@@ -24,6 +24,29 @@
           "maxLength": 4
         }
       }
+    },
+    "view": {
+      "type": "object",
+      "required": ["question", "options"],
+      "properties": {
+        "question": {
+          "type": "string",
+          "maxLength": 3000,
+          "maxGraphemes": 300,
+          "description": "The question being asked."
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "The options available for the poll."
+          },
+          "minLength": 2,
+          "maxLength": 4
+        }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -20,13 +20,19 @@
             "app.bsky.embed.video#view",
             "app.bsky.embed.external#view",
             "app.bsky.embed.record#view",
-            "app.bsky.embed.recordWithMedia#view"
+            "app.bsky.embed.recordWithMedia#view",
+            "app.bsky.embed.poll#view"
           ]
         },
         "replyCount": { "type": "integer" },
         "repostCount": { "type": "integer" },
         "likeCount": { "type": "integer" },
         "quoteCount": { "type": "integer" },
+        "pollAnswerCount": { "type": "integer" },
+        "pollAnswers": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
         "indexedAt": { "type": "string", "format": "datetime" },
         "viewer": { "type": "ref", "ref": "#viewerState" },
         "labels": {

--- a/lexicons/app/bsky/feed/getPollAnswers.json
+++ b/lexicons/app/bsky/feed/getPollAnswers.json
@@ -1,0 +1,83 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.getPollAnswers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get poll answers for a given poll which reference a post.",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the subject (eg, a post record)."
+          },
+          "cid": {
+            "type": "string",
+            "format": "cid",
+            "description": "CID of the subject record (aka, specific version of record), to filter likes."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri"],
+          "properties": {
+            "uri": {
+              "type": "string",
+              "format": "at-uri"
+            },
+            "cid": {
+              "type": "string",
+              "format": "cid"
+            },
+            "cursor": {
+              "type": "string"
+            },
+            "pollAnswers": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#pollAnswer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "pollAnswer": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor", "answer"],
+      "properties": {
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView"
+        },
+        "answer": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/feed/getPollAnswers.json
+++ b/lexicons/app/bsky/feed/getPollAnswers.json
@@ -17,7 +17,7 @@
           "cid": {
             "type": "string",
             "format": "cid",
-            "description": "CID of the subject record (aka, specific version of record), to filter likes."
+            "description": "CID of the subject record (aka, specific version of record), to filter poll answers."
           },
           "limit": {
             "type": "integer",

--- a/lexicons/app/bsky/feed/pollAnswer.json
+++ b/lexicons/app/bsky/feed/pollAnswer.json
@@ -14,8 +14,8 @@
           "createdAt": { "type": "string", "format": "datetime" },
           "answer": {
             "type": "integer",
-            "minimum": 0,
-            "maximum": 3,
+            "minimum": 1,
+            "maximum": 15,
             "description": "The index of the option selected by the user."
           }
         }

--- a/lexicons/app/bsky/feed/pollAnswer.json
+++ b/lexicons/app/bsky/feed/pollAnswer.json
@@ -1,0 +1,25 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.pollAnswer",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring a user's answer to a poll.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "answer", "createdAt"],
+        "properties": {
+          "subject": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "createdAt": { "type": "string", "format": "datetime" },
+          "answer": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 3,
+            "description": "The index of the option selected by the user."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

This is a set of 3 lexicons that are designed to allow the creation of, and interaction with polls, as part of the `bsky` lexicon family. Conceptually there are two parts of a poll:
- The actual **Poll**: This is not defined as an independent record, but an embedded part of a **Post** record. A poll simply contains a question as well as a set of answers, and is represented as a JSON object. As posts are non-editable, polls are then also non-editable.
- A **Poll Answer**: This is an independent record, which references a **Post**, in which a  **Poll** is embedded. A Poll Answer contains an **answer** field, which is a single numerical value. The answer field is intended to be used with a **bit mask** to determine which answer OR answers an actor has selected in a poll. This sets-up the ability to allow both single-answer, as well as multi-answer polls. As independent records, it is intended that an actor could edit their own poll answer in the future.

## Notes/Attribution

Based on discussion: https://github.com/bluesky-social/atproto/discussions/1310

This is PR strictly contains lexicon definitions cherry-picked from https://github.com/bluesky-social/atproto/pull/3248. That PR contains codegen and other work, too much for an initial review. I will be keeping that PR for reference.

