### PR TITLE
[sync] Fix types for Firehose options

### DIFF
--- a/.changeset/empty-apples-learn.md
+++ b/.changeset/empty-apples-learn.md
@@ -1,0 +1,5 @@
+---
+"@atproto/sync": patch
+---
+
+Fix types of `FirehoseOptions`

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -36,6 +36,7 @@
     "ws": "^8.12.0"
   },
   "devDependencies": {
+    "@types/ws": "^8.5.4",
     "jest": "^28.1.2",
     "typescript": "^5.6.3"
   }

--- a/packages/sync/src/runner/types.ts
+++ b/packages/sync/src/runner/types.ts
@@ -3,6 +3,6 @@ export interface EventRunner {
   trackEvent(
     did: string,
     seq: number,
-    hanlder: () => Promise<void>,
+    handler: () => Promise<void>,
   ): Promise<void>
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1512,6 +1512,9 @@ importers:
         specifier: ^8.12.0
         version: 8.18.0
     devDependencies:
+      '@types/ws':
+        specifier: ^8.5.4
+        version: 8.5.4
       jest:
         specifier: ^28.1.2
         version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
@@ -6536,7 +6539,7 @@ packages:
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 18.19.56
+      '@types/node': 18.19.67
     dev: true
 
   /@types/yargs-parser@21.0.0:


### PR DESCRIPTION
`FirehoseOptions`, the object passed to the `Firehose` constructor, is a union of some specific types and a config object type from `ws`. However, `ws` does not have types, so the union type is completely broken. This can be fixed by adding `@types/ws`

> [!WARNING]
> While it works in the monorepo, I have not verified that this works once packaged up. It would be good to verify that the built package's type are fixed - I don't know what the behaviour of `devDependencies` is in this context

# Before (useless)

<img width="599" alt="Screenshot 2025-03-02 at 22 48 50" src="https://github.com/user-attachments/assets/b75141bf-b370-4c70-97fc-10b87a0d77b9" />

# After

<img width="590" alt="Screenshot 2025-03-02 at 22 46 09" src="https://github.com/user-attachments/assets/a88bab8b-c27d-4029-8652-70102f57a7e8" />
