### PR TITLE
Show account picker instead of welcome screen when user already signed-in

### DIFF
--- a/.changeset/fair-moons-peel.md
+++ b/.changeset/fair-moons-peel.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-provider-ui": patch
+---
+
+Show sign-in screen instead of welcome screen when user already signed-in

--- a/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
@@ -10,8 +10,8 @@ import { ErrorView } from './views/error/error-view.tsx'
 
 const {
   __authorizeData: authorizeData,
-  __sessions: sessions,
   __customizationData: customizationData,
+  __sessions: initialSessions,
 } = window as typeof window & HydrationData['authorization-page']
 
 // When the user is logging in, make sure the page URL contains the
@@ -39,9 +39,9 @@ createRoot(container).render(
         )}
       >
         <AuthorizeView
-          customizationData={customizationData}
           authorizeData={authorizeData}
-          sessions={sessions}
+          customizationData={customizationData}
+          initialSessions={initialSessions}
         />
       </ErrorBoundary>
     </LocaleProvider>

--- a/packages/oauth/oauth-provider-ui/src/locales/an/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/an/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ast/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ast/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ca/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ca/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/da/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/da/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/de/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/de/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/el/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/el/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/en-GB/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en-GB/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr "<0/> is asking for permission to access your account (<1/>)."
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr "2FA Confirmation"
 
@@ -45,7 +45,7 @@ msgstr "An application on your device"
 msgid "An unknown error occurred"
 msgstr "An unknown error occurred"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr "Another account"
 
@@ -58,12 +58,12 @@ msgstr "Authenticate"
 msgid "Authorize"
 msgstr "Authorize"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr "Avatar"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr "By clicking <0>Authorize</0>, you allow this application to perform the 
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr "By creating an account you agree to the {0} and the {1} of this service."
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr "Cancel"
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr "Check your {0} email for a login code and enter it here."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr "Choose a username"
 
@@ -102,15 +103,15 @@ msgstr "Choose a username"
 msgid "Code"
 msgstr "Code"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr "Confirm"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr "Confirm your password to continue"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr "Confirmation code"
 
@@ -118,7 +119,7 @@ msgstr "Confirmation code"
 msgid "Create a new account"
 msgstr "Create a new account"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr "Create Account"
 
@@ -160,12 +161,12 @@ msgstr "Enter your email address"
 msgid "Enter your new password"
 msgstr "Enter your new password"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr "Enter your password"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr "Enter your username and password"
 
@@ -185,7 +186,7 @@ msgstr "Extra"
 msgid "Forgot Password"
 msgstr "Forgot Password"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr "Forgot?"
 
@@ -206,8 +207,8 @@ msgstr "Hide"
 msgid "Home"
 msgstr "Home"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr "Identifier"
 
@@ -228,11 +229,11 @@ msgstr "Invite code"
 msgid "Let's get your password reset!"
 msgstr "Let's get your password reset!"
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr "Login complete"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr "Login to account that is not listed"
 
@@ -256,7 +257,7 @@ msgstr "Missing"
 msgid "Moderate"
 msgstr "Moderate"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr "Name"
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr "Only letters, numbers, and hyphens"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr "Password"
@@ -304,7 +305,7 @@ msgstr "Password updated!"
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr "Password with at least {MIN_PASSWORD_LENGTH} characters"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 
@@ -318,8 +319,8 @@ msgstr "Privacy Policy"
 msgid "Read your email address"
 msgstr "Read your email address"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr "Remember this account on this device"
 
@@ -335,7 +336,7 @@ msgstr "Reset code"
 msgid "Reset Password"
 msgstr "Reset Password"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr "Reset your password"
 
@@ -343,26 +344,27 @@ msgstr "Reset your password"
 msgid "Select domain"
 msgstr "Select domain"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr "Select from an existing account"
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr "Sign in"
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr "Sign in as {0}"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr "Sign in as..."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -444,7 +446,7 @@ msgstr "Unexpected server response"
 msgid "Uniquely identify you"
 msgstr "Uniquely identify you"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr "Username or email address"
 
