### PR TITLE
Return verification views with empty display name values

### DIFF
--- a/.changeset/great-sheep-hear.md
+++ b/.changeset/great-sheep-hear.md
@@ -1,0 +1,5 @@
+---
+"@atproto/bsky": patch
+---
+
+Hydrate verification views with an empty displayName

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -145,7 +145,6 @@ export class ActorHydrator {
         Object.entries(actor.verifiedBy),
         ([actorDid, verificationMeta]) => {
           if (
-            verificationMeta.displayName &&
             verificationMeta.handle &&
             verificationMeta.rkey &&
             verificationMeta.sortedAt

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -145,7 +145,6 @@ export class ActorHydrator {
         Object.entries(actor.verifiedBy),
         ([actorDid, verificationMeta]) => {
           if (
-            typeof verificationMeta.displayName === 'string' &&
             verificationMeta.handle &&
             verificationMeta.rkey &&
             verificationMeta.sortedAt

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -145,6 +145,7 @@ export class ActorHydrator {
         Object.entries(actor.verifiedBy),
         ([actorDid, verificationMeta]) => {
           if (
+            typeof verificationMeta.displayName === 'string' &&
             verificationMeta.handle &&
             verificationMeta.rkey &&
             verificationMeta.sortedAt


### PR DESCRIPTION
It's currently possible to issue verifications for users without display names (which equates to empty strings). However, we do not currently hydrate verifications without a display name, which means they are not returned to the client, and therefore the verifier cannot revoke and re-issue a verification for the user (after they update their display name).

This PR removes that check so that the client can present the verifier with the option to clear this invalid verification and thereby issue a fresh one.