### PR TITLE
Lexicon resolver package

### DIFF
--- a/.changeset/orange-phones-type.md
+++ b/.changeset/orange-phones-type.md
@@ -2,4 +2,4 @@
 "@atproto/repo": patch
 ---
 
-Add option to verify CIDs found withing CARs
+Add option to verify CIDs found withing CARs.

--- a/.changeset/orange-phones-type.md
+++ b/.changeset/orange-phones-type.md
@@ -1,0 +1,5 @@
+---
+"@atproto/repo": patch
+---
+
+Add option to verify CIDs found withing CARs

--- a/.changeset/red-chairs-shave.md
+++ b/.changeset/red-chairs-shave.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lexicon": patch
+---
+
+Lexicon document validation compatible with published lexicons

--- a/.changeset/red-chairs-shave.md
+++ b/.changeset/red-chairs-shave.md
@@ -2,4 +2,4 @@
 "@atproto/lexicon": patch
 ---
 
-Lexicon document validation compatible with published lexicons
+Lexicon document validation compatible with published lexicons.

--- a/packages/lexicon-resolver/jest.config.js
+++ b/packages/lexicon-resolver/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  displayName: 'Common',
+  transform: { '^.+\\.(t|j)s$': '@swc/jest' },
+  setupFiles: ['<rootDir>/../../jest.setup.ts'],
+  moduleNameMapper: { '^(\\.\\.?\\/.+)\\.js$': ['$1.ts', '$1.js'] },
+}

--- a/packages/lexicon-resolver/package.json
+++ b/packages/lexicon-resolver/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@atproto/lexicon-resolver",
+  "version": "0.0.0",
+  "type": "commonjs",
+  "license": "MIT",
+  "description": "ATProto Lexicon resolution",
+  "keywords": [
+    "atproto",
+    "lexicon"
+  ],
+  "scripts": {
+    "test": "jest",
+    "build": "tsc --build tsconfig.json",
+    "codegen": "lex gen-api --yes ./src/client ../../lexicons/com/atproto/sync/getRecord.json"
+  },
+  "homepage": "https://atproto.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/atproto",
+    "directory": "packages/lexicon-resolver"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@atproto-labs/fetch-node": "workspace:^",
+    "@atproto/identity": "workspace:^",
+    "@atproto/lexicon": "workspace:^",
+    "@atproto/repo": "workspace:^",
+    "@atproto/syntax": "workspace:^",
+    "@atproto/xrpc": "workspace:^",
+    "multiformats": "^9.9.0"
+  },
+  "devDependencies": {
+    "@atproto/lex-cli": "workspace:^",
+    "jest": "^28.1.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/lexicon-resolver/package.json
+++ b/packages/lexicon-resolver/package.json
@@ -37,7 +37,9 @@
     "multiformats": "^9.9.0"
   },
   "devDependencies": {
+    "@atproto/common": "workspace:^",
     "@atproto/lex-cli": "workspace:^",
+    "@atproto/dev-env": "workspace:^",
     "jest": "^28.1.2",
     "typescript": "^5.6.3"
   }

--- a/packages/lexicon-resolver/src/client/index.ts
+++ b/packages/lexicon-resolver/src/client/index.ts
@@ -1,0 +1,67 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import {
+  XrpcClient,
+  type FetchHandler,
+  type FetchHandlerOptions,
+} from '@atproto/xrpc'
+import { schemas } from './lexicons.js'
+import { CID } from 'multiformats/cid'
+import { type OmitKey, type Un$Typed } from './util.js'
+import * as ComAtprotoSyncGetRecord from './types/com/atproto/sync/getRecord.js'
+
+export * as ComAtprotoSyncGetRecord from './types/com/atproto/sync/getRecord.js'
+
+export class AtpBaseClient extends XrpcClient {
+  com: ComNS
+
+  constructor(options: FetchHandler | FetchHandlerOptions) {
+    super(options, schemas)
+    this.com = new ComNS(this)
+  }
+
+  /** @deprecated use `this` instead */
+  get xrpc(): XrpcClient {
+    return this
+  }
+}
+
+export class ComNS {
+  _client: XrpcClient
+  atproto: ComAtprotoNS
+
+  constructor(client: XrpcClient) {
+    this._client = client
+    this.atproto = new ComAtprotoNS(client)
+  }
+}
+
+export class ComAtprotoNS {
+  _client: XrpcClient
+  sync: ComAtprotoSyncNS
+
+  constructor(client: XrpcClient) {
+    this._client = client
+    this.sync = new ComAtprotoSyncNS(client)
+  }
+}
+
+export class ComAtprotoSyncNS {
+  _client: XrpcClient
+
+  constructor(client: XrpcClient) {
+    this._client = client
+  }
+
+  getRecord(
+    params?: ComAtprotoSyncGetRecord.QueryParams,
+    opts?: ComAtprotoSyncGetRecord.CallOptions,
+  ): Promise<ComAtprotoSyncGetRecord.Response> {
+    return this._client
+      .call('com.atproto.sync.getRecord', params, undefined, opts)
+      .catch((e) => {
+        throw ComAtprotoSyncGetRecord.toKnownErr(e)
+      })
+  }
+}

