### PR TITLE
Allow `"use"` claims only in public jwk

### DIFF
--- a/.changeset/heavy-kangaroos-care.md
+++ b/.changeset/heavy-kangaroos-care.md
@@ -1,0 +1,5 @@
+---
+"@atproto/jwk": patch
+---
+
+Silently ignore invalid JWKs from JSON Web Key Set (as per spec)

--- a/.changeset/selfish-wasps-return.md
+++ b/.changeset/selfish-wasps-return.md
@@ -1,0 +1,5 @@
+---
+"@atproto/jwk": minor
+---
+
+Update key matching algorithm to support `key_ops`

--- a/.changeset/shiny-seals-wave.md
+++ b/.changeset/shiny-seals-wave.md
@@ -1,0 +1,5 @@
+---
+"@atproto/jwk": patch
+---
+
+Avoid using `revoked` and inactive keys from JWK sets

--- a/.changeset/tough-emus-explain.md
+++ b/.changeset/tough-emus-explain.md
@@ -1,0 +1,6 @@
+---
+"@atproto/jwk-webcrypto": minor
+"@atproto/jwk": minor
+---
+
+Only allow `"use"` claims in public jwk

--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -47,6 +47,7 @@ jobs:
     name: Test
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
     runs-on: ubuntu-22.04

--- a/packages/oauth/jwk/src/jwk.ts
+++ b/packages/oauth/jwk/src/jwk.ts
@@ -1,45 +1,96 @@
 import { z } from 'zod'
+import { isLastOccurrence } from './util'
 
-export const keyUsageSchema = z.enum([
+export const PUBLIC_KEY_USAGE = ['verify', 'encrypt', 'wrapKey'] as const
+export const publicKeyUsageSchema = z.enum(PUBLIC_KEY_USAGE)
+export type PublicKeyUsage = (typeof PUBLIC_KEY_USAGE)[number]
+export function isPublicKeyUsage(usage: unknown): usage is PublicKeyUsage {
+  return (PUBLIC_KEY_USAGE as readonly unknown[]).includes(usage)
+}
+
+/**
+ * Determines if the given key usage is consistent for "sig" (signature) public
+ * key use.
+ */
+export function isSigKeyUsage(v: KeyUsage) {
+  return v === 'verify'
+}
+
+/**
+ * Determines if the given key usage is consistent for "enc" (encryption) public
+ * key use.
+ *
+ * > When a key is used to wrap another key and a public key use
+ * > designation for the first key is desired, the "enc" (encryption)
+ * > key use value is used, since key wrapping is a kind of encryption.
+ * > The "enc" value is also to be used for public keys used for key
+ * > agreement operations.
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7517#section-4.2}
+ */
+export function isEncKeyUsage(v: KeyUsage) {
+  return v === 'encrypt' || v === 'wrapKey'
+}
+
+export const PRIVATE_KEY_USAGE = [
   'sign',
-  'verify',
-  'encrypt',
   'decrypt',
-  'wrapKey',
   'unwrapKey',
   'deriveKey',
   'deriveBits',
-])
+] as const
+export const privateKeyUsageSchema = z.enum(PRIVATE_KEY_USAGE)
+export type PrivateKeyUsage = (typeof PRIVATE_KEY_USAGE)[number]
+export function isPrivateKeyUsage(usage: unknown): usage is PrivateKeyUsage {
+  return (PRIVATE_KEY_USAGE as readonly unknown[]).includes(usage)
+}
 
-export type KeyUsage = z.infer<typeof keyUsageSchema>
+export const KEY_USAGE = [...PRIVATE_KEY_USAGE, ...PUBLIC_KEY_USAGE] as const
+export const keyUsageSchema = z.enum(KEY_USAGE)
+export type KeyUsage = (typeof KEY_USAGE)[number]
 
 /**
- * The "use" and "key_ops" JWK members SHOULD NOT be used together;
- * however, if both are used, the information they convey MUST be
- * consistent.  Applications should specify which of these members they
- * use, if either is to be used by the application.
- *
- * @todo Actually check that "use" and "key_ops" are consistent when both are present.
- * @see {@link https://datatracker.ietf.org/doc/html/rfc7517#section-4.3}
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7517#section-4 JSON Web Key (JWK) Format}
+ * @see {@link https://www.iana.org/assignments/jose/jose.xhtml#web-key-parameters IANA "JSON Web Key Parameters" registry}
  */
