### PR TITLE
fix(oauth-provider): hCaptcha error codes should be optional

### DIFF
--- a/.changeset/hip-turtles-poke.md
+++ b/.changeset/hip-turtles-poke.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+hCaptcha error codes should be optional

--- a/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
+++ b/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
@@ -54,9 +54,10 @@ export const hcaptchaVerifyResultSchema = z.object({
    */
   hostname: z.string(),
   /**
-   * optional: any error codes
+   * optional: any error codes returned by the hCaptcha API.
+   * @see {@link https://docs.hcaptcha.com/#siteverify-error-codes-table}
    */
-  'error-codes': z.array(z.string()),
+  'error-codes': z.array(z.string()).optional(),
   /**
    * ENTERPRISE feature: a score denoting malicious activity. Value ranges from
    * 0.0 (no risk) to 1.0 (confirmed threat).

--- a/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
+++ b/packages/oauth/oauth-provider/src/lib/hcaptcha.ts
@@ -52,7 +52,7 @@ export const hcaptchaVerifyResultSchema = z.object({
   /**
    * the hostname of the site where the challenge was passed
    */
-  hostname: z.string(),
+  hostname: z.string().nullable(),
   /**
    * optional: any error codes returned by the hCaptcha API.
    * @see {@link https://docs.hcaptcha.com/#siteverify-error-codes-table}


### PR DESCRIPTION
When trying to create an account using the signup flow with hCapctha configured, it currently fails as it expects there to be an error when calling the API.

Body sent in `/oauth/authorize/sign-up`:
```json
{"email":"abc@gmail.com","password":"REDACTED_PASSWORD","inviteCode":"abc@gmail.com","handle":"abc.partall.no","hcaptchaToken":"REDACTED_TOKEN","locale":"en"}
```

Looking at server side logs:
```
type:"InvalidRequestError"
message:"hCaptcha verification failed: [ { "code": "invalid_type", "expected": "array", "received": "undefined", "path": [ "error-codes" ], "message": "Required" } ]"
stack:"InvalidRequestError: hCaptcha verification failed at Function.from (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/errors/invalid-request-error.ts:30:12) at <anonymous> (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:67:35) at process.processTicksAndRejections (node:internal/process/task_queues:105:5) at async AccountManager.processHcaptchaToken (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:58:33) at async Promise.all (index 0) at async AccountManager.buildSignupData (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:98:42) at async AccountManager.signUp (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:117:18) at async OAuthProvider.signUp (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/oauth-provider.ts:752:25) at async <anonymous> (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/oauth-provider.ts:1259:25) at async <anonymous> (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/oauth-provider.ts:1167:45) caused by: ZodError: [ { "code": "invalid_type", "expected": "array", "received": "undefined", "path": [ "error-codes" ], "message": "Required" } ] at get error (/app/node_modules/.pnpm/zod@3.24.2/node_modules/zod/lib/types.js:55:31) at ZodObject.parseAsync (/app/node_modules/.pnpm/zod@3.24.2/node_modules/zod/lib/types.js:196:22) at process.processTicksAndRejections (node:internal/process/task_queues:105:5) at async HCaptchaClient.verify (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/lib/hcaptcha.ts:140:20) at async AccountManager.processHcaptchaToken (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:58:33) at async Promise.all (index 0) at async AccountManager.buildSignupData (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:98:42) at async AccountManager.signUp (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/account/account-manager.ts:117:18) at async OAuthProvider.signUp (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/oauth-provider.ts:752:25) at async <anonymous> (/app/node_modules/.pnpm/@atproto+oauth-provider@0.6.0/node_modules/@atproto/oauth-provider/src/oauth-provider.ts:1259:25)"
error:"invalid_request"
error_description:"hCaptcha verification failed"
status:400
expose:true
name:"InvalidRequestError"
```

hCaptcha docs:
<img width="1006" alt="Screenshot 2025-03-20 at 22 23 37" src="https://github.com/user-attachments/assets/23b9dd3d-f8a2-48eb-9edd-7d02ddea8c97" />

Tested success response code by going to `https://accounts.hcaptcha.com/demo?sitekey=XXX&secret=XXX` (replace XXX with actual token) and you can see what it returns back:
<img width="655" alt="Screenshot 2025-03-20 at 22 31 28" src="https://github.com/user-attachments/assets/d5912c79-2edb-4827-ba37-54ead5f348e5" />
And error:
<img width="642" alt="Screenshot 2025-03-20 at 22 32 57" src="https://github.com/user-attachments/assets/94989c29-c825-46d6-9de5-48d15608f54c" />