@@ -452,15 +454,15 @@ msgstr "Username or email address"
 msgid "Valid"
 msgstr "Valid"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr "Verify you are human"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr "Warning"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr "We're so excited to have you join us!"
 
@@ -472,7 +474,7 @@ msgstr "Weak"
 msgid "Wrong identifier or password"
 msgstr "Wrong identifier or password"
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr "You are being redirected..."
 
@@ -488,7 +490,7 @@ msgstr "You can now sign in with your new password."
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr "Your account"
 

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/eu/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/eu/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/fi/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fi/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr "<0/> demande la permission d'accéder à votre compte (<1/>)."
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr "Confirmation 2FA"
 
@@ -45,7 +45,7 @@ msgstr "Une application sur votre appareil"
 msgid "An unknown error occurred"
 msgstr "Une erreur inconnue s'est produite"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr "Un autre compte"
 
@@ -58,12 +58,12 @@ msgstr "Authentification"
 msgid "Authorize"
 msgstr "Authoriser l'accès"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr "Photo de profile"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr "En cliquant sur <0>Authoriser l'accès</0>, vous autorisez cette applica
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr "En créant un compte, vous acceptez les {0} et la {1} de ce service."
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr "Annuler"
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr "Vérifiez vos emails {0} pour un code de connexion et saisissez-le ici."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr "Choisissez un nom d'utilisateur"
 
@@ -102,15 +103,15 @@ msgstr "Choisissez un nom d'utilisateur"
 msgid "Code"
 msgstr "Code"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr "Confirmez votre mot de passe pour continuer"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr "Code de confirmation"
 
@@ -118,7 +119,7 @@ msgstr "Code de confirmation"
 msgid "Create a new account"
 msgstr "Créer un nouveau compte"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr "Créer un compte"
 
@@ -160,12 +161,12 @@ msgstr "Saisissez votre adresse email"
 msgid "Enter your new password"
 msgstr "Saisissez votre nouveau mot de passe"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr "Saisissez votre mot de passe"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr "Saisissez votre nom d'utilisateur et votre mot de passe"
 
@@ -185,7 +186,7 @@ msgstr "Extra"
 msgid "Forgot Password"
 msgstr "Mot de passe oublié"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr "Oublié ?"
 
@@ -206,8 +207,8 @@ msgstr "Cacher"
 msgid "Home"
 msgstr "Accueil"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr "Identifiant"
 
@@ -228,11 +229,11 @@ msgstr "Code d'invitation"
 msgid "Let's get your password reset!"
 msgstr "Réinitialisons votre mot de passe !"
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr "Connexion terminée"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr "Se connecter à un compte qui n'est pas listé"
 
@@ -256,7 +257,7 @@ msgstr "Manquant"
 msgid "Moderate"
 msgstr "Modéré"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr "Nom"
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr "Uniquement des lettres, des chiffres et des traits d'union"
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr "Mot de passe"
@@ -304,7 +305,7 @@ msgstr "Mot de passe mis à jour !"
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr "Mot de passe d'au moins {MIN_PASSWORD_LENGTH} caractères"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr "Veuillez vérifier le nom de domaine du site web avant de saisir votre mot de passe. N'entrez jamais votre mot de passe sur un domaine auquel vous ne faites pas confiance."
 
@@ -318,8 +319,8 @@ msgstr "Politique de Confidentialité"
 msgid "Read your email address"
 msgstr "Lire votre adresse email"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr "Se souvenir de ce compte sur cet appareil"
 
@@ -335,7 +336,7 @@ msgstr "Code de réinitialisation"
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr "Réinitialisez votre mot de passe"
 
