### PR TITLE
don't allow importRepo with a CAR intended for another identity

### DIFF
--- a/packages/repo/src/sync/consumer.ts
+++ b/packages/repo/src/sync/consumer.ts
@@ -68,6 +68,11 @@ export const verifyDiff = async (
     did,
     signingKey,
   )
+  if (repo?.did && repo.did !== updated.did) {
+    throw new Error(
+      `mismatched commit did (expected ${repo.did}, got ${updated.did})`,
+    )
+  }
   const diff = await DataDiff.of(updated.data, repo?.data ?? null)
   const writes = await util.diffToWriteDescripts(diff)
   const newBlocks = diff.newMstBlocks


### PR DESCRIPTION
patches up a footgun in the PDS from e.g. a bad migration tool that supplies the wrong carfile.
`verifyDiff` is only used by `importRepo` afaict so this shouldn't regress anything unrelated

ref: https://github.com/knotbin/airport/issues/6