### PR TITLE
Return an error if the wrong HTTP verb is used for a known XRPC method

### DIFF
--- a/.changeset/hot-cobras-attack.md
+++ b/.changeset/hot-cobras-attack.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Return an error if the wrong HTTP verb is used for a known XRPC method, even when a `catchall` is provided.


### PR DESCRIPTION
Currently, the check that asserts that the HTTP client used the right HTTP method is only triggered if there is no `catchall`. This PR introduces a change that will *not* trigger the `catchall` handler for invalid method used with known XRPC methods.