### PR TITLE
lexicons: add account management to describeServer links

### DIFF
--- a/lexicons/com/atproto/server/describeServer.json
+++ b/lexicons/com/atproto/server/describeServer.json
@@ -26,7 +26,7 @@
             },
             "links": {
               "type": "ref",
-              "description": "URLs of service policy documents.",
+              "description": "URLs of service interfaces and policy documents.",
               "ref": "#links"
             },
             "contact": {
@@ -45,6 +45,11 @@
     "links": {
       "type": "object",
       "properties": {
+        "accountManagement": {
+          "type": "string",
+          "format": "uri",
+          "description": "web interface for account self-management"
+        },
         "privacyPolicy": { "type": "string", "format": "uri" },
         "termsOfService": { "type": "string", "format": "uri" }
       }


### PR DESCRIPTION
Before merge:

- [ ] changeset (?)
- [ ] codegen

This allows PDS instances (and implementations) specify a URL for account self-management. For example, the PDS reference implementation puts this at `https://<hostname>/account` for self-hosters, but `https://bsky.social/account` for folks on the Bluesky mushroom PDS instances. Other PDS implementations might put them at a different path or hostname. The intended use case is for client apps to provide a link within the app to account settings.

Haven't deeply though this through, but tossing over this PR as a placeholder/reminder that we need a hook like this. Maybe should clarify whether this is not (or could be?) for account signup versus existing account management.