### PR TITLE
app.bsky: permit 100mb video uploads

### DIFF
--- a/.changeset/selfish-suns-melt.md
+++ b/.changeset/selfish-suns-melt.md
@@ -1,0 +1,6 @@
+---
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Permit 100mb video embeds.

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -10,7 +10,7 @@
         "video": {
           "type": "blob",
           "accept": ["video/mp4"],
-          "maxSize": 50000000
+          "maxSize": 100000000
         },
         "captions": {
           "type": "array",

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -9,6 +9,7 @@
       "properties": {
         "video": {
           "type": "blob",
+          "description": "The mp4 video file. May be up to 100mb, formerly limited to 50mb.",
           "accept": ["video/mp4"],
           "maxSize": 100000000
         },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5693,6 +5693,8 @@ export const schemaDict = {
         properties: {
           video: {
             type: 'blob',
+            description:
+              'The mp4 video file. May be up to 100mb, formerly limited to 50mb.',
             accept: ['video/mp4'],
             maxSize: 100000000,
           },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -5694,7 +5694,7 @@ export const schemaDict = {
           video: {
             type: 'blob',
             accept: ['video/mp4'],
-            maxSize: 50000000,
+            maxSize: 100000000,
           },
           captions: {
             type: 'array',

--- a/packages/api/src/client/types/app/bsky/embed/video.ts
+++ b/packages/api/src/client/types/app/bsky/embed/video.ts
@@ -13,6 +13,7 @@ const id = 'app.bsky.embed.video'
 
 export interface Main {
   $type?: 'app.bsky.embed.video'
+  /** The mp4 video file. May be up to 100mb, formerly limited to 50mb. */
   video: BlobRef
   captions?: Caption[]
   /** Alt text description of the video, for accessibility. */

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5693,6 +5693,8 @@ export const schemaDict = {
         properties: {
           video: {
             type: 'blob',
+            description:
+              'The mp4 video file. May be up to 100mb, formerly limited to 50mb.',
             accept: ['video/mp4'],
             maxSize: 100000000,
           },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -5694,7 +5694,7 @@ export const schemaDict = {
           video: {
             type: 'blob',
             accept: ['video/mp4'],
-            maxSize: 50000000,
+            maxSize: 100000000,
           },
           captions: {
             type: 'array',

--- a/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,7 @@ const id = 'app.bsky.embed.video'
 
 export interface Main {
   $type?: 'app.bsky.embed.video'
+  /** The mp4 video file. May be up to 100mb, formerly limited to 50mb. */
   video: BlobRef
   captions?: Caption[]
   /** Alt text description of the video, for accessibility. */

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5693,6 +5693,8 @@ export const schemaDict = {
         properties: {
           video: {
             type: 'blob',
+            description:
+              'The mp4 video file. May be up to 100mb, formerly limited to 50mb.',
             accept: ['video/mp4'],
             maxSize: 100000000,
           },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -5694,7 +5694,7 @@ export const schemaDict = {
           video: {
             type: 'blob',
             accept: ['video/mp4'],
-            maxSize: 50000000,
+            maxSize: 100000000,
           },
           captions: {
             type: 'array',

--- a/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,7 @@ const id = 'app.bsky.embed.video'
 
 export interface Main {
   $type?: 'app.bsky.embed.video'
+  /** The mp4 video file. May be up to 100mb, formerly limited to 50mb. */
   video: BlobRef
   captions?: Caption[]
   /** Alt text description of the video, for accessibility. */

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5693,6 +5693,8 @@ export const schemaDict = {
         properties: {
           video: {
             type: 'blob',
+            description:
+              'The mp4 video file. May be up to 100mb, formerly limited to 50mb.',
             accept: ['video/mp4'],
             maxSize: 100000000,
           },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -5694,7 +5694,7 @@ export const schemaDict = {
           video: {
             type: 'blob',
             accept: ['video/mp4'],
-            maxSize: 50000000,
+            maxSize: 100000000,
           },
           captions: {
             type: 'array',

--- a/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/embed/video.ts
@@ -13,6 +13,7 @@ const id = 'app.bsky.embed.video'
 
 export interface Main {
   $type?: 'app.bsky.embed.video'
+  /** The mp4 video file. May be up to 100mb, formerly limited to 50mb. */
   video: BlobRef
   captions?: Caption[]
   /** Alt text description of the video, for accessibility. */


### PR DESCRIPTION
This increases the video upload size limit from 50mb to 100mb in the `app.bsky.embed.video` lexicon.

Technically there is a minor compatibility issue at play here.  The PDS validates blob sizes at write time, so a PDS with an old version of this lexicon may be incompatible with a client assuming it can upload a 100mb video.  This is not expected to pose a major compatibility issue, partly because a. the PDS already de facto limits upload sizes it may accept, b. the user may choose to upload a smaller video (clients generally don't _increase_ original video sizes), and c. PDS distributions are generally updated within a timely manner these days.  Lowering the size limit, on the other hand, would be much more disruptive.