### PR TITLE
CBOR: parse safe uint64 as number

### DIFF
--- a/.changeset/three-papayas-begin.md
+++ b/.changeset/three-papayas-begin.md
@@ -1,0 +1,5 @@
+---
+"@atproto/common": patch
+---
+
+Parse safe uint64 as number

--- a/packages/common/src/ipld-multi.ts
+++ b/packages/common/src/ipld-multi.ts
@@ -18,9 +18,15 @@ cborx.addExtension({
   },
 })
 
+const decoder = new cborx.Decoder({
+  // @ts-ignore
+  int64AsNumber: true, // not in types for some reason
+  useRecords: false,
+})
+
 export const cborDecodeMulti = (encoded: Uint8Array): unknown[] => {
   const decoded: unknown[] = []
-  cborx.decodeMultiple(encoded, (value) => {
+  decoder.decodeMultiple(encoded, (value) => {
     decoded.push(value)
   })
   return decoded

--- a/packages/common/tests/ipld-multi.test.ts
+++ b/packages/common/tests/ipld-multi.test.ts
@@ -22,4 +22,13 @@ describe('ipld decode multi', () => {
     expect(decoded[0]).toEqual(one)
     expect(decoded[1]).toEqual(two)
   })
+
+  it('blah', async () => {
+    const one = {
+      test: Number.MAX_SAFE_INTEGER,
+    }
+    const encoded = cborEncode(one)
+    const decoded = cborDecodeMulti(encoded)
+    expect(Number.isInteger(decoded[0]?.['test'])).toBe(true)
+  })
 })

--- a/packages/common/tests/ipld-multi.test.ts
+++ b/packages/common/tests/ipld-multi.test.ts
@@ -23,7 +23,7 @@ describe('ipld decode multi', () => {
     expect(decoded[1]).toEqual(two)
   })
 
-  it('blah', async () => {
+  it('parses safe ints as number', async () => {
     const one = {
       test: Number.MAX_SAFE_INTEGER,
     }


### PR DESCRIPTION
`cbor-x` decodes `uint64`s as bigints even if they are safe to represent as javascript numbers (less than `2^57-1`). 

This was causing unnecessary validation errors in lexicon.

Fixes https://github.com/bluesky-social/atproto/issues/3479