### PR TITLE
fix(identity/did): allow redirects for did:web json fetch

### DIFF
--- a/packages/identity/src/did/web-resolver.ts
+++ b/packages/identity/src/did/web-resolver.ts
@@ -35,7 +35,6 @@ export class DidWebResolver extends BaseResolver {
     return timed(this.timeout, async (signal) => {
       const res = await fetch(url, {
         signal,
-        redirect: 'error',
         headers: { accept: 'application/did+ld+json,application/json' },
       })
 


### PR DESCRIPTION
Fixes regression in #3177; it should be permissible to have a "reasonable" number of redirects in the chain both for `.well-known/did-proto` and for `.well-known/did.json`.