### PR TITLE
Support more ways to instantiate an `Agent`

### DIFF
--- a/.changeset/small-melons-lay.md
+++ b/.changeset/small-melons-lay.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Support more ways to instantiate an `Agent`

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -1,7 +1,12 @@
 import AwaitLock from 'await-lock'
 import { TID, retry } from '@atproto/common-web'
 import { AtUri, ensureValidDid } from '@atproto/syntax'
-import { FetchHandler, XrpcClient, buildFetchHandler } from '@atproto/xrpc'
+import {
+  FetchHandler,
+  FetchHandlerOptions,
+  XrpcClient,
+  buildFetchHandler,
+} from '@atproto/xrpc'
 import {
   AppBskyActorDefs,
   AppBskyActorProfile,
@@ -100,14 +105,14 @@ export class Agent extends XrpcClient {
 
   readonly sessionManager: SessionManager
 
-  constructor(options: string | URL | SessionManager) {
+  constructor(options: SessionManager | FetchHandler | FetchHandlerOptions) {
     const sessionManager: SessionManager =
-      typeof options === 'string' || options instanceof URL
-        ? {
+      typeof options === 'object' && 'fetchHandler' in options
+        ? options
+        : {
             did: undefined,
             fetchHandler: buildFetchHandler(options),
           }
-        : options
 
     super((url, init) => {
       const headers = new Headers(init?.headers)


### PR DESCRIPTION
Currently, an `Agent` can be instanciated like so:

```ts
// From a base url `string`
const agent = new Agent('https://base-url.com')
```

```ts
// From a base `URL`
const agent = new Agent(new URL('https://base-url.com'))
```

```ts
// From a `SessionManager` interface, if we need to manipulate the headers
const agent = new Agent({
  did,
  fetchHandler: (path, init) => {
    const url = new URL(path, 'https://base-url.com')
    const headers = new Headers(init?.headers)
    headers.set('authorization', 'BaSiC ...')
    return globalThis.fetch(url, { ...init, headers })
  }
})
```

This change adds the possibility to instantiate an `Agent` using a more concise syntax, in particular when trying to add custom HTTP headers:

```ts
const agent = new Agent({
  service: 'https://...'
  headers: { authorization: 'BaSiC ...' }
})
```
