### PR TITLE
fix(api): pass refreshJwt to `deleteSession` on `logout()`

### DIFF
--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -337,7 +337,7 @@ export class CredentialSession implements SessionManager {
       try {
         await this.server.deleteSession(undefined, {
           headers: {
-            authorization: `Bearer ${this.session.accessJwt}`,
+            authorization: `Bearer ${this.session.refreshJwt}`,
           },
         })
       } catch {


### PR DESCRIPTION
Although the documentation does not explicitly state it, `com.atproto.server.deleteSession`  appears to require a refreshJwt in the Authorization header instead of an accessJwt.

https://docs.bsky.app/docs/api/com-atproto-server-delete-session

When I actually executed the API, I received a 400 error when using the accessJwt.

```bash
# Get accessJwt/refreshJwt with my account credential.
$ curl --silent -X POST -H "Content-Type: application/json" https://bsky.social/xrpc/com.atproto.server.createSession -d "{\"identifier\":\"$ID\",\"password\":\"$PASS\"}" | jq "{accessJwt, refreshJwt}"
{
  "accessJwt": "...",
  "refreshJwt": "..."
}

# Using accessJwt results in an error
$ curl --silent -X POST -H "Authorization: Bearer $ACCESS" https://bsky.social/xrpc/com.atproto.server.deleteSession
{"error":"InvalidToken","message":"Invalid token type"}

# Using refreshJwt succeeds
$ curl --silent -X POST -H "Authorization: Bearer $REFRESH" https://bsky.social/xrpc/com.atproto.server.deleteSession
```