### PR TITLE
:arrow_up: Add changeset for api and pds package with support for new ozone event type

### DIFF
--- a/.changeset/violet-phones-care.md
+++ b/.changeset/violet-phones-care.md
@@ -1,0 +1,6 @@
+---
+"@atproto/api": patch
+"@atproto/pds": patch
+---
+
+Add revoke credentials moderation event type to lexicons


### PR DESCRIPTION
api and pds packages were missing in the original changeset from this PR https://github.com/bluesky-social/atproto/pull/4170