### PR TITLE
Consistenlty log errors with pino

### DIFF
--- a/.changeset/smart-socks-destroy.md
+++ b/.changeset/smart-socks-destroy.md
@@ -1,0 +1,8 @@
+---
+"@atproto/xrpc-server": patch
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/pds": patch
+---
+
+Consistenlty log errors

--- a/packages/bsky/src/api/health.ts
+++ b/packages/bsky/src/api/health.ts
@@ -37,7 +37,7 @@ Most API routes are under /xrpc/
     try {
       await ctx.dataplane.ping({})
     } catch (err) {
-      req.log.error(err, 'failed health check')
+      req.log.error({ err }, 'failed health check')
       return res.status(503).send({ version, error: 'Service Unavailable' })
     }
     res.send({ version })

--- a/packages/bsky/src/data-plane/server/background.ts
+++ b/packages/bsky/src/data-plane/server/background.ts
@@ -16,7 +16,7 @@ export class BackgroundQueue {
     this.queue
       .add(() => task(this.db))
       .catch((err) => {
-        dbLogger.error(err, 'background queue task failed')
+        dbLogger.error({ err }, 'background queue task failed')
       })
   }
 

--- a/packages/bsky/src/error.ts
+++ b/packages/bsky/src/error.ts
@@ -3,7 +3,7 @@ import { XRPCError } from '@atproto/xrpc-server'
 import { httpLogger as log } from './logger'
 
 export const handler: ErrorRequestHandler = (err, _req, res, next) => {
-  log.error(err, 'unexpected internal server error')
+  log.error({ err }, 'unexpected internal server error')
   if (res.headersSent) {
     return next(err)
   }

--- a/packages/bsky/src/image/server.ts
+++ b/packages/bsky/src/image/server.ts
@@ -102,7 +102,7 @@ export function createMiddleware(
         // Cache in the background
         cache
           .put(cacheKey, cloneStream(processor))
-          .catch((err) => log.error(err, 'failed to cache image'))
+          .catch((err) => log.error({ err }, 'failed to cache image'))
 
         res.statusCode = 200
         res.setHeader('cache-control', `public, max-age=31536000`) // 1 year

--- a/packages/ozone/src/api/health.ts
+++ b/packages/ozone/src/api/health.ts
@@ -17,7 +17,7 @@ export const createRouter = (ctx: AppContext): Router => {
     try {
       await sql`select 1`.execute(ctx.db.db)
     } catch (err) {
-      req.log.error(err, 'failed health check')
+      req.log.error({ err }, 'failed health check')
       return res.status(503).send({ version, error: 'Service Unavailable' })
     }
     res.send({ version })

--- a/packages/ozone/src/background.ts
+++ b/packages/ozone/src/background.ts
@@ -58,7 +58,7 @@ export class BackgroundQueue {
         await task(this.db, abortController.signal)
       } catch (err) {
         if (!isCausedBySignal(err, abortController.signal)) {
-          dbLogger.error(err, 'background queue task failed')
+          dbLogger.error({ err }, 'background queue task failed')
         }
       } finally {
         abortController.abort()

--- a/packages/ozone/src/error.ts
+++ b/packages/ozone/src/error.ts
@@ -3,7 +3,7 @@ import { XRPCError } from '@atproto/xrpc-server'
 import { httpLogger as log } from './logger'
 
 export const handler: ErrorRequestHandler = (err, _req, res, next) => {
-  log.error(err, 'unexpected internal server error')
+  log.error({ err }, 'unexpected internal server error')
   if (res.headersSent) {
     return next(err)
   }

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -727,7 +727,7 @@ export class ModerationService {
               this.eventPusher
                 .attemptBlobEvent(evt.id)
                 .catch((err) =>
-                  log.error({ err, ...evt }, 'failed to push blob event'),
+                  log.error({ ...evt, err }, 'failed to push blob event'),
                 ),
             ),
           )

--- a/packages/ozone/src/team/index.ts
+++ b/packages/ozone/src/team/index.ts
@@ -225,11 +225,8 @@ export class TeamService {
           profiles.set(profile.did, profile)
         })
       }
-    } catch (error) {
-      httpLogger.error(
-        { error, dids },
-        'Failed to get profiles for team members',
-      )
+    } catch (err) {
+      httpLogger.error({ err, dids }, 'Failed to get profiles for team members')
     }
 
     return profiles

--- a/packages/pds/src/background.ts
+++ b/packages/pds/src/background.ts
@@ -15,7 +15,7 @@ export class BackgroundQueue {
     this.queue
       .add(() => task())
       .catch((err) => {
-        dbLogger.error(err, 'background queue task failed')
+        dbLogger.error({ err }, 'background queue task failed')
       })
   }
 

--- a/packages/pds/src/basic-routes.ts
+++ b/packages/pds/src/basic-routes.ts
@@ -41,7 +41,7 @@ Most API routes are under /xrpc/
     try {
       await sql`select 1`.execute(ctx.accountManager.db.db)
     } catch (err) {
-      req.log.error(err, 'failed health check')
+      req.log.error({ err }, 'failed health check')
       res.status(503).send({ version, error: 'Service Unavailable' })
       return
     }

--- a/packages/pds/src/error.ts
+++ b/packages/pds/src/error.ts
@@ -4,7 +4,7 @@ import { XRPCError } from '@atproto/xrpc-server'
 import { httpLogger as log } from './logger'
 
 export const handler: ErrorRequestHandler = (err, _req, res, next) => {
-  log.error(err, 'unexpected internal server error')
+  log.error({ err }, 'unexpected internal server error')
   if (res.headersSent) {
     return next(err)
   }

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -545,7 +545,7 @@ function createErrorMiddleware({
     const xrpcError = errorParser(err)
     if (xrpcError instanceof InternalServerError) {
       // log trace for unhandled exceptions
-      log.error(err, `unhandled exception in xrpc${methodSuffix}`)
+      log.error({ err }, `unhandled exception in xrpc${methodSuffix}`)
     } else {
       // do not log trace for known xrpc errors
       log.error(

--- a/packages/xrpc-server/src/stream/server.ts
+++ b/packages/xrpc-server/src/stream/server.ts
@@ -36,7 +36,7 @@ export class XrpcStreamServer {
         if (err instanceof DisconnectError) {
           return socket.close(err.wsCode, err.xrpcCode)
         } else {
-          logger.error(err, 'websocket server error')
+          logger.error({ err }, 'websocket server error')
           return socket.terminate()
         }
       }


### PR DESCRIPTION
Pino logger should always be called with a "mixin object" `logger.error({ err })`. Currently, some places are calling `logger.error(err)`. This change fixes that.