### PR TITLE
Appview: permit redirects during blob resolution

### DIFF
--- a/packages/bsky/src/api/blob-resolver.ts
+++ b/packages/bsky/src/api/blob-resolver.ts
@@ -193,6 +193,7 @@ export async function streamBlob(
         path: url.pathname + url.search,
         headers,
         signal: options.signal,
+        maxRedirections: 10,
       },
       (upstream) => {
         headersReceived = true


### PR DESCRIPTION
Followup to changes in #3177, ensure we still follow redirects during blob resolution.