### PR TITLE
:bug: Add datetime format in lexicon def for createdAt field on grantVerification input

### DIFF
--- a/lexicons/tools/ozone/verification/grantVerifications.json
+++ b/lexicons/tools/ozone/verification/grantVerifications.json
@@ -67,6 +67,7 @@
         },
         "createdAt": {
           "type": "string",
+          "format": "datetime",
           "description": "Timestamp for verification record. Defaults to current time when not specified."
         }
       }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -15779,6 +15779,7 @@ export const schemaDict = {
           },
           createdAt: {
             type: 'string',
+            format: 'datetime',
             description:
               'Timestamp for verification record. Defaults to current time when not specified.',
           },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -15779,6 +15779,7 @@ export const schemaDict = {
           },
           createdAt: {
             type: 'string',
+            format: 'datetime',
             description:
               'Timestamp for verification record. Defaults to current time when not specified.',
           },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -15779,6 +15779,7 @@ export const schemaDict = {
           },
           createdAt: {
             type: 'string',
+            format: 'datetime',
             description:
               'Timestamp for verification record. Defaults to current time when not specified.',
           },


### PR DESCRIPTION
Pointed out by this PR https://github.com/bluesky-social/atproto/pull/3805 we were missing the format def for `createdAt` field which can break some codegen tools. The original PR didn't have codegen so created this new PR.