### PR TITLE
Improve error description in case invalid DPoP nonce is used

### DIFF
--- a/.changeset/young-balloons-check.md
+++ b/.changeset/young-balloons-check.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Improve error description in case invalid DPoP nonce is used

--- a/packages/oauth/oauth-provider/src/dpop/dpop-manager.ts
+++ b/packages/oauth/oauth-provider/src/dpop/dpop-manager.ts
@@ -87,11 +87,15 @@ export class DpopManager {
     }
 
     if (payload['nonce'] && !this.dpopNonce?.check(payload['nonce'])) {
-      throw new UseDpopNonceError()
+      throw new UseDpopNonceError('DPoP nonce mismatch')
     }
 
     const htuNorm = normalizeHtu(htu)
-    if (!htuNorm || htuNorm !== normalizeHtu(payload['htu'])) {
+    if (!htuNorm) {
+      throw new TypeError('Invalid "htu" argument')
+    }
+
+    if (htuNorm !== normalizeHtu(payload['htu'])) {
       throw new InvalidDpopProofError('DPoP htu mismatch')
     }
 

--- a/packages/oauth/oauth-provider/src/lib/http/router.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/router.ts
@@ -104,10 +104,10 @@ export class Router<
           const host = req.headers.host || routerUrl?.host || 'localhost'
           const pathname = req.url || '/'
           url = new URL(pathname, `${protocol}//${host}`)
-        } catch (err) {
-          return next(
-            Object.assign(err as Error, { status: 400, statusCode: 400 }),
-          )
+        } catch (cause) {
+          const error =
+            cause instanceof Error ? cause : new Error('Invalid URL', { cause })
+          return next(Object.assign(error, { status: 400, statusCode: 400 }))
         }
       }
 


### PR DESCRIPTION
The following [issue](https://github.com/bluesky-social/atproto/issues/3410#issuecomment-2602138079) showed that the error message can contain `Authorization server requires nonce in DPoP proof` when a `nonce` is actually present in the proof.

This change uses a distinct error message in that particular case.