### PR TITLE
Draft: New public record `app.bsky.feed.honk`

### DIFF
--- a/lexicons/app/bsky/feed/honk.json
+++ b/lexicons/app/bsky/feed/honk.json
@@ -14,7 +14,7 @@
             "type": "string",
             "maxLength": 10,
             "maxGraphemes": 1,
-            "description": "DEPRECATED: Optional single character summary of the threat intesity, expressed as an emoji."
+            "description": "DEPRECATED: Optional single character summary of the threat intensity, expressed as an emoji."
           },
           "subject": { "type": "string", "format": "did" },
           "createdAt": { "type": "string", "format": "datetime" }


### PR DESCRIPTION
This proposal introduces a new record type `app.bsky.feed.honk`, for sending t̶h̶r̶e̶a̶t̶s̶ alerts to other users. The Lexicon optionally includes deprecated support for legacy h̶a̶r̶a̶s̶s̶m̶e̶n̶t̶ alerts using emoji.

Rationale:

1. Honk
2. Honk `app.bsky.feed.honk` honk?
3. Lets be honest, this is more irrational than rational
4. Honk :goose: 

Feedback and "honks" are welcome.