### PR TITLE
Require manual invocation of `i18n:extract`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "precodegen": "pnpm run --recursive --stream --filter '@atproto/lex-cli...' build --force",
     "codegen": "pnpm run --sort --recursive --stream --parallel codegen",
     "build": "pnpm run --sort --recursive --stream '/^(build|build:.+)$/'",
+    "i18n": "pnpm run --parallel i18n:extract",
     "dev": "NODE_ENV=development pnpm run --recursive --parallel --stream '/^(dev|dev:.+)$/'",
     "dev:tsc": "tsc --build tsconfig.json --preserveWatchOutput --watch",
     "test": "LOG_ENABLED=false ./packages/dev-infra/with-test-redis-and-db.sh pnpm test --stream --recursive",

--- a/packages/oauth/oauth-provider-frontend/package.json
+++ b/packages/oauth/oauth-provider-frontend/package.json
@@ -63,11 +63,10 @@
     "i18n:extract": "lingui extract --clean",
     "i18n:compile": "lingui compile --typescript",
     "i18n": "pnpm i18n:extract && pnpm i18n:compile",
-    "prebuild": "pnpm run i18n",
+    "prebuild": "pnpm run i18n:compile",
     "build": "vite build -- ignore additional npm args",
     "dev:ui": "vite --port 5173",
     "dev:src": "vite build --watch",
-    "dev:catalogs": "pnpm run i18n:extract --debounce 250 --watch > /dev/null",
     "dev:messages": "pnpm run i18n:compile --debounce 500 --watch"
   }
 }

--- a/packages/oauth/oauth-provider-ui/package.json
+++ b/packages/oauth/oauth-provider-ui/package.json
@@ -56,11 +56,10 @@
     "i18n:extract": "lingui extract --clean",
     "i18n:compile": "lingui compile --typescript",
     "i18n": "pnpm i18n:extract && pnpm i18n:compile",
-    "prebuild": "pnpm run i18n",
+    "prebuild": "pnpm run i18n:compile",
     "build": "vite build -- ignore additional npm args",
     "dev:ui": "vite --port 5174",
     "dev:src": "vite build --watch",
-    "dev:catalogs": "pnpm run i18n:extract --debounce 250 --watch > /dev/null",
     "dev:messages": "pnpm run i18n:compile --debounce 500 --watch"
   }
 }


### PR DESCRIPTION
Currently, the `lingui extract` command is being run as part of the `build` and `dev` commands. This causes very large diffs in PRs, even when no change are made to `.po` files.

With this change, only running `pnpm i18n` (from the root folder), or `pnpm i18n:extract` (from ui libs that support it) will cause the PO files to be re-computed.

From now on, the process to update translations is:
- Run `pnpm i18n` from the root of the project
- Adapt `.po` files as needed
- Commit changes

Other changes that do not include updates to translations should avoid committing `.po` files, unless very specific cases (e.g. a big amount of strings are removed, which could cause the app's JS to be un-necessarily large)