### PR TITLE
Unify `getPostThreadV2` and `getPostThreadHiddenV2` responses

### DIFF
--- a/.changeset/early-ties-return.md
+++ b/.changeset/early-ties-return.md
@@ -1,0 +1,8 @@
+---
+"@atproto/bsync": patch
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Unify `getPostThreadV2` and `getPostThreadHiddenV2` responses under `app.bsky.unspecced.defs` namespace and a single interface via `threadItemPost`.

--- a/lexicons/app/bsky/unspecced/defs.json
+++ b/lexicons/app/bsky/unspecced/defs.json
@@ -86,6 +86,71 @@
           }
         }
       }
+    },
+    "threadItem": {
+      "type": "object",
+      "required": ["uri", "depth", "value"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "depth": {
+          "type": "integer",
+          "description": "The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths."
+        },
+        "value": {
+          "type": "union",
+          "refs": [
+            "#threadItemPost",
+            "#threadItemNoUnauthenticated",
+            "#threadItemNotFound",
+            "#threadItemBlocked"
+          ]
+        }
+      }
+    },
+    "threadItemPost": {
+      "type": "object",
+      "required": ["post", "moreParents", "moreReplies", "opThread", "hiddenByThreadgate", "mutedByViewer"],
+      "properties": {
+        "post": { "type": "ref", "ref": "app.bsky.feed.defs#postView" },
+        "moreParents": {
+          "type": "boolean",
+          "description": "This post has more parents that were not present in the response. This is just a boolean, without the number of parents."
+        },
+        "moreReplies": {
+          "type": "integer",
+          "description": "This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate."
+        },
+        "opThread": {
+          "type": "boolean",
+          "description": "This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread."
+        },
+        "hiddenByThreadgate": {
+          "type": "boolean",
+          "description": "The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread."
+        },
+        "mutedByViewer": {
+          "type": "boolean",
+          "description": "This is by an account muted by the viewer requesting it."
+        }
+      }
+    },
+    "threadItemNoUnauthenticated": {
+      "type": "object",
+      "properties": {}
+    },
+    "threadItemNotFound": {
+      "type": "object",
+      "properties": {}
+    },
+    "threadItemBlocked": {
+      "type": "object",
+      "required": ["author"],
+      "properties": {
+        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" }
+      }
     }
   }
 }

--- a/lexicons/app/bsky/unspecced/getPostThreadHiddenV2.json
+++ b/lexicons/app/bsky/unspecced/getPostThreadHiddenV2.json
@@ -29,46 +29,13 @@
           "properties": {
             "thread": {
               "type": "array",
-              "description": "A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item.",
+              "description": "A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.",
               "items": {
                 "type": "ref",
-                "ref": "#threadHiddenItem"
+                "ref": "app.bsky.unspecced.defs#threadItem"
               }
             }
           }
-        }
-      }
-    },
-    "threadHiddenItem": {
-      "type": "object",
-      "required": ["uri", "depth", "value"],
-      "properties": {
-        "uri": {
-          "type": "string",
-          "format": "at-uri"
-        },
-        "depth": {
-          "type": "integer",
-          "description": "The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths."
-        },
-        "value": {
-          "type": "union",
-          "refs": ["#threadHiddenItemPost"]
-        }
-      }
-    },
-    "threadHiddenItemPost": {
-      "type": "object",
-      "required": ["post", "hiddenByThreadgate", "mutedByViewer"],
-      "properties": {
-        "post": { "type": "ref", "ref": "app.bsky.feed.defs#postView" },
-        "hiddenByThreadgate": {
-          "type": "boolean",
-          "description": "The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread."
-        },
-        "mutedByViewer": {
-          "type": "boolean",
-          "description": "This is by an account muted by the viewer requesting it."
         }
       }
     }

--- a/lexicons/app/bsky/unspecced/getPostThreadV2.json
+++ b/lexicons/app/bsky/unspecced/getPostThreadV2.json
@@ -57,7 +57,7 @@
               "description": "A flat list of thread items. The depth of each item is indicated by the depth property inside the item.",
               "items": {
                 "type": "ref",
-                "ref": "#threadItem"
+                "ref": "app.bsky.unspecced.defs#threadItem"
               }
             },
             "threadgate": {
@@ -70,63 +70,6 @@
             }
           }
         }
-      }
-    },
-    "threadItem": {
-      "type": "object",
-      "required": ["uri", "depth", "value"],
-      "properties": {
-        "uri": {
-          "type": "string",
-          "format": "at-uri"
-        },
-        "depth": {
-          "type": "integer",
-          "description": "The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths."
-        },
-        "value": {
-          "type": "union",
-          "refs": [
-            "#threadItemPost",
-            "#threadItemNoUnauthenticated",
-            "#threadItemNotFound",
-            "#threadItemBlocked"
-          ]
-        }
-      }
-    },
-    "threadItemPost": {
-      "type": "object",
-      "required": ["post", "moreParents", "moreReplies", "opThread"],
-      "properties": {
-        "post": { "type": "ref", "ref": "app.bsky.feed.defs#postView" },
-        "moreParents": {
-          "type": "boolean",
-          "description": "This post has more parents that were not present in the response. This is just a boolean, without the number of parents."
-        },
-        "moreReplies": {
-          "type": "integer",
-          "description": "This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate."
-        },
-        "opThread": {
-          "type": "boolean",
-          "description": "This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread."
-        }
-      }
-    },
-    "threadItemNoUnauthenticated": {
-      "type": "object",
-      "properties": {}
-    },
-    "threadItemNotFound": {
-      "type": "object",
-      "properties": {}
-    },
-    "threadItemBlocked": {
-      "type": "object",
-      "required": ["author"],
-      "properties": {
-        "author": { "type": "ref", "ref": "app.bsky.feed.defs#blockedAuthor" }
       }
     }
   }

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -128,8 +128,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -391,8 +391,8 @@ export * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 export * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 export * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 export * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-export * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 export * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+export * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 export * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 export * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 export * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -2107,6 +2107,13 @@ export class AppBskyFeedNS {
       })
   }
 
