### PR TITLE
Use more secure COEP header when hCaptcha is enabled

### DIFF
--- a/.changeset/chilly-rats-wink.md
+++ b/.changeset/chilly-rats-wink.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Use more secure COEP header when hCaptcha is enabled

--- a/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
+++ b/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
@@ -20,11 +20,6 @@ export function sendAuthorizePageFactory(customization: Customization) {
     SPA_CSP,
     customization?.hcaptcha ? HCAPTCHA_CSP : undefined,
   )
-  const coep = customization?.hcaptcha
-    ? // https://github.com/hCaptcha/react-hcaptcha/issues/259
-      // @TODO Remove the use of `unsafeNone` once the issue above is resolved
-      CrossOriginEmbedderPolicy.unsafeNone
-    : CrossOriginEmbedderPolicy.credentialless
 
   return async function sendAuthorizePage(
     req: IncomingMessage,
@@ -54,7 +49,7 @@ export function sendAuthorizePageFactory(customization: Customization) {
       meta: [{ name: 'robots', content: 'noindex' }],
       body: html`<div id="root"></div>`,
       csp,
-      coep,
+      coep: CrossOriginEmbedderPolicy.credentialless,
       scripts: [script, ...scripts],
       styles: [...styles, customizationCss],
     })


### PR DESCRIPTION
## Context

https://github.com/hCaptcha/react-hcaptcha/issues/259
https://github.com/bluesky-social/atproto/issues/3625