### PR TITLE
lex-cli: Add `.js` ext to imports in generated code (again)

### DIFF
--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -51,7 +51,7 @@ export function genCommonImports(file: SourceFile, baseNsid: string) {
       moduleSpecifier: `${baseNsid
         .split('.')
         .map((_str) => '..')
-        .join('/')}/lexicons`,
+        .join('/')}/lexicons.js`,
     })
     .addNamedImports([{ name: 'validate', alias: '_validate' }])
 
@@ -61,7 +61,7 @@ export function genCommonImports(file: SourceFile, baseNsid: string) {
       moduleSpecifier: `${baseNsid
         .split('.')
         .map((_str) => '..')
-        .join('/')}/util`,
+        .join('/')}/util.js`,
     })
     .addNamedImports([
       { name: '$Typed', isTypeOnly: true },


### PR DESCRIPTION
This is a complement to 77612fa0600b93bdc4d0363330863d6007765a78 of #2999.