### PR TITLE
Improve error reporting in case of failed PLC update operation

### DIFF
--- a/.changeset/eighty-eggs-nail.md
+++ b/.changeset/eighty-eggs-nail.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Export the `ResponseType` type used in the `XRPCError` constructor

--- a/.changeset/quiet-geese-begin.md
+++ b/.changeset/quiet-geese-begin.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Allow providing a custom `errorParser` option to XRPCServer

--- a/.changeset/weak-jobs-serve.md
+++ b/.changeset/weak-jobs-serve.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Improve error reporting in case of failed PLC update operation

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -55,11 +55,19 @@ export default function (server: Server, ctx: AppContext) {
 
       if (!account) {
         if (requester.startsWith('did:plc:')) {
-          await ctx.plcClient.updateHandle(
-            requester,
-            ctx.plcRotationKey,
-            handle,
-          )
+          try {
+            await ctx.plcClient.updateHandle(
+              requester,
+              ctx.plcRotationKey,
+              handle,
+            )
+          } catch (cause) {
+            throw new InvalidRequestError(
+              'Failed to update handle in PLC directory',
+              undefined,
+              { cause },
+            )
+          }
         } else {
           const resolved = await ctx.idResolver.did.resolveAtprotoData(
             requester,

--- a/packages/pds/src/api/com/atproto/identity/updateHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/updateHandle.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert'
-import { PlcClientError } from '@did-plc/lib'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { DAY, MINUTE } from '@atproto/common'
 import { normalizeAndValidateHandle } from '../../../../handle'
@@ -56,25 +55,11 @@ export default function (server: Server, ctx: AppContext) {
 
       if (!account) {
         if (requester.startsWith('did:plc:')) {
-          try {
-            await ctx.plcClient.updateHandle(
-              requester,
-              ctx.plcRotationKey,
-              handle,
-            )
-          } catch (err) {
-            const message =
-              (err instanceof PlcClientError &&
-                // extract the error message from the PLC response
-                typeof err.data === 'object' &&
-                err.data != null &&
-                'message' in err.data &&
-                typeof err.data.message === 'string' &&
-                err.data.message) ||
-              'Failed to update handle in PLC directory'
-
-            throw new InvalidRequestError(message, undefined, { cause: err })
-          }
+          await ctx.plcClient.updateHandle(
+            requester,
+            ctx.plcRotationKey,
+            handle,
+          )
         } else {
           const resolved = await ctx.idResolver.did.resolveAtprotoData(
             requester,

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -29,6 +29,17 @@ export type Options = {
     global?: ServerRateLimitDescription[]
     shared?: ServerRateLimitDescription[]
   }
+  /**
+   * By default, errors are converted to {@link XRPCError} using
+   * {@link XRPCError.fromError} before being rendered. If method handlers throw
+   * error objects that are not properly rendered in the HTTP response, this
+   * function can be used to properly convert them to {@link XRPCError}. The
+   * provided function will typically fallback to the default error conversion
+   * (`return XRPCError.fromError(err)`) if the error is not recognized.
+   *
+   * @note This function should not throw errors.
+   */
+  errorParser?: (err: unknown) => XRPCError
 }
 
 export type UndecodedParams = (typeof express.request)['query']
@@ -211,6 +222,8 @@ export type XRPCStreamHandlerConfig = {
   auth?: StreamAuthVerifier
   handler: XRPCStreamHandler
 }
+
+export { ResponseType }
 
 export class XRPCError extends Error {
   constructor(


### PR DESCRIPTION
Changes:
- `xrpc-server`: add a new `errorParser` option to the `XRPCServer` constructor, allowing to properly convert unknwon erros to `XRPCError`
- `pds`: sets a custom `errorParser` so that `PlcClientError` are not rendered as generic `{ "error": "InvalidRequest", "message": "Request failed with status code 400"}` errors