### PR TITLE
Add Generic Bsync Proto

### DIFF
--- a/packages/bsync/proto/bsync.proto
+++ b/packages/bsync/proto/bsync.proto
@@ -67,6 +67,38 @@ message ScanNotifOperationsResponse {
 }
 
 
+enum Method {
+  METHOD_UNSPECIFIED = 0;
+  METHOD_CREATE = 1;
+  METHOD_UPDATE = 2;
+  METHOD_DELETE = 3;
+}
+
+message Operation {
+  string collection = 1;
+  string actor_did = 2;
+  string id = 3;
+  Method method = 4;
+  bytes payload = 5;
+}
+
+message PutOperationRequest {
+  Operation operation = 1;
+}
+
+message PutOperationResponse {
+}
+
+message ScanOperationsRequest {
+  string cursor = 1;
+  int32 limit = 2;
+}
+
+message ScanOperationsResponse {
+  repeated Operation operations = 1;
+  string cursor = 2;
+}
+
 
 // Ping
 message PingRequest {}
@@ -79,6 +111,8 @@ service Service {
   rpc ScanMuteOperations(ScanMuteOperationsRequest) returns (ScanMuteOperationsResponse);
   rpc AddNotifOperation(AddNotifOperationRequest) returns (AddNotifOperationResponse);
   rpc ScanNotifOperations(ScanNotifOperationsRequest) returns (ScanNotifOperationsResponse);
+  rpc PutOperation(PutOperationRequest) returns (PutOperationResponse);
+  rpc ScanOperations(ScanOperationsRequest) returns (ScanOperationsResponse);
   // Ping
   rpc Ping(PingRequest) returns (PingResponse);
 }


### PR DESCRIPTION
Idea here is to use arbitrary key-value style data in bsync, modeled loosely after existing atproto shapes. Will leave this up to @rafaelbsky to codegen, but we live coded on these protobuf definitions together.