### PR TITLE
Bookmarks moderation endpoints

### DIFF
--- a/lexicons/app/bsky/bookmark/getModBookmarksByActor.json
+++ b/lexicons/app/bsky/bookmark/getModBookmarksByActor.json
@@ -1,0 +1,44 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.bookmark.getModBookmarksByActor",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Moderation endpoint to get bookmarks by actor. Requires moderation service auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "format": "did"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["bookmarks"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "bookmarks": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "app.bsky.bookmark.defs#bookmarkView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/bookmark/getModBookmarksBySubject.json
+++ b/lexicons/app/bsky/bookmark/getModBookmarksBySubject.json
@@ -1,0 +1,50 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.bookmark.getModBookmarksBySubject",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Moderation endpoint to get bookmarks by subject. Requires moderation service auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["subject"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the subject (eg, a post record)."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["bookmarks"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "bookmarks": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#bookmark" }
+            }
+          }
+        }
+      }
+    },
+    "bookmark": {
+      "type": "object",
+      "required": ["indexedAt", "actor"],
+      "properties": {
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "actor": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -23,6 +23,8 @@ import * as AppBskyBookmarkCreateBookmark from './types/app/bsky/bookmark/create
 import * as AppBskyBookmarkDefs from './types/app/bsky/bookmark/defs.js'
 import * as AppBskyBookmarkDeleteBookmark from './types/app/bsky/bookmark/deleteBookmark.js'
 import * as AppBskyBookmarkGetBookmarks from './types/app/bsky/bookmark/getBookmarks.js'
+import * as AppBskyBookmarkGetModBookmarksByActor from './types/app/bsky/bookmark/getModBookmarksByActor.js'
+import * as AppBskyBookmarkGetModBookmarksBySubject from './types/app/bsky/bookmark/getModBookmarksBySubject.js'
 import * as AppBskyEmbedDefs from './types/app/bsky/embed/defs.js'
 import * as AppBskyEmbedExternal from './types/app/bsky/embed/external.js'
 import * as AppBskyEmbedImages from './types/app/bsky/embed/images.js'
@@ -310,6 +312,8 @@ export * as AppBskyBookmarkCreateBookmark from './types/app/bsky/bookmark/create
 export * as AppBskyBookmarkDefs from './types/app/bsky/bookmark/defs.js'
 export * as AppBskyBookmarkDeleteBookmark from './types/app/bsky/bookmark/deleteBookmark.js'
 export * as AppBskyBookmarkGetBookmarks from './types/app/bsky/bookmark/getBookmarks.js'
+export * as AppBskyBookmarkGetModBookmarksByActor from './types/app/bsky/bookmark/getModBookmarksByActor.js'
+export * as AppBskyBookmarkGetModBookmarksBySubject from './types/app/bsky/bookmark/getModBookmarksBySubject.js'
 export * as AppBskyEmbedDefs from './types/app/bsky/embed/defs.js'
 export * as AppBskyEmbedExternal from './types/app/bsky/embed/external.js'
 export * as AppBskyEmbedImages from './types/app/bsky/embed/images.js'
@@ -1061,6 +1065,30 @@ export class AppBskyBookmarkNS {
   ): Promise<AppBskyBookmarkGetBookmarks.Response> {
     return this._client.call(
       'app.bsky.bookmark.getBookmarks',
+      params,
+      undefined,
+      opts,
+    )
+  }
+
+  getModBookmarksByActor(
+    params?: AppBskyBookmarkGetModBookmarksByActor.QueryParams,
+    opts?: AppBskyBookmarkGetModBookmarksByActor.CallOptions,
+  ): Promise<AppBskyBookmarkGetModBookmarksByActor.Response> {
+    return this._client.call(
+      'app.bsky.bookmark.getModBookmarksByActor',
+      params,
+      undefined,
+      opts,
+    )
+  }
+
+  getModBookmarksBySubject(
+    params?: AppBskyBookmarkGetModBookmarksBySubject.QueryParams,
+    opts?: AppBskyBookmarkGetModBookmarksBySubject.CallOptions,
+  ): Promise<AppBskyBookmarkGetModBookmarksBySubject.Response> {
+    return this._client.call(
+      'app.bsky.bookmark.getModBookmarksBySubject',
       params,
       undefined,
       opts,

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -1317,6 +1317,119 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyBookmarkGetModBookmarksByActor: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksByActor',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by actor. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'did',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.defs#bookmarkView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyBookmarkGetModBookmarksBySubject: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksBySubject',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by subject. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['subject'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'at-uri',
+              description: 'AT-URI of the subject (eg, a post record).',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.getModBookmarksBySubject#bookmark',
+                },
+              },
+            },
+          },
+        },
+      },
+      bookmark: {
+        type: 'object',
+        required: ['indexedAt', 'actor'],
+        properties: {
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+        },
+      },
+    },
+  },
   AppBskyEmbedDefs: {
     lexicon: 1,
     id: 'app.bsky.embed.defs',
@@ -18409,6 +18522,10 @@ export const ids = {
   AppBskyBookmarkDefs: 'app.bsky.bookmark.defs',
   AppBskyBookmarkDeleteBookmark: 'app.bsky.bookmark.deleteBookmark',
   AppBskyBookmarkGetBookmarks: 'app.bsky.bookmark.getBookmarks',
+  AppBskyBookmarkGetModBookmarksByActor:
+    'app.bsky.bookmark.getModBookmarksByActor',
+  AppBskyBookmarkGetModBookmarksBySubject:
+    'app.bsky.bookmark.getModBookmarksBySubject',
   AppBskyEmbedDefs: 'app.bsky.embed.defs',
   AppBskyEmbedExternal: 'app.bsky.embed.external',
   AppBskyEmbedImages: 'app.bsky.embed.images',

--- a/packages/api/src/client/types/app/bsky/bookmark/getModBookmarksByActor.ts
+++ b/packages/api/src/client/types/app/bsky/bookmark/getModBookmarksByActor.ts
@@ -1,0 +1,44 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyBookmarkDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksByActor'
+
+export type QueryParams = {
+  actor: string
+  limit?: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: AppBskyBookmarkDefs.BookmarkView[]
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}

--- a/packages/api/src/client/types/app/bsky/bookmark/getModBookmarksBySubject.ts
+++ b/packages/api/src/client/types/app/bsky/bookmark/getModBookmarksBySubject.ts
@@ -1,0 +1,61 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyActorDefs from '../actor/defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksBySubject'
+
+export type QueryParams = {
+  /** AT-URI of the subject (eg, a post record). */
+  subject: string
+  limit?: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: Bookmark[]
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}
+
+export interface Bookmark {
+  $type?: 'app.bsky.bookmark.getModBookmarksBySubject#bookmark'
+  indexedAt: string
+  actor: AppBskyActorDefs.ProfileView
+}
+
+const hashBookmark = 'bookmark'
+
+export function isBookmark<V>(v: V) {
+  return is$typed(v, id, hashBookmark)
+}
+
+export function validateBookmark<V>(v: V) {
+  return validate<Bookmark & V>(v, id, hashBookmark)
+}

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1287,6 +1287,18 @@ message GetActorBookmarksResponse {
   string cursor = 2;
 }
 
+message GetBookmarksBySubjectRequest {
+  RecordRef subject = 1;
+  int32 limit = 2;
+  string cursor = 3;
+}
+
+message GetBookmarksBySubjectResponse {
+  repeated Bookmark bookmarks = 1;
+  string cursor = 2;
+}
+
+
 
 // Polo-backed Graph Endpoints
 
@@ -1459,6 +1471,8 @@ service Service {
   rpc GetBookmarksByActorAndSubjects(GetBookmarksByActorAndSubjectsRequest) returns (GetBookmarksByActorAndSubjectsResponse);
   // Returns the bookmarks created by the actor.
   rpc GetActorBookmarks(GetActorBookmarksRequest) returns (GetActorBookmarksResponse);
+  // Returns bookmarks for a given subject.
+  rpc GetBookmarksBySubject(GetBookmarksBySubjectRequest) returns (GetBookmarksBySubjectResponse);
 
   // Identity
   rpc GetIdentityByDid(GetIdentityByDidRequest) returns (GetIdentityByDidResponse);

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -8,6 +8,8 @@ import searchActorsTypeahead from './app/bsky/actor/searchActorsTypeahead'
 import createBookmark from './app/bsky/bookmark/createBookmark'
 import deleteBookmark from './app/bsky/bookmark/deleteBookmark'
 import getBookmarks from './app/bsky/bookmark/getBookmarks'
+import getModBookmarksByActor from './app/bsky/bookmark/getModBookmarksByActor'
+import getModBookmarksBySubject from './app/bsky/bookmark/getModBookmarksBySubject'
 import getActorFeeds from './app/bsky/feed/getActorFeeds'
 import getActorLikes from './app/bsky/feed/getActorLikes'
 import getAuthorFeed from './app/bsky/feed/getAuthorFeed'
@@ -90,6 +92,8 @@ export default function (server: Server, ctx: AppContext) {
   createBookmark(server, ctx)
   deleteBookmark(server, ctx)
   getBookmarks(server, ctx)
+  getModBookmarksByActor(server, ctx)
+  getModBookmarksBySubject(server, ctx)
   getActorFeeds(server, ctx)
   getSuggestedFeeds(server, ctx)
   getAuthorFeed(server, ctx)

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -1001,12 +1001,11 @@ export class Hydrator {
 
   async hydrateBookmarks(
     bookmarkInfos: BookmarkInfo[],
+    actorDid: string,
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
-    const viewer = ctx.viewer
-    if (!viewer) return {}
     const bookmarksRes = await this.dataplane.getBookmarksByActorAndSubjects({
-      actorDid: viewer,
+      actorDid,
       uris: bookmarkInfos.map((b) => b.subject),
     })
 
@@ -1017,7 +1016,7 @@ export class Hydrator {
     // mapping DID -> stash key -> bookmark
     const bookmarksMap = new HydrationMap([
       [
-        viewer,
+        actorDid,
         new HydrationMap<Bookmark>(
           bookmarks.map((bookmark) => {
             const {

--- a/packages/bsky/src/lexicon/index.ts
+++ b/packages/bsky/src/lexicon/index.ts
@@ -20,6 +20,8 @@ import * as AppBskyActorSearchActorsTypeahead from './types/app/bsky/actor/searc
 import * as AppBskyBookmarkCreateBookmark from './types/app/bsky/bookmark/createBookmark.js'
 import * as AppBskyBookmarkDeleteBookmark from './types/app/bsky/bookmark/deleteBookmark.js'
 import * as AppBskyBookmarkGetBookmarks from './types/app/bsky/bookmark/getBookmarks.js'
+import * as AppBskyBookmarkGetModBookmarksByActor from './types/app/bsky/bookmark/getModBookmarksByActor.js'
+import * as AppBskyBookmarkGetModBookmarksBySubject from './types/app/bsky/bookmark/getModBookmarksBySubject.js'
 import * as AppBskyFeedDescribeFeedGenerator from './types/app/bsky/feed/describeFeedGenerator.js'
 import * as AppBskyFeedGetActorFeeds from './types/app/bsky/feed/getActorFeeds.js'
 import * as AppBskyFeedGetActorLikes from './types/app/bsky/feed/getActorLikes.js'
@@ -424,6 +426,30 @@ export class AppBskyBookmarkNS {
     >,
   ) {
     const nsid = 'app.bsky.bookmark.getBookmarks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksByActor<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksByActor.QueryParams,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerInput,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksByActor' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksBySubject<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksBySubject.QueryParams,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerInput,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksBySubject' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -1317,6 +1317,119 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyBookmarkGetModBookmarksByActor: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksByActor',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by actor. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'did',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.defs#bookmarkView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyBookmarkGetModBookmarksBySubject: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksBySubject',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by subject. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['subject'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'at-uri',
+              description: 'AT-URI of the subject (eg, a post record).',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.getModBookmarksBySubject#bookmark',
+                },
+              },
+            },
+          },
+        },
+      },
+      bookmark: {
+        type: 'object',
+        required: ['indexedAt', 'actor'],
+        properties: {
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+        },
+      },
+    },
+  },
   AppBskyEmbedDefs: {
     lexicon: 1,
     id: 'app.bsky.embed.defs',
@@ -13835,6 +13948,10 @@ export const ids = {
   AppBskyBookmarkDefs: 'app.bsky.bookmark.defs',
   AppBskyBookmarkDeleteBookmark: 'app.bsky.bookmark.deleteBookmark',
   AppBskyBookmarkGetBookmarks: 'app.bsky.bookmark.getBookmarks',
+  AppBskyBookmarkGetModBookmarksByActor:
+    'app.bsky.bookmark.getModBookmarksByActor',
+  AppBskyBookmarkGetModBookmarksBySubject:
+    'app.bsky.bookmark.getModBookmarksBySubject',
   AppBskyEmbedDefs: 'app.bsky.embed.defs',
   AppBskyEmbedExternal: 'app.bsky.embed.external',
   AppBskyEmbedImages: 'app.bsky.embed.images',

--- a/packages/bsky/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
@@ -1,0 +1,43 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyBookmarkDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksByActor'
+
+export type QueryParams = {
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: AppBskyBookmarkDefs.BookmarkView[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/bsky/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
@@ -1,0 +1,60 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyActorDefs from '../actor/defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksBySubject'
+
+export type QueryParams = {
+  /** AT-URI of the subject (eg, a post record). */
+  subject: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: Bookmark[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export interface Bookmark {
+  $type?: 'app.bsky.bookmark.getModBookmarksBySubject#bookmark'
+  indexedAt: string
+  actor: AppBskyActorDefs.ProfileView
+}
+
+const hashBookmark = 'bookmark'
+
+export function isBookmark<V>(v: V) {
+  return is$typed(v, id, hashBookmark)
+}
+
+export function validateBookmark<V>(v: V) {
+  return validate<Bookmark & V>(v, id, hashBookmark)
+}

--- a/packages/bsky/src/proto/bsky_connect.ts
+++ b/packages/bsky/src/proto/bsky_connect.ts
@@ -72,6 +72,8 @@ import {
   GetBlocksResponse,
   GetBookmarksByActorAndSubjectsRequest,
   GetBookmarksByActorAndSubjectsResponse,
+  GetBookmarksBySubjectRequest,
+  GetBookmarksBySubjectResponse,
   GetCountsForUsersRequest,
   GetCountsForUsersResponse,
   GetDidsByHandlesRequest,
@@ -1034,6 +1036,17 @@ export const Service = {
       name: 'GetActorBookmarks',
       I: GetActorBookmarksRequest,
       O: GetActorBookmarksResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Returns bookmarks for a given subject.
+     *
+     * @generated from rpc bsky.Service.GetBookmarksBySubject
+     */
+    getBookmarksBySubject: {
+      name: 'GetBookmarksBySubject',
+      I: GetBookmarksBySubjectRequest,
+      O: GetBookmarksBySubjectResponse,
       kind: MethodKind.Unary,
     },
     /**

--- a/packages/bsky/src/proto/bsky_pb.ts
+++ b/packages/bsky/src/proto/bsky_pb.ts
@@ -13674,6 +13674,140 @@ export class GetActorBookmarksResponse extends Message<GetActorBookmarksResponse
 }
 
 /**
+ * @generated from message bsky.GetBookmarksBySubjectRequest
+ */
+export class GetBookmarksBySubjectRequest extends Message<GetBookmarksBySubjectRequest> {
+  /**
+   * @generated from field: bsky.RecordRef subject = 1;
+   */
+  subject?: RecordRef
+
+  /**
+   * @generated from field: int32 limit = 2;
+   */
+  limit = 0
+
+  /**
+   * @generated from field: string cursor = 3;
+   */
+  cursor = ''
+
+  constructor(data?: PartialMessage<GetBookmarksBySubjectRequest>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetBookmarksBySubjectRequest'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'subject', kind: 'message', T: RecordRef },
+    { no: 2, name: 'limit', kind: 'scalar', T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: 'cursor', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetBookmarksBySubjectRequest {
+    return new GetBookmarksBySubjectRequest().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetBookmarksBySubjectRequest {
+    return new GetBookmarksBySubjectRequest().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetBookmarksBySubjectRequest {
+    return new GetBookmarksBySubjectRequest().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetBookmarksBySubjectRequest
+      | PlainMessage<GetBookmarksBySubjectRequest>
+      | undefined,
+    b:
+      | GetBookmarksBySubjectRequest
+      | PlainMessage<GetBookmarksBySubjectRequest>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetBookmarksBySubjectRequest, a, b)
+  }
+}
+
+/**
+ * @generated from message bsky.GetBookmarksBySubjectResponse
+ */
+export class GetBookmarksBySubjectResponse extends Message<GetBookmarksBySubjectResponse> {
+  /**
+   * @generated from field: repeated bsky.Bookmark bookmarks = 1;
+   */
+  bookmarks: Bookmark[] = []
+
+  /**
+   * @generated from field: string cursor = 2;
+   */
+  cursor = ''
+
+  constructor(data?: PartialMessage<GetBookmarksBySubjectResponse>) {
+    super()
+    proto3.util.initPartial(data, this)
+  }
+
+  static readonly runtime: typeof proto3 = proto3
+  static readonly typeName = 'bsky.GetBookmarksBySubjectResponse'
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: 'bookmarks', kind: 'message', T: Bookmark, repeated: true },
+    { no: 2, name: 'cursor', kind: 'scalar', T: 9 /* ScalarType.STRING */ },
+  ])
+
+  static fromBinary(
+    bytes: Uint8Array,
+    options?: Partial<BinaryReadOptions>,
+  ): GetBookmarksBySubjectResponse {
+    return new GetBookmarksBySubjectResponse().fromBinary(bytes, options)
+  }
+
+  static fromJson(
+    jsonValue: JsonValue,
+    options?: Partial<JsonReadOptions>,
+  ): GetBookmarksBySubjectResponse {
+    return new GetBookmarksBySubjectResponse().fromJson(jsonValue, options)
+  }
+
+  static fromJsonString(
+    jsonString: string,
+    options?: Partial<JsonReadOptions>,
+  ): GetBookmarksBySubjectResponse {
+    return new GetBookmarksBySubjectResponse().fromJsonString(
+      jsonString,
+      options,
+    )
+  }
+
+  static equals(
+    a:
+      | GetBookmarksBySubjectResponse
+      | PlainMessage<GetBookmarksBySubjectResponse>
+      | undefined,
+    b:
+      | GetBookmarksBySubjectResponse
+      | PlainMessage<GetBookmarksBySubjectResponse>
+      | undefined,
+  ): boolean {
+    return proto3.util.equals(GetBookmarksBySubjectResponse, a, b)
+  }
+}
+
+/**
  * GetFollowsFollowing gets the list of DIDs that the actor follows that also follow the targets
  *
  * @generated from message bsky.GetFollowsFollowingRequest

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1064,12 +1064,10 @@ export class Views {
   // ------------
   bookmark(
     key: string,
+    actorDid: string,
     state: HydrationState,
   ): Un$Typed<BookmarkView> | undefined {
-    const viewer = state.ctx?.viewer
-    if (!viewer) return
-
-    const bookmark = state.bookmarks?.get(viewer)?.get(key)
+    const bookmark = state.bookmarks?.get(actorDid)?.get(key)
     if (!bookmark) return
 
     const atUri = new AtUri(bookmark.subjectUri)

--- a/packages/bsky/tests/views/__snapshots__/bookmarks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/bookmarks.test.ts.snap
@@ -378,6 +378,244 @@ Array [
 ]
 `;
 
+exports[`appview bookmarks views moderation get bookmarks by actor blocks does not show posts as blocked 1`] = `
+Array [
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "item": Object {
+      "$type": "app.bsky.feed.defs#postView",
+      "author": Object {
+        "associated": Object {
+          "activitySubscription": Object {
+            "allowSubscriptions": "followers",
+          },
+        },
+        "did": "user(0)",
+        "handle": "carol.test",
+        "labels": Array [],
+      },
+      "bookmarkCount": 1,
+      "cid": "cids(0)",
+      "embed": Object {
+        "$type": "app.bsky.embed.recordWithMedia#view",
+        "media": Object {
+          "$type": "app.bsky.embed.images#view",
+          "images": Array [
+            Object {
+              "alt": "../dev-env/assets/key-landscape-small.jpg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(1)/cids(1)@jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(1)/cids(1)@jpeg",
+            },
+            Object {
+              "alt": "../dev-env/assets/key-alt.jpg",
+              "fullsize": "https://bsky.public.url/img/feed_fullsize/plain/user(1)/cids(2)@jpeg",
+              "thumb": "https://bsky.public.url/img/feed_thumbnail/plain/user(1)/cids(2)@jpeg",
+            },
+          ],
+        },
+        "record": Object {
+          "record": Object {
+            "$type": "app.bsky.embed.record#viewRecord",
+            "author": Object {
+              "associated": Object {
+                "activitySubscription": Object {
+                  "allowSubscriptions": "followers",
+                },
+              },
+              "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(4)@jpeg",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "did": "user(2)",
+              "displayName": "bobby",
+              "handle": "bob.test",
+              "labels": Array [],
+            },
+            "cid": "cids(3)",
+            "embeds": Array [],
+            "indexedAt": "1970-01-01T00:00:00.000Z",
+            "labels": Array [],
+            "likeCount": 0,
+            "quoteCount": 1,
+            "replyCount": 0,
+            "repostCount": 0,
+            "uri": "record(1)",
+            "value": Object {
+              "$type": "app.bsky.feed.post",
+              "createdAt": "1970-01-01T00:00:00.000Z",
+              "langs": Array [
+                "en-US",
+                "i-klingon",
+              ],
+              "text": "bob back at it again!",
+            },
+          },
+        },
+      },
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 2,
+      "quoteCount": 1,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "embed": Object {
+          "$type": "app.bsky.embed.recordWithMedia",
+          "media": Object {
+            "$type": "app.bsky.embed.images",
+            "images": Array [
+              Object {
+                "alt": "../dev-env/assets/key-landscape-small.jpg",
+                "image": Object {
+                  "$type": "blob",
+                  "mimeType": "image/jpeg",
+                  "ref": Object {
+                    "$link": "cids(1)",
+                  },
+                  "size": 4114,
+                },
+              },
+              Object {
+                "alt": "../dev-env/assets/key-alt.jpg",
+                "image": Object {
+                  "$type": "blob",
+                  "mimeType": "image/jpeg",
+                  "ref": Object {
+                    "$link": "cids(2)",
+                  },
+                  "size": 12736,
+                },
+              },
+            ],
+          },
+          "record": Object {
+            "record": Object {
+              "cid": "cids(3)",
+              "uri": "record(1)",
+            },
+          },
+        },
+        "text": "hi im carol",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(0)",
+    },
+    "subject": Object {
+      "cid": "cids(0)",
+      "uri": "record(0)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "item": Object {
+      "$type": "app.bsky.feed.defs#postView",
+      "author": Object {
+        "associated": Object {
+          "activitySubscription": Object {
+            "allowSubscriptions": "followers",
+          },
+        },
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(3)/cids(4)@jpeg",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "did": "user(2)",
+        "displayName": "bobby",
+        "handle": "bob.test",
+        "labels": Array [],
+      },
+      "bookmarkCount": 1,
+      "cid": "cids(3)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+      "likeCount": 0,
+      "quoteCount": 1,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "langs": Array [
+          "en-US",
+          "i-klingon",
+        ],
+        "text": "bob back at it again!",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(1)",
+    },
+    "subject": Object {
+      "cid": "cids(3)",
+      "uri": "record(1)",
+    },
+  },
+  Object {
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "item": Object {
+      "$type": "app.bsky.feed.defs#postView",
+      "author": Object {
+        "associated": Object {
+          "activitySubscription": Object {
+            "allowSubscriptions": "followers",
+          },
+        },
+        "avatar": "https://bsky.public.url/img/avatar/plain/user(5)/cids(4)@jpeg",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "did": "user(4)",
+        "displayName": "ali",
+        "handle": "alice.test",
+        "labels": Array [
+          Object {
+            "cid": "cids(6)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(4)",
+            "uri": "record(3)",
+            "val": "self-label-a",
+          },
+          Object {
+            "cid": "cids(6)",
+            "cts": "1970-01-01T00:00:00.000Z",
+            "src": "user(4)",
+            "uri": "record(3)",
+            "val": "self-label-b",
+          },
+        ],
+      },
+      "bookmarkCount": 1,
+      "cid": "cids(5)",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(5)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "src": "user(4)",
+          "uri": "record(2)",
+          "val": "self-label",
+        },
+      ],
+      "likeCount": 0,
+      "quoteCount": 0,
+      "record": Object {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "1970-01-01T00:00:00.000Z",
+        "labels": Object {
+          "$type": "com.atproto.label.defs#selfLabels",
+          "values": Array [
+            Object {
+              "val": "self-label",
+            },
+          ],
+        },
+        "text": "hey there",
+      },
+      "replyCount": 0,
+      "repostCount": 0,
+      "uri": "record(2)",
+    },
+    "subject": Object {
+      "cid": "cids(5)",
+      "uri": "record(2)",
+    },
+  },
+]
+`;
+
 exports[`appview bookmarks views moderation get bookmarks by subject gets actors who bookmarked 1`] = `
 Array [
   Object {

--- a/packages/bsky/tests/views/__snapshots__/bookmarks.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/bookmarks.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`appview bookmarks views listing shows posts and blocked posts correctly 1`] = `
+exports[`appview bookmarks views listing blocks shows posts and blocked posts correctly 1`] = `
 Array [
   Object {
     "createdAt": "1970-01-01T00:00:00.000Z",
@@ -216,7 +216,7 @@ Array [
 ]
 `;
 
-exports[`appview bookmarks views listing shows posts and blocked posts correctly 2`] = `
+exports[`appview bookmarks views listing blocks shows posts and blocked posts correctly 2`] = `
 Array [
   Object {
     "createdAt": "1970-01-01T00:00:00.000Z",
@@ -374,6 +374,75 @@ Array [
       "cid": "cids(5)",
       "uri": "record(4)",
     },
+  },
+]
+`;
+
+exports[`appview bookmarks views moderation get bookmarks by subject gets actors who bookmarked 1`] = `
+Array [
+  Object {
+    "actor": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "did": "user(0)",
+      "handle": "carol.test",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+  },
+  Object {
+    "actor": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(2)/cids(0)@jpeg",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "description": "hi im bob label_me",
+      "did": "user(1)",
+      "displayName": "bobby",
+      "handle": "bob.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
+  },
+  Object {
+    "actor": Object {
+      "associated": Object {
+        "activitySubscription": Object {
+          "allowSubscriptions": "followers",
+        },
+      },
+      "avatar": "https://bsky.public.url/img/avatar/plain/user(4)/cids(0)@jpeg",
+      "createdAt": "1970-01-01T00:00:00.000Z",
+      "description": "its me!",
+      "did": "user(3)",
+      "displayName": "ali",
+      "handle": "alice.test",
+      "indexedAt": "1970-01-01T00:00:00.000Z",
+      "labels": Array [
+        Object {
+          "cid": "cids(1)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "src": "user(3)",
+          "uri": "record(0)",
+          "val": "self-label-a",
+        },
+        Object {
+          "cid": "cids(1)",
+          "cts": "1970-01-01T00:00:00.000Z",
+          "src": "user(3)",
+          "uri": "record(0)",
+          "val": "self-label-b",
+        },
+      ],
+    },
+    "indexedAt": "1970-01-01T00:00:00.000Z",
   },
 ]
 `;

--- a/packages/bsky/tests/views/bookmarks.test.ts
+++ b/packages/bsky/tests/views/bookmarks.test.ts
@@ -437,6 +437,31 @@ describe('appview bookmarks views', () => {
           cid: sc.posts[alice][0].ref.cidStr,
         })
       })
+
+      describe('blocks', () => {
+        afterEach(async () => {
+          await sc.unblock(alice, bob)
+          await network.processAll()
+        })
+
+        it('does not show posts as blocked', async () => {
+          await create(alice, sc.posts[alice][0].ref)
+          await create(alice, sc.posts[bob][0].ref)
+          await create(alice, sc.posts[carol][0].ref)
+
+          await sc.block(alice, bob)
+          await network.processAll()
+
+          const {
+            data: { bookmarks },
+          } = await getModByActor(ozone, alice)
+          expect(bookmarks).toHaveLength(3)
+          // Even though there is a block between alice and bob,
+          // Ozone doesn't see the block.
+          assertPostViews(bookmarks)
+          expect(forSnapshot(bookmarks)).toMatchSnapshot()
+        })
+      })
     })
 
     describe('get bookmarks by subject', () => {

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -20,6 +20,8 @@ import * as AppBskyActorSearchActorsTypeahead from './types/app/bsky/actor/searc
 import * as AppBskyBookmarkCreateBookmark from './types/app/bsky/bookmark/createBookmark.js'
 import * as AppBskyBookmarkDeleteBookmark from './types/app/bsky/bookmark/deleteBookmark.js'
 import * as AppBskyBookmarkGetBookmarks from './types/app/bsky/bookmark/getBookmarks.js'
+import * as AppBskyBookmarkGetModBookmarksByActor from './types/app/bsky/bookmark/getModBookmarksByActor.js'
+import * as AppBskyBookmarkGetModBookmarksBySubject from './types/app/bsky/bookmark/getModBookmarksBySubject.js'
 import * as AppBskyFeedDescribeFeedGenerator from './types/app/bsky/feed/describeFeedGenerator.js'
 import * as AppBskyFeedGetActorFeeds from './types/app/bsky/feed/getActorFeeds.js'
 import * as AppBskyFeedGetActorLikes from './types/app/bsky/feed/getActorLikes.js'
@@ -555,6 +557,30 @@ export class AppBskyBookmarkNS {
     >,
   ) {
     const nsid = 'app.bsky.bookmark.getBookmarks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksByActor<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksByActor.QueryParams,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerInput,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksByActor' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksBySubject<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksBySubject.QueryParams,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerInput,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksBySubject' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -1317,6 +1317,119 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyBookmarkGetModBookmarksByActor: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksByActor',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by actor. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'did',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.defs#bookmarkView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyBookmarkGetModBookmarksBySubject: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksBySubject',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by subject. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['subject'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'at-uri',
+              description: 'AT-URI of the subject (eg, a post record).',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.getModBookmarksBySubject#bookmark',
+                },
+              },
+            },
+          },
+        },
+      },
+      bookmark: {
+        type: 'object',
+        required: ['indexedAt', 'actor'],
+        properties: {
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+        },
+      },
+    },
+  },
   AppBskyEmbedDefs: {
     lexicon: 1,
     id: 'app.bsky.embed.defs',
@@ -18409,6 +18522,10 @@ export const ids = {
   AppBskyBookmarkDefs: 'app.bsky.bookmark.defs',
   AppBskyBookmarkDeleteBookmark: 'app.bsky.bookmark.deleteBookmark',
   AppBskyBookmarkGetBookmarks: 'app.bsky.bookmark.getBookmarks',
+  AppBskyBookmarkGetModBookmarksByActor:
+    'app.bsky.bookmark.getModBookmarksByActor',
+  AppBskyBookmarkGetModBookmarksBySubject:
+    'app.bsky.bookmark.getModBookmarksBySubject',
   AppBskyEmbedDefs: 'app.bsky.embed.defs',
   AppBskyEmbedExternal: 'app.bsky.embed.external',
   AppBskyEmbedImages: 'app.bsky.embed.images',

--- a/packages/ozone/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
@@ -1,0 +1,43 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyBookmarkDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksByActor'
+
+export type QueryParams = {
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: AppBskyBookmarkDefs.BookmarkView[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/ozone/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
@@ -1,0 +1,60 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyActorDefs from '../actor/defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksBySubject'
+
+export type QueryParams = {
+  /** AT-URI of the subject (eg, a post record). */
+  subject: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: Bookmark[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export interface Bookmark {
+  $type?: 'app.bsky.bookmark.getModBookmarksBySubject#bookmark'
+  indexedAt: string
+  actor: AppBskyActorDefs.ProfileView
+}
+
+const hashBookmark = 'bookmark'
+
+export function isBookmark<V>(v: V) {
+  return is$typed(v, id, hashBookmark)
+}
+
+export function validateBookmark<V>(v: V) {
+  return validate<Bookmark & V>(v, id, hashBookmark)
+}

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -20,6 +20,8 @@ import * as AppBskyActorSearchActorsTypeahead from './types/app/bsky/actor/searc
 import * as AppBskyBookmarkCreateBookmark from './types/app/bsky/bookmark/createBookmark.js'
 import * as AppBskyBookmarkDeleteBookmark from './types/app/bsky/bookmark/deleteBookmark.js'
 import * as AppBskyBookmarkGetBookmarks from './types/app/bsky/bookmark/getBookmarks.js'
+import * as AppBskyBookmarkGetModBookmarksByActor from './types/app/bsky/bookmark/getModBookmarksByActor.js'
+import * as AppBskyBookmarkGetModBookmarksBySubject from './types/app/bsky/bookmark/getModBookmarksBySubject.js'
 import * as AppBskyFeedDescribeFeedGenerator from './types/app/bsky/feed/describeFeedGenerator.js'
 import * as AppBskyFeedGetActorFeeds from './types/app/bsky/feed/getActorFeeds.js'
 import * as AppBskyFeedGetActorLikes from './types/app/bsky/feed/getActorLikes.js'
@@ -555,6 +557,30 @@ export class AppBskyBookmarkNS {
     >,
   ) {
     const nsid = 'app.bsky.bookmark.getBookmarks' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksByActor<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksByActor.QueryParams,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerInput,
+      AppBskyBookmarkGetModBookmarksByActor.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksByActor' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getModBookmarksBySubject<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      AppBskyBookmarkGetModBookmarksBySubject.QueryParams,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerInput,
+      AppBskyBookmarkGetModBookmarksBySubject.HandlerOutput
+    >,
+  ) {
+    const nsid = 'app.bsky.bookmark.getModBookmarksBySubject' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 }

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -1317,6 +1317,119 @@ export const schemaDict = {
       },
     },
   },
+  AppBskyBookmarkGetModBookmarksByActor: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksByActor',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by actor. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['actor'],
+          properties: {
+            actor: {
+              type: 'string',
+              format: 'did',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.defs#bookmarkView',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  AppBskyBookmarkGetModBookmarksBySubject: {
+    lexicon: 1,
+    id: 'app.bsky.bookmark.getModBookmarksBySubject',
+    defs: {
+      main: {
+        type: 'query',
+        description:
+          'Moderation endpoint to get bookmarks by subject. Requires moderation service auth.',
+        parameters: {
+          type: 'params',
+          required: ['subject'],
+          properties: {
+            subject: {
+              type: 'string',
+              format: 'at-uri',
+              description: 'AT-URI of the subject (eg, a post record).',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['bookmarks'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              bookmarks: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:app.bsky.bookmark.getModBookmarksBySubject#bookmark',
+                },
+              },
+            },
+          },
+        },
+      },
+      bookmark: {
+        type: 'object',
+        required: ['indexedAt', 'actor'],
+        properties: {
+          indexedAt: {
+            type: 'string',
+            format: 'datetime',
+          },
+          actor: {
+            type: 'ref',
+            ref: 'lex:app.bsky.actor.defs#profileView',
+          },
+        },
+      },
+    },
+  },
   AppBskyEmbedDefs: {
     lexicon: 1,
     id: 'app.bsky.embed.defs',
@@ -18409,6 +18522,10 @@ export const ids = {
   AppBskyBookmarkDefs: 'app.bsky.bookmark.defs',
   AppBskyBookmarkDeleteBookmark: 'app.bsky.bookmark.deleteBookmark',
   AppBskyBookmarkGetBookmarks: 'app.bsky.bookmark.getBookmarks',
+  AppBskyBookmarkGetModBookmarksByActor:
+    'app.bsky.bookmark.getModBookmarksByActor',
+  AppBskyBookmarkGetModBookmarksBySubject:
+    'app.bsky.bookmark.getModBookmarksBySubject',
   AppBskyEmbedDefs: 'app.bsky.embed.defs',
   AppBskyEmbedExternal: 'app.bsky.embed.external',
   AppBskyEmbedImages: 'app.bsky.embed.images',

--- a/packages/pds/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/bookmark/getModBookmarksByActor.ts
@@ -1,0 +1,43 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyBookmarkDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksByActor'
+
+export type QueryParams = {
+  actor: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: AppBskyBookmarkDefs.BookmarkView[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/bookmark/getModBookmarksBySubject.ts
@@ -1,0 +1,60 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as AppBskyActorDefs from '../actor/defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'app.bsky.bookmark.getModBookmarksBySubject'
+
+export type QueryParams = {
+  /** AT-URI of the subject (eg, a post record). */
+  subject: string
+  limit: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  bookmarks: Bookmark[]
+}
+
+export type HandlerInput = void
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export interface Bookmark {
+  $type?: 'app.bsky.bookmark.getModBookmarksBySubject#bookmark'
+  indexedAt: string
+  actor: AppBskyActorDefs.ProfileView
+}
+
+const hashBookmark = 'bookmark'
+
+export function isBookmark<V>(v: V) {
+  return is$typed(v, id, hashBookmark)
+}
+
+export function validateBookmark<V>(v: V) {
+  return validate<Bookmark & V>(v, id, hashBookmark)
+}


### PR DESCRIPTION
Bookmarks API was introduced in https://github.com/bluesky-social/atproto/pull/4163, with an explanation of how we're storing that data.

This PR is still a draft, and I will add more info to it soon, but for now, I should clarify:

> [!IMPORTANT]
> Bookmarks are private to your account and are not visible to other users. To maintain platform safety and comply with legal requirements, our Trust & Safety team may access saved bookmarks when investigating potential violations of our Terms of Service, responding to valid legal requests, or addressing safety concerns.