@@ -343,26 +344,27 @@ msgstr "Réinitialisez votre mot de passe"
 msgid "Select domain"
 msgstr "Sélectionner le domaine"
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr "Sélectionner un compte"
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr "Se connecter"
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr "Se connecter en tant que {0}"
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr "Se connecter en tant que..."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr "S'inscrire"
 
@@ -444,7 +446,7 @@ msgstr "Réponse inattendue du serveur"
 msgid "Uniquely identify you"
 msgstr "Vous identifier de façon unique"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr "Nom d'utilisateur ou adresse email"
 
@@ -452,15 +454,15 @@ msgstr "Nom d'utilisateur ou adresse email"
 msgid "Valid"
 msgstr "Valide"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr "Vérifiez que vous êtes humain"
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr "Avertissement"
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr "Nous sommes ravis de vous accueillir parmi nous !"
 
@@ -472,7 +474,7 @@ msgstr "Faible"
 msgid "Wrong identifier or password"
 msgstr "Identifiant ou mot de passe incorrect"
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr "Vous êtes redirigé..."
 
@@ -488,7 +490,7 @@ msgstr "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe."
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr "Vous aver reçu un email avec un \"code de réinitialisation\". Saisissez ce code ici puis entrez votre nouveau mot de passe."
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr "Votre compte"
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ga/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ga/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/gl/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/gl/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/hi/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/hi/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/hu/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/hu/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ia/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ia/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/id/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/id/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/it/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/it/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/km/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/km/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ne/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ne/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/nl/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/nl/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/pl/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/pl/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/pt-BR/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/pt-BR/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ro/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ro/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/ru/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ru/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/th/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/th/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/tr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/tr/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/uk/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/uk/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/vi/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/vi/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/zh-CN/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/zh-CN/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/zh-HK/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/zh-HK/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/locales/zh-TW/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/zh-TW/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "<0/> is asking for permission to access your account (<1/>)."
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:217
+#: src/views/authorize/sign-in/sign-in-form.tsx:219
 msgid "2FA Confirmation"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An unknown error occurred"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:104
+#: src/views/authorize/sign-in/sign-in-picker.tsx:115
 msgid "Another account"
 msgstr ""
 
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:68
+#: src/views/authorize/sign-in/sign-in-picker.tsx:79
 msgid "Avatar"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:47
-#: src/views/authorize/sign-in/sign-in-form.tsx:130
+#: src/views/authorize/sign-in/sign-in-picker.tsx:59
+#: src/views/authorize/sign-in/sign-in-form.tsx:132
 #: src/views/authorize/reset-password/reset-password-view.tsx:65
 #: src/views/authorize/reset-password/reset-password-view.tsx:95
 #: src/components/forms/wizard-card.tsx:93
@@ -84,17 +84,18 @@ msgstr ""
 msgid "By creating an account you agree to the {0} and the {1} of this service."
 msgstr ""
 
+#: src/views/authorize/authorize-view.tsx:151
 #: src/views/authorize/welcome/welcome-view.tsx:51
 #: src/components/forms/form-card-async.tsx:85
 msgid "Cancel"
 msgstr ""
 
 #. placeholder {0}: secondFactor.hint
-#: src/views/authorize/sign-in/sign-in-form.tsx:230
+#: src/views/authorize/sign-in/sign-in-form.tsx:232
 msgid "Check your {0} email for a login code and enter it here."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:94
+#: src/views/authorize/sign-up/sign-up-view.tsx:97
 msgid "Choose a username"
 msgstr ""
 
@@ -102,15 +103,15 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Confirm"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:65
+#: src/views/authorize/sign-in/sign-in-view.tsx:69
 msgid "Confirm your password to continue"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:221
+#: src/views/authorize/sign-in/sign-in-form.tsx:223
 msgid "Confirmation code"
 msgstr ""
 
@@ -118,7 +119,7 @@ msgstr ""
 msgid "Create a new account"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:78
+#: src/views/authorize/sign-up/sign-up-view.tsx:80
 msgid "Create Account"
 msgstr ""
 
