### PR TITLE
Small XRPC fixes

### DIFF
--- a/.changeset/gentle-crews-vanish.md
+++ b/.changeset/gentle-crews-vanish.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc": minor
+---
+
+Rename `ResponseType.AuthRequired` into `ResponseType.AuthenticationRequired` to match actual error name.

--- a/.changeset/rotten-pillows-beg.md
+++ b/.changeset/rotten-pillows-beg.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc": minor
+---
+
+Remove un-necessary `ResponseTypeNames` in favor of `ResponseType`.

--- a/.changeset/shiny-horses-play.md
+++ b/.changeset/shiny-horses-play.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc": patch
+---
+
+Add missing `NotAcceptable` key in `ResponseTypeStrings`

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -5,7 +5,6 @@ import { isHttpError } from 'http-errors'
 import { z } from 'zod'
 import {
   ResponseType,
-  ResponseTypeNames,
   ResponseTypeStrings,
   XRPCError as XRPCClientError,
   httpResponseCodeToName,
@@ -290,7 +289,7 @@ export class XRPCError extends Error {
   }
 
   get typeName(): string | undefined {
-    return ResponseTypeNames[this.type]
+    return ResponseType[this.type]
   }
 
   get typeStr(): string | undefined {
@@ -378,13 +377,18 @@ export class AuthRequiredError extends XRPCError {
     customErrorName?: string,
     options?: ErrorOptions,
   ) {
-    super(ResponseType.AuthRequired, errorMessage, customErrorName, options)
+    super(
+      ResponseType.AuthenticationRequired,
+      errorMessage,
+      customErrorName,
+      options,
+    )
   }
 
   [Symbol.hasInstance](instance: unknown): boolean {
     return (
       instance instanceof XRPCError &&
-      instance.type === ResponseType.AuthRequired
+      instance.type === ResponseType.AuthenticationRequired
     )
   }
 }

--- a/packages/xrpc/src/types.ts
+++ b/packages/xrpc/src/types.ts
@@ -34,7 +34,7 @@ export enum ResponseType {
   InvalidResponse = 2,
   Success = 200,
   InvalidRequest = 400,
-  AuthRequired = 401,
+  AuthenticationRequired = 401,
   Forbidden = 403,
   XRPCNotSupported = 404,
   NotAcceptable = 406,
@@ -64,26 +64,8 @@ export function httpResponseCodeToEnum(status: number): ResponseType {
   }
 }
 
-export const ResponseTypeNames = {
-  [ResponseType.Unknown]: 'Unknown',
-  [ResponseType.InvalidResponse]: 'InvalidResponse',
-  [ResponseType.Success]: 'Success',
-  [ResponseType.InvalidRequest]: 'InvalidRequest',
-  [ResponseType.AuthRequired]: 'AuthenticationRequired',
-  [ResponseType.Forbidden]: 'Forbidden',
-  [ResponseType.XRPCNotSupported]: 'XRPCNotSupported',
-  [ResponseType.PayloadTooLarge]: 'PayloadTooLarge',
-  [ResponseType.UnsupportedMediaType]: 'UnsupportedMediaType',
-  [ResponseType.RateLimitExceeded]: 'RateLimitExceeded',
-  [ResponseType.InternalServerError]: 'InternalServerError',
-  [ResponseType.MethodNotImplemented]: 'MethodNotImplemented',
-  [ResponseType.UpstreamFailure]: 'UpstreamFailure',
-  [ResponseType.NotEnoughResources]: 'NotEnoughResources',
-  [ResponseType.UpstreamTimeout]: 'UpstreamTimeout',
-}
-
 export function httpResponseCodeToName(status: number): string {
-  return ResponseTypeNames[httpResponseCodeToEnum(status)]
+  return ResponseType[httpResponseCodeToEnum(status)]
 }
 
 export const ResponseTypeStrings = {
@@ -91,9 +73,10 @@ export const ResponseTypeStrings = {
   [ResponseType.InvalidResponse]: 'Invalid Response',
   [ResponseType.Success]: 'Success',
   [ResponseType.InvalidRequest]: 'Invalid Request',
-  [ResponseType.AuthRequired]: 'Authentication Required',
+  [ResponseType.AuthenticationRequired]: 'Authentication Required',
   [ResponseType.Forbidden]: 'Forbidden',
   [ResponseType.XRPCNotSupported]: 'XRPC Not Supported',
+  [ResponseType.NotAcceptable]: 'Not Acceptable',
   [ResponseType.PayloadTooLarge]: 'Payload Too Large',
   [ResponseType.UnsupportedMediaType]: 'Unsupported Media Type',
   [ResponseType.RateLimitExceeded]: 'Rate Limit Exceeded',
@@ -102,7 +85,7 @@ export const ResponseTypeStrings = {
   [ResponseType.UpstreamFailure]: 'Upstream Failure',
   [ResponseType.NotEnoughResources]: 'Not Enough Resources',
   [ResponseType.UpstreamTimeout]: 'Upstream Timeout',
-}
+} as const satisfies Record<ResponseType, string>
 
 export function httpResponseCodeToString(status: number): string {
   return ResponseTypeStrings[httpResponseCodeToEnum(status)]


### PR DESCRIPTION
Currently, the only purpose of `ResponseTypeNames` is to allow mapping `ResponseType` values (number) to the related property name (string).

```ts
ResponseType.Success // 200
ResponseTypeNames[200] = "Success"
```

This is redundant with the `ResponseType` enum itself as an enum can be used in two ways:

```ts
ResponseType.Success // 200
ResponseType[200] // "Success"
```

The only problem with replacing `ResponseTypeNames` with `ResponseType` is the fact that `401` is called `AuthRequired` in `ResponseType` and `AuthenticationRequired` in `ResponseTypeNames`.

By introducing the breaking change of renaming `AuthRequired` to `AuthenticationRequired` in `ResponseType`, we can get rid of the `ResponseTypeNames` object as it becomes completely redundant with the `ResponseType` enum.

There are two motivations for doing this:

1) Less code redundancy / smaller code footprint
2) Improved robustness

The "importance" of point (2) is outlined by the fact that `NotAcceptable`, defined in `ResponseType`, was missing in `ResponseTypeNames` (and `ResponseTypeStrings`). This is no longer possible with this change.