### PR TITLE
Codegen: Support for 'ref' and 'union' types in UserType (i.e. Lexicon defs section)

### DIFF
--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -128,16 +128,6 @@ export function genUserType(
     case 'token':
       genToken(file, lexUri, def)
       break
-    case 'ref': {
-      const ifaceName: string = toTitleCase(getHash(lexUri))
-      genRef(file, imports, lexUri, def, ifaceName)
-      break
-    }
-    case 'union': {
-      const ifaceName: string = toTitleCase(getHash(lexUri))
-      genRefUnion(file, imports, lexUri, def, ifaceName)
-      break
-    }
     case 'object': {
       const ifaceName: string = toTitleCase(getHash(lexUri))
       genObject(file, imports, lexUri, def, ifaceName, {
@@ -146,6 +136,16 @@ export function genUserType(
       genObjHelpers(file, lexUri, ifaceName, {
         requireTypeProperty: false,
       })
+      break
+    }
+    case 'ref': {
+      const ifaceName: string = toTitleCase(getHash(lexUri))
+      genRef(file, imports, lexUri, def, ifaceName)
+      break
+    }
+    case 'union': {
+      const ifaceName: string = toTitleCase(getHash(lexUri))
+      genRefUnion(file, imports, lexUri, def, ifaceName)
       break
     }
 

--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -10,6 +10,7 @@ import {
   type LexPrimitive,
   type LexToken,
   type LexUserType,
+  type LexRef,
   Lexicons,
 } from '@atproto/lexicon'
 import { toCamelCase, toScreamingSnakeCase, toTitleCase } from './util'
@@ -126,6 +127,11 @@ export function genUserType(
     case 'token':
       genToken(file, lexUri, def)
       break
+    case 'ref': {
+      const ifaceName: string = toTitleCase(getHash(lexUri))
+      genRef(file, imports, lexUri, def, ifaceName)
+      break;
+    }
     case 'object': {
       const ifaceName: string = toTitleCase(getHash(lexUri))
       genObject(file, imports, lexUri, def, ifaceName, {
@@ -152,6 +158,23 @@ export function genUserType(
         `genLexUserType() called with wrong definition type (${def.type}) in ${lexUri}`,
       )
   }
+}
+
+function genRef(
+  file: SourceFile,
+  imports: Set<string>,
+  lexUri: string,
+  def: LexRef,
+  ifaceName: string
+)
+{
+  const type = refToType(def.ref, stripScheme(stripHash(lexUri)), imports)
+  const iface = file.addTypeAlias({
+    name: ifaceName,
+    type: makeType(type, {nullable: false}),
+    isExported: true,
+  })
+  genComment(iface, def)
 }
 
 function genObject(

--- a/packages/lex-cli/src/codegen/lex-gen.ts
+++ b/packages/lex-cli/src/codegen/lex-gen.ts
@@ -7,10 +7,11 @@ import {
   type LexCidLink,
   type LexIpldType,
   type LexObject,
+  type LexRef,
+  type LexRefUnion,
   type LexPrimitive,
   type LexToken,
   type LexUserType,
-  type LexRef,
   Lexicons,
 } from '@atproto/lexicon'
 import { toCamelCase, toScreamingSnakeCase, toTitleCase } from './util'
@@ -130,7 +131,12 @@ export function genUserType(
     case 'ref': {
       const ifaceName: string = toTitleCase(getHash(lexUri))
       genRef(file, imports, lexUri, def, ifaceName)
-      break;
+      break
+    }
+    case 'union': {
+      const ifaceName: string = toTitleCase(getHash(lexUri))
+      genRefUnion(file, imports, lexUri, def, ifaceName)
+      break
     }
     case 'object': {
       const ifaceName: string = toTitleCase(getHash(lexUri))
@@ -175,6 +181,24 @@ function genRef(
     isExported: true,
   })
   genComment(iface, def)
+}
+
+function genRefUnion(
+  file: SourceFile,
+  imports: Set<string>,
+  lexUri: string,
+  def: LexRefUnion,
+  ifaceName: string
+)
+{
+  const types = def.refs.map((ref) => refToUnionType(ref, lexUri, imports))
+  //const iface =
+  file.addTypeAlias({
+    name: ifaceName,
+    type: makeType(types, {nullable: false}),
+    isExported: true,
+  })
+  //genComment(iface, def)
 }
 
 function genObject(

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -330,6 +330,7 @@ export const lexUserType = z.custom<
   | LexToken
   | LexObject
   | LexRef
+  | LexRefUnion
   | LexBoolean
   | LexInteger
   | LexString
@@ -368,6 +369,8 @@ export const lexUserType = z.custom<
         return lexObject.parse(val)
       case 'ref':
         return lexRef.parse(val)
+      case 'union':
+        return lexRefUnion.parse(val)
 
       case 'boolean':
         return lexBoolean.parse(val)

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -329,6 +329,7 @@ export const lexUserType = z.custom<
   | LexArray
   | LexToken
   | LexObject
+  | LexRef
   | LexBoolean
   | LexInteger
   | LexString
@@ -365,6 +366,8 @@ export const lexUserType = z.custom<
         return lexToken.parse(val)
       case 'object':
         return lexObject.parse(val)
+      case 'ref':
+        return lexRef.parse(val)
 
       case 'boolean':
         return lexBoolean.parse(val)


### PR DESCRIPTION
This PR adds support for the `ref` and `union` type in the `defs` section of a Lexicon schema.

For example:

```javascript
{
  "lexicon": 1,
  "id": "com.atproto.sync.defs",
  "defs": {
    "hostStatus": {
      "type": "string",
      "knownValues": ["active", "idle", "offline", "throttled", "banned"]
    },
    "dummy": {
      "type": "ref",
      "ref": "#hostStatus"
    },
    "dummy2": {
      "type": "union",
      "refs": [
        "app.bsky.feed.like",
        "app.bsky.feed.post",
        "#hostStatus",
        "app.bsky.feed.defs#postView"
      ]
    }
  }
}
```

Before, the `dummy` and `dummy2` would raise an error. With this change, an  type aliases are created for each.

```typescript
/**
 * GENERATED CODE - DO NOT MODIFY
 */
import { type ValidationResult, BlobRef } from '@atproto/lexicon'
import { CID } from 'multiformats/cid'
import { validate as _validate } from '../../../../lexicons'
import {
  type $Typed,
  is$typed as _is$typed,
  type OmitKey,
} from '../../../../util'
import type * as AppBskyFeedLike from '../../../app/bsky/feed/like.js'
import type * as AppBskyFeedPost from '../../../app/bsky/feed/post.js'
import type * as AppBskyFeedDefs from '../../../app/bsky/feed/defs.js'

const is$typed = _is$typed,
  validate = _validate
const id = 'com.atproto.sync.defs'

export type HostStatus =
  | 'active'
  | 'idle'
  | 'offline'
  | 'throttled'
  | 'banned'
  | (string & {})
export type Dummy = HostStatus
export type Dummy2 =
  | $Typed<AppBskyFeedLike.Main>
  | $Typed<AppBskyFeedPost.Main>
  | $Typed<HostStatus>
  | $Typed<AppBskyFeedDefs.PostView>



```