### PR TITLE
handles: Allow .arpa domains

### DIFF
--- a/packages/syntax/src/handle.ts
+++ b/packages/syntax/src/handle.ts
@@ -6,7 +6,6 @@ export const INVALID_HANDLE = 'handle.invalid'
 // See also: https://en.wikipedia.org/wiki/Top-level_domain#Reserved_domains
 export const DISALLOWED_TLDS = [
   '.local',
-  '.arpa',
   '.invalid',
   '.localhost',
   '.internal',


### PR DESCRIPTION
## Description
This PR allows users who control .arpa domains, such as myself (I personally control 72.190.23.in-addr.arpa and 0.0.0.2.2.c.0.0.0.2.6.2.ip6.arpa by way of owning the 23.190.72.0/24 and 2620:C2:2000::/48 IP prefixes) to use them as handles on the Bluesky platform. Admittedly, the .arpa domain is extremely limited in scope, and registration is limited to an incredibly small number of people across the globe. However, more importantly, DNS still works normally on .arpa domains. You can verify this yourself with running `dig`:
```shell
; dig @1.1.1.1 TXT _atproto.72.190.23.in-addr.arpa

; <<>> DiG 9.10.6 <<>> @1.1.1.1 TXT _atproto.72.190.23.in-addr.arpa
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 61574
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_atproto.72.190.23.in-addr.arpa. IN	TXT

;; ANSWER SECTION:
_atproto.72.190.23.in-addr.arpa. 60 IN	TXT	"did=did:plc:ckxxis2tjajxg7pvwkyrkg6x"

;; Query time: 26 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Wed Jul 30 22:14:41 PDT 2025
;; MSG SIZE  rcvd: 109

;
```

## Proposed Value
haha funny domain go brrrrrrrrrrrr