### PR TITLE
lex-cli: Convert kebab-case NSIDs to camelCase when generating property names

### DIFF
--- a/packages/lex-cli/src/codegen/common.ts
+++ b/packages/lex-cli/src/codegen/common.ts
@@ -135,10 +135,15 @@ export function asPredicate<V extends Validator>(validate: V) {
 export const lexiconsTs = (project, lexicons: LexiconDoc[]) =>
   gen(project, '/lexicons.ts', async (file) => {
     const nsidToEnum = (nsid: string): string => {
-      return nsid
-        .split('.')
-        .map((word) => word[0].toUpperCase() + word.slice(1))
-        .join('')
+      const authority = nsid.split('.')
+      const name = authority.pop()
+      return (
+        authority
+          // kebab-case to camelCase
+          .map((segment) => segment.replace(/-./g, (s) => s[1].toUpperCase()))
+          .map((word) => word[0].toUpperCase() + word.slice(1))
+          .join('') + name
+      )
     }
 
     //= import { type LexiconDoc, Lexicons } from '@atproto/lexicon'


### PR DESCRIPTION
Suppose you have a Lexicon file like this:

```json
{
  "lexicon": 1,
  "id": "example.foo-bar.test",
  "defs": {
    "main": {
      "type": "token"
    }
  }
}
```

Note that the domain authority part of the NSID has a hyphen in it, as allowed by the NSID syntax spec.

When trying to generate TypeScript code from the definition, `lex-gen` emits the hyphen as-is in a (unquoted) property name, leading to the following error:

```console
$ pnpm lex gen-api src lexicons/example/foo-bar/test.json
node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17
`&&m[o-1]==="\r"?o-1:o}getNamedDeclarations(){return this.namedDeclarations||…






SyntaxError: ',' expected. (28:15)
  26 |
  27 | export const ids = {
> 28 |     ExampleFoo-barTest: "example.foo-bar.test",
     |               ^
  29 |   } as const;
  30 |
    at _4 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:70566)
    at N4 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:20:955)
    at Object.M4 [as parse] (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:20:1477)
    at parse5 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:19983:24)
    at async coreFormat (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:20531:25)
    at async formatWithCursor (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:20743:14)
    at async Module.format2 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:22182:25)
    at async gen (node_modules/.pnpm/@atproto+lex-cli@0.8.0/node_modules/@atproto/lex-cli/dist/codegen/common.js:255:21)
    at async genClientApi (node_modules/.pnpm/@atproto+lex-cli@0.8.0/node_modules/@atproto/lex-cli/dist/codegen/client.js:30:20)
    at async Command.<anonymous> (node_modules/.pnpm/@atproto+lex-cli@0.8.0/node_modules/@atproto/lex-cli/dist/index.js:82:17) {
  loc: { start: { line: 28, column: 15 }, end: { line: 28, column: 15 } },
  cause: $f: ',' expected.
      at ed (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:8588)
      at ad (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:10521)
      at Hh (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:65509)
      at a4 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:70427)
      at l0 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:70169)
      at node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:20:1441
      at s4 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:17:70720)
      at Object.M4 [as parse] (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/plugins/typescript.mjs:20:1425)
      at parse5 (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:19983:24)
      at async coreFormat (node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:20531:25) {
    fileName: 'estree.ts',
    location: {
      end: { column: 14, line: 28, offset: 1239 },
      start: { column: 14, line: 28, offset: 1239 }
    }
  },
  codeFrame: '\x1B[0m \x1B[90m 26 |\x1B[39m\n' +
    ' \x1B[90m 27 |\x1B[39m \x1B[36mexport\x1B[39m \x1B[36mconst\x1B[39m ids \x1B[33m=\x1B[39m {\n' +
    '\x1B[31m\x1B[1m>\x1B[22m\x1B[39m\x1B[90m 28 |\x1B[39m     \x1B[33mExampleFoo\x1B[39m\x1B[33m-\x1B[39mbarTest\x1B[33m:\x1B[39m \x1B[32m"example.foo-bar.test"\x1B[39m\x1B[33m,\x1B[39m\n' +
    ' \x1B[90m    |\x1B[39m               \x1B[31m\x1B[1m^\x1B[22m\x1B[39m\n' +
    ' \x1B[90m 29 |\x1B[39m   } \x1B[36mas\x1B[39m \x1B[36mconst\x1B[39m\x1B[33m;\x1B[39m\n' +
    ' \x1B[90m 30 |\x1B[39m\x1B[0m'
}

Node.js v23.11.0
```

This patch fixes the error by converting the kebab-case to camelCase when generating property names.