+  getPosts(
+    params?: AppBskyFeedGetPosts.QueryParams,
+    opts?: AppBskyFeedGetPosts.CallOptions,
+  ): Promise<AppBskyFeedGetPosts.Response> {
+    return this._client.call('app.bsky.feed.getPosts', params, undefined, opts)
+  }
+
   getPostThread(
     params?: AppBskyFeedGetPostThread.QueryParams,
     opts?: AppBskyFeedGetPostThread.CallOptions,
@@ -2116,13 +2123,6 @@ export class AppBskyFeedNS {
       .catch((e) => {
         throw AppBskyFeedGetPostThread.toKnownErr(e)
       })
-  }
-
-  getPosts(
-    params?: AppBskyFeedGetPosts.QueryParams,
-    opts?: AppBskyFeedGetPosts.CallOptions,
-  ): Promise<AppBskyFeedGetPosts.Response> {
-    return this._client.call('app.bsky.feed.getPosts', params, undefined, opts)
   }
 
   getQuotes(

--- a/packages/api/src/client/types/app/bsky/unspecced/defs.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/defs.ts
@@ -10,6 +10,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import type * as AppBskyActorDefs from '../actor/defs.js'
+import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -124,4 +125,99 @@ export function isTrendView<V>(v: V) {
 
 export function validateTrendView<V>(v: V) {
   return validate<TrendView & V>(v, id, hashTrendView)
+}
+
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.defs#threadItem'
+  uri: string
+  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
+  depth: number
+  value:
+    | $Typed<ThreadItemPost>
+    | $Typed<ThreadItemNoUnauthenticated>
+    | $Typed<ThreadItemNotFound>
+    | $Typed<ThreadItemBlocked>
+    | { $type: string }
+}
+
+const hashThreadItem = 'threadItem'
+
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
+}
+
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
+}
+
+export interface ThreadItemPost {
+  $type?: 'app.bsky.unspecced.defs#threadItemPost'
+  post: AppBskyFeedDefs.PostView
+  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
+  moreParents: boolean
+  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
+  moreReplies: number
+  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
+  opThread: boolean
+  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
+  hiddenByThreadgate: boolean
+  /** This is by an account muted by the viewer requesting it. */
+  mutedByViewer: boolean
+}
+
+const hashThreadItemPost = 'threadItemPost'
+
+export function isThreadItemPost<V>(v: V) {
+  return is$typed(v, id, hashThreadItemPost)
+}
+
+export function validateThreadItemPost<V>(v: V) {
+  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
+}
+
+export interface ThreadItemNoUnauthenticated {
+  $type?: 'app.bsky.unspecced.defs#threadItemNoUnauthenticated'
+}
+
+const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
+
+export function isThreadItemNoUnauthenticated<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNoUnauthenticated)
+}
+
+export function validateThreadItemNoUnauthenticated<V>(v: V) {
+  return validate<ThreadItemNoUnauthenticated & V>(
+    v,
+    id,
+    hashThreadItemNoUnauthenticated,
+  )
+}
+
+export interface ThreadItemNotFound {
+  $type?: 'app.bsky.unspecced.defs#threadItemNotFound'
+}
+
+const hashThreadItemNotFound = 'threadItemNotFound'
+
+export function isThreadItemNotFound<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNotFound)
+}
+
+export function validateThreadItemNotFound<V>(v: V) {
+  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
+}
+
+export interface ThreadItemBlocked {
+  $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
+  author: AppBskyFeedDefs.BlockedAuthor
+}
+
+const hashThreadItemBlocked = 'threadItemBlocked'
+
+export function isThreadItemBlocked<V>(v: V) {
+  return is$typed(v, id, hashThreadItemBlocked)
+}
+
+export function validateThreadItemBlocked<V>(v: V) {
+  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
 }

--- a/packages/api/src/client/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
@@ -10,7 +10,7 @@ import {
   is$typed as _is$typed,
   type OmitKey,
 } from '../../../../util'
-import type * as AppBskyFeedDefs from '../feed/defs.js'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -26,8 +26,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
 }
 
 export interface CallOptions {
@@ -43,41 +43,4 @@ export interface Response {
 
 export function toKnownErr(e: any) {
   return e
-}
-
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value: $Typed<ThreadHiddenItemPost> | { $type: string }
-}
-
-const hashThreadHiddenItem = 'threadHiddenItem'
-
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
-}
-
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
-}
-
-export interface ThreadHiddenItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
-  hiddenByThreadgate: boolean
-  /** This is by an account muted by the viewer requesting it. */
-  mutedByViewer: boolean
-}
-
-const hashThreadHiddenItemPost = 'threadHiddenItemPost'
-
-export function isThreadHiddenItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItemPost)
-}
-
-export function validateThreadHiddenItemPost<V>(v: V) {
-  return validate<ThreadHiddenItemPost & V>(v, id, hashThreadHiddenItemPost)
 }

--- a/packages/api/src/client/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -10,6 +10,7 @@ import {
   is$typed as _is$typed,
   type OmitKey,
 } from '../../../../util'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
@@ -35,7 +36,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadItem[]
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
   /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
   hasHiddenReplies: boolean
@@ -54,95 +55,4 @@ export interface Response {
 
 export function toKnownErr(e: any) {
   return e
-}
-
-export interface ThreadItem {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value:
-    | $Typed<ThreadItemPost>
-    | $Typed<ThreadItemNoUnauthenticated>
-    | $Typed<ThreadItemNotFound>
-    | $Typed<ThreadItemBlocked>
-    | { $type: string }
-}
-
-const hashThreadItem = 'threadItem'
-
-export function isThreadItem<V>(v: V) {
-  return is$typed(v, id, hashThreadItem)
-}
-
-export function validateThreadItem<V>(v: V) {
-  return validate<ThreadItem & V>(v, id, hashThreadItem)
-}
-
-export interface ThreadItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
-  moreParents: boolean
-  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
-  moreReplies: number
-  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
-  opThread: boolean
-}
-
-const hashThreadItemPost = 'threadItemPost'
-
-export function isThreadItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadItemPost)
-}
-
-export function validateThreadItemPost<V>(v: V) {
-  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
-}
-
-export interface ThreadItemNoUnauthenticated {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated'
-}
-
-const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
-
-export function isThreadItemNoUnauthenticated<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNoUnauthenticated)
-}
-
-export function validateThreadItemNoUnauthenticated<V>(v: V) {
-  return validate<ThreadItemNoUnauthenticated & V>(
-    v,
-    id,
-    hashThreadItemNoUnauthenticated,
-  )
-}
-
-export interface ThreadItemNotFound {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound'
-}
-
-const hashThreadItemNotFound = 'threadItemNotFound'
-
-export function isThreadItemNotFound<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNotFound)
-}
-
-export function validateThreadItemNotFound<V>(v: V) {
-  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
-}
-
-export interface ThreadItemBlocked {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked'
-  author: AppBskyFeedDefs.BlockedAuthor
-}
-
-const hashThreadItemBlocked = 'threadItemBlocked'
-
-export function isThreadItemBlocked<V>(v: V) {
-  return is$typed(v, id, hashThreadItemBlocked)
-}
-
-export function validateThreadItemBlocked<V>(v: V) {
-  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
 }

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -1499,17 +1499,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1518,6 +1507,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -7239,6 +7239,48 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyFeedGetPosts: {
+    lexicon: 1,
+    id: 'app.bsky.feed.getPosts',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
+        parameters: {
+          type: 'params',
+          required: ['uris'],
+          properties: {
+            uris: {
+              type: 'array',
+              description: 'List of post AT-URIs to return hydrated views for.',
+              items: {
+                type: 'string',
+                format: 'at-uri',
+              },
+              maxLength: 25,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['posts'],
+            properties: {
+              posts: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.defs#postView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyFeedGetPostThread: {
     lexicon: 1,
     id: 'app.bsky.feed.getPostThread',
@@ -7300,48 +7342,6 @@ export const schemaDict = {
             name: 'NotFound',
           },
         ],
-      },
-    },
-  },
-  AppBskyFeedGetPosts: {
-    lexicon: 1,
-    id: 'app.bsky.feed.getPosts',
-    defs: {
-      main: {
-        type: 'query',
-        description:
-          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
-        parameters: {
-          type: 'params',
-          required: ['uris'],
-          properties: {
-            uris: {
-              type: 'array',
-              description: 'List of post AT-URIs to return hydrated views for.',
-              items: {
-                type: 'string',
-                format: 'at-uri',
-              },
-              maxLength: 25,
-            },
-          },
-        },
-        output: {
-          encoding: 'application/json',
-          schema: {
-            type: 'object',
-            required: ['posts'],
-            properties: {
-              posts: {
-                type: 'array',
-                items: {
-                  type: 'ref',
-                  ref: 'lex:app.bsky.feed.defs#postView',
-                },
-              },
-            },
-          },
-        },
       },
     },
   },
@@ -10201,6 +10201,90 @@ export const schemaDict = {
           },
         },
       },
