### PR TITLE
Update lexicons that return a list of profile views to include their sort keys

### DIFF
--- a/lexicons/app/bsky/feed/getRepostedBy.json
+++ b/lexicons/app/bsky/feed/getRepostedBy.json
@@ -41,11 +41,20 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "#repostedBy"
               }
             }
           }
         }
+      }
+    },
+    "repostedBy": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
       }
     }
   }

--- a/lexicons/app/bsky/graph/getBlocks.json
+++ b/lexicons/app/bsky/graph/getBlocks.json
@@ -28,11 +28,20 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "#block"
               }
             }
           }
         }
+      }
+    },
+    "block": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
       }
     }
   }

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -34,11 +34,20 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "#follower"
               }
             }
           }
         }
+      }
+    },
+    "follower": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
       }
     }
   }

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -34,11 +34,20 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "#follow"
               }
             }
           }
         }
+      }
+    },
+    "follow": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
       }
     }
   }

--- a/lexicons/app/bsky/graph/getMutes.json
+++ b/lexicons/app/bsky/graph/getMutes.json
@@ -28,11 +28,20 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "app.bsky.actor.defs#profileView"
+                "ref": "#mute"
               }
             }
           }
         }
+      }
+    },
+    "mutes": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
       }
     }
   }


### PR DESCRIPTION
This is a:

* Fix for #3368 
* Lexicon update

This PR would like to update the lexicon for a few requests that return `ProfileView` lists to also include the time based sort key in an `indexedAt` field for the backing model that the list is generated from, as well as a `createdAt` field.

In other words, make the changed requests match their `getLikes` sibling which provides the requisite information.

This allows offline first clients to seamlessly combine cached local responses with updates from the server.

As this is a breaking change, other alternatives include:

* Adding a new field in the #ProfileView lexicon definition for a `sourceModel` or something that has the:
    * `cid` for the associated model
    * `indexedAt` for the associated model
    * `createdAt` for the associated model
    
* Adding new methods to the API (`getBlockedActors`, `getLikingActors`, e.t.c) and a new def for that has a `ProfileView` embedded and a field for the requested metadata
    * `cid` for the associated model
    * `indexedAt` for the associated model
    * `createdAt` for the associated model
