### PR TITLE
Ozone: add metadata endpoint

### DIFF
--- a/.changeset/tall-rice-sparkle.md
+++ b/.changeset/tall-rice-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@atproto/ozone": patch
+---
+
+Added well-known metadata endpoint to ozone.

--- a/.github/workflows/build-and-push-ozone-aws.yaml
+++ b/.github/workflows/build-and-push-ozone-aws.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - divy/ozone-passthru
+      - divy/ozone-metadata
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/packages/ozone/src/api/well-known.ts
+++ b/packages/ozone/src/api/well-known.ts
@@ -31,5 +31,13 @@ export const createRouter = (ctx: AppContext): Router => {
     })
   })
 
+  router.get('/.well-known/ozone-metadata.json', (_req, res) => {
+    return res.json({
+      did: ctx.cfg.service.did,
+      url: ctx.cfg.service.publicUrl,
+      publicKey: ctx.signingKey.did(),
+    })
+  })
+
   return router
 }


### PR DESCRIPTION
The ozone distribution uses a [metadata endpoint](https://github.com/bluesky-social/ozone/blob/b6ad1e5e9102373b2c2e94dd99b758c0362b54ad/service/index.js#L34-L40) which allows ozone to help get itself configured through the UI.  Moving this up into the ozone backend itself is convenient when the backend and frontend aren't deployed together through the ozone distribution.

We can remove the endpoint from the ozone distribution once these changes are incorporated there.