### PR TITLE
Fixed flexibility of feed search 

### DIFF
--- a/packages/bsky/src/data-plane/server/routes/feed-gens.ts
+++ b/packages/bsky/src/data-plane/server/routes/feed-gens.ts
@@ -48,9 +48,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     const { ref } = db.db.dynamic
     const limit = req.limit
     const query = req.query.trim()
+    const formattedQuery = query.split(/\s+/).join('%')
     let builder = db.db
       .selectFrom('feed_generator')
-      .if(!!query, (q) => q.where('displayName', 'ilike', `%${query}%`))
+      .if(!!query, (q) => q.where('displayName', 'ilike', `%${formattedQuery}%`))
       .selectAll()
     const keyset = new TimeCidKeyset(
       ref('feed_generator.createdAt'),


### PR DESCRIPTION
relates to the following pr in the social app repository:

https://github.com/bluesky-social/social-app/pull/7779 

Searching through feeds no longer requires exact wording, even if your search skipped the middle word or punctuation, the result should still appear