### PR TITLE
Make random test fail less often

### DIFF
--- a/packages/crypto/tests/random.test.ts
+++ b/packages/crypto/tests/random.test.ts
@@ -10,6 +10,6 @@ describe('randomIntFromSeed()', () => {
     }
     const [zero, one] = counts
     expect(zero + one).toEqual(10000)
-    expect(Math.max(zero, one) / Math.min(zero, one)).toBeLessThan(1.05)
+    expect(Math.max(zero, one) / Math.min(zero, one)).toBeLessThan(1.1)
   })
 })


### PR DESCRIPTION
This test depends on random number generation and sometimes it causes builds to fail. This doesn't solve the underlying issue, it just makes those failures much rarer.

Other options:
1. remove the test, but I can see how it is useful to at least catch obvious mistakes introduced by a change.
2. use some random sequence that we can control from an initial seed that doesn't vary. So we would generate a sequence of values we know doesn't break the tests, and it would still work as a safeguard against obvious mistakes introduced by a change.