### PR TITLE
Allow HTTPS `redirect_uris` from any origin

### DIFF
--- a/.changeset/heavy-apes-rush.md
+++ b/.changeset/heavy-apes-rush.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider": patch
+---
+
+Allow HTTPS `redirect_uris` from any origin

--- a/packages/oauth/oauth-provider/src/client/client-manager.ts
+++ b/packages/oauth/oauth-provider/src/client/client-manager.ts
@@ -787,25 +787,6 @@ export class ClientManager {
           )
         }
       }
-
-      if (url.protocol === 'https:') {
-        // https://datatracker.ietf.org/doc/html/rfc8252#section-8.4
-        //
-        // > In addition to the collision-resistant properties, requiring a
-        // > URI scheme based on a domain name that is under the control of
-        // > the app can help to prove ownership in the event of a dispute
-        // > where two apps claim the same private-use URI scheme (where one
-        // > app is acting maliciously).
-        //
-        // Although this only applies to "native" clients (extract being from
-        // rfc8252), we apply this rule to "web" clients as well.
-
-        if (url.hostname !== clientIdUrl.hostname) {
-          throw new InvalidRedirectUriError(
-            `Redirect URI ${url} must be under the same domain as client_id ${metadata.client_uri}`,
-          )
-        }
-      }
     }
 
     return metadata


### PR DESCRIPTION
This change removes the restriction of the `redirect_uris` urls to be on the same origin as the client id.

Note that the ATProto spec needs to be adapted together with this PR. See this [PR](https://github.com/bluesky-social/atproto-website/pull/409)