### PR TITLE
oauth-client: recommend verifying state parameter before processing oauth callback

### DIFF
--- a/packages/oauth/oauth-client/README.md
+++ b/packages/oauth/oauth-client/README.md
@@ -147,11 +147,13 @@ Make user visit `url`. Then, once it was redirected to the callback URI, perform
 // Parse the query params from the callback URI
 const params = new URLSearchParams('code=...&state=...')
 
+if (params.state !== session.state) {
+  // fail authentication
+  return
+}
+
 // Process the callback using the OAuth client
 const result = await client.callback(params)
-
-// Verify the state (e.g. to link to an internal user)
-result.state === '434321' // true
 
 const oauthSession = result.session
 ```


### PR DESCRIPTION
Given that the state parameter is often used as a nonce in many clients (e.g., a random value) and not as a "this is the user account in our system" type value, you'd want to verify the state parameters match before actually completing the oauth callback handling.

Unless there's something I'm missing about the `client.callback` method that some how asserts that state matches before doing an oauth authorization code for token exchange?