### PR TITLE
explicitly check for empty string in labelers header

### DIFF
--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -131,7 +131,11 @@ export class AppContext {
       parsed = null
       log.info({ err, val }, 'failed to parse labeler header')
     }
-    if (!parsed) return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
+    // Explicitly check if the header was not supplied at all, and return the default labeler if it was not.
+    // A supplied header with an empty string should mean that _no_ labelers will be applied
+    if (parsed === null) {
+      return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
+    }
     return parsed
   }
 }

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -131,11 +131,7 @@ export class AppContext {
       parsed = null
       log.info({ err, val }, 'failed to parse labeler header')
     }
-    // Explicitly check if the header was not supplied at all, and return the default labeler if it was not.
-    // A supplied header with an empty string should mean that _no_ labelers will be applied
-    if (parsed === null) {
-      return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
-    }
+    if (!parsed) return defaultLabelerHeader(this.cfg.labelsFromIssuerDids)
     return parsed
   }
 }

--- a/packages/bsky/src/util.ts
+++ b/packages/bsky/src/util.ts
@@ -8,7 +8,9 @@ export type ParsedLabelers = {
 export const parseLabelerHeader = (
   header: string | undefined,
 ): ParsedLabelers | null => {
-  if (!header) return null
+  // An empty header is valid, so we shouldn't return null
+  // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+  if (header === undefined) return null
   const labelerDids = new Set<string>()
   const redactDids = new Set<string>()
   const parsed = parseList(header)


### PR DESCRIPTION
I believe the intention of having an empty `atproto-accept-labelers` header is to apply _no_ moderation services to the output. At present however, this doesn't quite work. You can disable any given moderation service, but you must supply at least one, even a fake labeler. The expectation should be:

- No `atproto-accept-labeler` header provided -> Apply the default moderation service
- Supply a header with any moderation service -> Only apply those moderation services
- Supply a header with an empty string as the value -> Apply no moderation services

Outputs:
```
// Passing a DID
{
  dids: [ 'did:plc:eotxm3k2kk6ravy6bu3w2e7t' ],
  redact: Set(1) { 'did:plc:eotxm3k2kk6ravy6bu3w2e7t' }
}

// Empty but supplied header
{ dids: [], redact: Set(0) {} }

// Non-existent header
null // which will give us the defualt headers
```