--- a/packages/lexicon-resolver/src/client/lexicons.ts
+++ b/packages/lexicon-resolver/src/client/lexicons.ts
@@ -1,0 +1,98 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import {
+  type LexiconDoc,
+  Lexicons,
+  ValidationError,
+  type ValidationResult,
+} from '@atproto/lexicon'
+import { type $Typed, is$typed, maybe$typed } from './util.js'
+
+export const schemaDict = {
+  ComAtprotoSyncGetRecord: {
+    lexicon: 1,
+    id: 'com.atproto.sync.getRecord',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Get data blocks needed to prove the existence or non-existence of record in the current version of repo. Does not require auth.',
+        parameters: {
+          type: 'params',
+          required: ['did', 'collection', 'rkey'],
+          properties: {
+            did: {
+              type: 'string',
+              format: 'did',
+              description: 'The DID of the repo.',
+            },
+            collection: {
+              type: 'string',
+              format: 'nsid',
+            },
+            rkey: {
+              type: 'string',
+              description: 'Record Key',
+              format: 'record-key',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/vnd.ipld.car',
+        },
+        errors: [
+          {
+            name: 'RecordNotFound',
+          },
+          {
+            name: 'RepoNotFound',
+          },
+          {
+            name: 'RepoTakendown',
+          },
+          {
+            name: 'RepoSuspended',
+          },
+          {
+            name: 'RepoDeactivated',
+          },
+        ],
+      },
+    },
+  },
+} as const satisfies Record<string, LexiconDoc>
+export const schemas = Object.values(schemaDict) satisfies LexiconDoc[]
+export const lexicons: Lexicons = new Lexicons(schemas)
+
+export function validate<T extends { $type: string }>(
+  v: unknown,
+  id: string,
+  hash: string,
+  requiredType: true,
+): ValidationResult<T>
+export function validate<T extends { $type?: string }>(
+  v: unknown,
+  id: string,
+  hash: string,
+  requiredType?: false,
+): ValidationResult<T>
+export function validate(
+  v: unknown,
+  id: string,
+  hash: string,
+  requiredType?: boolean,
+): ValidationResult {
+  return (requiredType ? is$typed : maybe$typed)(v, id, hash)
+    ? lexicons.validate(`${id}#${hash}`, v)
+    : {
+        success: false,
+        error: new ValidationError(
+          `Must be an object with "${hash === 'main' ? id : `${id}#${hash}`}" $type property`,
+        ),
+      }
+}
+
+export const ids = {
+  ComAtprotoSyncGetRecord: 'com.atproto.sync.getRecord',
+} as const

--- a/packages/lexicon-resolver/src/client/types/com/atproto/sync/getRecord.ts
+++ b/packages/lexicon-resolver/src/client/types/com/atproto/sync/getRecord.ts
@@ -1,0 +1,78 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'com.atproto.sync.getRecord'
+
+export type QueryParams = {
+  /** The DID of the repo. */
+  did: string
+  collection: string
+  /** Record Key */
+  rkey: string
+}
+export type InputSchema = undefined
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: Uint8Array
+}
+
+export class RecordNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export class RepoNotFoundError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export class RepoTakendownError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export class RepoSuspendedError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export class RepoDeactivatedError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+    if (e.error === 'RecordNotFound') return new RecordNotFoundError(e)
+    if (e.error === 'RepoNotFound') return new RepoNotFoundError(e)
+    if (e.error === 'RepoTakendown') return new RepoTakendownError(e)
+    if (e.error === 'RepoSuspended') return new RepoSuspendedError(e)
+    if (e.error === 'RepoDeactivated') return new RepoDeactivatedError(e)
+  }
+
+  return e
+}

--- a/packages/lexicon-resolver/src/client/util.ts
+++ b/packages/lexicon-resolver/src/client/util.ts
@@ -1,0 +1,82 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+
+import { type ValidationResult } from '@atproto/lexicon'
+
+export type OmitKey<T, K extends keyof T> = {
+  [K2 in keyof T as K2 extends K ? never : K2]: T[K2]
+}
+
+export type $Typed<V, T extends string = string> = V & { $type: T }
+export type Un$Typed<V extends { $type?: string }> = OmitKey<V, '$type'>
+
+export type $Type<Id extends string, Hash extends string> = Hash extends 'main'
+  ? Id
+  : `${Id}#${Hash}`
+
+function isObject<V>(v: V): v is V & object {
+  return v != null && typeof v === 'object'
+}
+
+function is$type<Id extends string, Hash extends string>(
+  $type: unknown,
+  id: Id,
+  hash: Hash,
+): $type is $Type<Id, Hash> {
+  return hash === 'main'
+    ? $type === id
+    : // $type === `${id}#${hash}`
+      typeof $type === 'string' &&
+        $type.length === id.length + 1 + hash.length &&
+        $type.charCodeAt(id.length) === 35 /* '#' */ &&
+        $type.startsWith(id) &&
+        $type.endsWith(hash)
+}
+
+export type $TypedObject<
+  V,
+  Id extends string,
+  Hash extends string,
+> = V extends {
+  $type: $Type<Id, Hash>
+}
+  ? V
+  : V extends { $type?: string }
+    ? V extends { $type?: infer T extends $Type<Id, Hash> }
+      ? V & { $type: T }
+      : never
+    : V & { $type: $Type<Id, Hash> }
+
+export function is$typed<V, Id extends string, Hash extends string>(
+  v: V,
+  id: Id,
+  hash: Hash,
+): v is $TypedObject<V, Id, Hash> {
+  return isObject(v) && '$type' in v && is$type(v.$type, id, hash)
+}
+
+export function maybe$typed<V, Id extends string, Hash extends string>(
+  v: V,
+  id: Id,
+  hash: Hash,
+): v is V & object & { $type?: $Type<Id, Hash> } {
+  return (
+    isObject(v) &&
+    ('$type' in v ? v.$type === undefined || is$type(v.$type, id, hash) : true)
+  )
+}
+
+export type Validator<R = unknown> = (v: unknown) => ValidationResult<R>
+export type ValidatorParam<V extends Validator> =
+  V extends Validator<infer R> ? R : never
+
+/**
+ * Utility function that allows to convert a "validate*" utility function into a
+ * type predicate.
+ */
+export function asPredicate<V extends Validator>(validate: V) {
+  return function <T>(v: T): v is T & ValidatorParam<V> {
+    return validate(v).success
+  }
+}

