### PR TITLE
Mark "userAgent" as optional in `RequestMetadata`

### DIFF
--- a/.changeset/brown-eggs-rhyme.md
+++ b/.changeset/brown-eggs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Mark "userAgent" as optional in `RequestMetadata`

--- a/packages/oauth/oauth-provider/src/device/device-manager.ts
+++ b/packages/oauth/oauth-provider/src/device/device-manager.ts
@@ -141,7 +141,7 @@ export class DeviceManager {
     await this.store.createDevice(deviceId, {
       sessionId,
       lastSeenAt: new Date(),
-      userAgent: deviceMetadata.userAgent,
+      userAgent: deviceMetadata.userAgent ?? null,
       ipAddress: deviceMetadata.ipAddress,
     })
 

--- a/packages/oauth/oauth-provider/src/lib/http/request.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/request.ts
@@ -168,7 +168,7 @@ export type ExtractRequestMetadataOptions = {
 }
 
 export type RequestMetadata = {
-  userAgent: string | null
+  userAgent?: string
   ipAddress: string
   port: number
 }
@@ -177,7 +177,7 @@ export function extractRequestMetadata(
   req: IncomingMessage,
   options?: ExtractRequestMetadataOptions,
 ): RequestMetadata {
-  const userAgent = req.headers['user-agent'] || null
+  const userAgent = req.headers['user-agent'] || undefined
   const ipAddress = extractIpAddress(req, options) || null
   const port = extractPort(req, options)
 


### PR DESCRIPTION
Small follow up on https://github.com/bluesky-social/atproto/pull/3525 that makes the exposed types in the hooks more convenient to work with.