### PR TITLE
feat(identity): allow custom fetch implementation

### DIFF
--- a/packages/identity/src/did/did-resolver.ts
+++ b/packages/identity/src/did/did-resolver.ts
@@ -9,11 +9,11 @@ export class DidResolver extends BaseResolver {
 
   constructor(opts: DidResolverOpts) {
     super(opts.didCache)
-    const { timeout = 3000, plcUrl = 'https://plc.directory' } = opts
+    const { fetch = globalThis.fetch, timeout = 3000, plcUrl = 'https://plc.directory' } = opts
     // do not pass cache to sub-methods or we will be double caching
     this.methods = {
-      plc: new DidPlcResolver(plcUrl, timeout),
-      web: new DidWebResolver(timeout),
+      plc: new DidPlcResolver(fetch, plcUrl, timeout),
+      web: new DidWebResolver(fetch, timeout),
     }
   }
 

--- a/packages/identity/src/did/plc-resolver.ts
+++ b/packages/identity/src/did/plc-resolver.ts
@@ -4,6 +4,7 @@ import { timed } from './util'
 
 export class DidPlcResolver extends BaseResolver {
   constructor(
+    public fetch: typeof globalThis.fetch,
     public plcUrl: string,
     public timeout: number,
     public cache?: DidCache,
@@ -14,7 +15,7 @@ export class DidPlcResolver extends BaseResolver {
   async resolveNoCheck(did: string): Promise<unknown> {
     return timed(this.timeout, async (signal) => {
       const url = new URL(`/${encodeURIComponent(did)}`, this.plcUrl)
-      const res = await fetch(url, {
+      const res = await this.fetch(url, {
         redirect: 'error',
         headers: { accept: 'application/did+ld+json,application/json' },
         signal,

--- a/packages/identity/src/did/web-resolver.ts
+++ b/packages/identity/src/did/web-resolver.ts
@@ -7,6 +7,7 @@ export const DOC_PATH = '/.well-known/did.json'
 
 export class DidWebResolver extends BaseResolver {
   constructor(
+    public fetch: typeof globalThis.fetch,
     public timeout: number,
     public cache?: DidCache,
   ) {
@@ -33,7 +34,7 @@ export class DidWebResolver extends BaseResolver {
     }
 
     return timed(this.timeout, async (signal) => {
-      const res = await fetch(url, {
+      const res = await this.fetch(url, {
         signal,
         redirect: 'error',
         headers: { accept: 'application/did+ld+json,application/json' },

--- a/packages/identity/src/handle/index.ts
+++ b/packages/identity/src/handle/index.ts
@@ -5,11 +5,13 @@ const SUBDOMAIN = '_atproto'
 const PREFIX = 'did='
 
 export class HandleResolver {
+  public fetch: typeof globalThis.fetch
   public timeout: number
   private backupNameservers: string[] | undefined
   private backupNameserverIps: string[] | undefined
 
   constructor(opts: HandleResolverOpts = {}) {
+    this.fetch = opts.fetch ?? globalThis.fetch
     this.timeout = opts.timeout ?? 3000
     this.backupNameservers = opts.backupNameservers
   }
@@ -49,7 +51,7 @@ export class HandleResolver {
   ): Promise<string | undefined> {
     const url = new URL('/.well-known/atproto-did', `https://${handle}`)
     try {
-      const res = await fetch(url, { signal })
+      const res = await this.fetch(url, { signal })
       const did = (await res.text()).split('\n')[0].trim()
       if (typeof did === 'string' && did.startsWith('did:')) {
         return did

--- a/packages/identity/src/id-resolver.ts
+++ b/packages/identity/src/id-resolver.ts
@@ -7,11 +7,12 @@ export class IdResolver {
   public did: DidResolver
 
   constructor(opts: IdentityResolverOpts = {}) {
-    const { timeout = 3000, plcUrl, didCache } = opts
+    const { fetch = globalThis.fetch, timeout = 3000, plcUrl, didCache } = opts
     this.handle = new HandleResolver({
+      fetch,
       timeout,
       backupNameservers: opts.backupNameservers,
     })
-    this.did = new DidResolver({ timeout, plcUrl, didCache })
+    this.did = new DidResolver({ fetch, timeout, plcUrl, didCache })
   }
 }

--- a/packages/identity/src/types.ts
+++ b/packages/identity/src/types.ts
@@ -4,6 +4,7 @@ export { didDocument } from '@atproto/common-web'
 export type { DidDocument } from '@atproto/common-web'
 
 export type IdentityResolverOpts = {
+  fetch?: typeof globalThis.fetch
   timeout?: number
   plcUrl?: string
   didCache?: DidCache
@@ -11,11 +12,13 @@ export type IdentityResolverOpts = {
 }
 
 export type HandleResolverOpts = {
+  fetch?: typeof globalThis.fetch
   timeout?: number
   backupNameservers?: string[]
 }
 
 export type DidResolverOpts = {
+  fetch?: typeof globalThis.fetch
   timeout?: number
   plcUrl?: string
   didCache?: DidCache


### PR DESCRIPTION
Implements the suggestion proposed by https://github.com/bluesky-social/atproto/issues/3292#issuecomment-2617130922 which provides an easier way to solve the issue manually.

As part of #3177 the dependency on `axios` was removed and HTTP requests in this package were migrated to use `fetch`. However, the current implementation calls the global `fetch` (indirectly accessing `globalThis`). If there is a need to replace the `fetch` implementation with a custom one, this package requires that the `globalThis.fetch` implementation is replaced globally.

This change adds `fetch?: typeof globalThis.fetch` to the options for `IdentityResolver`, `HandleResolver`, and `DidResolver` so that users can provide an alternate implementation of `fetch`. If no alternate implementation is provided then these options default to `globalThis.fetch`, maintaining the exact same behavior as the current implementation.