### PR TITLE
ozone: clearer invalid label message

### DIFF
--- a/packages/ozone/src/api/moderation/emitEvent.ts
+++ b/packages/ozone/src/api/moderation/emitEvent.ts
@@ -425,7 +425,9 @@ const validateLabels = (labels: string[]) => {
   for (const label of labels) {
     for (const char of badChars) {
       if (label.includes(char)) {
-        throw new InvalidRequestError(`Invalid label: ${label}`)
+        throw new InvalidRequestError(
+          `Invalid label: ${label} (contains disallowed character: "${char}")`,
+        )
       }
     }
   }


### PR DESCRIPTION
Tiny change to save myself a few minutes of running around trying to figure out why my label was invalid