### PR TITLE
Appview: add user-agent for feeds and resolving blobs

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -28,7 +28,7 @@ import {
   isDataplaneError,
   unpackIdentityServices,
 } from '../../../../data-plane'
-import { resHeaders } from '../../../util'
+import { BSKY_USER_AGENT, resHeaders } from '../../../util'
 import { ids } from '../../../../lexicon/lexicons'
 
 export default function (server: Server, ctx: AppContext) {
@@ -55,6 +55,7 @@ export default function (server: Server, ctx: AppContext) {
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
+        'user-agent': BSKY_USER_AGENT,
         authorization: req.headers['authorization'],
         'accept-language': req.headers['accept-language'],
         'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])

--- a/packages/bsky/src/api/blob-resolver.ts
+++ b/packages/bsky/src/api/blob-resolver.ts
@@ -28,6 +28,7 @@ import {
 import { parseCid } from '../hydration/util'
 import { httpLogger as log } from '../logger'
 import { Middleware, proxyResponseHeaders, responseSignal } from '../util/http'
+import { BSKY_USER_AGENT } from './util'
 
 export function createMiddleware(ctx: AppContext): Middleware {
   return async (req, res, next) => {
@@ -297,6 +298,8 @@ function getBlobHeaders(
   url: URL,
 ): Map<string, string> {
   const headers = new Map<string, string>()
+
+  headers.set('user-agent', BSKY_USER_AGENT)
 
   if (bypassKey && bypassHostname) {
     const matchesUrl = bypassHostname.startsWith('.')

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -1,5 +1,6 @@
 import { ParsedLabelers, formatLabelerHeader } from '../util'
 
+export const BSKY_USER_AGENT = 'BskyAppView'
 export const ATPROTO_CONTENT_LABELERS = 'Atproto-Content-Labelers'
 export const ATPROTO_REPO_REV = 'Atproto-Repo-Rev'
 


### PR DESCRIPTION
Appivew trying to be a friendly netizen.  In particular, some servers reject requests without a user-agent, which can impact the appview's ability to resolve blobs.