### PR TITLE
Lists API improvements

### DIFF
--- a/.changeset/real-moles-retire.md
+++ b/.changeset/real-moles-retire.md
@@ -1,0 +1,7 @@
+---
+"@atproto/api": patch
+---
+
+Adds `purpose` filtering to `app.bsky.graph.getList`.
+Adds `app.bsky.graph.getListsWithMembership`.
+Adds `app.bsky.graph.getStarterPacksWithMembership`.

--- a/.changeset/real-moles-retire.md
+++ b/.changeset/real-moles-retire.md
@@ -2,6 +2,6 @@
 "@atproto/api": patch
 ---
 
-Adds `purpose` filtering to `app.bsky.graph.getList`.
+Adds `purpose` filtering to `app.bsky.graph.getLists`.
 Adds `app.bsky.graph.getListsWithMembership`.
 Adds `app.bsky.graph.getStarterPacksWithMembership`.

--- a/lexicons/app/bsky/graph/getLists.json
+++ b/lexicons/app/bsky/graph/getLists.json
@@ -20,7 +20,15 @@
             "maximum": 100,
             "default": 50
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string" },
+          "purposes": {
+            "type": "array",
+            "description": "Optional filter by list purpose. If not specified, all supported types are returned.",
+            "items": {
+              "type": "string",
+              "knownValues": ["modlist", "curatelist"]
+            }
+          }
         }
       },
       "output": {

--- a/lexicons/app/bsky/graph/getListsWithMembership.json
+++ b/lexicons/app/bsky/graph/getListsWithMembership.json
@@ -1,0 +1,65 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getListsWithMembership",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates the lists created by the session user, and includes membership information about `actor` in those lists. Only supports curation and moderation lists (no reference lists, used in starter packs). Requires auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "The account (actor) to check for membership."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" },
+          "purposes": {
+            "type": "array",
+            "description": "Optional filter by list purpose. If not specified, all supported types are returned.",
+            "items": {
+              "type": "string",
+              "knownValues": ["modlist", "curatelist"]
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["listsWithMembership"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "listsWithMembership": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#listWithMembership" }
+            }
+          }
+        }
+      }
+    },
+    "listWithMembership": {
+      "description": "A list and an optional list item indicating membership of a target user to that list.",
+      "type": "object",
+      "required": ["list"],
+      "properties": {
+        "list": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#listView"
+        },
+        "listItem": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#listItemView"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+++ b/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
@@ -45,7 +45,7 @@
       "properties": {
         "starterPack": {
           "type": "ref",
-          "ref": "app.bsky.graph.defs#starterPackViewBasic"
+          "ref": "app.bsky.graph.defs#starterPackView"
         },
         "listItem": {
           "type": "ref",

--- a/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+++ b/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
@@ -1,0 +1,57 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.getStarterPacksWithMembership",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerates the starter packs created by the session user, and includes membership information about `actor` in those starter packs. Requires auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "The account (actor) to check for membership."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["starterPacksWithMembership"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "starterPacksWithMembership": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#starterPackWithMembership" }
+            }
+          }
+        }
+      }
+    },
+    "starterPackWithMembership": {
+      "description": "A starter pack and an optional list item indicating membership of a target user to that starter pack.",
+      "type": "object",
+      "required": ["starterPack"],
+      "properties": {
+        "starterPack": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#starterPackViewBasic"
+        },
+        "listItem": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#listItemView"
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -154,6 +154,7 @@ import * as AppBskyGraphGetList from './types/app/bsky/graph/getList.js'
 import * as AppBskyGraphGetListBlocks from './types/app/bsky/graph/getListBlocks.js'
 import * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes.js'
 import * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists.js'
+import * as AppBskyGraphGetListsWithMembership from './types/app/bsky/graph/getListsWithMembership.js'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
@@ -432,6 +433,7 @@ export * as AppBskyGraphGetList from './types/app/bsky/graph/getList.js'
 export * as AppBskyGraphGetListBlocks from './types/app/bsky/graph/getListBlocks.js'
 export * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes.js'
 export * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists.js'
+export * as AppBskyGraphGetListsWithMembership from './types/app/bsky/graph/getListsWithMembership.js'
 export * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 export * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 export * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
@@ -2882,6 +2884,18 @@ export class AppBskyGraphNS {
     opts?: AppBskyGraphGetLists.CallOptions,
   ): Promise<AppBskyGraphGetLists.Response> {
     return this._client.call('app.bsky.graph.getLists', params, undefined, opts)
+  }
+
+  getListsWithMembership(
+    params?: AppBskyGraphGetListsWithMembership.QueryParams,
+    opts?: AppBskyGraphGetListsWithMembership.CallOptions,
+  ): Promise<AppBskyGraphGetListsWithMembership.Response> {
+    return this._client.call(
+      'app.bsky.graph.getListsWithMembership',
+      params,
+      undefined,
+      opts,
+    )
   }
 
   getMutes(

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -159,6 +159,7 @@ import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
 import * as AppBskyGraphGetStarterPacks from './types/app/bsky/graph/getStarterPacks.js'
+import * as AppBskyGraphGetStarterPacksWithMembership from './types/app/bsky/graph/getStarterPacksWithMembership.js'
 import * as AppBskyGraphGetSuggestedFollowsByActor from './types/app/bsky/graph/getSuggestedFollowsByActor.js'
 import * as AppBskyGraphList from './types/app/bsky/graph/list.js'
 import * as AppBskyGraphListblock from './types/app/bsky/graph/listblock.js'
@@ -438,6 +439,7 @@ export * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 export * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 export * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
 export * as AppBskyGraphGetStarterPacks from './types/app/bsky/graph/getStarterPacks.js'
+export * as AppBskyGraphGetStarterPacksWithMembership from './types/app/bsky/graph/getStarterPacksWithMembership.js'
 export * as AppBskyGraphGetSuggestedFollowsByActor from './types/app/bsky/graph/getSuggestedFollowsByActor.js'
 export * as AppBskyGraphList from './types/app/bsky/graph/list.js'
 export * as AppBskyGraphListblock from './types/app/bsky/graph/listblock.js'
@@ -2934,6 +2936,18 @@ export class AppBskyGraphNS {
   ): Promise<AppBskyGraphGetStarterPacks.Response> {
     return this._client.call(
       'app.bsky.graph.getStarterPacks',
+      params,
+      undefined,
+      opts,
+    )
+  }
+
+  getStarterPacksWithMembership(
+    params?: AppBskyGraphGetStarterPacksWithMembership.QueryParams,
+    opts?: AppBskyGraphGetStarterPacksWithMembership.CallOptions,
+  ): Promise<AppBskyGraphGetStarterPacksWithMembership.Response> {
+    return this._client.call(
+      'app.bsky.graph.getStarterPacksWithMembership',
       params,
       undefined,
       opts,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8958,6 +8958,15 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
           },
         },
         output: {

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -9246,6 +9246,72 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetStarterPacksWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getStarterPacksWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the starter packs created by the session user, and includes membership information about `actor` in those starter packs. Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['starterPacksWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              starterPacksWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      starterPackWithMembership: {
+        description:
+          'A starter pack and an optional list item indicating membership of a target user to that starter pack.',
+        type: 'object',
+        required: ['starterPack'],
+        properties: {
+          starterPack: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetSuggestedFollowsByActor: {
     lexicon: 1,
     id: 'app.bsky.graph.getSuggestedFollowsByActor',
@@ -17893,6 +17959,8 @@ export const ids = {
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',
   AppBskyGraphGetStarterPacks: 'app.bsky.graph.getStarterPacks',
+  AppBskyGraphGetStarterPacksWithMembership:
+    'app.bsky.graph.getStarterPacksWithMembership',
   AppBskyGraphGetSuggestedFollowsByActor:
     'app.bsky.graph.getSuggestedFollowsByActor',
   AppBskyGraphList: 'app.bsky.graph.list',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -9302,7 +9302,7 @@ export const schemaDict = {
         properties: {
           starterPack: {
             type: 'ref',
-            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+            ref: 'lex:app.bsky.graph.defs#starterPackView',
           },
           listItem: {
             type: 'ref',

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8991,6 +8991,81 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetListsWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getListsWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the lists created by the session user, and includes membership information about `actor` in those lists. Only supports curation and moderation lists (no reference lists, used in starter packs). Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['listsWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              listsWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getListsWithMembership#listWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      listWithMembership: {
+        description:
+          'A list and an optional list item indicating membership of a target user to that list.',
+        type: 'object',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listView',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetMutes: {
     lexicon: 1,
     id: 'app.bsky.graph.getMutes',
@@ -17813,6 +17888,7 @@ export const ids = {
   AppBskyGraphGetListBlocks: 'app.bsky.graph.getListBlocks',
   AppBskyGraphGetListMutes: 'app.bsky.graph.getListMutes',
   AppBskyGraphGetLists: 'app.bsky.graph.getLists',
+  AppBskyGraphGetListsWithMembership: 'app.bsky.graph.getListsWithMembership',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',

--- a/packages/api/src/client/types/app/bsky/graph/getLists.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getLists.ts
@@ -21,6 +21,8 @@ export type QueryParams = {
   actor: string
   limit?: number
   cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
 }
 export type InputSchema = undefined
 

--- a/packages/api/src/client/types/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getListsWithMembership.ts
@@ -1,0 +1,64 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getListsWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit?: number
+  cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  listsWithMembership: ListWithMembership[]
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}
+
+/** A list and an optional list item indicating membership of a target user to that list. */
+export interface ListWithMembership {
+  $type?: 'app.bsky.graph.getListsWithMembership#listWithMembership'
+  list: AppBskyGraphDefs.ListView
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashListWithMembership = 'listWithMembership'
+
+export function isListWithMembership<V>(v: V) {
+  return is$typed(v, id, hashListWithMembership)
+}
+
+export function validateListWithMembership<V>(v: V) {
+  return validate<ListWithMembership & V>(v, id, hashListWithMembership)
+}

--- a/packages/api/src/client/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -47,7 +47,7 @@ export function toKnownErr(e: any) {
 /** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
 export interface StarterPackWithMembership {
   $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
-  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  starterPack: AppBskyGraphDefs.StarterPackView
   listItem?: AppBskyGraphDefs.ListItemView
 }
 

--- a/packages/api/src/client/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/api/src/client/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -1,0 +1,66 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getStarterPacksWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit?: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  starterPacksWithMembership: StarterPackWithMembership[]
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}
+
+/** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
+export interface StarterPackWithMembership {
+  $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
+  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashStarterPackWithMembership = 'starterPackWithMembership'
+
+export function isStarterPackWithMembership<V>(v: V) {
+  return is$typed(v, id, hashStarterPackWithMembership)
+}
+
+export function validateStarterPackWithMembership<V>(v: V) {
+  return validate<StarterPackWithMembership & V>(
+    v,
+    id,
+    hashStarterPackWithMembership,
+  )
+}

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -100,11 +100,9 @@ const presentation = (
   const { ctx, skeleton, hydration } = input
   const { listUri, listitems, cursor } = skeleton
   const list = ctx.views.list(listUri, hydration)
-  const items = mapDefined(listitems, ({ uri, did }) => {
-    const subject = ctx.views.profile(did, hydration)
-    if (!subject) return
-    return { uri, subject }
-  })
+  const items = mapDefined(listitems, ({ uri, did }) =>
+    ctx.views.listItemView(uri, did, hydration),
+  )
   if (!list) {
     throw new InvalidRequestError('List not found')
   }

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -3,7 +3,10 @@ import { InvalidRequestError } from '@atproto/xrpc-server'
 import { AppContext } from '../../../../context'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator'
 import { Server } from '../../../../lexicon'
-import { REFERENCELIST } from '../../../../lexicon/types/app/bsky/graph/defs'
+import {
+  CURATELIST,
+  MODLIST,
+} from '../../../../lexicon/types/app/bsky/graph/defs'
 import { QueryParams } from '../../../../lexicon/types/app/bsky/graph/getLists'
 import {
   HydrationFnInput,
@@ -19,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
   const getLists = createPipeline(
     skeleton,
     hydration,
-    noReferenceLists,
+    filterPurposes,
     presentation,
   )
   server.app.bsky.graph.getLists({
@@ -70,13 +73,21 @@ const hydration = async (
   return ctx.hydrator.hydrateLists(listUris, params.hydrateCtx)
 }
 
-const noReferenceLists = (
+const filterPurposes = (
   input: RulesFnInput<Context, Params, SkeletonState>,
 ) => {
-  const { skeleton, hydration } = input
+  const { skeleton, hydration, params } = input
+  const purposes = params.purposes || ['modlist', 'curatelist']
+
+  const acceptedPurposes = new Set()
+  if (purposes.includes('modlist')) acceptedPurposes.add(MODLIST)
+  if (purposes.includes('curatelist')) acceptedPurposes.add(CURATELIST)
+
+  // @NOTE: While we don't support filtering on the dataplane, this might result in empty pages.
+  // Despite the empty pages, the pagination still can enumerate all items for the specified filters.
   skeleton.listUris = skeleton.listUris.filter((uri) => {
     const list = hydration.lists?.get(uri)
-    return list?.record.purpose !== REFERENCELIST
+    return acceptedPurposes.has(list?.record.purpose)
   })
   return skeleton
 }

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -81,7 +81,9 @@ const filterPurposes = (
 
   const acceptedPurposes = new Set()
   if (purposes.includes('modlist')) acceptedPurposes.add(MODLIST)
+  if (purposes.includes(MODLIST)) acceptedPurposes.add(MODLIST)
   if (purposes.includes('curatelist')) acceptedPurposes.add(CURATELIST)
+  if (purposes.includes(CURATELIST)) acceptedPurposes.add(CURATELIST)
 
   // @NOTE: While we don't support filtering on the dataplane, this might result in empty pages.
   // Despite the empty pages, the pagination still can enumerate all items for the specified filters.

--- a/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
@@ -1,0 +1,174 @@
+import { mapDefined } from '@atproto/common'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context'
+import { ListMembershipState } from '../../../../hydration/graph'
+import {
+  HydrateCtx,
+  HydrationState,
+  Hydrator,
+  mergeManyStates,
+} from '../../../../hydration/hydrator'
+import { HydrationMap } from '../../../../hydration/util'
+import { Server } from '../../../../lexicon'
+import {
+  CURATELIST,
+  MODLIST,
+} from '../../../../lexicon/types/app/bsky/graph/defs'
+import { QueryParams } from '../../../../lexicon/types/app/bsky/graph/getListsWithMembership'
+import {
+  HydrationFnInput,
+  PresentationFnInput,
+  RulesFnInput,
+  SkeletonFnInput,
+  createPipeline,
+} from '../../../../pipeline'
+import { Views } from '../../../../views'
+import { clearlyBadCursor, resHeaders } from '../../../util'
+
+export default function (server: Server, ctx: AppContext) {
+  const getListsWithMembership = createPipeline(
+    skeleton,
+    hydration,
+    filterPurposes,
+    presentation,
+  )
+  server.app.bsky.graph.getListsWithMembership({
+    auth: ctx.authVerifier.standard,
+    handler: async ({ params, auth, req }) => {
+      const viewer = auth.credentials.iss
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+      })
+      const result = await getListsWithMembership(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
+
+      return {
+        encoding: 'application/json',
+        body: result,
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}
+
+const skeleton = async (
+  input: SkeletonFnInput<Context, Params>,
+): Promise<SkeletonState> => {
+  const { ctx, params } = input
+  if (clearlyBadCursor(params.cursor)) {
+    return { listUris: [] }
+  }
+
+  const [did] = await ctx.hydrator.actor.getDids([params.actor])
+  if (!did) throw new InvalidRequestError('Profile not found')
+
+  const { listUris, cursor } = await ctx.hydrator.dataplane.getActorLists({
+    actorDid: params.hydrateCtx.viewer,
+    cursor: params.cursor,
+    limit: params.limit,
+  })
+  return { listUris, cursor: cursor || undefined }
+}
+
+const hydration = async (
+  input: HydrationFnInput<Context, Params, SkeletonState>,
+) => {
+  const { ctx, params, skeleton } = input
+  const { actor } = params
+  const { listUris } = skeleton
+
+  const [
+    actorsHydrationState,
+    listsHydrationState,
+    { listitemUris: listItemUris },
+  ] = await Promise.all([
+    ctx.hydrator.hydrateProfiles([actor], params.hydrateCtx),
+    ctx.hydrator.hydrateLists(listUris, params.hydrateCtx),
+    ctx.hydrator.dataplane.getListMembership({
+      actorDid: actor,
+      listUris,
+    }),
+  ])
+
+  const listMembershipHydrationState: HydrationState = {
+    listMemberships: listUris.reduce((acc, cur, i) => {
+      const userMap = new HydrationMap<ListMembershipState>()
+
+      const listItemUri = listItemUris[i]
+      if (listItemUri) {
+        userMap.set(actor, {
+          actorListItemUri: listItemUri,
+        } satisfies ListMembershipState)
+      }
+
+      acc.set(cur, userMap)
+      return acc
+    }, new HydrationMap<HydrationMap<ListMembershipState>>()),
+  }
+
+  return mergeManyStates(
+    actorsHydrationState,
+    listsHydrationState,
+    listMembershipHydrationState,
+  )
+}
+
+const filterPurposes = (
+  input: RulesFnInput<Context, Params, SkeletonState>,
+) => {
+  const { skeleton, hydration, params } = input
+  const purposes = params.purposes || ['modlist', 'curatelist']
+
+  const acceptedPurposes = new Set()
+  if (purposes.includes('modlist')) acceptedPurposes.add(MODLIST)
+  if (purposes.includes('curatelist')) acceptedPurposes.add(CURATELIST)
+
+  // @NOTE: While we don't support filtering on the dataplane, this might result in empty pages.
+  // Despite the empty pages, the pagination still can enumerate all items for the specified filters.
+  skeleton.listUris = skeleton.listUris.filter((uri) => {
+    const list = hydration.lists?.get(uri)
+    return acceptedPurposes.has(list?.record.purpose)
+  })
+  return skeleton
+}
+
+const presentation = (
+  input: PresentationFnInput<Context, Params, SkeletonState>,
+) => {
+  const { ctx, params, skeleton, hydration } = input
+  const { listUris, cursor } = skeleton
+  const listsWithMembership = mapDefined(listUris, (uri) => {
+    const list = ctx.views.list(uri, hydration)
+    if (!list) return
+
+    const listItemUri = hydration.listMemberships
+      ?.get(uri)
+      ?.get(params.actor)?.actorListItemUri
+
+    return {
+      list,
+      listItem: listItemUri
+        ? ctx.views.listItemView(listItemUri, params.actor, hydration)
+        : undefined,
+    }
+  })
+  return { listsWithMembership, cursor }
+}
+
+type Context = {
+  hydrator: Hydrator
+  views: Views
+}
+
+type Params = QueryParams & {
+  hydrateCtx: HydrateCtx & { viewer: string }
+}
+
+type SkeletonState = {
+  listUris: string[]
+  cursor?: string
+}

--- a/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
@@ -71,9 +71,12 @@ const hydration = async (
   input: HydrationFnInput<Context, Params, SkeletonState>,
 ) => {
   const { ctx, params, skeleton } = input
-  const { actor } = params
-  const { listUris } = skeleton
-  return ctx.hydrator.hydrateListsMembership(listUris, actor, params.hydrateCtx)
+  const { actorDid, listUris } = skeleton
+  return ctx.hydrator.hydrateListsMembership(
+    listUris,
+    actorDid,
+    params.hydrateCtx,
+  )
 }
 
 const filterPurposes = (

--- a/packages/bsky/src/api/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -1,0 +1,170 @@
+import { mapDefined } from '@atproto/common'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context'
+import { ListMembershipState } from '../../../../hydration/graph'
+import {
+  HydrateCtx,
+  HydrationState,
+  Hydrator,
+  mergeManyStates,
+} from '../../../../hydration/hydrator'
+import { HydrationMap } from '../../../../hydration/util'
+import { Server } from '../../../../lexicon'
+import {
+  OutputSchema,
+  QueryParams,
+} from '../../../../lexicon/types/app/bsky/graph/getStarterPacksWithMembership'
+import {
+  HydrationFnInput,
+  PresentationFnInput,
+  SkeletonFnInput,
+  createPipeline,
+  noRules,
+} from '../../../../pipeline'
+import { Views } from '../../../../views'
+import { clearlyBadCursor, resHeaders } from '../../../util'
+
+export default function (server: Server, ctx: AppContext) {
+  const getStarterPacksWithMembership = createPipeline(
+    skeleton,
+    hydration,
+    noRules,
+    presentation,
+  )
+  server.app.bsky.graph.getStarterPacksWithMembership({
+    auth: ctx.authVerifier.standard,
+    handler: async ({ params, auth, req }) => {
+      const viewer = auth.credentials.iss
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+      })
+      const result = await getStarterPacksWithMembership(
+        { ...params, hydrateCtx: hydrateCtx.copy({ viewer }) },
+        ctx,
+      )
+
+      return {
+        encoding: 'application/json',
+        body: result,
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}
+
+const skeleton = async (
+  input: SkeletonFnInput<Context, Params>,
+): Promise<SkeletonState> => {
+  const { ctx, params } = input
+  if (clearlyBadCursor(params.cursor)) {
+    return { listUris: [], starterPackUris: [] }
+  }
+
+  const [did] = await ctx.hydrator.actor.getDids([params.actor])
+  if (!did) throw new InvalidRequestError('Profile not found')
+
+  const { uris: starterPackUris, cursor } =
+    await ctx.hydrator.dataplane.getActorStarterPacks({
+      actorDid: params.hydrateCtx.viewer,
+      cursor: params.cursor,
+      limit: params.limit,
+    })
+
+  const starterPackRecords =
+    await ctx.hydrator.graph.getStarterPacks(starterPackUris)
+  const listUris = mapDefined([...starterPackRecords.values()], (sp) => {
+    if (!sp) return
+    return sp.record.list
+  })
+
+  return { listUris, starterPackUris, cursor: cursor || undefined }
+}
+
+const hydration = async (
+  input: HydrationFnInput<Context, Params, SkeletonState>,
+) => {
+  const { ctx, params, skeleton } = input
+  const { actor } = params
+  const { listUris, starterPackUris } = skeleton
+
+  const [
+    spHydrationState,
+    actorsHydrationState,
+    listsHydrationState,
+    { listitemUris: listItemUris },
+  ] = await Promise.all([
+    ctx.hydrator.hydrateStarterPacksBasic(starterPackUris, params.hydrateCtx),
+    ctx.hydrator.hydrateProfiles([actor], params.hydrateCtx),
+    ctx.hydrator.hydrateLists(listUris, params.hydrateCtx),
+    ctx.hydrator.dataplane.getListMembership({
+      actorDid: actor,
+      listUris,
+    }),
+  ])
+
+  const listMembershipHydrationState: HydrationState = {
+    listMemberships: listUris.reduce((acc, cur, i) => {
+      const userMap = new HydrationMap<ListMembershipState>()
+
+      const listItemUri = listItemUris[i]
+      if (listItemUri) {
+        userMap.set(actor, {
+          actorListItemUri: listItemUri,
+        } satisfies ListMembershipState)
+      }
+
+      acc.set(cur, userMap)
+      return acc
+    }, new HydrationMap<HydrationMap<ListMembershipState>>()),
+  }
+
+  return mergeManyStates(
+    spHydrationState,
+    actorsHydrationState,
+    listsHydrationState,
+    listMembershipHydrationState,
+  )
+}
+
+const presentation = (
+  input: PresentationFnInput<Context, Params, SkeletonState>,
+): OutputSchema => {
+  const { ctx, params, skeleton, hydration } = input
+  const { listUris, starterPackUris: spUri, cursor } = skeleton
+
+  let i = 0
+  const starterPacksWithMembership = mapDefined(spUri, (starterPackUri) => {
+    const listUri = listUris[i++]
+    const starterPack = ctx.views.starterPackBasic(starterPackUri, hydration)
+    if (!starterPack) return
+
+    const listItemUri = hydration.listMemberships
+      ?.get(listUri)
+      ?.get(params.actor)?.actorListItemUri
+
+    return {
+      starterPack,
+      listItem: listItemUri
+        ? ctx.views.listItemView(listItemUri, params.actor, hydration)
+        : undefined,
+    }
+  })
+  return { starterPacksWithMembership, cursor }
+}
+
+type Context = {
+  hydrator: Hydrator
+  views: Views
+}
+
+type Params = QueryParams & {
+  hydrateCtx: HydrateCtx & { viewer: string }
+}
+
+type SkeletonState = {
+  listUris: string[]
+  starterPackUris: string[]
+  cursor?: string
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -29,6 +29,7 @@ import getList from './app/bsky/graph/getList'
 import getListBlocks from './app/bsky/graph/getListBlocks'
 import getListMutes from './app/bsky/graph/getListMutes'
 import getLists from './app/bsky/graph/getLists'
+import getListsWithMembership from './app/bsky/graph/getListsWithMembership'
 import getMutes from './app/bsky/graph/getMutes'
 import getRelationships from './app/bsky/graph/getRelationships'
 import getStarterPack from './app/bsky/graph/getStarterPack'
@@ -108,6 +109,7 @@ export default function (server: Server, ctx: AppContext) {
   getFollows(server, ctx)
   getList(server, ctx)
   getLists(server, ctx)
+  getListsWithMembership(server, ctx)
   getListMutes(server, ctx)
   getMutes(server, ctx)
   getRelationships(server, ctx)

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -34,6 +34,7 @@ import getMutes from './app/bsky/graph/getMutes'
 import getRelationships from './app/bsky/graph/getRelationships'
 import getStarterPack from './app/bsky/graph/getStarterPack'
 import getStarterPacks from './app/bsky/graph/getStarterPacks'
+import getStarterPacksWithMembership from './app/bsky/graph/getStarterPacksWithMembership'
 import getSuggestedFollowsByActor from './app/bsky/graph/getSuggestedFollowsByActor'
 import muteActor from './app/bsky/graph/muteActor'
 import muteActorList from './app/bsky/graph/muteActorList'
@@ -115,6 +116,7 @@ export default function (server: Server, ctx: AppContext) {
   getRelationships(server, ctx)
   getStarterPack(server, ctx)
   getStarterPacks(server, ctx)
+  getStarterPacksWithMembership(server, ctx)
   searchStarterPacks(server, ctx)
   muteActor(server, ctx)
   unmuteActor(server, ctx)

--- a/packages/bsky/src/hydration/graph.ts
+++ b/packages/bsky/src/hydration/graph.ts
@@ -22,6 +22,14 @@ export type ListViewerState = {
 
 export type ListViewerStates = HydrationMap<ListViewerState>
 
+export type ListMembershipState = {
+  actorListItemUri?: string
+}
+// list uri => actor did => state
+export type ListMembershipStates = HydrationMap<
+  HydrationMap<ListMembershipState>
+>
+
 export type Follow = RecordInfo<FollowRecord>
 export type Follows = HydrationMap<Follow>
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -384,27 +384,25 @@ export class Hydrator {
       }),
     ])
 
-    const listMembershipHydrationState: HydrationState = {
-      listMemberships: uris.reduce((acc, cur, i) => {
-        const userMap = new HydrationMap<ListMembershipState>()
-
+    // mapping uri -> did -> { actorListItemUri }
+    const listMemberships = new HydrationMap(
+      uris.map((uri, i) => {
         const listItemUri = listItemUris[i]
-        if (listItemUri) {
-          userMap.set(did, {
-            actorListItemUri: listItemUri,
-          } satisfies ListMembershipState)
-        }
-
-        acc.set(cur, userMap)
-        return acc
-      }, new HydrationMap<HydrationMap<ListMembershipState>>()),
-    }
-
-    return mergeManyStates(
-      actorsHydrationState,
-      listsHydrationState,
-      listMembershipHydrationState,
+        return [
+          uri,
+          new HydrationMap<ListMembershipState>([
+            listItemUri
+              ? [did, { actorListItemUri: listItemUri }]
+              : [did, null],
+          ]),
+        ]
+      }),
     )
+
+    return mergeManyStates(actorsHydrationState, listsHydrationState, {
+      listMemberships,
+      ctx,
+    })
   }
 
   // app.bsky.feed.defs#postView

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -43,6 +43,7 @@ import {
   GraphHydrator,
   ListAggs,
   ListItems,
+  ListMembershipStates,
   ListViewerStates,
   Lists,
   RelationshipPair,
@@ -109,6 +110,7 @@ export type HydrationState = {
   postgates?: Postgates
   lists?: Lists
   listAggs?: ListAggs
+  listMemberships?: ListMembershipStates
   listViewers?: ListViewerStates
   listItems?: ListItems
   likes?: Likes
@@ -1356,6 +1358,7 @@ export const mergeStates = (
     postgates: mergeMaps(stateA.postgates, stateB.postgates),
     lists: mergeMaps(stateA.lists, stateB.lists),
     listAggs: mergeMaps(stateA.listAggs, stateB.listAggs),
+    listMemberships: mergeMaps(stateA.listMemberships, stateB.listMemberships),
     listViewers: mergeMaps(stateA.listViewers, stateB.listViewers),
     listItems: mergeMaps(stateA.listItems, stateB.listItems),
     likes: mergeMaps(stateA.likes, stateB.likes),

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -132,6 +132,7 @@ import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
 import * as AppBskyGraphGetStarterPacks from './types/app/bsky/graph/getStarterPacks.js'
+import * as AppBskyGraphGetStarterPacksWithMembership from './types/app/bsky/graph/getStarterPacksWithMembership.js'
 import * as AppBskyGraphGetSuggestedFollowsByActor from './types/app/bsky/graph/getSuggestedFollowsByActor.js'
 import * as AppBskyGraphMuteActor from './types/app/bsky/graph/muteActor.js'
 import * as AppBskyGraphMuteActorList from './types/app/bsky/graph/muteActorList.js'
@@ -1883,6 +1884,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getStarterPacks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getStarterPacksWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetStarterPacksWithMembership.QueryParams,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerInput,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getStarterPacksWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -127,6 +127,7 @@ import * as AppBskyGraphGetList from './types/app/bsky/graph/getList.js'
 import * as AppBskyGraphGetListBlocks from './types/app/bsky/graph/getListBlocks.js'
 import * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes.js'
 import * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists.js'
+import * as AppBskyGraphGetListsWithMembership from './types/app/bsky/graph/getListsWithMembership.js'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
@@ -1822,6 +1823,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getLists' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getListsWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetListsWithMembership.QueryParams,
+      AppBskyGraphGetListsWithMembership.HandlerInput,
+      AppBskyGraphGetListsWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getListsWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8991,6 +8991,81 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetListsWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getListsWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the lists created by the session user, and includes membership information about `actor` in those lists. Only supports curation and moderation lists (no reference lists, used in starter packs). Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['listsWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              listsWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getListsWithMembership#listWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      listWithMembership: {
+        description:
+          'A list and an optional list item indicating membership of a target user to that list.',
+        type: 'object',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listView',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetMutes: {
     lexicon: 1,
     id: 'app.bsky.graph.getMutes',
@@ -13605,6 +13680,7 @@ export const ids = {
   AppBskyGraphGetListBlocks: 'app.bsky.graph.getListBlocks',
   AppBskyGraphGetListMutes: 'app.bsky.graph.getListMutes',
   AppBskyGraphGetLists: 'app.bsky.graph.getLists',
+  AppBskyGraphGetListsWithMembership: 'app.bsky.graph.getListsWithMembership',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8958,6 +8958,15 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
           },
         },
         output: {

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -9246,6 +9246,72 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetStarterPacksWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getStarterPacksWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the starter packs created by the session user, and includes membership information about `actor` in those starter packs. Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['starterPacksWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              starterPacksWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      starterPackWithMembership: {
+        description:
+          'A starter pack and an optional list item indicating membership of a target user to that starter pack.',
+        type: 'object',
+        required: ['starterPack'],
+        properties: {
+          starterPack: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetSuggestedFollowsByActor: {
     lexicon: 1,
     id: 'app.bsky.graph.getSuggestedFollowsByActor',
@@ -13685,6 +13751,8 @@ export const ids = {
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',
   AppBskyGraphGetStarterPacks: 'app.bsky.graph.getStarterPacks',
+  AppBskyGraphGetStarterPacksWithMembership:
+    'app.bsky.graph.getStarterPacksWithMembership',
   AppBskyGraphGetSuggestedFollowsByActor:
     'app.bsky.graph.getSuggestedFollowsByActor',
   AppBskyGraphList: 'app.bsky.graph.list',

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -9302,7 +9302,7 @@ export const schemaDict = {
         properties: {
           starterPack: {
             type: 'ref',
-            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+            ref: 'lex:app.bsky.graph.defs#starterPackView',
           },
           listItem: {
             type: 'ref',

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -20,6 +20,8 @@ export type QueryParams = {
   actor: string
   limit: number
   cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
 }
 export type InputSchema = undefined
 

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
@@ -1,0 +1,63 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getListsWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  listsWithMembership: ListWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A list and an optional list item indicating membership of a target user to that list. */
+export interface ListWithMembership {
+  $type?: 'app.bsky.graph.getListsWithMembership#listWithMembership'
+  list: AppBskyGraphDefs.ListView
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashListWithMembership = 'listWithMembership'
+
+export function isListWithMembership<V>(v: V) {
+  return is$typed(v, id, hashListWithMembership)
+}
+
+export function validateListWithMembership<V>(v: V) {
+  return validate<ListWithMembership & V>(v, id, hashListWithMembership)
+}

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -46,7 +46,7 @@ export type HandlerOutput = HandlerError | HandlerSuccess
 /** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
 export interface StarterPackWithMembership {
   $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
-  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  starterPack: AppBskyGraphDefs.StarterPackView
   listItem?: AppBskyGraphDefs.ListItemView
 }
 

--- a/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -1,0 +1,65 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getStarterPacksWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  starterPacksWithMembership: StarterPackWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
+export interface StarterPackWithMembership {
+  $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
+  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashStarterPackWithMembership = 'starterPackWithMembership'
+
+export function isStarterPackWithMembership<V>(v: V) {
+  return is$typed(v, id, hashStarterPackWithMembership)
+}
+
+export function validateStarterPackWithMembership<V>(v: V) {
+  return validate<StarterPackWithMembership & V>(
+    v,
+    id,
+    hashStarterPackWithMembership,
+  )
+}

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -44,6 +44,7 @@ import {
 import { Record as RepostRecord } from '../lexicon/types/app/bsky/feed/repost'
 import { isListRule } from '../lexicon/types/app/bsky/feed/threadgate'
 import {
+  ListItemView,
   ListView,
   ListViewBasic,
   StarterPackView,
@@ -623,6 +624,16 @@ export class Views {
           }
         : undefined,
     }
+  }
+
+  listItemView(
+    uri: string,
+    did: string,
+    state: HydrationState,
+  ): Un$Typed<ListItemView> | undefined {
+    const subject = this.profile(did, state)
+    if (!subject) return
+    return { uri, subject }
   }
 
   starterPackBasic(

--- a/packages/bsky/tests/views/__snapshots__/lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/lists.test.ts.snap
@@ -139,8 +139,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "listItemCount": 0,
-    "name": "cool curate list",
-    "purpose": "app.bsky.graph.defs#curatelist",
+    "name": "mod2",
+    "purpose": "app.bsky.graph.defs#modlist",
     "uri": "record(0)",
   },
   Object {
@@ -157,10 +157,86 @@ Array [
     },
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
-    "listItemCount": 3,
-    "name": "blah curate list!",
-    "purpose": "app.bsky.graph.defs#curatelist",
+    "listItemCount": 0,
+    "name": "mod1",
+    "purpose": "app.bsky.graph.defs#modlist",
     "uri": "record(1)",
+  },
+  Object {
+    "cid": "cids(2)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 2,
+    "name": "mod0",
+    "purpose": "app.bsky.graph.defs#modlist",
+    "uri": "record(2)",
+  },
+  Object {
+    "cid": "cids(3)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 0,
+    "name": "cur2",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(3)",
+  },
+  Object {
+    "cid": "cids(4)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 0,
+    "name": "cur1",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(4)",
+  },
+  Object {
+    "cid": "cids(5)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 3,
+    "name": "cur0",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(5)",
   },
 ]
 `;
@@ -471,8 +547,8 @@ Array [
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
     "listItemCount": 0,
-    "name": "cool curate list",
-    "purpose": "app.bsky.graph.defs#curatelist",
+    "name": "mod2",
+    "purpose": "app.bsky.graph.defs#modlist",
     "uri": "record(0)",
   },
   Object {
@@ -489,10 +565,86 @@ Array [
     },
     "indexedAt": "1970-01-01T00:00:00.000Z",
     "labels": Array [],
-    "listItemCount": 3,
-    "name": "blah curate list!",
-    "purpose": "app.bsky.graph.defs#curatelist",
+    "listItemCount": 0,
+    "name": "mod1",
+    "purpose": "app.bsky.graph.defs#modlist",
     "uri": "record(1)",
+  },
+  Object {
+    "cid": "cids(2)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 2,
+    "name": "mod0",
+    "purpose": "app.bsky.graph.defs#modlist",
+    "uri": "record(2)",
+  },
+  Object {
+    "cid": "cids(3)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 0,
+    "name": "cur2",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(3)",
+  },
+  Object {
+    "cid": "cids(4)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 0,
+    "name": "cur1",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(4)",
+  },
+  Object {
+    "cid": "cids(5)",
+    "creator": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "eve.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+    "labels": Array [],
+    "listItemCount": 3,
+    "name": "cur0",
+    "purpose": "app.bsky.graph.defs#curatelist",
+    "uri": "record(5)",
   },
 ]
 `;

--- a/packages/bsky/tests/views/lists.test.ts
+++ b/packages/bsky/tests/views/lists.test.ts
@@ -2,6 +2,10 @@ import { AtpAgent } from '@atproto/api'
 import { SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
 import { ids } from '../../src/lexicon/lexicons'
 import { OutputSchema as GetListsOutputSchema } from '../../src/lexicon/types/app/bsky/graph/getLists'
+import {
+  ListWithMembership,
+  OutputSchema as GetListsWithMembershipOutputSchema,
+} from '../../src/lexicon/types/app/bsky/graph/getListsWithMembership'
 import { forSnapshot, paginateAll } from '../_util'
 
 describe('bsky actor likes feed views', () => {
@@ -12,6 +16,11 @@ describe('bsky actor likes feed views', () => {
   let blockList: string
   let curateList: string
   let referenceList: string
+  let eveListItemCur: string
+  let frankieListItemCur: string
+  let frankieListItemMod: string
+  let gretaListItemMod: string
+
   let alice: string
   let eve: string
   let frankie: string
@@ -48,15 +57,31 @@ describe('bsky actor likes feed views', () => {
     const newCurList = await sc.createList(sc.dids.eve, 'cur0', 'curate')
     await sc.createList(sc.dids.eve, 'cur1', 'curate')
     await sc.createList(sc.dids.eve, 'cur2', 'curate')
-    await sc.addToList(sc.dids.eve, sc.dids.eve, newCurList)
+    const newEveListItemCur = await sc.addToList(
+      sc.dids.eve,
+      sc.dids.eve,
+      newCurList,
+    )
     await sc.addToList(sc.dids.eve, sc.dids.bob, newCurList)
-    await sc.addToList(sc.dids.eve, sc.dids.frankie, newCurList)
+    const newFrankieListItemCur = await sc.addToList(
+      sc.dids.eve,
+      sc.dids.frankie,
+      newCurList,
+    )
 
     const newBlockList = await sc.createList(sc.dids.eve, 'mod0', 'mod')
     await sc.createList(sc.dids.eve, 'mod1', 'mod')
     await sc.createList(sc.dids.eve, 'mod2', 'mod')
-    await sc.addToList(sc.dids.eve, sc.dids.frankie, newBlockList)
-    await sc.addToList(sc.dids.eve, sc.dids.greta, newBlockList)
+    const newFrankieListItemMod = await sc.addToList(
+      sc.dids.eve,
+      sc.dids.frankie,
+      newBlockList,
+    )
+    const newGretaListItemMod = await sc.addToList(
+      sc.dids.eve,
+      sc.dids.greta,
+      newBlockList,
+    )
 
     await sc.block(sc.dids.frankie, sc.dids.greta)
     await sc.block(sc.dids.frankie, sc.dids.eve)
@@ -65,6 +90,12 @@ describe('bsky actor likes feed views', () => {
     blockList = newBlockList.uriStr
     curateList = newCurList.uriStr
     referenceList = newRefList.uriStr
+
+    eveListItemCur = newEveListItemCur.uriStr
+    frankieListItemCur = newFrankieListItemCur.uriStr
+    frankieListItemMod = newFrankieListItemMod.uriStr
+    gretaListItemMod = newGretaListItemMod.uriStr
+
     alice = sc.dids.alice
     eve = sc.dids.eve
     frankie = sc.dids.frankie
@@ -235,5 +266,146 @@ describe('bsky actor likes feed views', () => {
     )
     expect(view.data.items.length).toBe(2)
     expect(forSnapshot(view.data.items)).toMatchSnapshot()
+  })
+
+  describe('list membership', () => {
+    const uriSort = (a: string, b: string) => (a > b ? 1 : -1)
+    const membershipsUris = (lwms: ListWithMembership[]): string[] =>
+      lwms
+        .map((lwm) => lwm.listItem?.uri)
+        .filter((li): li is string => typeof li === 'string')
+        .sort(uriSort)
+
+    it('returns all lists by the user', async () => {
+      const view = await agent.app.bsky.graph.getListsWithMembership(
+        { actor: frankie },
+        {
+          headers: await network.serviceHeaders(
+            eve,
+            ids.AppBskyGraphGetListsWithMembership,
+          ),
+        },
+      )
+      expect(view.data.listsWithMembership.length).toBe(6)
+    })
+
+    it('finds self membership', async () => {
+      const view = await agent.app.bsky.graph.getListsWithMembership(
+        { actor: eve },
+        {
+          headers: await network.serviceHeaders(
+            eve,
+            ids.AppBskyGraphGetListsWithMembership,
+          ),
+        },
+      )
+
+      expect(view.data.listsWithMembership.length).toBe(6)
+      const memberships = membershipsUris(view.data.listsWithMembership)
+      const expectedMemberships = [eveListItemCur].sort(uriSort)
+      expect(memberships).toEqual(expectedMemberships)
+    })
+
+    it('finds membership in curatelist and modlist if actor is in both and purpose filter includes both', async () => {
+      const view = await agent.app.bsky.graph.getListsWithMembership(
+        { actor: frankie },
+        {
+          headers: await network.serviceHeaders(
+            eve,
+            ids.AppBskyGraphGetListsWithMembership,
+          ),
+        },
+      )
+
+      expect(view.data.listsWithMembership.length).toBe(6)
+      const memberships = membershipsUris(view.data.listsWithMembership)
+      const expectedMemberships = [frankieListItemCur, frankieListItemMod].sort(
+        uriSort,
+      )
+      expect(memberships).toEqual(expectedMemberships)
+    })
+
+    it('finds modlist membership filtering by modlist', async () => {
+      const view = await agent.app.bsky.graph.getListsWithMembership(
+        { actor: greta, purposes: ['modlist'] },
+        {
+          headers: await network.serviceHeaders(
+            eve,
+            ids.AppBskyGraphGetListsWithMembership,
+          ),
+        },
+      )
+
+      expect(view.data.listsWithMembership.length).toBe(3)
+      const memberships = membershipsUris(view.data.listsWithMembership)
+      const expectedMemberships = [gretaListItemMod].sort(uriSort)
+      expect(memberships).toEqual(expectedMemberships)
+    })
+
+    it('does not find modlist membership filtering by curatelist', async () => {
+      const view = await agent.app.bsky.graph.getListsWithMembership(
+        { actor: greta, purposes: ['curatelist'] },
+        {
+          headers: await network.serviceHeaders(
+            eve,
+            ids.AppBskyGraphGetListsWithMembership,
+          ),
+        },
+      )
+
+      expect(view.data.listsWithMembership.length).toBe(3)
+      const memberships = membershipsUris(view.data.listsWithMembership)
+      expect(memberships.length).toBe(0)
+    })
+
+    it.each([
+      { expected: 6, purposes: [] },
+      { expected: 6, purposes: ['curatelist', 'modlist'] },
+      { expected: 3, purposes: ['curatelist'] },
+      { expected: 3, purposes: ['modlist'] },
+      { expected: 0, purposes: ['referencelist'] }, // not supported on getLists.
+    ])(
+      'paginates for purposes filter: $purposes',
+      async ({ expected, purposes }) => {
+        const results = (out: GetListsWithMembershipOutputSchema[]) =>
+          out.flatMap((res) => res.listsWithMembership)
+        const paginator = async (cursor?: string) => {
+          const res = await agent.app.bsky.graph.getListsWithMembership(
+            { actor: eve, purposes, limit: 2, cursor },
+            {
+              headers: await network.serviceHeaders(
+                eve,
+                ids.AppBskyGraphGetListsWithMembership,
+              ),
+            },
+          )
+          return res.data
+        }
+
+        const paginatedAll = await paginateAll(paginator)
+        paginatedAll.forEach((res) =>
+          expect(res.listsWithMembership.length).toBeLessThanOrEqual(2),
+        )
+
+        const full = await agent.app.bsky.graph.getListsWithMembership(
+          { actor: eve, purposes },
+          {
+            headers: await network.serviceHeaders(
+              eve,
+              ids.AppBskyGraphGetListsWithMembership,
+            ),
+          },
+        )
+        expect(full.data.listsWithMembership.length).toBe(expected)
+
+        const sortedFull = results([full.data]).sort((a, b) =>
+          a.list.uri > b.list.uri ? 1 : -1,
+        )
+        const sortedPaginated = results(paginatedAll).sort((a, b) =>
+          a.list.uri > b.list.uri ? 1 : -1,
+        )
+        expect(sortedPaginated).toEqual(sortedFull)
+      },
+    )
   })
 })

--- a/packages/bsky/tests/views/lists.test.ts
+++ b/packages/bsky/tests/views/lists.test.ts
@@ -1,13 +1,15 @@
 import { AtpAgent } from '@atproto/api'
 import { SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
 import { ids } from '../../src/lexicon/lexicons'
-import { forSnapshot } from '../_util'
+import { OutputSchema as GetListsOutputSchema } from '../../src/lexicon/types/app/bsky/graph/getLists'
+import { forSnapshot, paginateAll } from '../_util'
 
 describe('bsky actor likes feed views', () => {
   let network: TestNetwork
   let agent: AtpAgent
   let sc: SeedClient
 
+  let blockList: string
   let curateList: string
   let referenceList: string
   let alice: string
@@ -38,29 +40,30 @@ describe('bsky actor likes feed views', () => {
       password: 'hunter4real',
     })
 
-    const newRefList = await sc.createList(
-      sc.dids.eve,
-      'blah starter pack list!',
-      'reference',
-    )
-    const newCurrList = await sc.createList(
-      sc.dids.eve,
-      'blah curate list!',
-      'curate',
-    )
-
+    const newRefList = await sc.createList(sc.dids.eve, 'ref0', 'reference')
     await sc.addToList(sc.dids.eve, sc.dids.eve, newRefList)
     await sc.addToList(sc.dids.eve, sc.dids.bob, newRefList)
     await sc.addToList(sc.dids.eve, sc.dids.frankie, newRefList)
 
-    await sc.addToList(sc.dids.eve, sc.dids.eve, newCurrList)
-    await sc.addToList(sc.dids.eve, sc.dids.bob, newCurrList)
-    await sc.addToList(sc.dids.eve, sc.dids.frankie, newCurrList)
+    const newCurList = await sc.createList(sc.dids.eve, 'cur0', 'curate')
+    await sc.createList(sc.dids.eve, 'cur1', 'curate')
+    await sc.createList(sc.dids.eve, 'cur2', 'curate')
+    await sc.addToList(sc.dids.eve, sc.dids.eve, newCurList)
+    await sc.addToList(sc.dids.eve, sc.dids.bob, newCurList)
+    await sc.addToList(sc.dids.eve, sc.dids.frankie, newCurList)
 
+    const newBlockList = await sc.createList(sc.dids.eve, 'mod0', 'mod')
+    await sc.createList(sc.dids.eve, 'mod1', 'mod')
+    await sc.createList(sc.dids.eve, 'mod2', 'mod')
+    await sc.addToList(sc.dids.eve, sc.dids.frankie, newBlockList)
+    await sc.addToList(sc.dids.eve, sc.dids.greta, newBlockList)
+
+    await sc.block(sc.dids.frankie, sc.dids.greta)
     await sc.block(sc.dids.frankie, sc.dids.eve)
 
     await network.processAll()
-    curateList = newCurrList.uriStr
+    blockList = newBlockList.uriStr
+    curateList = newCurList.uriStr
     referenceList = newRefList.uriStr
     alice = sc.dids.alice
     eve = sc.dids.eve
@@ -73,12 +76,10 @@ describe('bsky actor likes feed views', () => {
   })
 
   it('does not include reference lists in getActorLists', async () => {
-    await sc.createList(eve, 'cool curate list', 'curate')
-    await network.processAll()
-    const view = await agent.api.app.bsky.graph.getLists({
+    const view = await agent.app.bsky.graph.getLists({
       actor: eve,
     })
-    expect(view.data.lists.length).toBe(2)
+    expect(view.data.lists.length).toBe(6)
     expect(forSnapshot(view.data.lists)).toMatchSnapshot()
   })
 
@@ -86,12 +87,79 @@ describe('bsky actor likes feed views', () => {
     const view = await agent.app.bsky.graph.getLists({
       actor: 'eve.test',
     })
-    expect(view.data.lists.length).toBe(2)
+    expect(view.data.lists.length).toBe(6)
     expect(forSnapshot(view.data.lists)).toMatchSnapshot()
   })
 
+  it('allows filtering by list purpose', async () => {
+    const viewCurate = await agent.app.bsky.graph.getLists({
+      actor: eve,
+      purposes: ['curatelist'],
+    })
+    expect(viewCurate.data.lists.length).toBe(3)
+
+    const viewMod = await agent.app.bsky.graph.getLists({
+      actor: eve,
+      purposes: ['modlist'],
+    })
+    expect(viewMod.data.lists.length).toBe(3)
+
+    const viewAll = await agent.app.bsky.graph.getLists({
+      actor: eve,
+      purposes: ['curatelist', 'modlist'],
+    })
+    expect(viewAll.data.lists.length).toBe(6)
+  })
+
+  it.each([
+    { expected: 6, purposes: [] },
+    { expected: 6, purposes: ['curatelist', 'modlist'] },
+    { expected: 3, purposes: ['curatelist'] },
+    { expected: 3, purposes: ['modlist'] },
+    { expected: 0, purposes: ['referencelist'] }, // not supported on getLists.
+  ])(
+    'paginates for purposes filter: $purposes',
+    async ({ expected, purposes }) => {
+      const results = (out: GetListsOutputSchema[]) =>
+        out.flatMap((res) => res.lists)
+      const paginator = async (cursor?: string) => {
+        const res = await agent.app.bsky.graph.getLists(
+          { actor: eve, purposes, limit: 2, cursor },
+          {
+            headers: await network.serviceHeaders(
+              eve,
+              ids.AppBskyGraphGetLists,
+            ),
+          },
+        )
+        return res.data
+      }
+
+      const paginatedAll = await paginateAll(paginator)
+      paginatedAll.forEach((res) =>
+        expect(res.lists.length).toBeLessThanOrEqual(2),
+      )
+
+      const full = await agent.app.bsky.graph.getLists(
+        { actor: eve, purposes },
+        {
+          headers: await network.serviceHeaders(eve, ids.AppBskyGraphGetLists),
+        },
+      )
+      expect(full.data.lists.length).toBe(expected)
+
+      const sortedFull = results([full.data]).sort((a, b) =>
+        a.uri > b.uri ? 1 : -1,
+      )
+      const sortedPaginated = results(paginatedAll).sort((a, b) =>
+        a.uri > b.uri ? 1 : -1,
+      )
+      expect(sortedPaginated).toEqual(sortedFull)
+    },
+  )
+
   it('does not include users with creator block relationship in reference lists for non-creator, in-list viewers', async () => {
-    const curView = await agent.api.app.bsky.graph.getList(
+    const curView = await agent.app.bsky.graph.getList(
       {
         list: curateList,
       },
@@ -102,7 +170,7 @@ describe('bsky actor likes feed views', () => {
     expect(curView.data.items.length).toBe(2)
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
-    const refView = await agent.api.app.bsky.graph.getList(
+    const refView = await agent.app.bsky.graph.getList(
       { list: referenceList },
       {
         headers: await network.serviceHeaders(frankie, ids.AppBskyGraphGetList),
@@ -113,7 +181,7 @@ describe('bsky actor likes feed views', () => {
   })
 
   it('does not include users with creator block relationship in reference lists for non-creator, not-in-list viewers', async () => {
-    const curView = await agent.api.app.bsky.graph.getList(
+    const curView = await agent.app.bsky.graph.getList(
       {
         list: curateList,
       },
@@ -122,7 +190,7 @@ describe('bsky actor likes feed views', () => {
     expect(curView.data.items.length).toBe(2)
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
-    const refView = await agent.api.app.bsky.graph.getList(
+    const refView = await agent.app.bsky.graph.getList(
       { list: referenceList },
       { headers: await network.serviceHeaders(greta, ids.AppBskyGraphGetList) },
     )
@@ -131,13 +199,13 @@ describe('bsky actor likes feed views', () => {
   })
 
   it('does not include users with creator block relationship in reference and curate lists for signed-out viewers', async () => {
-    const curView = await agent.api.app.bsky.graph.getList({
+    const curView = await agent.app.bsky.graph.getList({
       list: curateList,
     })
     expect(curView.data.items.length).toBe(2)
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
-    const refView = await agent.api.app.bsky.graph.getList({
+    const refView = await agent.app.bsky.graph.getList({
       list: referenceList,
     })
     expect(refView.data.items.length).toBe(2)
@@ -145,14 +213,14 @@ describe('bsky actor likes feed views', () => {
   })
 
   it('does include users with creator block relationship in reference lists for creator', async () => {
-    const curView = await agent.api.app.bsky.graph.getList(
+    const curView = await agent.app.bsky.graph.getList(
       { list: curateList },
       { headers: await network.serviceHeaders(eve, ids.AppBskyGraphGetList) },
     )
     expect(curView.data.items.length).toBe(3)
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
-    const refView = await agent.api.app.bsky.graph.getList(
+    const refView = await agent.app.bsky.graph.getList(
       { list: referenceList },
       { headers: await network.serviceHeaders(eve, ids.AppBskyGraphGetList) },
     )
@@ -161,14 +229,8 @@ describe('bsky actor likes feed views', () => {
   })
 
   it('does return all users regardless of creator block relationship in moderation lists', async () => {
-    const blockList = await sc.createList(eve, 'block list', 'mod')
-    await sc.addToList(eve, frankie, blockList)
-    await sc.addToList(eve, greta, blockList)
-    await sc.block(frankie, greta)
-    await network.processAll()
-
-    const view = await agent.api.app.bsky.graph.getList(
-      { list: blockList.uriStr },
+    const view = await agent.app.bsky.graph.getList(
+      { list: blockList },
       { headers: await network.serviceHeaders(alice, ids.AppBskyGraphGetList) },
     )
     expect(view.data.items.length).toBe(2)

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -127,6 +127,7 @@ import * as AppBskyGraphGetList from './types/app/bsky/graph/getList.js'
 import * as AppBskyGraphGetListBlocks from './types/app/bsky/graph/getListBlocks.js'
 import * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes.js'
 import * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists.js'
+import * as AppBskyGraphGetListsWithMembership from './types/app/bsky/graph/getListsWithMembership.js'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
@@ -1877,6 +1878,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getLists' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getListsWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetListsWithMembership.QueryParams,
+      AppBskyGraphGetListsWithMembership.HandlerInput,
+      AppBskyGraphGetListsWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getListsWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -132,6 +132,7 @@ import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
 import * as AppBskyGraphGetStarterPacks from './types/app/bsky/graph/getStarterPacks.js'
+import * as AppBskyGraphGetStarterPacksWithMembership from './types/app/bsky/graph/getStarterPacksWithMembership.js'
 import * as AppBskyGraphGetSuggestedFollowsByActor from './types/app/bsky/graph/getSuggestedFollowsByActor.js'
 import * as AppBskyGraphMuteActor from './types/app/bsky/graph/muteActor.js'
 import * as AppBskyGraphMuteActorList from './types/app/bsky/graph/muteActorList.js'
@@ -1938,6 +1939,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getStarterPacks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getStarterPacksWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetStarterPacksWithMembership.QueryParams,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerInput,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getStarterPacksWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8958,6 +8958,15 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
           },
         },
         output: {

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -9246,6 +9246,72 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetStarterPacksWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getStarterPacksWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the starter packs created by the session user, and includes membership information about `actor` in those starter packs. Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['starterPacksWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              starterPacksWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      starterPackWithMembership: {
+        description:
+          'A starter pack and an optional list item indicating membership of a target user to that starter pack.',
+        type: 'object',
+        required: ['starterPack'],
+        properties: {
+          starterPack: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetSuggestedFollowsByActor: {
     lexicon: 1,
     id: 'app.bsky.graph.getSuggestedFollowsByActor',
@@ -17893,6 +17959,8 @@ export const ids = {
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',
   AppBskyGraphGetStarterPacks: 'app.bsky.graph.getStarterPacks',
+  AppBskyGraphGetStarterPacksWithMembership:
+    'app.bsky.graph.getStarterPacksWithMembership',
   AppBskyGraphGetSuggestedFollowsByActor:
     'app.bsky.graph.getSuggestedFollowsByActor',
   AppBskyGraphList: 'app.bsky.graph.list',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -9302,7 +9302,7 @@ export const schemaDict = {
         properties: {
           starterPack: {
             type: 'ref',
-            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+            ref: 'lex:app.bsky.graph.defs#starterPackView',
           },
           listItem: {
             type: 'ref',

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8991,6 +8991,81 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetListsWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getListsWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the lists created by the session user, and includes membership information about `actor` in those lists. Only supports curation and moderation lists (no reference lists, used in starter packs). Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['listsWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              listsWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getListsWithMembership#listWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      listWithMembership: {
+        description:
+          'A list and an optional list item indicating membership of a target user to that list.',
+        type: 'object',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listView',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetMutes: {
     lexicon: 1,
     id: 'app.bsky.graph.getMutes',
@@ -17813,6 +17888,7 @@ export const ids = {
   AppBskyGraphGetListBlocks: 'app.bsky.graph.getListBlocks',
   AppBskyGraphGetListMutes: 'app.bsky.graph.getListMutes',
   AppBskyGraphGetLists: 'app.bsky.graph.getLists',
+  AppBskyGraphGetListsWithMembership: 'app.bsky.graph.getListsWithMembership',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -20,6 +20,8 @@ export type QueryParams = {
   actor: string
   limit: number
   cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
 }
 export type InputSchema = undefined
 

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
@@ -1,0 +1,63 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getListsWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  listsWithMembership: ListWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A list and an optional list item indicating membership of a target user to that list. */
+export interface ListWithMembership {
+  $type?: 'app.bsky.graph.getListsWithMembership#listWithMembership'
+  list: AppBskyGraphDefs.ListView
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashListWithMembership = 'listWithMembership'
+
+export function isListWithMembership<V>(v: V) {
+  return is$typed(v, id, hashListWithMembership)
+}
+
+export function validateListWithMembership<V>(v: V) {
+  return validate<ListWithMembership & V>(v, id, hashListWithMembership)
+}

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -46,7 +46,7 @@ export type HandlerOutput = HandlerError | HandlerSuccess
 /** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
 export interface StarterPackWithMembership {
   $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
-  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  starterPack: AppBskyGraphDefs.StarterPackView
   listItem?: AppBskyGraphDefs.ListItemView
 }
 

--- a/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -1,0 +1,65 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getStarterPacksWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  starterPacksWithMembership: StarterPackWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
+export interface StarterPackWithMembership {
+  $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
+  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashStarterPackWithMembership = 'starterPackWithMembership'
+
+export function isStarterPackWithMembership<V>(v: V) {
+  return is$typed(v, id, hashStarterPackWithMembership)
+}
+
+export function validateStarterPackWithMembership<V>(v: V) {
+  return validate<StarterPackWithMembership & V>(
+    v,
+    id,
+    hashStarterPackWithMembership,
+  )
+}

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -127,6 +127,7 @@ import * as AppBskyGraphGetList from './types/app/bsky/graph/getList.js'
 import * as AppBskyGraphGetListBlocks from './types/app/bsky/graph/getListBlocks.js'
 import * as AppBskyGraphGetListMutes from './types/app/bsky/graph/getListMutes.js'
 import * as AppBskyGraphGetLists from './types/app/bsky/graph/getLists.js'
+import * as AppBskyGraphGetListsWithMembership from './types/app/bsky/graph/getListsWithMembership.js'
 import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
@@ -1877,6 +1878,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getLists' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getListsWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetListsWithMembership.QueryParams,
+      AppBskyGraphGetListsWithMembership.HandlerInput,
+      AppBskyGraphGetListsWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getListsWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -132,6 +132,7 @@ import * as AppBskyGraphGetMutes from './types/app/bsky/graph/getMutes.js'
 import * as AppBskyGraphGetRelationships from './types/app/bsky/graph/getRelationships.js'
 import * as AppBskyGraphGetStarterPack from './types/app/bsky/graph/getStarterPack.js'
 import * as AppBskyGraphGetStarterPacks from './types/app/bsky/graph/getStarterPacks.js'
+import * as AppBskyGraphGetStarterPacksWithMembership from './types/app/bsky/graph/getStarterPacksWithMembership.js'
 import * as AppBskyGraphGetSuggestedFollowsByActor from './types/app/bsky/graph/getSuggestedFollowsByActor.js'
 import * as AppBskyGraphMuteActor from './types/app/bsky/graph/muteActor.js'
 import * as AppBskyGraphMuteActorList from './types/app/bsky/graph/muteActorList.js'
@@ -1938,6 +1939,18 @@ export class AppBskyGraphNS {
     >,
   ) {
     const nsid = 'app.bsky.graph.getStarterPacks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getStarterPacksWithMembership<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyGraphGetStarterPacksWithMembership.QueryParams,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerInput,
+      AppBskyGraphGetStarterPacksWithMembership.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.graph.getStarterPacksWithMembership' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8958,6 +8958,15 @@ export const schemaDict = {
             cursor: {
               type: 'string',
             },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
           },
         },
         output: {

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -9246,6 +9246,72 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetStarterPacksWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getStarterPacksWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the starter packs created by the session user, and includes membership information about `actor` in those starter packs. Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['starterPacksWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              starterPacksWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      starterPackWithMembership: {
+        description:
+          'A starter pack and an optional list item indicating membership of a target user to that starter pack.',
+        type: 'object',
+        required: ['starterPack'],
+        properties: {
+          starterPack: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetSuggestedFollowsByActor: {
     lexicon: 1,
     id: 'app.bsky.graph.getSuggestedFollowsByActor',
@@ -17893,6 +17959,8 @@ export const ids = {
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',
   AppBskyGraphGetStarterPacks: 'app.bsky.graph.getStarterPacks',
+  AppBskyGraphGetStarterPacksWithMembership:
+    'app.bsky.graph.getStarterPacksWithMembership',
   AppBskyGraphGetSuggestedFollowsByActor:
     'app.bsky.graph.getSuggestedFollowsByActor',
   AppBskyGraphList: 'app.bsky.graph.list',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -9302,7 +9302,7 @@ export const schemaDict = {
         properties: {
           starterPack: {
             type: 'ref',
-            ref: 'lex:app.bsky.graph.defs#starterPackViewBasic',
+            ref: 'lex:app.bsky.graph.defs#starterPackView',
           },
           listItem: {
             type: 'ref',

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8991,6 +8991,81 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyGraphGetListsWithMembership: {
+    lexicon: 1,
+    id: 'app.bsky.graph.getListsWithMembership',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Enumerates the lists created by the session user, and includes membership information about `actor` in those lists. Only supports curation and moderation lists (no reference lists, used in starter packs). Requires auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'at-identifier',
+              description: 'The account (actor) to check for membership.',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+            purposes: {
+              type: 'array',
+              description:
+                'Optional filter by list purpose. If not specified, all supported types are returned.',
+              items: {
+                type: 'string',
+                knownValues: ['modlist', 'curatelist'],
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['listsWithMembership'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              listsWithMembership: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.graph.getListsWithMembership#listWithMembership',
+                },
+              },
+            },
+          },
+        },
+      },
+      listWithMembership: {
+        description:
+          'A list and an optional list item indicating membership of a target user to that list.',
+        type: 'object',
+        required: ['list'],
+        properties: {
+          list: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listView',
+          },
+          listItem: {
+            type: 'ref',
+            ref: 'lex:app.bsky.graph.defs#listItemView',
+          },
+        },
+      },
+    },
+  },
   AppBskyGraphGetMutes: {
     lexicon: 1,
     id: 'app.bsky.graph.getMutes',
@@ -17813,6 +17888,7 @@ export const ids = {
   AppBskyGraphGetListBlocks: 'app.bsky.graph.getListBlocks',
   AppBskyGraphGetListMutes: 'app.bsky.graph.getListMutes',
   AppBskyGraphGetLists: 'app.bsky.graph.getLists',
+  AppBskyGraphGetListsWithMembership: 'app.bsky.graph.getListsWithMembership',
   AppBskyGraphGetMutes: 'app.bsky.graph.getMutes',
   AppBskyGraphGetRelationships: 'app.bsky.graph.getRelationships',
   AppBskyGraphGetStarterPack: 'app.bsky.graph.getStarterPack',

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getLists.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getLists.ts
@@ -20,6 +20,8 @@ export type QueryParams = {
   actor: string
   limit: number
   cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
 }
 export type InputSchema = undefined
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getListsWithMembership.ts
@@ -1,0 +1,63 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getListsWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+  /** Optional filter by list purpose. If not specified, all supported types are returned. */
+  purposes?: 'modlist' | 'curatelist' | (string & {})[]
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  listsWithMembership: ListWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A list and an optional list item indicating membership of a target user to that list. */
+export interface ListWithMembership {
+  $type?: 'app.bsky.graph.getListsWithMembership#listWithMembership'
+  list: AppBskyGraphDefs.ListView
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashListWithMembership = 'listWithMembership'
+
+export function isListWithMembership<V>(v: V) {
+  return is$typed(v, id, hashListWithMembership)
+}
+
+export function validateListWithMembership<V>(v: V) {
+  return validate<ListWithMembership & V>(v, id, hashListWithMembership)
+}

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -46,7 +46,7 @@ export type HandlerOutput = HandlerError | HandlerSuccess
 /** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
 export interface StarterPackWithMembership {
   $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
-  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  starterPack: AppBskyGraphDefs.StarterPackView
   listItem?: AppBskyGraphDefs.ListItemView
 }
 

--- a/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -1,0 +1,65 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyGraphDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.graph.getStarterPacksWithMembership'
+
+export type QueryParams = {
+  /** The account (actor) to check for membership. */
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  starterPacksWithMembership: StarterPackWithMembership[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** A starter pack and an optional list item indicating membership of a target user to that starter pack. */
+export interface StarterPackWithMembership {
+  $type?: 'app.bsky.graph.getStarterPacksWithMembership#starterPackWithMembership'
+  starterPack: AppBskyGraphDefs.StarterPackViewBasic
+  listItem?: AppBskyGraphDefs.ListItemView
+}
+
+const hashStarterPackWithMembership = 'starterPackWithMembership'
+
+export function isStarterPackWithMembership<V>(v: V) {
+  return is$typed(v, id, hashStarterPackWithMembership)
+}
+
+export function validateStarterPackWithMembership<V>(v: V) {
+  return validate<StarterPackWithMembership & V>(
+    v,
+    id,
+    hashStarterPackWithMembership,
+  )
+}


### PR DESCRIPTION
This makes a few improvements to our lists APIs. Easier to review each commit:
1. Adds `purpose` filtering to `app.bsky.graph.getList`.
2. Adds `app.bsky.graph.getListsWithMembership`.
3. Adds `app.bsky.graph.getStarterPacksWithMembership`.
4. Refactors common hydration between 2 and 3.
5. Changeset.

Currently, the client fetches from the PDS every single list item to check for membership, which can be quite a lot of data for lists with thousands of items.