### PR TITLE
Ozone: fix correctness and perf issues with reporter stats

### DIFF
--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -1,5 +1,5 @@
 import net from 'node:net'
-import { Insertable, sql } from 'kysely'
+import { Insertable, RawBuilder, sql } from 'kysely'
 import { CID } from 'multiformats/cid'
 import { AtpAgent } from '@atproto/api'
 import { addHoursToDate, chunkArray } from '@atproto/common'
@@ -1275,16 +1275,34 @@ export class ModerationService {
     }
   }
 
-  buildModerationQuery(
+  async buildModerationQuery(
     subjectType: 'account' | 'record',
     createdByDids: string[],
     isActionQuery: boolean,
   ): Promise<(Partial<ReporterStatsResult> & { did: string })[]> {
-    const isAccount = subjectType === 'account'
+    if (!createdByDids.length) return []
+
     const actionTypes = [
       'tools.ozone.moderation.defs#modEventTakedown',
       'tools.ozone.moderation.defs#modEventLabel',
     ] as const
+
+    const countAll = () => {
+      return sql<number>`COUNT(*)`
+    }
+    const countAllDistinctBy = (ref: RawBuilder) => {
+      return sql<number>`COUNT(DISTINCT ${ref})`
+    }
+    const countTakedownsDistinctBy = (ref: RawBuilder) => {
+      return sql<number>`COUNT(DISTINCT ${ref}) FILTER (
+        WHERE actions."action" = 'tools.ozone.moderation.defs#modEventTakedown'
+      )`
+    }
+    const countLabelsDistinctBy = (ref: RawBuilder) => {
+      return sql<number>`COUNT(DISTINCT ${ref}) FILTER (
+        WHERE actions."action" = 'tools.ozone.moderation.defs#modEventLabel'
+      )`
+    }
 
     const query = this.db.db
       .selectFrom('moderation_event as reports')
@@ -1293,48 +1311,83 @@ export class ModerationService {
         '=',
         'tools.ozone.moderation.defs#modEventReport',
       )
-      .where('reports.subjectUri', isAccount ? 'is' : 'is not', null)
+      .where(
+        'reports.subjectUri',
+        subjectType === 'account' ? 'is' : 'is not',
+        null,
+      )
       .where('reports.createdBy', 'in', createdByDids)
       .select(['reports.createdBy as did'])
 
-    if (isActionQuery) {
+    if (!isActionQuery) {
+      if (subjectType === 'account') {
+        return query
+          .select([
+            () => countAll().as('accountReportCount'),
+            (eb) =>
+              countAllDistinctBy(eb.ref('reports.subjectDid')).as(
+                'reportedAccountCount',
+              ),
+          ])
+          .groupBy('reports.createdBy')
+          .execute()
+      } else {
+        return query
+          .select([
+            () => countAll().as('recordReportCount'),
+            (eb) =>
+              countAllDistinctBy(eb.ref('reports.subjectUri')).as(
+                'reportedRecordCount',
+              ),
+          ])
+          .groupBy('reports.createdBy')
+          .execute()
+      }
+    }
+
+    if (subjectType === 'account') {
       return query
         .leftJoin('moderation_event as actions', (join) =>
           join
             .onRef('actions.subjectDid', '=', 'reports.subjectDid')
-            .on('actions.subjectUri', isAccount ? 'is' : 'is not', null)
+            .on('actions.subjectUri', 'is', null)
             .onRef('actions.createdAt', '>', 'reports.createdAt')
             .on('actions.action', 'in', actionTypes),
         )
         .select([
-          () =>
-            sql<number>`COUNT(DISTINCT actions."subjectDid") FILTER (
-              WHERE actions."action" = 'tools.ozone.moderation.defs#modEventTakedown'
-            )`.as(`takendown${isAccount ? 'Account' : 'Record'}Count`),
-
-          () =>
-            sql<number>`COUNT(DISTINCT actions."subjectDid") FILTER (
-              WHERE actions."action" = 'tools.ozone.moderation.defs#modEventLabel'
-            )`.as(`labeled${isAccount ? 'Account' : 'Record'}Count`),
+          (eb) =>
+            countTakedownsDistinctBy(eb.ref('actions.subjectDid')).as(
+              'takendownAccountCount',
+            ),
+          (eb) =>
+            countLabelsDistinctBy(eb.ref('actions.subjectDid')).as(
+              'labeledAccountCount',
+            ),
+        ])
+        .groupBy('reports.createdBy')
+        .execute()
+    } else {
+      return query
+        .leftJoin('moderation_event as actions', (join) =>
+          join
+            .onRef('actions.subjectDid', '=', 'reports.subjectDid')
+            .onRef('actions.subjectUri', '=', 'reports.subjectUri')
+            .onRef('actions.createdAt', '>', 'reports.createdAt')
+            .on('actions.action', 'in', actionTypes),
+        )
+        .select([
+          (eb) =>
+            countTakedownsDistinctBy(eb.ref('actions.subjectUri')).as(
+              'takendownRecordCount',
+            ),
+          (eb) =>
+            countLabelsDistinctBy(eb.ref('actions.subjectUri')).as(
+              'labeledRecordCount',
+            ),
         ])
         .groupBy('reports.createdBy')
         .execute()
     }
-
-    return query
-      .select([
-        (eb) =>
-          eb.fn.count<number>('reports.id').as(`${subjectType}ReportCount`),
-        (eb) =>
-          eb.fn
-            .count<number>(
-              isAccount ? 'reports.subjectDid' : 'reports.subjectUri',
-            )
-            .distinct()
-            .as(`reported${isAccount ? 'Account' : 'Record'}Count`),
-      ])
-      .groupBy('reports.createdBy')
-      .execute()
   }
 
   async getReporterStats(dids: string[]) {

--- a/packages/ozone/tests/get-reporter-stats.test.ts
+++ b/packages/ozone/tests/get-reporter-stats.test.ts
@@ -39,7 +39,12 @@ describe('reporter-stats', () => {
   }
 
   it('updates reporter stats based on actions', async () => {
-    const bobsPostSubject = {
+    const bobsPostSubject1 = {
+      $type: 'com.atproto.repo.strongRef',
+      uri: sc.posts[sc.dids.bob][0].ref.uriStr,
+      cid: sc.posts[sc.dids.bob][0].ref.cidStr,
+    }
+    const bobsPostSubject2 = {
       $type: 'com.atproto.repo.strongRef',
       uri: sc.posts[sc.dids.bob][1].ref.uriStr,
       cid: sc.posts[sc.dids.bob][1].ref.cidStr,
@@ -54,13 +59,19 @@ describe('reporter-stats', () => {
         reportedBy: sc.dids.alice,
         reasonType: ComAtprotoModerationDefs.REASONMISLEADING,
         reason: 'misleading',
-        subject: bobsPostSubject,
+        subject: bobsPostSubject1,
       }),
       sc.createReport({
         reportedBy: sc.dids.alice,
         reasonType: ComAtprotoModerationDefs.REASONOTHER,
         reason: 'test',
-        subject: bobsPostSubject,
+        subject: bobsPostSubject1,
+      }),
+      sc.createReport({
+        reportedBy: sc.dids.alice,
+        reasonType: ComAtprotoModerationDefs.REASONOTHER,
+        reason: 'test',
+        subject: bobsPostSubject2,
       }),
       sc.createReport({
         reportedBy: sc.dids.alice,
@@ -75,9 +86,9 @@ describe('reporter-stats', () => {
     expect(statsAfterReport).toMatchObject({
       did: sc.dids.alice,
       accountReportCount: 1,
-      recordReportCount: 2,
+      recordReportCount: 3,
       reportedAccountCount: 1,
-      reportedRecordCount: 1,
+      reportedRecordCount: 2,
       takendownAccountCount: 0,
       takendownRecordCount: 0,
       labeledAccountCount: 0,
@@ -86,7 +97,11 @@ describe('reporter-stats', () => {
 
     await Promise.all([
       modClient.performTakedown({
-        subject: bobsPostSubject,
+        subject: bobsPostSubject1,
+        policies: ['trolling'],
+      }),
+      modClient.performTakedown({
+        subject: bobsPostSubject2,
         policies: ['trolling'],
       }),
       modClient.emitEvent({
@@ -105,11 +120,11 @@ describe('reporter-stats', () => {
     expect(statsAfterAction).toMatchObject({
       did: sc.dids.alice,
       accountReportCount: 1,
-      recordReportCount: 2,
+      recordReportCount: 3,
       reportedAccountCount: 1,
-      reportedRecordCount: 1,
+      reportedRecordCount: 2,
       takendownAccountCount: 0,
-      takendownRecordCount: 1,
+      takendownRecordCount: 2,
       labeledAccountCount: 1,
       labeledRecordCount: 0,
     })


### PR DESCRIPTION
This fixes a couple issues with ozone reporter stats.  We were counting distinct accounts rather than records for takedowns and labels on `takendownRecordCount` and `labeledRecordCount`.  The join in that query also found all account actions rather than actions particular to the reported record.  In order to make the queries simpler to read I hoisted some logic up so that the queries themselves did not need to contain conditionals.  Lastly, we now handle the case where reporter stats are requested for an empty set of DIDs.