### PR TITLE
pds: client ip relative to trusted ips

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -122,7 +122,14 @@ export class PDS {
     server = API(server, ctx)
 
     const app = express()
-    app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'])
+    app.set('trust proxy', [
+      // e.g. load balancer
+      'loopback',
+      'linklocal',
+      'uniquelocal',
+      // e.g. trust x-forwarded-for via entryway ip
+      ...getTrustedIps(cfg),
+    ])
     app.use(loggerMiddleware)
     app.use(compression())
     app.use(authRoutes.createRouter(ctx)) // Before CORS
@@ -161,3 +168,8 @@ export class PDS {
 }
 
 export default PDS
+
+const getTrustedIps = (cfg: ServerConfig) => {
+  if (!cfg.rateLimits.enabled) return []
+  return cfg.rateLimits.bypassIps ?? []
+}


### PR DESCRIPTION
This allows requests originating from ratelimit bypass ips to pass along a client ip via x-forwarded-for.  The trusted bypass ips are skipped-over when calculating the client ip based on the contents of x-forwarded-for.