### PR TITLE
Correctly validate unions with refs mapping to record types

### DIFF
--- a/packages/lexicon/src/validators/complex.ts
+++ b/packages/lexicon/src/validators/complex.ts
@@ -1,6 +1,7 @@
 import { Lexicons } from '../lexicons'
 import {
   LexArray,
+  LexRecord,
   LexRefVariant,
   LexUserType,
   ValidationError,
@@ -25,6 +26,8 @@ export function validate(
       return array(lexicons, path, def, value)
     case 'blob':
       return blob(lexicons, path, def, value)
+    case 'record':
+      return record(lexicons, path, def, value)
     default:
       return validatePrimitive(lexicons, path, def, value)
   }
@@ -152,6 +155,24 @@ export function object(
   }
 
   return { success: true, value: resultValue }
+}
+
+export function record(
+  lexicons: Lexicons,
+  path: string,
+  def: LexRecord,
+  value: unknown,
+): ValidationResult {
+  if (!isObj(value) || !('$type' in value)) {
+    return {
+      success: false,
+      error: new ValidationError(
+        `${path} must be a record with a "$type" property`,
+      ),
+    }
+  }
+  const propPath = `${path}/record`
+  return validateOneOf(lexicons, propPath, def.record, value)
 }
 
 export function validateOneOf(

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -352,6 +352,18 @@ describe('General validation', () => {
     })
     expect(result.success).toBe(true)
 
+    result = lexicon.validate('com.example.testUnionWithRecordRef', {
+      union: {
+        $type: 'com.example.recordType',
+        // Test that the record type is validated against the record schema
+        test: 123,
+      },
+    })
+    expect(result.success).toBe(false)
+    expect(result['error']?.message).toBe(
+      'Object/union/record/test must be a string',
+    )
+
     result = lexicon.validate('com.example.testUnionWithUnkownRef', {
       union: {
         $type: 'com.example.unknownType',

--- a/packages/lexicon/tests/general.test.ts
+++ b/packages/lexicon/tests/general.test.ts
@@ -254,6 +254,112 @@ describe('General validation', () => {
     expect(result.success).toBeFalsy()
     expect(result['error']?.message).toBe('Object/union/test must be a string')
   })
+  it('union handles object, record and unknown refs', () => {
+    const schemas: LexiconDoc[] = [
+      {
+        lexicon: 1,
+        id: 'com.example.recordType',
+        defs: {
+          main: {
+            type: 'record',
+            key: 'tid',
+            record: {
+              type: 'object',
+              properties: {
+                test: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.objectType',
+        defs: {
+          main: {
+            type: 'object',
+            properties: {
+              test: { type: 'string' },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.testUnionWithObjectRef',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['union'],
+            properties: {
+              union: {
+                type: 'union',
+                refs: ['com.example.objectType'],
+              },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.testUnionWithRecordRef',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['union'],
+            properties: {
+              union: {
+                type: 'union',
+                refs: ['com.example.recordType'],
+              },
+            },
+          },
+        },
+      },
+      {
+        lexicon: 1,
+        id: 'com.example.testUnionWithUnkownRef',
+        defs: {
+          main: {
+            type: 'object',
+            required: ['union'],
+            properties: {
+              union: {
+                type: 'union',
+                // Union has no refs, so any type should be valid
+                refs: [],
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const lexicon = new Lexicons(schemas)
+    let result = lexicon.validate('com.example.testUnionWithObjectRef', {
+      union: {
+        $type: 'com.example.objectType',
+        test: 'string',
+      },
+    })
+    expect(result.success).toBe(true)
+
+    result = lexicon.validate('com.example.testUnionWithRecordRef', {
+      union: {
+        $type: 'com.example.recordType',
+        test: '123',
+      },
+    })
+    expect(result.success).toBe(true)
+
+    result = lexicon.validate('com.example.testUnionWithUnkownRef', {
+      union: {
+        $type: 'com.example.unknownType',
+        test: 'string',
+      },
+    })
+    expect(result.success).toBe(true)
+  })
 })
 
 describe('Record validation', () => {


### PR DESCRIPTION
According [to the spec](https://atproto.com/specs/lexicon#union),`record` should be a valid type of `ref` in a `union`:

> The schema definitions pointed to by a union are objects or types with a clear mapping to an object, like a record.

However, lexicon validation currently fails for `record` fields in `union`.

> ValidationError: Unexpected lexicon type: record

This PR fixes the issue by adding validation for `record`.