### PR TITLE
Adds a new embed type for code blocks that supports syntax highlighting

### DIFF
--- a/lexicons/app/bsky/embed/code.json
+++ b/lexicons/app/bsky/embed/code.json
@@ -1,0 +1,37 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.embed.code",
+  "description": "A code snippet embedded in a Bluesky record.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["code"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The source code content.",
+          "maxLength": 8000
+        },
+        "lang": {
+          "type": "string",
+          "description": "The programming language identifier.",
+          "maxLength": 20
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["code"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The source code content."
+        },
+        "lang": {
+          "type": "string",
+          "description": "The programming language identifier."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/embed/record.json
+++ b/lexicons/app/bsky/embed/record.json
@@ -60,7 +60,8 @@
               "app.bsky.embed.video#view",
               "app.bsky.embed.external#view",
               "app.bsky.embed.record#view",
-              "app.bsky.embed.recordWithMedia#view"
+              "app.bsky.embed.recordWithMedia#view",
+              "app.bsky.embed.code#view"
             ]
           }
         },

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -20,7 +20,8 @@
             "app.bsky.embed.video#view",
             "app.bsky.embed.external#view",
             "app.bsky.embed.record#view",
-            "app.bsky.embed.recordWithMedia#view"
+            "app.bsky.embed.recordWithMedia#view",
+            "app.bsky.embed.code#view"
           ]
         },
         "replyCount": { "type": "integer" },

--- a/lexicons/app/bsky/feed/post.json
+++ b/lexicons/app/bsky/feed/post.json
@@ -34,7 +34,8 @@
               "app.bsky.embed.video",
               "app.bsky.embed.external",
               "app.bsky.embed.record",
-              "app.bsky.embed.recordWithMedia"
+              "app.bsky.embed.recordWithMedia",
+              "app.bsky.embed.code"
             ]
           },
           "langs": {

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -48,6 +48,8 @@ import {
   uriToDid as creatorFromUri,
 } from '../util/uris'
 import {
+  CodeEmbed,
+  CodeEmbedView,
   Embed,
   EmbedBlocked,
   EmbedDetached,
@@ -67,6 +69,7 @@ import {
   RecordWithMediaView,
   VideoEmbed,
   VideoEmbedView,
+  isCodeEmbed,
   isExternalEmbed,
   isImagesEmbed,
   isRecordEmbed,
@@ -933,6 +936,8 @@ export class Views {
       return this.videoEmbed(creatorFromUri(postUri), embed)
     } else if (isExternalEmbed(embed)) {
       return this.externalEmbed(creatorFromUri(postUri), embed)
+    } else if (isCodeEmbed(embed)) {
+      return this.codeEmbed(embed)
     } else if (isRecordEmbed(embed)) {
       return this.recordEmbed(postUri, embed, state, depth)
     } else if (isRecordWithMedia(embed)) {
@@ -972,6 +977,14 @@ export class Views {
       thumbnail: this.videoUriBuilder.thumbnail({ did, cid }),
       alt: embed.alt,
       aspectRatio: embed.aspectRatio,
+    }
+  }
+
+  codeEmbed(embed: CodeEmbed): CodeEmbedView {
+    return {
+      $type: 'app.bsky.embed.code#view',
+      code: embed.code,
+      lang: embed.lang,
     }
   }
 

--- a/packages/bsky/src/views/types.ts
+++ b/packages/bsky/src/views/types.ts
@@ -20,6 +20,10 @@ import {
   View as VideoEmbedView,
 } from '../lexicon/types/app/bsky/embed/video'
 import {
+  Main as CodeEmbed,
+  View as CodeEmbedView,
+} from '../lexicon/types/app/bsky/embed/code'
+import {
   BlockedPost,
   GeneratorView,
   NotFoundPost,
@@ -59,6 +63,11 @@ export type {
 export { isMain as isRecordWithMedia } from '../lexicon/types/app/bsky/embed/recordWithMedia'
 export type { View as RecordWithMediaEmbedView } from '../lexicon/types/app/bsky/embed/recordWithMedia'
 export type {
+  Main as CodeEmbed,
+  View as CodeEmbedView,
+} from '../lexicon/types/app/bsky/embed/code'
+export { isMain as isCodeEmbed } from '../lexicon/types/app/bsky/embed/code'
+export type {
   BlockedPost,
   GeneratorView,
   NotFoundPost,
@@ -74,6 +83,7 @@ export type Embed =
   | ExternalEmbed
   | RecordEmbed
   | RecordWithMedia
+  | CodeEmbed
 
 export type EmbedView =
   | ImagesEmbedView
@@ -81,6 +91,7 @@ export type EmbedView =
   | ExternalEmbedView
   | RecordEmbedView
   | RecordWithMediaView
+  | CodeEmbedView
 
 export type MaybePostView = PostView | NotFoundPost | BlockedPost
 


### PR DESCRIPTION
This PR proposes a new embed type to enable code sharing in posts. This is an initial proposal to start the discussion and lay the groundwork for syntax-highlighted code blocks.

**Implementation Details:**
- New `app.bsky.embed.code` lexicon with `code` (max 8000 chars) and `lang` (max 20 chars) fields
- Follows existing embed patterns and integrates with current view system

**Follow-up Considerations:**
- UI/UX details (truncation, expanding, copy button)
- Additional metadata like line numbers could be added in future iterations

Interested in feedback on:
1. The lexicon structure and field limits
2. Integration approach with existing embed system