### PR TITLE
Fix URL regex in api/rich-text

### DIFF
--- a/packages/api/src/rich-text/detection.ts
+++ b/packages/api/src/rich-text/detection.ts
@@ -41,17 +41,19 @@ export function detectFacets(text: UnicodeString): Facet[] | undefined {
     // links
     const re = URL_REGEX
     while ((match = re.exec(text.utf16))) {
-      let uri = match[2]
-      if (!uri.startsWith('http')) {
+      let uri = match.groups?.uri
+      const protocol = match.groups?.protocol
+      const tld = match.groups?.tld
+      if (protocol === undefined) {
         const domain = match.groups?.domain
-        if (!domain || !isValidDomain(domain)) {
+        if (!domain || (tld !== undefined && !isValidDomain(domain))) {
           continue
         }
         uri = `https://${uri}`
       }
-      const start = text.utf16.indexOf(match[2], match.index)
-      const index = { start, end: start + match[2].length }
-      // strip ending puncuation
+      const start = text.utf16.indexOf(match.groups?.uri, match.index)
+      const index = { start, end: start + match.groups?.uri.length }
+      // strip ending punctuation
       if (/[.,;:!?]$/.test(uri)) {
         uri = uri.slice(0, -1)
         index.end--

--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,8 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
+// inspired by https://gist.github.com/dperini/729294 (2018/09/12 version)
+// gist credit: Diego Perini
 export const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+  /(?:^|\s|\()(?<uri>(?<protocol>https?:\/\/)?(?<domain>(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?)|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]*)?[a-z0-9\u00a1-\uffff]\.)+(?<tld>[a-z\u00a1-\uffff]{2,})\.?)(?::\d{2,5})?(?:[/?#]\S*)?)/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**

--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,8 +1,5 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
-// inspired by https://gist.github.com/dperini/729294 (2018/09/12 version)
-// gist credit: Diego Perini
-export const URL_REGEX =
-  /(?:^|\s|\()(?<uri>(?<protocol>https?:\/\/)?(?<domain>(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?)|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]*)?[a-z0-9\u00a1-\uffff]\.)+(?<tld>[a-z\u00a1-\uffff]{2,})\.?)(?::\d{2,5})?(?:[/?#]\S*)?)/gim
+
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**
@@ -12,3 +9,38 @@ export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 export const TAG_REGEX =
   // eslint-disable-next-line no-misleading-character-class
   /(^|\s)[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu
+
+// The RegEx below is inspired by https://gist.github.com/dperini/729294 (accessed in 2025/08/30)
+// Regular Expression for URL validation
+//
+// Author: Diego Perini
+// Created: 2010/12/05
+// Updated: 2018/09/12
+// License: MIT
+//
+// Copyright (c) 2010-2018 Diego Perini (http://www.iport.it)
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+export const URL_REGEX =
+  /(?:^|\s|\()(?<uri>(?<protocol>https?:\/\/)?(?<domain>(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?)|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]*)?[a-z0-9\u00a1-\uffff]\.)+(?<tld>[a-z\u00a1-\uffff]{2,}))(?::\d{2,5})?(?:[/?#]\S*)?)/gim
+//-(-prefix--)(uri---(-------protocol-------)-(domain---(not-private-and-loopback-ips)(---not-system-and-class-c-private-ips--)(----------not-class-b-private-ips-----------)(----------ip-1st-oct------------)(----------ip-2nd-and-3rd-oct---------)--(-----------ip-4th-oct------------)-(--------------------------------dns-domain---------------------------------)-(-------------tld------------))(---port---)-(---path---)-)

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -69,6 +69,7 @@ describe('detectFacets', () => {
     '198.185.159.145',
     'invalid IPs: http://127.0.0.1 https://255.255.255.255 https://0.0.0.0 https://169.254.1.1 https://1.1.1.011',
     'invalid URIs: https://google.a https://localhost',
+    'this is a website: google.com. The final dot it is not part of it',
   ]
   const outputs: string[][][] = [
     [['no mention']],
@@ -234,6 +235,11 @@ describe('detectFacets', () => {
       ],
     ],
     [['invalid URIs: https://google.a https://localhost']],
+    [
+      ['this is a website: '],
+      ['google.com', 'https://google.com'],
+      ['. The final dot it is not part of it'],
+    ],
   ]
   it('correctly handles a set of text inputs', async () => {
     for (let i = 0; i < inputs.length; i++) {

--- a/packages/api/tests/rich-text-detection.test.ts
+++ b/packages/api/tests/rich-text-detection.test.ts
@@ -60,6 +60,15 @@ describe('detectFacets', () => {
     'punctuation https://foo.com, https://bar.com/whatever; https://baz.com.',
     'parenthentical (https://foo.com)',
     'except for https://foo.com/thing_(cool)',
+    'HTTPS://google.com',
+    'https://google.COM',
+    'ko-fi.com',
+    '日本語.jp',
+    'GOOGLE.com',
+    'https://34.64.0.52',
+    '198.185.159.145',
+    'invalid IPs: http://127.0.0.1 https://255.255.255.255 https://0.0.0.0 https://169.254.1.1 https://1.1.1.011',
+    'invalid URIs: https://google.a https://localhost',
   ]
   const outputs: string[][][] = [
     [['no mention']],
@@ -212,6 +221,19 @@ describe('detectFacets', () => {
       ['except for '],
       ['https://foo.com/thing_(cool)', 'https://foo.com/thing_(cool)'],
     ],
+    [['HTTPS://google.com', 'HTTPS://google.com']],
+    [['https://google.COM', 'https://google.COM']],
+    [['ko-fi.com', 'https://ko-fi.com']],
+    [['日本語.jp', 'https://日本語.jp']],
+    [['GOOGLE.com', 'https://GOOGLE.com']],
+    [['https://34.64.0.52', 'https://34.64.0.52']],
+    [['198.185.159.145', 'https://198.185.159.145']],
+    [
+      [
+        'invalid IPs: http://127.0.0.1 https://255.255.255.255 https://0.0.0.0 https://169.254.1.1 https://1.1.1.011',
+      ],
+    ],
+    [['invalid URIs: https://google.a https://localhost']],
   ]
   it('correctly handles a set of text inputs', async () => {
     for (let i = 0; i < inputs.length; i++) {


### PR DESCRIPTION
This PR fixes  #4120 where the [RegEx in api/rich-text](https://github.com/bluesky-social/atproto/blob/331a356ce27ff1d0b24747b0c16f3b54b07a0a12/packages/api/src/rich-text/util.ts#L3) does not follow any standard. The current RegEx does not validate URIs such as `ko-fi.com` or `日本語.jp`.

The new RegEx is based on the [WHATWG Living Standard](https://url.spec.whatwg.org/) by using an altered version of a [well-reviewed gist by Diego Perini](https://gist.github.com/dperini/729294 ).


## The new RegEx

The new RegEx is considerably longer than the old one. This is mainly due to the complex IPv4 validation. It is also important to notice that the new RegEx does not cover (yet) IPv6.

If the complexity of the new RegEx makes this PR hard to review, the IPv4 validation can be relaxed (allowing any pattern in the format  4 groups of digits that can have between 1 and 3 digits each [ `(\d{1,3}\.){3}\d{1,3}` ]).

Here is the original RegEx from Perini:
```js
/^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
```

And here is the one that I used:
```js
/(?:^|\s|\()(?<uri>(?<protocol>https?:\/\/)?(?<domain>(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}\.(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?)|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]*)?[a-z0-9\u00a1-\uffff]\.)+(?<tld>[a-z\u00a1-\uffff]{2,})\.?)(?::\d{2,5})?(?:[/?#]\S*)?)/gim
```

**Main differences between Perini's and my RegEx**:

1. Removal of the required begin of line (`^`) and end of line (`$`) tokens;
2. Removal of 64 characters/bytes limit to the domain;
3. Only `http` and `https` protocols are accepted, if a protocol is present;
4. Keeping of `(?:^|\s|\()` from the old RegEx at the beginning;
5. Extensive use of named capture groups;
6. Change from `(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4])` to `(?:1\d\d|2[0-4]\d|25[0-4]|[1-9]\d?))`, putting `[1-9]\d?` in the last position (necessary after the removal of `$` ).

## The new logic

The added named groups and the new logic in the `detectFacets` function solves the problem of not accepting URLs in the upper-case format. It also helps with readability of the code.

The validation of a URI by its TLD part is made only when the TLD exists, i.e., it is not an IP.

## Tests

This fix is compatible with all previous tests that existed and it also add more tests in [here](https://github.com/arturo32/atproto/blob/dafe564e5c9291565e487da65a5110e7830b8bb3/packages/api/tests/rich-text-detection.test.ts#L18):

```js
'HTTPS://google.com',
'https://google.COM',
'ko-fi.com',
'日本語.jp',
'GOOGLE.com',
'https://34.64.0.52',
'198.185.159.145',
'invalid IPs: http://127.0.0.1 https://255.255.255.255 https://0.0.0.0 https://169.254.1.1 https://1.1.1.011',
'invalid URIs: https://google.a https://localhost',
```

The last two are considered only text.

## Notes

This PR, if accepted, should close https://github.com/bluesky-social/atproto/pull/3002 as it solves the case-sensitive problem.