--- a/packages/lexicon-resolver/src/index.ts
+++ b/packages/lexicon-resolver/src/index.ts
@@ -1,0 +1,2 @@
+export * from './record.js'
+export * from './lexicon.js'

--- a/packages/lexicon-resolver/src/lexicon.ts
+++ b/packages/lexicon-resolver/src/lexicon.ts
@@ -1,0 +1,73 @@
+import dns from 'node:dns/promises'
+import { CID } from 'multiformats/cid'
+import { LexiconDoc, parseLexiconDoc } from '@atproto/lexicon'
+import { Commit } from '@atproto/repo'
+import { AtUri, NSID, ensureValidDid } from '@atproto/syntax'
+import { ResolveRecordOptions, resolveRecord } from './record.js'
+
+const DNS_SUBDOMAIN = '_lexicon'
+const DNS_PREFIX = 'did='
+export const LEXICON_SCHEMA_NSID = 'com.atproto.lexicon.schema'
+
+export type ResolveLexiconOptions = ResolveRecordOptions & {
+  authorityDid?: string
+}
+
+export type LexiconResolution = {
+  commit: Commit
+  uri: AtUri
+  cid: CID
+  lexicon: LexiconDoc & LexiconSchemaRecord
+}
+
+export async function resolveLexicon(
+  nsidStr: NSID | string,
+  options: ResolveLexiconOptions = {},
+): Promise<LexiconResolution> {
+  const nsid = typeof nsidStr === 'string' ? NSID.parse(nsidStr) : nsidStr
+  const did = options.authorityDid ?? (await getLexiconAuthorityDid(nsid))
+  if (!did) {
+    throw new Error(`Could not resolve a DID authority for NSID: ${nsid}`)
+  }
+  const verified = await resolveRecord(
+    AtUri.make(did, LEXICON_SCHEMA_NSID, nsid.toString()),
+    options,
+  )
+  const lexicon = parseLexiconDoc(verified.record)
+  if (!isLexiconSchemaRecord(lexicon)) {
+    throw new Error('Invalid lexicon schema record')
+  }
+  const { uri, cid, commit } = verified
+  return { commit, uri, cid, lexicon }
+}
+
+export async function getLexiconAuthorityDid(nsidStr: NSID | string) {
+  const nsid = typeof nsidStr === 'string' ? NSID.parse(nsidStr) : nsidStr
+  const did = await resolveDns(nsid.authority)
+  if (did != null) ensureValidDid(did)
+  return did
+}
+
+async function resolveDns(authority: string): Promise<string | undefined> {
+  let chunkedResults: string[][]
+  try {
+    chunkedResults = await dns.resolveTxt(`${DNS_SUBDOMAIN}.${authority}`)
+  } catch (err) {
+    return undefined
+  }
+  return parseDnsResult(chunkedResults)
+}
+
+function parseDnsResult(chunkedResults: string[][]): string | undefined {
+  const results = chunkedResults.map((chunks) => chunks.join(''))
+  const found = results.filter((i) => i.startsWith(DNS_PREFIX))
+  if (found.length !== 1) {
+    return undefined
+  }
+  return found[0].slice(DNS_PREFIX.length)
+}
+
+type LexiconSchemaRecord = { $type: typeof LEXICON_SCHEMA_NSID }
+function isLexiconSchemaRecord(v: unknown): v is LexiconSchemaRecord {
+  return v?.['$type'] === LEXICON_SCHEMA_NSID
+}