+      threadItem: {
+        type: 'object',
+        required: ['uri', 'depth', 'value'],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'at-uri',
+          },
+          depth: {
+            type: 'integer',
+            description:
+              'The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths.',
+          },
+          value: {
+            type: 'union',
+            refs: [
+              'lex:app.bsky.unspecced.defs#threadItemPost',
+              'lex:app.bsky.unspecced.defs#threadItemNoUnauthenticated',
+              'lex:app.bsky.unspecced.defs#threadItemNotFound',
+              'lex:app.bsky.unspecced.defs#threadItemBlocked',
+            ],
+          },
+        },
+      },
+      threadItemPost: {
+        type: 'object',
+        required: [
+          'post',
+          'moreParents',
+          'moreReplies',
+          'opThread',
+          'hiddenByThreadgate',
+          'mutedByViewer',
+        ],
+        properties: {
+          post: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.defs#postView',
+          },
+          moreParents: {
+            type: 'boolean',
+            description:
+              'This post has more parents that were not present in the response. This is just a boolean, without the number of parents.',
+          },
+          moreReplies: {
+            type: 'integer',
+            description:
+              'This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate.',
+          },
+          opThread: {
+            type: 'boolean',
+            description:
+              'This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread.',
+          },
+          hiddenByThreadgate: {
+            type: 'boolean',
+            description:
+              'The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread.',
+          },
+          mutedByViewer: {
+            type: 'boolean',
+            description:
+              'This is by an account muted by the viewer requesting it.',
+          },
+        },
+      },
+      threadItemNoUnauthenticated: {
+        type: 'object',
+        properties: {},
+      },
+      threadItemNotFound: {
+        type: 'object',
+        properties: {},
+      },
+      threadItemBlocked: {
+        type: 'object',
+        required: ['author'],
+        properties: {
+          author: {
+            type: 'ref',
+            ref: 'lex:app.bsky.feed.defs#blockedAuthor',
+          },
+        },
+      },
     },
   },
   AppBskyUnspeccedGetConfig: {
@@ -10329,54 +10413,13 @@ export const schemaDict = {
               thread: {
                 type: 'array',
                 description:
-                  'A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item.',
+                  'A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem',
+                  ref: 'lex:app.bsky.unspecced.defs#threadItem',
                 },
               },
             },
-          },
-        },
-      },
-      threadHiddenItem: {
-        type: 'object',
-        required: ['uri', 'depth', 'value'],
-        properties: {
-          uri: {
-            type: 'string',
-            format: 'at-uri',
-          },
-          depth: {
-            type: 'integer',
-            description:
-              'The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths.',
-          },
-          value: {
-            type: 'union',
-            refs: [
-              'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost',
-            ],
-          },
-        },
-      },
-      threadHiddenItemPost: {
-        type: 'object',
-        required: ['post', 'hiddenByThreadgate', 'mutedByViewer'],
-        properties: {
-          post: {
-            type: 'ref',
-            ref: 'lex:app.bsky.feed.defs#postView',
-          },
-          hiddenByThreadgate: {
-            type: 'boolean',
-            description:
-              'The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread.',
-          },
-          mutedByViewer: {
-            type: 'boolean',
-            description:
-              'This is by an account muted by the viewer requesting it.',
           },
         },
       },
@@ -10447,7 +10490,7 @@ export const schemaDict = {
                   'A flat list of thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadV2#threadItem',
+                  ref: 'lex:app.bsky.unspecced.defs#threadItem',
                 },
               },
               threadgate: {
@@ -10460,73 +10503,6 @@ export const schemaDict = {
                   'Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them.',
               },
             },
-          },
-        },
-      },
-      threadItem: {
-        type: 'object',
-        required: ['uri', 'depth', 'value'],
-        properties: {
-          uri: {
-            type: 'string',
-            format: 'at-uri',
-          },
-          depth: {
-            type: 'integer',
-            description:
-              'The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths.',
-          },
-          value: {
-            type: 'union',
-            refs: [
-              'lex:app.bsky.unspecced.getPostThreadV2#threadItemPost',
-              'lex:app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated',
-              'lex:app.bsky.unspecced.getPostThreadV2#threadItemNotFound',
-              'lex:app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
-            ],
-          },
-        },
-      },
-      threadItemPost: {
-        type: 'object',
-        required: ['post', 'moreParents', 'moreReplies', 'opThread'],
-        properties: {
-          post: {
-            type: 'ref',
-            ref: 'lex:app.bsky.feed.defs#postView',
-          },
-          moreParents: {
-            type: 'boolean',
-            description:
-              'This post has more parents that were not present in the response. This is just a boolean, without the number of parents.',
-          },
-          moreReplies: {
-            type: 'integer',
-            description:
-              'This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate.',
-          },
-          opThread: {
-            type: 'boolean',
-            description:
-              'This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread.',
-          },
-        },
-      },
-      threadItemNoUnauthenticated: {
-        type: 'object',
-        properties: {},
-      },
-      threadItemNotFound: {
-        type: 'object',
-        properties: {},
-      },
-      threadItemBlocked: {
-        type: 'object',
-        required: ['author'],
-        properties: {
-          author: {
-            type: 'ref',
-            ref: 'lex:app.bsky.feed.defs#blockedAuthor',
           },
         },
       },
