### PR TITLE
Allow using globs in lex-cli paths

### DIFF
--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -29,6 +29,8 @@
     "@atproto/syntax": "workspace:^",
     "chalk": "^4.1.2",
     "commander": "^9.4.0",
+    "glob": "^10.3.10",
+    "is-glob": "^4.0.3",
     "prettier": "^3.2.5",
     "ts-morph": "^24.0.0",
     "yesno": "^0.4.0",

--- a/packages/lex-cli/src/util.ts
+++ b/packages/lex-cli/src/util.ts
@@ -4,10 +4,15 @@ import chalk from 'chalk'
 import { ZodError, type ZodFormattedError } from 'zod'
 import { type LexiconDoc, parseLexiconDoc } from '@atproto/lexicon'
 import { type FileDiff, type GeneratedAPI } from './types'
+import isGlob from 'is-glob'
+import { glob } from 'glob'
 
 export function readAllLexicons(paths: string[]): LexiconDoc[] {
   const docs: LexiconDoc[] = []
-  for (const path of paths) {
+  const pathsToSearch = paths.flatMap((path) =>
+    isGlob(path) ? glob.sync(path) : [path],
+  )
+  for (const path of pathsToSearch) {
     if (!path.endsWith('.json') || !fs.statSync(path).isFile()) {
       continue
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -753,6 +753,12 @@ importers:
       commander:
         specifier: ^9.4.0
         version: 9.4.0
+      glob:
+        specifier: ^10.3.10
+        version: 10.3.10
+      is-glob:
+        specifier: ^4.0.3
+        version: 4.0.3
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -12044,8 +12050,8 @@ packages:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.3
-      minipass: 5.0.0
+      minimatch: 9.0.5
+      minipass: 7.1.2
       path-scurry: 1.10.1
 
   /glob@11.0.1:
@@ -12076,6 +12082,7 @@ packages:
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -12694,7 +12701,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-finalizationregistry@1.1.0:
     resolution: {integrity: sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==}
@@ -12724,7 +12730,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -14056,6 +14061,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -14124,11 +14130,11 @@ packages:
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -14703,7 +14709,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       lru-cache: 10.2.0
-      minipass: 5.0.0
+      minipass: 7.1.2
 
   /path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}


### PR DESCRIPTION
This PR checks whether input paths to `lex-cli` are "glob"-like patterns, and expands them if necessary.

## Why do this
Currently `@atproto/lex-cli` commands rely on shell filename expansion to collect the list of lexicons to target. This works in the general case, but causes a series of issues:

1. Prevents the commands from being mapped to `npm run`-like shortcuts (shell expansion doesn't work in them)
2. Causes problems when a shell doesn't have "`**`" expansion turned on (like, to my genuine surprise, [`bash` in many distros](https://unix.stackexchange.com/questions/700199/why-is-the-bash-double-star-globstar-operator-often-disabled-by-default))
3. Makes it harder to do things like "target all Lexicons except for the ones in this folder"

## Possible concerns

1. **This PR pulls in two new dependencies:** [`is-glob`](https://www.npmjs.com/package/is-glob) and [`glob`](https://www.npmjs.com/package/glob). Your policy says not to do PRs that "introduce new unnecessary dependencies", but I believe this is fine because:
    - This library is meant to be used as a `cli` rather than getting bundled
    - Node 24 made `fs.glob` stable, so you'll be able to remove the `glob` dependency at some point
    - The small size increase from `is-glob` is worth not having to run `glob` on every path
    - I'm happy to extract any of these libraries' functionality into this repository
2. **This PR might change the behavior of existing code.** This is possible, but unlikely to happen in practice:
    - If shell filename expansion was working before, it will continue working (which means most existing cases won't hit the `glob` path)
    - Most people don't make their valid paths accidentally "glob"-like
    - If you have to do breaking changes like this, the earlier, the better :)


