### PR TITLE
Fix potential memory leak

### DIFF
--- a/.changeset/lemon-ligers-taste.md
+++ b/.changeset/lemon-ligers-taste.md
@@ -1,0 +1,5 @@
+---
+"@atproto-labs/fetch-node": patch
+---
+
+Fix potential memory leak

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -127,6 +127,13 @@ export function unicastFetchWrap<C = FetchContext>({
             })
 
             if (!didLookup) {
+              // We need to ensure that the body is discarded. We can either
+              // consume the whole body (for await loop) in order to keep the
+              // socket alive, or cancel the request. Since we sent "connection:
+              // close", there is no point in consuming the whole response
+              // (which would cause un-necessary bandwidth).
+              //
+              // https://undici.nodejs.org/#/?id=garbage-collection
               await response.body?.cancel()
 
               // If you encounter this error, either upgrade to Node.js >=21 or


### PR DESCRIPTION
In the `unicastFetchWrap`, if the `didLookup` is false, the function will throw without canceling the response body, causing a memory leak. This change fixes that.