@@ -12897,8 +12873,8 @@ export const ids = {
   AppBskyFeedGetFeedSkeleton: 'app.bsky.feed.getFeedSkeleton',
   AppBskyFeedGetLikes: 'app.bsky.feed.getLikes',
   AppBskyFeedGetListFeed: 'app.bsky.feed.getListFeed',
-  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetPosts: 'app.bsky.feed.getPosts',
+  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetQuotes: 'app.bsky.feed.getQuotes',
   AppBskyFeedGetRepostedBy: 'app.bsky.feed.getRepostedBy',
   AppBskyFeedGetSuggestedFeeds: 'app.bsky.feed.getSuggestedFeeds',

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/defs.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/defs.ts
@@ -10,6 +10,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import type * as AppBskyActorDefs from '../actor/defs.js'
+import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -124,4 +125,99 @@ export function isTrendView<V>(v: V) {
 
 export function validateTrendView<V>(v: V) {
   return validate<TrendView & V>(v, id, hashTrendView)
+}
+
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.defs#threadItem'
+  uri: string
+  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
+  depth: number
+  value:
+    | $Typed<ThreadItemPost>
+    | $Typed<ThreadItemNoUnauthenticated>
+    | $Typed<ThreadItemNotFound>
+    | $Typed<ThreadItemBlocked>
+    | { $type: string }
+}
+
+const hashThreadItem = 'threadItem'
+
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
+}
+
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
+}
+
+export interface ThreadItemPost {
+  $type?: 'app.bsky.unspecced.defs#threadItemPost'
+  post: AppBskyFeedDefs.PostView
+  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
+  moreParents: boolean
+  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
+  moreReplies: number
+  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
+  opThread: boolean
+  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
+  hiddenByThreadgate: boolean
+  /** This is by an account muted by the viewer requesting it. */
+  mutedByViewer: boolean
+}
+
+const hashThreadItemPost = 'threadItemPost'
+
+export function isThreadItemPost<V>(v: V) {
+  return is$typed(v, id, hashThreadItemPost)
+}
+
+export function validateThreadItemPost<V>(v: V) {
+  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
+}
+
+export interface ThreadItemNoUnauthenticated {
+  $type?: 'app.bsky.unspecced.defs#threadItemNoUnauthenticated'
+}
+
+const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
+
+export function isThreadItemNoUnauthenticated<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNoUnauthenticated)
+}
+
+export function validateThreadItemNoUnauthenticated<V>(v: V) {
+  return validate<ThreadItemNoUnauthenticated & V>(
+    v,
+    id,
+    hashThreadItemNoUnauthenticated,
+  )
+}
+
+export interface ThreadItemNotFound {
+  $type?: 'app.bsky.unspecced.defs#threadItemNotFound'
+}
+
+const hashThreadItemNotFound = 'threadItemNotFound'
+
+export function isThreadItemNotFound<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNotFound)
+}
+
+export function validateThreadItemNotFound<V>(v: V) {
+  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
+}
+
+export interface ThreadItemBlocked {
+  $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
+  author: AppBskyFeedDefs.BlockedAuthor
+}
+
+const hashThreadItemBlocked = 'threadItemBlocked'
+
+export function isThreadItemBlocked<V>(v: V) {
+  return is$typed(v, id, hashThreadItemBlocked)
+}
+
+export function validateThreadItemBlocked<V>(v: V) {
+  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
@@ -11,7 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import type * as AppBskyFeedDefs from '../feed/defs.js'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -56,40 +56,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value: $Typed<ThreadHiddenItemPost> | { $type: string }
-}
-
-const hashThreadHiddenItem = 'threadHiddenItem'
-
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
-}
-
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
-}
-
-export interface ThreadHiddenItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
-  hiddenByThreadgate: boolean
-  /** This is by an account muted by the viewer requesting it. */
-  mutedByViewer: boolean
-}
-
-const hashThreadHiddenItemPost = 'threadHiddenItemPost'
-
-export function isThreadHiddenItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItemPost)
-}
-
-export function validateThreadHiddenItemPost<V>(v: V) {
-  return validate<ThreadHiddenItemPost & V>(v, id, hashThreadHiddenItemPost)
-}

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -11,6 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
@@ -36,7 +37,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadItem[]
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
   /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
   hasHiddenReplies: boolean
@@ -67,94 +68,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadItem {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value:
-    | $Typed<ThreadItemPost>
-    | $Typed<ThreadItemNoUnauthenticated>
-    | $Typed<ThreadItemNotFound>
-    | $Typed<ThreadItemBlocked>
-    | { $type: string }
-}
-
-const hashThreadItem = 'threadItem'
-
-export function isThreadItem<V>(v: V) {
-  return is$typed(v, id, hashThreadItem)
-}
-
-export function validateThreadItem<V>(v: V) {
-  return validate<ThreadItem & V>(v, id, hashThreadItem)
-}
-
-export interface ThreadItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
-  moreParents: boolean
-  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
-  moreReplies: number
-  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
-  opThread: boolean
-}
-
-const hashThreadItemPost = 'threadItemPost'
-
-export function isThreadItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadItemPost)
-}
-
-export function validateThreadItemPost<V>(v: V) {
-  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
-}
-
-export interface ThreadItemNoUnauthenticated {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated'
-}
-
-const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
-
-export function isThreadItemNoUnauthenticated<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNoUnauthenticated)
-}
-
-export function validateThreadItemNoUnauthenticated<V>(v: V) {
-  return validate<ThreadItemNoUnauthenticated & V>(
-    v,
-    id,
-    hashThreadItemNoUnauthenticated,
-  )
-}
-
-export interface ThreadItemNotFound {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound'
-}
-
-const hashThreadItemNotFound = 'threadItemNotFound'
-
-export function isThreadItemNotFound<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNotFound)
-}
-
-export function validateThreadItemNotFound<V>(v: V) {
-  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
-}
-
-export interface ThreadItemBlocked {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked'
-  author: AppBskyFeedDefs.BlockedAuthor
-}
-
-const hashThreadItemBlocked = 'threadItemBlocked'
-
-export function isThreadItemBlocked<V>(v: V) {
-  return is$typed(v, id, hashThreadItemBlocked)
-}
-
-export function validateThreadItemBlocked<V>(v: V) {
-  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
-}

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -59,11 +59,8 @@ import {
   isRecord as isLabelerRecord,
 } from '../lexicon/types/app/bsky/labeler/service'
 import { RecordDeleted as NotificationRecordDeleted } from '../lexicon/types/app/bsky/notification/defs'
-import { ThreadHiddenItem } from '../lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
-import {
-  QueryParams as GetPostThreadV2QueryParams,
-  ThreadItem,
-} from '../lexicon/types/app/bsky/unspecced/getPostThreadV2'
+import { QueryParams as GetPostThreadV2QueryParams } from '../lexicon/types/app/bsky/unspecced/getPostThreadV2'
+import { ThreadItem } from '../lexicon/types/app/bsky/unspecced/defs'
 import { isSelfLabels } from '../lexicon/types/com/atproto/label/defs'
 import { $Typed, Un$Typed } from '../lexicon/util'
 import { Notification } from '../proto/bsky_pb'
