### PR TITLE
Fix flaky appeal test

### DIFF
--- a/packages/pds/tests/takedown-appeal.test.ts
+++ b/packages/pds/tests/takedown-appeal.test.ts
@@ -35,6 +35,7 @@ describe('appeal account takedown', () => {
       email: 'jeff@test.com',
       password: 'password',
     })
+    await network.processAll()
 
     // Emit a takedown event
     await network.ozone.getModClient().performTakedown({


### PR DESCRIPTION
This flaky test has been pestering us for a bit (example: https://github.com/bluesky-social/atproto/actions/runs/12773790391/job/35606617878?pr=2519)

Pretty sure this was just the account creation event not getting processed by the appview yet (which ozone hits to fill out handles for `queryStatuses`)