### PR TITLE
lexicon: validate 'uri' string length

### DIFF
--- a/.changeset/tiny-drinks-explode.md
+++ b/.changeset/tiny-drinks-explode.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lexicon": patch
+---
+
+validate 'uri' string length

--- a/packages/lexicon/src/validators/formats.ts
+++ b/packages/lexicon/src/validators/formats.ts
@@ -1,6 +1,6 @@
 import { isValidISODateString } from 'iso-datestring-validator'
 import { CID } from 'multiformats/cid'
-import { validateLanguage } from '@atproto/common-web'
+import { validateLanguage, utf8Len } from '@atproto/common-web'
 import {
   ensureValidAtUri,
   ensureValidDid,
@@ -33,6 +33,12 @@ export function uri(path: string, value: string): ValidationResult {
     return {
       success: false,
       error: new ValidationError(`${path} must be a uri`),
+    }
+  }
+  if (utf8Len(value) > 8192) {
+    return {
+      success: false,
+      error: new ValidationError(`${path} URI must be 8 KBytes or less`),
     }
   }
   return { success: true, value }


### PR DESCRIPTION
Link to relevant part of spec: https://atproto.com/specs/lexicon#uri

This sort of change can be fraught to introduce, because it is going to make existing records invalid. I think in this case, that will be rare enough that we can go ahead.

The go SDK does this check already during dynamic Lexicon validation (though we don't use that codepath anywhere yet; eg the appview doesn't do any real lexicon validation).