### PR TITLE
Oauth: fix typo in jwk error

### DIFF
--- a/packages/oauth/jwk/src/keyset.ts
+++ b/packages/oauth/jwk/src/keyset.ts
@@ -186,7 +186,7 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
     }
 
     throw new JwkError(
-      `No singing key found for ${kid || alg || use || '<unknown>'}`,
+      `No signing key found for ${kid || alg || use || '<unknown>'}`,
       ERR_JWK_NOT_FOUND,
     )
   }


### PR DESCRIPTION
Just a small typo.  Resolves #3742. 