### PR TITLE
Revert hcaptcha COEP requirements

### DIFF
--- a/.changeset/giant-maps-camp.md
+++ b/.changeset/giant-maps-camp.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Revert "Use more secure COEP header when hCaptcha is enabled"

--- a/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
+++ b/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
@@ -20,6 +20,11 @@ export function sendAuthorizePageFactory(customization: Customization) {
     SPA_CSP,
     customization?.hcaptcha ? HCAPTCHA_CSP : undefined,
   )
+  const coep = customization?.hcaptcha
+    ? // https://github.com/hCaptcha/react-hcaptcha/issues/259
+      // @TODO Remove the use of `unsafeNone` once the issue above is resolved
+      CrossOriginEmbedderPolicy.unsafeNone
+    : CrossOriginEmbedderPolicy.credentialless
 
   return async function sendAuthorizePage(
     req: IncomingMessage,
@@ -49,7 +54,7 @@ export function sendAuthorizePageFactory(customization: Customization) {
       meta: [{ name: 'robots', content: 'noindex' }],
       body: html`<div id="root"></div>`,
       csp,
-      coep: CrossOriginEmbedderPolicy.credentialless,
+      coep,
       scripts: [script, ...scripts],
       styles: [...styles, customizationCss],
     })


### PR DESCRIPTION
Reverts https://github.com/bluesky-social/atproto/pull/3755.  Hcaptcha will also need to provide a COEP header for this to be ready.