### PR TITLE
Modify parsing URLs and hashtags

### DIFF
--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,6 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 export const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+  /(^|[^a-zA-Z0-9])((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**
@@ -9,4 +9,4 @@ export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
  */
 export const TAG_REGEX =
   // eslint-disable-next-line no-misleading-character-class
-  /(^|\s)[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu
+  /(^|[^a-zA-Z0-9])[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu


### PR DESCRIPTION
This is an extended PR of https://github.com/bluesky-social/atproto/pull/3142 

# Original PR description
This fixes the parsing of URLs that are prefixed by a dot (.), i.e. when the user forgot a space between the end of a sentence and a link.

I noticed the problem [in this post](https://staging.bsky.app/profile/phillewis.bsky.social/post/3juec5butr62x) where the link should be clickable.

![image](https://private-user-images.githubusercontent.com/3137263/391206437-645e563b-e080-456f-a921-a04a71dd0f3d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk0MTcyOTQsIm5iZiI6MTc0OTQxNjk5NCwicGF0aCI6Ii8zMTM3MjYzLzM5MTIwNjQzNy02NDVlNTYzYi1lMDgwLTQ1NmYtYTkyMS1hMDRhNzFkZDBmM2QucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDYwOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA2MDhUMjEwOTU0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ODliMTc0YjY0OTI2MjhkMmU5ZDZiZmU4NGY2ZWVkMDFiMzZmMTY3NjZhNDhiNTA4YWQxOTMyNzFjMTZlODM0YiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.TtjsKYHQbXgona-2jv3aAvj-vngZQQLH6siHEDCaKRM)

The fix is done by preventing the second alternative capture group from having a domain end in .https:// (which would be an invalid domain anyway), since that would capture out.https in the example message Check this out.https://afterdot.com.

------------------------
This PR also fixes hashtags and not only ".", for almost patterns like following:
【Website】https://example.com/
