### PR TITLE
PDS: allow admins to update to any valid handle

### DIFF
--- a/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
+++ b/packages/pds/src/api/com/atproto/admin/updateAccountHandle.ts
@@ -13,7 +13,7 @@ export default function (server: Server, ctx: AppContext) {
         ctx,
         handle: input.body.handle,
         did,
-        allowReserved: true,
+        allowAnyValid: true,
       })
 
       // Pessimistic check to handle spam: also enforced by updateHandle() and the db.

--- a/packages/pds/src/handle/index.ts
+++ b/packages/pds/src/handle/index.ts
@@ -8,9 +8,9 @@ export const normalizeAndValidateHandle = async (opts: {
   ctx: AppContext
   handle: string
   did?: string
-  allowReserved?: boolean
+  allowAnyValid?: boolean
 }): Promise<string> => {
-  const { ctx, did, allowReserved } = opts
+  const { ctx, did, allowAnyValid } = opts
   // base formatting validation
   const handle = baseNormalizeAndValidate(opts.handle)
   // tld validation
@@ -21,7 +21,7 @@ export const normalizeAndValidateHandle = async (opts: {
     )
   }
   // slur check
-  if (hasExplicitSlur(handle)) {
+  if (!allowAnyValid && hasExplicitSlur(handle)) {
     throw new InvalidRequestError(
       'Inappropriate language in handle',
       'InvalidHandle',
@@ -32,7 +32,7 @@ export const normalizeAndValidateHandle = async (opts: {
     ensureHandleServiceConstraints(
       handle,
       ctx.cfg.identity.serviceHandleDomains,
-      allowReserved,
+      allowAnyValid,
     )
   } else {
     if (opts.did === undefined) {


### PR DESCRIPTION
On `admin.updateAccountHandle`, permit any valid handle as a break glass measure.