### PR TITLE
remove deprecated firehose message types

### DIFF
--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -17,13 +17,7 @@
       "message": {
         "schema": {
           "type": "union",
-          "refs": [
-            "#commit",
-            "#sync",
-            "#identity",
-            "#account",
-            "#info"
-          ]
+          "refs": ["#commit", "#sync", "#identity", "#account", "#info"]
         }
       },
       "errors": [

--- a/lexicons/com/atproto/sync/subscribeRepos.json
+++ b/lexicons/com/atproto/sync/subscribeRepos.json
@@ -22,9 +22,6 @@
             "#sync",
             "#identity",
             "#account",
-            "#handle",
-            "#migrate",
-            "#tombstone",
             "#info"
           ]
         }
@@ -184,39 +181,6 @@
             "throttled"
           ]
         }
-      }
-    },
-    "handle": {
-      "type": "object",
-      "description": "DEPRECATED -- Use #identity event instead",
-      "required": ["seq", "did", "handle", "time"],
-      "properties": {
-        "seq": { "type": "integer" },
-        "did": { "type": "string", "format": "did" },
-        "handle": { "type": "string", "format": "handle" },
-        "time": { "type": "string", "format": "datetime" }
-      }
-    },
-    "migrate": {
-      "type": "object",
-      "description": "DEPRECATED -- Use #account event instead",
-      "required": ["seq", "did", "migrateTo", "time"],
-      "nullable": ["migrateTo"],
-      "properties": {
-        "seq": { "type": "integer" },
-        "did": { "type": "string", "format": "did" },
-        "migrateTo": { "type": "string" },
-        "time": { "type": "string", "format": "datetime" }
-      }
-    },
-    "tombstone": {
-      "type": "object",
-      "description": "DEPRECATED -- Use #account event instead",
-      "required": ["seq", "did", "time"],
-      "properties": {
-        "seq": { "type": "integer" },
-        "did": { "type": "string", "format": "did" },
-        "time": { "type": "string", "format": "datetime" }
       }
     },
     "info": {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -3827,9 +3827,6 @@ export const schemaDict = {
               'lex:com.atproto.sync.subscribeRepos#sync',
               'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#account',
-              'lex:com.atproto.sync.subscribeRepos#handle',
-              'lex:com.atproto.sync.subscribeRepos#migrate',
-              'lex:com.atproto.sync.subscribeRepos#tombstone',
               'lex:com.atproto.sync.subscribeRepos#info',
             ],
           },
@@ -4030,68 +4027,6 @@ export const schemaDict = {
               'desynchronized',
               'throttled',
             ],
-          },
-        },
-      },
-      handle: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #identity event instead',
-        required: ['seq', 'did', 'handle', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          handle: {
-            type: 'string',
-            format: 'handle',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      migrate: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'migrateTo', 'time'],
-        nullable: ['migrateTo'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          migrateTo: {
-            type: 'string',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      tombstone: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
           },
         },
       },

--- a/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/api/src/client/types/com/atproto/sync/subscribeRepos.ts
@@ -122,62 +122,6 @@ export function validateAccount<V>(v: V) {
   return validate<Account & V>(v, id, hashAccount)
 }
 
