### PR TITLE
Bad Lexicon Codegen! a fix for object properties with atypical keys

### DIFF
--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -212,7 +212,7 @@ function genObject(
           types.push('{ $type: string }')
         }
         iface.addProperty({
-          name: `${propKey}${req ? '' : '?'}`,
+          name: `'${propKey}'${req ? '' : '?'}`,
           type: makeType(types, { nullable: propNullable }),
         })
         continue
@@ -222,7 +222,7 @@ function genObject(
           let propAst
           if (propDef.items.type === 'ref') {
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `'${propKey}'${req ? '' : '?'}`,
               type: makeType(
                 refToType(
                   propDef.items.ref,
@@ -243,7 +243,7 @@ function genObject(
               types.push('{ $type: string }')
             }
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `'${propKey}'${req ? '' : '?'}`,
               type: makeType(types, {
                 nullable: propNullable,
                 array: true,
@@ -251,7 +251,7 @@ function genObject(
             })
           } else {
             propAst = iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `'${propKey}'${req ? '' : '?'}`,
               type: makeType(primitiveOrBlobToType(propDef.items), {
                 nullable: propNullable,
                 array: true,
@@ -263,7 +263,7 @@ function genObject(
           //= propName: type
           genComment(
             iface.addProperty({
-              name: `${propKey}${req ? '' : '?'}`,
+              name: `'${propKey}'${req ? '' : '?'}`,
               type: makeType(primitiveOrBlobToType(propDef), {
                 nullable: propNullable,
               }),
@@ -385,7 +385,7 @@ export function genXrpcParams(
           paramDef.default !== undefined)
       genComment(
         iface.addProperty({
-          name: `${paramKey}${req ? '' : '?'}`,
+          name: `'${paramKey}'${req ? '' : '?'}`,
           type:
             paramDef.type === 'array'
               ? primitiveToType(paramDef.items) + '[]'


### PR DESCRIPTION
In my little ["science project"](https://bsky.app/profile/distraction.engineer/post/3lql7jiqaac2a), my latest [rabbit hole](https://bsky.app/profile/distraction.engineer/post/3lqvdpyoyfs2a) has me attempting to port my Mastodon/ActivityPub bridging PDS fork to use Lexicons with proper `/xrpc/` endpoints.

Early on I ran into an issue creating a "query" Lexicon, as the `lex` tool was erroring in my `OutputSchema`.. A summary of the codegen output is as follows:

```typescript
/**
 * GENERATED CODE - DO NOT MODIFY
 */
import express from 'express'
import { type ValidationResult, BlobRef } from '@atproto/lexicon'
import { CID } from 'multiformats/cid'
import { validate as _validate } from '../../../../lexicons'
import {
  type $Typed,
  is$typed as _is$typed,
  type OmitKey,
} from '../../../../util'
import { HandlerAuth, HandlerPipeThrough } from '@atproto/xrpc-server'

// ...

export interface OutputSchema {
  @context: string[] // <-------- AHHHHHHHHHHHH!
  id: string
  url?: string
  type: 'Person' | (string & {})
  name?: string
  preferredUsername?: string
  /** HTML encoded profile page */
  summary?: string
  inbox?: string
  outbox?: string
  followers?: string
  following?: string
  featured?: string
}

// ...
```

Obviously `@context` (without quotes) isn't a valid way to name a key. ActivityPub is based on [JSON-LD](https://json-ld.org/), and to support outputting a valid JSON-LD document, keys like `@context` are required.

<https://atproto.com/specs/record-key#record-key-syntax>

"Technically", the AtProto Lexicon spec does forbid the use of `@` in key names, but the CodeGen tool also doesn't enforce it, and crashes-out to some ugly difficult to understand errors.

I've attached a patch that solves both of our problems (no more ugly errors, and I can use non-standard names). In essence, what it does is it wraps _all_ user defined property keys with single quotes `'@context'`, in such a way that it doesn't also break the optional checks (i.e. the appending of a `?`).

As a side effect, because Prettier is part of the workflow, any properties that don't actually need quotes around them gets them removed, so you end up with something like this, which is simply "more valid" than it was before:

```typescript
// ...

export interface OutputSchema {
  '@context': string[]
  id: string
  url?: string
  type: 'Person' | (string & {})
  name?: string
  preferredUsername?: string
  /** HTML encoded profile page */
  summary?: string
  inbox?: string
  outbox?: string
  followers?: string
  following?: string
  featured?: string
}

// ...
```