### PR TITLE
Reset rate limit codegen

### DIFF
--- a/packages/bsky/src/lexicon/types/app/bsky/actor/getPreferences.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/getPreferences.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/getProfiles.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/putPreferences.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/putPreferences.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getActorLikes.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -53,6 +53,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getFeed.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getListFeed.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -51,6 +51,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getPosts.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getPosts.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getQuotes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -66,6 +66,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/sendInteractions.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/sendInteractions.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getList.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getListBlocks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getListBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getListMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getRelationships.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getRelationships.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPack.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPack.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/muteActor.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/muteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/muteActorList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/muteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/muteThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/muteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActor.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteThread.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/unmuteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/labeler/getServices.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/labeler/getServices.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/putPreferences.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/putPreferences.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/registerPush.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/registerPush.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/notification/updateSeen.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/notification/updateSeen.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getConfig.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getConfig.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -68,6 +68,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/video/getJobStatus.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/video/getJobStatus.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/video/getUploadLimits.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/video/getUploadLimits.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/app/bsky/video/uploadVideo.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/video/uploadVideo.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/getConvo.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/getConvo.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/getLog.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/getLog.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/getMessages.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/getMessages.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/listConvos.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/listConvos.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/muteConvo.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/muteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/convo/updateRead.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/convo/updateRead.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
+++ b/packages/bsky/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/searchAccounts.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/searchAccounts.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/sendEmail.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/sendEmail.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
@@ -56,6 +56,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/resolveHandle.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/resolveHandle.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/identity/updateHandle.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/identity/updateHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/label/queryLabels.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/label/queryLabels.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/moderation/createReport.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/moderation/createReport.ts
@@ -60,6 +60,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -54,6 +54,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/describeRepo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/describeRepo.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/getRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/getRecord.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/importRepo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/importRepo.ts
@@ -30,6 +30,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -61,6 +61,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/repo/uploadBlob.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/repo/uploadBlob.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/activateAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/activateAccount.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/confirmEmail.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/confirmEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -71,6 +71,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createInviteCode.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createInviteCode.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createInviteCodes.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createInviteCodes.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/createSession.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/deactivateAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/deactivateAccount.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/deleteAccount.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/deleteAccount.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/deleteSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/deleteSession.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/getServiceAuth.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/getServiceAuth.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/getSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/refreshSession.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/refreshSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/resetPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/resetPassword.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getBlob.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getBlob.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getBlocks.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getCheckout.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getCheckout.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getHead.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getHead.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/listBlobs.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/listBlobs.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/listRepos.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/listRepos.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/temp/fetchLabels.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/bsky/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/getPreferences.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/getPreferences.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/getProfiles.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/getProfiles.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/putPreferences.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/putPreferences.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getActorLikes.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getActorLikes.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -53,6 +53,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getFeed.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getFeed.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getListFeed.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getListFeed.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -51,6 +51,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getPosts.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getPosts.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getQuotes.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getQuotes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -66,6 +66,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/sendInteractions.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/sendInteractions.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getBlocks.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getList.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getList.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getListBlocks.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getListBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getListMutes.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getListMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getRelationships.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getRelationships.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPack.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPack.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/muteActor.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/muteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/muteActorList.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/muteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/muteThread.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/muteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteActor.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteThread.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/unmuteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/labeler/getServices.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/labeler/getServices.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/putPreferences.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/putPreferences.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/registerPush.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/registerPush.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/notification/updateSeen.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/notification/updateSeen.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getConfig.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getConfig.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -68,6 +68,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/video/getJobStatus.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/video/getJobStatus.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/video/getUploadLimits.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/video/getUploadLimits.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/app/bsky/video/uploadVideo.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/video/uploadVideo.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvo.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvo.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/getLog.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/getLog.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/getMessages.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/getMessages.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/listConvos.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/listConvos.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/muteConvo.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/muteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/updateRead.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/updateRead.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/searchAccounts.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/searchAccounts.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/sendEmail.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/sendEmail.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
@@ -56,6 +56,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/resolveHandle.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/resolveHandle.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/identity/updateHandle.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/identity/updateHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/label/queryLabels.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/label/queryLabels.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/moderation/createReport.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/moderation/createReport.ts
@@ -60,6 +60,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -54,6 +54,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/describeRepo.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/describeRepo.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/getRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/getRecord.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/importRepo.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/importRepo.ts
@@ -30,6 +30,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -61,6 +61,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/uploadBlob.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/uploadBlob.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/activateAccount.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/activateAccount.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/confirmEmail.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/confirmEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -71,6 +71,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createInviteCode.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createInviteCode.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createInviteCodes.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createInviteCodes.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/createSession.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/deactivateAccount.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/deactivateAccount.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/deleteAccount.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/deleteAccount.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/deleteSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/deleteSession.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/getServiceAuth.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/getServiceAuth.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/getSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/refreshSession.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/refreshSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/resetPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/resetPassword.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getBlob.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getBlob.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getBlocks.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getCheckout.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getCheckout.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getHead.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getHead.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/listBlobs.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/listBlobs.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/listRepos.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/listRepos.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/temp/fetchLabels.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/communication/createTemplate.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/communication/createTemplate.ts
@@ -51,6 +51,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/communication/deleteTemplate.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/communication/deleteTemplate.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/communication/listTemplates.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/communication/listTemplates.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/communication/updateTemplate.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/communication/updateTemplate.ts
@@ -54,6 +54,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -68,6 +68,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getEvent.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getEvent.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRecord.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRecord.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRecords.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRecords.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRepo.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRepo.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRepos.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getRepos.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -72,6 +72,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -103,6 +103,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/server/getConfig.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/server/getConfig.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/addValues.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/addValues.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/deleteSet.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/deleteSet.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/deleteValues.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/deleteValues.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/getValues.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/getValues.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/querySets.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/querySets.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/set/upsertSet.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/set/upsertSet.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/setting/listOptions.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/setting/listOptions.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/setting/removeOptions.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/setting/removeOptions.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/setting/upsertOption.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/setting/upsertOption.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/signature/findCorrelation.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/signature/findCorrelation.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/signature/findRelatedAccounts.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/signature/findRelatedAccounts.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/signature/searchAccounts.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/signature/searchAccounts.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/team/addMember.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/team/addMember.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/team/deleteMember.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/team/deleteMember.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/team/listMembers.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/team/listMembers.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/ozone/src/lexicon/types/tools/ozone/team/updateMember.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/team/updateMember.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getPreferences.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfile.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getProfiles.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/getSuggestions.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/putPreferences.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActors.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/searchActorsTypeahead.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/describeFeedGenerator.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getActorFeeds.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getActorLikes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getActorLikes.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getAuthorFeed.ts
@@ -53,6 +53,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getFeed.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getFeedGenerator.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getFeedGenerators.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getLikes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getListFeed.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getListFeed.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPostThread.ts
@@ -51,6 +51,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getPosts.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getPosts.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getQuotes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getQuotes.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getRepostedBy.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getSuggestedFeeds.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getTimeline.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/searchPosts.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/searchPosts.ts
@@ -66,6 +66,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/feed/sendInteractions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/sendInteractions.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getActorStarterPacks.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getBlocks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getFollows.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getKnownFollowers.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getList.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getList.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getListBlocks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getListBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getListMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getListMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getMutes.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getRelationships.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getRelationships.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPack.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPack.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacks.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/muteActor.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/muteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/muteActorList.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/muteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/muteThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/muteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/searchStarterPacks.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/unmuteActor.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/unmuteActor.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/unmuteActorList.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/graph/unmuteThread.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/unmuteThread.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/labeler/getServices.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/labeler/getServices.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/getUnreadCount.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/listNotifications.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/putPreferences.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/putPreferences.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/registerPush.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/registerPush.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/notification/updateSeen.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getConfig.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getConfig.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestionsSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getTaggedSuggestions.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getTrendingTopics.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/searchActorsSkeleton.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/searchPostsSkeleton.ts
@@ -68,6 +68,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/searchStarterPacksSkeleton.ts
@@ -50,6 +50,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/video/getJobStatus.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/video/getJobStatus.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/video/getUploadLimits.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/video/getUploadLimits.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/app/bsky/video/uploadVideo.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/video/uploadVideo.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/actor/deleteAccount.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/actor/exportAccountData.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/deleteMessageForSelf.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/getConvo.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/getConvo.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/getConvoForMembers.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/getLog.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/getLog.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/getMessages.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/getMessages.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/leaveConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/listConvos.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/listConvos.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/muteConvo.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/muteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessage.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessage.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/sendMessageBatch.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/unmuteConvo.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/convo/updateRead.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/convo/updateRead.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/moderation/getActorMetadata.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/moderation/getMessageContext.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
+++ b/packages/pds/src/lexicon/types/chat/bsky/moderation/updateActorAccess.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/deleteAccount.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/disableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/disableInviteCodes.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/enableAccountInvites.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getAccountInfo.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getAccountInfos.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/getSubjectStatus.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/searchAccounts.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/searchAccounts.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/sendEmail.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/sendEmail.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/updateAccountPassword.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/admin/updateSubjectStatus.ts
@@ -56,6 +56,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/getRecommendedDidCredentials.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/requestPlcOperationSignature.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/resolveHandle.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/signPlcOperation.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/submitPlcOperation.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/identity/updateHandle.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/label/queryLabels.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/label/queryLabels.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/moderation/createReport.ts
@@ -60,6 +60,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/deleteRecord.ts
@@ -54,6 +54,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/describeRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/describeRepo.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/getRecord.ts
@@ -49,6 +49,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/importRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/importRepo.ts
@@ -30,6 +30,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listMissingBlobs.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/listRecords.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/putRecord.ts
@@ -61,6 +61,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/repo/uploadBlob.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/activateAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/activateAccount.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/checkAccountStatus.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/confirmEmail.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/confirmEmail.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAccount.ts
@@ -71,6 +71,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createAppPassword.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/createInviteCode.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createInviteCode.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/createInviteCodes.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createInviteCodes.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/createSession.ts
@@ -59,6 +59,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/deactivateAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/deactivateAccount.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/deleteAccount.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/deleteAccount.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/deleteSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/deleteSession.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/describeServer.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/describeServer.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getAccountInviteCodes.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getServiceAuth.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/getSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/listAppPasswords.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/listAppPasswords.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/refreshSession.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/refreshSession.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/requestAccountDelete.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/requestEmailConfirmation.ts
@@ -25,6 +25,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/requestEmailUpdate.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/requestPasswordReset.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/reserveSigningKey.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/resetPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/resetPassword.ts
@@ -34,6 +34,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/revokeAppPassword.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/server/updateEmail.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/server/updateEmail.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getBlob.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getBlob.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getBlocks.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getBlocks.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getCheckout.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getCheckout.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getHead.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getHead.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getLatestCommit.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRecord.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRepo.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/getRepoStatus.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/listBlobs.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/listBlobs.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/listRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/listRepos.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/notifyOfUpdate.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/requestCrawl.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/temp/addReservedHandle.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/temp/checkSignupQueue.ts
@@ -39,6 +39,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/temp/fetchLabels.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/temp/fetchLabels.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/temp/requestPhoneVerification.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/communication/createTemplate.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/communication/createTemplate.ts
@@ -51,6 +51,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/communication/deleteTemplate.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/communication/deleteTemplate.ts
@@ -32,6 +32,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/communication/listTemplates.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/communication/listTemplates.ts
@@ -38,6 +38,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/communication/updateTemplate.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/communication/updateTemplate.ts
@@ -54,6 +54,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -68,6 +68,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getEvent.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getEvent.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getRecord.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getRecord.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getRecords.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getRecords.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getRepo.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getRepo.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getRepos.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getRepos.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -72,6 +72,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryStatuses.ts
@@ -103,6 +103,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/searchRepos.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/server/getConfig.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/server/getConfig.ts
@@ -41,6 +41,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/addValues.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/addValues.ts
@@ -35,6 +35,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/deleteSet.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/deleteSet.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/deleteValues.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/deleteValues.ts
@@ -36,6 +36,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/getValues.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/getValues.ts
@@ -45,6 +45,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/querySets.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/querySets.ts
@@ -46,6 +46,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/set/upsertSet.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/set/upsertSet.ts
@@ -37,6 +37,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/setting/listOptions.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/setting/listOptions.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/setting/removeOptions.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/setting/removeOptions.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/setting/upsertOption.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/setting/upsertOption.ts
@@ -52,6 +52,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/signature/findCorrelation.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/signature/findCorrelation.ts
@@ -40,6 +40,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/signature/findRelatedAccounts.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/signature/findRelatedAccounts.ts
@@ -44,6 +44,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/signature/searchAccounts.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/signature/searchAccounts.ts
@@ -43,6 +43,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/team/addMember.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/team/addMember.ts
@@ -47,6 +47,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/team/deleteMember.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/team/deleteMember.ts
@@ -33,6 +33,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/team/listMembers.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/team/listMembers.ts
@@ -42,6 +42,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,

--- a/packages/pds/src/lexicon/types/tools/ozone/team/updateMember.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/team/updateMember.ts
@@ -48,6 +48,7 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
   input: HandlerInput
   req: express.Request
   res: express.Response
+  resetRouteRateLimits: () => Promise<void>
 }
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,


### PR DESCRIPTION
Followup to https://github.com/bluesky-social/atproto/pull/3420 where we added a new parameter for route handlers in lex-cli, but never re-ran codegen