### PR TITLE
bump PDS JSON request limit to 1MB

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -62,7 +62,7 @@ export class PDS {
     const server = createServer({
       validateResponse: false,
       payload: {
-        jsonLimit: 150 * 1024, // 150kb
+        jsonLimit: 1024 * 1024, // 1mb
         textLimit: 100 * 1024, // 100kb
         blobLimit: cfg.service.blobUploadLimit,
       },


### PR DESCRIPTION
We've generally discussed a 1MB limit for records. I didn't realize that we actually cap request sizes at 150KB in the PDS reference implementation.

This PR is a bit of a provocation: maybe increasing this limit would lead to abuse? It is about an order of magnitude larger limit, so it increases attack surface but not to a totally crazy degree. Potentially we should reduce the state best practice around record size to ~150KB, not increase this limit?