### PR TITLE
Fix typo in lexicon

### DIFF
--- a/lexicons/chat/bsky/actor/defs.json
+++ b/lexicons/chat/bsky/actor/defs.json
@@ -25,7 +25,7 @@
         },
         "chatDisabled": {
           "type": "boolean",
-          "description": "Set to true when the actor cannot actively participate in converations"
+          "description": "Set to true when the actor cannot actively participate in conversations"
         },
         "verification": {
           "type": "ref",


### PR DESCRIPTION
This PR fixes a small typo in `lexicons/chat/bsky/actor/defs.json`:

`converations`
⬇️
`conversations`