### PR TITLE
Change prettier from eslint plugin to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,9 +5,9 @@
     "plugin:@typescript-eslint/base",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript"
+    "prettier",
   ],
   "plugins": ["n"],
   "ignorePatterns": ["dist", "node_modules"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,8 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
-    "plugin:import/typescript"
-    "prettier",
+    "plugin:import/typescript",
+    "prettier"
   ],
   "plugins": ["n"],
   "ignorePatterns": ["dist", "node_modules"],

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test.sqlite
 \#*\#
 *~
 *.swp
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -47,11 +47,10 @@
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-n": "^17.15.0",
-    "eslint-plugin-prettier": "^5.1.3",
     "jest": "^28.1.2",
     "node-gyp": "^9.3.1",
     "pino-pretty": "^9.1.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.6.2",
     "prettier-config-standard": "^7.0.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81",
   "scripts": {
     "lint:fix": "pnpm lint --fix",
-    "lint": "eslint . --ext .ts,.js,.tsx,.jsx",
-    "style:fix": "prettier --write .",
-    "style": "prettier --check .",
+    "lint": "eslint --cache . --ext .ts,.js,.tsx,.jsx",
+    "style:fix": "prettier --cache --write .",
+    "style": "prettier --cache --check .",
     "verify": "pnpm --stream '/^verify:.+$/'",
     "verify:style": "pnpm run style",
     "verify:lint": "pnpm lint",

--- a/packages/oauth/oauth-client-browser-example/src/components/button-dropdown.tsx
+++ b/packages/oauth/oauth-client-browser-example/src/components/button-dropdown.tsx
@@ -100,7 +100,9 @@ function Item({ item: { label, onClick, items }, ...props }: ItemProps) {
         </button>
       )}
 
-      {items?.map((item, index) => <Item key={index} item={item} />)}
+      {items?.map((item, index) => (
+        <Item key={index} item={item} />
+      ))}
     </div>
   )
 }

