### PR TITLE
fix: oauth footer links not working

### DIFF
--- a/.changeset/rude-shoes-applaud.md
+++ b/.changeset/rude-shoes-applaud.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider-frontend": patch
+---
+
+Fix oauth footer links not working

--- a/packages/oauth/oauth-provider-frontend/src/components/Footer.tsx
+++ b/packages/oauth/oauth-provider-frontend/src/components/Footer.tsx
@@ -13,8 +13,8 @@ export function Footer() {
       <div className="flex flex-wrap">
         {links?.map((link) => (
           <InlineLink
-            href={link.href}
             className="text-text-light mr-4 text-sm"
+            href={link.href}
             key={link.href}
           >
             {localizeString(link.title)}

--- a/packages/oauth/oauth-provider-frontend/src/components/Link.tsx
+++ b/packages/oauth/oauth-provider-frontend/src/components/Link.tsx
@@ -1,16 +1,24 @@
-import { Link as RouterLink, LinkComponentProps } from '@tanstack/react-router'
+import {
+  Link as RouterLink,
+  type LinkComponentProps,
+} from '@tanstack/react-router'
 import { clsx } from 'clsx'
-import { ButtonStyleProps, useButtonStyles } from '#/components/Button'
+import { type ReactNode } from 'react'
+import { type ButtonStyleProps, useButtonStyles } from '#/components/Button'
 
 export type LinkProps = LinkComponentProps & {
   label?: string
+  children?: ReactNode | string
 }
 
 export function Link({ children, label, ...rest }: LinkProps) {
+  const isExternal = !rest.to && rest.href
+  const Component = isExternal ? 'a' : RouterLink
+
   return (
-    <RouterLink {...rest} aria-label={label || rest.href || rest.to}>
+    <Component {...rest} aria-label={label || rest.href || rest.to}>
       {children}
-    </RouterLink>
+    </Component>
   )
 }
 


### PR DESCRIPTION
Fixes issue where https://bsky.social/account footer is only linking to https://bsky.social/account/sign-in

This is due to `@tanstack/react-router`'s Link component not liking the use of href to external (non router managed paths), `to` is used everywhere else to link to other router managed pages, so they work fine.

Before patch:
<img width="1398" alt="Screenshot 2025-05-26 at 23 39 07" src="https://github.com/user-attachments/assets/5260cc14-2da0-4a9a-bc7e-cefb99322f9c" />
After:
<img width="1410" alt="Screenshot 2025-05-26 at 23 42 57" src="https://github.com/user-attachments/assets/279831e2-6b41-4608-8313-13f7434712df" />


Not that familiar with react-router, so there may be better ways to tell the Link component to be external

cc: @matthieusieben 