### PR TITLE
add `reqId` to interactions

### DIFF
--- a/.changeset/brave-chairs-pull.md
+++ b/.changeset/brave-chairs-pull.md
@@ -1,0 +1,6 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+---
+
+add `recId` to feed interactions

--- a/.changeset/brave-chairs-pull.md
+++ b/.changeset/brave-chairs-pull.md
@@ -3,4 +3,4 @@
 "@atproto/api": patch
 ---
 
-add `recId` to feed interactions
+add `reqId` to feed interactions

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -67,9 +67,9 @@
           "description": "Context provided by feed generator that may be passed back alongside interactions.",
           "maxLength": 2000
         },
-        "recId": {
+        "reqId": {
           "type": "string",
-          "description": "Unique identiifer per request that may be passed back alongside interactions.",
+          "description": "Unique identifier per request that may be passed back alongside interactions.",
           "maxLength": 100
         }
       }
@@ -204,11 +204,6 @@
           "type": "string",
           "description": "Context that will be passed through to client and may be passed to feed generator back alongside interactions.",
           "maxLength": 2000
-        },
-        "recId": {
-          "type": "string",
-          "description": "Unique identiifer per request that may be passed back alongside interactions.",
-          "maxLength": 100
         }
       }
     },
@@ -261,9 +256,9 @@
           "description": "Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.",
           "maxLength": 2000
         },
-        "recId": {
+        "reqId": {
           "type": "string",
-          "description": "Unique identiifer per request that may be passed back alongside interactions.",
+          "description": "Unique identifier per request that may be passed back alongside interactions.",
           "maxLength": 100
         }
       }

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -66,6 +66,11 @@
           "type": "string",
           "description": "Context provided by feed generator that may be passed back alongside interactions.",
           "maxLength": 2000
+        },
+        "recId": {
+          "type": "string",
+          "description": "Unique identiifer per request that may be passed back alongside interactions.",
+          "maxLength": 100
         }
       }
     },
@@ -199,6 +204,11 @@
           "type": "string",
           "description": "Context that will be passed through to client and may be passed to feed generator back alongside interactions.",
           "maxLength": 2000
+        },
+        "recId": {
+          "type": "string",
+          "description": "Unique identiifer per request that may be passed back alongside interactions.",
+          "maxLength": 100
         }
       }
     },
@@ -250,6 +260,11 @@
           "type": "string",
           "description": "Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.",
           "maxLength": 2000
+        },
+        "recId": {
+          "type": "string",
+          "description": "Unique identiifer per request that may be passed back alongside interactions.",
+          "maxLength": 100
         }
       }
     },

--- a/lexicons/app/bsky/feed/getFeedSkeleton.json
+++ b/lexicons/app/bsky/feed/getFeedSkeleton.json
@@ -36,6 +36,11 @@
                 "type": "ref",
                 "ref": "app.bsky.feed.defs#skeletonFeedPost"
               }
+            },
+            "reqId": {
+              "type": "string",
+              "description": "Unique identifier per request that may be passed back alongside interactions.",
+              "maxLength": 100
             }
           }
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6221,10 +6221,10 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -6454,12 +6454,6 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
-            type: 'string',
-            description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
-            maxLength: 100,
-          },
         },
       },
       skeletonReasonRepost: {
@@ -6529,10 +6523,10 @@ export const schemaDict = {
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -7082,6 +7076,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.feed.defs#skeletonFeedPost',
                 },
+              },
+              reqId: {
+                type: 'string',
+                description:
+                  'Unique identifier per request that may be passed back alongside interactions.',
+                maxLength: 100,
               },
             },
           },

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6221,6 +6221,12 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       replyRef: {
@@ -6448,6 +6454,12 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       skeletonReasonRepost: {
@@ -6516,6 +6528,12 @@ export const schemaDict = {
             description:
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
+          },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
           },
         },
       },

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -100,6 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -298,6 +300,8 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -376,6 +380,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -100,8 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -300,8 +300,6 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -380,8 +378,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/api/src/client/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/feed/getFeedSkeleton.ts
@@ -28,6 +28,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   feed: AppBskyFeedDefs.SkeletonFeedPost[]
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 export interface CallOptions {

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -257,6 +257,7 @@ const skeletonFromFeedGen = async (
       ? { uri: item.reason.repost }
       : undefined,
     feedContext: item.feedContext,
+    recId: item.recId,
   }))
 
   return { ...skele, resHeaders, feedItems }
