### PR TITLE
:sparkles: Add batchId filter for queryEvents

### DIFF
--- a/lexicons/tools/ozone/moderation/queryEvents.json
+++ b/lexicons/tools/ozone/moderation/queryEvents.json
@@ -120,6 +120,10 @@
             },
             "description": "If specified, only events where the modTool name matches any of the given values are returned"
           },
+          "batchId": {
+            "type": "string",
+            "description": "If specified, only events where the batchId matches the given value are returned"
+          },
           "ageAssuranceState": {
             "type": "string",
             "description": "If specified, only events where the age assurance state matches the given value are returned",

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -15760,6 +15760,11 @@ export const schemaDict = {
               description:
                 'If specified, only events where the modTool name matches any of the given values are returned',
             },
+            batchId: {
+              type: 'string',
+              description:
+                'If specified, only events where the batchId matches the given value are returned',
+            },
             ageAssuranceState: {
               type: 'string',
               description:

--- a/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/queryEvents.ts
@@ -50,6 +50,8 @@ export type QueryParams = {
   policies?: string[]
   /** If specified, only events where the modTool name matches any of the given values are returned */
   modTool?: string[]
+  /** If specified, only events where the batchId matches the given value are returned */
+  batchId?: string
   /** If specified, only events where the age assurance state matches the given value are returned */
   ageAssuranceState?:
     | 'pending'

--- a/packages/ozone/src/api/moderation/queryEvents.ts
+++ b/packages/ozone/src/api/moderation/queryEvents.ts
@@ -28,6 +28,7 @@ export default function (server: Server, ctx: AppContext) {
         policies,
         modTool,
         ageAssuranceState,
+        batchId,
       } = params
       const db = ctx.db
       const modService = ctx.modService(db)
@@ -53,6 +54,7 @@ export default function (server: Server, ctx: AppContext) {
         policies,
         modTool,
         ageAssuranceState,
+        batchId,
       })
       return {
         encoding: 'application/json',

--- a/packages/ozone/src/db/migrations/20250813T000000000Z-mod-tool-batch-id-index.ts
+++ b/packages/ozone/src/db/migrations/20250813T000000000Z-mod-tool-batch-id-index.ts
@@ -1,0 +1,14 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Only small percentage of moderation events have a batchId in modTool meta property so we're creating a partial index
+  await sql`
+    CREATE INDEX moderation_event_mod_tool_batch_id_idx
+    ON moderation_event (("modTool" -> 'meta' ->> 'batchId'))
+    WHERE "modTool" #> '{meta,batchId}' IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('moderation_event_mod_tool_batch_id_idx').execute()
+}

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -15760,6 +15760,11 @@ export const schemaDict = {
               description:
                 'If specified, only events where the modTool name matches any of the given values are returned',
             },
+            batchId: {
+              type: 'string',
+              description:
+                'If specified, only events where the batchId matches the given value are returned',
+            },
             ageAssuranceState: {
               type: 'string',
               description:

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -49,6 +49,8 @@ export type QueryParams = {
   policies?: string[]
   /** If specified, only events where the modTool name matches any of the given values are returned */
   modTool?: string[]
+  /** If specified, only events where the batchId matches the given value are returned */
+  batchId?: string
   /** If specified, only events where the age assurance state matches the given value are returned */
   ageAssuranceState?:
     | 'pending'

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -188,6 +188,7 @@ export class ModerationService {
     policies?: string[]
     modTool?: string[]
     ageAssuranceState?: string
+    batchId?: string
   }): Promise<{ cursor?: string; events: ModerationEventRow[] }> {
     const {
       subject,
@@ -211,6 +212,7 @@ export class ModerationService {
       policies,
       modTool,
       ageAssuranceState,
+      batchId,
     } = opts
     const { ref } = this.db.db.dynamic
     let builder = this.db.db.selectFrom('moderation_event').selectAll()
@@ -315,6 +317,11 @@ export class ModerationService {
       builder = builder
         .where('modTool', 'is not', null)
         .where(sql`("modTool" ->> 'name')`, 'in', modTool)
+    }
+    if (batchId) {
+      builder = builder
+        .where('modTool', 'is not', null)
+        .where(sql`("modTool" -> 'meta' ->> 'batchId')`, '=', batchId)
     }
     if (ageAssuranceState) {
       builder = builder

--- a/packages/ozone/tests/mod-tool.test.ts
+++ b/packages/ozone/tests/mod-tool.test.ts
@@ -125,4 +125,144 @@ describe('mod-tool tracking', () => {
     expect(eventIds).toContain(event2.id)
     expect(eventIds).not.toContain(event3.id)
   })
+
+  it('filters events by batchId and supports pagination', async () => {
+    const subject = {
+      $type: 'com.atproto.repo.strongRef',
+      uri: sc.posts[sc.dids.carol][0].ref.uriStr,
+      cid: sc.posts[sc.dids.carol][0].ref.cidStr,
+    }
+
+    const batchId1 = 'batch-123'
+    const batchId2 = 'batch-456'
+
+    // Create events with first batchId
+    const event1 = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['batch1-event1'],
+        negateLabelVals: [],
+      },
+      subject,
+      modTool: {
+        name: 'automod/1.1.3',
+        meta: { batchId: batchId1 },
+      },
+    })
+
+    const event2 = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['batch1-event2'],
+        negateLabelVals: [],
+      },
+      subject,
+      modTool: {
+        name: 'automod/1.1.3',
+        meta: { batchId: batchId1 },
+      },
+    })
+
+    const event3 = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['batch1-event3'],
+        negateLabelVals: [],
+      },
+      subject,
+      modTool: {
+        name: 'ozone-ui/workspace',
+        meta: { batchId: batchId1 },
+      },
+    })
+
+    // Create events with second batchId
+    const event4 = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['batch2-event1'],
+        negateLabelVals: [],
+      },
+      subject,
+      modTool: {
+        name: 'ozone-ui/workspace',
+        meta: { batchId: batchId2 },
+      },
+    })
+
+    // Create event without batchId
+    const event5 = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['no-batch'],
+        negateLabelVals: [],
+      },
+      subject,
+    })
+
+    // Test filtering by first batchId
+    const batch1Results = await modClient.queryEvents({
+      subject: subject.uri,
+      batchId: batchId1,
+    })
+
+    expect(batch1Results.events).toHaveLength(3)
+    const batch1EventIds = batch1Results.events.map((e) => e.id)
+    expect(batch1EventIds).toContain(event1.id)
+    expect(batch1EventIds).toContain(event2.id)
+    expect(batch1EventIds).toContain(event3.id)
+    expect(batch1EventIds).not.toContain(event4.id)
+    expect(batch1EventIds).not.toContain(event5.id)
+
+    // Verify all events have the correct batchId
+    batch1Results.events.forEach((event) => {
+      expect(event.modTool?.meta?.batchId).toBe(batchId1)
+    })
+
+    // Test filtering by second batchId
+    const batch2Results = await modClient.queryEvents({
+      subject: subject.uri,
+      batchId: batchId2,
+    })
+
+    expect(batch2Results.events).toHaveLength(1)
+    expect(batch2Results.events[0].id).toBe(event4.id)
+    expect(batch2Results.events[0].modTool?.meta?.batchId).toBe(batchId2)
+
+    // Test pagination with batchId filter
+    const paginatedResults = await modClient.queryEvents({
+      subject: subject.uri,
+      batchId: batchId1,
+      limit: 2,
+    })
+
+    expect(paginatedResults.events).toHaveLength(2)
+    expect(paginatedResults.cursor).toBeTruthy()
+
+    // Get next page
+    const nextPageResults = await modClient.queryEvents({
+      subject: subject.uri,
+      batchId: batchId1,
+      limit: 2,
+      cursor: paginatedResults.cursor,
+    })
+
+    expect(nextPageResults.events).toHaveLength(1)
+
+    // Verify all paginated results have correct batchId
+    const allPaginatedEvents = paginatedResults.events.concat(
+      nextPageResults.events,
+    )
+    allPaginatedEvents.forEach((event) => {
+      expect(event.modTool?.meta?.batchId).toBe(batchId1)
+    })
+
+    // Verify we got all 3 events across pages
+    const allPaginatedIds = paginatedResults.events
+      .map((e) => e.id)
+      .concat(nextPageResults.events.map((e) => e.id))
+    expect(allPaginatedIds).toContain(event1.id)
+    expect(allPaginatedIds).toContain(event2.id)
+    expect(allPaginatedIds).toContain(event3.id)
+  })
 })

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -15760,6 +15760,11 @@ export const schemaDict = {
               description:
                 'If specified, only events where the modTool name matches any of the given values are returned',
             },
+            batchId: {
+              type: 'string',
+              description:
+                'If specified, only events where the batchId matches the given value are returned',
+            },
             ageAssuranceState: {
               type: 'string',
               description:

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/queryEvents.ts
@@ -49,6 +49,8 @@ export type QueryParams = {
   policies?: string[]
   /** If specified, only events where the modTool name matches any of the given values are returned */
   modTool?: string[]
+  /** If specified, only events where the batchId matches the given value are returned */
+  batchId?: string
   /** If specified, only events where the age assurance state matches the given value are returned */
   ageAssuranceState?:
     | 'pending'


### PR DESCRIPTION
Adds `batchId` as a filter param for `tools.ozone.moderation.queryEvents` endpoint and adds a conditional index on the batchId property in moderation_event table for faster lookup.
Primary use-case of this is going to be looking up all actions associated with a given batchId so the standalone partial index should give us the perf needed.