### PR TITLE
Move sequenceCommit into actor store transaction

### DIFF
--- a/.changeset/good-dryers-poke.md
+++ b/.changeset/good-dryers-poke.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Fix bug where racing writes to the same repository can get sequenced out-of-order.

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - serialized-sequencing
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-and-push-pds-ghcr.yaml
+++ b/.github/workflows/build-and-push-pds-ghcr.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - serialized-sequencing
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -12,6 +12,7 @@ import {
   isDelete,
   isUpdate,
 } from '../../../../lexicon/types/com/atproto/repo/applyWrites'
+import { dbLogger } from '../../../../logger'
 import {
   BadCommitSwapError,
   InvalidRecordError,
@@ -133,7 +134,14 @@ export default function (server: Server, ctx: AppContext) {
         return commit
       })
 
-      await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
+      await ctx.accountManager
+        .updateRepoRoot(did, commit.cid, commit.rev)
+        .catch((err) => {
+          dbLogger.error(
+            { err, did, cid: commit.cid, rev: commit.rev },
+            'failed to update account root',
+          )
+        })
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -3,6 +3,7 @@ import { InvalidRecordKeyError } from '@atproto/syntax'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { AppContext } from '../../../../context'
 import { Server } from '../../../../lexicon'
+import { dbLogger } from '../../../../logger'
 import {
   BadCommitSwapError,
   InvalidRecordError,
@@ -94,7 +95,14 @@ export default function (server: Server, ctx: AppContext) {
         return commit
       })
 
-      await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
+      await ctx.accountManager
+        .updateRepoRoot(did, commit.cid, commit.rev)
+        .catch((err) => {
+          dbLogger.error(
+            { err, did, cid: commit.cid, rev: commit.rev },
+            'failed to update account root',
+          )
+        })
 
       return {
         encoding: 'application/json',

--- a/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/deleteRecord.ts
@@ -2,6 +2,7 @@ import { CID } from 'multiformats/cid'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { AppContext } from '../../../../context'
 import { Server } from '../../../../lexicon'
+import { dbLogger } from '../../../../logger'
 import {
   BadCommitSwapError,
   BadRecordSwapError,
@@ -75,8 +76,16 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       if (commit !== null) {
-        await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
+        await ctx.accountManager
+          .updateRepoRoot(did, commit.cid, commit.rev)
+          .catch((err) => {
+            dbLogger.error(
+              { err, did, cid: commit.cid, rev: commit.rev },
+              'failed to update account root',
+            )
+          })
       }
+
       return {
         encoding: 'application/json',
         body: {

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -7,6 +7,7 @@ import { AppContext } from '../../../../context'
 import { Server } from '../../../../lexicon'
 import { ids } from '../../../../lexicon/lexicons'
 import { Record as ProfileRecord } from '../../../../lexicon/types/app/bsky/actor/profile'
+import { dbLogger } from '../../../../logger'
 import {
   BadCommitSwapError,
   BadRecordSwapError,
@@ -123,7 +124,14 @@ export default function (server: Server, ctx: AppContext) {
       )
 
       if (commit !== null) {
-        await ctx.accountManager.updateRepoRoot(did, commit.cid, commit.rev)
+        await ctx.accountManager
+          .updateRepoRoot(did, commit.cid, commit.rev)
+          .catch((err) => {
+            dbLogger.error(
+              { err, did, cid: commit.cid, rev: commit.rev },
+              'failed to update account root',
+            )
+          })
       }
 
       return {


### PR DESCRIPTION
Some commits are ending up out-of-order on a PDS's firehose. For instance commits `A->B->C` may be emitted in the order `A->C->B`.

This is because the sequencer database is a separate database from the user's actor store. While transactions to a user's repository are forced to be done serially by sqlite, the sequencer does not enforce that serialization. We rely on the fact that we send the event to the sequencer DB _immediately_ after processing the write in the user's repository. Unfortunately, it seems that events can end up getting processed by the sequencer out-of-order (especially when under high load).

To ensure that events are added to the sequencer in the same order that they are processed in the repository, we sequence the commit prior to commiting the transaction on the actor store. This maintains the write lock on the actor store and ensures that a racing write in the same repository cannot be completed until the previous write is commited (and therefore sequenced). This as the added benefit that a failure in sequencing will cause the write to the user's repository to roll back.

The downside of this approach is that a failure to commit the transaction in the user's actorstore will cause a write to go out that hasn't actually made it to the user's repository. I think some possibility for non-transactional behavior is inherent here because we're doing a write across two separate databases, but this seems like the least likely case since the transaction is unlikely to fail on `commit`. I verified that we encounter sqlite locks (`SQLITE_BUSY` errors) on the conflicting _commands_ not on transaction commit.

I also made failures to update the user's repo root in the account database non-failing as it provides misleading feedback to the user (receiving a 500 when the write was actually made _and_ went out on the firehose) and is non-critical information that is only used to service `com.atproto.sync.listRepos`.