### PR TITLE
feat: password reset discovery and sign-in/up autofill

### DIFF
--- a/packages/oauth/oauth-client-browser-example/src/auth/credential/credential-sign-in-form.tsx
+++ b/packages/oauth/oauth-client-browser-example/src/auth/credential/credential-sign-in-form.tsx
@@ -55,6 +55,10 @@ export function CredentialSignInForm({
           <input
             id="identifier"
             name="identifier"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="username"
+            spellCheck="false"
             type="text"
             className="relative m-0 block w-full flex-auto bg-transparent bg-clip-padding px-3 py-[0.25rem] text-base leading-[1.6] text-inherit outline-none dark:placeholder:text-neutral-100"
             placeholder="@handle or email"
@@ -68,6 +72,10 @@ export function CredentialSignInForm({
           <input
             id="password"
             name="password"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="current-password"
+            spellCheck="false"
             type="password"
             className="relative m-0 block w-full flex-auto bg-transparent bg-clip-padding px-3 py-[0.25rem] text-base leading-[1.6] text-inherit outline-none dark:placeholder:text-neutral-100"
             placeholder="Password"

--- a/packages/oauth/oauth-provider-frontend/src/locales/an/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/an/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ast/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ast/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ca/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ca/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/da/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/da/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/de/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/el/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/el/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/en-GB/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/en-GB/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr "@handle or email"
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr "Are you sure you want to revoke access? This application won't be able to access your account anymore."
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr "Back to sign in"
 
@@ -61,12 +61,12 @@ msgstr "Branding"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr "Click here to send a new code to your email."
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr "Code"
 
@@ -82,7 +82,7 @@ msgstr "Connected apps"
 msgid "Credentials"
 msgstr "Credentials"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr "Don't see the email? <0>Try sending again.</0>"
 
@@ -98,11 +98,11 @@ msgstr "Email code is required"
 msgid "Email is required"
 msgstr "Email is required"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr "Enter a new password"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr "Enter your email"
 
@@ -130,11 +130,11 @@ msgstr "Failed to resend code"
 msgid "Failed to sign out"
 msgstr "Failed to sign out"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr "Get reset code"
 
@@ -187,9 +187,9 @@ msgstr "No connected apps"
 msgid "No devices"
 msgstr "No devices"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr "Password"
 
@@ -207,7 +207,7 @@ msgstr "Remove this device"
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr "Reset password"
 
@@ -234,7 +234,7 @@ msgstr "Select the account you would like to manage."
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -297,8 +297,8 @@ msgstr "We weren't able to load your accounts. Please refresh the page to try ag
 msgid "Whoops! An error occurred."
 msgstr "Whoops! An error occurred."
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr "XXXXX-XXXXX"
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/es/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/eu/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/eu/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/fi/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/fi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/fr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr "@identifiant ou adresse email"
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr "Êtes-vous sûr de vouloir supprimer l'accès? Cette application ne sera plus en mesure d'accéder à vos informations."
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr "Retour vers la page de connexion"
 
@@ -61,12 +61,12 @@ msgstr "Personnalisation"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr "Cliquez ici pour envoyer un nouveau code dans votre boîte mail."
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr "Code"
 
@@ -82,7 +82,7 @@ msgstr "Applications connectées"
 msgid "Credentials"
 msgstr "Identifiants"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr "Vous ne voyez pas l'email ? <0>Essayez d'envoyer à nouveau.</0>"
 
@@ -98,11 +98,11 @@ msgstr "Veuillez entrer le code de vérification envoyé par email"
 msgid "Email is required"
 msgstr "L'adresse email est requise"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr "Entrez un nouveau mot de passe"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr "Entrez votre adresse email"
 
@@ -130,11 +130,11 @@ msgstr "Échec de l'envoi du code par email"
 msgid "Failed to sign out"
 msgstr "Échec de la déconnexion"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr "Mot de passe oublié ?"
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr "Obtenir le code de réinitialisation"
 
@@ -187,9 +187,9 @@ msgstr "Aucune application connectée"
 msgid "No devices"
 msgstr "Aucun appareil"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -207,7 +207,7 @@ msgstr "Déconnecter cet appareil"
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr "Réinitialiser le mot de passe"
 
@@ -234,7 +234,7 @@ msgstr "Sélectionnez le compte que vous souhaitez gérer."
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr "Se connecter"
 
@@ -297,8 +297,8 @@ msgstr "Nous n'avons pas pu charger vos comptes. Veuillez réactualiser la page 
 msgid "Whoops! An error occurred."
 msgstr "Oups ! Une erreur s'est produite."
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr "XXXXX-XXXXX"
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ga/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ga/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/gl/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/gl/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/hi/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/hi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/hu/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/hu/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ia/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ia/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/id/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/id/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/it/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/it/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ja/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/km/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/km/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ne/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ne/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/nl/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/nl/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/pl/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/pl/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/pt-BR/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/pt-BR/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ro/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ro/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/ru/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/ru/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/sv/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/th/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/th/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/tr/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/tr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/uk/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/uk/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/vi/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/vi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/zh-CN/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/zh-CN/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/zh-HK/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/zh-HK/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/locales/zh-TW/messages.po
+++ b/packages/oauth/oauth-provider-frontend/src/locales/zh-TW/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:157
+#: src/routes/account/_minimalLayout/sign-in.tsx:162
 msgid "@handle or email"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Are you sure you want to revoke access? This application won't be able to
 msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:133
-#: src/routes/account/_minimalLayout/reset-password.tsx:206
+#: src/routes/account/_minimalLayout/reset-password.tsx:212
 msgid "Back to sign in"
 msgstr ""
 
@@ -61,12 +61,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:330
+#: src/routes/account/_minimalLayout/reset-password.tsx:345
 msgid "Click here to send a new code to your email."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:195
-#: src/routes/account/_minimalLayout/reset-password.tsx:233
+#: src/routes/account/_minimalLayout/sign-in.tsx:204
+#: src/routes/account/_minimalLayout/reset-password.tsx:239
 msgid "Code"
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Credentials"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:325
+#: src/routes/account/_minimalLayout/reset-password.tsx:340
 msgid "Don't see the email? <0>Try sending again.</0>"
 msgstr ""
 
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Email is required"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:275
+#: src/routes/account/_minimalLayout/reset-password.tsx:290
 msgid "Enter a new password"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:165
+#: src/routes/account/_minimalLayout/reset-password.tsx:171
 msgid "Enter your email"
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Failed to sign out"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:237
+#: src/routes/account/_minimalLayout/sign-in.tsx:250
 msgid "Forgot password?"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/reset-password.tsx:197
+#: src/routes/account/_minimalLayout/reset-password.tsx:203
 msgid "Get reset code"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgstr ""
 msgid "No devices"
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:172
-#: src/routes/account/_minimalLayout/sign-in.tsx:178
-#: src/routes/account/_minimalLayout/reset-password.tsx:268
+#: src/routes/account/_minimalLayout/sign-in.tsx:177
+#: src/routes/account/_minimalLayout/sign-in.tsx:187
+#: src/routes/account/_minimalLayout/reset-password.tsx:278
 msgid "Password"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/reset-password.tsx:29
 #: src/routes/account/_minimalLayout/reset-password.tsx:140
-#: src/routes/account/_minimalLayout/reset-password.tsx:319
+#: src/routes/account/_minimalLayout/reset-password.tsx:334
 msgid "Reset password"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 
 #: src/routes/account/_minimalLayout/sign-in.tsx:32
 #: src/routes/account/_minimalLayout/sign-in.tsx:136
-#: src/routes/account/_minimalLayout/sign-in.tsx:228
+#: src/routes/account/_minimalLayout/sign-in.tsx:241
 msgid "Sign in"
 msgstr ""
 
@@ -297,8 +297,8 @@ msgstr ""
 msgid "Whoops! An error occurred."
 msgstr ""
 
-#: src/routes/account/_minimalLayout/sign-in.tsx:200
-#: src/routes/account/_minimalLayout/reset-password.tsx:239
+#: src/routes/account/_minimalLayout/sign-in.tsx:213
+#: src/routes/account/_minimalLayout/reset-password.tsx:249
 msgid "XXXXX-XXXXX"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-frontend/src/routes/account/_minimalLayout/reset-password.tsx
+++ b/packages/oauth/oauth-provider-frontend/src/routes/account/_minimalLayout/reset-password.tsx
@@ -161,6 +161,12 @@ function ResetPassword() {
                         </Form.Label>
                         <Form.Text
                           name={field.name}
+                          autoCapitalize="none"
+                          autoCorrect="off"
+                          autoComplete="email"
+                          spellCheck="false"
+                          type="email"
+                          enterKeyHint="next"
                           value={field.state.value}
                           placeholder={_(msg`Enter your email`)}
                           onBlur={field.handleBlur}
@@ -233,7 +239,11 @@ function ResetPassword() {
                               <Trans>Code</Trans>
                             </Form.Label>
                             <Form.Text
-                              autoComplete="off"
+                              autoComplete="one-time-code"
+                              autoCapitalize="characters"
+                              autoCorrect="off"
+                              spellCheck="false"
+                              enterKeyHint="next"
                               name={field.name}
                               value={field.state.value}
                               placeholder={_(msg`XXXXX-XXXXX`)}
@@ -269,7 +279,12 @@ function ResetPassword() {
                             </Form.Label>
                             <Form.Text
                               type="password"
-                              autoComplete="off"
+                              autoComplete="new-password"
+                              autoCapitalize="none"
+                              autoCorrect="off"
+                              spellCheck="false"
+                              enterKeyHint="done"
+                              minLength={MIN_PASSWORD_LENGTH}
                               name={field.name}
                               value={field.state.value}
                               placeholder={_(msg`Enter a new password`)}

--- a/packages/oauth/oauth-provider-frontend/src/routes/account/_minimalLayout/sign-in.tsx
+++ b/packages/oauth/oauth-provider-frontend/src/routes/account/_minimalLayout/sign-in.tsx
@@ -153,6 +153,11 @@ function LoginForm() {
                   </Form.Label>
                   <Form.Text
                     name={field.name}
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    autoComplete="username"
+                    spellCheck="false"
+                    type="text"
                     value={field.state.value}
                     placeholder={_(msg`@handle or email`)}
                     onBlur={field.handleBlur}
@@ -172,8 +177,12 @@ function LoginForm() {
                     <Trans>Password</Trans>
                   </Form.Label>
                   <Form.Text
-                    type="password"
                     name={field.name}
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    autoComplete="current-password"
+                    spellCheck="false"
+                    type="password"
                     value={field.state.value}
                     placeholder={_(msg`Password`)}
                     onBlur={field.handleBlur}
@@ -195,6 +204,10 @@ function LoginForm() {
                       <Trans>Code</Trans>
                     </Form.Label>
                     <Form.Text
+                      autoComplete="one-time-code"
+                      autoCapitalize="characters"
+                      autoCorrect="off"
+                      spellCheck="false"
                       name={field.name}
                       value={field.state.value}
                       placeholder={_(msg`XXXXX-XXXXX`)}

--- a/packages/oauth/oauth-provider-ui/src/components/forms/input-token.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/input-token.tsx
@@ -47,9 +47,9 @@ export function InputToken({
     <InputText
       {...props}
       type="text"
-      autoCapitalize="none"
+      autoCapitalize="characters"
       autoCorrect="off"
-      autoComplete="off"
+      autoComplete="one-time-code"
       spellCheck="false"
       minLength={11}
       maxLength={11}

--- a/packages/oauth/oauth-provider/src/router/create-account-page-middleware.ts
+++ b/packages/oauth/oauth-provider/src/router/create-account-page-middleware.ts
@@ -6,6 +6,7 @@ import {
   validateFetchDest,
   validateFetchMode,
   validateOrigin,
+  writeRedirect,
 } from '../lib/http/index.js'
 import type { OAuthProvider } from '../oauth-provider.js'
 import { sendAccountPageFactory } from './assets/send-account-page.js'
@@ -28,6 +29,13 @@ export function createAccountPageMiddleware<
 
   const router = new Router<Ctx, Req, Res>(issuerUrl)
 
+  // Create password reset discovery endpoint
+  // https://w3c.github.io/webappsec-change-password-url/
+  router.get('/.well-known/change-password', (_req, res) => {
+    writeRedirect(res, new URL('/account/reset-password', issuerUrl).toString())
+  })
+
+  // Create frontend account pages
   router.get<never>(/^\/account(?:\/.*)?$/, async function (req, res) {
     try {
       res.setHeader('Referrer-Policy', 'same-origin')


### PR DESCRIPTION
Adds .well-known path to auto discover password reset URLs. Used by password managers to link directly to page. Spec: https://w3c.github.io/webappsec-change-password-url/ (also god blog: https://web.dev/articles/change-password-url)

![Apple showing reset button when they detect compromised passwords](https://github.com/user-attachments/assets/d7060bef-7013-4bf7-92b5-876fe74fb9f5)
![1Password doing the same](https://github.com/user-attachments/assets/6afa0dab-10a1-44b9-b78f-f5ad47709e70)


Also updates some text input fields to give a better UX with autofilling
https://www.chromium.org/developers/design-documents/create-amazing-password-forms/

<img width="1042" alt="Screenshot 2025-05-23 at 19 34 45" src="https://github.com/user-attachments/assets/abfc0156-98a3-4519-bd04-2a868493a674" />

@matthieusieben you seem to be the expert in the oauth flow, so feel free to cherry-pick some of the improvements or close the PR if its not something y'all want to implement :) (or let me know if you want me to change anything)