### PR TITLE
Add vscode settings and recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "wengerk.highlight-bad-chars",
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,50 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.language": "en,en-US",
+  "cSpell.userWords": [
+    "algs",
+    "appview",
+    "atproto",
+    "blockstore",
+    "bluesky",
+    "bsky",
+    "bsync",
+    "clsx",
+    "consolas",
+    "dpop",
+    "googleusercontent",
+    "hexeditor",
+    "ingester",
+    "insertable",
+    "jwks",
+    "keypair",
+    "kysely",
+    "merkle",
+    "msid",
+    "multibase",
+    "multiformats",
+    "nameserver",
+    "oidc",
+    "pkce",
+    "ponyfill",
+    "proxied",
+    "ssrf",
+    "undici",
+    "webcrypto",
+    "whatwg",
+    "xrpc"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.sortImports": "never"
+  },
   "files.associations": {
     "**/tsconfig/*.json": "jsonc"
-  }
+  },
+  "files.defaultLanguage": "ts",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "prettier.semi": false,
+  "prettier.singleQuote": true,
+  "prettier.trailingComma": "es5",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
This adds a local `settings` for VSCode that includes only defaults that make sense to use for everyone working in this project with VSCode.

The goal is *not* to impose a particular setup to contributors besides the rules imposed by our linting & code style.