### PR TITLE
Prevent @atproto/repo readCar blocking the event loop

### DIFF
--- a/packages/repo/src/car.ts
+++ b/packages/repo/src/car.ts
@@ -131,10 +131,19 @@ async function* readCarBlocksIterGenerator(
   reader: BufferedReader,
 ): AsyncIterable<CarBlock> {
   try {
+    let blocksSinceBreak = 0;
     while (!reader.isDone) {
       const blockSize = await reader.readVarint()
       if (blockSize === null) {
         break
+      }
+      blocksSinceBreak = (blocksSinceBreak + 1) % 100;
+      if (blocksSinceBreak === 0) {
+        // Every 100 records let the event loop run again so we don't block the main thread
+        // This is needed because just an await without there being any IO keeps processing
+        // the pending tasks and doesn't allow other phases of the event loop (like timers)
+        // to run
+        await new Promise(resolve => setImmediate(resolve))
       }
       const blockBytes = await reader.read(blockSize)
       const cid = parseCidFromBytes(blockBytes.slice(0, 36))


### PR DESCRIPTION
Currently using any of the readCar variants with a CAR file that's already in memory results in the event loop being blocked for the duration of the read preventing other operations.

The cause of this as far as I know is that since there is no actual IO going on to read the next blocks, all the async / await operations in the generator just queue up tasks that run within the same phase of the event loop so the rest of the event loop is starved.

This PR is a very naive way of addressing that, but seems to work in my tests, just yield the event loop every 100 blocks with a setImmediate.

Very basic timing on loading my CAR file (30,000 blocks) which takes ~1 minute doesn't show any significant performance degradation with this, (where as there is a small noticeable degradation if I yield every block)

This helps with feed generators and similar back-filling using the sync.getRepo command without blocking all other operations.

I suspect it may also help prevent importRepo operations in the PDS blocking but have not tested that case.