### PR TITLE
Set COEP header to "unsafe-none" when hcaptcha is enabled

### DIFF
--- a/.changeset/fifty-hairs-heal.md
+++ b/.changeset/fifty-hairs-heal.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Fix CSP directives for assets loaded through an `src`.

--- a/.changeset/green-bobcats-join.md
+++ b/.changeset/green-bobcats-join.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Make CSP header shorter (by combining <script> tags in the backend, when possible)

--- a/.changeset/hot-doors-build.md
+++ b/.changeset/hot-doors-build.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Disable un-necessary pre-loading of assets

--- a/.changeset/light-pans-tap.md
+++ b/.changeset/light-pans-tap.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Fixes issue in internal HTML generation class

--- a/.changeset/light-seals-watch.md
+++ b/.changeset/light-seals-watch.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Set `Cross-Origin-Embedder-Policy` to `unsafe-none` when HCaptcha is enabled

--- a/packages/oauth/oauth-provider/src/assets/app/backend-data.ts
+++ b/packages/oauth/oauth-provider/src/assets/app/backend-data.ts
@@ -5,9 +5,14 @@ import {
   ErrorData,
 } from './backend-types.ts'
 
-function readBackendData<T>(key: string): T | undefined {
+function readBackendData<T>(key: string, required: true): T
+function readBackendData<T>(key: string, requires?: false): T | undefined
+function readBackendData<T>(key: string, required = false): T | undefined {
   const value = window[key] as T | undefined
   delete window[key] // Prevent accidental usage / potential leaks to dependencies
+  if (required && value === undefined) {
+    throw new TypeError(`Backend data "${key}" is missing`)
+  }
   return value
 }
 
@@ -15,11 +20,14 @@ function readBackendData<T>(key: string): T | undefined {
 // page HTML. See "declareBackendData()" in the backend.
 
 /** @deprecated Do not import directly. Only import this from main.tsx */
-export const availableLocales =
-  readBackendData<AvailableLocales>('__availableLocales')
+export const availableLocales = readBackendData<AvailableLocales>(
+  '__availableLocales',
+  true,
+)
 /** @deprecated Do not import directly. Only import this from main.tsx */
 export const customizationData = readBackendData<CustomizationData>(
   '__customizationData',
+  true,
 )
 /** @deprecated Do not import directly. Only import this from main.tsx */
 export const errorData = readBackendData<ErrorData>('__errorData')

--- a/packages/oauth/oauth-provider/src/assets/asset.ts
+++ b/packages/oauth/oauth-provider/src/assets/asset.ts
@@ -1,9 +1,8 @@
 import type { Readable } from 'node:stream'
+import type { ManifestItem } from '@atproto-labs/rollup-plugin-bundle-manifest'
 
 export type Asset = {
   url: string
-  type?: string
-  isEntry: boolean
-  sha256: string
+  item: ManifestItem
   createStream: () => Readable
 }

--- a/packages/oauth/oauth-provider/src/assets/assets-middleware.ts
+++ b/packages/oauth/oauth-provider/src/assets/assets-middleware.ts
@@ -38,13 +38,13 @@ export function authorizeAssetsMiddleware(): Middleware {
       return next(err)
     }
 
-    if (req.headers['if-none-match'] === asset.sha256) {
+    if (req.headers['if-none-match'] === asset.item.sha256) {
       return void res.writeHead(304).end()
     }
 
-    res.setHeader('ETag', asset.sha256)
+    res.setHeader('ETag', asset.item.sha256)
     res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
 
-    writeStream(res, asset.createStream(), { contentType: asset.type })
+    writeStream(res, asset.createStream(), { contentType: asset.item.mime })
   }
 }

--- a/packages/oauth/oauth-provider/src/assets/index.ts
+++ b/packages/oauth/oauth-provider/src/assets/index.ts
@@ -64,9 +64,7 @@ function manifestItemToAsset(filename: string, manifest: ManifestItem): Asset {
 
   return {
     url: posix.join(ASSETS_URL_PREFIX, filename),
-    type: manifest.mime,
-    isEntry: manifest.type === 'chunk' && manifest.isEntry,
-    sha256: manifest.sha256,
+    item: manifest,
     createStream: data
       ? () => Readable.from(Buffer.from(data, 'base64'))
       : () =>

--- a/packages/oauth/oauth-provider/src/lib/html/html.ts
+++ b/packages/oauth/oauth-provider/src/lib/html/html.ts
@@ -9,7 +9,7 @@ export class Html implements Iterable<string> {
 
   private constructor(fragments: Iterable<Html | string>, guard: symbol) {
     if (guard !== symbol) {
-      // Force developers to use `Html.dangerouslyCreate` to create an Html
+      // Forces developers to use `Html.dangerouslyCreate` to create an Html
       // instance, to make it clear that the content needs to be trusted.
       throw new TypeError(
         'Use Html.dangerouslyCreate() to create an Html instance',
@@ -22,7 +22,12 @@ export class Html implements Iterable<string> {
   }
 
   toString(): string {
-    return this.#fragments.join('')
+    // More efficient than `return this.#fragments.join('')` because it avoids
+    // creating intermediate strings when items of this.#fragments are Html
+    // instances (as all their toString() would end-up being called, creating
+    // lots of intermediary strings). The approach here allows to do a full scan
+    // of all the child nodes and concatenate them in a single pass.
+    return Array.from(this).join('')
   }
 
   [Symbol.toPrimitive](hint): string {

--- a/packages/oauth/oauth-provider/src/lib/html/html.ts
+++ b/packages/oauth/oauth-provider/src/lib/html/html.ts
@@ -49,11 +49,7 @@ export class Html implements Iterable<string> {
 
   *[Symbol.iterator](): IterableIterator<string> {
     for (const fragment of this.#fragments) {
-      if (typeof fragment === 'string') {
-        yield fragment
-      } else {
-        yield* fragment
-      }
+      yield String(fragment)
     }
   }
 

--- a/packages/oauth/oauth-provider/src/lib/html/util.ts
+++ b/packages/oauth/oauth-provider/src/lib/html/util.ts
@@ -15,7 +15,3 @@ export function* stringReplacer(
   }
   yield source.slice(previousIndex)
 }
-
-export function isString(value: unknown): value is string {
-  return typeof value === 'string'
-}

--- a/packages/oauth/oauth-provider/src/lib/http/response.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/response.ts
@@ -1,5 +1,9 @@
 import type { ServerResponse } from 'node:http'
 import { type Readable, pipeline } from 'node:stream'
+import {
+  SecurityHeadersOptions,
+  setSecurityHeaders,
+} from './security-headers.js'
 import type { Handler, Middleware } from './types.js'
 
 export function appendHeader(
@@ -88,11 +92,15 @@ export function staticJsonMiddleware(
   }
 }
 
+export type WriteHtmlOptions = WriteResponseOptions & SecurityHeadersOptions
+
 export function writeHtml(
   res: ServerResponse,
   html: Buffer | string,
-  { contentType = 'text/html', ...options }: WriteResponseOptions = {},
+  { contentType = 'text/html', ...options }: WriteHtmlOptions = {},
 ): void {
+  // HTML pages should always be served with safety protection headers
+  setSecurityHeaders(res, options)
   writeBuffer(res, html, { ...options, contentType })
 }
 

--- a/packages/oauth/oauth-provider/src/lib/http/security-headers.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/security-headers.ts
@@ -1,0 +1,91 @@
+import type { ServerResponse } from 'node:http'
+import { type CspConfig, buildCsp } from '../csp/index.js'
+
+/**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy COEP on MDN}
+ */
+export enum CrossOriginEmbedderPolicy {
+  unsafeNone = 'unsafe-none',
+  requireCorp = 'require-corp',
+  credentialless = 'credentialless',
+}
+
+/**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy CORP on MDN}
+ */
+export enum CrossOriginResourcePolicy {
+  sameSite = 'same-site',
+  sameOrigin = 'same-origin',
+  crossOrigin = 'cross-origin',
+}
+
+/**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy COOP on MDN}
+ */
+export enum CrossOriginOpenerPolicy {
+  unsafeNone = 'unsafe-none',
+  sameOriginAllowPopups = 'same-origin-allow-popups',
+  sameOrigin = 'same-origin',
+  noopenerAllowPopups = 'noopener-allow-popups',
+}
+
+export type HTTPStrictTransportSecurityConfig = {
+  maxAge: number
+  includeSubDomains?: boolean
+  preload?: boolean
+}
+
+export type SecurityHeadersOptions = {
+  /**
+   * Defaults to `default-src: 'none'`. Use an empty object to disable CSP.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy CSP on MDN}
+   */
+  csp?: CspConfig
+  coep?: CrossOriginEmbedderPolicy
+  corp?: CrossOriginResourcePolicy
+  coop?: CrossOriginOpenerPolicy
+  /**
+   * Defaults to 2 years. Use `false` to disable HSTS.
+   */
+  hsts?: HTTPStrictTransportSecurityConfig | false
+}
+
+export function setSecurityHeaders(
+  res: ServerResponse,
+  {
+    csp = { 'default-src': ["'none'"] },
+    coep = CrossOriginEmbedderPolicy.requireCorp,
+    corp = CrossOriginResourcePolicy.sameOrigin,
+    coop = CrossOriginOpenerPolicy.sameOrigin,
+    hsts = { maxAge: 63072000 },
+  }: SecurityHeadersOptions,
+): void {
+  // @NOTE Never set CSP through http-equiv meta as not all directives will
+  // be honored. Always set it through the Content-Security-Policy header.
+  const cspString = buildCsp(csp)
+  if (cspString) {
+    res.setHeader('Content-Security-Policy', cspString)
+  }
+
+  res.setHeader('Cross-Origin-Embedder-Policy', coep)
+  res.setHeader('Cross-Origin-Resource-Policy', corp)
+  res.setHeader('Cross-Origin-Opener-Policy', coop)
+
+  if (hsts) {
+    res.setHeader('Strict-Transport-Security', buildHstsValue(hsts))
+  }
+
+  // @TODO: make these headers configurable (?)
+  res.setHeader('Permissions-Policy', 'otp-credentials=*, document-domain=()')
+  res.setHeader('Referrer-Policy', 'same-origin')
+  res.setHeader('X-Frame-Options', 'DENY')
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  res.setHeader('X-XSS-Protection', '0')
+}
+
+function buildHstsValue(config: HTTPStrictTransportSecurityConfig): string {
+  let value = `max-age=${config.maxAge}`
+  if (config.includeSubDomains) value += '; includeSubDomains'
+  if (config.preload) value += '; preload'
+  return value
+}

--- a/packages/oauth/oauth-provider/src/lib/util/type.ts
+++ b/packages/oauth/oauth-provider/src/lib/util/type.ts
@@ -10,6 +10,24 @@ export type Override<T, V> = Simplify<{
 export type Awaitable<T> = T | Promise<T>
 
 /**
+ * Converts a tuple to the equivalent type of combining every item into a single
+ * one. If any of the item in the tuple is non nullish, the result will be non
+ * nullish.
+ */
+export type CombinedTuple<T extends readonly unknown[]> = T extends []
+  ? undefined
+  : Exclude<
+      T[number],
+      // If any item in the tuple is never `null` (resp. `undefined`), exclude
+      // `null` (resp. `undefined`) from `T[number]`
+      {
+        [K in keyof T]-?:
+          | (null extends T[K] ? never : null)
+          | (undefined extends T[K] ? never : undefined)
+      }[keyof T]
+    >
+
+/**
  * Similar to {@link Required} but also ensures that all values are defined.
  */
 export type RequiredDefined<T> = { [K in keyof T]-?: Exclude<T[K], undefined> }

--- a/packages/oauth/oauth-provider/src/output/backend-data.ts
+++ b/packages/oauth/oauth-provider/src/output/backend-data.ts
@@ -1,0 +1,18 @@
+import { Html, js } from '../lib/html/index.js'
+
+export function declareBackendData(values: Record<string, unknown>): Html {
+  return Html.dangerouslyCreate(backendDataGenerator(values))
+}
+
+export function* backendDataGenerator(
+  values: Record<string, unknown>,
+): Generator<Html> {
+  for (const [key, val] of Object.entries(values)) {
+    yield js`window[${key}]=${val};`
+  }
+  // The script tag is removed after the data is assigned to the global
+  // variables to prevent other scripts from reading the values. The "app"
+  // script will read the global variable and then unset it. See
+  // `readBackendData()` in "src/assets/app/backend-data.ts".
+  yield js`document.currentScript.remove();`
+}

--- a/packages/oauth/oauth-provider/src/output/send-web-page.ts
+++ b/packages/oauth/oauth-provider/src/output/send-web-page.ts
@@ -38,12 +38,14 @@ export async function sendWebPage(
 function assetToCsp(asset: Html | AssetRef): CspValue {
   if (asset instanceof Html) {
     // Inline assets are "allowed" by their hash
-    const hash = createHash('sha256').update(asset.toString()).digest('base64')
-    return `'sha256-${hash}'`
+    const hash = createHash('sha256')
+    for (const fragment of asset) hash.update(fragment)
+    return `'sha256-${hash.digest('base64')}'`
   } else {
-    // External assets are referenced by their full url
-    if (asset.url.startsWith('https:')) return asset.url as `https:${string}`
-    if (asset.url.startsWith('http:')) return asset.url as `http:${string}`
+    // External assets are referenced by their origin
+    if (asset.url.startsWith('https:') || asset.url.startsWith('http:')) {
+      return new URL(asset.url).origin as `https:${string}` | `http:${string}`
+    }
 
     // Internal assets are served from the same origin
     return `'self'`

--- a/packages/oauth/oauth-provider/src/output/send-web-page.ts
+++ b/packages/oauth/oauth-provider/src/output/send-web-page.ts
@@ -1,82 +1,51 @@
 import { createHash } from 'node:crypto'
 import type { ServerResponse } from 'node:http'
-import { CspConfig, CspValue, buildCsp, mergeCsp } from '../lib/csp/index.js'
+import { CspConfig, CspValue, mergeCsp } from '../lib/csp/index.js'
 import {
   AssetRef,
   BuildDocumentOptions,
   Html,
   buildDocument,
-  js,
 } from '../lib/html/index.js'
-import { WriteResponseOptions, writeHtml } from '../lib/http/response.js'
+import { WriteHtmlOptions, writeHtml } from '../lib/http/response.js'
 
-export function declareBackendData(name: string, data: unknown) {
-  // The script tag is removed after the data is assigned to the global variable
-  // to prevent other scripts from deducing the value of the variable. The "app"
-  // script will read the global variable and then unset it. See
-  // "readBackendData" in "src/assets/app/backend-types.ts".
-  return js`window[${name}]=${data};document.currentScript.remove();`
+export const DEFAULT_CSP: CspConfig = {
+  'upgrade-insecure-requests': true,
+  'default-src': ["'none'"],
 }
 
-export type SendWebPageOptions = BuildDocumentOptions &
-  WriteResponseOptions & {
-    csp?: CspConfig
-  }
+export type SendWebPageOptions = BuildDocumentOptions & WriteHtmlOptions
 
 export async function sendWebPage(
   res: ServerResponse,
-  options: SendWebPageOptions,
+  { csp: inputCsp, ...options }: SendWebPageOptions,
 ): Promise<void> {
-  const csp = mergeCsp(options.csp, {
-    'default-src': ["'none'"],
+  // @NOTE the csp string might be quite long. In that case it might be tempting
+  // to set it through the http-equiv <meta> in the HTML. However, some
+  // directives cannot be enforced by browsers when set through the meta tag
+  // (e.g. 'frame-ancestors'). Therefore, it's better to set the CSP through the
+  // HTTP header.
+  const csp = mergeCsp(DEFAULT_CSP, inputCsp, {
     'base-uri': options.base?.origin as undefined | `https://${string}`,
-    'script-src': ["'self'", ...assetsToCsp(options.scripts)],
-    'style-src': ["'self'", ...assetsToCsp(options.styles)],
-    'img-src': ["'self'", 'data:', 'https:'],
-    'connect-src': ["'self'"],
-    'upgrade-insecure-requests': true,
-
-    // Prevents the CSP to be embedded in a page <meta>:
-    'frame-ancestors': ["'none'"],
+    'script-src': options.scripts?.map(assetToCsp),
+    'style-src': options.styles?.map(assetToCsp),
   })
 
-  // @NOTE the csp string might become too long. However, since we need to
-  // specify the "frame-ancestors" directive, we can't use a meta tag. For that
-  // reason, we won't try to avoid too long headers and let the proxy throw
-  // in case of a too long header.
-  res.setHeader('Content-Security-Policy', buildCsp(csp))
-
-  // @TODO: make these headers configurable (?)
-  res.setHeader('Permissions-Policy', 'otp-credentials=*, document-domain=()')
-  res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless')
-  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin')
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-  res.setHeader('Referrer-Policy', 'same-origin')
-  res.setHeader('X-Frame-Options', 'DENY')
-  res.setHeader('X-Content-Type-Options', 'nosniff')
-  res.setHeader('X-XSS-Protection', '0')
-  res.setHeader('Strict-Transport-Security', 'max-age=63072000')
-
-  const html = buildDocument(options)
-
-  return writeHtml(res, html.toString(), options)
+  const html = buildDocument(options).toString()
+  return writeHtml(res, html, { ...options, csp })
 }
 
-export function* assetsToCsp(
-  assets?: Iterable<Html | AssetRef>,
-): Generator<CspValue> {
-  if (assets) {
-    for (const asset of assets) {
-      yield assetToCsp(asset)
-    }
-  }
-}
-
-export function assetToCsp(asset: Html | AssetRef): CspValue {
+function assetToCsp(asset: Html | AssetRef): CspValue {
   if (asset instanceof Html) {
+    // Inline assets are "allowed" by their hash
     const hash = createHash('sha256').update(asset.toString()).digest('base64')
     return `'sha256-${hash}'`
   } else {
-    return `'sha256-${asset.sha256}'`
+    // External assets are referenced by their full url
+    if (asset.url.startsWith('https:')) return asset.url as `https:${string}`
+    if (asset.url.startsWith('http:')) return asset.url as `http:${string}`
+
+    // Internal assets are served from the same origin
+    return `'self'`
   }
 }


### PR DESCRIPTION
- Removes un-necessary CSP directives (making CSP header shorted)
- Optimize backend injected data by generating fewer <script> tags (alloiwng to make CSP header shorter)
- Enables configuration of COEP, CORP & COOP headers in HTML responses
- Fixes issue in HTML class that would cause the output to sometimes be empty (preventing proper generation CSP headers)
- Disables pre-loading of assets that are referenced in the page (they were loaded twice)
- Improve type safety in front-end code by asserting backend vars are injected

Fixes #3625