### PR TITLE
Additional granular show less options

### DIFF
--- a/.changeset/tall-bugs-relax.md
+++ b/.changeset/tall-bugs-relax.md
@@ -1,0 +1,8 @@
+---
+"@atproto/ozone": patch
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Add more granular `requestLess` interaction events

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -238,6 +238,8 @@
           "type": "string",
           "knownValues": [
             "app.bsky.feed.defs#requestLess",
+            "app.bsky.feed.defs#requestLessFromUser",
+            "app.bsky.feed.defs#requestLessFromTopic",
             "app.bsky.feed.defs#requestMore",
             "app.bsky.feed.defs#clickthroughItem",
             "app.bsky.feed.defs#clickthroughAuthor",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -6504,6 +6504,8 @@ export const schemaDict = {
             type: 'string',
             knownValues: [
               'app.bsky.feed.defs#requestLess',
+              'app.bsky.feed.defs#requestLessFromUser',
+              'app.bsky.feed.defs#requestLessFromTopic',
               'app.bsky.feed.defs#requestMore',
               'app.bsky.feed.defs#clickthroughItem',
               'app.bsky.feed.defs#clickthroughAuthor',

--- a/packages/api/src/client/types/app/bsky/feed/defs.ts
+++ b/packages/api/src/client/types/app/bsky/feed/defs.ts
@@ -364,6 +364,8 @@ export interface Interaction {
   item?: string
   event?:
     | 'app.bsky.feed.defs#requestLess'
+    | 'app.bsky.feed.defs#requestLessFromUser'
+    | 'app.bsky.feed.defs#requestLessFromTopic'
     | 'app.bsky.feed.defs#requestMore'
     | 'app.bsky.feed.defs#clickthroughItem'
     | 'app.bsky.feed.defs#clickthroughAuthor'

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -6504,6 +6504,8 @@ export const schemaDict = {
             type: 'string',
             knownValues: [
               'app.bsky.feed.defs#requestLess',
+              'app.bsky.feed.defs#requestLessFromUser',
+              'app.bsky.feed.defs#requestLessFromTopic',
               'app.bsky.feed.defs#requestMore',
               'app.bsky.feed.defs#clickthroughItem',
               'app.bsky.feed.defs#clickthroughAuthor',

--- a/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/feed/defs.ts
@@ -364,6 +364,8 @@ export interface Interaction {
   item?: string
   event?:
     | 'app.bsky.feed.defs#requestLess'
+    | 'app.bsky.feed.defs#requestLessFromUser'
+    | 'app.bsky.feed.defs#requestLessFromTopic'
     | 'app.bsky.feed.defs#requestMore'
     | 'app.bsky.feed.defs#clickthroughItem'
     | 'app.bsky.feed.defs#clickthroughAuthor'

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -6504,6 +6504,8 @@ export const schemaDict = {
             type: 'string',
             knownValues: [
               'app.bsky.feed.defs#requestLess',
+              'app.bsky.feed.defs#requestLessFromUser',
+              'app.bsky.feed.defs#requestLessFromTopic',
               'app.bsky.feed.defs#requestMore',
               'app.bsky.feed.defs#clickthroughItem',
               'app.bsky.feed.defs#clickthroughAuthor',

--- a/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/feed/defs.ts
@@ -364,6 +364,8 @@ export interface Interaction {
   item?: string
   event?:
     | 'app.bsky.feed.defs#requestLess'
+    | 'app.bsky.feed.defs#requestLessFromUser'
+    | 'app.bsky.feed.defs#requestLessFromTopic'
     | 'app.bsky.feed.defs#requestMore'
     | 'app.bsky.feed.defs#clickthroughItem'
     | 'app.bsky.feed.defs#clickthroughAuthor'

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -6504,6 +6504,8 @@ export const schemaDict = {
             type: 'string',
             knownValues: [
               'app.bsky.feed.defs#requestLess',
+              'app.bsky.feed.defs#requestLessFromUser',
+              'app.bsky.feed.defs#requestLessFromTopic',
               'app.bsky.feed.defs#requestMore',
               'app.bsky.feed.defs#clickthroughItem',
               'app.bsky.feed.defs#clickthroughAuthor',

--- a/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/feed/defs.ts
@@ -364,6 +364,8 @@ export interface Interaction {
   item?: string
   event?:
     | 'app.bsky.feed.defs#requestLess'
+    | 'app.bsky.feed.defs#requestLessFromUser'
+    | 'app.bsky.feed.defs#requestLessFromTopic'
     | 'app.bsky.feed.defs#requestMore'
     | 'app.bsky.feed.defs#clickthroughItem'
     | 'app.bsky.feed.defs#clickthroughAuthor'


### PR DESCRIPTION
Allows for adding a post-show-less form to let the user specify exactly why they didn't like a post