### PR TITLE
Replace slice() with subarray() in car file parsing

### DIFF
--- a/.changeset/gold-mice-burn.md
+++ b/.changeset/gold-mice-burn.md
@@ -1,0 +1,5 @@
+---
+"@atproto/repo": patch
+---
+
+improve performance of reading repos from car files

--- a/packages/repo/src/car.ts
+++ b/packages/repo/src/car.ts
@@ -137,8 +137,8 @@ async function* readCarBlocksIterGenerator(
         break
       }
       const blockBytes = await reader.read(blockSize)
-      const cid = parseCidFromBytes(blockBytes.slice(0, 36))
-      const bytes = blockBytes.slice(36)
+      const cid = parseCidFromBytes(blockBytes.subarray(0, 36))
+      const bytes = blockBytes.subarray(36)
       yield { cid, bytes }
     }
   } finally {
@@ -169,8 +169,8 @@ class BufferedReader {
 
   async read(bytesToRead: number): Promise<Uint8Array> {
     await this.readUntilBuffered(bytesToRead)
-    const value = this.buffer.slice(0, bytesToRead)
-    this.buffer = this.buffer.slice(bytesToRead)
+    const value = this.buffer.subarray(0, bytesToRead)
+    this.buffer = this.buffer.subarray(bytesToRead)
     return value
   }
 


### PR DESCRIPTION
See https://bsky.app/profile/did:plc:ragtjsm2j2vknwkz3zp4oxrd/post/3lru2skt7wk2m

Somewhere around Node 16, slice became deprecated and its semantics changed so that it copies into new buffers. On large CAR files which have been read into buffers, this can cause parsing to take a very long time. The `subarray()` method avoids the allocations.

I'd suggest reviewing the entire codebase for this. I did find some other usages, but felt a little gunshy about just doing a search & replace. Uint8Array subarray support is broad so I don't think this creates compat issues in eg web or RN (though RN is a wildcard on this kind of thing).