### PR TITLE
Add namespace option to BrowserOAuthClient

### DIFF
--- a/packages/oauth/oauth-client-browser/README.md
+++ b/packages/oauth/oauth-client-browser/README.md
@@ -153,6 +153,8 @@ following optional configuration options:
   needed unless you run an entire atproto stack locally. Defaults to
   `https://plc.directory`.
 
+- `namespace`: An optional string used by the client to generate keys for browser storage (LocalStorage and IndexedDB). This is typically only needed if you are hosting multiple AppViews on the same domain in order to keep the OAuth response data separate from one another.
+
 ## Usage
 
 Once the `client` is set up, it can be used to initiate & manage OAuth sessions.


### PR DESCRIPTION
Hi, this is my first atproto PR so please let me know if there's anything I can do to make it easier to review!

## What problem is this trying to solve?

Currently, if you attempt to host multiple AppViews on the same domain using the browser-based OAuth client they will share the same localStorage keys and indexedDB database name. This can cause problems when, for instance, one app tries to refresh a token that was issued on behalf of the other app's client ID. Ideally we could host multiple apps on different paths of the same domain and each would use their own independent authentication values.

I recognize that this may be an uncommon use-case, but I personally have my blog's "AppView" (with an associated CMS interface using ATProto+OAuth) and a separate ATProto-based flashcard studying tool both hosted as static-generated sites on the same domain using GitHub Pages.

Could I host one or both apps under a different domain to work around this issue? Sure, and feel free to tell me to take a hike if this is not a common enough use-case to warrant the team's attention and I should work around it in another way. I first wanted to take a stab at providing a solution for it within the official library rather than seeking alternative OAuth tooling or adjusting my hosting setup.

## My solution

This PR adds a `namespace` option to `BrowserOAuthClient` allowing users to specify the namespace used for browser storage. When specified, it will override the default namespace for localStorage keys and the default indexedDb database name as well as the broadcast channels and popup state prefix keys.

I chose this approach to avoid unexpectedly breaking existing functionality. If you do not specify a custom namespace, the behavior is identical to the current version. A more "elegant" solution might be to automatically generate per-app namespaces based on the app's Client ID, but this could unexpectedly break existing sessions in some apps and would thus require a major version bump which seems excessive for this small of an issue.

Thanks for taking a look 🙂 