@@ -160,12 +161,12 @@ msgstr ""
 msgid "Enter your new password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-view.tsx:90
 msgid "Enter your password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:104
-#: src/views/authorize/sign-in/sign-in-view.tsx:120
+#: src/views/authorize/sign-in/sign-in-view.tsx:109
+#: src/views/authorize/sign-in/sign-in-view.tsx:126
 msgid "Enter your username and password"
 msgstr ""
 
@@ -185,7 +186,7 @@ msgstr ""
 msgid "Forgot Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:181
+#: src/views/authorize/sign-in/sign-in-form.tsx:183
 msgid "Forgot?"
 msgstr ""
 
@@ -206,8 +207,8 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:81
-#: src/views/authorize/sign-in/sign-in-form.tsx:138
+#: src/views/authorize/sign-in/sign-in-picker.tsx:92
+#: src/views/authorize/sign-in/sign-in-form.tsx:140
 msgid "Identifier"
 msgstr ""
 
@@ -228,11 +229,11 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:178
+#: src/views/authorize/authorize-view.tsx:188
 msgid "Login complete"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:97
+#: src/views/authorize/sign-in/sign-in-picker.tsx:108
 msgid "Login to account that is not listed"
 msgstr ""
 
@@ -256,7 +257,7 @@ msgstr ""
 msgid "Moderate"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:74
+#: src/views/authorize/sign-in/sign-in-picker.tsx:85
 msgid "Name"
 msgstr ""
 
@@ -279,7 +280,7 @@ msgid "Only letters, numbers, and hyphens"
 msgstr ""
 
 #: src/views/authorize/sign-up/sign-up-account-form.tsx:128
-#: src/views/authorize/sign-in/sign-in-form.tsx:162
+#: src/views/authorize/sign-in/sign-in-form.tsx:164
 #: src/components/forms/input-password.tsx:53
 msgid "Password"
 msgstr ""
@@ -304,7 +305,7 @@ msgstr ""
 msgid "Password with at least {MIN_PASSWORD_LENGTH} characters"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:196
+#: src/views/authorize/sign-in/sign-in-form.tsx:198
 msgid "Please verify the domain name of the website before entering your password. Never enter your password on a domain you do not trust."
 msgstr ""
 
@@ -318,8 +319,8 @@ msgstr ""
 msgid "Read your email address"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:205
-#: src/views/authorize/sign-in/sign-in-form.tsx:210
+#: src/views/authorize/sign-in/sign-in-form.tsx:207
+#: src/views/authorize/sign-in/sign-in-form.tsx:212
 msgid "Remember this account on this device"
 msgstr ""
 
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:179
+#: src/views/authorize/sign-in/sign-in-form.tsx:181
 msgid "Reset your password"
 msgstr ""
 
@@ -343,26 +344,27 @@ msgstr ""
 msgid "Select domain"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-view.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:141
 msgid "Select from an existing account"
 msgstr ""
 
 #: src/views/authorize/welcome/welcome-view.tsx:45
-#: src/views/authorize/sign-in/sign-in-view.tsx:48
-#: src/views/authorize/sign-in/sign-in-form.tsx:135
+#: src/views/authorize/sign-in/sign-in-view.tsx:52
+#: src/views/authorize/sign-in/sign-in-form.tsx:137
 msgid "Sign in"
 msgstr ""
 
 #. placeholder {0}: account.name
-#: src/views/authorize/sign-in/sign-in-picker.tsx:67
+#: src/views/authorize/sign-in/sign-in-picker.tsx:78
 msgid "Sign in as {0}"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-picker.tsx:53
+#: src/views/authorize/sign-in/sign-in-picker.tsx:64
 msgid "Sign in as..."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:84
+#: src/views/authorize/sign-up/sign-up-view.tsx:86
+#: src/views/authorize/sign-in/sign-in-picker.tsx:53
 msgid "Sign up"
 msgstr ""
 
