### PR TITLE
pds: fix account management migration, partial failure in some cases

### DIFF
--- a/.changeset/cyan-fishes-dress.md
+++ b/.changeset/cyan-fishes-dress.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+fix account management migration 005.


### PR DESCRIPTION
A recent PDS migration from #3659 was able to fail under the following conditions:
 - an account was deleted from the pds
 - the same account previously used the oauth functionality with "remember me" selected.

The issue would arise when a foreign key constraint was tripped loading data into the `account_device` table if it referenced an account that no longer exists.  A check was added into this part of the migration to ensure the foreign key constraint would be met.  All prior steps in the migration were made idempotent, so a migration that previously failed at this step should succeed on the next run.