### PR TITLE
OAuth: Allow `onSignedUp` hook to access hcaptcha result data

### DIFF
--- a/.changeset/afraid-spies-exist.md
+++ b/.changeset/afraid-spies-exist.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Fix hcaptcha verification based on score

--- a/.changeset/great-tips-hide.md
+++ b/.changeset/great-tips-hide.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": minor
+---
+
+Remove onSignupHcaptchaResult hook

--- a/.changeset/serious-timers-notice.md
+++ b/.changeset/serious-timers-notice.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": minor
+---
+
+Allow `onSignedUp` hook to access hcaptcha result data.

--- a/.changeset/slimy-flowers-punch.md
+++ b/.changeset/slimy-flowers-punch.md
@@ -2,4 +2,4 @@
 "@atproto/oauth-provider": patch
 ---
 
-Improve HCaptocha error reporting
+Improve HCaptcha error reporting

--- a/.changeset/slimy-flowers-punch.md
+++ b/.changeset/slimy-flowers-punch.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Improve HCaptocha error reporting

--- a/packages/oauth/oauth-provider/src/account/account-store.ts
+++ b/packages/oauth/oauth-provider/src/account/account-store.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { ensureValidHandle, normalizeHandle } from '@atproto/syntax'
 import { ClientId } from '../client/client-id.js'
 import { DeviceId } from '../device/device-id.js'
+import { HcaptchaVerifyResult } from '../lib/hcaptcha.js'
 import { localeSchema } from '../lib/locale.js'
 import { Awaitable, buildInterfaceChecker } from '../lib/util/type.js'
 import {
@@ -13,6 +14,7 @@ import {
 } from '../oauth-errors.js'
 import { Sub } from '../oidc/sub.js'
 import { Account } from './account.js'
+import { SignUpInput } from './sign-up-input.js'
 
 // @NOTE Change the length here to force stronger passwords (through a reset)
 export const oldPasswordSchema = z.string().min(1)
@@ -49,6 +51,7 @@ export const emailSchema = z
   })
   .transform((value) => value.toLowerCase())
 export const inviteCodeSchema = z.string().min(1)
