### PR TITLE
Add `setPostInteractionSettings` and related prefs

### DIFF
--- a/.changeset/tame-cobras-lick.md
+++ b/.changeset/tame-cobras-lick.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Add `setPostInteractionSettings` for configuring default interaction settings for creation of posts

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -174,7 +174,8 @@
           "#mutedWordsPref",
           "#hiddenPostsPref",
           "#bskyAppStatePref",
-          "#labelersPref"
+          "#labelersPref",
+          "#postInteractionSettingsPref"
         ]
       }
     },
@@ -466,6 +467,33 @@
           "type": "string",
           "format": "datetime",
           "description": "The date and time at which the NUX will expire and should be considered completed."
+        }
+      }
+    },
+    "postInteractionSettingsPref": {
+      "type": "object",
+      "description": "Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.",
+      "required": ["threadgateAllowRules", "postgateEmbeddingRules"],
+      "properties": {
+        "threadgateAllowRules": {
+          "type": "array",
+          "maxLength": 5,
+          "items": {
+            "type": "union",
+            "refs": [
+              "app.bsky.feed.threadgate#mentionRule",
+              "app.bsky.feed.threadgate#followingRule",
+              "app.bsky.feed.threadgate#listRule"
+            ]
+          }
+        },
+        "postgateEmbeddingRules": {
+          "type": "array",
+          "maxLength": 5,
+          "items": {
+            "type": "union",
+            "refs": ["app.bsky.feed.postgate#disableRule"]
+          }
         }
       }
     }

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -472,10 +472,11 @@
     },
     "postInteractionSettingsPref": {
       "type": "object",
-      "description": "Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.",
+      "description": "Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.",
       "required": [],
       "properties": {
         "threadgateAllowRules": {
+          "description": "Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply.",
           "type": "array",
           "maxLength": 5,
           "items": {
@@ -488,6 +489,7 @@
           }
         },
         "postgateEmbeddingRules": {
+          "description": "Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed.",
           "type": "array",
           "maxLength": 5,
           "items": {

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -473,7 +473,7 @@
     "postInteractionSettingsPref": {
       "type": "object",
       "description": "Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.",
-      "required": ["threadgateAllowRules", "postgateEmbeddingRules"],
+      "required": [],
       "properties": {
         "threadgateAllowRules": {
           "type": "array",

--- a/lexicons/app/bsky/feed/postgate.json
+++ b/lexicons/app/bsky/feed/postgate.json
@@ -26,6 +26,7 @@
             "description": "List of AT-URIs embedding this post that the author has detached from."
           },
           "embeddingRules": {
+            "description": "List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed.",
             "type": "array",
             "maxLength": 5,
             "items": {

--- a/lexicons/app/bsky/feed/threadgate.json
+++ b/lexicons/app/bsky/feed/threadgate.json
@@ -16,6 +16,7 @@
             "description": "Reference (AT-URI) to the post record."
           },
           "allow": {
+            "description": "List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply.",
             "type": "array",
             "maxLength": 5,
             "items": {

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -588,6 +588,10 @@ export class Agent extends XrpcClient {
         activeProgressGuide: undefined,
         nuxs: [],
       },
+      postInteractionSettings: {
+        threadgateAllowRules: [],
+        postgateEmbeddingRules: [],
+      },
     }
     const res = await this.app.bsky.actor.getPreferences({})
     const labelPrefs: AppBskyActorDefs.ContentLabelPref[] = []
@@ -692,6 +696,14 @@ export class Agent extends XrpcClient {
         prefs.bskyAppState.queuedNudges = v.queuedNudges || []
         prefs.bskyAppState.activeProgressGuide = v.activeProgressGuide
         prefs.bskyAppState.nuxs = v.nuxs || []
+      } else if (
+        AppBskyActorDefs.isPostInteractionSettingsPref(pref) &&
+        AppBskyActorDefs.validatePostInteractionSettingsPref(pref).success
+      ) {
+        prefs.postInteractionSettings.threadgateAllowRules =
+          pref.threadgateAllowRules || []
+        prefs.postInteractionSettings.postgateEmbeddingRules =
+          pref.postgateEmbeddingRules || []
       }
     }
 
@@ -1463,6 +1475,43 @@ export class Agent extends XrpcClient {
           {
             ...bskyAppStatePref,
             $type: 'app.bsky.actor.defs#bskyAppStatePref',
+          },
+        ])
+    })
+  }
+
+  async setPostInteractionSettings(
+    settings: AppBskyActorDefs.PostInteractionSettingsPref,
+  ) {
+    if (
+      !AppBskyActorDefs.validatePostInteractionSettingsPref(settings).success
+    ) {
+      throw new Error('Invalid post interaction settings')
+    }
+
+    await this.updatePreferences((prefs: AppBskyActorDefs.Preferences) => {
+      let prev = prefs.findLast(
+        (pref) =>
+          AppBskyActorDefs.isPostInteractionSettingsPref(pref) &&
+          AppBskyActorDefs.validatePostInteractionSettingsPref(pref).success,
+      ) as AppBskyActorDefs.PostInteractionSettingsPref
+
+      if (!prev) {
+        prev = {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        }
+      }
+
+      prev.threadgateAllowRules = settings.threadgateAllowRules || []
+      prev.postgateEmbeddingRules = settings.postgateEmbeddingRules || []
+
+      return prefs
+        .filter((p) => !AppBskyActorDefs.isPostInteractionSettingsPref(p))
+        .concat([
+          {
+            ...prev,
+            $type: 'app.bsky.actor.defs#postInteractionSettingsPref',
           },
         ])
     })

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -589,8 +589,8 @@ export class Agent extends XrpcClient {
         nuxs: [],
       },
       postInteractionSettings: {
-        threadgateAllowRules: [],
-        postgateEmbeddingRules: [],
+        threadgateAllowRules: undefined,
+        postgateEmbeddingRules: undefined,
       },
     }
     const res = await this.app.bsky.actor.getPreferences({})
@@ -701,9 +701,9 @@ export class Agent extends XrpcClient {
         AppBskyActorDefs.validatePostInteractionSettingsPref(pref).success
       ) {
         prefs.postInteractionSettings.threadgateAllowRules =
-          pref.threadgateAllowRules || []
+          pref.threadgateAllowRules
         prefs.postInteractionSettings.postgateEmbeddingRules =
-          pref.postgateEmbeddingRules || []
+          pref.postgateEmbeddingRules
       }
     }
 
@@ -1498,13 +1498,19 @@ export class Agent extends XrpcClient {
 
       if (!prev) {
         prev = {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          /**
+           * Matches handling of `threadgate.allow` where `undefined` means "everyone"
+           */
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         }
       }
 
-      prev.threadgateAllowRules = settings.threadgateAllowRules || []
-      prev.postgateEmbeddingRules = settings.postgateEmbeddingRules || []
+      /**
+       * Matches handling of `threadgate.allow` where `undefined` means "everyone"
+       */
+      prev.threadgateAllowRules = settings.threadgateAllowRules
+      prev.postgateEmbeddingRules = settings.postgateEmbeddingRules
 
       return prefs
         .filter((p) => !AppBskyActorDefs.isPostInteractionSettingsPref(p))

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4719,7 +4719,7 @@ export const schemaDict = {
         type: 'object',
         description:
           'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
-        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        required: [],
         properties: {
           threadgateAllowRules: {
             type: 'array',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4718,10 +4718,12 @@ export const schemaDict = {
       postInteractionSettingsPref: {
         type: 'object',
         description:
-          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+          'Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.',
         required: [],
         properties: {
           threadgateAllowRules: {
+            description:
+              'Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -4734,6 +4736,8 @@ export const schemaDict = {
             },
           },
           postgateEmbeddingRules: {
+            description:
+              'Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -7149,6 +7153,8 @@ export const schemaDict = {
                 'List of AT-URIs embedding this post that the author has detached from.',
             },
             embeddingRules: {
+              description:
+                'List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
               type: 'array',
               maxLength: 5,
               items: {
@@ -7362,6 +7368,8 @@ export const schemaDict = {
               description: 'Reference (AT-URI) to the post record.',
             },
             allow: {
+              description:
+                'List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
               type: 'array',
               maxLength: 5,
               items: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -4381,6 +4381,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#postInteractionSettingsPref',
           ],
         },
       },
@@ -4711,6 +4712,34 @@ export const schemaDict = {
             format: 'datetime',
             description:
               'The date and time at which the NUX will expire and should be considered completed.',
+          },
+        },
+      },
+      postInteractionSettingsPref: {
+        type: 'object',
+        description:
+          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        properties: {
+          threadgateAllowRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.threadgate#mentionRule',
+                'lex:app.bsky.feed.threadgate#followingRule',
+                'lex:app.bsky.feed.threadgate#listRule',
+              ],
+            },
+          },
+          postgateEmbeddingRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: ['lex:app.bsky.feed.postgate#disableRule'],
+            },
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -536,14 +536,16 @@ export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
 }
 
-/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+/** Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
+  /** Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
+  /** Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -8,6 +8,8 @@ import { CID } from 'multiformats/cid'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 import * as AppBskyGraphDefs from '../graph/defs'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
+import * as AppBskyFeedThreadgate from '../feed/threadgate'
+import * as AppBskyFeedPostgate from '../feed/postgate'
 
 export interface ProfileViewBasic {
   did: string
@@ -188,6 +190,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | PostInteractionSettingsPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -531,4 +534,35 @@ export function isNux(v: unknown): v is Nux {
 
 export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
+}
+
+/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+export interface PostInteractionSettingsPref {
+  threadgateAllowRules: (
+    | AppBskyFeedThreadgate.MentionRule
+    | AppBskyFeedThreadgate.FollowingRule
+    | AppBskyFeedThreadgate.ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  postgateEmbeddingRules: (
+    | AppBskyFeedPostgate.DisableRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  [k: string]: unknown
+}
+
+export function isPostInteractionSettingsPref(
+  v: unknown,
+): v is PostInteractionSettingsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#postInteractionSettingsPref'
+  )
+}
+
+export function validatePostInteractionSettingsPref(
+  v: unknown,
+): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#postInteractionSettingsPref', v)
 }

--- a/packages/api/src/client/types/app/bsky/actor/defs.ts
+++ b/packages/api/src/client/types/app/bsky/actor/defs.ts
@@ -538,13 +538,13 @@ export function validateNux(v: unknown): ValidationResult {
 
 /** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
-  threadgateAllowRules: (
+  threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
-  postgateEmbeddingRules: (
+  postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }
   )[]

--- a/packages/api/src/client/types/app/bsky/feed/postgate.ts
+++ b/packages/api/src/client/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,7 @@ export interface Record {
   post: string
   /** List of AT-URIs embedding this post that the author has detached from. */
   detachedEmbeddingUris?: string[]
+  /** List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   embeddingRules?: (DisableRule | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }

--- a/packages/api/src/client/types/app/bsky/feed/threadgate.ts
+++ b/packages/api/src/client/types/app/bsky/feed/threadgate.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 export interface Record {
   /** Reference (AT-URI) to the post record. */
   post: string
+  /** List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   allow?: (
     | MentionRule
     | FollowingRule

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -91,11 +91,6 @@ export interface BskyInterestsPreference {
   [key: string]: any
 }
 
-export interface PostInteractionSettingsPreference {
-  threadgateAllowRules: AppBskyFeedThreadgate.Record['allow']
-  postgateEmbeddingRules: AppBskyFeedPostgate.Record['embeddingRules']
-}
-
 /**
  * Bluesky preferences
  */
@@ -118,5 +113,5 @@ export interface BskyPreferences {
     activeProgressGuide: AppBskyActorDefs.BskyAppProgressGuide | undefined
     nuxs: AppBskyActorDefs.Nux[]
   }
-  postInteractionSettings: PostInteractionSettingsPreference
+  postInteractionSettings: AppBskyActorDefs.PostInteractionSettingsPref
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,4 +1,8 @@
-import { AppBskyActorDefs } from './client'
+import {
+  AppBskyActorDefs,
+  AppBskyFeedThreadgate,
+  AppBskyFeedPostgate,
+} from './client'
 import { ModerationPrefs } from './moderation/types'
 
 /**
@@ -87,6 +91,11 @@ export interface BskyInterestsPreference {
   [key: string]: any
 }
 
+export interface PostInteractionSettingsPreference {
+  threadgateAllowRules: AppBskyFeedThreadgate.Record['allow']
+  postgateEmbeddingRules: AppBskyFeedPostgate.Record['embeddingRules']
+}
+
 /**
  * Bluesky preferences
  */
@@ -109,4 +118,5 @@ export interface BskyPreferences {
     activeProgressGuide: AppBskyActorDefs.BskyAppProgressGuide | undefined
     nuxs: AppBskyActorDefs.Nux[]
   }
+  postInteractionSettings: PostInteractionSettingsPreference
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,8 +1,4 @@
-import {
-  AppBskyActorDefs,
-  AppBskyFeedThreadgate,
-  AppBskyFeedPostgate,
-} from './client'
+import { AppBskyActorDefs } from './client'
 import { ModerationPrefs } from './moderation/types'
 
 /**

--- a/packages/api/tests/atp-agent.test.ts
+++ b/packages/api/tests/atp-agent.test.ts
@@ -278,6 +278,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setAdultContentEnabled(true)
@@ -319,6 +323,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -362,6 +370,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setContentLabelPref('misinfo', 'hide')
@@ -403,6 +415,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -449,6 +465,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -499,6 +519,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -547,6 +571,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -597,6 +625,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -646,6 +678,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.addPinnedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -694,6 +730,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -750,6 +790,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.removeSavedFeed('at://bob.com/app.bsky.feed.generator/fake')
@@ -798,6 +842,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -848,6 +896,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: true })
@@ -897,6 +949,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setFeedViewPrefs('home', { hideReplies: false })
@@ -945,6 +1001,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -1002,6 +1062,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setThreadViewPrefs({ sort: 'random' })
@@ -1057,6 +1121,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -1114,6 +1182,10 @@ describe('agent', () => {
           queuedNudges: [],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setInterestsPref({ tags: ['foo', 'bar'] })
@@ -1169,6 +1241,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: [],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
     })
@@ -1353,6 +1429,10 @@ describe('agent', () => {
           queuedNudges: ['two'],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setAdultContentEnabled(false)
@@ -1410,6 +1490,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -1470,6 +1554,10 @@ describe('agent', () => {
           queuedNudges: ['two'],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.removeLabeler('did:plc:other')
@@ -1524,6 +1612,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -1580,6 +1672,10 @@ describe('agent', () => {
           queuedNudges: ['two'],
           nuxs: [],
         },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        },
       })
 
       await agent.setPersonalDetails({ birthDate: '2023-09-11T18:05:42.556Z' })
@@ -1634,6 +1730,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: ['two'],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -1701,6 +1801,10 @@ describe('agent', () => {
           activeProgressGuide: undefined,
           queuedNudges: ['two', 'three'],
           nuxs: [],
+        },
+        postInteractionSettings: {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
         },
       })
 
@@ -3333,6 +3437,59 @@ describe('agent', () => {
         expect(() => agent.bskyAppUpsertNux({ name: 'a' })).rejects.toThrow()
         expect(() =>
           agent.bskyAppUpsertNux({ id: 'a', completed: false, foo: 'bar' }),
+        ).rejects.toThrow()
+      })
+    })
+
+    describe('setPostInteractionSettings', () => {
+      let agent: AtpAgent
+
+      beforeAll(async () => {
+        agent = new AtpAgent({ service: network.pds.url })
+
+        await agent.createAccount({
+          handle: 'pints.test',
+          email: 'pints@test.com',
+          password: 'password',
+        })
+      })
+
+      it('works', async () => {
+        const next: AppBskyActorDefs.PostInteractionSettingsPref = {
+          threadgateAllowRules: [
+            { $type: 'app.bsky.feed.threadgate#mentionRule' },
+          ],
+          postgateEmbeddingRules: [],
+        }
+
+        await agent.setPostInteractionSettings(next)
+
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.postInteractionSettings).toEqual(next)
+      })
+
+      it('clears', async () => {
+        const next: AppBskyActorDefs.PostInteractionSettingsPref = {
+          threadgateAllowRules: [],
+          postgateEmbeddingRules: [],
+        }
+
+        await agent.setPostInteractionSettings(next)
+
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.postInteractionSettings).toEqual(next)
+      })
+
+      it('validates inputs', async () => {
+        // @ts-expect-error
+        expect(() => agent.setPostInteractionSettings({})).rejects.toThrow()
+        expect(() =>
+          agent.setPostInteractionSettings({
+            threadgateAllowRules: [{ key: 'string' }],
+            postgateEmbeddingRules: [],
+          }),
         ).rejects.toThrow()
       })
     })

--- a/packages/api/tests/atp-agent.test.ts
+++ b/packages/api/tests/atp-agent.test.ts
@@ -279,8 +279,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -325,8 +325,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -371,8 +371,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -417,8 +417,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -467,8 +467,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -520,8 +520,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -573,8 +573,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -626,8 +626,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -679,8 +679,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -732,8 +732,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -791,8 +791,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -844,8 +844,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -897,8 +897,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -950,8 +950,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1003,8 +1003,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1063,8 +1063,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1123,8 +1123,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1183,8 +1183,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1243,8 +1243,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
     })
@@ -1430,8 +1430,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1492,8 +1492,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1555,8 +1555,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1614,8 +1614,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1673,8 +1673,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1732,8 +1732,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -1803,8 +1803,8 @@ describe('agent', () => {
           nuxs: [],
         },
         postInteractionSettings: {
-          threadgateAllowRules: [],
-          postgateEmbeddingRules: [],
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
         },
       })
 
@@ -3482,9 +3482,30 @@ describe('agent', () => {
         expect(prefs.postInteractionSettings).toEqual(next)
       })
 
+      /**
+       * Logic matches threadgate `allow` logic, where `undefined` means "anyone
+       * can reply" and an empty array means "no one can reply".
+       *
+       * Postgate `embeddingRules` behaves differently, where `undefined` and
+       * an empty array both mean "no particular rules applied".
+       *
+       * Both props are optional though, so for easier sharing of types, we
+       * allow `undefined`.
+       */
+      it('clears using undefined', async () => {
+        const next: AppBskyActorDefs.PostInteractionSettingsPref = {
+          threadgateAllowRules: undefined,
+          postgateEmbeddingRules: undefined,
+        }
+
+        await agent.setPostInteractionSettings(next)
+
+        const prefs = await agent.getPreferences()
+
+        expect(prefs.postInteractionSettings).toEqual(next)
+      })
+
       it('validates inputs', async () => {
-        // @ts-expect-error
-        expect(() => agent.setPostInteractionSettings({})).rejects.toThrow()
         expect(() =>
           agent.setPostInteractionSettings({
             threadgateAllowRules: [{ key: 'string' }],

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -86,6 +86,10 @@ describe('agent', () => {
         queuedNudges: [],
         nuxs: [],
       },
+      postInteractionSettings: {
+        threadgateAllowRules: [],
+        postgateEmbeddingRules: [],
+      },
     })
   })
 
@@ -136,6 +140,10 @@ describe('agent', () => {
         queuedNudges: [],
         nuxs: [],
       },
+      postInteractionSettings: {
+        threadgateAllowRules: [],
+        postgateEmbeddingRules: [],
+      },
     })
     expect(agent.labelers).toStrictEqual(['did:plc:other'])
 
@@ -170,6 +178,10 @@ describe('agent', () => {
         activeProgressGuide: undefined,
         queuedNudges: [],
         nuxs: [],
+      },
+      postInteractionSettings: {
+        threadgateAllowRules: [],
+        postgateEmbeddingRules: [],
       },
     })
     expect(agent.labelers).toStrictEqual([])
@@ -227,6 +239,10 @@ describe('agent', () => {
         activeProgressGuide: undefined,
         queuedNudges: [],
         nuxs: [],
+      },
+      postInteractionSettings: {
+        threadgateAllowRules: [],
+        postgateEmbeddingRules: [],
       },
     })
   })

