### PR TITLE
Loosen unspecced constraint on saved feed IDs

### DIFF
--- a/.changeset/sixty-ducks-clean.md
+++ b/.changeset/sixty-ducks-clean.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+loosen contraints for saved feed preferences

--- a/.changeset/sixty-ducks-clean.md
+++ b/.changeset/sixty-ducks-clean.md
@@ -2,4 +2,4 @@
 "@atproto/api": patch
 ---
 
-loosen contraints for saved feed preferences
+Loosen constraints for saved feed preferences

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -61,7 +61,9 @@ export function getSavedFeedType(
 }
 
 export function validateSavedFeed(savedFeed: AppBskyActorDefs.SavedFeed) {
-  new TID(savedFeed.id)
+  if (!savedFeed.id) {
+    throw new Error('Saved feed must have an `id` - use a TID')
+  }
 
   if (['feed', 'list'].includes(savedFeed.type)) {
     const uri = new AtUri(savedFeed.value)

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { TID } from '@atproto/common-web'
 import { AtUri } from '@atproto/syntax'
 import { AppBskyActorDefs } from './client'
 import { Nux } from './client/types/app/bsky/actor/defs'

--- a/packages/api/tests/atp-agent.test.ts
+++ b/packages/api/tests/atp-agent.test.ts
@@ -2998,16 +2998,28 @@ describe('agent', () => {
         })
 
         describe(`validateSavedFeed`, () => {
-          it(`throws if invalid TID`, () => {
+          it(`throws if missing id`, () => {
             // really only checks length at time of writing
             expect(() =>
               validateSavedFeed({
-                id: 'a',
+                id: '',
                 type: 'feed',
                 value: feedUri(),
                 pinned: false,
               }),
             ).toThrow()
+          })
+
+          it(`does not throw if a UUID is used as id`, () => {
+            // really only checks length at time of writing
+            expect(() =>
+              validateSavedFeed({
+                id: '497dcba3-ecbf-4587-a2dd-5eb0665e6880',
+                type: 'feed',
+                value: feedUri(),
+                pinned: false,
+              }),
+            ).not.toThrow()
           })
 
           it(`throws if mismatched types`, () => {


### PR DESCRIPTION
`app.bsky.actor.defs#savedFeed` looks like this - `id` is just specified as a `string`

```json
"savedFeed": {
  "type": "object",
  "required": ["id", "type", "value", "pinned"],
  "properties": {
    "id": {
      "type": "string"
    },
    "type": {
      "type": "string",
      "knownValues": ["feed", "list", "timeline"]
    },
    "value": {
      "type": "string"
    },
    "pinned": {
      "type": "boolean"
    }
  }
```

Then, the helper methods for updating saved feeds preferences validate the items, which includes ensuring the `id` is a valid TID. Unfortunately, since this constraint is not encoded in the lexicon, other clients have used other values such as UUIDs.

Since we probably shouldn't tighten the lexicon retroactively and the bad data is already out there, I think we should just loosen the constraint. There's no reason this ID actually needs to be a TID.

Alternatively, our helper methods could detected invalid `id`s and replace them with TIDs. If that's preferred, I can do that instead.