+export type InviteCode = z.infer<typeof inviteCodeSchema>
 
 export const authenticateAccountDataSchema = z
   .object({
@@ -116,6 +119,11 @@ export {
 export type AccountInfo = {
   account: Account
   info: DeviceAccountInfo
+}
+
+export type SignUpData = SignUpInput & {
+  hcaptchaResult?: HcaptchaVerifyResult
+  inviteCode?: InviteCode
 }
 
 export interface AccountStore {

--- a/packages/oauth/oauth-provider/src/account/sign-up-input.ts
+++ b/packages/oauth/oauth-provider/src/account/sign-up-input.ts
@@ -2,10 +2,10 @@ import { z } from 'zod'
 import { hcaptchaTokenSchema } from '../lib/hcaptcha.js'
 import { createAccountDataSchema } from './account-store.js'
 
-export const signUpDataSchema = createAccountDataSchema
+export const signUpInputSchema = createAccountDataSchema
   .extend({
     hcaptchaToken: hcaptchaTokenSchema.optional(),
   })
   .strict()
 
-export type SignUpData = z.TypeOf<typeof signUpDataSchema>
+export type SignUpInput = z.TypeOf<typeof signUpInputSchema>

--- a/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
+++ b/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
@@ -27,9 +27,11 @@ export const hcaptchaConfigSchema = z.object({
    */
   tokenSalt: z.string().min(1),
   /**
-   * The risk score over which the user is considered a threat and will be
+   * The risk score above which the user is considered a threat and will be
    * denied access. This will be ignored if the enterprise features are not
    * available.
+   *
+   * Note: Score values ranges from 0.0 (no risk) to 1.0 (confirmed threat).
    */
   scoreThreshold: z.number().optional(),
 })
@@ -128,7 +130,7 @@ export class HCaptchaClient {
     this.fetch = bindFetch(fetch)
   }
 
-  async verify(
+  public async verify(
     behaviorType: 'login' | 'signup',
     response: string,
     remoteip: string,
@@ -160,20 +162,21 @@ export class HCaptchaClient {
     }
   }
 
-  isAllowed({ success, hostname, score }: HcaptchaVerifyResult) {
+  protected isAllowed({ success, hostname, score }: HcaptchaVerifyResult) {
     return (
       success &&
       // Fool-proofing: If this is false, the user is trying to use a token
       // generated for the same siteKey, but on another domain.
       hostname === this.hostname &&
       // Ignore if enterprise feature is not enabled
-      score != null &&
-      this.config.scoreThreshold != null &&
-      score < this.config.scoreThreshold
+      (score == null ||
+        // Ignore if disabled through config
+        this.config.scoreThreshold == null ||
+        score < this.config.scoreThreshold)
     )
   }
 
-  hashToken(value: string) {
+  protected hashToken(value: string) {
     const hash = createHash('sha256')
     hash.update(this.config.tokenSalt)
     hash.update(value)

--- a/packages/oauth/oauth-provider/src/oauth-hooks.ts
+++ b/packages/oauth/oauth-provider/src/oauth-hooks.ts
@@ -7,7 +7,7 @@ import {
 } from '@atproto/oauth-types'
 import { Account } from './account/account.js'
 import { SignInData } from './account/sign-in-data.js'
-import { SignUpData } from './account/sign-up-data.js'
+import { SignUpInput } from './account/sign-up-input.js'
 import { ClientAuth } from './client/client-auth.js'
 import { ClientId } from './client/client-id.js'
 import { ClientInfo } from './client/client-info.js'
@@ -17,7 +17,7 @@ import { HcaptchaConfig, HcaptchaVerifyResult } from './lib/hcaptcha.js'
 import { RequestMetadata } from './lib/http/request.js'
 import { Awaitable } from './lib/util/type.js'
 import { AccessDeniedError, OAuthError } from './oauth-errors.js'
-import { DeviceAccountInfo, DeviceId } from './oauth-store.js'
+import { DeviceAccountInfo, DeviceId, SignUpData } from './oauth-store.js'
 
 // Make sure all types needed to implement the OAuthHooks are exported
 export {
@@ -42,6 +42,7 @@ export {
   type RequestMetadata,
   type SignInData,
   type SignUpData,
+  type SignUpInput,
 }
 
 export type OAuthHooks = {
@@ -78,7 +79,6 @@ export type OAuthHooks = {
    * @throws {InvalidRequestError} to deny the sign-up
    */
   onSignupHcaptchaResult?: (data: {
-    data: SignUpData
     /**
      * This indicates not only wether the hCaptcha challenge succeeded, but also
      * if the score was low enough according to the
@@ -88,6 +88,8 @@ export type OAuthHooks = {
      */
     allowed: boolean
     result: HcaptchaVerifyResult
+
+    input: SignUpInput
     deviceId: DeviceId
     deviceMetadata: RequestMetadata
   }) => Awaitable<void>
@@ -97,10 +99,9 @@ export type OAuthHooks = {
    * has passed (including hcaptcha).
    */
   onSignupAttempt?: (data: {
-    data: SignUpData
+    input: SignUpInput
     deviceId: DeviceId
     deviceMetadata: RequestMetadata
-    hcaptchaResult?: HcaptchaVerifyResult
   }) => Awaitable<void>
 
   /**

--- a/packages/oauth/oauth-provider/src/oauth-hooks.ts
+++ b/packages/oauth/oauth-provider/src/oauth-hooks.ts
@@ -73,28 +73,6 @@ export type OAuthHooks = {
   }) => Awaitable<undefined | OAuthAuthorizationDetails>
 
   /**
-   * This hook is called whenever an hcaptcha challenge is verified
-   * during sign-up (if hcaptcha is enabled).
-   *
-   * @throws {InvalidRequestError} to deny the sign-up
-   */
-  onSignupHcaptchaResult?: (data: {
-    /**
-     * This indicates not only wether the hCaptcha challenge succeeded, but also
-     * if the score was low enough according to the
-     * {@link HcaptchaConfig.scoreThreshold}.
-     *
-     * @see {@link HCaptchaClient.isAllowed}
-     */
-    allowed: boolean
-    result: HcaptchaVerifyResult
-
-    input: SignUpInput
-    deviceId: DeviceId
-    deviceMetadata: RequestMetadata
-  }) => Awaitable<void>
-
-  /**
    * This hook is called when a user attempts to sign up, after every validation
    * has passed (including hcaptcha).
    */

--- a/packages/oauth/oauth-provider/src/oauth-provider.ts
+++ b/packages/oauth/oauth-provider/src/oauth-provider.ts
@@ -45,7 +45,7 @@ import {
 } from './account/account-store.js'
 import { Account } from './account/account.js'
 import { signInDataSchema } from './account/sign-in-data.js'
-import { signUpDataSchema } from './account/sign-up-data.js'
+import { signUpInputSchema } from './account/sign-up-input.js'
 import { authorizeAssetsMiddleware } from './assets/assets-middleware.js'
 import { ClientAuth, authJwkThumbprint } from './client/client-auth.js'
 import {
@@ -1588,7 +1588,7 @@ export class OAuthProvider extends OAuthVerifier {
 
     router.post(
       '/oauth/authorize/sign-up',
-      apiHandler(signUpDataSchema, async function (req, res, data, ctx) {
+      apiHandler(signUpInputSchema, async function (req, res, data, ctx) {
         return server.signUp(ctx, data)
       }),
     )


### PR DESCRIPTION
This change reworks the way sign-up hooks are triggered:

- The `onSignupAttempt` is now triggered before hcaptcha verification. The reason for an earlier check is to prevent sing-ups based, for example, on ip addresses.
- The `onSignedUp` hook and store's `createAccount` method now receives the hcaptcha verification result, allowing them to store hcaptcha results
- Remove `onSignupHcaptchaResult` hook

This change also fixes hcaptcha score validation