### PR TITLE
Update node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-n": "^17.15.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^28.1.2",
-    "node-gyp": "^9.3.1",
+    "node-gyp": "^11.1.0",
     "pino-pretty": "^9.1.0",
     "prettier": "^3.2.5",
     "prettier-config-standard": "^7.0.0",


### PR DESCRIPTION
Python >= v3.12 requires node-gyp >= v10 (taken from the node-gyp repo)