### PR TITLE
Add `@context` for multikey to service DID documents

### DIFF
--- a/packages/bsky/src/api/well-known.ts
+++ b/packages/bsky/src/api/well-known.ts
@@ -11,7 +11,10 @@ export const createRouter = (ctx: AppContext): Router => {
 
     router.get('/.well-known/did.json', (_req, res) => {
       res.json({
-        '@context': ['https://www.w3.org/ns/did/v1'],
+        '@context': [
+          'https://www.w3.org/ns/did/v1',
+          'https://w3id.org/security/multikey/v1',
+        ],
         id: did,
         verificationMethod: [
           {

--- a/packages/ozone/src/api/well-known.ts
+++ b/packages/ozone/src/api/well-known.ts
@@ -11,7 +11,10 @@ export const createRouter = (ctx: AppContext): Router => {
       return res.sendStatus(404)
     }
     res.json({
-      '@context': ['https://www.w3.org/ns/did/v1'],
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/multikey/v1',
+      ],
       id: ctx.cfg.service.did,
       verificationMethod: [
         {


### PR DESCRIPTION
Currently, the `did:web` DID documents served by `bsky` and `ozone` don't import the `multikey` context while they use the `Multikey` type. This leads to the DID documents expand to documents with a wrong URI for the `Multikey` type and no `publicKeyMultibase` property at all:

https://json-ld.org/playground/#startTab=tab-expanded&json-ld=https%3A%2F%2Fapi.bsky.app%2F.well-known%2Fdid.json

```jsonc
[{ /* … */
"https://w3id.org/security#verificationMethod": [{
  "https://w3id.org/security#controller": [
    {
      "@id": "did:web:api.bsky.app"
    }
  ],
  "@id": "did:web:api.bsky.app#atproto",
  "@type": [
    "https://api.bsky.app/.well-known/Multikey"
  ]
}]}]
```

This patch adds the `multikey` context to the service DID documents, so that they can be properly consumed by JSON-LD processors. After this change, the DID documents should expand to something like the following:

https://json-ld.org/playground/#startTab=tab-expanded&json-ld=%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2Fns%2Fdid%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fmultikey%2Fv1%22%5D%2C%22id%22%3A%22did%3Aweb%3Aapi.bsky.app%22%2C%22verificationMethod%22%3A%5B%7B%22id%22%3A%22did%3Aweb%3Aapi.bsky.app%23atproto%22%2C%22type%22%3A%22Multikey%22%2C%22controller%22%3A%22did%3Aweb%3Aapi.bsky.app%22%2C%22publicKeyMultibase%22%3A%22zQ3shpRzb2NDriwCSSsce6EqGxG23kVktHZc57C3NEcuNy1jg%22%7D%5D%2C%22service%22%3A%5B%7B%22id%22%3A%22%23bsky_notif%22%2C%22type%22%3A%22BskyNotificationService%22%2C%22serviceEndpoint%22%3A%22https%3A%2F%2Fapi.bsky.app%22%7D%2C%7B%22id%22%3A%22%23bsky_appview%22%2C%22type%22%3A%22BskyAppView%22%2C%22serviceEndpoint%22%3A%22https%3A%2F%2Fapi.bsky.app%22%7D%5D%7D

```jsonc
[{ /* … */
"https://w3id.org/security#verificationMethod": [{
  "https://w3id.org/security#controller": [
    {
      "@id": "did:web:api.bsky.app"
    }
  ],
  "@id": "did:web:api.bsky.app#atproto",
  "https://w3id.org/security#publicKeyMultibase": [
    {
      "@type": "https://w3id.org/security#multibase",
      "@value": "zQ3shpRzb2NDriwCSSsce6EqGxG23kVktHZc57C3NEcuNy1jg"
    }
  ],
  "@type": [
    "https://w3id.org/security#Multikey"
  ]
}]}]
```

Note that the `BskyNotificationService`, `BskyAppView` and `AtprotoLabeler` types are still not properly defined. Regardless, I guess the change can improve interoperability with non-atproto-specific DID processors with a minimal change.