### PR TITLE
oauth-provider-ui: Add Japanese translation

### DIFF
--- a/packages/oauth/oauth-provider-ui/src/authorization-page.html
+++ b/packages/oauth/oauth-provider-ui/src/authorization-page.html
@@ -57,22 +57,22 @@
       const name = 'Bluesky'
       const links = [
         {
-          title: { en: 'Home' },
+          title: { en: 'Home', ja: 'ホーム' },
           href: 'https://bsky.social/',
           rel: 'canonical', // prevents the login page from being indexed by search engines
         },
         {
-          title: { en: 'Terms of Service' },
+          title: { en: 'Terms of Service', ja: '利用規約' },
           href: 'https://bsky.social/about/support/tos',
           rel: 'terms-of-service',
         },
         {
-          title: { en: 'Privacy Policy' },
+          title: { en: 'Privacy Policy', ja: 'プライバシーポリシー' },
           href: 'https://bsky.social/about/support/privacy-policy',
           rel: 'privacy-policy',
         },
         {
-          title: { en: 'Support' },
+          title: { en: 'Support', ja: 'サポート' },
           href: 'https://blueskyweb.zendesk.com/hc/en-us',
           rel: 'help',
         },
@@ -106,7 +106,7 @@
 
       document.cookie = `csrf-${requestUri}=xyz; path=/`
 
-      window.__availableLocales = ['en', 'fr']
+      window.__availableLocales = ['en', 'fr', 'ja']
 
       window.__customizationData = {
         availableUserDomains,

--- a/packages/oauth/oauth-provider-ui/src/error-page.html
+++ b/packages/oauth/oauth-provider-ui/src/error-page.html
@@ -57,22 +57,22 @@
       const name = 'Bluesky'
       const links = [
         {
-          title: { en: 'Home' },
+          title: { en: 'Home', ja: 'ホーム' },
           href: 'https://bsky.social/',
           rel: 'canonical', // prevents the login page from being indexed by search engines
         },
         {
-          title: { en: 'Terms of Service' },
+          title: { en: 'Terms of Service', ja: '利用規約' },
           href: 'https://bsky.social/about/support/tos',
           rel: 'terms-of-service',
         },
         {
-          title: { en: 'Privacy Policy' },
+          title: { en: 'Privacy Policy', ja: 'プライバシーポリシー' },
           href: 'https://bsky.social/about/support/privacy-policy',
           rel: 'privacy-policy',
         },
         {
-          title: { en: 'Support' },
+          title: { en: 'Support', ja: 'サポート' },
           href: 'https://blueskyweb.zendesk.com/hc/en-us',
           rel: 'help',
         },
@@ -104,7 +104,7 @@
 
       const requestUri = 'foo-bar'
 
-      window.__availableLocales = ['en', 'fr']
+      window.__availableLocales = ['en', 'fr', 'ja']
 
       window.__customizationData = {
         availableUserDomains,

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -8,59 +8,59 @@ msgstr ""
 "Language: ja\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"PO-Revision-Date: 2025-03-20 01:34+0900\n"
+"Last-Translator: dolciss\n"
+"Language-Team: Japanese\n"
 "Plural-Forms: \n"
 
 #: src/views/authorize/accept/accept-form.tsx:76
 msgid "<0/> is asking for permission to access your account (<1/>)."
-msgstr ""
+msgstr "<0/> があなたのアカウント (<1/>) へのアクセス権限を要求しています。"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
-msgstr ""
+msgstr "２要素認証"
 
 #: src/components/utils/error-message.tsx:27
 msgid "A second authentication factor is required"
-msgstr ""
+msgstr "２番目の認証要素が必要です"
 
 #: src/views/authorize/accept/accept-form.tsx:144
 msgid "Access your account data (except chat messages)"
-msgstr ""
+msgstr "あなたのアカウントデータにアクセス （チャットメッセージを除く）"
 
 #: src/views/authorize/accept/accept-form.tsx:146
 msgid "Access your chat messages"
-msgstr ""
+msgstr "チャットメッセージにアクセス"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:138
 msgid "Account"
-msgstr ""
+msgstr "アカウント"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:71
 msgid "Already have a code?"
-msgstr ""
+msgstr "コードをすでに持っていますか？"
 
 #: src/components/utils/client-name.tsx:35
 msgid "An application on your device"
-msgstr ""
+msgstr "デバイス上のアプリ"
 
 #: src/components/utils/error-message.tsx:87
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "何らかのエラーが発生しました"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:110
 msgid "Another account"
-msgstr ""
+msgstr "他のアカウント"
 
 #: src/views/authorize/welcome/welcome-view.tsx:28
 msgid "Authenticate"
-msgstr ""
+msgstr "認証"
 
 #: src/views/authorize/accept/accept-view.tsx:55
 #: src/views/authorize/accept/accept-form.tsx:56
 msgid "Authorize"
-msgstr ""
+msgstr "許可"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:47
 #: src/views/authorize/sign-in/sign-in-form.tsx:130
@@ -68,420 +68,420 @@ msgstr ""
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
 msgid "Back"
-msgstr ""
+msgstr "戻る"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:152
 msgid "Between {minLength} and {maxLength} characters"
-msgstr ""
+msgstr "{minLength} 文字以上 {maxLength} 文字以下"
 
 #: src/views/authorize/accept/accept-form.tsx:89
 msgid "By clicking <0>Authorize</0>, you allow this application to perform the following actions in accordance with their <1>terms of service</1> and <2>privacy policy</2>:"
-msgstr ""
+msgstr "<0>許可</0>をクリックすると、<1>利用規約</1>と<2>プライバシーポリシー</2>に従って、このアプリが次のアクションを実行することを許可します："
 
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:30
 msgid "By creating an account you agree to the {0} and the {1} of this service."
-msgstr ""
+msgstr "アカウントを作成するとこのサービスの {0} および {1} に同意したことになります。"
 
 #: src/views/authorize/welcome/welcome-view.tsx:51
 msgid "Cancel"
-msgstr ""
+msgstr "キャンセル"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
-msgstr ""
+msgstr "確認コードが記載されたメール {0} を確認し、ここに入力してください。"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:94
 msgid "Choose a username"
-msgstr ""
+msgstr "ユーザー名を選んでください"
 
 #: src/components/utils/error-card.tsx:76
 msgid "Code"
-msgstr ""
+msgstr "コード"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:135
 msgid "Confirm"
-msgstr ""
+msgstr "確認"
 
 #: src/views/authorize/sign-in/sign-in-view.tsx:65
 msgid "Confirm your password to continue"
-msgstr ""
+msgstr "続けるにはパスワードを確認してください"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
-msgstr ""
+msgstr "確認コード"
 
 #: src/views/authorize/welcome/welcome-view.tsx:35
 msgid "Create a new account"
-msgstr ""
+msgstr "新規アカウントの作成"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:78
 msgid "Create Account"
-msgstr ""
+msgstr "アカウントを作成"
 
 #: src/views/authorize/accept/accept-form.tsx:60
 msgid "Deny access"
-msgstr ""
+msgstr "アクセス拒否"
 
 #: src/components/utils/error-card.tsx:83
 msgid "Description"
-msgstr ""
+msgstr "説明"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:114
 msgid "Email"
-msgstr ""
+msgstr "メールアドレス"
 
 #: src/views/authorize/reset-password/reset-password-request-form.tsx:55
 #: src/views/authorize/reset-password/reset-password-request-form.tsx:60
 #: src/components/forms/input-email-address.tsx:51
 msgid "Email address"
-msgstr ""
+msgstr "メールアドレス"
 
 #: src/components/forms/input-new-password.tsx:44
 msgid "Enter a password"
-msgstr ""
+msgstr "パスワードを入力"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:85
 msgid "Enter the code you received to reset your password."
-msgstr ""
+msgstr "パスワードを変更するために受け取ったコードを入力してください。"
 
 #: src/views/authorize/reset-password/reset-password-request-form.tsx:71
 msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
-msgstr ""
+msgstr "アカウントの作成に使用したメールアドレスを入力します。新しいパスワードを設定できるように、「リセットコード」をお送りします。"
 
 #: src/views/authorize/reset-password/reset-password-request-form.tsx:58
 msgid "Enter your email address"
-msgstr ""
+msgstr "メールアドレスを入力してください"
 
 #: src/components/forms/input-new-password.tsx:45
 msgid "Enter your new password"
-msgstr ""
+msgstr "新しいパスワードを入力してください"
 
 #: src/views/authorize/sign-in/sign-in-view.tsx:86
 msgid "Enter your password"
-msgstr ""
+msgstr "パスワードを入力"
 
 #: src/views/authorize/sign-in/sign-in-view.tsx:104
 #: src/views/authorize/sign-in/sign-in-view.tsx:120
 msgid "Enter your username and password"
-msgstr ""
+msgstr "ユーザー名とパスワードを入力してください"
 
 #: src/views/error/error-view.tsx:27
 msgid "Error"
-msgstr ""
+msgstr "エラー"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:102
 msgid "example-com-xxxxx-xxxxx"
-msgstr ""
+msgstr "example-com-xxxxx-xxxxx"
 
 #: src/components/utils/password-strength-label.tsx:25
 msgid "Extra"
-msgstr ""
+msgstr "最強"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:53
 msgid "Forgot Password"
-msgstr ""
+msgstr "パスワードを忘れた"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:178
 msgid "Forgot?"
-msgstr ""
+msgstr "忘れた？"
 
 #: src/views/authorize/accept/accept-view.tsx:40
 msgid "Grant access to your <0>{0}</0> account"
-msgstr ""
+msgstr "<0>{0}</0> アカウントへのアクセスを許可"
 
 #: src/components/utils/help-card.tsx:32
 msgid "Having trouble? <0>Contact support</0>"
-msgstr ""
+msgstr "なにか問題が発生しましたか？ <0>サポートに連絡</0>"
 
 #: src/components/forms/button-toggle-visibility.tsx:34
 msgid "Hide"
-msgstr ""
+msgstr "隠す"
 
 #: src/components/utils/link-title.tsx:15
 msgid "Home"
-msgstr ""
+msgstr "ホーム"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:86
 msgid "Identifier"
-msgstr ""
+msgstr "識別子"
 
 #: src/locales/locale-selector.tsx:48
 msgid "Interface language selector"
-msgstr ""
+msgstr "言語選択"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:275
 msgid "Invalid"
-msgstr ""
+msgstr "無効"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:96
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:101
 msgid "Invite code"
-msgstr ""
+msgstr "招待コード"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:55
 msgid "Let's get your password reset!"
-msgstr ""
+msgstr "パスワードをリセットしましょう！"
 
 #: src/views/authorize/authorize-view.tsx:172
 msgid "Login complete"
-msgstr ""
+msgstr "ログイン完了"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:104
 msgid "Login to account that is not listed"
-msgstr ""
+msgstr "リストにないアカウントにログイン"
 
 #: src/components/forms/input-token.tsx:59
 msgid "Looks like {example}"
-msgstr ""
+msgstr "{example} のように"
 
 #: src/components/forms/button-toggle-visibility.tsx:34
 msgid "Make visible"
-msgstr ""
+msgstr "表示する"
 
 #: src/components/utils/password-strength-label.tsx:33
 msgid "Missing"
-msgstr ""
+msgstr "無し"
 
 #: src/components/utils/password-strength-label.tsx:29
 msgid "Moderate"
-msgstr ""
+msgstr "中程度"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:80
 msgid "Name"
-msgstr ""
+msgstr "名前"
 
 #: src/views/authorize/reset-password/reset-password-confirm-form.tsx:76
 msgid "New password"
-msgstr ""
+msgstr "新しいパスワード"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:60
 #: src/views/authorize/reset-password/reset-password-view.tsx:90
 #: src/components/forms/wizard-card.tsx:96
 msgid "Next"
-msgstr ""
+msgstr "次へ"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:119
 msgid "Okay"
-msgstr ""
+msgstr "OK"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:157
 msgid "Only letters, numbers, and hyphens"
-msgstr ""
+msgstr "英数字とハイフンのみ"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
-msgstr ""
+msgstr "パスワード"
 
 #: src/components/utils/password-strength-label.tsx:23
 msgid "Password strength"
-msgstr ""
+msgstr "パスワード強度"
 
 #: src/components/utils/password-strength-meter.tsx:45
 msgid "Password strength indicator"
-msgstr ""
+msgstr "パスワード強度表示"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:106
 msgid "Password Updated"
-msgstr ""
+msgstr "パスワードが更新されました"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:113
 msgid "Password updated!"
-msgstr ""
+msgstr "パスワードが更新されました！"
 
 #: src/components/forms/input-new-password.tsx:46
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
-msgstr ""
+msgstr "パスワードは {MIN_PASSWORD_LENGTH} 文字以上"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:192
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
-msgstr ""
+msgstr "パスワードを入力する前に、ウェブサイトのドメインを確認してください。信用できないドメインには絶対パスワードを入力しないでください。"
 
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:42
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:45
 #: src/components/utils/link-title.tsx:17
 msgid "Privacy Policy"
-msgstr ""
+msgstr "プライバシーポリシー"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:206
 #: src/views/authorize/sign-in/sign-in-form.tsx:211
 msgid "Remember this account on this device"
-msgstr ""
+msgstr "このアカウントをこのデバイスに記憶する"
 
 #: src/views/authorize/accept/accept-form.tsx:123
 msgid "Requested permissions"
-msgstr ""
+msgstr "権限を要求"
 
 #: src/views/authorize/reset-password/reset-password-confirm-form.tsx:61
 msgid "Reset code"
-msgstr ""
+msgstr "リセットコード"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:82
 msgid "Reset Password"
-msgstr ""
+msgstr "パスワードをリセット"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:176
 msgid "Reset your password"
-msgstr ""
+msgstr "パスワードをリセット"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:196
 msgid "Select domain"
-msgstr ""
+msgstr "ドメインを選択"
 
 #: src/views/authorize/sign-in/sign-in-view.tsx:135
 msgid "Select from an existing account"
-msgstr ""
+msgstr "既存のアカウントから選択"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:202
 msgid "Session"
-msgstr ""
+msgstr "セッション"
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
 msgid "Sign in"
-msgstr ""
+msgstr "サインイン"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:75
 msgid "Sign in as {0}"
-msgstr ""
+msgstr "{0} でサインイン"
 
 #: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign in as..."
-msgstr ""
+msgstr "アカウントの選択"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:84
 msgid "Sign up"
-msgstr ""
+msgstr "サインアップ"
 
 #: src/components/forms/wizard-card.tsx:106
 msgid "Step {currentPosition} of {count}"
-msgstr ""
+msgstr "ステップ {currentPosition} / {count}"
 
 #: src/components/utils/password-strength-label.tsx:27
 msgid "Strong"
-msgstr ""
+msgstr "強い"
 
 #: src/components/forms/form-card-async.tsx:96
 msgid "Submit"
-msgstr ""
+msgstr "送信"
 
 #: src/components/utils/link-title.tsx:21
 msgid "Support"
-msgstr ""
+msgstr "サポート"
 
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:34
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:37
 #: src/components/utils/link-title.tsx:19
 msgid "Terms of Service"
-msgstr ""
+msgstr "利用規約"
 
 #: src/components/utils/error-message.tsx:52
 msgid "That handle cannot be used"
-msgstr ""
+msgstr "そのハンドルは使用できません"
 
 #: src/components/utils/error-message.tsx:69
 msgid "The data you submitted is invalid. Please check the form and try again."
-msgstr ""
+msgstr "送信データが正しくありません。フォームをチェックしてもう一度お試しください。"
 
 #: src/components/utils/error-message.tsx:43
 msgid "The domain name is not allowed"
-msgstr ""
+msgstr "ドメイン名が正しくありません"
 
 #: src/components/utils/error-message.tsx:45
 msgid "The handle contains inappropriate language"
-msgstr ""
+msgstr "ハンドルが不適切な言語を含んでいます"
 
 #: src/components/utils/error-message.tsx:50
 msgid "The handle is already in use"
-msgstr ""
+msgstr "ハンドルはすでに使用されています"
 
 #: src/components/utils/error-message.tsx:41
 msgid "The handle is invalid"
-msgstr ""
+msgstr "ハンドルは無効です"
 
 #: src/components/utils/error-message.tsx:35
 msgid "The invite code is not valid"
-msgstr ""
+msgstr "招待コードが有効ではありません"
 
 #: src/components/utils/error-message.tsx:77
 msgid "This authorization request has been denied. Please try again."
-msgstr ""
+msgstr "この承認リクエストは拒否されました。もう一度お試しください。"
 
 #: src/components/utils/error-message.tsx:57
 msgid "This email is already used"
-msgstr ""
+msgstr "このメールアドレスはすでに使用されています"
 
 #: src/components/utils/error-message.tsx:48
 msgid "This handle is reserved"
-msgstr ""
+msgstr "このハンドルは予約されています"
 
 #: src/components/utils/error-message.tsx:64
 msgid "This sign-in session has expired"
-msgstr ""
+msgstr "このサインインセッションの有効期限が切れました"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:166
 msgid "Type your desired username"
-msgstr ""
+msgstr "希望するユーザー名をタイプしてください"
 
 #: src/components/utils/error-message.tsx:84
 msgid "Unexpected server response"
-msgstr ""
+msgstr "予期しないサーバー応答"
 
 #: src/views/authorize/accept/accept-form.tsx:142
 msgid "Uniquely identify you"
-msgstr ""
+msgstr "あなたを一意に識別"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:143
 msgid "Username or email address"
-msgstr ""
+msgstr "ユーザー名またはメールアドレス"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:270
 msgid "Valid"
-msgstr ""
+msgstr "有効"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:135
 msgid "Verify you are human"
-msgstr ""
+msgstr "あなたが人間か確認"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:189
 msgid "Warning"
-msgstr ""
+msgstr "警告"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "We're so excited to have you join us!"
-msgstr ""
+msgstr "私たちはあなたが参加してくれることをとても楽しみにしています！"
 
 #: src/components/utils/password-strength-label.tsx:31
 msgid "Weak"
-msgstr ""
+msgstr "弱い"
 
 #: src/components/utils/error-message.tsx:31
 msgid "Wrong identifier or password"
-msgstr ""
+msgstr "識別子またはパスワードが間違っています"
 
 #: src/views/authorize/authorize-view.tsx:173
 msgid "You are being redirected..."
-msgstr ""
+msgstr "リダイレクトしています…"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:235
 msgid "You can change this username to any domain name you control after your account is set up."
-msgstr ""
+msgstr "アカウントのセットアップ後にユーザー名とドメインを変更することができます。"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:116
 msgid "You can now sign in with your new password."
-msgstr ""
+msgstr "新しいパスワードでサインインできるようになりました。"
 
 #: src/views/authorize/reset-password/reset-password-confirm-form.tsx:54
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
-msgstr ""
+msgstr "「リセットコード」が記載されたメールが届きます。ここにコードを入力し、新しいパスワードを入力します。"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:116
 msgid "Your account"
-msgstr ""
+msgstr "あなたのアカウント"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:217
 msgid "Your full username will be: {0}"
-msgstr ""
+msgstr "あなたのフルのユーザー名： {0}"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:108
 msgid "Your password has been updated!"
-msgstr ""
+msgstr "パスワードが変更されました！"

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -19,7 +19,7 @@ msgstr "<0/> があなたのアカウント (<1/>) へのアクセス権限を�
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
-msgstr "２要素認証"
+msgstr "２要素認証の確認"
 
 #: src/components/utils/error-message.tsx:27
 msgid "A second authentication factor is required"
@@ -80,7 +80,7 @@ msgstr "<0>許可</0>をクリックすると、<1>利用規約</1>と<2>プラ�
 
 #: src/views/authorize/sign-up/sign-up-disclaimer.tsx:30
 msgid "By creating an account you agree to the {0} and the {1} of this service."
-msgstr "アカウントを作成するとこのサービスの {0} および {1} に同意したことになります。"
+msgstr "アカウントを作成することで、このサービスの {0} および {1} に同意したものとみなされます。"
 
 #: src/views/authorize/welcome/welcome-view.tsx:51
 msgid "Cancel"
@@ -232,7 +232,7 @@ msgstr "リストにないアカウントにログイン"
 
 #: src/components/forms/input-token.tsx:59
 msgid "Looks like {example}"
-msgstr "{example} のように"
+msgstr "{example} みたいなもの"
 
 #: src/components/forms/button-toggle-visibility.tsx:34
 msgid "Make visible"
@@ -440,7 +440,7 @@ msgstr "有効"
 
 #: src/views/authorize/sign-up/sign-up-view.tsx:135
 msgid "Verify you are human"
-msgstr "あなたが人間か確認"
+msgstr "あなたが人間であることを確認"
 
 #: src/views/authorize/sign-in/sign-in-form.tsx:189
 msgid "Warning"
@@ -480,7 +480,7 @@ msgstr "あなたのアカウント"
 
 #: src/views/authorize/sign-up/sign-up-handle-form.tsx:217
 msgid "Your full username will be: {0}"
-msgstr "あなたのフルのユーザー名： {0}"
+msgstr "あなたのフルユーザー名： {0}"
 
 #: src/views/authorize/reset-password/reset-password-view.tsx:108
 msgid "Your password has been updated!"


### PR DESCRIPTION
Thanks for making the strings easier to translate on #2945.
I translated it into Japanese, please merge it if there is no problem.