### PR TITLE
Support JSONC in lex-cli

### DIFF
--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -29,6 +29,7 @@
     "@atproto/syntax": "workspace:^",
     "chalk": "^4.1.2",
     "commander": "^9.4.0",
+    "jsonc-parse": "^1.5.5",
     "prettier": "^3.2.5",
     "ts-morph": "^24.0.0",
     "yesno": "^0.4.0",

--- a/packages/lex-cli/src/util.ts
+++ b/packages/lex-cli/src/util.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs'
+import nodepath from 'node:path'
 import { join } from 'node:path'
 import chalk from 'chalk'
 import { ZodError, type ZodFormattedError } from 'zod'
+import JSONC from "jsonc-parse";
+
 import { type LexiconDoc, parseLexiconDoc } from '@atproto/lexicon'
 import { type FileDiff, type GeneratedAPI } from './types'
 
@@ -9,7 +12,7 @@ export function readAllLexicons(paths: string[]): LexiconDoc[] {
   paths = [...paths].sort() // incoming path order may have come from locale-dependent shell globs
   const docs: LexiconDoc[] = []
   for (const path of paths) {
-    if (!path.endsWith('.json') || !fs.statSync(path).isFile()) {
+    if (!(path.endsWith('.json') || path.endsWith('.jsonc')) || !fs.statSync(path).isFile()) {
       continue
     }
     try {
@@ -31,7 +34,12 @@ export function readLexicon(path: string): LexiconDoc {
     throw e
   }
   try {
-    obj = JSON.parse(str)
+    let ext: string = nodepath.extname(path)
+    if (ext === '.jsonc') {
+      obj = JSONC.parse(str)
+    } else {
+      obj = JSON.parse(str)
+    }
   } catch (e) {
     console.error(`Failed to parse JSON in file`, path)
     throw e

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,6 +759,9 @@ importers:
       commander:
         specifier: ^9.4.0
         version: 9.4.0
+      jsonc-parse:
+        specifier: ^1.5.5
+        version: 1.5.5
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -6761,6 +6764,11 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@luxass/strip-json-comments@1.4.0:
+    resolution: {integrity: sha512-Zl343to4u/t8jz1q7R/1UY6hLX+344cwPLEXsIYthVwdU5zyjuVBGcpf2E24+QZkwFfRfmnHTcscreQzWn3hiA==}
+    engines: {node: '>=18'}
+    dev: false
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -13739,6 +13747,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dev: true
+
+  /jsonc-parse@1.5.5:
+    resolution: {integrity: sha512-6xSVqUb+VBwXSJoyDPzgK1toG+JoOcfjWrmZNBL5ZmKnokV9dLshqyLU8NkcLavKbT5tKEr+3T0d4/7d+wVdVw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@luxass/strip-json-comments': 1.4.0
+    dev: false
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}


### PR DESCRIPTION
Uses the https://www.npmjs.com/package/jsonc-parse package to add JSONC support for lexicon files in lex-cli