--- a/packages/lexicon-resolver/src/record.ts
+++ b/packages/lexicon-resolver/src/record.ts
@@ -1,0 +1,103 @@
+import { CID } from 'multiformats/cid'
+import { IdResolver } from '@atproto/identity'
+import { RepoRecord } from '@atproto/lexicon'
+import {
+  Commit,
+  MST,
+  MemoryBlockstore,
+  RepoVerificationError,
+  def as repoDef,
+  readCarWithRoot,
+  verifyCommitSig,
+} from '@atproto/repo'
+import { AtUri, ensureValidDid } from '@atproto/syntax'
+import { BuildFetchHandlerOptions, FetchHandler } from '@atproto/xrpc'
+import { safeFetchWrap } from '@atproto-labs/fetch-node'
+import { AtpBaseClient as Client } from './client/index.js'
+
+export type ResolveRecordOptions = {
+  idResolver?: IdResolver
+  forceRefresh?: boolean
+  rpc?: Partial<BuildFetchHandlerOptions> | FetchHandler
+}
+
+export type RecordResolution = {
+  commit: Commit
+  uri: AtUri
+  cid: CID
+  record: RepoRecord
+}
+
+export async function resolveRecord(
+  uriStr: AtUri | string,
+  options: ResolveRecordOptions = {},
+): Promise<RecordResolution> {
+  const { idResolver = new IdResolver(), forceRefresh, rpc } = options
+  const uri = typeof uriStr === 'string' ? new AtUri(uriStr) : uriStr
+  const did = await getDidFromUri(uri, { idResolver })
+  const identity = await idResolver.did.resolveAtprotoData(did, forceRefresh)
+  const client = new Client(
+    typeof rpc === 'function'
+      ? rpc
+      : { service: identity.pds, fetch: safeFetch, ...rpc },
+  )
+  const { data: proofBytes } = await client.com.atproto.sync.getRecord({
+    did,
+    collection: uri.collection,
+    rkey: uri.rkey,
+  })
+  const verified = await verifyRecordProof(proofBytes, {
+    uri: AtUri.make(did, uri.collection, uri.rkey),
+    signingKey: identity.signingKey,
+  })
+  return verified
+}
+
+export const safeFetch = safeFetchWrap({
+  allowIpHost: false,
+  allowImplicitRedirect: true,
+  responseMaxSize: (1024 + 10) * 1024, // 1MB + 10kB, just a bit larger than max record size
+})
+
+async function getDidFromUri(
+  uri: AtUri,
+  { idResolver }: { idResolver: IdResolver },
+) {
+  let did: string
+  if (uri.host.startsWith('did:')) {
+    did = uri.host
+  } else {
+    const resolved = await idResolver.handle.resolve(uri.host)
+    if (!resolved) {
+      throw new Error('Could not resolve handle found in AT-URI.')
+    }
+    did = resolved
+  }
+  ensureValidDid(did)
+  return did
+}
+
+async function verifyRecordProof(
+  proofBytes: Uint8Array,
+  { uri, signingKey }: { uri: AtUri; signingKey: string },
+) {
+  const { root, blocks } = await readCarWithRoot(proofBytes)
+  const blockstore = new MemoryBlockstore(blocks)
+  const commit = await blockstore.readObj(root, repoDef.commit)
+  if (commit.did !== uri.host) {
+    throw new RepoVerificationError(`Invalid repo did: ${commit.did}`)
+  }
+  const validSig = await verifyCommitSig(commit, signingKey)
+  if (!validSig) {
+    throw new RepoVerificationError(
+      `Invalid signature on commit: ${root.toString()}`,
+    )
+  }
+  const mst = MST.load(blockstore, commit.data)
+  const cid = await mst.get(`${uri.collection}/${uri.rkey}`)
+  if (!cid) {
+    throw new RepoVerificationError('Record not found')
+  }
+  const record = await blockstore.readRecord(cid)
+  return { commit, uri, cid, record }
+}

--- a/packages/lexicon-resolver/src/record.ts
+++ b/packages/lexicon-resolver/src/record.ts
@@ -28,6 +28,12 @@ export type RecordResolution = {
   record: RepoRecord
 }
 