--- a/packages/api/tests/moderation-prefs.test.ts
+++ b/packages/api/tests/moderation-prefs.test.ts
@@ -87,8 +87,8 @@ describe('agent', () => {
         nuxs: [],
       },
       postInteractionSettings: {
-        threadgateAllowRules: [],
-        postgateEmbeddingRules: [],
+        threadgateAllowRules: undefined,
+        postgateEmbeddingRules: undefined,
       },
     })
   })
@@ -141,8 +141,8 @@ describe('agent', () => {
         nuxs: [],
       },
       postInteractionSettings: {
-        threadgateAllowRules: [],
-        postgateEmbeddingRules: [],
+        threadgateAllowRules: undefined,
+        postgateEmbeddingRules: undefined,
       },
     })
     expect(agent.labelers).toStrictEqual(['did:plc:other'])
@@ -180,8 +180,8 @@ describe('agent', () => {
         nuxs: [],
       },
       postInteractionSettings: {
-        threadgateAllowRules: [],
-        postgateEmbeddingRules: [],
+        threadgateAllowRules: undefined,
+        postgateEmbeddingRules: undefined,
       },
     })
     expect(agent.labelers).toStrictEqual([])
@@ -241,8 +241,8 @@ describe('agent', () => {
         nuxs: [],
       },
       postInteractionSettings: {
-        threadgateAllowRules: [],
-        postgateEmbeddingRules: [],
+        threadgateAllowRules: undefined,
+        postgateEmbeddingRules: undefined,
       },
     })
   })

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4719,7 +4719,7 @@ export const schemaDict = {
         type: 'object',
         description:
           'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
-        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        required: [],
         properties: {
           threadgateAllowRules: {
             type: 'array',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4718,10 +4718,12 @@ export const schemaDict = {
       postInteractionSettingsPref: {
         type: 'object',
         description:
-          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+          'Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.',
         required: [],
         properties: {
           threadgateAllowRules: {
+            description:
+              'Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -4734,6 +4736,8 @@ export const schemaDict = {
             },
           },
           postgateEmbeddingRules: {
+            description:
+              'Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -7149,6 +7153,8 @@ export const schemaDict = {
                 'List of AT-URIs embedding this post that the author has detached from.',
             },
             embeddingRules: {
+              description:
+                'List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
               type: 'array',
               maxLength: 5,
               items: {
@@ -7362,6 +7368,8 @@ export const schemaDict = {
               description: 'Reference (AT-URI) to the post record.',
             },
             allow: {
+              description:
+                'List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
               type: 'array',
               maxLength: 5,
               items: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -4381,6 +4381,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#postInteractionSettingsPref',
           ],
         },
       },
@@ -4711,6 +4712,34 @@ export const schemaDict = {
             format: 'datetime',
             description:
               'The date and time at which the NUX will expire and should be considered completed.',
+          },
+        },
+      },
+      postInteractionSettingsPref: {
+        type: 'object',
+        description:
+          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        properties: {
+          threadgateAllowRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.threadgate#mentionRule',
+                'lex:app.bsky.feed.threadgate#followingRule',
+                'lex:app.bsky.feed.threadgate#listRule',
+              ],
+            },
+          },
+          postgateEmbeddingRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: ['lex:app.bsky.feed.postgate#disableRule'],
+            },
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -536,14 +536,16 @@ export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
 }
 
