### PR TITLE
oauth-provider-ui: Make translatable "Back" on accept-form

### DIFF
--- a/packages/oauth/oauth-provider-ui/src/views/authorize/accept/accept-form.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/accept/accept-form.tsx
@@ -49,7 +49,7 @@ export function AcceptForm({
         event.preventDefault()
         onAccept()
       }}
-      cancel={onBack && <Button onClick={onBack}>Back</Button>}
+      cancel={onBack && <Button onClick={onBack}><Trans>Back</Trans></Button>}
       actions={
         <>
           <Button type="submit" color="brand">


### PR DESCRIPTION
I was trying to translate oauth and noticed that the back button is not translatable
![image](https://github.com/user-attachments/assets/21c67241-36dc-421a-a826-66ceecaa5510)