+/**
+ * Resolve a record from the network, verifying its authenticity.
+ * @param uriStr AtUri or string representing one for the record that will be resolved.
+ * @param options
+ * @returns
+ */
 export async function resolveRecord(
   uriStr: AtUri | string,
   options: ResolveRecordOptions = {},

--- a/packages/lexicon-resolver/src/record.ts
+++ b/packages/lexicon-resolver/src/record.ts
@@ -81,7 +81,9 @@ async function verifyRecordProof(
   proofBytes: Uint8Array,
   { uri, signingKey }: { uri: AtUri; signingKey: string },
 ) {
-  const { root, blocks } = await readCarWithRoot(proofBytes)
+  const { root, blocks } = await readCarWithRoot(proofBytes, {
+    verifyCids: true,
+  })
   const blockstore = new MemoryBlockstore(blocks)
   const commit = await blockstore.readObj(root, repoDef.commit)
   if (commit.did !== uri.host) {

--- a/packages/lexicon-resolver/tests/lexicon.test.ts
+++ b/packages/lexicon-resolver/tests/lexicon.test.ts
@@ -1,0 +1,256 @@
+import { SeedClient, TestNetworkNoAppView, usersSeed } from '@atproto/dev-env'
+import { NSID } from '@atproto/syntax'
+import { getLexiconDidAuthority, resolveLexicon } from '../src/lexicon.js'
+
+const dnsEntries: [entry: string, result: string][] = []
+
+jest.mock('node:dns/promises', () => {
+  return {
+    resolveTxt: (entry: string) => {
+      const found = dnsEntries.find(([e]) => e === entry)
+      if (found) return [[found[1]]]
+      if (entry === '_lexicon.simple.test') {
+        return [['did=did:example:simpleDid']]
+      }
+      if (entry === '_lexicon.noisy.test') {
+        return [
+          ['blah blah blah'],
+          ['did:example:fakeDid'],
+          ['atproto=did:example:fakeDid'],
+          ['did=did:example:noisyDid'],
+          [
+            'chunk long domain aspdfoiuwerpoaisdfupasodfiuaspdfoiuasdpfoiausdfpaosidfuaspodifuaspdfoiuasdpfoiasudfpasodifuaspdofiuaspdfoiuasd',
+            'apsodfiuweproiasudfpoasidfu',
+          ],
+        ]
+      }
+      if (entry === '_lexicon.bad.test') {
+        return [
+          ['blah blah blah'],
+          ['did:example:fakeDid'],
+          ['atproto=did:example:fakeDid'],
+          [
+            'chunk long domain aspdfoiuwerpoaisdfupasodfiuaspdfoiuasdpfoiausdfpaosidfuaspodifuaspdfoiuasdpfoiasudfpasodifuaspdofiuaspdfoiuasd',
+            'apsodfiuweproiasudfpoasidfu',
+          ],
+        ]
+      }
+      if (entry === '_lexicon.invalid.test') {
+        return [['did=not:a:did']]
+      }
+      if (entry === '_lexicon.multi.test') {
+        return [['did=did:example:firstDid'], ['did=did:example:secondDid']]
+      }
+      return []
+    },
+  }
+})
+
+describe('Lexicon resolution', () => {
+  let network: TestNetworkNoAppView
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'lex_lexicon_resolution',
+    })
+    sc = network.getSeedClient()
+    await usersSeed(sc)
+    dnsEntries.push(['_lexicon.alice.example', `did=${sc.dids.alice}`])
+  })
+
+  afterAll(async () => {
+    jest.unmock('node:dns/promises')
+    await network.close()
+  })
+
+  it('resolves lexicon.', async () => {
+    const client = network.pds.getClient()
+    const lex = await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.alice, rkey: 'example.alice.name1' },
+      { id: 'example.alice.name1', lexicon: 1, defs: {} },
+      sc.getHeaders(sc.dids.alice),
+    )
+    const result = await resolveLexicon('example.alice.name1', {
+      rpc: { fetch },
+      idResolver: network.pds.ctx.idResolver,
+      forceRefresh: true,
+    })
+    expect(result.commit.did).toEqual(sc.dids.alice)
+    expect(result.cid.toString()).toEqual(lex.cid)
+    expect(result.uri.toString()).toEqual(lex.uri)
+    expect(result.nsid.toString()).toEqual('example.alice.name1')
+    expect(result.lexicon).toEqual({
+      $type: 'com.atproto.lexicon.schema',
+      id: 'example.alice.name1',
+      lexicon: 1,
+      defs: {},
+    })
+  })
+
+  it('fails on mismatched id.', async () => {
+    const client = network.pds.getClient()
+    await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.alice, rkey: 'example.alice.name2' },
+      { id: 'example.test1.name2.bad', lexicon: 1, defs: {} },
+      sc.getHeaders(sc.dids.alice),
+    )
+    await expect(
+      resolveLexicon('example.alice.name2', {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Lexicon schema record id does not match NSID')
+  })
+
+  it('fails on missing DNS entry.', async () => {
+    const client = network.pds.getClient()
+    await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.bob, rkey: 'example.bob.name' },
+      { id: 'example.bob.name', lexicon: 1, defs: {} },
+      sc.getHeaders(sc.dids.bob),
+    )
+    await expect(
+      resolveLexicon('example.bob.name', {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow(
+      'Could not resolve a DID authority for NSID: example.bob.name',
+    )
+  })
+
+  it('fails on missing record.', async () => {
+    await expect(
+      resolveLexicon('example.alice.missing', {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Record not found')
+  })
+
+  it('fails on bad verification.', async () => {
+    const client = network.pds.getClient()
+    const alicekey = await network.pds.ctx.actorStore.keypair(sc.dids.alice)
+    const bobkey = await network.pds.ctx.actorStore.keypair(sc.dids.bob)
+    await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.alice, rkey: 'example.alice.badsig' },
+      { id: 'example.alice.badsig', lexicon: 1, defs: {} },
+      sc.getHeaders(sc.dids.alice),
+    )
+    // switch alice's key away from the one used by her pds
+    await network.pds.ctx.plcClient.updateAtprotoKey(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      bobkey.did(),
+    )
+    await expect(
+      resolveLexicon('example.alice.badsig', {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Invalid signature on commit')
+    // reset alice's key
+    await network.pds.ctx.plcClient.updateAtprotoKey(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      alicekey.did(),
+    )
+  })
+
+  it('fails on invalid lexicon document.', async () => {
+    const client = network.pds.getClient()
+    await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.alice, rkey: 'example.alice.baddoc' },
+      { id: 'example.alice.baddoc', lexicon: 999, defs: {} },
+      sc.getHeaders(sc.dids.alice),
+    )
+    await expect(
+      resolveLexicon('example.alice.baddoc', {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Invalid literal value, expected 1')
+  })
+
+  it('resolves lexicon based on override authority.', async () => {
+    const client = network.pds.getClient()
+    await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.alice, rkey: 'example.alice.override' },
+      {
+        id: 'example.alice.override',
+        lexicon: 1,
+        defs: { alice: { type: 'string' } },
+      },
+      sc.getHeaders(sc.dids.alice),
+    )
+    const carolLex = await client.com.atproto.lexicon.schema.create(
+      { repo: sc.dids.carol, rkey: 'example.alice.override' },
+      {
+        id: 'example.alice.override',
+        lexicon: 1,
+        defs: { carol: { type: 'string' } },
+      },
+      sc.getHeaders(sc.dids.carol),
+    )
+    const result = await resolveLexicon('example.alice.override', {
+      didAuthority: sc.dids.carol,
+      rpc: { fetch },
+      idResolver: network.pds.ctx.idResolver,
+      forceRefresh: true,
+    })
+    expect(result.commit.did).toEqual(sc.dids.carol)
+    expect(result.cid.toString()).toEqual(carolLex.cid)
+    expect(result.uri.toString()).toEqual(carolLex.uri)
+    expect(result.nsid.toString()).toEqual('example.alice.override')
+    expect(result.lexicon).toEqual({
+      $type: 'com.atproto.lexicon.schema',
+      id: 'example.alice.override',
+      lexicon: 1,
+      defs: { carol: { type: 'string' } },
+    })
+  })
+
+  describe('DID authority', () => {
+    it('handles a simple DNS resolution', async () => {
+      const did = await getLexiconDidAuthority('test.simple.name')
+      expect(did).toBe('did:example:simpleDid')
+    })
+
+    it('handles a noisy DNS resolution', async () => {
+      const did = await getLexiconDidAuthority('test.noisy.name')
+      expect(did).toBe('did:example:noisyDid')
+    })
+
+    it('handles a bad DNS resolution', async () => {
+      const did = await getLexiconDidAuthority('test.bad.name')
+      expect(did).toBeUndefined()
+    })
+
+    it('throws on multiple dids under same domain', async () => {
+      const did = await getLexiconDidAuthority('test.multi.name')
+      expect(did).toBeUndefined()
+    })
+
+    it('fails on invalid NSID', async () => {
+      await expect(getLexiconDidAuthority('not an nsid')).rejects.toThrow(
+        'Disallowed characters in NSID',
+      )
+    })
+
+    it('fails on invalid DID result', async () => {
+      const did = await getLexiconDidAuthority('test.invalid.name')
+      expect(did).toBeUndefined()
+    })
+
+    it('accepts NSID object', async () => {
+      const did = await getLexiconDidAuthority(NSID.parse('test.simple.name'))
+      expect(did).toBe('did:example:simpleDid')
+    })
+  })
+})

--- a/packages/lexicon-resolver/tests/lexicon.test.ts
+++ b/packages/lexicon-resolver/tests/lexicon.test.ts
@@ -1,6 +1,6 @@
 import { SeedClient, TestNetworkNoAppView, usersSeed } from '@atproto/dev-env'
 import { NSID } from '@atproto/syntax'
-import { getLexiconDidAuthority, resolveLexicon } from '../src/lexicon.js'
+import { getLexiconDidAuthority, resolveLexicon } from '../src/index.js'
 
 const dnsEntries: [entry: string, result: string][] = []
 

--- a/packages/lexicon-resolver/tests/record.test.ts
+++ b/packages/lexicon-resolver/tests/record.test.ts
@@ -1,6 +1,6 @@
 import { dataToCborBlock } from '@atproto/common'
 import { SeedClient, TestNetworkNoAppView, usersSeed } from '@atproto/dev-env'
-import { resolveRecord } from '../src/record.js'
+import { resolveRecord } from '../src/index.js'
 
 describe.only('Record resolution', () => {
   let network: TestNetworkNoAppView

--- a/packages/lexicon-resolver/tests/record.test.ts
+++ b/packages/lexicon-resolver/tests/record.test.ts
@@ -1,0 +1,82 @@
+import { dataToCborBlock } from '@atproto/common'
+import { SeedClient, TestNetworkNoAppView, usersSeed } from '@atproto/dev-env'
+import { resolveRecord } from '../src/record.js'
+
+describe.only('Record resolution', () => {
+  let network: TestNetworkNoAppView
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'lex_record_resolution',
+    })
+    sc = network.getSeedClient()
+    await usersSeed(sc)
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('resolves record by AT-URI object.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post1')
+    const result = await resolveRecord(post.ref.uri, {
+      rpc: { fetch },
+      idResolver: network.pds.ctx.idResolver,
+    })
+    expect(result.commit.did).toEqual(sc.dids.alice)
+    expect(result.cid.toString()).toEqual(post.ref.cidStr)
+    expect(result.uri.toString()).toEqual(post.ref.uriStr)
+    expect(result.record.text).toEqual('post1')
+  })
+
+  it('resolves record by AT-URI string.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post2')
+    const result = await resolveRecord(post.ref.uriStr, {
+      rpc: { fetch },
+      idResolver: network.pds.ctx.idResolver,
+    })
+    expect(result.commit.did).toEqual(sc.dids.alice)
+    expect(result.cid.toString()).toEqual(post.ref.cidStr)
+    expect(result.uri.toString()).toEqual(post.ref.uriStr)
+    expect(result.record.text).toEqual('post2')
+  })
+
+  it("does not resolve record that doesn't exist.", async () => {
+    await expect(
+      resolveRecord(`at://${sc.dids.alice}/app.bsky.feed.post/2222222222222`, {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+      }),
+    ).rejects.toThrow('Record not found')
+  })
+
+  it('does not resolve record with bad commit signature.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post3')
+    const verified = await resolveRecord(post.ref.uri, {
+      rpc: { fetch },
+      idResolver: network.pds.ctx.idResolver,
+    })
+    const goodCommitBlock = await dataToCborBlock(verified.commit)
+    const badCommitBlock = await dataToCborBlock({
+      ...verified.commit,
+      sig: new Uint8Array(),
+    })
+    await network.pds.ctx.actorStore.transact(sc.dids.alice, (txn) =>
+      txn.repo.db.db
+        .updateTable('repo_block')
+        .set({
+          content: badCommitBlock.bytes,
+          size: badCommitBlock.bytes.byteLength,
+        })
+        .where('cid', '=', goodCommitBlock.cid.toString())
+        .execute(),
+    )
+    await expect(
+      resolveRecord(post.ref.uri, {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+      }),
+    ).rejects.toThrow('Invalid signature on commit')
+  })
+})