@@ -270,4 +271,5 @@ export type AlgoResponse = {
 
 export type AlgoResponseItem = FeedItem & {
   feedContext?: string
+  recId?: string
 }

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -147,7 +147,7 @@ const presentation = (
     }
   })
   return {
-    feed: feed.map((fi) => ({...fi, reqId: skeleton.reqId})),
+    feed: feed.map((fi) => ({ ...fi, reqId: skeleton.reqId })),
     cursor: skeleton.cursor,
     timerSkele: skeleton.timerSkele,
     timerHydr: skeleton.timerHydr,

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -274,5 +274,4 @@ export type AlgoResponse = {
 
 export type AlgoResponseItem = FeedItem & {
   feedContext?: string
-  reqId?: string
 }

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -88,6 +88,7 @@ const skeleton = async (
   const timerSkele = new ServerTimer('skele').start()
   const {
     feedItems: algoItems,
+    reqId,
     cursor,
     resHeaders,
     ...passthrough
@@ -96,6 +97,7 @@ const skeleton = async (
   return {
     cursor,
     items: algoItems,
+    reqId,
     timerSkele: timerSkele.stop(),
     timerHydr: new ServerTimer('hydr').start(),
     resHeaders,
@@ -145,7 +147,7 @@ const presentation = (
     }
   })
   return {
-    feed,
+    feed: feed.map((fi) => ({...fi, reqId: skeleton.reqId})),
     cursor: skeleton.cursor,
     timerSkele: skeleton.timerSkele,
     timerHydr: skeleton.timerHydr,
@@ -163,6 +165,7 @@ type Params = GetFeedParams & {
 
 type Skeleton = {
   items: AlgoResponseItem[]
+  reqId?: string
   passthrough: Record<string, unknown> // pass through additional items in feedgen response
   resHeaders?: Record<string, string>
   cursor?: string
@@ -257,7 +260,6 @@ const skeletonFromFeedGen = async (
       ? { uri: item.reason.repost }
       : undefined,
     feedContext: item.feedContext,
-    recId: item.recId,
   }))
 
   return { ...skele, resHeaders, feedItems }
@@ -267,9 +269,10 @@ export type AlgoResponse = {
   feedItems: AlgoResponseItem[]
   resHeaders?: Record<string, string>
   cursor?: string
+  reqId?: string
 }
 
 export type AlgoResponseItem = FeedItem & {
   feedContext?: string
-  recId?: string
+  reqId?: string
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6221,10 +6221,10 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -6454,12 +6454,6 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
-            type: 'string',
-            description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
-            maxLength: 100,
-          },
         },
       },
       skeletonReasonRepost: {
@@ -6529,10 +6523,10 @@ export const schemaDict = {
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -7082,6 +7076,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.feed.defs#skeletonFeedPost',
                 },
+              },
+              reqId: {
+                type: 'string',
+                description:
+                  'Unique identifier per request that may be passed back alongside interactions.',
+                maxLength: 100,
               },
             },
           },

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6221,6 +6221,12 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       replyRef: {
@@ -6448,6 +6454,12 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       skeletonReasonRepost: {
@@ -6516,6 +6528,12 @@ export const schemaDict = {
             description:
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
+          },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
           },
         },
       },

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,6 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -298,6 +300,8 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -376,6 +380,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,8 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -300,8 +300,6 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -380,8 +378,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -29,6 +29,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   feed: AppBskyFeedDefs.SkeletonFeedPost[]
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 export type HandlerInput = undefined

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -646,6 +646,7 @@ Array [
         "threadMuted": false,
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-1",
@@ -686,6 +687,7 @@ Array [
         "threadMuted": false,
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-2",
@@ -811,6 +813,7 @@ Array [
         "threadMuted": false,
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-4",
@@ -950,6 +953,7 @@ Array [
         },
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-5",
@@ -1145,6 +1149,7 @@ Array [
       },
       "indexedAt": "1970-01-01T00:00:00.000Z",
     },
+    "reqId": "req-id-abc-def-ghi",
   },
 ]
 `;
@@ -1207,6 +1212,7 @@ Array [
       "repostCount": 0,
       "uri": "record(0)",
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-2",
@@ -1315,6 +1321,7 @@ Array [
       "repostCount": 0,
       "uri": "record(2)",
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-4",
@@ -1428,6 +1435,7 @@ Array [
         "uri": "record(5)",
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
 ]
 `;
