### PR TITLE
RFC: Enable aspect ratio for external links

### DIFF
--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -24,7 +24,17 @@
           "type": "blob",
           "accept": ["image/*"],
           "maxSize": 1000000
-        }
+        },
+        "aspectRatio": {"type": "ref", "ref": "#aspectRatio"}
+      }
+    },
+    "aspectRatio": {
+      "type": "object",
+      "description": "width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit.",
+      "required": ["width", "height"],
+      "properties": {
+        "width": {"type": "integer", "minimum": 1},
+        "height": {"type": "integer", "minimum": 1}
       }
     },
     "view": {
@@ -44,7 +54,8 @@
         "uri": { "type": "string", "format": "uri" },
         "title": { "type": "string" },
         "description": { "type": "string" },
-        "thumb": { "type": "string", "format": "uri" }
+        "thumb": { "type": "string", "format": "uri" },
+        "aspectRatio": {"type": "ref", "ref": "#aspectRatio"}
       }
     }
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5134,6 +5134,26 @@ export const schemaDict = {
             accept: ['image/*'],
             maxSize: 1000000,
           },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
+          },
+        },
+      },
+      aspectRatio: {
+        type: 'object',
+        description:
+          'width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit.',
+        required: ['width', 'height'],
+        properties: {
+          width: {
+            type: 'integer',
+            minimum: 1,
+          },
+          height: {
+            type: 'integer',
+            minimum: 1,
+          },
         },
       },
       view: {
@@ -5163,6 +5183,10 @@ export const schemaDict = {
           thumb: {
             type: 'string',
             format: 'uri',
+          },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/embed/external.ts
+++ b/packages/api/src/client/types/app/bsky/embed/external.ts
@@ -30,6 +30,7 @@ export interface External {
   title: string
   description: string
   thumb?: BlobRef
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 
@@ -43,6 +44,25 @@ export function isExternal(v: unknown): v is External {
 
 export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
+/** width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit. */
+export interface AspectRatio {
+  width: number
+  height: number
+  [k: string]: unknown
+}
+
+export function isAspectRatio(v: unknown): v is AspectRatio {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#aspectRatio'
+  )
+}
+
+export function validateAspectRatio(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#aspectRatio', v)
 }
 
 export interface View {
@@ -67,6 +87,7 @@ export interface ViewExternal {
   title: string
   description: string
   thumb?: string
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5134,6 +5134,26 @@ export const schemaDict = {
             accept: ['image/*'],
             maxSize: 1000000,
           },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
+          },
+        },
+      },
+      aspectRatio: {
+        type: 'object',
+        description:
+          'width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit.',
+        required: ['width', 'height'],
+        properties: {
+          width: {
+            type: 'integer',
+            minimum: 1,
+          },
+          height: {
+            type: 'integer',
+            minimum: 1,
+          },
         },
       },
       view: {
@@ -5163,6 +5183,10 @@ export const schemaDict = {
           thumb: {
             type: 'string',
             format: 'uri',
+          },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/external.ts
@@ -30,6 +30,7 @@ export interface External {
   title: string
   description: string
   thumb?: BlobRef
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 
@@ -43,6 +44,25 @@ export function isExternal(v: unknown): v is External {
 
 export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
+/** width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit. */
+export interface AspectRatio {
+  width: number
+  height: number
+  [k: string]: unknown
+}
+
+export function isAspectRatio(v: unknown): v is AspectRatio {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#aspectRatio'
+  )
+}
+
+export function validateAspectRatio(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#aspectRatio', v)
 }
 
 export interface View {
@@ -67,6 +87,7 @@ export interface ViewExternal {
   title: string
   description: string
   thumb?: string
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5134,6 +5134,26 @@ export const schemaDict = {
             accept: ['image/*'],
             maxSize: 1000000,
           },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
+          },
+        },
+      },
+      aspectRatio: {
+        type: 'object',
+        description:
+          'width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit.',
+        required: ['width', 'height'],
+        properties: {
+          width: {
+            type: 'integer',
+            minimum: 1,
+          },
+          height: {
+            type: 'integer',
+            minimum: 1,
+          },
         },
       },
       view: {
@@ -5163,6 +5183,10 @@ export const schemaDict = {
           thumb: {
             type: 'string',
             format: 'uri',
+          },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/embed/external.ts
@@ -30,6 +30,7 @@ export interface External {
   title: string
   description: string
   thumb?: BlobRef
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 
@@ -43,6 +44,25 @@ export function isExternal(v: unknown): v is External {
 
 export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
+/** width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit. */
+export interface AspectRatio {
+  width: number
+  height: number
+  [k: string]: unknown
+}
+
+export function isAspectRatio(v: unknown): v is AspectRatio {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#aspectRatio'
+  )
+}
+
+export function validateAspectRatio(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#aspectRatio', v)
 }
 
 export interface View {
@@ -67,6 +87,7 @@ export interface ViewExternal {
   title: string
   description: string
   thumb?: string
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5134,6 +5134,26 @@ export const schemaDict = {
             accept: ['image/*'],
             maxSize: 1000000,
           },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
+          },
+        },
+      },
+      aspectRatio: {
+        type: 'object',
+        description:
+          'width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit.',
+        required: ['width', 'height'],
+        properties: {
+          width: {
+            type: 'integer',
+            minimum: 1,
+          },
+          height: {
+            type: 'integer',
+            minimum: 1,
+          },
         },
       },
       view: {
@@ -5163,6 +5183,10 @@ export const schemaDict = {
           thumb: {
             type: 'string',
             format: 'uri',
+          },
+          aspectRatio: {
+            type: 'ref',
+            ref: 'lex:app.bsky.embed.external#aspectRatio',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/external.ts
@@ -30,6 +30,7 @@ export interface External {
   title: string
   description: string
   thumb?: BlobRef
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 
@@ -43,6 +44,25 @@ export function isExternal(v: unknown): v is External {
 
 export function validateExternal(v: unknown): ValidationResult {
   return lexicons.validate('app.bsky.embed.external#external', v)
+}
+
+/** width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit. */
+export interface AspectRatio {
+  width: number
+  height: number
+  [k: string]: unknown
+}
+
+export function isAspectRatio(v: unknown): v is AspectRatio {
+  return (
+    isObj(v) &&
+    hasProp(v, '$type') &&
+    v.$type === 'app.bsky.embed.external#aspectRatio'
+  )
+}
+
+export function validateAspectRatio(v: unknown): ValidationResult {
+  return lexicons.validate('app.bsky.embed.external#aspectRatio', v)
 }
 
 export interface View {
@@ -67,6 +87,7 @@ export interface ViewExternal {
   title: string
   description: string
   thumb?: string
+  aspectRatio?: AspectRatio
   [k: string]: unknown
 }
 


### PR DESCRIPTION
_Note: This is a followup from https://github.com/bluesky-social/social-app/pull/7680_

### Request
In order to polish the feed for external links, allow the client to display the image in the correct aspect ratio

To stay consistent I have based myself off of [this PR](https://github.com/bluesky-social/atproto/pull/1306) for adding this support for images. If I understood correctly this needs to be merged before I can then make a PR in the `social-app` that will resolve this aspect ratio from the thumbnail (something like `const {path, mime, height, width} = resolvedLink.thumb.source`)

