### PR TITLE
Fix json and text uploads: don't parse bodies with input encoding of */*

### DIFF
--- a/.changeset/dull-shirts-laugh.md
+++ b/.changeset/dull-shirts-laugh.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Fix json and text uploads: don't parse bodies with input encoding of */*.

--- a/packages/pds/tests/file-uploads.test.ts
+++ b/packages/pds/tests/file-uploads.test.ts
@@ -273,4 +273,36 @@ describe('file uploads', () => {
 
     expect(found?.mimeType).toBe('test/fake')
   })
+
+  it('handles text', async () => {
+    const file = 'hello world!'
+    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+      headers: sc.getHeaders(alice),
+      encoding: 'text/plain',
+    } as any)
+
+    const found = await aliceDb.db
+      .selectFrom('blob')
+      .selectAll()
+      .where('cid', '=', res.data.blob.ref.toString())
+      .executeTakeFirst()
+
+    expect(found?.mimeType).toBe('text/plain')
+  })
+
+  it('handles json', async () => {
+    const file = '{"hello":"world"}'
+    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+      headers: sc.getHeaders(alice),
+      encoding: 'application/json',
+    } as any)
+
+    const found = await aliceDb.db
+      .selectFrom('blob')
+      .selectAll()
+      .where('cid', '=', res.data.blob.ref.toString())
+      .executeTakeFirst()
+
+    expect(found?.mimeType).toBe('application/json')
+  })
 })