--- a/packages/oauth/oauth-provider-ui/src/components/forms/input-checkbox.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/input-checkbox.tsx
@@ -47,7 +47,7 @@ export function InputCheckbox({
             children
               ? // Prefer the local "<label>" element (through "htmlFor") over the wrapping "<fieldset>" to describe the checkbox.
                 undefined
-              : ariaLabelledBy ?? ctx.labelId
+              : (ariaLabelledBy ?? ctx.labelId)
           }
           ref={mergeRefs([ref, inputRef])}
           id={inputId}

--- a/packages/oauth/oauth-provider-ui/src/components/utils/error-card.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/utils/error-card.tsx
@@ -34,7 +34,7 @@ export const ErrorCard = memo(function ErrorCard({
         ? // Already parsed:
           error
         : // If "error" is a json object, try parsing it as a JsonErrorResponse:
-          Api.parseError(error) ?? error,
+          (Api.parseError(error) ?? error),
     [error],
   )
 

--- a/packages/oauth/oauth-provider/src/lib/http/middleware.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/middleware.ts
@@ -114,9 +114,9 @@ function buildFallbackPayload(
     status,
     error: err
       ? expose
-        ? getProp(err, 'code', 'string') ??
+        ? (getProp(err, 'code', 'string') ??
           getProp(err, 'error', 'string') ??
-          'unknown_error'
+          'unknown_error')
         : 'system_error'
       : 'not_found',
     error_description:

--- a/packages/pds/src/account-manager/helpers/account.ts
+++ b/packages/pds/src/account-manager/helpers/account.ts
@@ -252,7 +252,7 @@ export const updateAccountTakedownStatus = async (
   takedown: StatusAttr,
 ) => {
   const takedownRef = takedown.applied
-    ? takedown.ref ?? new Date().toISOString()
+    ? (takedown.ref ?? new Date().toISOString())
     : null
   await db.executeWithRetry(
     db.db.updateTable('actor').set({ takedownRef }).where('did', '=', did),

--- a/packages/pds/src/actor-store/blob/transactor.ts
+++ b/packages/pds/src/actor-store/blob/transactor.ts
@@ -130,7 +130,7 @@ export class BlobTransactor extends BlobReader {
 
   async updateBlobTakedownStatus(blob: CID, takedown: StatusAttr) {
     const takedownRef = takedown.applied
-      ? takedown.ref ?? new Date().toISOString()
+      ? (takedown.ref ?? new Date().toISOString())
       : null
     await this.db.db
       .updateTable('blob')

--- a/packages/pds/src/actor-store/record/transactor.ts
+++ b/packages/pds/src/actor-store/record/transactor.ts
@@ -98,7 +98,7 @@ export class RecordTransactor extends RecordReader {
 
   async updateRecordTakedownStatus(uri: AtUri, takedown: StatusAttr) {
     const takedownRef = takedown.applied
-      ? takedown.ref ?? new Date().toISOString()
+      ? (takedown.ref ?? new Date().toISOString())
       : null
     await this.db.db
       .updateTable('record')

--- a/packages/pds/src/repo/prepare.ts
+++ b/packages/pds/src/repo/prepare.ts
@@ -283,7 +283,7 @@ export const blobsForWrite = (
     mimeType: ref.mimeType,
     constraints:
       validate && recordType
-        ? CONSTRAINTS[recordType]?.[path.join('/')] ?? {}
+        ? (CONSTRAINTS[recordType]?.[path.join('/')] ?? {})
         : {},
   }))
 }

--- a/packages/xrpc/src/types.ts
+++ b/packages/xrpc/src/types.ts
@@ -150,7 +150,7 @@ export class XRPCError extends Error {
     const status: ResponseType =
       typeof statusCode === 'number'
         ? httpResponseCodeToEnum(statusCode)
-        : fallbackStatus ?? ResponseType.Unknown
+        : (fallbackStatus ?? ResponseType.Unknown)
 
     const message = causeErr?.message ?? String(cause)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       eslint-plugin-n:
         specifier: ^17.15.0
         version: 17.15.0(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^5.1.3
-        version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
       jest:
         specifier: ^28.1.2
         version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
@@ -66,14 +63,14 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       prettier:
-        specifier: ^3.2.5
-        version: 3.2.5
+        specifier: ^3.6.2
+        version: 3.6.2
       prettier-config-standard:
         specifier: ^7.0.0
-        version: 7.0.0(prettier@3.2.5)
+        version: 7.0.0(prettier@3.6.2)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.11
-        version: 0.6.11(prettier@3.2.5)
+        version: 0.6.11(prettier@3.6.2)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -6833,11 +6830,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@pkgr/core@0.1.1:
-    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-    dev: true
-
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
     dev: false
@@ -11421,27 +11413,6 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
-    resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.57.0
-      eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      prettier: 3.2.5
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.8.8
-    dev: true
-
   /eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11691,10 +11662,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-    dev: true
 
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -15575,22 +15542,15 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-config-standard@7.0.0(prettier@3.2.5):
+  /prettier-config-standard@7.0.0(prettier@3.6.2):
     resolution: {integrity: sha512-NgZy4TYupJR6aMMuV/Aqs0ONnVhlFT8PXVkYRskxREq8EUhJHOddVfBxPV6fWpgcASpJSgvvhVLk0CBO5M3Hvw==}
     peerDependencies:
       prettier: ^2.6.0 || ^3.0.0
     dependencies:
-      prettier: 3.2.5
+      prettier: 3.6.2
     dev: true
 
-  /prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      fast-diff: 1.3.0
-    dev: true
-
-  /prettier-plugin-tailwindcss@0.6.11(prettier@3.2.5):
+  /prettier-plugin-tailwindcss@0.6.11(prettier@3.6.2):
     resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
@@ -15645,7 +15605,7 @@ packages:
       prettier-plugin-svelte:
         optional: true
     dependencies:
-      prettier: 3.2.5
+      prettier: 3.6.2
     dev: true
 
   /prettier@2.7.1:
@@ -15661,6 +15621,12 @@ packages:
 
   /prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
+  /prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -17086,14 +17052,6 @@ packages:
       csso: 4.2.0
       picocolors: 1.0.1
       stable: 0.1.8
-    dev: true
-
-  /synckit@0.8.8:
-    resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    dependencies:
-      '@pkgr/core': 0.1.1
-      tslib: 2.8.0
     dev: true
 
   /tailwindcss@3.4.3:


### PR DESCRIPTION
Basically just reapplying https://github.com/bluesky-social/social-app/pull/3373 from `social-app` to `atproto`

What this PR does is
- replace the prettier eslint _plugin_ with the eslint _config_. This is the recommended way to do it: https://prettier.io/docs/integrating-with-linters (and is much faster)
- adds `--cache` to both eslint and prettier. This speeds both up significantly
- updates prettier and runs it

I would also recommend adding `lint-staged` - I enjoy using it in `social-app`, although it's a little controversial so I won't add it in this PR! 