### PR TITLE
@atproto/lex-cli, @atproto/lexicon, @atproto/xrpc-server: Support for arrays of encodings and automatic decoding more json formats

### DIFF
--- a/packages/lex-cli/src/codegen/client.ts
+++ b/packages/lex-cli/src/codegen/client.ts
@@ -498,8 +498,14 @@ function genClientXrpcCommon(
   }
   if (def.type === 'procedure' && def.input) {
     let encodingType = 'string'
-    if (def.input.encoding !== '*/*') {
-      encodingType = def.input.encoding
+
+    // MK: Transform an array of encodings into a comma separated string
+    const encoding = Array.isArray(def.input.encoding)
+      ? def.input.encoding.join(',')
+      : def.input.encoding
+
+    if (encoding !== '*/*') {
+      encodingType = encoding
         .split(',')
         .map((v) => `'${v.trim()}'`)
         .join(' | ')
@@ -518,7 +524,10 @@ function genClientXrpcCommon(
   res.addProperty({ name: 'success', type: 'boolean' })
   res.addProperty({ name: 'headers', type: 'HeadersMap' })
   if (def.output?.schema) {
-    if (def.output.encoding?.includes(',')) {
+    if (
+      !Array.isArray(def.output.encoding) && // MK: For compatibility, we confirm that the encoding isn't an array
+      def.output.encoding.includes(',') // def.output.encoding?.includes(',')
+    ) {
       res.addProperty({ name: 'data', type: 'OutputSchema | Uint8Array' })
     } else {
       res.addProperty({ name: 'data', type: 'OutputSchema' })

--- a/packages/lex-cli/src/codegen/server.ts
+++ b/packages/lex-cli/src/codegen/server.ts
@@ -389,15 +389,24 @@ function genServerXrpcMethod(
       isExported: true,
     })
 
+    // MK: Since the "stream.Readable" code uses the same transform to as an array of encodings,
+    // to maintain compatibility, we transform the array into a comma separated string
+    const encoding = Array.isArray(def.input.encoding)
+      ? def.input.encoding.join(',')
+      : def.input.encoding
+
     handlerInput.addProperty({
       name: 'encoding',
-      type: def.input.encoding
+      type: encoding
         .split(',')
         .map((v) => `'${v.trim()}'`)
         .join(' | '),
     })
     if (def.input.schema) {
-      if (def.input.encoding.includes(',')) {
+      if (
+        typeof def.input.encoding === 'string' && // MK: For compatibility, we confirm that the encoding is a string
+        def.input.encoding.includes(',')
+      ) {
         handlerInput.addProperty({
           name: 'body',
           type: 'InputSchema | stream.Readable',
@@ -405,7 +414,10 @@ function genServerXrpcMethod(
       } else {
         handlerInput.addProperty({ name: 'body', type: 'InputSchema' })
       }
-    } else if (def.input.encoding) {
+    } else if (
+      def.input.encoding &&
+      typeof def.input.encoding === 'string' // MK: For compatibility, we confirm that the encoding is a string
+    ) {
       handlerInput.addProperty({ name: 'body', type: 'stream.Readable' })
     }
   } else {
@@ -425,17 +437,26 @@ function genServerXrpcMethod(
       isExported: true,
     })
 
+    // MK: Since the "stream.Readable" code uses the same transform to as an array of encodings,
+    // to maintain compatibility, we transform the array into a comma separated string
+    const encoding = Array.isArray(def.output.encoding)
+      ? def.output.encoding.join(',')
+      : def.output.encoding
+
     if (def.output.encoding) {
       handlerSuccess.addProperty({
         name: 'encoding',
-        type: def.output.encoding
+        type: encoding
           .split(',')
           .map((v) => `'${v.trim()}'`)
           .join(' | '),
       })
     }
     if (def.output?.schema) {
-      if (def.output.encoding.includes(',')) {
+      if (
+        typeof def.output.encoding === 'string' && // MK: For compatibility, we confirm that the encoding is a string
+        def.output.encoding.includes(',')
+      ) {
         handlerSuccess.addProperty({
           name: 'body',
           type: 'OutputSchema | Uint8Array | stream.Readable',
@@ -443,7 +464,10 @@ function genServerXrpcMethod(
       } else {
         handlerSuccess.addProperty({ name: 'body', type: 'OutputSchema' })
       }
-    } else if (def.output?.encoding) {
+    } else if (
+      def.output?.encoding &&
+      typeof def.output.encoding === 'string' // MK: For compatibility, we confirm that the encoding is a string
+    ) {
       handlerSuccess.addProperty({
         name: 'body',
         type: 'Uint8Array | stream.Readable',

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -240,7 +240,7 @@ export type LexXrpcParameters = z.infer<typeof lexXrpcParameters>
 export const lexXrpcBody = z
   .object({
     description: z.string().optional(),
-    encoding: z.string(),
+    encoding: z.union([z.string(), z.string().array()]),
     // @NOTE using discriminatedUnion with a refined schema requires zod >= 4
     schema: z.union([lexRefVariant, lexObject]).optional(),
   })

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -81,7 +81,10 @@ export class Server {
     })
     this.options = opts
     this.middleware = {
-      json: jsonParser({ limit: opts?.payload?.jsonLimit }),
+      json: jsonParser({
+        limit: opts?.payload?.jsonLimit,
+        type: ['application/json', 'application/*+json'],
+      }),
       text: textParser({ limit: opts?.payload?.textLimit }),
     }
 
@@ -297,7 +300,11 @@ export class Server {
 
           if (
             output.encoding === 'application/json' ||
-            output.encoding === 'json'
+            output.encoding === 'json' ||
+            (output.encoding.startsWith('application/') &&
+              output.encoding
+                .split(';')[0]
+                .indexOf('+json', 'application/'.length) !== -1)
           ) {
             const json = lexToJson(output.body)
             res.json(json)

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -223,8 +223,13 @@ export function normalizeMime(v: string): string | false {
   return shortType
 }
 
-export function isValidEncoding(possibleStr: string, value: string): boolean {
-  const possible = possibleStr.split(',').map((v) => v.trim())
+export function isValidEncoding(
+  possibleStr: string | string[],
+  value: string,
+): boolean {
+  const possible = Array.isArray(possibleStr)
+    ? possibleStr
+    : possibleStr.split(',').map((v) => v.trim())
   const normalized = normalizeMime(value)
   if (!normalized) return false
   if (possible.includes('*/*')) return true

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -118,10 +118,13 @@ export function validateInput(
   }
 
   // mimetype
-  const inputEncoding = normalizeMime(req.headers['content-type'] || '')
+  const contentType = req.headers['content-type'] || ''
+  const inputEncoding = normalizeMime(contentType)
   if (
     def.input?.encoding &&
-    (!inputEncoding || !isValidEncoding(def.input?.encoding, inputEncoding))
+    (!inputEncoding ||
+      (!isValidEncoding(def.input?.encoding, inputEncoding) &&
+        !isValidEncoding(def.input?.encoding, contentType)))
   ) {
     if (!inputEncoding) {
       throw new InvalidRequestError(
@@ -211,7 +214,7 @@ export function validateOutput(
   }
 }
 
-export function normalizeMime(v: string) {
+export function normalizeMime(v: string): string | false {
   if (!v) return false
   const fullType = mime.contentType(v)
   if (!fullType) return false
@@ -220,12 +223,12 @@ export function normalizeMime(v: string) {
   return shortType
 }
 
-function isValidEncoding(possibleStr: string, value: string) {
+export function isValidEncoding(possibleStr: string, value: string): boolean {
   const possible = possibleStr.split(',').map((v) => v.trim())
   const normalized = normalizeMime(value)
   if (!normalized) return false
   if (possible.includes('*/*')) return true
-  return possible.includes(normalized)
+  return possible.includes(normalized) || possible.includes(value)
 }
 
 type BodyPresence = 'missing' | 'empty' | 'present'

--- a/packages/xrpc-server/tests/util.test.ts
+++ b/packages/xrpc-server/tests/util.test.ts
@@ -1,11 +1,14 @@
 import { isValidEncoding, normalizeMime } from '../src/util'
 
 describe('isValidEncoding', () => {
-  const validTests: [string, string][] = [
+  const validTests: [string | string[], string][] = [
     ['application/json', 'json'], // MK : this should not be valid...
     ['application/json', 'application/json'],
     ['application/json', 'application/json; charset=utf-8'],
     ['application/json; charset=utf-8', 'application/json; charset=utf-8'],
+    [['application/json', 'application/ld+json'], 'json'], // MK: this should not be valid...
+    [['application/json', 'application/ld+json'], 'application/json'],
+    [['application/json', 'application/ld+json'], 'application/ld+json'],
   ]
 
   for (const [possible, value] of validTests) {
@@ -14,7 +17,7 @@ describe('isValidEncoding', () => {
     })
   }
 
-  const invalidTests: [string, string][] = [
+  const invalidTests: [string | string[], string][] = [
     ['json', 'application/json'],
     ['application', 'application/json'],
     ['application/json', 'application'],
@@ -27,6 +30,11 @@ describe('isValidEncoding', () => {
     ['application/ld+json', 'json'], // MK: ...because THESE are not valid...
     ['application/ld+json', '+json'],
     ['application/ld+json', 'ld+json'],
+    [[], 'application/json'],
+    [[], ''],
+    [['application/json', 'application/ld+json'], ''],
+    [['application/activity+json', 'application/ld+json'], 'application/json'],
+    [['application/json', 'application/ld+json'], 'ld+json'], // MK: ...and this
   ]
 
   for (const [possible, value] of invalidTests) {

--- a/packages/xrpc-server/tests/util.test.ts
+++ b/packages/xrpc-server/tests/util.test.ts
@@ -1,0 +1,61 @@
+import { isValidEncoding, normalizeMime } from '../src/util'
+
+describe('isValidEncoding', () => {
+  const validTests: [string, string][] = [
+    ['application/json', 'json'], // MK : this should not be valid...
+    ['application/json', 'application/json'],
+    ['application/json', 'application/json; charset=utf-8'],
+    ['application/json; charset=utf-8', 'application/json; charset=utf-8'],
+  ]
+
+  for (const [possible, value] of validTests) {
+    it(`should return true if the encoding is valid: ${possible} == ${value}`, () => {
+      expect(isValidEncoding(possible, value)).toBe(true)
+    })
+  }
+
+  const invalidTests: [string, string][] = [
+    ['json', 'application/json'],
+    ['application', 'application/json'],
+    ['application/json', 'application'],
+    ['application/json', 'application/*'],
+    ['application/json', '*/json'],
+    ['application/json', '*/*'],
+    ['application/json; charset=utf-8', 'application/json'],
+    ['application/json', 'application/ld+json'],
+    ['application/ld+json', 'application/json'],
+    ['application/ld+json', 'json'], // MK: ...because THESE are not valid...
+    ['application/ld+json', '+json'],
+    ['application/ld+json', 'ld+json'],
+  ]
+
+  for (const [possible, value] of invalidTests) {
+    it(`should return false if the encoding is invalid: ${possible} != ${value}`, () => {
+      expect(isValidEncoding(possible, value)).toBe(false)
+    })
+  }
+})
+
+describe('normalizeMime', () => {
+  const validTests: [string, string | false][] = [
+    ['application/json', 'application/json'],
+    ['application/json; charset=utf-8', 'application/json'],
+    ['json', 'application/json'],
+    ['dog', false],
+    ['dog/json', 'dog/json'],
+    ['dog/jason', 'dog/jason'],
+    ['dog/ld+json', 'dog/ld+json'],
+    ['dog/ld+jsoon', 'dog/ld+jsoon'],
+    ['', false],
+    ['*/*', '*/*'],
+    ['application/*', 'application/*'],
+    ['application/*+json', 'application/*+json'],
+    ['application/ld+json', 'application/ld+json'],
+  ]
+
+  for (const [value, expected] of validTests) {
+    it(`should return the normalized value, or false if invalid: ${value}: ${normalizeMime(value)} -> ${expected}`, () => {
+      expect(normalizeMime(value)).toBe(expected)
+    })
+  }
+})


### PR DESCRIPTION
This builds off #3984, so start there.

TODO: Insert link to AT Protocol specification change here: ???

TODO: Insert link to equivalent Go PR that enables multiple encoding in a Lexcon here: ???

To support protocols like ActivityPub in Lexicon, allowing you to specify multiple valid encoding types is desirable.

Using an extended version of my previous example:

```json
{
  "lexicon": 1,
  "id": "org.w3.activitypub.putInbox",
  "defs": {
    "main": {
      "type": "procedure",
      "input": {
        "encoding": [
          "application/json",
          "application/activity+json",
          "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
        ],
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      },
      "output": {
        "encoding": "application/activity+json",
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      }
    }
  }
}
```

This patch enables Lexicons to support this syntax via `@atproto/lex-cli`, it changes the definition in `@atproto/lexicon` to a union of either a string or an array of strings, and @atproto/xrpc-server` supports verifying that inputs (and outputs) are one of the listed.

**IMPORTANT NOTE**: The logic is that Lexicons support multiple encodings, but a document will still only ever have one. Typescript _should_ error accordingly if this is attempted in an implementation of a `procedure` or `query`.

This change also necessitated that `@atproto/xrpc-server` should json parse more than just `application/json` files. [Express.js's JSON middleware](https://expressjs.com/en/api.html#express.json) defers to a library [`type-is`](https://www.npmjs.com/package/type-is) for mime type matching. Type-Is provides several examples, including `application/*+json`, which certainly matches all of the JSON format variations I can think of (i.e. `ld+json`, `activity+json`, `vnd+json`, etc). So I adjusted the instantiation of the Express.js JSON middleware to correctly handle inputs, and added a pattern match for outputs (i.e. effectively `application/*.json`, and if a semicolon is present, everything after it is ignored).

Finally, I expanded the Jest tests to include arrays of encodings.