### PR TITLE
PDS: support websocket permessage-deflate

### DIFF
--- a/.changeset/fast-rice-happen.md
+++ b/.changeset/fast-rice-happen.md
@@ -1,0 +1,5 @@
+---
+"@atproto/xrpc-server": patch
+---
+
+Support websocket server configuration.

--- a/.changeset/sixty-tigers-pull.md
+++ b/.changeset/sixty-tigers-pull.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Support websocket permessage-deflate config PDS_WS_PERMESSAGE_DEFLATE.

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -324,6 +324,10 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     didAuthority: env.lexiconDidAuthority,
   }
 
+  const wsCfg: WebSocketConfig = {
+    perMessageDeflate: env.wsPerMessageDeflate,
+  }
+
   return {
     service: serviceCfg,
     db: dbCfg,
@@ -345,6 +349,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     lexicon: lexiconCfg,
     proxy: proxyCfg,
     oauth: oauthCfg,
+    ws: wsCfg,
   }
 }
 
@@ -369,6 +374,7 @@ export type ServerConfig = {
   proxy: ProxyConfig
   oauth: OAuthConfig
   lexicon: LexiconResolverConfig
+  ws: WebSocketConfig
 }
 
 export type ServiceConfig = {
@@ -519,4 +525,8 @@ export type ModServiceConfig = {
 export type ReportServiceConfig = {
   url: string
   did: string
+}
+
+export type WebSocketConfig = {
+  perMessageDeflate?: boolean
 }

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -151,6 +151,9 @@ export const readEnv = (): ServerEnvironment => {
     proxyMaxResponseSize: envInt('PDS_PROXY_MAX_RESPONSE_SIZE'),
     proxyMaxRetries: envInt('PDS_PROXY_MAX_RETRIES'),
     proxyPreferCompressed: envBool('PDS_PROXY_PREFER_COMPRESSED'),
+
+    // websocket
+    wsPerMessageDeflate: envBool('PDS_WS_PERMESSAGE_DEFLATE'),
   }
 }
 
@@ -301,4 +304,7 @@ export type ServerEnvironment = {
   proxyMaxResponseSize?: number
   proxyMaxRetries?: number
   proxyPreferCompressed?: boolean
+
+  // ws
+  wsPerMessageDeflate?: boolean
 }

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -142,6 +142,9 @@ export class PDS {
             ],
           }
         : undefined,
+      ws: {
+        perMessageDeflate: cfg.ws.perMessageDeflate,
+      },
     })
 
     apiRoutes(server, ctx)

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -386,9 +386,11 @@ export class Server {
     const authVerifier = this.createAuthVerifier(cfg)
 
     const { handler } = cfg
+    const { ws } = this.options
     this.subscriptions.set(
       nsid,
       new XrpcStreamServer({
+        ...ws,
         noServer: true,
         handler: async function* (req, signal) {
           try {

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -1,6 +1,7 @@
 import { IncomingMessage } from 'node:http'
 import { Readable } from 'node:stream'
 import { NextFunction, Request, Response } from 'express'
+import { ServerOptions as WsServerOptions } from 'ws'
 import { z } from 'zod'
 import { ErrorResult, XRPCError } from './errors'
 import { CalcKeyFn, CalcPointsFn, RateLimiterI } from './rate-limiter'
@@ -34,6 +35,7 @@ export type Options = {
    * @note This function should not throw errors.
    */
   errorParser?: (err: unknown) => XRPCError
+  ws?: Omit<WsServerOptions, 'noServer' | 'server' | 'host' | 'path' | 'port'>
 }
 
 export type UndecodedParams = Request['query']


### PR DESCRIPTION
This adds support for opt-in permessage-deflate on the PDS via `PDS_WS_PERMESSAGE_DEFLATE`.  Also adds ability to configure ws server options on xrpc-server.