@@ -1531,11 +1528,13 @@ export class Views {
       uri,
       depth,
       value: {
-        $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+        $type: 'app.bsky.unspecced.defs#threadItemPost',
         post: postView,
         moreParents: moreParents ?? false,
         moreReplies,
         opThread: isOPThread,
+        hiddenByThreadgate: false, // Hidden posts are handled by threadHiddenV2
+        mutedByViewer: false, // Hidden posts are handled by threadHiddenV2
       },
     }
   }
@@ -1551,7 +1550,7 @@ export class Views {
       uri,
       depth,
       value: {
-        $type: 'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated',
+        $type: 'app.bsky.unspecced.defs#threadItemNoUnauthenticated',
       },
     }
   }
@@ -1567,7 +1566,7 @@ export class Views {
       uri,
       depth,
       value: {
-        $type: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound',
+        $type: 'app.bsky.unspecced.defs#threadItemNotFound',
       },
     }
   }
@@ -1587,7 +1586,7 @@ export class Views {
       uri,
       depth,
       value: {
-        $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+        $type: 'app.bsky.unspecced.defs#threadItemBlocked',
         author: {
           did: authorDid,
           viewer: this.blockedProfileViewer(authorDid, state),
@@ -1608,7 +1607,7 @@ export class Views {
       branchingFactor: number
       prioritizeFollowedUsers: boolean
     },
-  ): ThreadHiddenItem[] {
+  ): ThreadItem[] {
     const { anchor: anchorUri, uris } = skeleton
 
     // Not found.
@@ -1773,10 +1772,13 @@ export class Views {
     return {
       ...base,
       value: {
-        $type: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost',
+        $type: 'app.bsky.unspecced.defs#threadItemPost',
         post: postView,
         hiddenByThreadgate,
         mutedByViewer,
+        moreParents: false, // Hidden replies don't have parents.
+        moreReplies: 0, // Hidden replies don't have replies hydrated.
+        opThread: false, // Hidden replies don't contain OP threads.
       },
     }
   }

--- a/packages/bsky/src/views/threads-v2.ts
+++ b/packages/bsky/src/views/threads-v2.ts
@@ -2,17 +2,15 @@ import { asPredicate } from '@atproto/api'
 import { HydrateCtx } from '../hydration/hydrator'
 import { validateRecord as validatePostRecord } from '../lexicon/types/app/bsky/feed/post'
 import {
-  ThreadHiddenItem,
-  ThreadHiddenItemPost,
-} from '../lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
-import {
   QueryParams as GetPostThreadV2QueryParams,
+} from '../lexicon/types/app/bsky/unspecced/getPostThreadV2'
+import {
   ThreadItem,
   ThreadItemBlocked,
   ThreadItemNoUnauthenticated,
   ThreadItemNotFound,
   ThreadItemPost,
-} from '../lexicon/types/app/bsky/unspecced/getPostThreadV2'
+} from '../lexicon/types/app/bsky/unspecced/defs'
 import { $Typed } from '../lexicon/util'
 
 type ThreadMaybeHiddenPostNode = ThreadPostNode | ThreadHiddenPostNode
@@ -64,15 +62,15 @@ type ThreadPostNode = {
   replies: ThreadTree[] | undefined
 }
 
-type ThreadHiddenItemValue<T extends ThreadHiddenItem['value']> = Omit<
-  ThreadHiddenItem,
+type ThreadHiddenItemValue<T extends ThreadItem['value']> = Omit<
+  ThreadItem,
   'value'
 > & {
   value: T
 }
 
 export type ThreadHiddenItemValuePost = ThreadHiddenItemValue<
-  $Typed<ThreadHiddenItemPost>
+  $Typed<ThreadItemPost>
 >
 
 // This is an intermediary type that doesn't map to the views.
@@ -80,7 +78,7 @@ export type ThreadHiddenItemValuePost = ThreadHiddenItemValue<
 // while also differentiating between hidden and visible cases.
 export type ThreadHiddenAnchorPostNode = {
   type: 'hiddenAnchor'
-  item: Omit<ThreadHiddenItem, 'value'> & { value: undefined }
+  item: Omit<ThreadItem, 'value'> & { value: undefined }
   replies: ThreadHiddenPostNode[] | undefined
 }
 
@@ -109,7 +107,7 @@ export type ThreadTree = ThreadTreeVisible | ThreadTreeHidden
 
 /** This function mutates the tree parameter. */
 export function sortTrimFlattenThreadTree<
-  TItem extends ThreadItem | ThreadHiddenItem,
+  TItem extends ThreadItem | ThreadItem,
 >(anchorTree: ThreadTree, options: SortTrimFlattenOptions): TItem[] {
   const sortedAnchorTree = sortTrimThreadTree(anchorTree, options)
 
@@ -309,7 +307,7 @@ function topSortValue(likeCount: number, hasOPLike: boolean): number {
   return Math.log(3 + likeCount) * (hasOPLike ? 1.45 : 1.0)
 }
 
-function flattenTree<TItem extends ThreadItem | ThreadHiddenItem>(
+function flattenTree<TItem extends ThreadItem | ThreadItem>(
   tree: ThreadTree,
 ): TItem[] {
   return [
@@ -335,7 +333,7 @@ function flattenTree<TItem extends ThreadItem | ThreadHiddenItem>(
   ]
 }
 
-function* flattenInDirection<TItem extends ThreadItem | ThreadHiddenItem>({
+function* flattenInDirection<TItem extends ThreadItem | ThreadItem>({
   tree,
   direction,
 }: {

--- a/packages/bsky/tests/views/__snapshots__/thread-v2.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/thread-v2.test.ts.snap
@@ -8,9 +8,11 @@ Object {
       "depth": -1,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -46,9 +48,11 @@ Object {
       "depth": 0,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -102,9 +106,11 @@ Object {
       "depth": -1,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -140,9 +146,11 @@ Object {
       "depth": 0,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -188,9 +196,11 @@ Object {
       "depth": 1,
       "uri": "record(2)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -244,9 +254,11 @@ Object {
       "depth": -2,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -282,9 +294,11 @@ Object {
       "depth": -1,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -330,9 +344,11 @@ Object {
       "depth": 0,
       "uri": "record(2)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -386,9 +402,11 @@ Object {
       "depth": -1,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -424,9 +442,11 @@ Object {
       "depth": 0,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -480,9 +500,11 @@ Object {
       "depth": -1,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -518,9 +540,11 @@ Object {
       "depth": 0,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -566,9 +590,11 @@ Object {
       "depth": 1,
       "uri": "record(2)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -622,9 +648,11 @@ Object {
       "depth": -2,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -660,9 +688,11 @@ Object {
       "depth": -1,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -708,9 +738,11 @@ Object {
       "depth": 0,
       "uri": "record(2)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -764,9 +796,11 @@ Object {
       "depth": 0,
       "uri": "record(0)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -802,9 +836,11 @@ Object {
       "depth": 1,
       "uri": "record(1)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -850,9 +886,11 @@ Object {
       "depth": 2,
       "uri": "record(2)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": true,
         "post": Object {
           "author": Object {
@@ -898,9 +936,11 @@ Object {
       "depth": 1,
       "uri": "record(3)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -946,9 +986,11 @@ Object {
       "depth": 1,
       "uri": "record(4)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -994,9 +1036,11 @@ Object {
       "depth": 2,
       "uri": "record(5)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {
@@ -1042,9 +1086,11 @@ Object {
       "depth": 1,
       "uri": "record(6)",
       "value": Object {
-        "$type": "app.bsky.unspecced.getPostThreadV2#threadItemPost",
+        "$type": "app.bsky.unspecced.defs#threadItemPost",
+        "hiddenByThreadgate": false,
         "moreParents": false,
         "moreReplies": 0,
+        "mutedByViewer": false,
         "opThread": false,
         "post": Object {
           "author": Object {

--- a/packages/bsky/tests/views/thread-v2.test.ts
+++ b/packages/bsky/tests/views/thread-v2.test.ts
@@ -1,22 +1,17 @@
 import assert from 'node:assert'
-import {
-  AppBskyUnspeccedGetPostThreadHiddenV2,
-  AppBskyUnspeccedGetPostThreadV2,
-  AtpAgent,
-} from '@atproto/api'
+import { AppBskyUnspeccedDefs, AtpAgent } from '@atproto/api'
 import { SeedClient, TestNetwork } from '@atproto/dev-env'
 import { ids } from '../../src/lexicon/lexicons'
-import {
-  OutputSchema as OutputSchemaHiddenThread,
-  ThreadHiddenItem,
-  ThreadHiddenItemPost,
-} from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
+import { OutputSchema as OutputSchemaHiddenThread } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
 import {
   OutputSchema as OutputSchemaThread,
   QueryParams as QueryParamsThread,
-  ThreadItemPost,
 } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadV2'
-import { ThreadItemValuePost } from '../../src/views/threads-v2'
+import { ThreadItemPost } from '../../src/lexicon/types/app/bsky/unspecced/defs'
+import {
+  ThreadItemValuePost,
+  ThreadHiddenItemValuePost,
+} from '../../src/views/threads-v2'
 import { forSnapshot } from '../_util'
 import * as seeds from '../seed/thread-v2'
 import { TAG_BUMP_DOWN, TAG_HIDE } from '../seed/thread-v2'
@@ -29,7 +24,7 @@ const props = (overrides: Partial<PostProps> = {}): PostProps => ({
 })
 
 type PostPropsHidden = Pick<
-  ThreadHiddenItemPost,
+  ThreadItemPost,
   'hiddenByThreadgate' | 'mutedByViewer'
 >
 const propsHidden = (
@@ -76,7 +71,7 @@ describe('appview thread views v2', () => {
         expect.objectContaining({
           depth: 0,
           value: {
-            $type: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound',
+            $type: 'app.bsky.unspecced.defs#threadItemNotFound',
           },
         }),
       ])
@@ -1259,7 +1254,7 @@ describe('appview thread views v2', () => {
             uri: seed.r['0'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+              $type: 'app.bsky.unspecced.defs#threadItemBlocked',
             }),
           }),
         ])
@@ -1284,14 +1279,14 @@ describe('appview thread views v2', () => {
             uri: seed.r['0'].ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+              $type: 'app.bsky.unspecced.defs#threadItemBlocked',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['0.0'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1343,14 +1338,14 @@ describe('appview thread views v2', () => {
             uri: seed.root.ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+              $type: 'app.bsky.unspecced.defs#threadItemBlocked',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['1'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           // 1.0 is blocked, but 1.1 is not
@@ -1358,7 +1353,7 @@ describe('appview thread views v2', () => {
             uri: seed.r['1.1'].ref.uriStr,
             depth: 1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1383,14 +1378,14 @@ describe('appview thread views v2', () => {
             uri: seed.r['1'].ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+              $type: 'app.bsky.unspecced.defs#threadItemBlocked',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['1.0'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1415,21 +1410,21 @@ describe('appview thread views v2', () => {
             uri: seed.root.ref.uriStr,
             depth: -2,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked',
+              $type: 'app.bsky.unspecced.defs#threadItemBlocked',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['1'].ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['1.1'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1479,14 +1474,14 @@ describe('appview thread views v2', () => {
             uri: seed.r['2'].ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound',
+              $type: 'app.bsky.unspecced.defs#threadItemNotFound',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['2.0'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1511,21 +1506,21 @@ describe('appview thread views v2', () => {
             uri: seed.root.ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['0'].ref.uriStr,
             depth: 1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['0.0'].ref.uriStr,
             depth: 2,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -1548,7 +1543,7 @@ describe('appview thread views v2', () => {
             uri: seed.root.ref.uriStr,
             depth: -1,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           expect.objectContaining({
@@ -1556,7 +1551,7 @@ describe('appview thread views v2', () => {
             depth: 0,
             value: expect.objectContaining({
               $type:
-                'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated',
+                'app.bsky.unspecced.defs#threadItemNoUnauthenticated',
             }),
           }),
         ])
@@ -1579,7 +1574,7 @@ describe('appview thread views v2', () => {
             uri: seed.root.ref.uriStr,
             depth: -3,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
           expect.objectContaining({
@@ -1587,7 +1582,7 @@ describe('appview thread views v2', () => {
             depth: -2,
             value: expect.objectContaining({
               $type:
-                'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated',
+                'app.bsky.unspecced.defs#threadItemNoUnauthenticated',
             }),
           }),
           expect.objectContaining({
@@ -1595,14 +1590,14 @@ describe('appview thread views v2', () => {
             depth: -1,
             value: expect.objectContaining({
               $type:
-                'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated',
+                'app.bsky.unspecced.defs#threadItemNoUnauthenticated',
             }),
           }),
           expect.objectContaining({
             uri: seed.r['3.0.0'].ref.uriStr,
             depth: 0,
             value: expect.objectContaining({
-              $type: 'app.bsky.unspecced.getPostThreadV2#threadItemPost',
+              $type: 'app.bsky.unspecced.defs#threadItemPost',
             }),
           }),
         ])
@@ -2103,7 +2098,7 @@ function assertPosts(
 ): asserts t is ThreadItemValuePost[] {
   t.forEach((i) => {
     assert(
-      AppBskyUnspeccedGetPostThreadV2.isThreadItemPost(i.value),
+      AppBskyUnspeccedDefs.isThreadItemPost(i.value),
       `Expected thread item to have a post as value`,
     )
   })
@@ -2111,10 +2106,10 @@ function assertPosts(
 
 function assertHiddenPosts(
   t: OutputSchemaHiddenThread['thread'],
-): asserts t is ThreadHiddenItem[] {
+): asserts t is ThreadHiddenItemValuePost[] {
   t.forEach((i) => {
     assert(
-      AppBskyUnspeccedGetPostThreadHiddenV2.isThreadHiddenItemPost(i.value),
+      AppBskyUnspeccedDefs.isThreadItemPost(i.value),
       `Expected thread item to have a hidden post as value`,
     )
   })

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -1549,17 +1549,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1568,6 +1557,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/defs.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/defs.ts
@@ -10,6 +10,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import type * as AppBskyActorDefs from '../actor/defs.js'
+import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -124,4 +125,99 @@ export function isTrendView<V>(v: V) {
 
 export function validateTrendView<V>(v: V) {
   return validate<TrendView & V>(v, id, hashTrendView)
+}
+
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.defs#threadItem'
+  uri: string
+  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
+  depth: number
+  value:
+    | $Typed<ThreadItemPost>
+    | $Typed<ThreadItemNoUnauthenticated>
+    | $Typed<ThreadItemNotFound>
+    | $Typed<ThreadItemBlocked>
+    | { $type: string }
+}
+
+const hashThreadItem = 'threadItem'
+
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
+}
+
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
+}
+
+export interface ThreadItemPost {
+  $type?: 'app.bsky.unspecced.defs#threadItemPost'
+  post: AppBskyFeedDefs.PostView
+  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
+  moreParents: boolean
+  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
+  moreReplies: number
+  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
+  opThread: boolean
+  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
+  hiddenByThreadgate: boolean
+  /** This is by an account muted by the viewer requesting it. */
+  mutedByViewer: boolean
+}
+
+const hashThreadItemPost = 'threadItemPost'
+
+export function isThreadItemPost<V>(v: V) {
+  return is$typed(v, id, hashThreadItemPost)
+}
+
+export function validateThreadItemPost<V>(v: V) {
+  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
+}
+
+export interface ThreadItemNoUnauthenticated {
+  $type?: 'app.bsky.unspecced.defs#threadItemNoUnauthenticated'
+}
+
+const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
+
+export function isThreadItemNoUnauthenticated<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNoUnauthenticated)
+}
+
+export function validateThreadItemNoUnauthenticated<V>(v: V) {
+  return validate<ThreadItemNoUnauthenticated & V>(
+    v,
+    id,
+    hashThreadItemNoUnauthenticated,
+  )
+}
+
+export interface ThreadItemNotFound {
+  $type?: 'app.bsky.unspecced.defs#threadItemNotFound'
+}
+
+const hashThreadItemNotFound = 'threadItemNotFound'
+
+export function isThreadItemNotFound<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNotFound)
+}
+
+export function validateThreadItemNotFound<V>(v: V) {
+  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
+}
+
+export interface ThreadItemBlocked {
+  $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
+  author: AppBskyFeedDefs.BlockedAuthor
+}
+
+const hashThreadItemBlocked = 'threadItemBlocked'
+
+export function isThreadItemBlocked<V>(v: V) {
+  return is$typed(v, id, hashThreadItemBlocked)
+}
+
+export function validateThreadItemBlocked<V>(v: V) {
+  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
@@ -11,7 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import type * as AppBskyFeedDefs from '../feed/defs.js'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -56,40 +56,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value: $Typed<ThreadHiddenItemPost> | { $type: string }
-}
-
-const hashThreadHiddenItem = 'threadHiddenItem'
-
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
-}
-
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
-}
-
-export interface ThreadHiddenItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
-  hiddenByThreadgate: boolean
-  /** This is by an account muted by the viewer requesting it. */
-  mutedByViewer: boolean
-}
-
-const hashThreadHiddenItemPost = 'threadHiddenItemPost'
-
-export function isThreadHiddenItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItemPost)
-}
-
-export function validateThreadHiddenItemPost<V>(v: V) {
-  return validate<ThreadHiddenItemPost & V>(v, id, hashThreadHiddenItemPost)
-}

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -11,6 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
@@ -36,7 +37,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadItem[]
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
   /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
   hasHiddenReplies: boolean
@@ -67,94 +68,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadItem {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value:
-    | $Typed<ThreadItemPost>
-    | $Typed<ThreadItemNoUnauthenticated>
-    | $Typed<ThreadItemNotFound>
-    | $Typed<ThreadItemBlocked>
-    | { $type: string }
-}
-
-const hashThreadItem = 'threadItem'
-
-export function isThreadItem<V>(v: V) {
-  return is$typed(v, id, hashThreadItem)
-}
-
-export function validateThreadItem<V>(v: V) {
-  return validate<ThreadItem & V>(v, id, hashThreadItem)
-}
-
-export interface ThreadItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
-  moreParents: boolean
-  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
-  moreReplies: number
-  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
-  opThread: boolean
-}
-
-const hashThreadItemPost = 'threadItemPost'
-
-export function isThreadItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadItemPost)
-}
-
-export function validateThreadItemPost<V>(v: V) {
-  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
-}
-
-export interface ThreadItemNoUnauthenticated {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated'
-}
-
-const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
-
-export function isThreadItemNoUnauthenticated<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNoUnauthenticated)
-}
-
-export function validateThreadItemNoUnauthenticated<V>(v: V) {
-  return validate<ThreadItemNoUnauthenticated & V>(
-    v,
-    id,
-    hashThreadItemNoUnauthenticated,
-  )
-}
-
-export interface ThreadItemNotFound {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound'
-}
-
-const hashThreadItemNotFound = 'threadItemNotFound'
-
-export function isThreadItemNotFound<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNotFound)
-}
-
-export function validateThreadItemNotFound<V>(v: V) {
-  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
-}
-
-export interface ThreadItemBlocked {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked'
-  author: AppBskyFeedDefs.BlockedAuthor
-}
-
-const hashThreadItemBlocked = 'threadItemBlocked'
-
-export function isThreadItemBlocked<V>(v: V) {
-  return is$typed(v, id, hashThreadItemBlocked)
-}
-
-export function validateThreadItemBlocked<V>(v: V) {
-  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
-}

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -1549,17 +1549,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1568,6 +1557,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/defs.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/defs.ts
@@ -10,6 +10,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import type * as AppBskyActorDefs from '../actor/defs.js'
+import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -124,4 +125,99 @@ export function isTrendView<V>(v: V) {
 
 export function validateTrendView<V>(v: V) {
   return validate<TrendView & V>(v, id, hashTrendView)
+}
+
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.defs#threadItem'
+  uri: string
+  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
+  depth: number
+  value:
+    | $Typed<ThreadItemPost>
+    | $Typed<ThreadItemNoUnauthenticated>
+    | $Typed<ThreadItemNotFound>
+    | $Typed<ThreadItemBlocked>
+    | { $type: string }
+}
+
+const hashThreadItem = 'threadItem'
+
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
+}
+
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
+}
+
+export interface ThreadItemPost {
+  $type?: 'app.bsky.unspecced.defs#threadItemPost'
+  post: AppBskyFeedDefs.PostView
+  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
+  moreParents: boolean
+  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
+  moreReplies: number
+  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
+  opThread: boolean
+  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
+  hiddenByThreadgate: boolean
+  /** This is by an account muted by the viewer requesting it. */
+  mutedByViewer: boolean
+}
+
+const hashThreadItemPost = 'threadItemPost'
+
+export function isThreadItemPost<V>(v: V) {
+  return is$typed(v, id, hashThreadItemPost)
+}
+
+export function validateThreadItemPost<V>(v: V) {
+  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
+}
+
+export interface ThreadItemNoUnauthenticated {
+  $type?: 'app.bsky.unspecced.defs#threadItemNoUnauthenticated'
+}
+
+const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
+
+export function isThreadItemNoUnauthenticated<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNoUnauthenticated)
+}
+
+export function validateThreadItemNoUnauthenticated<V>(v: V) {
+  return validate<ThreadItemNoUnauthenticated & V>(
+    v,
+    id,
+    hashThreadItemNoUnauthenticated,
+  )
+}
+
+export interface ThreadItemNotFound {
+  $type?: 'app.bsky.unspecced.defs#threadItemNotFound'
+}
+
+const hashThreadItemNotFound = 'threadItemNotFound'
+
+export function isThreadItemNotFound<V>(v: V) {
+  return is$typed(v, id, hashThreadItemNotFound)
+}
+
+export function validateThreadItemNotFound<V>(v: V) {
+  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
+}
+
+export interface ThreadItemBlocked {
+  $type?: 'app.bsky.unspecced.defs#threadItemBlocked'
+  author: AppBskyFeedDefs.BlockedAuthor
+}
+
+const hashThreadItemBlocked = 'threadItemBlocked'
+
+export function isThreadItemBlocked<V>(v: V) {
+  return is$typed(v, id, hashThreadItemBlocked)
+}
+
+export function validateThreadItemBlocked<V>(v: V) {
+  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2.ts
@@ -11,7 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
-import type * as AppBskyFeedDefs from '../feed/defs.js'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of thread hidden items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -56,40 +56,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value: $Typed<ThreadHiddenItemPost> | { $type: string }
-}
-
-const hashThreadHiddenItem = 'threadHiddenItem'
-
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
-}
-
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
-}
-
-export interface ThreadHiddenItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread. */
-  hiddenByThreadgate: boolean
-  /** This is by an account muted by the viewer requesting it. */
-  mutedByViewer: boolean
-}
-
-const hashThreadHiddenItemPost = 'threadHiddenItemPost'
-
-export function isThreadHiddenItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItemPost)
-}
-
-export function validateThreadHiddenItemPost<V>(v: V) {
-  return validate<ThreadHiddenItemPost & V>(v, id, hashThreadHiddenItemPost)
-}

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -11,6 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'
+import type * as AppBskyUnspeccedDefs from './defs.js'
 import type * as AppBskyFeedDefs from '../feed/defs.js'
 
 const is$typed = _is$typed,
@@ -36,7 +37,7 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadItem[]
+  thread: AppBskyUnspeccedDefs.ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
   /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
   hasHiddenReplies: boolean
@@ -67,94 +68,3 @@ export type HandlerReqCtx<HA extends HandlerAuth = never> = {
 export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
-
-export interface ThreadItem {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItem'
-  uri: string
-  /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
-  depth: number
-  value:
-    | $Typed<ThreadItemPost>
-    | $Typed<ThreadItemNoUnauthenticated>
-    | $Typed<ThreadItemNotFound>
-    | $Typed<ThreadItemBlocked>
-    | { $type: string }
-}
-
-const hashThreadItem = 'threadItem'
-
-export function isThreadItem<V>(v: V) {
-  return is$typed(v, id, hashThreadItem)
-}
-
-export function validateThreadItem<V>(v: V) {
-  return validate<ThreadItem & V>(v, id, hashThreadItem)
-}
-
-export interface ThreadItemPost {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemPost'
-  post: AppBskyFeedDefs.PostView
-  /** This post has more parents that were not present in the response. This is just a boolean, without the number of parents. */
-  moreParents: boolean
-  /** This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate. */
-  moreReplies: number
-  /** This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread. */
-  opThread: boolean
-}
-
-const hashThreadItemPost = 'threadItemPost'
-
-export function isThreadItemPost<V>(v: V) {
-  return is$typed(v, id, hashThreadItemPost)
-}
-
-export function validateThreadItemPost<V>(v: V) {
-  return validate<ThreadItemPost & V>(v, id, hashThreadItemPost)
-}
-
-export interface ThreadItemNoUnauthenticated {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNoUnauthenticated'
-}
-
-const hashThreadItemNoUnauthenticated = 'threadItemNoUnauthenticated'
-
-export function isThreadItemNoUnauthenticated<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNoUnauthenticated)
-}
-
-export function validateThreadItemNoUnauthenticated<V>(v: V) {
-  return validate<ThreadItemNoUnauthenticated & V>(
-    v,
-    id,
-    hashThreadItemNoUnauthenticated,
-  )
-}
-
-export interface ThreadItemNotFound {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemNotFound'
-}
-
-const hashThreadItemNotFound = 'threadItemNotFound'
-
-export function isThreadItemNotFound<V>(v: V) {
-  return is$typed(v, id, hashThreadItemNotFound)
-}
-
-export function validateThreadItemNotFound<V>(v: V) {
-  return validate<ThreadItemNotFound & V>(v, id, hashThreadItemNotFound)
-}
-
-export interface ThreadItemBlocked {
-  $type?: 'app.bsky.unspecced.getPostThreadV2#threadItemBlocked'
-  author: AppBskyFeedDefs.BlockedAuthor
-}
-
-const hashThreadItemBlocked = 'threadItemBlocked'
-
-export function isThreadItemBlocked<V>(v: V) {
-  return is$typed(v, id, hashThreadItemBlocked)
-}
-
-export function validateThreadItemBlocked<V>(v: V) {
-  return validate<ThreadItemBlocked & V>(v, id, hashThreadItemBlocked)
-}


### PR DESCRIPTION
Removes `threadHiddenItem` etc and unifies both endpoints to return `threadItem` and `threadItemPost`. I think this is the right move for a couple reasons:

1. While it's true that some of these properties are not necessary on the response from `getPostThreadV2` and vice versa, the intent from a client perspective is to receive data with the same shape. Properties like `hiddenByThreadgate` are purely "state" on a given post, and the implicit contract between the two endpoints is that one only returns posts that are visible, and the other returns posts that are hidden and fetched as a separate request.
2. Unneeded atm, but if we ever want to show full threads (beyond the top level replies) in the hidden response, we would need to make a change similar to this that would further duplicate props between post types. We might as well avoid that and use the same shape. They are the same data, after all, only that some fall under a different use case (hidden).

This will allow API consumers to utilize the same logic for traversing threads without the need for creating their own custom union type.