### PR TITLE
check searchPosts specifically for case-sensitive NSID

### DIFF
--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -16,6 +16,7 @@ import {
 import { uriToDid as creatorFromUri } from '../../../../util/uris'
 import { Views } from '../../../../views'
 import { resHeaders } from '../../../util'
+import createError from 'http-errors'
 
 export default function (server: Server, ctx: AppContext) {
   const searchPosts = createPipeline(
@@ -27,6 +28,10 @@ export default function (server: Server, ctx: AppContext) {
   server.app.bsky.feed.searchPosts({
     auth: ctx.authVerifier.standardOptional,
     handler: async ({ auth, params, req }) => {
+      // case-sensitive match on this specific endpoint name
+      if (!req.url?.startsWith('/xrpc/app.bsky.feed.searchPosts')) {
+        throw createError(404, 'Unknown Endpoint')
+      }
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })


### PR DESCRIPTION
We should probably have all the endpoint checks be case-sensitive, which is probably code in `xrpc-server`?

But this is a bandaid specifically for `searchPosts`, where folks have been messing with capitalization to bypass rate-limits and other restrictions.