### PR TITLE
Fix format for createdAt

### DIFF
--- a/lexicons/tools/ozone/verification/grantVerifications.json
+++ b/lexicons/tools/ozone/verification/grantVerifications.json
@@ -67,6 +67,7 @@
         },
         "createdAt": {
           "type": "string",
+          "format": "datetime",
           "description": "Timestamp for verification record. Defaults to current time when not specified."
         }
       }


### PR DESCRIPTION
The createdAt format field is incorrect. It should have datetime attached to it to match the other createdAt types. This broke my source generator since it was treating it as a string.