### PR TITLE
Allow passing `allowTakendown` to createSession

### DIFF
--- a/.changeset/new-owls-applaud.md
+++ b/.changeset/new-owls-applaud.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Allow passing `allowTakendown` to createSession

--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -309,6 +309,7 @@ export class CredentialSession implements SessionManager {
         identifier: opts.identifier,
         password: opts.password,
         authFactorToken: opts.authFactorToken,
+        allowTakendown: opts.allowTakendown,
       })
       this.session = {
         accessJwt: res.data.accessJwt,

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -47,6 +47,7 @@ export interface AtpAgentLoginOpts {
   identifier: string
   password: string
   authFactorToken?: string | undefined
+  allowTakendown?: boolean
 }
 
 /**


### PR DESCRIPTION
https://github.com/bluesky-social/atproto/pull/3251 added a new param, `allowTakendown`, to createSession. However, the API package doesn't expose it directly, instead providing the `login` method. We need to add a new optional parameter to `login` which just gets passed through.