### PR TITLE
Optimize parsing of `CID` values

### DIFF
--- a/.changeset/empty-stingrays-prove.md
+++ b/.changeset/empty-stingrays-prove.md
@@ -1,0 +1,5 @@
+---
+"@atproto/common-web": patch
+---
+
+Optimize parsing of `CID` values

--- a/.changeset/short-seals-fry.md
+++ b/.changeset/short-seals-fry.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lexicon": patch
+---
+
+Improve typing of `BlobRef.toJSON()`

--- a/packages/common-web/src/types.ts
+++ b/packages/common-web/src/types.ts
@@ -2,12 +2,19 @@ import { CID } from 'multiformats/cid'
 import { z } from 'zod'
 import { Def } from './check'
 
-const cidSchema = z
-  .any()
-  .refine((obj: unknown) => CID.asCID(obj) !== null, {
-    message: 'Not a CID',
-  })
-  .transform((obj: unknown) => CID.asCID(obj) as CID)
+const cidSchema = z.unknown().transform((obj, ctx) => {
+  const cid = CID.asCID(obj)
+
+  if (cid == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Not a valid CID',
+    })
+    return z.NEVER
+  }
+
+  return cid
+})
 
 const carHeader = z.object({
   version: z.literal(1),

--- a/packages/common-web/src/types.ts
+++ b/packages/common-web/src/types.ts
@@ -2,7 +2,7 @@ import { CID } from 'multiformats/cid'
 import { z } from 'zod'
 import { Def } from './check'
 
-const cidSchema = z.unknown().transform((obj, ctx) => {
+const cidSchema = z.unknown().transform((obj, ctx): CID => {
   const cid = CID.asCID(obj)
 
   if (cid == null) {

--- a/packages/lexicon/src/blob-refs.ts
+++ b/packages/lexicon/src/blob-refs.ts
@@ -65,6 +65,11 @@ export class BlobRef {
   }
 
   toJSON() {
-    return ipldToJson(this.ipld())
+    return ipldToJson(this.ipld()) as {
+      $type: 'blob'
+      ref: { $link: string }
+      mimeType: string
+      size: number
+    }
   }
 }


### PR DESCRIPTION
- Avoid double call to `CID.asCID`
- Improve typing of `BlobRef.toJSON()`