### PR TITLE
PDS: avoid extra lookup when configured with appview details

### DIFF
--- a/.changeset/breezy-poems-attend.md
+++ b/.changeset/breezy-poems-attend.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Avoid extra lookup when configured with appview details

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -260,6 +260,15 @@ export const parseProxyHeader = async (
   }
 
   const did = proxyTo.slice(0, hashIndex)
+
+  // Special case a configured appview, while still proxying correctly any other appview
+  if (
+    ctx.cfg.bskyAppView &&
+    proxyTo === `${ctx.cfg.bskyAppView.did}#bsky_appview`
+  ) {
+    return { did, url: ctx.cfg.bskyAppView.url }
+  }
+
   const didDoc = await ctx.idResolver.did.resolve(did)
   if (!didDoc) {
     throw new InvalidRequestError('could not resolve proxy did')
@@ -269,14 +278,6 @@ export const parseProxyHeader = async (
   const url = getServiceEndpoint(didDoc, { id: serviceId })
   if (!url) {
     throw new InvalidRequestError('could not resolve proxy did service url')
-  }
-
-  // Special case a configured appview, while still proxying correctly any other appview
-  if (
-    ctx.cfg.bskyAppView &&
-    proxyTo === `${ctx.cfg.bskyAppView.did}#bsky_appview`
-  ) {
-    return { did, url: ctx.cfg.bskyAppView.url }
   }
 
   return { did, url }


### PR DESCRIPTION
Just reshuffling some code here, so that if the pds is configured with appview details and a request is service proxying to that same appview, we avoid the unused did doc lookup.

There is a small change in behavior here, but I think it aligns with what is expected: if the service unpublishes their did doc (or the relevant service endpoint in that did doc), we stick to the pds's config rather than failing.  This pds config is indeed an override behavior.