### PR TITLE
fetch-node: ensure unicast checks allow psl domains

### DIFF
--- a/.changeset/silver-birds-run.md
+++ b/.changeset/silver-birds-run.md
@@ -1,0 +1,5 @@
+---
+"@atproto-labs/fetch-node": patch
+---
+
+Unicast checks should permit PSL domains.

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -9,7 +9,7 @@ import {
   FetchRequestError,
 } from '@atproto-labs/fetch'
 import ipaddr from 'ipaddr.js'
-import { isValid as isValidDomain } from 'psl'
+import { parse as pslParse } from 'psl'
 import { Agent, Client } from 'undici'
 
 import { isUnicastIp } from './util.js'
@@ -183,6 +183,14 @@ export function unicastLookup(
       }
     }
   })
+}
+
+// see lupomontero/psl#258 for context on psl usage.
+// in short, this ensures a structurally valid domain
+// plus a "listed" tld.
+function isValidDomain(domain: string) {
+  const parsed = pslParse(domain)
+  return !parsed.error && parsed.listed
 }
 
 function isNotUnicast(ip: ipaddr.IPv4 | ipaddr.IPv6): boolean {


### PR DESCRIPTION
The unicast check in here was unintentionally only passing through domains that are not themselves public suffix domains.  We want to use the logic from the `psl` package to check that the domain is valid and on a public TLD, but we did not want to omit domains on the PSL such as `s3-us-east-2.amazonaws.com` or `github.io`.

Some details here: https://github.com/lupomontero/psl/issues/258

Should resolve @snarfed's issue here: https://github.com/bluesky-social/atproto/pull/3370#issuecomment-2596713118