### PR TITLE
Update V2 additional replies naming convention

### DIFF
--- a/.changeset/brave-beers-thank.md
+++ b/.changeset/brave-beers-thank.md
@@ -1,0 +1,7 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Rename `getPostThreadHiddenV2` to `getPostThreadOtherV2` to better reflect the intent of the API.

--- a/lexicons/app/bsky/unspecced/getPostThreadOtherV2.json
+++ b/lexicons/app/bsky/unspecced/getPostThreadOtherV2.json
@@ -1,10 +1,10 @@
 {
   "lexicon": 1,
-  "id": "app.bsky.unspecced.getPostThreadHiddenV2",
+  "id": "app.bsky.unspecced.getPostThreadOtherV2",
   "defs": {
     "main": {
       "type": "query",
-      "description": "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get the hidden posts in a thread. It is based in an anchor post at any depth of the tree, and returns hidden replies (recursive replies, with branching to their replies) below the anchor. It does not include ancestors nor the anchor. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
+      "description": "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
       "parameters": {
         "type": "params",
         "required": ["anchor"],
@@ -29,17 +29,17 @@
           "properties": {
             "thread": {
               "type": "array",
-              "description": "A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.",
+              "description": "A flat list of other thread items. The depth of each item is indicated by the depth property inside the item.",
               "items": {
                 "type": "ref",
-                "ref": "#threadHiddenItem"
+                "ref": "#threadItem"
               }
             }
           }
         }
       }
     },
-    "threadHiddenItem": {
+    "threadItem": {
       "type": "object",
       "required": ["uri", "depth", "value"],
       "properties": {

--- a/lexicons/app/bsky/unspecced/getPostThreadV2.json
+++ b/lexicons/app/bsky/unspecced/getPostThreadV2.json
@@ -50,7 +50,7 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["thread", "hasHiddenReplies"],
+          "required": ["thread", "hasOtherReplies"],
           "properties": {
             "thread": {
               "type": "array",
@@ -64,9 +64,9 @@
               "type": "ref",
               "ref": "app.bsky.feed.defs#threadgateView"
             },
-            "hasHiddenReplies": {
+            "hasOtherReplies": {
               "type": "boolean",
-              "description": "Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them."
+              "description": "Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them."
             }
           }
         }

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -128,8 +128,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -183,7 +183,7 @@ import * as AppBskyRichtextFacet from './types/app/bsky/richtext/facet.js'
 import * as AppBskyUnspeccedDefs from './types/app/bsky/unspecced/defs.js'
 import * as AppBskyUnspeccedGetConfig from './types/app/bsky/unspecced/getConfig.js'
 import * as AppBskyUnspeccedGetPopularFeedGenerators from './types/app/bsky/unspecced/getPopularFeedGenerators.js'
-import * as AppBskyUnspeccedGetPostThreadHiddenV2 from './types/app/bsky/unspecced/getPostThreadHiddenV2.js'
+import * as AppBskyUnspeccedGetPostThreadOtherV2 from './types/app/bsky/unspecced/getPostThreadOtherV2.js'
 import * as AppBskyUnspeccedGetPostThreadV2 from './types/app/bsky/unspecced/getPostThreadV2.js'
 import * as AppBskyUnspeccedGetSuggestedFeeds from './types/app/bsky/unspecced/getSuggestedFeeds.js'
 import * as AppBskyUnspeccedGetSuggestedFeedsSkeleton from './types/app/bsky/unspecced/getSuggestedFeedsSkeleton.js'
@@ -391,8 +391,8 @@ export * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 export * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 export * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 export * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-export * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 export * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+export * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 export * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 export * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 export * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -446,7 +446,7 @@ export * as AppBskyRichtextFacet from './types/app/bsky/richtext/facet.js'
 export * as AppBskyUnspeccedDefs from './types/app/bsky/unspecced/defs.js'
 export * as AppBskyUnspeccedGetConfig from './types/app/bsky/unspecced/getConfig.js'
 export * as AppBskyUnspeccedGetPopularFeedGenerators from './types/app/bsky/unspecced/getPopularFeedGenerators.js'
-export * as AppBskyUnspeccedGetPostThreadHiddenV2 from './types/app/bsky/unspecced/getPostThreadHiddenV2.js'
+export * as AppBskyUnspeccedGetPostThreadOtherV2 from './types/app/bsky/unspecced/getPostThreadOtherV2.js'
 export * as AppBskyUnspeccedGetPostThreadV2 from './types/app/bsky/unspecced/getPostThreadV2.js'
 export * as AppBskyUnspeccedGetSuggestedFeeds from './types/app/bsky/unspecced/getSuggestedFeeds.js'
 export * as AppBskyUnspeccedGetSuggestedFeedsSkeleton from './types/app/bsky/unspecced/getSuggestedFeedsSkeleton.js'
@@ -2107,6 +2107,13 @@ export class AppBskyFeedNS {
       })
   }
 
+  getPosts(
+    params?: AppBskyFeedGetPosts.QueryParams,
+    opts?: AppBskyFeedGetPosts.CallOptions,
+  ): Promise<AppBskyFeedGetPosts.Response> {
+    return this._client.call('app.bsky.feed.getPosts', params, undefined, opts)
+  }
+
   getPostThread(
     params?: AppBskyFeedGetPostThread.QueryParams,
     opts?: AppBskyFeedGetPostThread.CallOptions,
@@ -2116,13 +2123,6 @@ export class AppBskyFeedNS {
       .catch((e) => {
         throw AppBskyFeedGetPostThread.toKnownErr(e)
       })
-  }
-
-  getPosts(
-    params?: AppBskyFeedGetPosts.QueryParams,
-    opts?: AppBskyFeedGetPosts.CallOptions,
-  ): Promise<AppBskyFeedGetPosts.Response> {
-    return this._client.call('app.bsky.feed.getPosts', params, undefined, opts)
   }
 
   getQuotes(
@@ -3443,12 +3443,12 @@ export class AppBskyUnspeccedNS {
     )
   }
 
-  getPostThreadHiddenV2(
-    params?: AppBskyUnspeccedGetPostThreadHiddenV2.QueryParams,
-    opts?: AppBskyUnspeccedGetPostThreadHiddenV2.CallOptions,
-  ): Promise<AppBskyUnspeccedGetPostThreadHiddenV2.Response> {
+  getPostThreadOtherV2(
+    params?: AppBskyUnspeccedGetPostThreadOtherV2.QueryParams,
+    opts?: AppBskyUnspeccedGetPostThreadOtherV2.CallOptions,
+  ): Promise<AppBskyUnspeccedGetPostThreadOtherV2.Response> {
     return this._client.call(
-      'app.bsky.unspecced.getPostThreadHiddenV2',
+      'app.bsky.unspecced.getPostThreadOtherV2',
       params,
       undefined,
       opts,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -7239,6 +7239,48 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyFeedGetPosts: {
+    lexicon: 1,
+    id: 'app.bsky.feed.getPosts',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
+        parameters: {
+          type: 'params',
+          required: ['uris'],
+          properties: {
+            uris: {
+              type: 'array',
+              description: 'List of post AT-URIs to return hydrated views for.',
+              items: {
+                type: 'string',
+                format: 'at-uri',
+              },
+              maxLength: 25,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['posts'],
+            properties: {
+              posts: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.defs#postView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyFeedGetPostThread: {
     lexicon: 1,
     id: 'app.bsky.feed.getPostThread',
@@ -7300,48 +7342,6 @@ export const schemaDict = {
             name: 'NotFound',
           },
         ],
-      },
-    },
-  },
-  AppBskyFeedGetPosts: {
-    lexicon: 1,
-    id: 'app.bsky.feed.getPosts',
-    defs: {
-      main: {
-        type: 'query',
-        description:
-          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
-        parameters: {
-          type: 'params',
-          required: ['uris'],
-          properties: {
-            uris: {
-              type: 'array',
-              description: 'List of post AT-URIs to return hydrated views for.',
-              items: {
-                type: 'string',
-                format: 'at-uri',
-              },
-              maxLength: 25,
-            },
-          },
-        },
-        output: {
-          encoding: 'application/json',
-          schema: {
-            type: 'object',
-            required: ['posts'],
-            properties: {
-              posts: {
-                type: 'array',
-                items: {
-                  type: 'ref',
-                  ref: 'lex:app.bsky.feed.defs#postView',
-                },
-              },
-            },
-          },
-        },
       },
     },
   },
@@ -10354,14 +10354,14 @@ export const schemaDict = {
       },
     },
   },
-  AppBskyUnspeccedGetPostThreadHiddenV2: {
+  AppBskyUnspeccedGetPostThreadOtherV2: {
     lexicon: 1,
-    id: 'app.bsky.unspecced.getPostThreadHiddenV2',
+    id: 'app.bsky.unspecced.getPostThreadOtherV2',
     defs: {
       main: {
         type: 'query',
         description:
-          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get the hidden posts in a thread. It is based in an anchor post at any depth of the tree, and returns hidden replies (recursive replies, with branching to their replies) below the anchor. It does not include ancestors nor the anchor. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
+          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
         parameters: {
           type: 'params',
           required: ['anchor'],
@@ -10389,17 +10389,17 @@ export const schemaDict = {
               thread: {
                 type: 'array',
                 description:
-                  'A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.',
+                  'A flat list of other thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem',
+                  ref: 'lex:app.bsky.unspecced.getPostThreadOtherV2#threadItem',
                 },
               },
             },
           },
         },
       },
-      threadHiddenItem: {
+      threadItem: {
         type: 'object',
         required: ['uri', 'depth', 'value'],
         properties: {
@@ -10477,7 +10477,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['thread', 'hasHiddenReplies'],
+            required: ['thread', 'hasOtherReplies'],
             properties: {
               thread: {
                 type: 'array',
@@ -10492,10 +10492,10 @@ export const schemaDict = {
                 type: 'ref',
                 ref: 'lex:app.bsky.feed.defs#threadgateView',
               },
-              hasHiddenReplies: {
+              hasOtherReplies: {
                 type: 'boolean',
                 description:
-                  'Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them.',
+                  'Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them.',
               },
             },
           },
@@ -16510,8 +16510,8 @@ export const ids = {
   AppBskyFeedGetFeedSkeleton: 'app.bsky.feed.getFeedSkeleton',
   AppBskyFeedGetLikes: 'app.bsky.feed.getLikes',
   AppBskyFeedGetListFeed: 'app.bsky.feed.getListFeed',
-  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetPosts: 'app.bsky.feed.getPosts',
+  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetQuotes: 'app.bsky.feed.getQuotes',
   AppBskyFeedGetRepostedBy: 'app.bsky.feed.getRepostedBy',
   AppBskyFeedGetSuggestedFeeds: 'app.bsky.feed.getSuggestedFeeds',
@@ -16568,8 +16568,8 @@ export const ids = {
   AppBskyUnspeccedGetConfig: 'app.bsky.unspecced.getConfig',
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
-  AppBskyUnspeccedGetPostThreadHiddenV2:
-    'app.bsky.unspecced.getPostThreadHiddenV2',
+  AppBskyUnspeccedGetPostThreadOtherV2:
+    'app.bsky.unspecced.getPostThreadOtherV2',
   AppBskyUnspeccedGetPostThreadV2: 'app.bsky.unspecced.getPostThreadV2',
   AppBskyUnspeccedGetSuggestedFeeds: 'app.bsky.unspecced.getSuggestedFeeds',
   AppBskyUnspeccedGetSuggestedFeedsSkeleton:

--- a/packages/api/src/client/types/app/bsky/unspecced/getPostThreadOtherV2.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPostThreadOtherV2.ts
@@ -14,7 +14,7 @@ import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
-const id = 'app.bsky.unspecced.getPostThreadHiddenV2'
+const id = 'app.bsky.unspecced.getPostThreadOtherV2'
 
 export interface QueryParams {
   /** Reference (AT-URI) to post record. This is the anchor post. */
@@ -26,8 +26,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of other thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: ThreadItem[]
 }
 
 export interface CallOptions {
@@ -45,20 +45,20 @@ export function toKnownErr(e: any) {
   return e
 }
 
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.getPostThreadOtherV2#threadItem'
   uri: string
   /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
   depth: number
   value: $Typed<AppBskyUnspeccedDefs.ThreadItemPost> | { $type: string }
 }
 
-const hashThreadHiddenItem = 'threadHiddenItem'
+const hashThreadItem = 'threadItem'
 
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
 }
 
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
 }

--- a/packages/api/src/client/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -38,8 +38,8 @@ export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
   thread: ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
-  /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
-  hasHiddenReplies: boolean
+  /** Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them. */
+  hasOtherReplies: boolean
 }
 
 export interface CallOptions {

--- a/packages/bsky/src/api/app/bsky/unspecced/getPostThreadOtherV2.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPostThreadOtherV2.ts
@@ -3,7 +3,7 @@ import { AppContext } from '../../../../context'
 import { Code, DataPlaneClient, isDataplaneError } from '../../../../data-plane'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Server } from '../../../../lexicon'
-import { QueryParams } from '../../../../lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
+import { QueryParams } from '../../../../lexicon/types/app/bsky/unspecced/getPostThreadOtherV2'
 import {
   HydrationFnInput,
   PresentationFnInput,
@@ -25,13 +25,13 @@ const BELOW = 1
 const BRANCHING_FACTOR = 0
 
 export default function (server: Server, ctx: AppContext) {
-  const getPostThreadHidden = createPipeline(
+  const getPostThreadOther = createPipeline(
     skeleton,
     hydration,
     noRules, // handled in presentation: 3p block-violating replies are turned to #blockedPost, viewer blocks turned to #notFoundPost.
     presentation,
   )
-  server.app.bsky.unspecced.getPostThreadHiddenV2({
+  server.app.bsky.unspecced.getPostThreadOtherV2({
     auth: ctx.authVerifier.optionalStandardOrRole,
     handler: async ({ params, auth, req }) => {
       const { viewer, includeTakedowns, include3pBlocks } =
@@ -46,7 +46,7 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/json',
-        body: await getPostThreadHidden({ ...params, hydrateCtx }, ctx),
+        body: await getPostThreadOther({ ...params, hydrateCtx }, ctx),
         headers: resHeaders({
           labelers: hydrateCtx.labelers,
         }),
@@ -94,7 +94,7 @@ const presentation = (
   inputs: PresentationFnInput<Context, Params, Skeleton>,
 ) => {
   const { ctx, params, skeleton, hydration } = inputs
-  const thread = ctx.views.threadHiddenV2(skeleton, hydration, {
+  const thread = ctx.views.threadOtherV2(skeleton, hydration, {
     below: BELOW,
     branchingFactor: BRANCHING_FACTOR,
     prioritizeFollowedUsers: params.prioritizeFollowedUsers,

--- a/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
@@ -85,7 +85,7 @@ const presentation = (
   inputs: PresentationFnInput<Context, Params, Skeleton>,
 ) => {
   const { ctx, params, skeleton, hydration } = inputs
-  const { hasHiddenReplies, thread } = ctx.views.threadV2(skeleton, hydration, {
+  const { hasOtherReplies, thread } = ctx.views.threadV2(skeleton, hydration, {
     above: calculateAbove(ctx, params),
     below: calculateBelow(ctx, skeleton.anchor, params),
     branchingFactor: params.branchingFactor,
@@ -100,7 +100,7 @@ const presentation = (
     postUriToThreadgateUri(rootUri),
     hydration,
   )
-  return { hasHiddenReplies, thread, threadgate }
+  return { hasOtherReplies, thread, threadgate }
 }
 
 type Context = {

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -49,7 +49,7 @@ import registerPush from './app/bsky/notification/registerPush'
 import updateSeen from './app/bsky/notification/updateSeen'
 import getConfig from './app/bsky/unspecced/getConfig'
 import getPopularFeedGenerators from './app/bsky/unspecced/getPopularFeedGenerators'
-import getPostThreadHiddenV2 from './app/bsky/unspecced/getPostThreadHiddenV2'
+import getPostThreadOtherV2 from './app/bsky/unspecced/getPostThreadOtherV2'
 import getPostThreadV2 from './app/bsky/unspecced/getPostThreadV2'
 import getUnspeccedSuggestedFeeds from './app/bsky/unspecced/getSuggestedFeeds'
 import getSuggestedStarterPacks from './app/bsky/unspecced/getSuggestedStarterPacks'
@@ -84,7 +84,7 @@ export default function (server: Server, ctx: AppContext) {
   getListFeed(server, ctx)
   getQuotes(server, ctx)
   getPostThread(server, ctx)
-  getPostThreadHiddenV2(server, ctx)
+  getPostThreadOtherV2(server, ctx)
   getPostThreadV2(server, ctx)
   getPosts(server, ctx)
   searchPosts(server, ctx)

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -145,7 +145,7 @@ import * as AppBskyNotificationRegisterPush from './types/app/bsky/notification/
 import * as AppBskyNotificationUpdateSeen from './types/app/bsky/notification/updateSeen.js'
 import * as AppBskyUnspeccedGetConfig from './types/app/bsky/unspecced/getConfig.js'
 import * as AppBskyUnspeccedGetPopularFeedGenerators from './types/app/bsky/unspecced/getPopularFeedGenerators.js'
-import * as AppBskyUnspeccedGetPostThreadHiddenV2 from './types/app/bsky/unspecced/getPostThreadHiddenV2.js'
+import * as AppBskyUnspeccedGetPostThreadOtherV2 from './types/app/bsky/unspecced/getPostThreadOtherV2.js'
 import * as AppBskyUnspeccedGetPostThreadV2 from './types/app/bsky/unspecced/getPostThreadV2.js'
 import * as AppBskyUnspeccedGetSuggestedFeeds from './types/app/bsky/unspecced/getSuggestedFeeds.js'
 import * as AppBskyUnspeccedGetSuggestedFeedsSkeleton from './types/app/bsky/unspecced/getSuggestedFeedsSkeleton.js'
@@ -1499,17 +1499,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1518,6 +1507,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 
@@ -1946,14 +1946,14 @@ export class AppBskyUnspeccedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThreadHiddenV2<AV extends AuthVerifier>(
+  getPostThreadOtherV2<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
-      AppBskyUnspeccedGetPostThreadHiddenV2.Handler<ExtractAuth<AV>>,
-      AppBskyUnspeccedGetPostThreadHiddenV2.HandlerReqCtx<ExtractAuth<AV>>
+      AppBskyUnspeccedGetPostThreadOtherV2.Handler<ExtractAuth<AV>>,
+      AppBskyUnspeccedGetPostThreadOtherV2.HandlerReqCtx<ExtractAuth<AV>>
     >,
   ) {
-    const nsid = 'app.bsky.unspecced.getPostThreadHiddenV2' // @ts-ignore
+    const nsid = 'app.bsky.unspecced.getPostThreadOtherV2' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -7239,6 +7239,48 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyFeedGetPosts: {
+    lexicon: 1,
+    id: 'app.bsky.feed.getPosts',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
+        parameters: {
+          type: 'params',
+          required: ['uris'],
+          properties: {
+            uris: {
+              type: 'array',
+              description: 'List of post AT-URIs to return hydrated views for.',
+              items: {
+                type: 'string',
+                format: 'at-uri',
+              },
+              maxLength: 25,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['posts'],
+            properties: {
+              posts: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.defs#postView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyFeedGetPostThread: {
     lexicon: 1,
     id: 'app.bsky.feed.getPostThread',
@@ -7300,48 +7342,6 @@ export const schemaDict = {
             name: 'NotFound',
           },
         ],
-      },
-    },
-  },
-  AppBskyFeedGetPosts: {
-    lexicon: 1,
-    id: 'app.bsky.feed.getPosts',
-    defs: {
-      main: {
-        type: 'query',
-        description:
-          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
-        parameters: {
-          type: 'params',
-          required: ['uris'],
-          properties: {
-            uris: {
-              type: 'array',
-              description: 'List of post AT-URIs to return hydrated views for.',
-              items: {
-                type: 'string',
-                format: 'at-uri',
-              },
-              maxLength: 25,
-            },
-          },
-        },
-        output: {
-          encoding: 'application/json',
-          schema: {
-            type: 'object',
-            required: ['posts'],
-            properties: {
-              posts: {
-                type: 'array',
-                items: {
-                  type: 'ref',
-                  ref: 'lex:app.bsky.feed.defs#postView',
-                },
-              },
-            },
-          },
-        },
       },
     },
   },
@@ -10354,14 +10354,14 @@ export const schemaDict = {
       },
     },
   },
-  AppBskyUnspeccedGetPostThreadHiddenV2: {
+  AppBskyUnspeccedGetPostThreadOtherV2: {
     lexicon: 1,
-    id: 'app.bsky.unspecced.getPostThreadHiddenV2',
+    id: 'app.bsky.unspecced.getPostThreadOtherV2',
     defs: {
       main: {
         type: 'query',
         description:
-          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get the hidden posts in a thread. It is based in an anchor post at any depth of the tree, and returns hidden replies (recursive replies, with branching to their replies) below the anchor. It does not include ancestors nor the anchor. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
+          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
         parameters: {
           type: 'params',
           required: ['anchor'],
@@ -10389,17 +10389,17 @@ export const schemaDict = {
               thread: {
                 type: 'array',
                 description:
-                  'A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.',
+                  'A flat list of other thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem',
+                  ref: 'lex:app.bsky.unspecced.getPostThreadOtherV2#threadItem',
                 },
               },
             },
           },
         },
       },
-      threadHiddenItem: {
+      threadItem: {
         type: 'object',
         required: ['uri', 'depth', 'value'],
         properties: {
@@ -10477,7 +10477,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['thread', 'hasHiddenReplies'],
+            required: ['thread', 'hasOtherReplies'],
             properties: {
               thread: {
                 type: 'array',
@@ -10492,10 +10492,10 @@ export const schemaDict = {
                 type: 'ref',
                 ref: 'lex:app.bsky.feed.defs#threadgateView',
               },
-              hasHiddenReplies: {
+              hasOtherReplies: {
                 type: 'boolean',
                 description:
-                  'Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them.',
+                  'Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them.',
               },
             },
           },
@@ -12892,8 +12892,8 @@ export const ids = {
   AppBskyFeedGetFeedSkeleton: 'app.bsky.feed.getFeedSkeleton',
   AppBskyFeedGetLikes: 'app.bsky.feed.getLikes',
   AppBskyFeedGetListFeed: 'app.bsky.feed.getListFeed',
-  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetPosts: 'app.bsky.feed.getPosts',
+  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetQuotes: 'app.bsky.feed.getQuotes',
   AppBskyFeedGetRepostedBy: 'app.bsky.feed.getRepostedBy',
   AppBskyFeedGetSuggestedFeeds: 'app.bsky.feed.getSuggestedFeeds',
@@ -12950,8 +12950,8 @@ export const ids = {
   AppBskyUnspeccedGetConfig: 'app.bsky.unspecced.getConfig',
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
-  AppBskyUnspeccedGetPostThreadHiddenV2:
-    'app.bsky.unspecced.getPostThreadHiddenV2',
+  AppBskyUnspeccedGetPostThreadOtherV2:
+    'app.bsky.unspecced.getPostThreadOtherV2',
   AppBskyUnspeccedGetPostThreadV2: 'app.bsky.unspecced.getPostThreadV2',
   AppBskyUnspeccedGetSuggestedFeeds: 'app.bsky.unspecced.getSuggestedFeeds',
   AppBskyUnspeccedGetSuggestedFeedsSkeleton:

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
@@ -15,7 +15,7 @@ import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
-const id = 'app.bsky.unspecced.getPostThreadHiddenV2'
+const id = 'app.bsky.unspecced.getPostThreadOtherV2'
 
 export interface QueryParams {
   /** Reference (AT-URI) to post record. This is the anchor post. */
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of other thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -57,20 +57,20 @@ export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
 
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.getPostThreadOtherV2#threadItem'
   uri: string
   /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
   depth: number
   value: $Typed<AppBskyUnspeccedDefs.ThreadItemPost> | { $type: string }
 }
 
-const hashThreadHiddenItem = 'threadHiddenItem'
+const hashThreadItem = 'threadItem'
 
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
 }
 
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
 }

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -39,8 +39,8 @@ export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
   thread: ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
-  /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
-  hasHiddenReplies: boolean
+  /** Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them. */
+  hasOtherReplies: boolean
 }
 
 export type HandlerInput = undefined

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -75,13 +75,13 @@ import {
   uriToDid as creatorFromUri,
 } from '../util/uris'
 import {
-  ThreadOtherAnchorPostNode,
-  ThreadOtherItemValuePost,
-  ThreadOtherPostNode,
   ThreadItemValueBlocked,
   ThreadItemValueNoUnauthenticated,
   ThreadItemValueNotFound,
   ThreadItemValuePost,
+  ThreadOtherAnchorPostNode,
+  ThreadOtherItemValuePost,
+  ThreadOtherPostNode,
   ThreadTree,
   ThreadTreeVisible,
   sortTrimFlattenThreadTree,

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -59,7 +59,7 @@ import {
   isRecord as isLabelerRecord,
 } from '../lexicon/types/app/bsky/labeler/service'
 import { RecordDeleted as NotificationRecordDeleted } from '../lexicon/types/app/bsky/notification/defs'
-import { ThreadHiddenItem } from '../lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
+import { ThreadItem as ThreadOtherItem } from '../lexicon/types/app/bsky/unspecced/getPostThreadOtherV2'
 import {
   QueryParams as GetPostThreadV2QueryParams,
   ThreadItem,
@@ -75,9 +75,9 @@ import {
   uriToDid as creatorFromUri,
 } from '../util/uris'
 import {
-  ThreadHiddenAnchorPostNode,
-  ThreadHiddenItemValuePost,
-  ThreadHiddenPostNode,
+  ThreadOtherAnchorPostNode,
+  ThreadOtherItemValuePost,
+  ThreadOtherPostNode,
   ThreadItemValueBlocked,
   ThreadItemValueNoUnauthenticated,
   ThreadItemValueNotFound,
@@ -1161,7 +1161,7 @@ export class Views {
       prioritizeFollowedUsers: boolean
       sort: GetPostThreadV2QueryParams['sort']
     },
-  ): { hasHiddenReplies: boolean; thread: ThreadItem[] } {
+  ): { hasOtherReplies: boolean; thread: ThreadItem[] } {
     const { anchor: anchorUri, uris } = skeleton
 
     // Not found.
@@ -1169,7 +1169,7 @@ export class Views {
     const post = state.posts?.get(anchorUri)
     if (!post || !postView) {
       return {
-        hasHiddenReplies: false,
+        hasOtherReplies: false,
         thread: [
           this.threadV2ItemNotFound({
             uri: anchorUri,
@@ -1182,7 +1182,7 @@ export class Views {
     // Blocked (only 1p for anchor).
     if (this.viewerBlockExists(postView.author.did, state)) {
       return {
-        hasHiddenReplies: false,
+        hasOtherReplies: false,
         thread: [
           this.threadV2ItemBlocked({
             uri: anchorUri,
@@ -1229,7 +1229,7 @@ export class Views {
 
     const anchorDepth = 0 // The depth of the anchor post is always 0.
     let anchorTree: ThreadTree
-    let hasHiddenReplies = false
+    let hasOtherReplies = false
 
     if (this.noUnauthenticatedPost(state, postView)) {
       anchorTree = {
@@ -1241,7 +1241,7 @@ export class Views {
         parent,
       }
     } else {
-      const { replies, hasHiddenReplies: hasHiddenRepliesShadow } =
+      const { replies, hasOtherReplies: hasOtherRepliesShadow } =
         !anchorViolatesThreadGate
           ? this.threadV2Replies(
               {
@@ -1257,8 +1257,8 @@ export class Views {
               },
               state,
             )
-          : { replies: undefined, hasHiddenReplies: false }
-      hasHiddenReplies = hasHiddenRepliesShadow
+          : { replies: undefined, hasOtherReplies: false }
+      hasOtherReplies = hasOtherRepliesShadow
 
       anchorTree = {
         type: 'post',
@@ -1287,7 +1287,7 @@ export class Views {
     })
 
     return {
-      hasHiddenReplies,
+      hasOtherReplies,
       thread,
     }
   }
@@ -1432,14 +1432,14 @@ export class Views {
       prioritizeFollowedUsers: boolean
     },
     state: HydrationState,
-  ): { replies: ThreadTreeVisible[] | undefined; hasHiddenReplies: boolean } {
+  ): { replies: ThreadTreeVisible[] | undefined; hasOtherReplies: boolean } {
     // Reached the `below` limit.
     if (depth > below) {
-      return { replies: undefined, hasHiddenReplies: false }
+      return { replies: undefined, hasOtherReplies: false }
     }
 
     const childrenUris = childrenByParentUri[parentUri] ?? []
-    let hasHiddenReplies = false
+    let hasOtherReplies = false
     const replies = mapDefined(childrenUris, (uri) => {
       const replyInclusion = this.checkThreadV2ReplyInclusion({
         uri,
@@ -1452,14 +1452,14 @@ export class Views {
       const { authorDid, post, postView } = replyInclusion
 
       // Hidden.
-      const { isHidden } = this.isHiddenThreadPost(
+      const { isOther } = this.isOtherThreadPost(
         { post, postView, prioritizeFollowedUsers, rootUri, uri },
         state,
       )
-      if (isHidden) {
+      if (isOther) {
         // Only care about anchor replies
         if (depth === 1) {
-          hasHiddenReplies = true
+          hasOtherReplies = true
         }
         return undefined
       }
@@ -1504,7 +1504,7 @@ export class Views {
 
     return {
       replies,
-      hasHiddenReplies,
+      hasOtherReplies,
     }
   }
 
@@ -1537,8 +1537,8 @@ export class Views {
         moreParents: moreParents ?? false,
         moreReplies,
         opThread: isOPThread,
-        hiddenByThreadgate: false, // Hidden posts are handled by threadHiddenV2
-        mutedByViewer: false, // Hidden posts are handled by threadHiddenV2
+        hiddenByThreadgate: false, // Hidden posts are handled by threadOtherV2
+        mutedByViewer: false, // Hidden posts are handled by threadOtherV2
       },
     }
   }
@@ -1599,7 +1599,7 @@ export class Views {
     }
   }
 
-  threadHiddenV2(
+  threadOtherV2(
     skeleton: { anchor: string; uris: string[] },
     state: HydrationState,
     {
@@ -1611,7 +1611,7 @@ export class Views {
       branchingFactor: number
       prioritizeFollowedUsers: boolean
     },
-  ): ThreadHiddenItem[] {
+  ): ThreadOtherItem[] {
     const { anchor: anchorUri, uris } = skeleton
 
     // Not found.
@@ -1634,10 +1634,10 @@ export class Views {
     const rootUri = getRootUri(anchorUri, post)
     const opDid = uriToDid(rootUri)
 
-    const anchorTree: ThreadHiddenAnchorPostNode = {
+    const anchorTree: ThreadOtherAnchorPostNode = {
       type: 'hiddenAnchor',
-      item: this.threadHiddenV2ItemPostAnchor({ depth: 0, uri: anchorUri }),
-      replies: this.threadHiddenV2Replies(
+      item: this.threadOtherV2ItemPostAnchor({ depth: 0, uri: anchorUri }),
+      replies: this.threadOtherV2Replies(
         {
           parentUri: anchorUri,
           rootUri,
@@ -1660,7 +1660,7 @@ export class Views {
     })
   }
 
-  private threadHiddenV2Replies(
+  private threadOtherV2Replies(
     {
       parentUri,
       rootUri,
@@ -1677,7 +1677,7 @@ export class Views {
       prioritizeFollowedUsers: boolean
     },
     state: HydrationState,
-  ): ThreadHiddenPostNode[] | undefined {
+  ): ThreadOtherPostNode[] | undefined {
     // Reached the `below` limit.
     if (depth > below) {
       return undefined
@@ -1695,13 +1695,13 @@ export class Views {
       }
       const { post, postView } = replyInclusion
 
-      // Hidden.
-      const { isHidden, hiddenByThreadgate, mutedByViewer } =
-        this.isHiddenThreadPost(
+      // Other posts to pull out
+      const { isOther, hiddenByThreadgate, mutedByViewer } =
+        this.isOtherThreadPost(
           { post, postView, rootUri, prioritizeFollowedUsers, uri },
           state,
         )
-      if (isHidden) {
+      if (isOther) {
         // Only show hidden anchor replies, not all hidden.
         if (depth > 1) {
           return undefined
@@ -1712,7 +1712,7 @@ export class Views {
       }
 
       // Recurse down.
-      const replies = this.threadHiddenV2Replies(
+      const replies = this.threadOtherV2Replies(
         {
           parentUri: uri,
           rootUri,
@@ -1724,7 +1724,7 @@ export class Views {
         state,
       )
 
-      const item = this.threadHiddenV2ItemPost({
+      const item = this.threadOtherV2ItemPost({
         depth,
         hiddenByThreadgate,
         mutedByViewer,
@@ -1732,7 +1732,7 @@ export class Views {
         uri,
       })
 
-      const tree: ThreadHiddenPostNode = {
+      const tree: ThreadOtherPostNode = {
         type: 'hiddenPost',
         item: item,
         tags: post.tags,
@@ -1743,13 +1743,13 @@ export class Views {
     })
   }
 
-  private threadHiddenV2ItemPostAnchor({
+  private threadOtherV2ItemPostAnchor({
     depth,
     uri,
   }: {
     depth: number
     uri: string
-  }): ThreadHiddenAnchorPostNode['item'] {
+  }): ThreadOtherAnchorPostNode['item'] {
     return {
       uri,
       depth,
@@ -1759,7 +1759,7 @@ export class Views {
     }
   }
 
-  private threadHiddenV2ItemPost({
+  private threadOtherV2ItemPost({
     depth,
     hiddenByThreadgate,
     mutedByViewer,
@@ -1771,8 +1771,8 @@ export class Views {
     mutedByViewer: boolean
     postView: PostView
     uri: string
-  }): ThreadHiddenItemValuePost {
-    const base = this.threadHiddenV2ItemPostAnchor({ depth, uri })
+  }): ThreadOtherItemValuePost {
+    const base = this.threadOtherV2ItemPostAnchor({ depth, uri })
     return {
       ...base,
       value: {
@@ -1780,9 +1780,9 @@ export class Views {
         post: postView,
         hiddenByThreadgate,
         mutedByViewer,
-        moreParents: false, // Hidden replies don't have parents.
-        moreReplies: 0, // Hidden replies don't have replies hydrated.
-        opThread: false, // Hidden replies don't contain OP threads.
+        moreParents: false, // "Other" replies don't have parents.
+        moreReplies: 0, // "Other" replies don't have replies hydrated.
+        opThread: false, // "Other" replies don't contain OP threads.
       },
     }
   }
@@ -1834,7 +1834,7 @@ export class Views {
     return { authorDid, post, postView }
   }
 
-  private isHiddenThreadPost(
+  private isOtherThreadPost(
     {
       post,
       postView,
@@ -1850,7 +1850,7 @@ export class Views {
     },
     state: HydrationState,
   ): {
-    isHidden: boolean
+    isOther: boolean
     hiddenByTag: boolean
     hiddenByThreadgate: boolean
     mutedByViewer: boolean
@@ -1873,7 +1873,7 @@ export class Views {
     const mutedByViewer = this.viewerMuteExists(authorDid, state)
 
     return {
-      isHidden: hiddenByTag || hiddenByThreadgate || mutedByViewer,
+      isOther: hiddenByTag || hiddenByThreadgate || mutedByViewer,
       hiddenByTag,
       hiddenByThreadgate,
       mutedByViewer,

--- a/packages/bsky/src/views/threads-v2.ts
+++ b/packages/bsky/src/views/threads-v2.ts
@@ -7,18 +7,18 @@ import {
   ThreadItemNotFound,
   ThreadItemPost,
 } from '../lexicon/types/app/bsky/unspecced/defs'
-import { ThreadHiddenItem } from '../lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
+import { ThreadItem as ThreadOtherItem } from '../lexicon/types/app/bsky/unspecced/getPostThreadOtherV2'
 import {
   QueryParams as GetPostThreadV2QueryParams,
   ThreadItem,
 } from '../lexicon/types/app/bsky/unspecced/getPostThreadV2'
 import { $Typed } from '../lexicon/util'
 
-type ThreadMaybeHiddenPostNode = ThreadPostNode | ThreadHiddenPostNode
+type ThreadMaybeOtherPostNode = ThreadPostNode | ThreadOtherPostNode
 type ThreadNodeWithReplies =
   | ThreadPostNode
-  | ThreadHiddenPostNode
-  | ThreadHiddenAnchorPostNode
+  | ThreadOtherPostNode
+  | ThreadOtherAnchorPostNode
 
 type ThreadItemValue<T extends ThreadItem['value']> = Omit<
   ThreadItem,
@@ -63,37 +63,37 @@ type ThreadPostNode = {
   replies: ThreadTree[] | undefined
 }
 
-type ThreadHiddenItemValue<T extends ThreadHiddenItem['value']> = Omit<
-  ThreadHiddenItem,
+type ThreadOtherItemValue<T extends ThreadOtherItem['value']> = Omit<
+  ThreadOtherItem,
   'value'
 > & {
   value: T
 }
 
-export type ThreadHiddenItemValuePost = ThreadHiddenItemValue<
+export type ThreadOtherItemValuePost = ThreadOtherItemValue<
   $Typed<ThreadItemPost>
 >
 
 // This is an intermediary type that doesn't map to the views.
 // It is useful to differentiate between the anchor post and the replies for the hidden case,
 // while also differentiating between hidden and visible cases.
-export type ThreadHiddenAnchorPostNode = {
+export type ThreadOtherAnchorPostNode = {
   type: 'hiddenAnchor'
-  item: Omit<ThreadHiddenItem, 'value'> & { value: undefined }
-  replies: ThreadHiddenPostNode[] | undefined
+  item: Omit<ThreadOtherItem, 'value'> & { value: undefined }
+  replies: ThreadOtherPostNode[] | undefined
 }
 
-export type ThreadHiddenPostNode = {
+export type ThreadOtherPostNode = {
   type: 'hiddenPost'
-  item: ThreadHiddenItemValuePost
+  item: ThreadOtherItemValuePost
   tags: Set<string>
-  replies: ThreadHiddenPostNode[] | undefined
+  replies: ThreadOtherPostNode[] | undefined
 }
 
 const isNodeWithReplies = (node: ThreadTree): node is ThreadNodeWithReplies =>
   'replies' in node && node.replies !== undefined
 
-const isPostNode = (node: ThreadTree): node is ThreadMaybeHiddenPostNode =>
+const isPostNode = (node: ThreadTree): node is ThreadMaybeOtherPostNode =>
   node.type === 'post' || node.type === 'hiddenPost'
 
 export type ThreadTreeVisible =
@@ -102,9 +102,9 @@ export type ThreadTreeVisible =
   | ThreadNotFoundNode
   | ThreadPostNode
 
-export type ThreadTreeHidden = ThreadHiddenAnchorPostNode | ThreadHiddenPostNode
+export type ThreadTreeOther = ThreadOtherAnchorPostNode | ThreadOtherPostNode
 
-export type ThreadTree = ThreadTreeVisible | ThreadTreeHidden
+export type ThreadTree = ThreadTreeVisible | ThreadTreeOther
 
 /** This function mutates the tree parameter. */
 export function sortTrimFlattenThreadTree(
@@ -146,8 +146,8 @@ function sortTrimThreadTree(
       if (!isPostNode(bn)) {
         return -1
       }
-      const aNode: ThreadMaybeHiddenPostNode = an
-      const bNode: ThreadMaybeHiddenPostNode = bn
+      const aNode: ThreadMaybeOtherPostNode = an
+      const bNode: ThreadMaybeOtherPostNode = bn
 
       // First applies bumping.
       const bump = applyBumping(aNode, bNode, opts)
@@ -171,8 +171,8 @@ function sortTrimThreadTree(
 }
 
 function applyBumping(
-  aNode: ThreadMaybeHiddenPostNode,
-  bNode: ThreadMaybeHiddenPostNode,
+  aNode: ThreadMaybeOtherPostNode,
+  bNode: ThreadMaybeOtherPostNode,
   opts: SortTrimFlattenOptions,
 ): number | null {
   if (!isPostNode(aNode)) {
@@ -191,7 +191,7 @@ function applyBumping(
   } = opts
 
   type BumpDirection = 'up' | 'down'
-  type BumpPredicateFn = (i: ThreadMaybeHiddenPostNode) => boolean
+  type BumpPredicateFn = (i: ThreadMaybeOtherPostNode) => boolean
 
   const maybeBump = (
     bump: BumpDirection,
@@ -276,8 +276,8 @@ function applyBumping(
 }
 
 function applySorting(
-  aNode: ThreadMaybeHiddenPostNode,
-  bNode: ThreadMaybeHiddenPostNode,
+  aNode: ThreadMaybeOtherPostNode,
+  bNode: ThreadMaybeOtherPostNode,
   opts: SortTrimFlattenOptions,
 ): number {
   const a = aNode.item.value

--- a/packages/bsky/tests/views/__snapshots__/thread-v2.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/thread-v2.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`appview thread views v2 simple thread returns thread anchored on 1 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -1,
@@ -100,7 +100,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on 2 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -1,
@@ -248,7 +248,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on 2.0 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -2,
@@ -396,7 +396,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on 3 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -1,
@@ -494,7 +494,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on r 0 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -1,
@@ -642,7 +642,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on r 0.0 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": -2,
@@ -790,7 +790,7 @@ Object {
 
 exports[`appview thread views v2 simple thread returns thread anchored on root 1`] = `
 Object {
-  "hasHiddenReplies": false,
+  "hasOtherReplies": false,
   "thread": Array [
     Object {
       "depth": 0,

--- a/packages/bsky/tests/views/thread-v2.test.ts
+++ b/packages/bsky/tests/views/thread-v2.test.ts
@@ -9,8 +9,8 @@ import {
   QueryParams as QueryParamsThread,
 } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadV2'
 import {
-  ThreadOtherItemValuePost,
   ThreadItemValuePost,
+  ThreadOtherItemValuePost,
 } from '../../src/views/threads-v2'
 import { forSnapshot } from '../_util'
 import * as seeds from '../seed/thread-v2'

--- a/packages/bsky/tests/views/thread-v2.test.ts
+++ b/packages/bsky/tests/views/thread-v2.test.ts
@@ -3,13 +3,13 @@ import { AppBskyUnspeccedDefs, AtpAgent } from '@atproto/api'
 import { SeedClient, TestNetwork } from '@atproto/dev-env'
 import { ids } from '../../src/lexicon/lexicons'
 import { ThreadItemPost } from '../../src/lexicon/types/app/bsky/unspecced/defs'
-import { OutputSchema as OutputSchemaHiddenThread } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadHiddenV2'
+import { OutputSchema as OutputSchemaHiddenThread } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2'
 import {
   OutputSchema as OutputSchemaThread,
   QueryParams as QueryParamsThread,
 } from '../../src/lexicon/types/app/bsky/unspecced/getPostThreadV2'
 import {
-  ThreadHiddenItemValuePost,
+  ThreadOtherItemValuePost,
   ThreadItemValuePost,
 } from '../../src/views/threads-v2'
 import { forSnapshot } from '../_util'
@@ -96,10 +96,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: 0, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: 1, uri: seed.r['0'].ref.uriStr }),
@@ -122,10 +122,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -1, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: 0, uri: seed.r['0'].ref.uriStr }),
@@ -144,10 +144,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -2, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: -1, uri: seed.r['0'].ref.uriStr }),
@@ -166,10 +166,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -1, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: 0, uri: seed.r['1'].ref.uriStr }),
@@ -187,10 +187,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -1, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: 0, uri: seed.r['2'].ref.uriStr }),
@@ -209,10 +209,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -2, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: -1, uri: seed.r['2'].ref.uriStr }),
@@ -231,10 +231,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({ depth: -1, uri: seed.root.ref.uriStr }),
         expect.objectContaining({ depth: 0, uri: seed.r['3'].ref.uriStr }),
@@ -290,10 +290,10 @@ describe('appview thread views v2', () => {
               ),
             },
           )
-          const { thread: t, hasHiddenReplies } = data
+          const { thread: t, hasOtherReplies } = data
 
           assertPosts(t)
-          expect(hasHiddenReplies).toBe(false)
+          expect(hasOtherReplies).toBe(false)
           const anchorIndex = t.findIndex((i) => i.uri === post.ref.uriStr)
           const anchorPost = t[anchorIndex]
 
@@ -333,10 +333,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toHaveLength(16) // anchor + 15 ancestors, as limited by `maxThreadParents`.
 
         const first = t.at(0)
@@ -367,10 +367,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toHaveLength(1)
 
         const first = t.at(0)
@@ -394,10 +394,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toHaveLength(11)
         const first = t.at(0)
         expect(first!.uri).toBe(seed.root.ref.uriStr)
@@ -417,10 +417,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toHaveLength(4)
 
         const first = t.at(0)
@@ -593,10 +593,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         if ('length' in args) {
           expect(data.thread).toHaveLength(args.length)
         } else {
@@ -632,10 +632,10 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
       assertPosts(t)
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       expect(t).toEqual([
         expect.objectContaining({
           uri: seed.root.ref.uriStr,
@@ -780,10 +780,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         const opThreadPostsUris = new Set(
           opThreadPosts.map((k) =>
             k === 'root' ? seed.root.ref.uriStr : seed.r[k].ref.uriStr,
@@ -884,10 +884,10 @@ describe('appview thread views v2', () => {
               ),
             },
           )
-          const { thread: t, hasHiddenReplies } = data
+          const { thread: t, hasOtherReplies } = data
 
           assertPosts(t)
-          expect(hasHiddenReplies).toBe(false)
+          expect(hasOtherReplies).toBe(false)
           const tUris = t.map((i) => i.uri)
           const postUris = postKeys.map((k) =>
             k === 'root' ? seed.root.ref.uriStr : seed.r[k].ref.uriStr,
@@ -937,10 +937,10 @@ describe('appview thread views v2', () => {
                 ),
               },
             )
-            const { thread: t, hasHiddenReplies } = data
+            const { thread: t, hasOtherReplies } = data
 
             assertPosts(t)
-            expect(hasHiddenReplies).toBe(false)
+            expect(hasOtherReplies).toBe(false)
             const tUris = t.map((i) => i.uri)
             const postUris = postKeys.map((k) =>
               k === 'root' ? seed.root.ref.uriStr : seed.r[k].ref.uriStr,
@@ -1089,10 +1089,10 @@ describe('appview thread views v2', () => {
                 ),
               },
             )
-            const { thread: t, hasHiddenReplies } = data
+            const { thread: t, hasOtherReplies } = data
 
             assertPosts(t)
-            expect(hasHiddenReplies).toBe(false)
+            expect(hasOtherReplies).toBe(false)
             const tUris = t.map((i) => i.uri)
             const postUris = postKeys.map((k) =>
               k === 'root' ? seed.root.ref.uriStr : seed.r[k].ref.uriStr,
@@ -1128,10 +1128,10 @@ describe('appview thread views v2', () => {
               ),
             },
           )
-          const { thread: t, hasHiddenReplies } = data
+          const { thread: t, hasOtherReplies } = data
 
           assertPosts(t)
-          expect(hasHiddenReplies).toBe(false)
+          expect(hasOtherReplies).toBe(false)
           return t
         }
 
@@ -1223,10 +1223,10 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
         assertPosts(t)
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({ uri: seed.root.ref.uriStr }),
           expect.objectContaining({ uri: seed.r['3'].ref.uriStr }),
@@ -1246,9 +1246,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.r['0'].ref.uriStr,
@@ -1271,9 +1271,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.r['0'].ref.uriStr,
@@ -1305,9 +1305,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({ uri: seed.root.ref.uriStr }),
@@ -1330,9 +1330,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.root.ref.uriStr,
@@ -1370,9 +1370,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.r['1'].ref.uriStr,
@@ -1402,9 +1402,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.root.ref.uriStr,
@@ -1442,9 +1442,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({ uri: seed.root.ref.uriStr }),
@@ -1466,9 +1466,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.r['2'].ref.uriStr,
@@ -1498,9 +1498,9 @@ describe('appview thread views v2', () => {
             },
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.root.ref.uriStr,
@@ -1535,9 +1535,9 @@ describe('appview thread views v2', () => {
             },
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.root.ref.uriStr,
@@ -1565,9 +1565,9 @@ describe('appview thread views v2', () => {
             },
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         expect(t).toEqual([
           expect.objectContaining({
             uri: seed.root.ref.uriStr,
@@ -1622,9 +1622,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(true)
+        expect(hasOtherReplies).toBe(true)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({
@@ -1644,13 +1644,13 @@ describe('appview thread views v2', () => {
       })
 
       it(`top-level muted replies are returned when fetching hidden, sorted by newest`, async () => {
-        const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+        const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
           { anchor: seed.root.ref.uriStr },
           {
             headers: await network.serviceHeaders(
               // Fetching as `op` mutes `opMuted`.
               seed.users.op.did,
-              ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+              ids.AppBskyUnspeccedGetPostThreadOtherV2,
             ),
           },
         )
@@ -1681,9 +1681,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(true)
+        expect(hasOtherReplies).toBe(true)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({
@@ -1703,13 +1703,13 @@ describe('appview thread views v2', () => {
       })
 
       it(`fetches hidden replies includes own mutes, not OP mutes, sorted by newest`, async () => {
-        const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+        const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
           { anchor: seed.root.ref.uriStr },
           {
             headers: await network.serviceHeaders(
               // Fetching as `muter` mutes `muted`.
               seed.users.muter.did,
-              ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+              ids.AppBskyUnspeccedGetPostThreadOtherV2,
             ),
           },
         )
@@ -1737,9 +1737,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(false)
+        expect(hasOtherReplies).toBe(false)
         assertPosts(t)
         // No muted posts by `opMuted`, gets the full thread.
         expect(t.length).toBe(1 + Object.keys(seed.r).length) // root + replies
@@ -1765,9 +1765,9 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
-      expect(hasHiddenReplies).toBe(true)
+      expect(hasOtherReplies).toBe(true)
       assertPosts(t)
       expect(t).toEqual([
         expect.objectContaining({
@@ -1792,12 +1792,12 @@ describe('appview thread views v2', () => {
     })
 
     it(`top-level threadgated replies are returned to OP when fetching hidden, sorted by newest`, async () => {
-      const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+      const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
         { anchor: seed.root.ref.uriStr },
         {
           headers: await network.serviceHeaders(
             seed.users.op.did,
-            ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+            ids.AppBskyUnspeccedGetPostThreadOtherV2,
           ),
         },
       )
@@ -1832,9 +1832,9 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
-      expect(hasHiddenReplies).toBe(false)
+      expect(hasOtherReplies).toBe(false)
       assertPosts(t)
       expect(t).toEqual([
         expect.objectContaining({
@@ -1895,9 +1895,9 @@ describe('appview thread views v2', () => {
           ),
         },
       )
-      const { thread: t, hasHiddenReplies } = data
+      const { thread: t, hasOtherReplies } = data
 
-      expect(hasHiddenReplies).toBe(true)
+      expect(hasOtherReplies).toBe(true)
       assertPosts(t)
       expect(t).toEqual([
         expect.objectContaining({
@@ -1928,13 +1928,13 @@ describe('appview thread views v2', () => {
     })
 
     it(`top-level threadgated replies are returned to other viewers when fetching hidden, sorted by newest`, async () => {
-      const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+      const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
         { anchor: seed.root.ref.uriStr },
         {
           headers: await network.serviceHeaders(
             // `viewer` also gets the replies as hidden.
             seed.users.viewer.did,
-            ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+            ids.AppBskyUnspeccedGetPostThreadOtherV2,
           ),
         },
       )
@@ -1978,9 +1978,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(true)
+        expect(hasOtherReplies).toBe(true)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({ uri: seed.root.ref.uriStr }),
@@ -2002,7 +2002,7 @@ describe('appview thread views v2', () => {
       })
 
       it('finds the hidden by tag', async () => {
-        const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+        const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
           {
             anchor: seed.root.ref.uriStr,
             prioritizeFollowedUsers,
@@ -2010,7 +2010,7 @@ describe('appview thread views v2', () => {
           {
             headers: await network.serviceHeaders(
               seed.users.viewer.did,
-              ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+              ids.AppBskyUnspeccedGetPostThreadOtherV2,
             ),
           },
         )
@@ -2041,9 +2041,9 @@ describe('appview thread views v2', () => {
             ),
           },
         )
-        const { thread: t, hasHiddenReplies } = data
+        const { thread: t, hasOtherReplies } = data
 
-        expect(hasHiddenReplies).toBe(true)
+        expect(hasOtherReplies).toBe(true)
         assertPosts(t)
         expect(t).toEqual([
           expect.objectContaining({ uri: seed.root.ref.uriStr }),
@@ -2064,7 +2064,7 @@ describe('appview thread views v2', () => {
       })
 
       it('finds the hidden by tag', async () => {
-        const { data } = await agent.app.bsky.unspecced.getPostThreadHiddenV2(
+        const { data } = await agent.app.bsky.unspecced.getPostThreadOtherV2(
           {
             anchor: seed.root.ref.uriStr,
             prioritizeFollowedUsers,
@@ -2072,7 +2072,7 @@ describe('appview thread views v2', () => {
           {
             headers: await network.serviceHeaders(
               seed.users.viewer.did,
-              ids.AppBskyUnspeccedGetPostThreadHiddenV2,
+              ids.AppBskyUnspeccedGetPostThreadOtherV2,
             ),
           },
         )
@@ -2103,7 +2103,7 @@ function assertPosts(
 
 function assertHiddenPosts(
   t: OutputSchemaHiddenThread['thread'],
-): asserts t is ThreadHiddenItemValuePost[] {
+): asserts t is ThreadOtherItemValuePost[] {
   t.forEach((i) => {
     assert(
       AppBskyUnspeccedDefs.isThreadItemPost(i.value),

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -145,7 +145,7 @@ import * as AppBskyNotificationRegisterPush from './types/app/bsky/notification/
 import * as AppBskyNotificationUpdateSeen from './types/app/bsky/notification/updateSeen.js'
 import * as AppBskyUnspeccedGetConfig from './types/app/bsky/unspecced/getConfig.js'
 import * as AppBskyUnspeccedGetPopularFeedGenerators from './types/app/bsky/unspecced/getPopularFeedGenerators.js'
-import * as AppBskyUnspeccedGetPostThreadHiddenV2 from './types/app/bsky/unspecced/getPostThreadHiddenV2.js'
+import * as AppBskyUnspeccedGetPostThreadOtherV2 from './types/app/bsky/unspecced/getPostThreadOtherV2.js'
 import * as AppBskyUnspeccedGetPostThreadV2 from './types/app/bsky/unspecced/getPostThreadV2.js'
 import * as AppBskyUnspeccedGetSuggestedFeeds from './types/app/bsky/unspecced/getSuggestedFeeds.js'
 import * as AppBskyUnspeccedGetSuggestedFeedsSkeleton from './types/app/bsky/unspecced/getSuggestedFeedsSkeleton.js'
@@ -1549,17 +1549,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1568,6 +1557,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 
@@ -1996,14 +1996,14 @@ export class AppBskyUnspeccedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThreadHiddenV2<AV extends AuthVerifier>(
+  getPostThreadOtherV2<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
-      AppBskyUnspeccedGetPostThreadHiddenV2.Handler<ExtractAuth<AV>>,
-      AppBskyUnspeccedGetPostThreadHiddenV2.HandlerReqCtx<ExtractAuth<AV>>
+      AppBskyUnspeccedGetPostThreadOtherV2.Handler<ExtractAuth<AV>>,
+      AppBskyUnspeccedGetPostThreadOtherV2.HandlerReqCtx<ExtractAuth<AV>>
     >,
   ) {
-    const nsid = 'app.bsky.unspecced.getPostThreadHiddenV2' // @ts-ignore
+    const nsid = 'app.bsky.unspecced.getPostThreadOtherV2' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -7239,6 +7239,48 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyFeedGetPosts: {
+    lexicon: 1,
+    id: 'app.bsky.feed.getPosts',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
+        parameters: {
+          type: 'params',
+          required: ['uris'],
+          properties: {
+            uris: {
+              type: 'array',
+              description: 'List of post AT-URIs to return hydrated views for.',
+              items: {
+                type: 'string',
+                format: 'at-uri',
+              },
+              maxLength: 25,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['posts'],
+            properties: {
+              posts: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.defs#postView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyFeedGetPostThread: {
     lexicon: 1,
     id: 'app.bsky.feed.getPostThread',
@@ -7300,48 +7342,6 @@ export const schemaDict = {
             name: 'NotFound',
           },
         ],
-      },
-    },
-  },
-  AppBskyFeedGetPosts: {
-    lexicon: 1,
-    id: 'app.bsky.feed.getPosts',
-    defs: {
-      main: {
-        type: 'query',
-        description:
-          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
-        parameters: {
-          type: 'params',
-          required: ['uris'],
-          properties: {
-            uris: {
-              type: 'array',
-              description: 'List of post AT-URIs to return hydrated views for.',
-              items: {
-                type: 'string',
-                format: 'at-uri',
-              },
-              maxLength: 25,
-            },
-          },
-        },
-        output: {
-          encoding: 'application/json',
-          schema: {
-            type: 'object',
-            required: ['posts'],
-            properties: {
-              posts: {
-                type: 'array',
-                items: {
-                  type: 'ref',
-                  ref: 'lex:app.bsky.feed.defs#postView',
-                },
-              },
-            },
-          },
-        },
       },
     },
   },
@@ -10354,14 +10354,14 @@ export const schemaDict = {
       },
     },
   },
-  AppBskyUnspeccedGetPostThreadHiddenV2: {
+  AppBskyUnspeccedGetPostThreadOtherV2: {
     lexicon: 1,
-    id: 'app.bsky.unspecced.getPostThreadHiddenV2',
+    id: 'app.bsky.unspecced.getPostThreadOtherV2',
     defs: {
       main: {
         type: 'query',
         description:
-          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get the hidden posts in a thread. It is based in an anchor post at any depth of the tree, and returns hidden replies (recursive replies, with branching to their replies) below the anchor. It does not include ancestors nor the anchor. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
+          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
         parameters: {
           type: 'params',
           required: ['anchor'],
@@ -10389,17 +10389,17 @@ export const schemaDict = {
               thread: {
                 type: 'array',
                 description:
-                  'A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.',
+                  'A flat list of other thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem',
+                  ref: 'lex:app.bsky.unspecced.getPostThreadOtherV2#threadItem',
                 },
               },
             },
           },
         },
       },
-      threadHiddenItem: {
+      threadItem: {
         type: 'object',
         required: ['uri', 'depth', 'value'],
         properties: {
@@ -10477,7 +10477,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['thread', 'hasHiddenReplies'],
+            required: ['thread', 'hasOtherReplies'],
             properties: {
               thread: {
                 type: 'array',
@@ -10492,10 +10492,10 @@ export const schemaDict = {
                 type: 'ref',
                 ref: 'lex:app.bsky.feed.defs#threadgateView',
               },
-              hasHiddenReplies: {
+              hasOtherReplies: {
                 type: 'boolean',
                 description:
-                  'Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them.',
+                  'Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them.',
               },
             },
           },
@@ -16510,8 +16510,8 @@ export const ids = {
   AppBskyFeedGetFeedSkeleton: 'app.bsky.feed.getFeedSkeleton',
   AppBskyFeedGetLikes: 'app.bsky.feed.getLikes',
   AppBskyFeedGetListFeed: 'app.bsky.feed.getListFeed',
-  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetPosts: 'app.bsky.feed.getPosts',
+  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetQuotes: 'app.bsky.feed.getQuotes',
   AppBskyFeedGetRepostedBy: 'app.bsky.feed.getRepostedBy',
   AppBskyFeedGetSuggestedFeeds: 'app.bsky.feed.getSuggestedFeeds',
@@ -16568,8 +16568,8 @@ export const ids = {
   AppBskyUnspeccedGetConfig: 'app.bsky.unspecced.getConfig',
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
-  AppBskyUnspeccedGetPostThreadHiddenV2:
-    'app.bsky.unspecced.getPostThreadHiddenV2',
+  AppBskyUnspeccedGetPostThreadOtherV2:
+    'app.bsky.unspecced.getPostThreadOtherV2',
   AppBskyUnspeccedGetPostThreadV2: 'app.bsky.unspecced.getPostThreadV2',
   AppBskyUnspeccedGetSuggestedFeeds: 'app.bsky.unspecced.getSuggestedFeeds',
   AppBskyUnspeccedGetSuggestedFeedsSkeleton:

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
@@ -15,7 +15,7 @@ import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
-const id = 'app.bsky.unspecced.getPostThreadHiddenV2'
+const id = 'app.bsky.unspecced.getPostThreadOtherV2'
 
 export interface QueryParams {
   /** Reference (AT-URI) to post record. This is the anchor post. */
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of other thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -57,20 +57,20 @@ export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
 
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.getPostThreadOtherV2#threadItem'
   uri: string
   /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
   depth: number
   value: $Typed<AppBskyUnspeccedDefs.ThreadItemPost> | { $type: string }
 }
 
-const hashThreadHiddenItem = 'threadHiddenItem'
+const hashThreadItem = 'threadItem'
 
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
 }
 
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
 }

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -39,8 +39,8 @@ export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
   thread: ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
-  /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
-  hasHiddenReplies: boolean
+  /** Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them. */
+  hasOtherReplies: boolean
 }
 
 export type HandlerInput = undefined

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -108,8 +108,8 @@ import * as AppBskyFeedGetFeedGenerators from './types/app/bsky/feed/getFeedGene
 import * as AppBskyFeedGetFeedSkeleton from './types/app/bsky/feed/getFeedSkeleton.js'
 import * as AppBskyFeedGetLikes from './types/app/bsky/feed/getLikes.js'
 import * as AppBskyFeedGetListFeed from './types/app/bsky/feed/getListFeed.js'
-import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetPosts from './types/app/bsky/feed/getPosts.js'
+import * as AppBskyFeedGetPostThread from './types/app/bsky/feed/getPostThread.js'
 import * as AppBskyFeedGetQuotes from './types/app/bsky/feed/getQuotes.js'
 import * as AppBskyFeedGetRepostedBy from './types/app/bsky/feed/getRepostedBy.js'
 import * as AppBskyFeedGetSuggestedFeeds from './types/app/bsky/feed/getSuggestedFeeds.js'
@@ -145,7 +145,7 @@ import * as AppBskyNotificationRegisterPush from './types/app/bsky/notification/
 import * as AppBskyNotificationUpdateSeen from './types/app/bsky/notification/updateSeen.js'
 import * as AppBskyUnspeccedGetConfig from './types/app/bsky/unspecced/getConfig.js'
 import * as AppBskyUnspeccedGetPopularFeedGenerators from './types/app/bsky/unspecced/getPopularFeedGenerators.js'
-import * as AppBskyUnspeccedGetPostThreadHiddenV2 from './types/app/bsky/unspecced/getPostThreadHiddenV2.js'
+import * as AppBskyUnspeccedGetPostThreadOtherV2 from './types/app/bsky/unspecced/getPostThreadOtherV2.js'
 import * as AppBskyUnspeccedGetPostThreadV2 from './types/app/bsky/unspecced/getPostThreadV2.js'
 import * as AppBskyUnspeccedGetSuggestedFeeds from './types/app/bsky/unspecced/getSuggestedFeeds.js'
 import * as AppBskyUnspeccedGetSuggestedFeedsSkeleton from './types/app/bsky/unspecced/getSuggestedFeedsSkeleton.js'
@@ -1549,17 +1549,6 @@ export class AppBskyFeedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThread<AV extends AuthVerifier>(
-    cfg: ConfigOf<
-      AV,
-      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
-      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
-    >,
-  ) {
-    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
-    return this._server.xrpc.method(nsid, cfg)
-  }
-
   getPosts<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
@@ -1568,6 +1557,17 @@ export class AppBskyFeedNS {
     >,
   ) {
     const nsid = 'app.bsky.feed.getPosts' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getPostThread<AV extends AuthVerifier>(
+    cfg: ConfigOf<
+      AV,
+      AppBskyFeedGetPostThread.Handler<ExtractAuth<AV>>,
+      AppBskyFeedGetPostThread.HandlerReqCtx<ExtractAuth<AV>>
+    >,
+  ) {
+    const nsid = 'app.bsky.feed.getPostThread' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 
@@ -1996,14 +1996,14 @@ export class AppBskyUnspeccedNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
-  getPostThreadHiddenV2<AV extends AuthVerifier>(
+  getPostThreadOtherV2<AV extends AuthVerifier>(
     cfg: ConfigOf<
       AV,
-      AppBskyUnspeccedGetPostThreadHiddenV2.Handler<ExtractAuth<AV>>,
-      AppBskyUnspeccedGetPostThreadHiddenV2.HandlerReqCtx<ExtractAuth<AV>>
+      AppBskyUnspeccedGetPostThreadOtherV2.Handler<ExtractAuth<AV>>,
+      AppBskyUnspeccedGetPostThreadOtherV2.HandlerReqCtx<ExtractAuth<AV>>
     >,
   ) {
-    const nsid = 'app.bsky.unspecced.getPostThreadHiddenV2' // @ts-ignore
+    const nsid = 'app.bsky.unspecced.getPostThreadOtherV2' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -7239,6 +7239,48 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyFeedGetPosts: {
+    lexicon: 1,
+    id: 'app.bsky.feed.getPosts',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
+        parameters: {
+          type: 'params',
+          required: ['uris'],
+          properties: {
+            uris: {
+              type: 'array',
+              description: 'List of post AT-URIs to return hydrated views for.',
+              items: {
+                type: 'string',
+                format: 'at-uri',
+              },
+              maxLength: 25,
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['posts'],
+            properties: {
+              posts: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.feed.defs#postView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   AppBskyFeedGetPostThread: {
     lexicon: 1,
     id: 'app.bsky.feed.getPostThread',
@@ -7300,48 +7342,6 @@ export const schemaDict = {
             name: 'NotFound',
           },
         ],
-      },
-    },
-  },
-  AppBskyFeedGetPosts: {
-    lexicon: 1,
-    id: 'app.bsky.feed.getPosts',
-    defs: {
-      main: {
-        type: 'query',
-        description:
-          "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'.",
-        parameters: {
-          type: 'params',
-          required: ['uris'],
-          properties: {
-            uris: {
-              type: 'array',
-              description: 'List of post AT-URIs to return hydrated views for.',
-              items: {
-                type: 'string',
-                format: 'at-uri',
-              },
-              maxLength: 25,
-            },
-          },
-        },
-        output: {
-          encoding: 'application/json',
-          schema: {
-            type: 'object',
-            required: ['posts'],
-            properties: {
-              posts: {
-                type: 'array',
-                items: {
-                  type: 'ref',
-                  ref: 'lex:app.bsky.feed.defs#postView',
-                },
-              },
-            },
-          },
-        },
       },
     },
   },
@@ -10354,14 +10354,14 @@ export const schemaDict = {
       },
     },
   },
-  AppBskyUnspeccedGetPostThreadHiddenV2: {
+  AppBskyUnspeccedGetPostThreadOtherV2: {
     lexicon: 1,
-    id: 'app.bsky.unspecced.getPostThreadHiddenV2',
+    id: 'app.bsky.unspecced.getPostThreadOtherV2',
     defs: {
       main: {
         type: 'query',
         description:
-          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get the hidden posts in a thread. It is based in an anchor post at any depth of the tree, and returns hidden replies (recursive replies, with branching to their replies) below the anchor. It does not include ancestors nor the anchor. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
+          "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests.",
         parameters: {
           type: 'params',
           required: ['anchor'],
@@ -10389,17 +10389,17 @@ export const schemaDict = {
               thread: {
                 type: 'array',
                 description:
-                  'A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item.',
+                  'A flat list of other thread items. The depth of each item is indicated by the depth property inside the item.',
                 items: {
                   type: 'ref',
-                  ref: 'lex:app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem',
+                  ref: 'lex:app.bsky.unspecced.getPostThreadOtherV2#threadItem',
                 },
               },
             },
           },
         },
       },
-      threadHiddenItem: {
+      threadItem: {
         type: 'object',
         required: ['uri', 'depth', 'value'],
         properties: {
@@ -10477,7 +10477,7 @@ export const schemaDict = {
           encoding: 'application/json',
           schema: {
             type: 'object',
-            required: ['thread', 'hasHiddenReplies'],
+            required: ['thread', 'hasOtherReplies'],
             properties: {
               thread: {
                 type: 'array',
@@ -10492,10 +10492,10 @@ export const schemaDict = {
                 type: 'ref',
                 ref: 'lex:app.bsky.feed.defs#threadgateView',
               },
-              hasHiddenReplies: {
+              hasOtherReplies: {
                 type: 'boolean',
                 description:
-                  'Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them.',
+                  'Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them.',
               },
             },
           },
@@ -16510,8 +16510,8 @@ export const ids = {
   AppBskyFeedGetFeedSkeleton: 'app.bsky.feed.getFeedSkeleton',
   AppBskyFeedGetLikes: 'app.bsky.feed.getLikes',
   AppBskyFeedGetListFeed: 'app.bsky.feed.getListFeed',
-  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetPosts: 'app.bsky.feed.getPosts',
+  AppBskyFeedGetPostThread: 'app.bsky.feed.getPostThread',
   AppBskyFeedGetQuotes: 'app.bsky.feed.getQuotes',
   AppBskyFeedGetRepostedBy: 'app.bsky.feed.getRepostedBy',
   AppBskyFeedGetSuggestedFeeds: 'app.bsky.feed.getSuggestedFeeds',
@@ -16568,8 +16568,8 @@ export const ids = {
   AppBskyUnspeccedGetConfig: 'app.bsky.unspecced.getConfig',
   AppBskyUnspeccedGetPopularFeedGenerators:
     'app.bsky.unspecced.getPopularFeedGenerators',
-  AppBskyUnspeccedGetPostThreadHiddenV2:
-    'app.bsky.unspecced.getPostThreadHiddenV2',
+  AppBskyUnspeccedGetPostThreadOtherV2:
+    'app.bsky.unspecced.getPostThreadOtherV2',
   AppBskyUnspeccedGetPostThreadV2: 'app.bsky.unspecced.getPostThreadV2',
   AppBskyUnspeccedGetSuggestedFeeds: 'app.bsky.unspecced.getSuggestedFeeds',
   AppBskyUnspeccedGetSuggestedFeedsSkeleton:

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadOtherV2.ts
@@ -15,7 +15,7 @@ import type * as AppBskyUnspeccedDefs from './defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
-const id = 'app.bsky.unspecced.getPostThreadHiddenV2'
+const id = 'app.bsky.unspecced.getPostThreadOtherV2'
 
 export interface QueryParams {
   /** Reference (AT-URI) to post record. This is the anchor post. */
@@ -27,8 +27,8 @@ export interface QueryParams {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  /** A flat list of hidden thread items. The depth of each item is indicated by the depth property inside the item. */
-  thread: ThreadHiddenItem[]
+  /** A flat list of other thread items. The depth of each item is indicated by the depth property inside the item. */
+  thread: ThreadItem[]
 }
 
 export type HandlerInput = undefined
@@ -57,20 +57,20 @@ export type Handler<HA extends HandlerAuth = never> = (
   ctx: HandlerReqCtx<HA>,
 ) => Promise<HandlerOutput> | HandlerOutput
 
-export interface ThreadHiddenItem {
-  $type?: 'app.bsky.unspecced.getPostThreadHiddenV2#threadHiddenItem'
+export interface ThreadItem {
+  $type?: 'app.bsky.unspecced.getPostThreadOtherV2#threadItem'
   uri: string
   /** The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths. */
   depth: number
   value: $Typed<AppBskyUnspeccedDefs.ThreadItemPost> | { $type: string }
 }
 
-const hashThreadHiddenItem = 'threadHiddenItem'
+const hashThreadItem = 'threadItem'
 
-export function isThreadHiddenItem<V>(v: V) {
-  return is$typed(v, id, hashThreadHiddenItem)
+export function isThreadItem<V>(v: V) {
+  return is$typed(v, id, hashThreadItem)
 }
 
-export function validateThreadHiddenItem<V>(v: V) {
-  return validate<ThreadHiddenItem & V>(v, id, hashThreadHiddenItem)
+export function validateThreadItem<V>(v: V) {
+  return validate<ThreadItem & V>(v, id, hashThreadItem)
 }

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getPostThreadV2.ts
@@ -39,8 +39,8 @@ export interface OutputSchema {
   /** A flat list of thread items. The depth of each item is indicated by the depth property inside the item. */
   thread: ThreadItem[]
   threadgate?: AppBskyFeedDefs.ThreadgateView
-  /** Whether this thread has hidden replies. If true, a call can be made to the `getPostThreadHiddenV2` endpoint to retrieve them. */
-  hasHiddenReplies: boolean
+  /** Whether this thread has additional replies. If true, a call can be made to the `getPostThreadOtherV2` endpoint to retrieve them. */
+  hasOtherReplies: boolean
 }
 
 export type HandlerInput = undefined


### PR DESCRIPTION
These are "other", or "extra" replies, so this PR updates the naming to be more aligned with the API intent.