### PR TITLE
use legally registered name for company

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 Dual MIT/Apache-2.0 License
 
-Copyright (c) 2022-2025 Bluesky PBC, and Contributors
+Copyright (c) 2022-2025 Bluesky Social PBC, and Contributors
 
 Except as otherwise noted in individual files, this software is licensed under the MIT license (<http://opensource.org/licenses/MIT>), or the Apache License, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0>).
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ make help
 
 ## About AT Protocol
 
-The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://bsky.social). Learn more at:
+The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky Social PBC](https://bsky.social). Learn more at:
 
 - [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
 - [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atp",
   "version": "0.0.1",
   "repository": "git@github.com:bluesky-social/atproto.git",
-  "author": "Bluesky PBC <hello@blueskyweb.xyz>",
+  "author": "Bluesky Social PBC <hello@blueskyweb.xyz>",
   "license": "MIT",
   "private": true,
   "engines": {


### PR DESCRIPTION
I had this wrong previously; the formal company name does include "Social".