@@ -444,7 +446,7 @@ msgstr ""
 msgid "Uniquely identify you"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:143
+#: src/views/authorize/sign-in/sign-in-form.tsx:145
 msgid "Username or email address"
 msgstr ""
 
@@ -452,15 +454,15 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:135
+#: src/views/authorize/sign-up/sign-up-view.tsx:138
 msgid "Verify you are human"
 msgstr ""
 
-#: src/views/authorize/sign-in/sign-in-form.tsx:193
+#: src/views/authorize/sign-in/sign-in-form.tsx:195
 msgid "Warning"
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:80
+#: src/views/authorize/sign-up/sign-up-view.tsx:82
 msgid "We're so excited to have you join us!"
 msgstr ""
 
@@ -472,7 +474,7 @@ msgstr ""
 msgid "Wrong identifier or password"
 msgstr ""
 
-#: src/views/authorize/authorize-view.tsx:179
+#: src/views/authorize/authorize-view.tsx:189
 msgid "You are being redirected..."
 msgstr ""
 
@@ -488,7 +490,7 @@ msgstr ""
 msgid "You will receive an email with a \"reset code\". Enter that code here then enter your new password."
 msgstr ""
 
-#: src/views/authorize/sign-up/sign-up-view.tsx:116
+#: src/views/authorize/sign-up/sign-up-view.tsx:119
 msgid "Your account"
 msgstr ""
 

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
@@ -176,7 +176,7 @@ export function AuthorizeView({
             ? undefined
             : () => {
                 selectSub(null)
-                setView(sessions.length ? View.SignIn : View.Welcome)
+                showHome()
               }
         }
       />

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
@@ -20,7 +20,7 @@ export type AuthorizeViewProps = Override<
   {
     customizationData?: CustomizationData
     authorizeData: AuthorizeData
-    sessions: readonly Session[]
+    initialSessions: readonly Session[]
   }
 >
 
@@ -35,7 +35,7 @@ enum View {
 
 export function AuthorizeView({
   authorizeData,
-  sessions: initialSessions,
+  initialSessions,
   customizationData,
 
   // LayoutTitlePage
@@ -43,9 +43,14 @@ export function AuthorizeView({
 }: AuthorizeViewProps) {
   const { t } = useLingui()
 
-  const forceSignIn = authorizeData?.loginHint != null
+  const forceSignIn = authorizeData.loginHint != null
 
-  const initialView = forceSignIn ? View.SignIn : View.Welcome
+  const canSignUp =
+    !forceSignIn && Boolean(customizationData?.availableUserDomains?.length)
+
+  const initialView =
+    !canSignUp || initialSessions.length ? View.SignIn : View.Welcome
+
   const [view, setView] = useState<View>(initialView)
 
   const showDone = useBoundDispatch(setView, View.Done)
@@ -53,7 +58,6 @@ export function AuthorizeView({
   const showResetPassword = useBoundDispatch(setView, View.ResetPassword)
   const showSignUp = useBoundDispatch(setView, View.SignUp)
   const showAccept = useBoundDispatch(setView, View.Accept)
-  const showWelcome = useBoundDispatch(setView, View.Welcome)
 
   const [resetPasswordHint, setResetPasswordHint] = useState<
     string | undefined
@@ -74,6 +78,10 @@ export function AuthorizeView({
     onRedirected: showDone,
   })
 
+  const homeView = !canSignUp || sessions.length ? View.SignIn : View.Welcome
+  const showHome = useBoundDispatch(setView, homeView)
+  const showSignUpIfAllowed = canSignUp ? showSignUp : undefined
+
   // Navigate when the user signs-in (selects a new session)
   const session = sessions.find((s) => s.selected && !s.loginRequired)
   useEffect(() => {
@@ -83,16 +91,16 @@ export function AuthorizeView({
     }
   }, [session, doAccept, showAccept])
 
-  const canSignUp =
-    Boolean(customizationData?.availableUserDomains?.length) &&
-    !authorizeData.loginHint
-
   // Fool-proofing
-  const resetNeeded =
-    (view === View.SignUp && !canSignUp) || (view === View.Accept && !session)
   useEffect(() => {
-    if (resetNeeded) showWelcome()
-  }, [resetNeeded, showWelcome])
+    if (view === View.SignUp && !canSignUp) setView(homeView)
+  }, [view, homeView, !canSignUp])
+  useEffect(() => {
+    if (view === View.Accept && !session) setView(homeView)
+  }, [view, homeView, !session])
+  useEffect(() => {
+    if (view === View.Welcome && homeView !== View.Welcome) setView(homeView)
+  }, [view, homeView])
 
   if (view === View.Welcome) {
     return (
@@ -100,8 +108,8 @@ export function AuthorizeView({
         {...props}
         customizationData={customizationData}
         onSignIn={showSignIn}
-        onSignUp={canSignUp ? showSignUp : undefined}
-        onCancel={() => doReject()}
+        onSignUp={showSignUpIfAllowed}
+        onCancel={doReject}
       />
     )
   }
@@ -112,7 +120,7 @@ export function AuthorizeView({
         {...props}
         customizationData={customizationData}
         onValidateNewHandle={doValidateNewHandle}
-        onBack={showWelcome}
+        onBack={showHome}
         onDone={doSignUp}
       />
     )
@@ -125,7 +133,7 @@ export function AuthorizeView({
         emailDefault={resetPasswordHint}
         onresetPasswordRequest={doInitiatePasswordReset}
         onResetPasswordConfirm={doConfirmResetPassword}
-        onBack={forceSignIn ? showSignIn : showWelcome}
+        onBack={showHome}
       />
     )
   }
@@ -138,7 +146,9 @@ export function AuthorizeView({
         sessions={sessions}
         selectSub={selectSub}
         onSignIn={doSignIn}
-        onBack={forceSignIn ? () => doReject() : showWelcome}
+        onSignUp={showSignUpIfAllowed}
+        onBack={homeView === View.SignIn ? doReject : showHome}
+        backLabel={homeView === View.SignIn ? t`Cancel` : undefined}
         onForgotPassword={(email) => {
           showResetPassword()
           setResetPasswordHint(email)
@@ -160,7 +170,7 @@ export function AuthorizeView({
         account={session.account}
         scopeDetails={authorizeData.scopeDetails}
         onAccept={() => doAccept(session.account.sub)}
-        onReject={() => doReject()}
+        onReject={doReject}
         onBack={
           forceSignIn
             ? undefined

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-form.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-form.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { useCallback, useRef, useState } from 'react'
+import { ReactNode, useCallback, useRef, useState } from 'react'
 import { Button } from '../../../components/forms/button.tsx'
 import { Fieldset } from '../../../components/forms/fieldset.tsx'
 import {
@@ -34,6 +34,7 @@ export type SignInFormProps = Override<
     rememberDefault?: boolean
 
     onBack?: () => void
+    backLabel?: ReactNode
     onForgotPassword?: (emailHint?: string) => void
     onSubmit: (
       credentials: SignInFormOutput,
@@ -49,6 +50,7 @@ export function SignInForm({
 
   onSubmit,
   onBack,
+  backLabel,
   onForgotPassword,
 
   // FormCardAsync
@@ -127,7 +129,7 @@ export function SignInForm({
       ref={mergeRefs([ref, formRef])}
       onLoading={setLoading}
       onCancel={onBack}
-      cancelLabel={t`Back`}
+      cancelLabel={backLabel ?? t`Back`}
       append={children}
       invalid={
         invalid || !username || !password || (secondFactor != null && !otp)

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-picker.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-picker.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from '@lingui/react/macro'
+import { ReactNode } from 'react'
 import type { Account } from '@atproto/oauth-provider-api'
 import { Button } from '../../../components/forms/button.tsx'
 import {
@@ -21,6 +22,9 @@ export type SignInPickerProps = Override<
     onAccount: (account: Account) => void
     onOther?: () => void
     onBack?: () => void
+    onSignUp?: () => void
+
+    backLabel?: ReactNode
   }
 >
 
@@ -30,6 +34,9 @@ export function SignInPicker({
   onAccount,
   onOther = undefined,
   onBack,
+  onSignUp,
+
+  backLabel,
 
   // FormCard
   children,
@@ -40,12 +47,16 @@ export function SignInPicker({
     <FormCard
       {...props}
       append={children}
-      actions={null}
+      actions={
+        onSignUp && (
+          <Button onClick={onSignUp} color="primary" transparent>
+            <Trans>Sign up</Trans>
+          </Button>
+        )
+      }
       cancel={
         onBack && (
-          <Button onClick={onBack}>
-            <Trans>Back</Trans>
-          </Button>
+          <Button onClick={onBack}>{backLabel || <Trans>Back</Trans>}</Button>
         )
       }
     >

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-in/sign-in-view.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import type { Session } from '@atproto/oauth-provider-api'
 import {
   LayoutTitlePage,
@@ -20,8 +20,10 @@ export type SignInViewProps = Override<
       credentials: SignInFormOutput,
       signal: AbortSignal,
     ) => void | PromiseLike<void>
+    onSignUp?: () => void
     onForgotPassword?: (emailHint?: string) => void
     onBack?: () => void
+    backLabel?: ReactNode
   }
 >
 
@@ -31,8 +33,10 @@ export function SignInView({
   selectSub,
 
   onSignIn,
+  onSignUp,
   onForgotPassword,
   onBack,
+  backLabel,
 
   // LayoutTitlePage
   title,
@@ -89,6 +93,7 @@ export function SignInView({
           onSubmit={onSignIn}
           onForgotPassword={onForgotPassword}
           onBack={onBack}
+          backLabel={backLabel}
           usernameDefault={loginHint}
           usernameReadonly={true}
         />
@@ -107,6 +112,7 @@ export function SignInView({
           onSubmit={onSignIn}
           onForgotPassword={onForgotPassword}
           onBack={onBack}
+          backLabel={backLabel}
         />
       </LayoutTitlePage>
     )
@@ -139,6 +145,8 @@ export function SignInView({
         onAccount={(a) => selectSub(a.sub)}
         onOther={() => setShowSignInForm(true)}
         onBack={onBack}
+        backLabel={backLabel}
+        onSignUp={onSignUp}
       />
     </LayoutTitlePage>
   )

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-view.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from '@lingui/react/macro'
-import { useCallback, useState } from 'react'
+import { ReactNode, useCallback, useState } from 'react'
 import type { CustomizationData } from '@atproto/oauth-provider-api'
 import { WizardCard } from '../../../components/forms/wizard-card.tsx'
 import {
@@ -22,6 +22,7 @@ export type SignUpViewProps = Override<
     customizationData?: CustomizationData
 
     onBack?: () => void
+    backLabel?: ReactNode
     onValidateNewHandle: (
       data: { handle: string },
       signal?: AbortSignal,
@@ -47,6 +48,7 @@ export function SignUpView({
   onValidateNewHandle,
   onDone,
   onBack,
+  backLabel,
 
   // LayoutTitlePage
   ...props
@@ -83,6 +85,7 @@ export function SignUpView({
       <WizardCard
         doneLabel={<Trans>Sign up</Trans>}
         onBack={onBack}
+        backLabel={backLabel}
         onDone={doDone}
         steps={[
           // We use the handle input first since the "onValidateNewHandle" check


### PR DESCRIPTION
Whenever at least one account is signed in on the device, the welcome screen is replaced with the account picker view.

<img width="1210" alt="Capture d’écran 2025-06-02 à 16 19 28" src="https://github.com/user-attachments/assets/342c47b0-6af9-4c08-ab6d-2efd066969ba" />
