### PR TITLE
Make SDK always call preferences APIs without proxy

### DIFF
--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -588,7 +588,10 @@ export class Agent extends XrpcClient {
         hideBadges: false,
       },
     }
-    const res = await this.app.bsky.actor.getPreferences({})
+    const res = await this.app.bsky.actor.getPreferences(
+      {},
+      { headers: { 'atproto-proxy': '' } },
+    )
     const labelPrefs: AppBskyActorDefs.ContentLabelPref[] = []
     for (const pref of res.data.preferences) {
       if (predicate.isValidAdultContentPref(pref)) {
@@ -1381,14 +1384,18 @@ export class Agent extends XrpcClient {
   ) {
     try {
       await this.#prefsLock.acquireAsync()
-      const res = await this.app.bsky.actor.getPreferences({})
+      const res = await this.app.bsky.actor.getPreferences(
+        {},
+        { headers: { 'atproto-proxy': '' } },
+      )
       const newPrefs = cb(res.data.preferences)
       if (newPrefs === false) {
         return res.data.preferences
       }
-      await this.app.bsky.actor.putPreferences({
-        preferences: newPrefs,
-      })
+      await this.app.bsky.actor.putPreferences(
+        { preferences: newPrefs },
+        { headers: { 'atproto-proxy': '' } },
+      )
       return newPrefs
     } finally {
       this.#prefsLock.release()


### PR DESCRIPTION
This change avoids unintended 404 errors when using `getPreferences` / `putPreferences` with `@atproto/api`.
The issue is mainly observed on zeppelin.social (see #4133), but depending on the PDS configuration it can also occur on bsky.app and other clients.

Compared to other APIs, the handling of `atproto-proxy` for these endpoints is unusual. Requests are only proxied if the `atproto-proxy` value differs from the PDS’s default appview, which makes it unpredictable for the client whether the request will be proxied or not.

If the request is unintentionally proxied, social-app fails to display the content. This behavior is likely necessary to avoid bypassing age verification and similar checks, but under certain conditions the app stops functioning entirely.

In this change, when the `Agent`’s preferences API wrapper is called, it overrides the proxy settings (`withProxy`, `configureProxy`) and sets `atproto-proxy` to an empty string. This is admittedly not an ideal approach, but it prevents the error.

The reason for making the change in the SDK rather than in social-app is:

* The change is simple and straightforward
* Third-party clients with the same issue also benefit
* The risk of negative side effects from not being able to choose the proxy target is minimal (support for applying `atproto-proxy` to these APIs was only added about a month ago)