### PR TITLE
@atproto/xrpc-server: (partial) fix for Lexicon input and output encodings with extra arguments after semicolon (;)

### DIFF
--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -118,10 +118,13 @@ export function validateInput(
   }
 
   // mimetype
-  const inputEncoding = normalizeMime(req.headers['content-type'] || '')
+  const contentType = req.headers['content-type'] || ''
+  const inputEncoding = normalizeMime(contentType)
   if (
     def.input?.encoding &&
-    (!inputEncoding || !isValidEncoding(def.input?.encoding, inputEncoding))
+    (!inputEncoding ||
+      (!isValidEncoding(def.input?.encoding, inputEncoding) &&
+        !isValidEncoding(def.input?.encoding, contentType)))
   ) {
     if (!inputEncoding) {
       throw new InvalidRequestError(
@@ -211,7 +214,7 @@ export function validateOutput(
   }
 }
 
-export function normalizeMime(v: string) {
+export function normalizeMime(v: string): string | false {
   if (!v) return false
   const fullType = mime.contentType(v)
   if (!fullType) return false
@@ -220,12 +223,12 @@ export function normalizeMime(v: string) {
   return shortType
 }
 
-function isValidEncoding(possibleStr: string, value: string) {
+export function isValidEncoding(possibleStr: string, value: string): boolean {
   const possible = possibleStr.split(',').map((v) => v.trim())
   const normalized = normalizeMime(value)
   if (!normalized) return false
   if (possible.includes('*/*')) return true
-  return possible.includes(normalized)
+  return possible.includes(normalized) || possible.includes(value)
 }
 
 type BodyPresence = 'missing' | 'empty' | 'present'

--- a/packages/xrpc-server/tests/util.test.ts
+++ b/packages/xrpc-server/tests/util.test.ts
@@ -1,0 +1,61 @@
+import { isValidEncoding, normalizeMime } from '../src/util'
+
+describe('isValidEncoding', () => {
+  const validTests: [string, string][] = [
+    ['application/json', 'json'], // MK : this should not be valid...
+    ['application/json', 'application/json'],
+    ['application/json', 'application/json; charset=utf-8'],
+    ['application/json; charset=utf-8', 'application/json; charset=utf-8'],
+  ]
+
+  for (const [possible, value] of validTests) {
+    it(`should return true if the encoding is valid: ${possible} == ${value}`, () => {
+      expect(isValidEncoding(possible, value)).toBe(true)
+    })
+  }
+
+  const invalidTests: [string, string][] = [
+    ['json', 'application/json'],
+    ['application', 'application/json'],
+    ['application/json', 'application'],
+    ['application/json', 'application/*'],
+    ['application/json', '*/json'],
+    ['application/json', '*/*'],
+    ['application/json; charset=utf-8', 'application/json'],
+    ['application/json', 'application/ld+json'],
+    ['application/ld+json', 'application/json'],
+    ['application/ld+json', 'json'], // MK: ...because THESE are not valid...
+    ['application/ld+json', '+json'],
+    ['application/ld+json', 'ld+json'],
+  ]
+
+  for (const [possible, value] of invalidTests) {
+    it(`should return false if the encoding is invalid: ${possible} != ${value}`, () => {
+      expect(isValidEncoding(possible, value)).toBe(false)
+    })
+  }
+})
+
+describe('normalizeMime', () => {
+  const validTests: [string, string | false][] = [
+    ['application/json', 'application/json'],
+    ['application/json; charset=utf-8', 'application/json'],
+    ['json', 'application/json'],
+    ['dog', false],
+    ['dog/json', 'dog/json'],
+    ['dog/jason', 'dog/jason'],
+    ['dog/ld+json', 'dog/ld+json'],
+    ['dog/ld+jsoon', 'dog/ld+jsoon'],
+    ['', false],
+    ['*/*', '*/*'],
+    ['application/*', 'application/*'],
+    ['application/*+json', 'application/*+json'],
+    ['application/ld+json', 'application/ld+json'],
+  ]
+
+  for (const [value, expected] of validTests) {
+    it(`should return the normalized value, or false if invalid: ${value}: ${normalizeMime(value)} -> ${expected}`, () => {
+      expect(normalizeMime(value)).toBe(expected)
+    })
+  }
+})


### PR DESCRIPTION
Given the follow Lexicon for a `procedure` (or `query` w/o an input):

```json
{
  "lexicon": 1,
  "id": "org.w3.activitypub.putInbox",
  "defs": {
    "main": {
      "type": "procedure",
      "input": {
        "encoding": "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"",
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      },
      "output": {
        "encoding": "application/activity+json",
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      }
    }
  }
}
```

Plus an appropriately hooked up handler function.

Attempting to send a message that xrpc endpoint will fail.

```bash
$ curl -s http://test:2583/xrpc/org.w3.activitypub.putInbox -H "Content-Type: application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"" -d '{"type":"Follow"}'|jq
{
  "error": "InvalidRequest",
  "message": "Wrong request encoding (Content-Type): application/ld+json"
}
```

This patch provides a naive fix for _exact match_ cases.

```bash
$ curl -s http://test:2583/xrpc/org.w3.activitypub.putInbox -H "Content-Type: application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"" -d '{"type":"Follow"}'|jq
{
  "@context": "https://www.w3.org/ns/activitystreams",
  "type": "Reject",
  "object": {
    "type": "Follow"
  }
}
```

To properly fix this, the code that currently uses `normalizeMime` will need to be changed.

I've also included some Jest tests that show it working, plus a small criticism (noted as `// MK`). I'm happy to remove these, but it seemed the easiest way to show what I meant.