### PR TITLE
Add lexicons for endpoints that return a list of profile views to include their sort keys

### DIFF
--- a/lexicons/app/bsky/feed/getReposters.json
+++ b/lexicons/app/bsky/feed/getReposters.json
@@ -1,0 +1,61 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.feed.getRepostedBy",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get a list of reposts for a given post.",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Reference (AT-URI) of post record"
+          },
+          "cid": {
+            "type": "string",
+            "format": "cid",
+            "description": "If supplied, filters to reposts of specific version (by CID) of the post record."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "repostedBy"],
+          "properties": {
+            "uri": { "type": "string", "format": "at-uri" },
+            "cid": { "type": "string", "format": "cid" },
+            "cursor": { "type": "string" },
+            "repostedBy": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#reposter"
+              }
+            }
+          }
+        }
+      }
+    },
+    "reposter": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getBlockers.json
+++ b/lexicons/app/bsky/graph/getBlockers.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getBlocks",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates which accounts the requesting account is currently blocking. Requires auth.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["blocks"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "blocks": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#blocker"
+              }
+            }
+          }
+        }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getFollowedProfiles.json
+++ b/lexicons/app/bsky/graph/getFollowedProfiles.json
@@ -1,0 +1,54 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getFollows",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates accounts which a specified account (actor) follows.",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": { "type": "string", "format": "at-identifier" },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["subject", "follows"],
+          "properties": {
+            "subject": {
+              "type": "ref",
+              "ref": "app.bsky.actor.defs#profileView"
+            },
+            "cursor": { "type": "string" },
+            "follows": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#follow"
+              }
+            }
+          }
+        }
+      }
+    },
+    "follow": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getFollowerProfiles.json
+++ b/lexicons/app/bsky/graph/getFollowerProfiles.json
@@ -1,0 +1,54 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getFollowers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates accounts which follow a specified account (actor).",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": { "type": "string", "format": "at-identifier" },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["subject", "followers"],
+          "properties": {
+            "subject": {
+              "type": "ref",
+              "ref": "app.bsky.actor.defs#profileView"
+            },
+            "cursor": { "type": "string" },
+            "followers": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#follower"
+              }
+            }
+          }
+        }
+      }
+    },
+    "follower": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getMutedProfiles.json
+++ b/lexicons/app/bsky/graph/getMutedProfiles.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getMutes",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates accounts that the requesting account (actor) currently has muted. Requires auth.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["mutes"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "mutes": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#mute"
+              }
+            }
+          }
+        }
+      }
+    },
+    "mutes": {
+      "type": "object",
+      "required": ["indexedAt", "createdAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "createdAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a:

* Fix for #3368 
* Lexicon update
* A follow up to #3570 to not have breaking changes.

This PR would like to add lexicons to supercede existing ones for a few requests that return `ProfileView` arrays to also include the time based sort key in an `indexedAt` field for the backing model that the list is generated from, as well as a `createdAt` field.

In other words, make the changed requests match their `getLikes` sibling which provides the requisite information.

This allows offline first clients to seamlessly combine cached local responses with updates from the server.

