### PR TITLE
Fix putRecord auth check

### DIFF
--- a/.changeset/nine-plants-peel.md
+++ b/.changeset/nine-plants-peel.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": minor
+---
+
+Fix putRecord auth check

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -63,8 +63,17 @@ export default function (server: Server, ctx: AppContext) {
         })
       }
 
-      const { did } = auth.credentials
-      if (did !== repo) {
+      const account = await ctx.accountManager.getAccount(repo, {
+        includeDeactivated: true,
+      })
+
+      if (!account) {
+        throw new InvalidRequestError(`Could not find repo: ${repo}`)
+      } else if (account.deactivatedAt) {
+        throw new InvalidRequestError('Account is deactivated')
+      }
+      const did = account.did
+      if (did !== auth.credentials.did) {
         throw new AuthRequiredError()
       }
 

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -455,6 +455,18 @@ describe('crud operations', () => {
       })
     })
 
+    it('still works if repo is specified by handle', async () => {
+      await bobAgent.api.com.atproto.repo.putRecord({
+        repo: "bob.test",
+        collection: ids.AppBskyGraphFollow,
+        rkey: TID.nextStr(),
+        record: {
+          subject: aliceAgent.accountDid,
+          createdAt: new Date().toISOString(),
+        },
+      })
+    })
+
     it('does not produce commit on no-op update', async () => {
       const { repo } = bobAgent.api.com.atproto
       const rootRes1 = await bobAgent.api.com.atproto.sync.getLatestCommit({

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -457,7 +457,7 @@ describe('crud operations', () => {
 
     it('still works if repo is specified by handle', async () => {
       await bobAgent.api.com.atproto.repo.putRecord({
-        repo: "bob.test",
+        repo: 'bob.test',
         collection: ids.AppBskyGraphFollow,
         rkey: TID.nextStr(),
         record: {


### PR DESCRIPTION
Related thread: https://bsky.app/profile/bnewbold.net/post/3lwcopaeubs2y

The check in `putRecord` assumed `repo` is a DID, but it may also be a handle. This PR uses the same logic as before (before OAuth scopes were introduced), and also mirrors the checks in `createRecord`.

Note: It builds, but not yet tested!