### PR TITLE
Support multiple redirect URIs for @atproto/oauth-client-browser

### DIFF
--- a/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts
+++ b/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts
@@ -368,10 +368,10 @@ export class BrowserOAuthClient extends OAuthClient implements Disposable {
 
   async signInCallback() {
     const params = this.readCallbackParams()
-    const redirectUri = this.readRedirectUrl()
+    const redirectUrl = this.readRedirectUrl()
 
     // Not a (valid) OAuth redirect
-    if (!params || !redirectUri) return null
+    if (!params || !redirectUrl) return null
 
     // Replace the current history entry without the params (this will prevent
     // the following code to run again if the user refreshes the page)
@@ -405,7 +405,7 @@ export class BrowserOAuthClient extends OAuthClient implements Disposable {
     }
 
     return this.callback(params, {
-      redirect_uri: redirectUri,
+      redirect_uri: redirectUrl.toString(),
     })
       .then(async (result) => {
         if (result.state?.startsWith(POPUP_STATE_PREFIX)) {


### PR DESCRIPTION
I think this might be the appropriate fix here, but I'm not sure if it really is, or if it might break things. This continues on from #4139 but for the browser package.

Whilst working on this, eslint and types in vscode were all manner of weird, so I'm not as confident on this change: https://bsky.app/profile/thisismissem.social/post/3lxfetdclwc2f

cc @matthieusieben 