-/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+/** Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
+  /** Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
+  /** Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -8,6 +8,8 @@ import { CID } from 'multiformats/cid'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 import * as AppBskyGraphDefs from '../graph/defs'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
+import * as AppBskyFeedThreadgate from '../feed/threadgate'
+import * as AppBskyFeedPostgate from '../feed/postgate'
 
 export interface ProfileViewBasic {
   did: string
@@ -188,6 +190,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | PostInteractionSettingsPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -531,4 +534,35 @@ export function isNux(v: unknown): v is Nux {
 
 export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
+}
+
+/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+export interface PostInteractionSettingsPref {
+  threadgateAllowRules: (
+    | AppBskyFeedThreadgate.MentionRule
+    | AppBskyFeedThreadgate.FollowingRule
+    | AppBskyFeedThreadgate.ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  postgateEmbeddingRules: (
+    | AppBskyFeedPostgate.DisableRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  [k: string]: unknown
+}
+
+export function isPostInteractionSettingsPref(
+  v: unknown,
+): v is PostInteractionSettingsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#postInteractionSettingsPref'
+  )
+}
+
+export function validatePostInteractionSettingsPref(
+  v: unknown,
+): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#postInteractionSettingsPref', v)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/actor/defs.ts
@@ -538,13 +538,13 @@ export function validateNux(v: unknown): ValidationResult {
 
 /** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
-  threadgateAllowRules: (
+  threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
-  postgateEmbeddingRules: (
+  postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }
   )[]

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,7 @@ export interface Record {
   post: string
   /** List of AT-URIs embedding this post that the author has detached from. */
   detachedEmbeddingUris?: string[]
