### PR TITLE
Fix #4136: Support multiple redirect URIs in @atproto/oauth-client

### DIFF
--- a/.changeset/shy-cherries-argue.md
+++ b/.changeset/shy-cherries-argue.md
@@ -1,0 +1,8 @@
+---
+"@atproto/oauth-client": patch
+"@atproto/oauth-client-node": patch
+---
+
+Fix support for multiple redirect URIs in `@atproto/oauth-client`
+
+Previously the callback method assumed a singular `redirect_uris` value, and enforced only performing the callback with the first registered redirect URI. This change allows passing the actual redirect URI to the `callback` method, much like the `authorize` method supports.

--- a/packages/oauth/oauth-client/src/oauth-client.ts
+++ b/packages/oauth/oauth-client/src/oauth-client.ts
@@ -47,7 +47,7 @@ import {
   SessionStore,
 } from './session-getter.js'
 import { InternalStateData, StateStore } from './state-store.js'
-import { AuthorizeOptions, ClientMetadata } from './types.js'
+import { AuthorizeOptions, CallbackOptions, ClientMetadata } from './types.js'
 import { CustomEventTarget } from './util.js'
 import { validateClientMetadata } from './validate-client-metadata.js'
 
@@ -364,7 +364,10 @@ export class OAuthClient extends CustomEventTarget<OAuthClientEventMap> {
     // @TODO investigate actual necessity & feasibility of this feature
   }
 
-  async callback(params: URLSearchParams): Promise<{
+  async callback(
+    params: URLSearchParams,
+    options: CallbackOptions = {},
+  ): Promise<{
     session: OAuthSession
     state: string | null
   }> {
@@ -413,6 +416,13 @@ export class OAuthClient extends CustomEventTarget<OAuthClientEventMap> {
         stateData.dpopKey,
       )
 
+      const redirectUri =
+        options?.redirect_uri ?? server.clientMetadata.redirect_uris[0]
+      if (!server.clientMetadata.redirect_uris.includes(redirectUri)) {
+        // The server will enforce this, but let's catch it early
+        throw new TypeError('Invalid redirect_uri')
+      }
+
       if (issuerParam != null) {
         if (!server.issuer) {
           throw new OAuthCallbackError(
@@ -438,7 +448,11 @@ export class OAuthClient extends CustomEventTarget<OAuthClientEventMap> {
         )
       }
 
-      const tokenSet = await server.exchangeCode(codeParam, stateData.verifier)
+      const tokenSet = await server.exchangeCode(
+        codeParam,
+        stateData.verifier,
+        redirectUri,
+      )
       try {
         await this.sessionGetter.setStored(tokenSet.sub, {
           dpopKey: stateData.dpopKey,

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -5,6 +5,7 @@ import {
   OAuthAuthorizationServerMetadata,
   OAuthEndpointName,
   OAuthParResponse,
+  OAuthRedirectUri,
   OAuthTokenRequest,
   oauthParResponseSchema,
 } from '@atproto/oauth-types'
@@ -94,7 +95,7 @@ export class OAuthServerAgent {
   async exchangeCode(
     code: string,
     codeVerifier?: string,
-    redirectUri?: string,
+    redirectUri?: OAuthRedirectUri,
   ): Promise<TokenSet> {
     const now = Date.now()
 

--- a/packages/oauth/oauth-client/src/oauth-server-agent.ts
+++ b/packages/oauth/oauth-client/src/oauth-server-agent.ts
@@ -91,12 +91,18 @@ export class OAuthServerAgent {
     }
   }
 
-  async exchangeCode(code: string, codeVerifier?: string): Promise<TokenSet> {
+  async exchangeCode(
+    code: string,
+    codeVerifier?: string,
+    redirectUri?: string,
+  ): Promise<TokenSet> {
     const now = Date.now()
 
     const tokenResponse = await this.request('token', {
       grant_type: 'authorization_code',
-      redirect_uri: this.clientMetadata.redirect_uris[0]!,
+      // redirectUri should always be passed by the calling code, but if it is
+      // not, default to the first redirect_uri registered for the client:
+      redirect_uri: redirectUri ?? this.clientMetadata.redirect_uris[0],
       code,
       code_verifier: codeVerifier,
     })

--- a/packages/oauth/oauth-client/src/types.ts
+++ b/packages/oauth/oauth-client/src/types.ts
@@ -25,6 +25,10 @@ export type AuthorizeOptions = Simplify<
   }
 >
 
+export type CallbackOptions = Simplify<
+  Partial<Pick<OAuthAuthorizationRequestParameters, 'redirect_uri'>>
+>
+
 export const clientMetadataSchema = oauthClientMetadataSchema.extend({
   client_id: z.union([
     oauthClientIdDiscoverableSchema,


### PR DESCRIPTION
Previously the callback method assumed a singular `redirect_uris` value, and enforced only performing the callback with the first registered redirect URI (via `exchangeCode` being hardcoded to pick the first value from `redirect_uris`). This change allows passing the actual redirect URI to the `callback` method, much like the `authorize` method supports.

Fixes #4136

**Note:** I have not added support for multiple redirect URIs to `@atproto/oauth-client-browser` since the methods exposed there (`signInCallback` via `init`) does not currently support any additional options besides a `refresh` boolean. `readCallbackParams` would probably need to be modified to "discover" the correct redirect URI for which to use and subsequently pass to the `callback` method.