@@ -1498,6 +1506,7 @@ Array [
         "threadMuted": false,
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-2",
@@ -1623,6 +1632,7 @@ Array [
         "threadMuted": false,
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
   Object {
     "feedContext": "item-4",
@@ -1762,6 +1772,7 @@ Array [
         },
       },
     },
+    "reqId": "req-id-abc-def-ghi",
   },
 ]
 `;

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -848,6 +848,7 @@ describe('feed generation', () => {
         body: {
           feed: feedResults,
           cursor: cursorResult,
+          reqId: 'req-id-abc-def-ghi',
           $auth: jwtBody(req.headers.authorization), // for testing purposes
         },
       }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6221,10 +6221,10 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -6454,12 +6454,6 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
-            type: 'string',
-            description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
-            maxLength: 100,
-          },
         },
       },
       skeletonReasonRepost: {
@@ -6529,10 +6523,10 @@ export const schemaDict = {
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -7082,6 +7076,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.feed.defs#skeletonFeedPost',
                 },
+              },
+              reqId: {
+                type: 'string',
+                description:
+                  'Unique identifier per request that may be passed back alongside interactions.',
+                maxLength: 100,
               },
             },
           },

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6221,6 +6221,12 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       replyRef: {
@@ -6448,6 +6454,12 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       skeletonReasonRepost: {
@@ -6516,6 +6528,12 @@ export const schemaDict = {
             description:
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
+          },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
           },
         },
       },

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,6 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -298,6 +300,8 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -376,6 +380,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,8 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -300,8 +300,6 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -380,8 +378,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -29,6 +29,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   feed: AppBskyFeedDefs.SkeletonFeedPost[]
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 export type HandlerInput = undefined

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6221,10 +6221,10 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -6454,12 +6454,6 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
-          recId: {
-            type: 'string',
-            description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
-            maxLength: 100,
-          },
         },
       },
       skeletonReasonRepost: {
@@ -6529,10 +6523,10 @@ export const schemaDict = {
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
           },
-          recId: {
+          reqId: {
             type: 'string',
             description:
-              'Unique identiifer per request that may be passed back alongside interactions.',
+              'Unique identifier per request that may be passed back alongside interactions.',
             maxLength: 100,
           },
         },
@@ -7082,6 +7076,12 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:app.bsky.feed.defs#skeletonFeedPost',
                 },
+              },
+              reqId: {
+                type: 'string',
+                description:
+                  'Unique identifier per request that may be passed back alongside interactions.',
+                maxLength: 100,
               },
             },
           },

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6221,6 +6221,12 @@ export const schemaDict = {
               'Context provided by feed generator that may be passed back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       replyRef: {
@@ -6448,6 +6454,12 @@ export const schemaDict = {
               'Context that will be passed through to client and may be passed to feed generator back alongside interactions.',
             maxLength: 2000,
           },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
+          },
         },
       },
       skeletonReasonRepost: {
@@ -6516,6 +6528,12 @@ export const schemaDict = {
             description:
               'Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.',
             maxLength: 2000,
+          },
+          recId: {
+            type: 'string',
+            description:
+              'Unique identiifer per request that may be passed back alongside interactions.',
+            maxLength: 100,
           },
         },
       },

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,6 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -298,6 +300,8 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -376,6 +380,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
+  /** Unique identiifer per request that may be passed back alongside interactions. */
+  recId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -100,8 +100,8 @@ export interface FeedViewPost {
   reason?: $Typed<ReasonRepost> | $Typed<ReasonPin> | { $type: string }
   /** Context provided by feed generator that may be passed back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashFeedViewPost = 'feedViewPost'
@@ -300,8 +300,6 @@ export interface SkeletonFeedPost {
     | { $type: string }
   /** Context that will be passed through to client and may be passed to feed generator back alongside interactions. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
 }
 
 const hashSkeletonFeedPost = 'skeletonFeedPost'
@@ -380,8 +378,8 @@ export interface Interaction {
     | (string & {})
   /** Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton. */
   feedContext?: string
-  /** Unique identiifer per request that may be passed back alongside interactions. */
-  recId?: string
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 const hashInteraction = 'interaction'

--- a/packages/pds/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/getFeedSkeleton.ts
@@ -29,6 +29,8 @@ export type InputSchema = undefined
 export interface OutputSchema {
   cursor?: string
   feed: AppBskyFeedDefs.SkeletonFeedPost[]
+  /** Unique identifier per request that may be passed back alongside interactions. */
+  reqId?: string
 }
 
 export type HandlerInput = undefined


### PR DESCRIPTION
Small PR that adds rec IDs to individual items in feeds to be sent back in `sendInteraction`.

cc @iwsmith 