### PR TITLE
feat(lex-cli): loosen the validation of the root document

### DIFF
--- a/.changeset/hot-lizards-kick.md
+++ b/.changeset/hot-lizards-kick.md
@@ -1,0 +1,6 @@
+---
+"@atproto/lexicon": patch
+"@atproto/lex-cli": patch
+---
+
+Loosen the validation of lexicon doc to allow metadata fields, such as `$schema`

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -420,7 +420,6 @@ export const lexiconDoc = z
     description: z.string().optional(),
     defs: z.record(lexUserType),
   })
-  .strict()
   .superRefine((doc, ctx) => {
     for (const defId in doc.defs) {
       const def = doc.defs[defId]

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -100,6 +100,23 @@ describe('General validation', () => {
       parseLexiconDoc(schema)
     }).toThrow('Required field \\"foo\\" not defined')
   })
+  it('passes when unknown fields are present only at the root level', () => {
+    const schema = {
+      $schema: 'https://example.com/schema.json',
+      lexicon: 1,
+      id: 'com.example.unknownFields',
+      defs: {
+        test: {
+          type: 'object',
+          properties: {
+            test: { type: 'string' },
+          },
+        },
+      },
+    }
+
+    expect(() => parseLexiconDoc(schema)).not.toThrow()
+  })
   it('fails when unknown fields are present', () => {
     const schema = {
       lexicon: 1,


### PR DESCRIPTION
 This PR allows extra properties to be specified for lexicons at the root of the declaration file. Everything under the `deps` field still remains strictly validated.

## Motivation

I've been trying to experiment with json schemas for the lexicon declarations in my project, and I realized that the codegen cli does not allow me to compile declarations with extra properties (including `$schema`):

```
Invalid lexicon /home/prenaissance/<some_path>/atproto/lexicons/comment.json
Issues at :
 - Unrecognized key(s) in object: '$schema'
 ```
 
 The schema validators were made to use `ZodSchema::strict()` in https://github.com/bluesky-social/atproto/pull/1088, in response to the issue from https://github.com/bluesky-social/atproto/pull/1080, but allowing extra properties at the root level of the document would do no harm. 
 
