### PR TITLE
Appview: apply needs-review to individual records

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -82,7 +82,7 @@ const noBlocksOrNeedsReview = (inputs: {
     return (
       !ctx.views.viewerBlockExists(authorDid, hydration) &&
       !hydration.postBlocks?.get(uri)?.embed &&
-      ctx.views.viewerSeesNeedsReview(authorDid, hydration)
+      ctx.views.viewerSeesNeedsReview({ did: authorDid, uri }, hydration)
     )
   })
   return skeleton

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -182,7 +182,7 @@ const noBlockOrMutesOrNeedsReview = (
       item.reason === 'like' ||
       item.reason === 'follow'
     ) {
-      if (!ctx.views.viewerSeesNeedsReview(did, hydration)) {
+      if (!ctx.views.viewerSeesNeedsReview({ did, uri: item.uri }, hydration)) {
         return false
       }
     }

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -176,13 +176,23 @@ export class Views {
     return uri
   }
 
-  viewerSeesNeedsReview(did: string, state: HydrationState): boolean {
+  viewerSeesNeedsReview(
+    { did, uri }: { did?: string; uri?: string },
+    state: HydrationState,
+  ): boolean {
     const { labels, profileViewers, ctx } = state
-    return (
-      !labels?.get(did)?.needsReview ||
-      ctx?.viewer === did ||
-      !!profileViewers?.get(did)?.following
-    )
+    did = did || (uri && uriToDid(uri))
+    if (!did) {
+      return true
+    }
+    if (
+      labels?.get(did)?.needsReview ||
+      (uri && labels?.get(uri)?.needsReview)
+    ) {
+      // content marked as needs review
+      return ctx?.viewer === did || !!profileViewers?.get(did)?.following
+    }
+    return true
   }
 
   replyIsHiddenByThreadgate(
@@ -972,7 +982,7 @@ export class Views {
       if (this.viewerBlockExists(post.author.did, state)) {
         return this.blockedPost(uri, post.author.did, state)
       }
-      if (!this.viewerSeesNeedsReview(post.author.did, state)) {
+      if (!this.viewerSeesNeedsReview({ uri, did: post.author.did }, state)) {
         return undefined
       }
       return {


### PR DESCRIPTION
These labels previously only applied at the account level.  This provides more granular application at the record level.