--- a/packages/lexicon-resolver/tests/record.test.ts
+++ b/packages/lexicon-resolver/tests/record.test.ts
@@ -23,6 +23,7 @@ describe.only('Record resolution', () => {
     const result = await resolveRecord(post.ref.uri, {
       rpc: { fetch },
       idResolver: network.pds.ctx.idResolver,
+      forceRefresh: true,
     })
     expect(result.commit.did).toEqual(sc.dids.alice)
     expect(result.cid.toString()).toEqual(post.ref.cidStr)
@@ -35,6 +36,7 @@ describe.only('Record resolution', () => {
     const result = await resolveRecord(post.ref.uriStr, {
       rpc: { fetch },
       idResolver: network.pds.ctx.idResolver,
+      forceRefresh: true,
     })
     expect(result.commit.did).toEqual(sc.dids.alice)
     expect(result.cid.toString()).toEqual(post.ref.cidStr)
@@ -47,36 +49,55 @@ describe.only('Record resolution', () => {
       resolveRecord(`at://${sc.dids.alice}/app.bsky.feed.post/2222222222222`, {
         rpc: { fetch },
         idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
       }),
     ).rejects.toThrow('Record not found')
   })
 
   it('does not resolve record with bad commit signature.', async () => {
+    const alicekey = await network.pds.ctx.actorStore.keypair(sc.dids.alice)
+    const bobkey = await network.pds.ctx.actorStore.keypair(sc.dids.bob)
     const post = await sc.post(sc.dids.alice, 'post3')
-    const verified = await resolveRecord(post.ref.uri, {
-      rpc: { fetch },
-      idResolver: network.pds.ctx.idResolver,
-    })
-    const goodCommitBlock = await dataToCborBlock(verified.commit)
-    const badCommitBlock = await dataToCborBlock({
-      ...verified.commit,
-      sig: new Uint8Array(),
-    })
+    // switch alice's key away from the one used by her pds
+    await network.pds.ctx.plcClient.updateAtprotoKey(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      bobkey.did(),
+    )
+    await expect(
+      resolveRecord(post.ref.uri, {
+        rpc: { fetch },
+        idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Invalid signature on commit')
+    // reset alice's key
+    await network.pds.ctx.plcClient.updateAtprotoKey(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      alicekey.did(),
+    )
+  })
+
+  it('does not resolve record with corrupted CAR block.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post4')
+    const badBlock = await dataToCborBlock({})
     await network.pds.ctx.actorStore.transact(sc.dids.alice, (txn) =>
       txn.repo.db.db
         .updateTable('repo_block')
         .set({
-          content: badCommitBlock.bytes,
-          size: badCommitBlock.bytes.byteLength,
+          content: badBlock.bytes,
+          size: badBlock.bytes.byteLength,
         })
-        .where('cid', '=', goodCommitBlock.cid.toString())
+        .where('cid', '=', post.ref.cidStr)
         .execute(),
     )
     await expect(
       resolveRecord(post.ref.uri, {
         rpc: { fetch },
         idResolver: network.pds.ctx.idResolver,
+        forceRefresh: true,
       }),
-    ).rejects.toThrow('Invalid signature on commit')
+    ).rejects.toThrow('Not a valid CID for bytes')
   })
 })

--- a/packages/lexicon-resolver/tsconfig.build.json
+++ b/packages/lexicon-resolver/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../tsconfig/node.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noUnusedLocals": false
+  },
+  "include": ["src"]
+}

