### PR TITLE
feat(oauth): add Pwned Passwords check

### DIFF
--- a/.changeset/great-seals-act.md
+++ b/.changeset/great-seals-act.md
@@ -1,0 +1,8 @@
+---
+"@atproto/oauth-provider-ui": minor
+"@atproto/oauth-provider": minor
+"@atproto/dev-env": patch
+"@atproto/pds": patch
+---
+
+Add compromised passwords check to oAuth signup

--- a/packages/dev-env/src/pds.ts
+++ b/packages/dev-env/src/pds.ts
@@ -55,6 +55,7 @@ export class TestPds {
       // colors are required from a config perspective.
       warningColor: undefined,
       successColor: '#02c39a',
+      enableHibpCheck: true,
       logoUrl:
         // Using a "data:" instead of a real URL to avoid making CORS requests in dev.
         // License: https://uxwing.com/license/

--- a/packages/oauth/oauth-provider-ui/src/components/utils/error-message.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/utils/error-message.tsx
@@ -2,6 +2,7 @@ import { Trans } from '@lingui/react/macro'
 import { ReactNode, memo } from 'react'
 import {
   AccessDeniedError,
+  CompromisedPasswordError,
   EmailTakenError,
   HandleUnavailableError,
   InvalidCredentialsError,
@@ -33,6 +34,17 @@ export const ErrorMessage = memo(function ErrorMessage({
 
   if (error instanceof InvalidInviteCodeError) {
     return <Trans>The invite code is not valid</Trans>
+  }
+
+  if (error instanceof CompromisedPasswordError) {
+    return (
+      <Trans>
+        This password has appeared in one or more data breaches. For your
+        security, please choose a different password that has not been
+        compromised. Consider using a password manager to generate and store
+        strong, unique passwords.
+      </Trans>
+    )
   }
 
   if (error instanceof HandleUnavailableError) {

--- a/packages/oauth/oauth-provider-ui/src/lib/api.ts
+++ b/packages/oauth/oauth-provider-ui/src/lib/api.ts
@@ -57,6 +57,9 @@ export class Api extends JsonClient<ApiEndpoints> {
     if (UnknownRequestUriError.is(json)) {
       return new UnknownRequestUriError(json)
     }
+    if (CompromisedPasswordError.is(json)) {
+      return new CompromisedPasswordError(json)
+    }
     if (InvalidRequestError.is(json)) {
       return new InvalidRequestError(json)
     }
@@ -142,6 +145,17 @@ export class InvalidCredentialsError<
       super.is(json) &&
       json.error_description === 'Invalid identifier or password'
     )
+  }
+}
+
+export type CompromisedPasswordPayload = InvalidRequestPayload & {
+  error_description: 'Compromised password'
+}
+export class CompromisedPasswordError<
+  P extends CompromisedPasswordPayload = CompromisedPasswordPayload,
+> extends InvalidRequestError<P> {
+  static is(json: unknown): json is CompromisedPasswordPayload {
+    return super.is(json) && json.error_description === 'Compromised password'
   }
 }
 

--- a/packages/oauth/oauth-provider/src/account/account-store.ts
+++ b/packages/oauth/oauth-provider/src/account/account-store.ts
@@ -124,6 +124,7 @@ export type AccountInfo = {
 export type SignUpData = SignUpInput & {
   hcaptchaResult?: HcaptchaVerifyResult
   inviteCode?: InviteCode
+  hibpCheck?: boolean
 }
 
 export interface AccountStore {

--- a/packages/oauth/oauth-provider/src/lib/hibp.ts
+++ b/packages/oauth/oauth-provider/src/lib/hibp.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto'
-import { z } from 'zod'
 import {
   Fetch,
   FetchBound,
@@ -7,15 +6,6 @@ import {
   fetchOkProcessor,
 } from '@atproto-labs/fetch'
 import { pipe } from '@atproto-labs/pipe'
-
-export const hibpConfigSchema = z.object({
-  /**
-   * Whether to enable HaveIBeenPwned password breach check
-   */
-  enabled: z.boolean().optional(),
-})
-
-export type HibpConfig = z.infer<typeof hibpConfigSchema>
 
 const HIBP_API_URL = 'https://api.pwnedpasswords.com/range'
 

--- a/packages/oauth/oauth-provider/src/lib/hibp.ts
+++ b/packages/oauth/oauth-provider/src/lib/hibp.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import {
+  Fetch,
+  FetchBound,
+  bindFetch,
+  fetchOkProcessor,
+} from '@atproto-labs/fetch'
+import { pipe } from '@atproto-labs/pipe'
+
+export const hibpConfigSchema = z.object({
+  /**
+   * Whether to enable HaveIBeenPwned password breach check
+   */
+  enabled: z.boolean().optional(),
+})
+
+export type HibpConfig = z.infer<typeof hibpConfigSchema>
+
+const HIBP_API_URL = 'https://api.pwnedpasswords.com/range'
+
+export class HibpClient {
+  protected readonly fetch: FetchBound
+
+  constructor(fetch: Fetch = globalThis.fetch) {
+    this.fetch = bindFetch(fetch)
+  }
+
+  async isPasswordBreached(password: string): Promise<boolean> {
+    const hash = createHash('sha1').update(password).digest('hex').toUpperCase()
+    const prefix = hash.slice(0, 5)
+    const suffix = hash.slice(5)
+
+    try {
+      const response = await this.fetch(`${HIBP_API_URL}/${prefix}`, {
+        headers: {
+          'Add-Padding': 'true', // https://haveibeenpwned.com/API/v3#PwnedPasswordsPadding
+          'User-Agent': 'atproto-oauth-provider',
+        },
+      }).then(pipe(fetchOkProcessor(), async (res) => res.text()))
+
+      const lines = response.split('\n')
+      for (const line of lines) {
+        const [hashSuffix, count] = line.split(':')
+
+        if (hashSuffix.trim() === suffix && count > 0) {
+          return true
+        }
+      }
+
+      return false
+    } catch {
+      return false
+    }
+  }
+}

--- a/packages/oauth/oauth-provider/src/output/build-customization-data.ts
+++ b/packages/oauth/oauth-provider/src/output/build-customization-data.ts
@@ -83,6 +83,10 @@ export const customizationSchema = z.object({
    * Enables hCaptcha during sign-up.
    */
   hcaptcha: hcaptchaConfigSchema.optional(),
+  /**
+   * Enables Hibp check during sign-up.
+   */
+  enableHibpCheck: z.boolean().optional(),
 })
 export type CustomizationInput = z.input<typeof customizationSchema>
 export type Customization = z.infer<typeof customizationSchema>

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -271,6 +271,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
                   tokenSalt: env.hcaptchaTokenSalt,
                 }
               : undefined,
+          enableHibpCheck: env.enableHibpCheck ?? false,
           branding: {
             name: env.serviceName ?? 'Personal PDS',
             logo: env.logoUrl,
@@ -447,6 +448,7 @@ export type OAuthConfig = {
     | false
     | {
         hcaptcha?: HcaptchaConfig
+        enableHibpCheck?: boolean
         branding: BrandingInput
       }
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -22,6 +22,7 @@ export const readEnv = (): ServerEnvironment => {
     hcaptchaSiteKey: envStr('PDS_HCAPTCHA_SITE_KEY'),
     hcaptchaSecretKey: envStr('PDS_HCAPTCHA_SECRET_KEY'),
     hcaptchaTokenSalt: envStr('PDS_HCAPTCHA_TOKEN_SALT'),
+    enableHibpCheck: envBool('PDS_ENABLE_HIBP_CHECK'),
 
     // branding
     brandColor: envStr('PDS_PRIMARY_COLOR'),
@@ -160,6 +161,7 @@ export type ServerEnvironment = {
   hcaptchaSiteKey?: string
   hcaptchaSecretKey?: string
   hcaptchaTokenSalt?: string
+  enableHibpCheck?: boolean
 
   // branding
   brandColor?: string

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -347,6 +347,7 @@ export class AppContext {
           inviteCodeRequired: cfg.invites.required,
           availableUserDomains: cfg.identity.serviceHandleDomains,
           hcaptcha: cfg.oauth.provider.hcaptcha,
+          enableHibpCheck: cfg.oauth.provider.enableHibpCheck,
           branding: cfg.oauth.provider.branding,
           safeFetch,
           metadata: {

--- a/packages/pds/tests/oauth.test.ts
+++ b/packages/pds/tests/oauth.test.ts
@@ -383,7 +383,9 @@ describe('HIBP password breach detection', () => {
     await page.clickOnButton("S'inscrire")
 
     // Should show error message about compromised password
-    await page.ensureTextVisibility('Compromised password')
+    await page.ensureTextVisibility(
+      'This password has appeared in one or more data breaches.',
+    )
 
     // TODO: Find out why we can't use "using" here
     await page[Symbol.asyncDispose]()


### PR DESCRIPTION
Integrate https://haveibeenpwned.com/API/v3#PwnedPasswords breached/compromised password check in oAuth account registry flow.

Should help with ATO attacks by enforcing better security hygiene.

<img width="1197" alt="Screenshot 2025-03-11 at 00 26 54" src="https://github.com/user-attachments/assets/b86aa44b-339e-442a-be5d-6675bdcafd59" />
