### PR TITLE
Use Form encoded body instead of JSON for OAuth requests

### DIFF
--- a/.changeset/seven-pans-press.md
+++ b/.changeset/seven-pans-press.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-types": patch
+---
+
+Parse JSON encoded Authorization Request Parameters

--- a/.changeset/ten-tools-exercise.md
+++ b/.changeset/ten-tools-exercise.md
@@ -1,0 +1,5 @@
+---
+"@atproto/oauth-client": patch
+---
+
+Use `application/x-www-form-urlencoded` content instead of JSON for OAuth requests

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -317,9 +317,21 @@ function entryHasDefinedValue(
 }
 
 function stringifyEntryValue(entry: [string, unknown]): [string, string] {
-  const value: unknown = entry[1]
-  if (typeof value === 'string') return entry as [string, string]
+  const name = entry[0]
+  const value = entry[1]
 
-  const name: string = entry[0]
-  return [name, JSON.stringify(value)]
+  switch (typeof value) {
+    case 'string':
+      return entry as [string, string]
+    case 'number':
+    case 'boolean':
+      return [name, String(value)]
+    default: {
+      const enc = JSON.stringify(value)
+      if (enc === undefined) {
+        throw new Error(`Unsupported value type for ${name}: ${String(value)}`)
+      }
+      return [name, enc]
+    }
+  }
 }

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -322,7 +322,7 @@ function stringifyEntryValue(entry: [string, unknown]): [string, string] {
 
   switch (typeof value) {
     case 'string':
-      return entry as [string, string]
+      return [name, value]
     case 'number':
     case 'boolean':
       return [name, String(value)]

--- a/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
+++ b/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
@@ -10,9 +10,12 @@ import { oauthScopeSchema } from './oauth-scope.js'
 import { oidcClaimsParameterSchema } from './oidc-claims-parameter.js'
 import { oidcClaimsPropertiesSchema } from './oidc-claims-properties.js'
 import { oidcEntityTypeSchema } from './oidc-entity-type.js'
-import { jsonObjectPreprocess } from './util.js'
+import { jsonObjectPreprocess, numberPreprocess } from './util.js'
 
 /**
+ * @note non string parameters will be converted from their string
+ * representation since oauth request parameters are typically sent as URL
+ * encoded form data or URL encoded query string.
  * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest | OIDC}
  */
 export const oauthAuthorizationRequestParametersSchema = z.object({
@@ -48,7 +51,7 @@ export const oauthAuthorizationRequestParametersSchema = z.object({
   // PAPE [OpenID.PAPE] max_auth_age request parameter.) When max_age is used,
   // the ID Token returned MUST include an auth_time Claim Value. Note that
   // max_age=0 is equivalent to prompt=login.
-  max_age: z.number().int().min(0).optional(),
+  max_age: z.preprocess(numberPreprocess, z.number().int().min(0)).optional(),
 
   claims: z
     .preprocess(

--- a/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
+++ b/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
@@ -10,6 +10,7 @@ import { oauthScopeSchema } from './oauth-scope.js'
 import { oidcClaimsParameterSchema } from './oidc-claims-parameter.js'
 import { oidcClaimsPropertiesSchema } from './oidc-claims-properties.js'
 import { oidcEntityTypeSchema } from './oidc-entity-type.js'
+import { jsonObjectPreprocess } from './util.js'
 
 /**
  * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest | OIDC}
@@ -50,11 +51,14 @@ export const oauthAuthorizationRequestParametersSchema = z.object({
   max_age: z.number().int().min(0).optional(),
 
   claims: z
-    .record(
-      oidcEntityTypeSchema,
+    .preprocess(
+      jsonObjectPreprocess,
       z.record(
-        oidcClaimsParameterSchema,
-        z.union([z.literal(null), oidcClaimsPropertiesSchema]),
+        oidcEntityTypeSchema,
+        z.record(
+          oidcClaimsParameterSchema,
+          z.union([z.literal(null), oidcClaimsPropertiesSchema]),
+        ),
       ),
     )
     .optional(),
@@ -85,7 +89,9 @@ export const oauthAuthorizationRequestParametersSchema = z.object({
   prompt: z.enum(['none', 'login', 'consent', 'select_account']).optional(),
 
   // https://datatracker.ietf.org/doc/html/rfc9396
-  authorization_details: oauthAuthorizationDetailsSchema.optional(),
+  authorization_details: z
+    .preprocess(jsonObjectPreprocess, oauthAuthorizationDetailsSchema)
+    .optional(),
 })
 
 /**

--- a/packages/oauth/oauth-types/src/util.ts
+++ b/packages/oauth/oauth-types/src/util.ts
@@ -78,3 +78,11 @@ export const jsonObjectPreprocess = (val: unknown) => {
 
   return val
 }
+
+export const numberPreprocess = (val: unknown): unknown => {
+  if (typeof val === 'string') {
+    const number = Number(val)
+    if (!Number.isNaN(number)) return number
+  }
+  return val
+}

--- a/packages/oauth/oauth-types/src/util.ts
+++ b/packages/oauth/oauth-types/src/util.ts
@@ -66,3 +66,15 @@ export function extractUrlPath(url) {
 
   return url.substring(pathStart, pathEnd)
 }
+
+export const jsonObjectPreprocess = (val: unknown) => {
+  if (typeof val === 'string' && val.startsWith('{') && val.endsWith('}')) {
+    try {
+      return JSON.parse(val)
+    } catch {
+      return val
+    }
+  }
+
+  return val
+}


### PR DESCRIPTION
As reported by @tom-sherman our OAuth requests are not using the proper encoding (JSON instead of Form encoded). This fixes that.

Fixes: #3723