-/** DEPRECATED -- Use #identity event instead */
-export interface Handle {
-  $type?: 'com.atproto.sync.subscribeRepos#handle'
-  seq: number
-  did: string
-  handle: string
-  time: string
-}
-
-const hashHandle = 'handle'
-
-export function isHandle<V>(v: V) {
-  return is$typed(v, id, hashHandle)
-}
-
-export function validateHandle<V>(v: V) {
-  return validate<Handle & V>(v, id, hashHandle)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Migrate {
-  $type?: 'com.atproto.sync.subscribeRepos#migrate'
-  seq: number
-  did: string
-  migrateTo: string | null
-  time: string
-}
-
-const hashMigrate = 'migrate'
-
-export function isMigrate<V>(v: V) {
-  return is$typed(v, id, hashMigrate)
-}
-
-export function validateMigrate<V>(v: V) {
-  return validate<Migrate & V>(v, id, hashMigrate)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Tombstone {
-  $type?: 'com.atproto.sync.subscribeRepos#tombstone'
-  seq: number
-  did: string
-  time: string
-}
-
-const hashTombstone = 'tombstone'
-
-export function isTombstone<V>(v: V) {
-  return is$typed(v, id, hashTombstone)
-}
-
-export function validateTombstone<V>(v: V) {
-  return validate<Tombstone & V>(v, id, hashTombstone)
-}
-
 export interface Info {
   $type?: 'com.atproto.sync.subscribeRepos#info'
   name: 'OutdatedCursor' | (string & {})

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -3827,9 +3827,6 @@ export const schemaDict = {
               'lex:com.atproto.sync.subscribeRepos#sync',
               'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#account',
-              'lex:com.atproto.sync.subscribeRepos#handle',
-              'lex:com.atproto.sync.subscribeRepos#migrate',
-              'lex:com.atproto.sync.subscribeRepos#tombstone',
               'lex:com.atproto.sync.subscribeRepos#info',
             ],
           },
@@ -4030,68 +4027,6 @@ export const schemaDict = {
               'desynchronized',
               'throttled',
             ],
-          },
-        },
-      },
-      handle: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #identity event instead',
-        required: ['seq', 'did', 'handle', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          handle: {
-            type: 'string',
-            format: 'handle',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      migrate: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'migrateTo', 'time'],
-        nullable: ['migrateTo'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          migrateTo: {
-            type: 'string',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      tombstone: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/bsky/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -22,9 +22,6 @@ export type OutputSchema =
   | $Typed<Sync>
   | $Typed<Identity>
   | $Typed<Account>
-  | $Typed<Handle>
-  | $Typed<Migrate>
-  | $Typed<Tombstone>
   | $Typed<Info>
   | { $type: string }
 export type HandlerError = ErrorFrame<'FutureCursor' | 'ConsumerTooSlow'>
@@ -148,62 +145,6 @@ export function isAccount<V>(v: V) {
 
 export function validateAccount<V>(v: V) {
   return validate<Account & V>(v, id, hashAccount)
-}
-
-/** DEPRECATED -- Use #identity event instead */
-export interface Handle {
-  $type?: 'com.atproto.sync.subscribeRepos#handle'
-  seq: number
-  did: string
-  handle: string
-  time: string
-}
-
-const hashHandle = 'handle'
-
-export function isHandle<V>(v: V) {
-  return is$typed(v, id, hashHandle)
-}
-
-export function validateHandle<V>(v: V) {
-  return validate<Handle & V>(v, id, hashHandle)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Migrate {
-  $type?: 'com.atproto.sync.subscribeRepos#migrate'
-  seq: number
-  did: string
-  migrateTo: string | null
-  time: string
-}
-
-const hashMigrate = 'migrate'
-
-export function isMigrate<V>(v: V) {
-  return is$typed(v, id, hashMigrate)
-}
-
-export function validateMigrate<V>(v: V) {
-  return validate<Migrate & V>(v, id, hashMigrate)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Tombstone {
-  $type?: 'com.atproto.sync.subscribeRepos#tombstone'
-  seq: number
-  did: string
-  time: string
-}
-
-const hashTombstone = 'tombstone'
-
-export function isTombstone<V>(v: V) {
-  return is$typed(v, id, hashTombstone)
-}
-
-export function validateTombstone<V>(v: V) {
-  return validate<Tombstone & V>(v, id, hashTombstone)
 }
 
 export interface Info {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -3827,9 +3827,6 @@ export const schemaDict = {
               'lex:com.atproto.sync.subscribeRepos#sync',
               'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#account',
-              'lex:com.atproto.sync.subscribeRepos#handle',
-              'lex:com.atproto.sync.subscribeRepos#migrate',
-              'lex:com.atproto.sync.subscribeRepos#tombstone',
               'lex:com.atproto.sync.subscribeRepos#info',
             ],
           },
@@ -4030,68 +4027,6 @@ export const schemaDict = {
               'desynchronized',
               'throttled',
             ],
-          },
-        },
-      },
-      handle: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #identity event instead',
-        required: ['seq', 'did', 'handle', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          handle: {
-            type: 'string',
-            format: 'handle',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      migrate: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'migrateTo', 'time'],
-        nullable: ['migrateTo'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          migrateTo: {
-            type: 'string',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      tombstone: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -22,9 +22,6 @@ export type OutputSchema =
   | $Typed<Sync>
   | $Typed<Identity>
   | $Typed<Account>
-  | $Typed<Handle>
-  | $Typed<Migrate>
-  | $Typed<Tombstone>
   | $Typed<Info>
   | { $type: string }
 export type HandlerError = ErrorFrame<'FutureCursor' | 'ConsumerTooSlow'>
@@ -148,62 +145,6 @@ export function isAccount<V>(v: V) {
 
 export function validateAccount<V>(v: V) {
   return validate<Account & V>(v, id, hashAccount)
-}
-
-/** DEPRECATED -- Use #identity event instead */
-export interface Handle {
-  $type?: 'com.atproto.sync.subscribeRepos#handle'
-  seq: number
-  did: string
-  handle: string
-  time: string
-}
-
-const hashHandle = 'handle'
-
-export function isHandle<V>(v: V) {
-  return is$typed(v, id, hashHandle)
-}
-
-export function validateHandle<V>(v: V) {
-  return validate<Handle & V>(v, id, hashHandle)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Migrate {
-  $type?: 'com.atproto.sync.subscribeRepos#migrate'
-  seq: number
-  did: string
-  migrateTo: string | null
-  time: string
-}
-
-const hashMigrate = 'migrate'
-
-export function isMigrate<V>(v: V) {
-  return is$typed(v, id, hashMigrate)
-}
-
-export function validateMigrate<V>(v: V) {
-  return validate<Migrate & V>(v, id, hashMigrate)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Tombstone {
-  $type?: 'com.atproto.sync.subscribeRepos#tombstone'
-  seq: number
-  did: string
-  time: string
-}
-
-const hashTombstone = 'tombstone'
-
-export function isTombstone<V>(v: V) {
-  return is$typed(v, id, hashTombstone)
-}
-
-export function validateTombstone<V>(v: V) {
-  return validate<Tombstone & V>(v, id, hashTombstone)
 }
 
 export interface Info {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -3827,9 +3827,6 @@ export const schemaDict = {
               'lex:com.atproto.sync.subscribeRepos#sync',
               'lex:com.atproto.sync.subscribeRepos#identity',
               'lex:com.atproto.sync.subscribeRepos#account',
-              'lex:com.atproto.sync.subscribeRepos#handle',
-              'lex:com.atproto.sync.subscribeRepos#migrate',
-              'lex:com.atproto.sync.subscribeRepos#tombstone',
               'lex:com.atproto.sync.subscribeRepos#info',
             ],
           },
@@ -4030,68 +4027,6 @@ export const schemaDict = {
               'desynchronized',
               'throttled',
             ],
-          },
-        },
-      },
-      handle: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #identity event instead',
-        required: ['seq', 'did', 'handle', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          handle: {
-            type: 'string',
-            format: 'handle',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      migrate: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'migrateTo', 'time'],
-        nullable: ['migrateTo'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          migrateTo: {
-            type: 'string',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
-          },
-        },
-      },
-      tombstone: {
-        type: 'object',
-        description: 'DEPRECATED -- Use #account event instead',
-        required: ['seq', 'did', 'time'],
-        properties: {
-          seq: {
-            type: 'integer',
-          },
-          did: {
-            type: 'string',
-            format: 'did',
-          },
-          time: {
-            type: 'string',
-            format: 'datetime',
           },
         },
       },

--- a/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
+++ b/packages/pds/src/lexicon/types/com/atproto/sync/subscribeRepos.ts
@@ -22,9 +22,6 @@ export type OutputSchema =
   | $Typed<Sync>
   | $Typed<Identity>
   | $Typed<Account>
-  | $Typed<Handle>
-  | $Typed<Migrate>
-  | $Typed<Tombstone>
   | $Typed<Info>
   | { $type: string }
 export type HandlerError = ErrorFrame<'FutureCursor' | 'ConsumerTooSlow'>
@@ -148,62 +145,6 @@ export function isAccount<V>(v: V) {
 
 export function validateAccount<V>(v: V) {
   return validate<Account & V>(v, id, hashAccount)
-}
-
-/** DEPRECATED -- Use #identity event instead */
-export interface Handle {
-  $type?: 'com.atproto.sync.subscribeRepos#handle'
-  seq: number
-  did: string
-  handle: string
-  time: string
-}
-
-const hashHandle = 'handle'
-
-export function isHandle<V>(v: V) {
-  return is$typed(v, id, hashHandle)
-}
-
-export function validateHandle<V>(v: V) {
-  return validate<Handle & V>(v, id, hashHandle)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Migrate {
-  $type?: 'com.atproto.sync.subscribeRepos#migrate'
-  seq: number
-  did: string
-  migrateTo: string | null
-  time: string
-}
-
-const hashMigrate = 'migrate'
-
-export function isMigrate<V>(v: V) {
-  return is$typed(v, id, hashMigrate)
-}
-
-export function validateMigrate<V>(v: V) {
-  return validate<Migrate & V>(v, id, hashMigrate)
-}
-
-/** DEPRECATED -- Use #account event instead */
-export interface Tombstone {
-  $type?: 'com.atproto.sync.subscribeRepos#tombstone'
-  seq: number
-  did: string
-  time: string
-}
-
-const hashTombstone = 'tombstone'
-
-export function isTombstone<V>(v: V) {
-  return is$typed(v, id, hashTombstone)
-}
-
-export function validateTombstone<V>(v: V) {
-  return validate<Tombstone & V>(v, id, hashTombstone)
 }
 
 export interface Info {


### PR DESCRIPTION
So far this is just lexicon JSON updates and codegen.

Doesn't fully remove all the relevant code paths; probably makes sense to do that part along with implementing `#sync` events? As many of the same bits are touched. And some care is probably needed with sequencer, which might contain old message types.