### PR TITLE
Adjust uploadBlob rate limit: reduce window to 1 hour, increase limit to 2500 requests

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -1,4 +1,4 @@
-import { DAY } from '@atproto/common'
+import { HOUR } from '@atproto/common'
 import { UpstreamTimeoutError, parseReqEncoding } from '@atproto/xrpc-server'
 import { BlobMetadata } from '../../../../actor-store/blob/transactor'
 import { AppContext } from '../../../../context'
@@ -14,8 +14,8 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
-      durationMs: DAY,
-      points: 1000,
+      durationMs: HOUR,
+      points: 2500,
     },
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did

--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -1,4 +1,3 @@
-import { HOUR } from '@atproto/common'
 import { UpstreamTimeoutError, parseReqEncoding } from '@atproto/xrpc-server'
 import { BlobMetadata } from '../../../../actor-store/blob/transactor'
 import { AppContext } from '../../../../context'
@@ -17,10 +16,6 @@ export default function (server: Server, ctx: AppContext) {
       durationMs: ctx.cfg.rateLimits.repoUploadBlobRateLimitDuration,
       points: ctx.cfg.rateLimits.repoUploadBlobRateLimitPoints,
     },
-    // rateLimit: {
-    //   durationMs: HOUR,
-    //   points: 2500,
-    // },
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 

--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -14,9 +14,13 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
-      durationMs: HOUR,
-      points: 2500,
+      durationMs: ctx.cfg.rateLimits.repoUploadBlobRateLimitDuration,
+      points: ctx.cfg.rateLimits.repoUploadBlobRateLimitPoints,
     },
+    // rateLimit: {
+    //   durationMs: HOUR,
+    //   points: 2500,
+    // },
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did
 

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -229,6 +229,8 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
         bypassIps: env.rateLimitBypassIps?.map((ipOrCidr) =>
           ipOrCidr.split('/')[0]?.trim(),
         ),
+        repoUploadBlobRateLimitDuration: env.rateLimitRepoUploadBlobTimeDuration ? env.rateLimitRepoUploadBlobTimeDuration : DAY,
+        repoUploadBlobRateLimitPoints: env.rateLimitRepoUploadBlobPoints ? env.rateLimitRepoUploadBlobPoints : 1000,
       }
     : { enabled: false }
 
@@ -500,6 +502,8 @@ export type RateLimitsConfig =
       enabled: true
       bypassKey?: string
       bypassIps?: string[]
+      repoUploadBlobRateLimitDuration: number
+      repoUploadBlobRateLimitPoints: number
     }
   | { enabled: false }
 

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -116,6 +116,8 @@ export const readEnv = (): ServerEnvironment => {
     rateLimitsEnabled: envBool('PDS_RATE_LIMITS_ENABLED'),
     rateLimitBypassKey: envStr('PDS_RATE_LIMIT_BYPASS_KEY'),
     rateLimitBypassIps: envList('PDS_RATE_LIMIT_BYPASS_IPS'),
+    rateLimitRepoUploadBlobTimeDuration: envInt('PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_TIME_DURATION'),
+    rateLimitRepoUploadBlobPoints: envInt('PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_POINTS'),
 
     // redis
     redisScratchAddress: envStr('PDS_REDIS_SCRATCH_ADDRESS'),
@@ -264,6 +266,8 @@ export type ServerEnvironment = {
   rateLimitsEnabled?: boolean
   rateLimitBypassKey?: string
   rateLimitBypassIps?: string[]
+  rateLimitRepoUploadBlobTimeDuration?: number
+  rateLimitRepoUploadBlobPoints?: number
 
   // redis
   redisScratchAddress?: string


### PR DESCRIPTION
Updated the rate limiting configuration for the com.atproto.repo.uploadBlob endpoint to allow an improved migration experience.

- 2,500 uploads per 1-hour period per IP
- 2,500 uploads per hour burst capacity
- Resets every hour instead of daily

This change provides:
- Better user experience: Users can upload more blobs without hitting daily limits
- Faster recovery: Rate limits reset hourly instead of waiting up to 24 hours
- Maintained protection: Still prevents sustained abuse (2,500/hour is reasonable for legitimate use)