--- a/packages/pds/tests/file-uploads.test.ts
+++ b/packages/pds/tests/file-uploads.test.ts
@@ -73,7 +73,7 @@ describe('file uploads', () => {
 
   it('uploads files', async () => {
     smallFile = await fs.readFile('../dev-env/assets/key-portrait-small.jpg')
-    const res = await agent.api.com.atproto.repo.uploadBlob(smallFile, {
+    const res = await agent.com.atproto.repo.uploadBlob(smallFile, {
       headers: sc.getHeaders(alice),
       encoding: 'image/jpeg',
     })
@@ -112,7 +112,7 @@ describe('file uploads', () => {
   })
 
   it('can fetch the file after being referenced', async () => {
-    const { headers, data } = await agent.api.com.atproto.sync.getBlob({
+    const { headers, data } = await agent.com.atproto.sync.getBlob({
       did: alice,
       cid: smallBlob.ref.toString(),
     })
@@ -129,7 +129,7 @@ describe('file uploads', () => {
 
   it('does not allow referencing a file that is outside blob constraints', async () => {
     largeFile = await fs.readFile('../dev-env/assets/hd-key.jpg')
-    const res = await agent.api.com.atproto.repo.uploadBlob(largeFile, {
+    const res = await agent.com.atproto.repo.uploadBlob(largeFile, {
       headers: sc.getHeaders(alice),
       encoding: 'image/jpeg',
     })
@@ -158,27 +158,21 @@ describe('file uploads', () => {
 
   it('permits duplicate uploads of the same file', async () => {
     const file = await fs.readFile('../dev-env/assets/key-landscape-small.jpg')
-    const { data: uploadA } = await agent.api.com.atproto.repo.uploadBlob(
-      file,
-      {
-        headers: sc.getHeaders(alice),
-        encoding: 'image/jpeg',
-      } as any,
-    )
-    const { data: uploadB } = await agent.api.com.atproto.repo.uploadBlob(
-      file,
-      {
-        headers: sc.getHeaders(bob),
-        encoding: 'image/jpeg',
-      } as any,
-    )
+    const { data: uploadA } = await agent.com.atproto.repo.uploadBlob(file, {
+      headers: sc.getHeaders(alice),
+      encoding: 'image/jpeg',
+    } as any)
+    const { data: uploadB } = await agent.com.atproto.repo.uploadBlob(file, {
+      headers: sc.getHeaders(bob),
+      encoding: 'image/jpeg',
+    } as any)
     expect(uploadA).toEqual(uploadB)
 
     await sc.updateProfile(alice, {
       displayName: 'Alice',
       avatar: uploadA.blob,
     })
-    const profileA = await agent.api.app.bsky.actor.profile.get({
+    const profileA = await agent.app.bsky.actor.profile.get({
       repo: alice,
       rkey: 'self',
     })
@@ -188,14 +182,14 @@ describe('file uploads', () => {
       displayName: 'Bob',
       avatar: uploadB.blob,
     })
-    const profileB = await agent.api.app.bsky.actor.profile.get({
+    const profileB = await agent.app.bsky.actor.profile.get({
       repo: bob,
       rkey: 'self',
     })
     // @ts-expect-error "cid" is not documented as "com.atproto.repo.uploadBlob" output
     expect((profileB.value as any).avatar.cid).toEqual(uploadA.cid)
     const { data: uploadAfterPermanent } =
-      await agent.api.com.atproto.repo.uploadBlob(file, {
+      await agent.com.atproto.repo.uploadBlob(file, {
         headers: sc.getHeaders(alice),
         encoding: 'image/jpeg',
       } as any)
@@ -209,7 +203,7 @@ describe('file uploads', () => {
   })
 
   it('supports compression during upload', async () => {
-    const { data: uploaded } = await agent.api.com.atproto.repo.uploadBlob(
+    const { data: uploaded } = await agent.com.atproto.repo.uploadBlob(
       gzipSync(smallFile),
       {
         encoding: 'image/jpeg',
@@ -224,7 +218,7 @@ describe('file uploads', () => {
 
   it('corrects a bad mimetype', async () => {
     const file = await fs.readFile('../dev-env/assets/key-landscape-large.jpg')
-    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+    const res = await agent.com.atproto.repo.uploadBlob(file, {
       headers: sc.getHeaders(alice),
       encoding: 'video/mp4',
     } as any)
@@ -242,7 +236,7 @@ describe('file uploads', () => {
 
   it('handles pngs', async () => {
     const file = await fs.readFile('../dev-env/assets/at.png')
-    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+    const res = await agent.com.atproto.repo.uploadBlob(file, {
       headers: sc.getHeaders(alice),
       encoding: 'image/png',
     })
@@ -260,7 +254,7 @@ describe('file uploads', () => {
 
   it('handles unknown mimetypes', async () => {
     const file = await randomBytes(20000)
-    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+    const res = await agent.com.atproto.repo.uploadBlob(file, {
       headers: sc.getHeaders(alice),
       encoding: 'test/fake',
     } as any)
@@ -276,7 +270,7 @@ describe('file uploads', () => {
 
   it('handles text', async () => {
     const file = 'hello world!'
-    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+    const res = await agent.com.atproto.repo.uploadBlob(file, {
       headers: sc.getHeaders(alice),
       encoding: 'text/plain',
     } as any)
@@ -292,7 +286,7 @@ describe('file uploads', () => {
 
   it('handles json', async () => {
     const file = '{"hello":"world"}'
-    const res = await agent.api.com.atproto.repo.uploadBlob(file, {
+    const res = await agent.com.atproto.repo.uploadBlob(file, {
       headers: sc.getHeaders(alice),
       encoding: 'application/json',
     } as any)

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -164,7 +164,9 @@ export function createInputVerifier(
       )
     }
 
-    await bodyParser(req, res)
+    if (input.encoding !== ENCODING_ANY) {
+      await bodyParser(req, res)
+    }
 
     if (input.schema) {
       try {
@@ -241,11 +243,13 @@ export function normalizeMime(v?: string): string | false {
   return shortType
 }
 
+const ENCODING_ANY = '*/*'
+
 function isValidEncoding(possibleStr: string, value: string) {
   const possible = possibleStr.split(',').map((v) => v.trim())
   const normalized = normalizeMime(value)
   if (!normalized) return false
-  if (possible.includes('*/*')) return true
+  if (possible.includes(ENCODING_ANY)) return true
   return possible.includes(normalized)
 }
 

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -292,7 +292,7 @@ describe('Bodies', () => {
   // This does not work because the xrpc-server will add a json middleware
   // regardless of the "input" definition. This is probably a behavior that
   // should be fixed in the xrpc-server.
-  it.skip('supports upload of json data', async () => {
+  it('supports upload of json data', async () => {
     const jsonFile = new Blob([Buffer.from(`{"foo":"bar","baz":[3, null]}`)], {
       type: 'application/json',
     })

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -289,9 +289,6 @@ describe('Bodies', () => {
     expect(fileResponse.data.cid).toEqual(expectedCid.toString())
   })
 
-  // This does not work because the xrpc-server will add a json middleware
-  // regardless of the "input" definition. This is probably a behavior that
-  // should be fixed in the xrpc-server.
   it('supports upload of json data', async () => {
     const jsonFile = new Blob([Buffer.from(`{"foo":"bar","baz":[3, null]}`)], {
       type: 'application/json',


### PR DESCRIPTION
Uploads of json and text content were failing, as xrpc-server would consume the request body by attempting to parse them.  This step could also apply lower text/json-specific size limitations.  This has been addressed by skipping body parsing when the lexicon's input encoding is `*/*`, which indicates that the handler accepts any content-type and will determine how to process the body.

Resolves #4026 