--- a/packages/lexicon-resolver/tsconfig.json
+++ b/packages/lexicon-resolver/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.tests.json" }
+  ]
+}

--- a/packages/lexicon-resolver/tsconfig.tests.json
+++ b/packages/lexicon-resolver/tsconfig.tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig/tests.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noUnusedLocals": false
+  },
+  "include": ["./tests"]
+}

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -412,6 +412,8 @@ export type LexUserType = z.infer<typeof lexUserType>
 
 export const lexiconDoc = z
   .object({
+    // Compatibility with lexicon publishing
+    $type: z.literal('com.atproto.lexicon.schema').optional(),
     lexicon: z.literal(1),
     id: z.string().refine((v: string) => NSID.isValid(v), {
       message: 'Must be a valid NSID',

--- a/packages/repo/src/car.ts
+++ b/packages/repo/src/car.ts
@@ -54,10 +54,15 @@ async function* iterateBlocks(blocks: BlockMap) {
   }
 }
 
+export type ReadCarOptions = {
+  verifyCids?: boolean
+}
+
 export const readCar = async (
   bytes: Uint8Array,
+  opts?: ReadCarOptions,
 ): Promise<{ roots: CID[]; blocks: BlockMap }> => {
-  const { roots, blocks } = await readCarStream([bytes])
+  const { roots, blocks } = await readCarStream([bytes], opts)
   const blockMap = new BlockMap()
   for await (const block of blocks) {
     blockMap.set(block.cid, block.bytes)
@@ -67,8 +72,9 @@ export const readCar = async (
 
 export const readCarWithRoot = async (
   bytes: Uint8Array,
+  opts?: ReadCarOptions,
 ): Promise<{ root: CID; blocks: BlockMap }> => {
-  const { roots, blocks } = await readCar(bytes)
+  const { roots, blocks } = await readCar(bytes, opts)
   if (roots.length !== 1) {
     throw new Error(`Expected one root, got ${roots.length}`)
   }
@@ -84,6 +90,7 @@ export type CarBlockIterable = AsyncGenerator<CarBlock, void, unknown> & {
 
 export const readCarStream = async (
   car: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  opts?: ReadCarOptions,
 ): Promise<{
   roots: CID[]
   blocks: CarBlockIterable
@@ -101,7 +108,7 @@ export const readCarStream = async (
     }
     return {
       roots: header.roots,
-      blocks: readCarBlocksIter(reader),
+      blocks: readCarBlocksIter(reader, opts),
     }
   } catch (err) {
     await reader.close()
@@ -109,27 +116,32 @@ export const readCarStream = async (
   }
 }
 
-const readCarBlocksIter = (reader: BufferedReader) => {
-  const iter = readCarBlocksIterGenerator(reader) as CarBlockIterable
-
-  iter.dump = async () => {
-    // try/finally to ensure that reader.close is called even if blocks.return throws.
-    try {
-      // Prevent the iterator from being started after this method is called.
-      await iter.return()
-    } finally {
-      // @NOTE the "finally" block of the async generator won't be called
-      // if the iteration was never started so we need to manually close here.
-      await reader.close()
-    }
+const readCarBlocksIter = (
+  reader: BufferedReader,
+  opts?: ReadCarOptions,
+): CarBlockIterable => {
+  let generator = readCarBlocksIterGenerator(reader)
+  if (opts?.verifyCids) {
+    generator = verifyIncomingCarBlocks(generator)
   }
-
-  return iter
+  return Object.assign(generator, {
+    async dump() {
+      // try/finally to ensure that reader.close is called even if blocks.return throws.
+      try {
+        // Prevent the iterator from being started after this method is called.
+        await generator.return()
+      } finally {
+        // @NOTE the "finally" block of the async generator won't be called
+        // if the iteration was never started so we need to manually close here.
+        await reader.close()
+      }
+    },
+  })
 }
 
 async function* readCarBlocksIterGenerator(
   reader: BufferedReader,
-): AsyncIterable<CarBlock> {
+): AsyncGenerator<CarBlock, void, unknown> {
   try {
     while (!reader.isDone) {
       const blockSize = await reader.readVarint()
@@ -148,7 +160,7 @@ async function* readCarBlocksIterGenerator(
 
 export async function* verifyIncomingCarBlocks(
   car: AsyncIterable<CarBlock>,
-): AsyncIterable<CarBlock> {
+): AsyncGenerator<CarBlock, void, unknown> {
   for await (const block of car) {
     await verifyCidForBytes(block.cid, block.bytes)
     yield block

--- a/packages/repo/tests/car.test.ts
+++ b/packages/repo/tests/car.test.ts
@@ -55,4 +55,30 @@ describe('car', () => {
     }
     await expect(iterate).rejects.toThrow('Oops!')
   })
+
+  it('verifies CIDs', async () => {
+    const block0 = await dataToCborBlock({ block: 0 })
+    const block1 = await dataToCborBlock({ block: 1 })
+    const block2 = await dataToCborBlock({ block: 2 })
+    const block3 = await dataToCborBlock({ block: 3 })
+    const badBlock = await dataToCborBlock({ block: 'bad' })
+    const blockIter = async function* () {
+      yield block0
+      yield block1
+      yield block2
+      yield { cid: block3.cid, bytes: badBlock.bytes }
+    }
+    const flush = async function (iter: AsyncIterable<unknown>) {
+      for await (const _ of iter) {
+        // no-op
+      }
+    }
+    const badCar = await readCarStream(
+      writeCarStream(block0.cid, blockIter()),
+      { verifyCids: true },
+    )
+    await expect(flush(badCar.blocks)).rejects.toThrow(
+      'Not a valid CID for bytes',
+    )
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,40 @@ importers:
         specifier: ^5.6.3
         version: 5.8.2
 
+  packages/lexicon-resolver:
+    dependencies:
+      '@atproto-labs/fetch-node':
+        specifier: workspace:^
+        version: link:../internal/fetch-node
+      '@atproto/identity':
+        specifier: workspace:^
+        version: link:../identity
+      '@atproto/lexicon':
+        specifier: workspace:^
+        version: link:../lexicon
+      '@atproto/repo':
+        specifier: workspace:^
+        version: link:../repo
+      '@atproto/syntax':
+        specifier: workspace:^
+        version: link:../syntax
+      '@atproto/xrpc':
+        specifier: workspace:^
+        version: link:../xrpc
+      multiformats:
+        specifier: ^9.9.0
+        version: 9.9.0
+    devDependencies:
+      '@atproto/lex-cli':
+        specifier: workspace:^
+        version: link:../lex-cli
+      jest:
+        specifier: ^28.1.2
+        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.8.3
+
   packages/oauth/jwk:
     dependencies:
       multiformats:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,12 @@ importers:
         specifier: ^9.9.0
         version: 9.9.0
     devDependencies:
+      '@atproto/common':
+        specifier: workspace:^
+        version: link:../common
+      '@atproto/dev-env':
+        specifier: workspace:^
+        version: link:../dev-env
       '@atproto/lex-cli':
         specifier: workspace:^
         version: link:../lex-cli

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "./packages/internal/xrpc-utils" },
     { "path": "./packages/lex-cli" },
     { "path": "./packages/lexicon" },
+    { "path": "./packages/lexicon-resolver" },
     { "path": "./packages/oauth/jwk" },
     { "path": "./packages/oauth/jwk-jose" },
     { "path": "./packages/oauth/jwk-webcrypto" },


### PR DESCRIPTION
This adds a new package @atproto/lexicon-resolver, which implements lexicon resolution as specified in [Lexicon Publication and Resolution](https://atproto.com/specs/lexicon#lexicon-publication-and-resolution).

A couple other additions came along the way:
 - Added an option to the CAR helpers in @atproto/repo for verifying CID -> content mappings within the CAR.
 - Made lexicon document validation permissive of an optional `$type` field for compatibility with published lexicon schema records.