### PR TITLE
fix: allow handle format with tld shorter than 3 characters

### DIFF
--- a/.changeset/dirty-snakes-wave.md
+++ b/.changeset/dirty-snakes-wave.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Allow handle format with tld shorter than 3 characters

--- a/packages/oauth/oauth-provider/src/account/account-store.ts
+++ b/packages/oauth/oauth-provider/src/account/account-store.ts
@@ -19,9 +19,18 @@ export const newPasswordSchema = z.string().min(8)
 export const tokenSchema = z.string().regex(/^[A-Z2-7]{5}-[A-Z2-7]{5}$/)
 export const handleSchema = z
   .string()
-  .min(3)
-  .max(30)
-  .regex(/^[a-z0-9][a-z0-9-]+[a-z0-9](?:\.[a-z0-9][a-z0-9-]+[a-z0-9])+$/)
+  .refine((value) => value.split('.').length >= 3, {
+    message: 'Handle must be on a subdomain (handle.domain.tld)',
+  })
+  .refine((value) => value.split('.')[0].length >= 3, {
+    message: 'Handle must be at least 3 characters long',
+  })
+  .refine((value) => value.split('.')[0].length <= 18, {
+    message: 'Handle must be at most 18 characters long',
+  })
+  .refine((value) => /^[a-z0-9]+$/.test(value.split('.')[0]), {
+    message: 'Handle must only contain lowercase letters and numbers',
+  })
 export const emailSchema = z
   .string()
   .email()


### PR DESCRIPTION
When trying to sign up in the oAuth flow with a tld or domain shorter than 3 char, you end up getting blocked by zod validation against the post body.

Example of failing ones:
"hello.norwegian.no"
"hello.vg.com"

Ref implementation done in https://github.com/bluesky-social/atproto/pull/2945
