### PR TITLE
Appview: skip actor cache for viewer

### DIFF
--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -381,6 +381,7 @@ message GetActorRepostsResponse {
 //     - should this include handles?  apply repo takedown?
 message GetActorsRequest {
   repeated string dids = 1;
+  repeated string skip_cache_for_dids = 2;
 }
 
 message ActorInfo {

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -70,10 +70,10 @@ export const skeleton = async (inputs: {
   if (!did) {
     throw new InvalidRequestError('Profile not found')
   }
-  const actors = await ctx.hydrator.actor.getActors(
-    [did],
-    params.hydrateCtx.includeTakedowns,
-  )
+  const actors = await ctx.hydrator.actor.getActors([did], {
+    includeTakedowns: params.hydrateCtx.includeTakedowns,
+    skipCache: params.hydrateCtx.viewer,
+  })
   const actor = actors.get(did)
   if (!actor) {
     throw new InvalidRequestError('Profile not found')

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -72,7 +72,7 @@ export const skeleton = async (inputs: {
   }
   const actors = await ctx.hydrator.actor.getActors([did], {
     includeTakedowns: params.hydrateCtx.includeTakedowns,
-    skipCache: params.hydrateCtx.viewer,
+    skipCacheForDids: params.hydrateCtx.skipCacheForViewer,
   })
   const actor = actors.get(did)
   if (!actor) {

--- a/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
@@ -76,6 +76,8 @@ type SkeletonState = {
 }
 
 const getPriority = async (ctx: Context, did: string) => {
-  const actors = await ctx.hydrator.actor.getActors([did], { skipCache: did })
+  const actors = await ctx.hydrator.actor.getActors([did], {
+    skipCacheForDids: [did],
+  })
   return !!actors.get(did)?.priorityNotifications
 }

--- a/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
@@ -76,6 +76,6 @@ type SkeletonState = {
 }
 
 const getPriority = async (ctx: Context, did: string) => {
-  const actors = await ctx.hydrator.actor.getActors([did])
+  const actors = await ctx.hydrator.actor.getActors([did], { skipCache: did })
   return !!actors.get(did)?.priorityNotifications
 }

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -246,6 +246,6 @@ type SkeletonState = {
 }
 
 const getPriority = async (ctx: Context, did: string) => {
-  const actors = await ctx.hydrator.actor.getActors([did])
+  const actors = await ctx.hydrator.actor.getActors([did], { skipCache: did })
   return !!actors.get(did)?.priorityNotifications
 }

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -246,6 +246,8 @@ type SkeletonState = {
 }
 
 const getPriority = async (ctx: Context, did: string) => {
-  const actors = await ctx.hydrator.actor.getActors([did], { skipCache: did })
+  const actors = await ctx.hydrator.actor.getActors([did], {
+    skipCacheForDids: [did],
+  })
   return !!actors.get(did)?.priorityNotifications
 }

--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -12,7 +12,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const actors = await ctx.hydrator.actor.getActors(dids, {
         includeTakedowns: true,
-        skipCache: dids,
+        skipCacheForDids: dids,
       })
 
       const infos = mapDefined(dids, (did) => {

--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -10,7 +10,10 @@ export default function (server: Server, ctx: AppContext) {
       const { dids } = params
       const { includeTakedowns } = ctx.authVerifier.parseCreds(auth)
 
-      const actors = await ctx.hydrator.actor.getActors(dids, true)
+      const actors = await ctx.hydrator.actor.getActors(dids, {
+        includeTakedowns: true,
+        skipCache: dids,
+      })
 
       const infos = mapDefined(dids, (did) => {
         const info = actors.get(did)

--- a/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
@@ -47,7 +47,12 @@ export default function (server: Server, ctx: AppContext) {
           }
         }
       } else if (did) {
-        const res = (await ctx.hydrator.actor.getActors([did], true)).get(did)
+        const res = (
+          await ctx.hydrator.actor.getActors([did], {
+            includeTakedowns: true,
+            skipCache: did,
+          })
+        ).get(did)
         if (res) {
           body = {
             subject: {

--- a/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
@@ -50,7 +50,7 @@ export default function (server: Server, ctx: AppContext) {
         const res = (
           await ctx.hydrator.actor.getActors([did], {
             includeTakedowns: true,
-            skipCache: did,
+            skipCacheForDids: [did],
           })
         ).get(did)
         if (res) {

--- a/packages/bsky/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/bsky/src/api/com/atproto/repo/getRecord.ts
@@ -14,7 +14,9 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError(`Could not find repo: ${repo}`)
       }
 
-      const actors = await ctx.hydrator.actor.getActors([did], includeTakedowns)
+      const actors = await ctx.hydrator.actor.getActors([did], {
+        includeTakedowns,
+      })
       if (!actors.get(did)) {
         throw new InvalidRequestError(`Could not find repo: ${repo}`)
       }

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -104,19 +104,12 @@ export class ActorHydrator {
     dids: string[],
     opts: {
       includeTakedowns?: boolean
-      skipCache?: string | string[] | null
+      skipCacheForDids?: string[]
     } = {},
   ): Promise<Actors> {
-    const { includeTakedowns = false, skipCache } = opts
+    const { includeTakedowns = false, skipCacheForDids } = opts
     if (!dids.length) return new HydrationMap<Actor>()
-    const res = await this.dataplane.getActors({
-      dids,
-      skipCacheForDids: skipCache
-        ? typeof skipCache === 'string'
-          ? [skipCache]
-          : skipCache
-        : undefined,
-    })
+    const res = await this.dataplane.getActors({ dids, skipCacheForDids })
     return dids.reduce((acc, did, i) => {
       const actor = res.actors[i]
       const isNoHosted =

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -100,9 +100,23 @@ export class ActorHydrator {
     return res.filter((did) => did !== undefined)
   }
 
-  async getActors(dids: string[], includeTakedowns = false): Promise<Actors> {
+  async getActors(
+    dids: string[],
+    opts: {
+      includeTakedowns?: boolean
+      skipCache?: string | string[] | null
+    } = {},
+  ): Promise<Actors> {
+    const { includeTakedowns = false, skipCache } = opts
     if (!dids.length) return new HydrationMap<Actor>()
-    const res = await this.dataplane.getActors({ dids })
+    const res = await this.dataplane.getActors({
+      dids,
+      skipCacheForDids: skipCache
+        ? typeof skipCache === 'string'
+          ? [skipCache]
+          : skipCache
+        : undefined,
+    })
     return dids.reduce((acc, did, i) => {
       const actor = res.actors[i]
       const isNoHosted =

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -71,6 +71,11 @@ export class HydrateCtx {
   includeActorTakedowns = this.vals.includeActorTakedowns
   include3pBlocks = this.vals.include3pBlocks
   constructor(private vals: HydrateCtxVals) {}
+  // Convenience with use with dataplane.getActors cache control
+  get skipCacheForViewer() {
+    if (!this.viewer) return
+    return [this.viewer]
+  }
   copy<V extends Partial<HydrateCtxVals>>(vals?: V): HydrateCtx & V {
     return new HydrateCtx({ ...this.vals, ...vals }) as HydrateCtx & V
   }
@@ -191,7 +196,10 @@ export class Hydrator {
   ): Promise<HydrationState> {
     const includeTakedowns = ctx.includeTakedowns || ctx.includeActorTakedowns
     const [actors, labels, profileViewersState] = await Promise.all([
-      this.actor.getActors(dids, { includeTakedowns, skipCache: ctx.viewer }),
+      this.actor.getActors(dids, {
+        includeTakedowns,
+        skipCacheForDids: ctx.skipCacheForViewer,
+      }),
       this.label.getLabelsForSubjects(labelSubjectsForDid(dids), ctx.labelers),
       this.hydrateProfileViewers(dids, ctx),
     ])
@@ -306,7 +314,7 @@ export class Hydrator {
       ),
       this.actor.getActors(includeAuthorDids, {
         includeTakedowns: ctx.includeTakedowns,
-        skipCache: ctx.viewer,
+        skipCacheForDids: ctx.skipCacheForViewer,
       }),
     ])
 

--- a/packages/bsky/src/proto/bsky_pb.ts
+++ b/packages/bsky/src/proto/bsky_pb.ts
@@ -4474,6 +4474,11 @@ export class GetActorsRequest extends Message<GetActorsRequest> {
    */
   dids: string[] = []
 
+  /**
+   * @generated from field: repeated string skip_cache_for_dids = 2;
+   */
+  skipCacheForDids: string[] = []
+
   constructor(data?: PartialMessage<GetActorsRequest>) {
     super()
     proto3.util.initPartial(data, this)
@@ -4485,6 +4490,13 @@ export class GetActorsRequest extends Message<GetActorsRequest> {
     {
       no: 1,
       name: 'dids',
+      kind: 'scalar',
+      T: 9 /* ScalarType.STRING */,
+      repeated: true,
+    },
+    {
+      no: 2,
+      name: 'skip_cache_for_dids',
       kind: 'scalar',
       T: 9 /* ScalarType.STRING */,
       repeated: true,


### PR DESCRIPTION
This applies new cache control behavior to dataplane calls to `GetActors` within the appview.  In short, we want to ensure the user always sees fresh data about themselves.  There are a few other places where we skip the cache, mostly in moderation and admin-specific settings.