+  /** List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   embeddingRules?: (DisableRule | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/threadgate.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/threadgate.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 export interface Record {
   /** Reference (AT-URI) to the post record. */
   post: string
+  /** List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   allow?: (
     | MentionRule
     | FollowingRule

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4719,7 +4719,7 @@ export const schemaDict = {
         type: 'object',
         description:
           'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
-        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        required: [],
         properties: {
           threadgateAllowRules: {
             type: 'array',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4718,10 +4718,12 @@ export const schemaDict = {
       postInteractionSettingsPref: {
         type: 'object',
         description:
-          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+          'Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.',
         required: [],
         properties: {
           threadgateAllowRules: {
+            description:
+              'Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -4734,6 +4736,8 @@ export const schemaDict = {
             },
           },
           postgateEmbeddingRules: {
+            description:
+              'Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -7149,6 +7153,8 @@ export const schemaDict = {
                 'List of AT-URIs embedding this post that the author has detached from.',
             },
             embeddingRules: {
+              description:
+                'List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
               type: 'array',
               maxLength: 5,
               items: {
@@ -7362,6 +7368,8 @@ export const schemaDict = {
               description: 'Reference (AT-URI) to the post record.',
             },
             allow: {
+              description:
+                'List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
               type: 'array',
               maxLength: 5,
               items: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -4381,6 +4381,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#postInteractionSettingsPref',
           ],
         },
       },
@@ -4711,6 +4712,34 @@ export const schemaDict = {
             format: 'datetime',
             description:
               'The date and time at which the NUX will expire and should be considered completed.',
+          },
+        },
+      },
+      postInteractionSettingsPref: {
+        type: 'object',
+        description:
+          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        properties: {
+          threadgateAllowRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.threadgate#mentionRule',
+                'lex:app.bsky.feed.threadgate#followingRule',
+                'lex:app.bsky.feed.threadgate#listRule',
+              ],
+            },
+          },
+          postgateEmbeddingRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: ['lex:app.bsky.feed.postgate#disableRule'],
+            },
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -536,14 +536,16 @@ export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
 }
 
-/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+/** Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
+  /** Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
+  /** Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -8,6 +8,8 @@ import { CID } from 'multiformats/cid'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 import * as AppBskyGraphDefs from '../graph/defs'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
+import * as AppBskyFeedThreadgate from '../feed/threadgate'
+import * as AppBskyFeedPostgate from '../feed/postgate'
 
 export interface ProfileViewBasic {
   did: string
@@ -188,6 +190,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | PostInteractionSettingsPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -531,4 +534,35 @@ export function isNux(v: unknown): v is Nux {
 
 export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
+}
+
+/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+export interface PostInteractionSettingsPref {
+  threadgateAllowRules: (
+    | AppBskyFeedThreadgate.MentionRule
+    | AppBskyFeedThreadgate.FollowingRule
+    | AppBskyFeedThreadgate.ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  postgateEmbeddingRules: (
+    | AppBskyFeedPostgate.DisableRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  [k: string]: unknown
+}
+
+export function isPostInteractionSettingsPref(
+  v: unknown,
+): v is PostInteractionSettingsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#postInteractionSettingsPref'
+  )
+}
+
+export function validatePostInteractionSettingsPref(
+  v: unknown,
+): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#postInteractionSettingsPref', v)
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/actor/defs.ts
@@ -538,13 +538,13 @@ export function validateNux(v: unknown): ValidationResult {
 
 /** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
-  threadgateAllowRules: (
+  threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
-  postgateEmbeddingRules: (
+  postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }
   )[]

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,7 @@ export interface Record {
   post: string
   /** List of AT-URIs embedding this post that the author has detached from. */
   detachedEmbeddingUris?: string[]