-export const jwkBaseSchema = z.object({
-  kty: z.string().min(1),
+const jwkBaseSchema = z.object({
+  kty: z.string().min(1).optional(),
+  use: z.enum(['sig', 'enc']).optional(),
+  key_ops: z
+    .array(keyUsageSchema)
+    .min(1, { message: 'At least one key usage must be specified' })
+    // https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
+    // > Duplicate key operation values MUST NOT be present in the array.
+    .refine((ops) => ops.every(isLastOccurrence), {
+      message: 'key_ops must not contain duplicates',
+    })
+    .optional(),
   alg: z.string().min(1).optional(),
   kid: z.string().min(1).optional(),
-  ext: z.boolean().optional(),
-  use: z.enum(['sig', 'enc']).optional(),
-  key_ops: z.array(keyUsageSchema).optional(),
 
   x5c: z.array(z.string()).optional(), // X.509 Certificate Chain
   x5t: z.string().min(1).optional(), // X.509 Certificate SHA-1 Thumbprint
   'x5t#S256': z.string().min(1).optional(), // X.509 Certificate SHA-256 Thumbprint
   x5u: z.string().url().optional(), // X.509 URL
+
+  // https://www.w3.org/TR/webcrypto/
+  ext: z.boolean().optional(), // Extractable
+
+  // Federation Historical Keys Response
+  // https://openid.net/specs/openid-federation-1_0.html#name-federation-historical-keys-res
+  iat: z.number().int().optional(), // Issued At (timestamp)
+  exp: z.number().int().optional(), // Expiration Time (timestamp)
+  nbf: z.number().int().optional(), // Not Before (timestamp)
+  revoked: z //  properties of the revocation
+    .object({
+      revoked_at: z.number().int(),
+      reason: z.string().optional(),
+    })
+    .optional(),
 })
 
-/**
- * @todo: properly implement this
- */
-export const jwkRsaKeySchema = jwkBaseSchema.extend({
+export type JwkBase = z.infer<typeof jwkBaseSchema>
+
+const jwkRsaKeySchema = jwkBaseSchema.extend({
   kty: z.literal('RSA'),
   alg: z
     .enum(['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512'])
@@ -62,12 +113,11 @@ export const jwkRsaKeySchema = jwkBaseSchema.extend({
         t: z.string().optional(),
       }),
     )
-    .nonempty()
-
+    .min(1)
     .optional(), // Other Primes Info
 })
 
-export const jwkEcKeySchema = jwkBaseSchema.extend({
+const jwkEcKeySchema = jwkBaseSchema.extend({
   kty: z.literal('EC'),
   alg: z.enum(['ES256', 'ES384', 'ES512']).optional(),
   crv: z.enum(['P-256', 'P-384', 'P-521']),
@@ -78,7 +128,7 @@ export const jwkEcKeySchema = jwkBaseSchema.extend({
   d: z.string().min(1).optional(), // ECC Private Key
 })
 
-export const jwkEcSecp256k1KeySchema = jwkBaseSchema.extend({
+const jwkEcSecp256k1KeySchema = jwkBaseSchema.extend({
   kty: z.literal('EC'),
   alg: z.enum(['ES256K']).optional(),
   crv: z.enum(['secp256k1']),
@@ -89,7 +139,7 @@ export const jwkEcSecp256k1KeySchema = jwkBaseSchema.extend({
   d: z.string().min(1).optional(), // ECC Private Key
 })
 
-export const jwkOkpKeySchema = jwkBaseSchema.extend({
+const jwkOkpKeySchema = jwkBaseSchema.extend({
   kty: z.literal('OKP'),
   alg: z.enum(['EdDSA']).optional(),
   crv: z.enum(['Ed25519', 'Ed448']),
@@ -98,54 +148,116 @@ export const jwkOkpKeySchema = jwkBaseSchema.extend({
   d: z.string().min(1).optional(), // ECC Private Key
 })
 
-export const jwkSymKeySchema = jwkBaseSchema.extend({
+const jwkSymKeySchema = jwkBaseSchema.extend({
   kty: z.literal('oct'), // Octet Sequence (used to represent symmetric keys)
   alg: z.enum(['HS256', 'HS384', 'HS512']).optional(),
 
   k: z.string(), // Key Value (base64url encoded)
 })
 
-export const jwkUnknownKeySchema = jwkBaseSchema.extend({
-  kty: z
-    .string()
-    .refine((v) => v !== 'RSA' && v !== 'EC' && v !== 'OKP' && v !== 'oct'),
-})
-
+/**
+ * Zod parser for known JWK types
+ */
 export const jwkSchema = z
   .union([
-    jwkUnknownKeySchema,
     jwkRsaKeySchema,
     jwkEcKeySchema,
     jwkEcSecp256k1KeySchema,
     jwkOkpKeySchema,
     jwkSymKeySchema,
   ])
+  // @TODO These rules should be applied to jwkBaseSchema, but Zod 3 doesn't
+  // support extending refined schemas. Move these to the base schema when we
+  // upgrade to Zod 4.
   .refine(
-    (k) =>
-      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
-      // > The "use" parameter is employed to indicate whether a public key is
-      // > used for encrypting data or verifying the signature on data.
-      !k.use ||
-      !k.key_ops ||
-      k.key_ops.every(
-        k.use === 'sig' ? (o) => o === 'verify' : (o) => o === 'decrypt',
-      ),
+    // https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+    // > The "use" (public key use) parameter identifies the intended use of the
+    // > public key
+    (k): boolean => k.use == null || isPublicJwk(k),
     {
-      message: 'use and key_ops must be consistent',
+      message: '"use" can only be used with public keys',
+      path: ['use'],
+    },
+  )
+  .refine(
+    (k): boolean => !k.key_ops?.some(isPrivateKeyUsage) || isPrivateJwk(k),
+    {
+      message: 'private key usage not allowed for public keys',
+      path: ['key_ops'],
+    },
+  )
+  .refine(
+    // https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
+    // > The "use" and "key_ops" JWK members SHOULD NOT be used together;
+    // > however, if both are used, the information they convey MUST be
+    // > consistent.
+    (k): boolean =>
+      k.use == null ||
+      k.key_ops == null ||
+      (k.use === 'sig' && k.key_ops.every(isSigKeyUsage)) ||
+      (k.use === 'enc' && k.key_ops.every(isEncKeyUsage)),
+    {
+      message: '"key_ops" must be consistent with "use"',
       path: ['key_ops'],
     },
   )
 
-export type Jwk = z.infer<typeof jwkSchema>
+export type Jwk = z.output<typeof jwkSchema>
 
-/** @deprecated use {@link jwkSchema} */
+/** @deprecated use {@link jwkSchema} instead */
 export const jwkValidator = jwkSchema
 
 export const jwkPubSchema = jwkSchema
-  .refine((k) => k.kid != null, 'kid is required')
-  .refine((k) => !('k' in k) && !('d' in k), 'private key not allowed')
+  // @NOTE for legacy reasons, we don't impose the presence of either "use" or "key_ops"
+  .refine(isPublicJwk, {
+    message: 'private key not allowed',
+  })
+  .refine((k): boolean => !k.key_ops || k.key_ops.every(isPublicKeyUsage), {
+    message: '"key_ops" must not contain private key usage for public keys',
+    path: ['key_ops'],
+  })
+  .refine(hasKid, {
+    message: '"kid" is required',
+    path: ['kid'],
+  })
 
-export const jwkPrivateSchema = jwkSchema.refine(
-  (k) => ('k' in k && k.k != null) || ('d' in k && k.d != null),
-  'private key required',
-)
+export type PublicJwk = z.output<typeof jwkPubSchema>
+
+export const jwkPrivateSchema = jwkSchema
+  // @NOTE we don't impose the presence of "kid"
+  .refine(isPrivateJwk, {
+    message: 'private key required',
+  })
+
+export type PrivateJwk = z.output<typeof jwkPrivateSchema>
+
+export function hasKid<J extends object>(
+  jwk: J,
+): jwk is J & { kid: NonNullable<unknown> } {
+  return 'kid' in jwk && jwk.kid != null
+}
+
+export function hasSharedSecretJwk<J extends object>(
+  jwk: J,
+): jwk is J & { k: NonNullable<unknown> } {
+  return 'k' in jwk && jwk.k != null
+}
+
+export function hasPrivateSecretJwk<J extends object>(
+  jwk: J,
+): jwk is J & { d: NonNullable<unknown> } {
+  return 'd' in jwk && jwk.d != null
+}
+
+export function isPrivateJwk<J extends object>(jwk: J) {
+  return hasPrivateSecretJwk(jwk) || hasSharedSecretJwk(jwk)
+}
+
+export function isPublicJwk<J extends object>(
+  jwk: J,
+): jwk is Extract<
+  Exclude<J, { k: NonNullable<unknown> }>,
+  { d?: NonNullable<unknown> }
+> & { d?: never } {
+  return !hasPrivateSecretJwk(jwk) && !hasSharedSecretJwk(jwk)
+}

--- a/packages/oauth/jwk/src/jwks.ts
+++ b/packages/oauth/jwk/src/jwks.ts
@@ -6,17 +6,34 @@ import { jwkPubSchema, jwkSchema } from './jwk.js'
  * collection of JSON Web Keys (JWKs), that can be both public and private.
  */
 export const jwksSchema = z.object({
-  keys: z.array(jwkSchema),
+  keys: z.array(z.unknown()).transform((input) => {
+    // > Implementations SHOULD ignore JWKs within a JWK Set that use "kty"
+    // > (key type) values that are not understood by them, that are missing
+    // > required members, or for which values are out of the supported
+    // > ranges.
+    return input
+      .map((item) => jwkSchema.safeParse(item))
+      .filter((res) => res.success)
+      .map((res) => res.data)
+  }),
 })
 
 export type Jwks = z.infer<typeof jwksSchema>
 
 /**
- * Public JSON Web Key Set schema. All keys must be public keys, have a `kid`,
- * and `use` or `key_ops` defined.
+ * Public JSON Web Key Set schema.
  */
 export const jwksPubSchema = z.object({
-  keys: z.array(jwkPubSchema),
+  keys: z.array(z.unknown()).transform((input) => {
+    // > Implementations SHOULD ignore JWKs within a JWK Set that use "kty"
+    // > (key type) values that are not understood by them, that are missing
+    // > required members, or for which values are out of the supported
+    // > ranges.
+    return input
+      .map((item) => jwkPubSchema.safeParse(item))
+      .filter((res) => res.success)
+      .map((res) => res.data)
+  }),
 })
 
 export type JwksPub = z.infer<typeof jwksPubSchema>

--- a/packages/oauth/jwk/src/key.ts
+++ b/packages/oauth/jwk/src/key.ts
@@ -1,60 +1,91 @@
 import { jwkAlgorithms } from './alg.js'
-import { JwkError } from './errors.js'
-import { Jwk, jwkSchema } from './jwk.js'
+import {
+  Jwk,
+  KeyUsage,
+  PUBLIC_KEY_USAGE,
+  PrivateJwk,
+  PublicJwk,
+  PublicKeyUsage,
+  hasSharedSecretJwk,
+  isEncKeyUsage,
+  isPrivateJwk,
+  isPublicKeyUsage,
+  isSigKeyUsage,
+  jwkPubSchema,
+  jwkSchema,
+} from './jwk.js'
 import { VerifyOptions, VerifyResult } from './jwt-verify.js'
 import { JwtHeader, JwtPayload, SignedJwt } from './jwt.js'
 import { cachedGetter } from './util.js'
 
-const jwkSchemaReadonly = jwkSchema.readonly()
+export type KeyMatchOptions = {
+  usage?: KeyUsage
+  kid?: string | string[]
+  alg?: string | string[]
+}
+
+export type ActivityCheckOptions = {
+  allowRevoked?: boolean
+  clockTolerance?: number
+  currentDate?: Date
+}
 
 export abstract class Key<J extends Jwk = Jwk> {
-  constructor(readonly jwk: Readonly<J>) {
-    // @TODO "use" is actually only for public keys. We should allow missing
-    // "use" here and automatically add it to the exposed `publicJwk`
+  constructor(readonly jwk: Readonly<J>) {}
 
-    // A key should always be used either for signing or encryption.
-    if (!jwk.use) throw new JwkError('Missing "use" Parameter value')
-  }
-
+  @cachedGetter
   get isPrivate(): boolean {
-    const { jwk } = this
-    if ('d' in jwk && jwk.d !== undefined) return true
-    if ('k' in jwk && jwk.k !== undefined) return true
-    return false
-  }
-
-  get isSymetric(): boolean {
-    const { jwk } = this
-    if ('k' in jwk && jwk.k !== undefined) return true
-    return false
-  }
-
-  get privateJwk(): Readonly<J> | undefined {
-    return this.isPrivate ? this.jwk : undefined
+    return isPrivateJwk(this.jwk)
   }
 
   @cachedGetter
-  get publicJwk():
-    | Readonly<Exclude<J, { kty: 'oct' }> & { d?: never }>
-    | undefined {
-    if (this.isSymetric) return undefined
+  get isSymetric(): boolean {
+    return hasSharedSecretJwk(this.jwk)
+  }
 
-    return jwkSchemaReadonly.parse({
+  get privateJwk(): Readonly<PrivateJwk> | undefined {
+    if (!this.isPrivate) return undefined
+
+    return this.jwk as Readonly<PrivateJwk>
+  }
+
+  @cachedGetter
+  get publicJwk(): Readonly<PublicJwk> | undefined {
+    if (this.isSymetric) return undefined
+    if (!this.isPrivate) return this.jwk as Readonly<PublicJwk>
+
+    const validated = jwkPubSchema.safeParse({
       ...this.jwk,
       d: undefined,
       k: undefined,
-    }) as Exclude<J, { kty: 'oct' }> & { d?: never }
+      key_ops: buildPublicKeyOps(this.keyOps) ?? PUBLIC_KEY_USAGE,
+    })
+
+    // One reason why the parsing might fail is if key_ops is empty. This check
+    // also allows to future proof the code (e.g if another type of private key
+    // is added that uses a different property than "d" or "k" to store its
+    // private value).
+    if (!validated.success) return undefined
+
+    return Object.freeze(validated.data)
   }
 
   @cachedGetter
   get bareJwk(): Readonly<Jwk> | undefined {
     if (this.isSymetric) return undefined
     const { kty, crv, e, n, x, y } = this.jwk as any
-    return jwkSchemaReadonly.parse({ crv, e, kty, n, x, y })
+    return Object.freeze(jwkSchema.parse({ crv, e, kty, n, x, y }))
   }
 
-  get use() {
-    return this.jwk.use!
+  /**
+   * @note Only defined on public keys
+   */
+  get use(): 'sig' | 'enc' | undefined {
+    return this.jwk.use
+  }
+
+  get keyOps(): readonly KeyUsage[] | undefined {
+    return this.jwk.key_ops
   }
 
   /**
@@ -84,6 +115,65 @@ export abstract class Key<J extends Jwk = Jwk> {
     return Object.freeze(Array.from(jwkAlgorithms(this.jwk)))
   }
 
+  get revoked() {
+    return this.jwk.revoked
+  }
+
+  isActive(options?: ActivityCheckOptions) {
+    if (!options?.allowRevoked && this.revoked) return false
+
+    const tolerance = options?.clockTolerance ?? 0
+    if (tolerance !== Infinity) {
+      const now = options?.currentDate?.getTime() ?? Date.now()
+      const { exp, nbf } = this.jwk
+
+      if (nbf != null && !(now >= nbf * 1e3 - tolerance)) return false
+      if (exp != null && !(now < exp * 1e3 + tolerance)) return false
+    }
+
+    return true
+  }
+
+  matches(opts: KeyMatchOptions): boolean {
+    if (opts.kid != null) {
+      const matchesKid = Array.isArray(opts.kid)
+        ? this.kid != null && opts.kid.includes(this.kid)
+        : this.kid === opts.kid
+      if (!matchesKid) return false
+    }
+
+    if (opts.alg != null) {
+      const matchesAlg = Array.isArray(opts.alg)
+        ? opts.alg.some((a) => this.algorithms.includes(a))
+        : this.algorithms.includes(opts.alg)
+      if (!matchesAlg) return false
+    }
+
+    if (opts.usage != null) {
+      const matchesOps =
+        this.keyOps == null ||
+        this.keyOps.includes(opts.usage) ||
+        // @NOTE Because this.jwk represents the private key (typically used for
+        // private operations), the public counterpart operations are allowed.
+        (opts.usage === 'verify' && this.keyOps.includes('sign')) ||
+        (opts.usage === 'encrypt' && this.keyOps.includes('decrypt')) ||
+        (opts.usage === 'wrapKey' && this.keyOps.includes('unwrapKey'))
+      if (!matchesOps) return false
+
+      const matchesUse =
+        this.use == null ||
+        (this.use === 'sig' && isSigKeyUsage(opts.usage)) ||
+        (this.use === 'enc' && isEncKeyUsage(opts.usage))
+      if (!matchesUse) return false
+
+      // @NOTE This is only relevant when "key_ops" and "use" are undefined
+      const matchesKeyType = this.isPrivate || isPublicKeyUsage(opts.usage)
+      if (!matchesKeyType) return false
+    }
+
+    return true
+  }
+
   /**
    * Create a signed JWT
    */
@@ -98,4 +188,21 @@ export abstract class Key<J extends Jwk = Jwk> {
     token: SignedJwt,
     options?: VerifyOptions<C>,
   ): Promise<VerifyResult<C>>
+}
+
+function buildPublicKeyOps(
+  keyUsages?: readonly KeyUsage[],
+): PublicKeyUsage[] | undefined {
+  if (keyUsages == null) return undefined
+
+  // https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
+  // > Duplicate key operation values MUST NOT be present in the array.
+  const publicOps = new Set(keyUsages.filter(isPublicKeyUsage))
+
+  // @NOTE Translating private key usage into public key usage
+  if (keyUsages.includes('sign')) publicOps.add('verify')
+  if (keyUsages.includes('decrypt')) publicOps.add('encrypt')
+  if (keyUsages.includes('unwrapKey')) publicOps.add('wrapKey')
+
+  return Array.from(publicOps)
 }

--- a/packages/oauth/jwk/src/keyset.ts
+++ b/packages/oauth/jwk/src/keyset.ts
@@ -6,37 +6,34 @@ import {
   JwtCreateError,
   JwtVerifyError,
 } from './errors.js'
-import { Jwk } from './jwk.js'
-import { Jwks, JwksPub } from './jwks.js'
+import { PrivateKeyUsage } from './jwk.js'
+import { JwksPub } from './jwks.js'
 import { unsafeDecodeJwt } from './jwt-decode.js'
 import { VerifyOptions, VerifyResult } from './jwt-verify.js'
 import { JwtHeader, JwtPayload, SignedJwt } from './jwt.js'
-import { Key } from './key.js'
+import { ActivityCheckOptions, Key, KeyMatchOptions } from './key.js'
 import {
-  DeepReadonly,
   Override,
-  UnReadonly,
   cachedGetter,
   isDefined,
   matchesAny,
   preferredOrderCmp,
 } from './util.js'
 
-export type JwtSignHeader = Override<JwtHeader, Pick<KeySearch, 'alg' | 'kid'>>
+export type JwtSignHeader = Override<
+  JwtHeader,
+  Pick<KeyMatchOptions, 'alg' | 'kid'>
+>
 
 export type JwtPayloadGetter<P = JwtPayload> = (
   header: JwtHeader,
   key: Key,
 ) => P | PromiseLike<P>
 
-export type KeySearch = {
-  use?: 'sig' | 'enc'
-  kid?: string | string[]
-  alg?: string | string[]
-}
+export type { KeyMatchOptions }
 
-const extractPrivateJwk = (key: Key): Jwk | undefined => key.privateJwk
-const extractPublicJwk = (key: Key): Jwk | undefined => key.publicJwk
+const extractPrivateJwk = (key: Key) => key.privateJwk
+const extractPublicJwk = (key: Key) => key.publicJwk
 
 export class Keyset<K extends Key = Key> implements Iterable<K> {
   private readonly keys: readonly K[]
@@ -67,15 +64,15 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
   ) {
     const keys: K[] = []
 
-    const kids = new Set<string>()
+    const keyIds = new Set<string>()
     for (const key of iterable) {
       if (!key) continue
 
       keys.push(key)
 
       if (key.kid) {
-        if (kids.has(key.kid)) throw new JwkError(`Duplicate key: ${key.kid}`)
-        else kids.add(key.kid)
+        if (keyIds.has(key.kid)) throw new JwkError(`Duplicate key: ${key.kid}`)
+        else keyIds.add(key.kid)
       }
     }
 
@@ -101,66 +98,59 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
   }
 
   @cachedGetter
-  get publicJwks(): DeepReadonly<JwksPub> {
-    return {
-      keys: Array.from(this, extractPublicJwk).filter(isDefined),
-    }
+  get publicJwks() {
+    return Object.freeze({
+      keys: Object.freeze(Array.from(this, extractPublicJwk).filter(isDefined)),
+    })
   }
 
   @cachedGetter
-  get privateJwks(): DeepReadonly<Jwks> {
-    return {
-      keys: Array.from(this, extractPrivateJwk).filter(isDefined),
-    }
+  get privateJwks() {
+    return Object.freeze({
+      keys: Object.freeze(
+        Array.from(this, extractPrivateJwk).filter(isDefined),
+      ),
+    })
   }
 
   has(kid: string): boolean {
     return this.keys.some((key) => key.kid === kid)
   }
 
-  get(search: KeySearch): K {
-    for (const key of this.list(search)) {
+  get(options: KeyMatchOptions & ActivityCheckOptions): K {
+    for (const key of this.list(options)) {
       return key
     }
 
     throw new JwkError(
-      `Key not found ${search.kid || search.alg || '<unknown>'}`,
+      `Key not found ${options.kid ?? options.alg ?? options.usage ?? '<unknown>'}`,
       ERR_JWK_NOT_FOUND,
     )
   }
 
-  *list(search: KeySearch): Generator<K> {
-    // Optimization: Empty string or empty array will not match any key
-    if (search.kid?.length === 0) return
-    if (search.alg?.length === 0) return
-
+  *list<O extends KeyMatchOptions & ActivityCheckOptions>(options: O) {
     for (const key of this) {
-      if (search.use && key.use !== search.use) continue
-
-      if (Array.isArray(search.kid)) {
-        if (!key.kid || !search.kid.includes(key.kid)) continue
-      } else if (search.kid) {
-        if (key.kid !== search.kid) continue
+      if (key.isActive(options) && key.matches(options)) {
+        yield key
       }
-
-      if (Array.isArray(search.alg)) {
-        if (!search.alg.some((a) => key.algorithms.includes(a))) continue
-      } else if (typeof search.alg === 'string') {
-        if (!key.algorithms.includes(search.alg)) continue
-      }
-
-      yield key
     }
   }
 
-  findPrivateKey({ kid, alg, use }: KeySearch): { key: Key; alg: string } {
+  findPrivateKey({
+    kid,
+    alg,
+    usage,
+  }: KeyMatchOptions & { usage: PrivateKeyUsage }): {
+    key: Key
+    alg: string
+  } {
     const matchingKeys: Key[] = []
 
-    for (const key of this.list({ kid, alg, use })) {
-      // Not a private key
-      if (!key.isPrivate) continue
+    // Allow the loop bellow to return early when a single "alg" is provided
+    if (Array.isArray(alg) && alg.length === 1) alg = alg[0]
 
-      // Skip negotiation if a specific "alg" was provided
+    for (const key of this.list({ kid, alg, usage })) {
+      // Skip negotiation if a single "alg" was provided
       if (typeof alg === 'string') return { key, alg }
 
       matchingKeys.push(key)
@@ -188,7 +178,7 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
     }
 
     throw new JwkError(
-      `No private key found for ${kid || alg || use || '<unknown>'}`,
+      `No private key found for ${kid || alg || usage}`,
       ERR_JWK_NOT_FOUND,
     )
   }
@@ -205,7 +195,7 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
       const { key, alg } = this.findPrivateKey({
         alg: sAlg,
         kid: sKid,
-        use: 'sig',
+        usage: 'sign',
       })
       const protectedHeader = { ...header, alg, kid: key.kid }
 
@@ -221,14 +211,14 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
 
   async verifyJwt<C extends string = never>(
     token: SignedJwt,
-    options?: VerifyOptions<C>,
+    options?: ActivityCheckOptions & VerifyOptions<C>,
   ): Promise<VerifyResult<C> & { key: K }> {
     const { header } = unsafeDecodeJwt(token)
     const { kid, alg } = header
 
     const errors: unknown[] = []
 
-    for (const key of this.list({ kid, alg })) {
+    for (const key of this.list({ ...options, kid, alg, usage: 'verify' })) {
       try {
         const result = await key.verifyJwt<C>(token, options)
         return { ...result, key }
@@ -247,8 +237,8 @@ export class Keyset<K extends Key = Key> implements Iterable<K> {
     }
   }
 
-  toJSON(): JwksPub {
-    // Make a copy to prevent mutation of the original keyset
-    return structuredClone(this.publicJwks) as UnReadonly<JwksPub>
+  toJSON() {
+    // Make a copy to allow mutation of the result
+    return structuredClone(this.publicJwks) as JwksPub
   }
 }

--- a/packages/oauth/jwk/src/util.ts
+++ b/packages/oauth/jwk/src/util.ts
@@ -13,24 +13,6 @@ export type RequiredKey<T, K extends keyof T = never> = Simplify<
   }
 >
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type DeepReadonly<T> = T extends Function
-  ? T
-  : T extends object
-    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-    : T extends readonly (infer U)[]
-      ? readonly DeepReadonly<U>[]
-      : T
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type UnReadonly<T> = T extends Function
-  ? T
-  : T extends object
-    ? { -readonly [K in keyof T]: UnReadonly<T[K]> }
-    : T extends readonly (infer U)[]
-      ? UnReadonly<U>[]
-      : T
-
 export const isDefined = <T>(i: T | undefined): i is T => i !== undefined
 
 export const preferredOrderCmp =
@@ -196,4 +178,10 @@ export const segmentedStringRefinementFactory = <C extends number>(
     }
     return true
   }
+}
+
+export function isLastOccurrence<
+  T extends number | boolean | string | null | undefined | symbol | bigint,
+>(v: T, i: number, arr: readonly T[]): boolean {
+  return arr.indexOf(v, i + 1) === -1
 }

--- a/packages/oauth/oauth-client-expo/android/src/main/java/expo/modules/atprotooauthclient/Crypto.kt
+++ b/packages/oauth/oauth-client-expo/android/src/main/java/expo/modules/atprotooauthclient/Crypto.kt
@@ -45,7 +45,6 @@ class Crypto {
 
     return EncodedJWK().apply {
       kty = privateJwk.keyType.value
-      use = "sig"
       crv = privateJwk.curve.toString()
       kid = keyIdString
       x = privateJwk.x.toString()

--- a/packages/oauth/oauth-client-expo/android/src/main/java/expo/modules/atprotooauthclient/Records.kt
+++ b/packages/oauth/oauth-client-expo/android/src/main/java/expo/modules/atprotooauthclient/Records.kt
@@ -8,9 +8,6 @@ class EncodedJWK : Record {
   var kty: String = ""
 
   @Field
-  var use: String = ""
-
-  @Field
   var crv: String = ""
 
   @Field

--- a/packages/oauth/oauth-client-expo/ios/Crypto.swift
+++ b/packages/oauth/oauth-client-expo/ios/Crypto.swift
@@ -25,7 +25,6 @@ class CryptoUtil: NSObject {
 
     let jwk = EncodedJWK()
     jwk.kty = "EC"
-    jwk.use = "sig"
     jwk.crv = "P-256"
     jwk.kid = kid
     jwk.x = x

--- a/packages/oauth/oauth-client-expo/ios/Records.swift
+++ b/packages/oauth/oauth-client-expo/ios/Records.swift
@@ -5,9 +5,6 @@ struct EncodedJWK: Record {
   var kty: String
 
   @Field
-  var use: String
-
-  @Field
   var crv: String
 
   @Field

--- a/packages/oauth/oauth-client-expo/src/ExpoAtprotoOAuthClientModule.ts
+++ b/packages/oauth/oauth-client-expo/src/ExpoAtprotoOAuthClientModule.ts
@@ -4,13 +4,12 @@ import { ExpoAtprotoOAuthClientModuleEvents } from './ExpoAtprotoOAuthClientModu
 
 export type NativeJwk = {
   kty: 'EC'
-  use: 'sig' | 'enc' | undefined
   crv: 'P-256'
   kid: string
   x: string
   y: string
   d: string
-  alg: string
+  alg: 'ES256'
 }
 
 declare class ExpoAtprotoOAuthClientModule extends NativeModule<ExpoAtprotoOAuthClientModuleEvents> {

--- a/packages/oauth/oauth-client-expo/src/utils/expo-key.ts
+++ b/packages/oauth/oauth-client-expo/src/utils/expo-key.ts
@@ -1,4 +1,5 @@
 import {
+  type Jwk,
   type JwtHeader,
   type JwtPayload,
   Key,
@@ -9,12 +10,13 @@ import {
 import type { NativeJwk } from '../ExpoAtprotoOAuthClientModule'
 import { default as NativeModule } from '../ExpoAtprotoOAuthClientModule'
 
-export class ExpoKey extends Key<NativeJwk> {
+export type ExpoJwk = Jwk & NativeJwk & { key_ops: ['sign'] }
+export class ExpoKey extends Key<ExpoJwk> {
   async createJwt(header: JwtHeader, payload: JwtPayload): Promise<SignedJwt> {
     return NativeModule.createJwt(
       JSON.stringify(header),
       JSON.stringify(payload),
-      this.jwk,
+      toNativeJwk(this.jwk),
     )
   }
 
@@ -22,15 +24,27 @@ export class ExpoKey extends Key<NativeJwk> {
     token: SignedJwt,
     options: VerifyOptions<C> = {},
   ): Promise<VerifyResult<C>> {
-    return NativeModule.verifyJwt(token, this.jwk, options)
+    return NativeModule.verifyJwt(token, toNativeJwk(this.jwk), options)
   }
 
   static async generate(algs: string[]): Promise<ExpoKey> {
     if (algs.includes('ES256')) {
       const jwk = await NativeModule.generatePrivateJwk('ES256')
-      return new ExpoKey(jwk)
+      return new ExpoKey({ ...jwk, key_ops: ['sign'] })
     }
 
     throw TypeError(`No supported algorithm found in: ${algs.join(', ')}`)
+  }
+}
+
+function toNativeJwk(jwk: ExpoJwk): NativeJwk {
+  return {
+    kty: jwk.kty,
+    crv: jwk.crv,
+    kid: jwk.kid,
+    x: jwk.x,
+    y: jwk.y,
+    d: jwk.d,
+    alg: jwk.alg,
   }
 }

--- a/packages/oauth/oauth-client/src/oauth-client-auth.ts
+++ b/packages/oauth/oauth-client/src/oauth-client-auth.ts
@@ -44,12 +44,10 @@ export function negotiateClientAuthMethod(
     // @NOTE we can't use `keyset.findPrivateKey` here because we can't enforce
     // that the returned key contains a "kid". The following implementation is
     // more robust against keysets containing keys without a "kid" property.
-    for (const key of keyset.list({ use: 'sig', alg })) {
+    for (const key of keyset.list({ alg, usage: 'sign' })) {
       // Return the first key from the key set that matches the server's
       // supported algorithms.
-      if (key.isPrivate && key.kid) {
-        return { method: 'private_key_jwt', kid: key.kid }
-      }
+      if (key.kid) return { method: 'private_key_jwt', kid: key.kid }
     }
 
     throw new Error(
@@ -111,7 +109,7 @@ export function createClientCredentialsFactory(
 
       // @NOTE throws if no matching key can be found
       const { key, alg } = keyset.findPrivateKey({
-        use: 'sig',
+        usage: 'sign',
         kid: authMethod.kid,
         alg: supportedAlgs(serverMetadata),
       })


### PR DESCRIPTION
This pr addresses invalid assumptions that was made when the `jwk` tools were created:

- `use` and `key_ops` SHOULD NOT (per spec) be used together
- `use` MUST NOT be used for private keys

