### PR TITLE
PDS: account deletion robustness

### DIFF
--- a/.changeset/new-bulldogs-wait.md
+++ b/.changeset/new-bulldogs-wait.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+More robust account deletion, add retry to actor store dir removal

--- a/.changeset/popular-nails-clean.md
+++ b/.changeset/popular-nails-clean.md
@@ -1,0 +1,5 @@
+---
+"@atproto/common": patch
+---
+
+Support node standard rm options for rmIfExists()

--- a/packages/common/src/fs.ts
+++ b/packages/common/src/fs.ts
@@ -1,4 +1,4 @@
-import { constants } from 'node:fs'
+import { constants, RmOptions } from 'node:fs'
 import fs from 'node:fs/promises'
 import { isErrnoException } from '@atproto/common-web'
 
@@ -29,10 +29,11 @@ export const readIfExists = async (
 
 export const rmIfExists = async (
   filepath: string,
-  recursive = false,
+  options: RmOptions | boolean = false,
 ): Promise<void> => {
   try {
-    await fs.rm(filepath, { recursive })
+    const opts = typeof options === 'boolean' ? { recursive: options } : options
+    await fs.rm(filepath, opts)
   } catch (err) {
     if (isErrnoException(err) && err.code === 'ENOENT') {
       return

--- a/packages/common/src/fs.ts
+++ b/packages/common/src/fs.ts
@@ -1,4 +1,4 @@
-import { constants, RmOptions } from 'node:fs'
+import { RmOptions, constants } from 'node:fs'
 import fs from 'node:fs/promises'
 import { isErrnoException } from '@atproto/common-web'
 

--- a/packages/pds/src/actor-store/actor-store.ts
+++ b/packages/pds/src/actor-store/actor-store.ts
@@ -13,6 +13,7 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import { ActorStoreConfig } from '../config'
 import { retrySqlite } from '../db'
 import { DiskBlobStore } from '../disk-blobstore'
+import { recursiveWithRetry } from '../util/fs'
 import { ActorStoreReader } from './actor-store-reader'
 import { ActorStoreResources } from './actor-store-resources'
 import { ActorStoreTransactor } from './actor-store-transactor'
@@ -143,7 +144,7 @@ export class ActorStore {
     }
 
     const { directory } = await this.getLocation(did)
-    await rmIfExists(directory, true)
+    await rmIfExists(directory, recursiveWithRetry)
   }
 
   async reserveKeypair(did?: string): Promise<string> {

--- a/packages/pds/src/disk-blobstore.ts
+++ b/packages/pds/src/disk-blobstore.ts
@@ -7,6 +7,7 @@ import { fileExists, isErrnoException, rmIfExists } from '@atproto/common'
 import { randomStr } from '@atproto/crypto'
 import { BlobNotFoundError, BlobStore } from '@atproto/repo'
 import { httpLogger as log } from './logger'
+import { recursiveWithRetry } from './util/fs'
 
 export class DiskBlobStore implements BlobStore {
   constructor(
@@ -141,9 +142,12 @@ export class DiskBlobStore implements BlobStore {
   }
 
   async deleteAll(): Promise<void> {
-    await rmIfExists(path.join(this.location, this.did), true)
-    await rmIfExists(path.join(this.tmpLocation, this.did), true)
-    await rmIfExists(path.join(this.quarantineLocation, this.did), true)
+    await rmIfExists(path.join(this.location, this.did), recursiveWithRetry)
+    await rmIfExists(path.join(this.tmpLocation, this.did), recursiveWithRetry)
+    await rmIfExists(
+      path.join(this.quarantineLocation, this.did),
+      recursiveWithRetry,
+    )
   }
 }
 

--- a/packages/pds/src/scripts/sequencer-recovery/recoverer.ts
+++ b/packages/pds/src/scripts/sequencer-recovery/recoverer.ts
@@ -23,6 +23,7 @@ import {
   prepareUpdate,
 } from '../../repo'
 import { AccountEvt, CommitEvt, SeqEvt, Sequencer } from '../../sequencer'
+import { recursiveWithRetry } from '../../util/fs'
 import { RecoveryDb } from './recovery-db'
 import { UserQueues } from './user-queues'
 
@@ -181,7 +182,7 @@ const processAccountEvt = async (ctx: RecovererContext, evt: AccountEvt) => {
     return
   }
   const { directory } = await ctx.actorStore.getLocation(evt.did)
-  await rmIfExists(directory, true)
+  await rmIfExists(directory, recursiveWithRetry)
   await ctx.accountManager.deleteAccount(evt.did)
 }
 

--- a/packages/pds/src/util/fs.ts
+++ b/packages/pds/src/util/fs.ts
@@ -1,0 +1,7 @@
+import { RmOptions } from 'node:fs'
+
+export const recursiveWithRetry: RmOptions = {
+  recursive: true,
+  maxRetries: 5,
+  retryDelay: 50,
+}


### PR DESCRIPTION
Removing a directory and its contents isn't an atomic operation, and can fail partially.  The actor store directory removal step of account deletion was able to fail with an `ENOTEMPTY`, `EBUSY`, or other generic filesystem error.  This adds support for retries using node's builtin functionality, requires a small patch to @atproto/common.