+  /** List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   embeddingRules?: (DisableRule | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/threadgate.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/threadgate.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 export interface Record {
   /** Reference (AT-URI) to the post record. */
   post: string
+  /** List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   allow?: (
     | MentionRule
     | FollowingRule

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4719,7 +4719,7 @@ export const schemaDict = {
         type: 'object',
         description:
           'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
-        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        required: [],
         properties: {
           threadgateAllowRules: {
             type: 'array',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4718,10 +4718,12 @@ export const schemaDict = {
       postInteractionSettingsPref: {
         type: 'object',
         description:
-          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+          'Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.',
         required: [],
         properties: {
           threadgateAllowRules: {
+            description:
+              'Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -4734,6 +4736,8 @@ export const schemaDict = {
             },
           },
           postgateEmbeddingRules: {
+            description:
+              'Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
             type: 'array',
             maxLength: 5,
             items: {
@@ -7149,6 +7153,8 @@ export const schemaDict = {
                 'List of AT-URIs embedding this post that the author has detached from.',
             },
             embeddingRules: {
+              description:
+                'List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed.',
               type: 'array',
               maxLength: 5,
               items: {
@@ -7362,6 +7368,8 @@ export const schemaDict = {
               description: 'Reference (AT-URI) to the post record.',
             },
             allow: {
+              description:
+                'List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply.',
               type: 'array',
               maxLength: 5,
               items: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -4381,6 +4381,7 @@ export const schemaDict = {
             'lex:app.bsky.actor.defs#hiddenPostsPref',
             'lex:app.bsky.actor.defs#bskyAppStatePref',
             'lex:app.bsky.actor.defs#labelersPref',
+            'lex:app.bsky.actor.defs#postInteractionSettingsPref',
           ],
         },
       },
@@ -4711,6 +4712,34 @@ export const schemaDict = {
             format: 'datetime',
             description:
               'The date and time at which the NUX will expire and should be considered completed.',
+          },
+        },
+      },
+      postInteractionSettingsPref: {
+        type: 'object',
+        description:
+          'Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly.',
+        required: ['threadgateAllowRules', 'postgateEmbeddingRules'],
+        properties: {
+          threadgateAllowRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: [
+                'lex:app.bsky.feed.threadgate#mentionRule',
+                'lex:app.bsky.feed.threadgate#followingRule',
+                'lex:app.bsky.feed.threadgate#listRule',
+              ],
+            },
+          },
+          postgateEmbeddingRules: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'union',
+              refs: ['lex:app.bsky.feed.postgate#disableRule'],
+            },
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -536,14 +536,16 @@ export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
 }
 
-/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+/** Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
+  /** Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
+  /** Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -8,6 +8,8 @@ import { CID } from 'multiformats/cid'
 import * as ComAtprotoLabelDefs from '../../../com/atproto/label/defs'
 import * as AppBskyGraphDefs from '../graph/defs'
 import * as ComAtprotoRepoStrongRef from '../../../com/atproto/repo/strongRef'
+import * as AppBskyFeedThreadgate from '../feed/threadgate'
+import * as AppBskyFeedPostgate from '../feed/postgate'
 
 export interface ProfileViewBasic {
   did: string
@@ -188,6 +190,7 @@ export type Preferences = (
   | HiddenPostsPref
   | BskyAppStatePref
   | LabelersPref
+  | PostInteractionSettingsPref
   | { $type: string; [k: string]: unknown }
 )[]
 
@@ -531,4 +534,35 @@ export function isNux(v: unknown): v is Nux {
 
 export function validateNux(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.actor.defs#nux', v)
+}
+
+/** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
+export interface PostInteractionSettingsPref {
+  threadgateAllowRules: (
+    | AppBskyFeedThreadgate.MentionRule
+    | AppBskyFeedThreadgate.FollowingRule
+    | AppBskyFeedThreadgate.ListRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  postgateEmbeddingRules: (
+    | AppBskyFeedPostgate.DisableRule
+    | { $type: string; [k: string]: unknown }
+  )[]
+  [k: string]: unknown
+}
+
+export function isPostInteractionSettingsPref(
+  v: unknown,
+): v is PostInteractionSettingsPref {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.actor.defs#postInteractionSettingsPref'
+  )
+}
+
+export function validatePostInteractionSettingsPref(
+  v: unknown,
+): ValidationResult {
+  return lexicons.validate('app.bsky.actor.defs#postInteractionSettingsPref', v)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/actor/defs.ts
@@ -538,13 +538,13 @@ export function validateNux(v: unknown): ValidationResult {
 
 /** Default post interaction settings for the account. Should mirror the ruleset defs of the threadgate and postgate records exactly. */
 export interface PostInteractionSettingsPref {
-  threadgateAllowRules: (
+  threadgateAllowRules?: (
     | AppBskyFeedThreadgate.MentionRule
     | AppBskyFeedThreadgate.FollowingRule
     | AppBskyFeedThreadgate.ListRule
     | { $type: string; [k: string]: unknown }
   )[]
-  postgateEmbeddingRules: (
+  postgateEmbeddingRules?: (
     | AppBskyFeedPostgate.DisableRule
     | { $type: string; [k: string]: unknown }
   )[]

--- a/packages/pds/src/lexicon/types/app/bsky/feed/postgate.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/postgate.ts
@@ -12,6 +12,7 @@ export interface Record {
   post: string
   /** List of AT-URIs embedding this post that the author has detached from. */
   detachedEmbeddingUris?: string[]
+  /** List of rules defining who can embed this post. If value is an empty array or is undefined, no particular rules apply and anyone can embed. */
   embeddingRules?: (DisableRule | { $type: string; [k: string]: unknown })[]
   [k: string]: unknown
 }

--- a/packages/pds/src/lexicon/types/app/bsky/feed/threadgate.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/threadgate.ts
@@ -9,6 +9,7 @@ import { CID } from 'multiformats/cid'
 export interface Record {
   /** Reference (AT-URI) to the post record. */
   post: string
+  /** List of rules defining who can reply to this post. If value is an empty array, no one can reply. If value is undefined, anyone can reply. */
   allow?: (
     | MentionRule
     | FollowingRule


### PR DESCRIPTION
Introduces a new preferences object whereby the user can specify their preferred default threadgate/postgate rules. This data will be used to pre-fill their post interaction settings when creating new posts. It will not apply to previously existing posts.

```ts
agent.setPostInteractionSettings({
  threadgateAllowRules: AppBskyFeedThreadgate.Record['allow']
  postgateEmbeddingRules: AppBskyFeedPostgate.Record['embeddingRules']
})
```

I also added some clarifying descriptions to the lexicons so that they output to the types. The handling around these is a little different, and unclear. Main thing: `threadgate['allow']` being set to `undefined` means "no rules specified, anyone can reply" and `[]` means "no _allow_ rules were added by the user, no one can reply". This is some historical baggage that would require a larger refactor to handle, and so it's not handled here.