### PR TITLE
:white_check_mark: Update snapshot check for tags array

### DIFF
--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -5,6 +5,7 @@ import { CID } from 'multiformats/cid'
 import { Server } from 'node:http'
 import { AddressInfo } from 'node:net'
 import { FeedViewPost } from '../src/lexicon/types/app/bsky/feed/defs'
+import { ToolsOzoneModerationDefs } from '@atproto/api'
 
 // Swap out identifiers and dates with stable
 // values for the purpose of snapshot testing
@@ -201,4 +202,22 @@ export async function stopServer(server: Server) {
       }
     })
   })
+}
+
+const normalizeSubjectStatus = (
+  subject: ToolsOzoneModerationDefs.SubjectStatusView,
+) => {
+  return { ...subject, tags: subject.tags?.sort() }
+}
+
+export const forSubjectStatusSnapshot = (
+  status:
+    | ToolsOzoneModerationDefs.SubjectStatusView
+    | ToolsOzoneModerationDefs.SubjectStatusView[],
+) => {
+  if (Array.isArray(status)) {
+    return forSnapshot(status.map(normalizeSubjectStatus))
+  }
+
+  return forSnapshot(normalizeSubjectStatus(status))
 }

--- a/packages/pds/tests/takedown-appeal.test.ts
+++ b/packages/pds/tests/takedown-appeal.test.ts
@@ -1,6 +1,6 @@
 import { AtpAgent, ComAtprotoModerationDefs } from '@atproto/api'
 import { SeedClient, TestNetwork } from '@atproto/dev-env'
-import { forSnapshot } from './_util'
+import { forSubjectStatusSnapshot } from './_util'
 import { ids } from '../src/lexicon/lexicons'
 
 describe('appeal account takedown', () => {
@@ -97,7 +97,9 @@ describe('appeal account takedown', () => {
     )
 
     expect(result.subjectStatuses[0].appealed).toBe(true)
-    expect(forSnapshot(result.subjectStatuses[0])).toMatchSnapshot()
+    expect(
+      forSubjectStatusSnapshot(result.subjectStatuses[0]),
+    ).toMatchSnapshot()
   })
 
   it('takendown actor is not allowed to create reports.', async () => {


### PR DESCRIPTION
On one hand, we could sort the array on write but right now, it kind of keeps the order in which the tags were added and it feels like a nice "feature" so I'm just gonna "fix" this on the snapshot side.