### PR TITLE
Small xrpc-server optimizations

### DIFF
--- a/.changeset/eight-cars-impress.md
+++ b/.changeset/eight-cars-impress.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Throw `InternalServerError` instead of a `zod` validation error when handler output is not valid

--- a/.changeset/gentle-camels-study.md
+++ b/.changeset/gentle-camels-study.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Minor performance optimizations

--- a/.changeset/olive-mirrors-wave.md
+++ b/.changeset/olive-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Expose `parseReqEncoding` utility

--- a/packages/xrpc-server/src/index.ts
+++ b/packages/xrpc-server/src/index.ts
@@ -5,5 +5,10 @@ export * from './server'
 export * from './stream'
 export * from './types'
 
-export { ServerTimer, parseReqNsid, serverTimingHeader } from './util'
+export {
+  ServerTimer,
+  parseReqEncoding,
+  parseReqNsid,
+  serverTimingHeader,
+} from './util'
 export type { ServerTiming } from './util'


### PR DESCRIPTION
This commit is part of #3806 and was extracted for clarity.

The main purpose was to expose `parseReqEncoding`. While doing that, I realized there was an optimization opportunity in the was the encoding is checked both for input and output:
- `validateOutput` performs several times the same check on `output`, which is now covered by a single `if`.
- `createInputVerifier` was parsing the definition's allowed encoding on every request. That value is now parsed a single time (at startup), and the check is only performed if needed.