### PR TITLE
feat(pds): support SMTP host/port config alongside SMTP URL

### DIFF
--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -147,8 +147,21 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
         'Partial email config, must set both emailFromAddress and emailSmtpUrl',
       )
     }
-    emailCfg = {
+    if (env.emailSmtpUrl && env.emailSmtpHost) {
+      throw new Error(
+        'Cannot set both emailSmtpUrl and emailSmtpHost env vars'
+      )
+    }
+    emailCfg = env.emailSmtpUrl ? {
       smtpUrl: env.emailSmtpUrl,
+      fromAddress: env.emailFromAddress,
+    } : {
+      smtpHost: env.emailSmtpHost || 'localhost',
+      smtpPort: env.emailSmtpPort || 25,
+      smtpPool: env.emailSmtpPool,
+      smtpSecure: env.emailSmtpSecure,
+      smtpAuthUser: env.emailSmtpAuthUser,
+      smtpAuthPassword: env.emailSmtpAuthPassword,
       fromAddress: env.emailFromAddress,
     }
   }
@@ -162,8 +175,16 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
         'Partial moderation email config, must set both emailFromAddress and emailSmtpUrl',
       )
     }
-    moderationEmailCfg = {
+    moderationEmailCfg = env.moderationEmailSmtpUrl ? {
       smtpUrl: env.moderationEmailSmtpUrl,
+      fromAddress: env.moderationEmailAddress,
+    } : {
+      smtpHost: env.moderationEmailSmtpHost || 'localhost',
+      smtpPort: env.moderationEmailSmtpPort || 25,
+      smtpPool: env.moderationEmailSmtpPool,
+      smtpSecure: env.moderationEmailSmtpSecure,
+      smtpAuthUser: env.moderationEmailSmtpAuthUser,
+      smtpAuthPassword: env.moderationEmailSmtpAuthPassword,
       fromAddress: env.moderationEmailAddress,
     }
   }
@@ -480,10 +501,20 @@ export type InvitesConfig =
       required: false
     }
 
-export type EmailConfig = {
+export type EmailUrlConfig = {
   smtpUrl: string
   fromAddress: string
 }
+export type EmailHostConfig = {
+  smtpHost: string
+  smtpPort: number
+  smtpPool?: boolean
+  smtpSecure?: boolean
+  smtpAuthUser?: string
+  smtpAuthPassword?: string
+  fromAddress: string
+}
+export type EmailConfig = EmailUrlConfig | EmailHostConfig
 
 export type SubscriptionConfig = {
   maxBuffer: number

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -240,8 +240,20 @@ export type ServerEnvironment = {
   // email
   emailSmtpUrl?: string
   emailFromAddress?: string
+  emailSmtpHost?: string
+  emailSmtpPort?: number
+  emailSmtpPool?: boolean
+  emailSmtpSecure?: boolean
+  emailSmtpAuthUser?: string
+  emailSmtpAuthPassword?: string
   moderationEmailSmtpUrl?: string
   moderationEmailAddress?: string
+  moderationEmailSmtpHost?: string
+  moderationEmailSmtpPort?: number
+  moderationEmailSmtpPool?: boolean
+  moderationEmailSmtpSecure?: boolean
+  moderationEmailSmtpAuthUser?: string
+  moderationEmailSmtpAuthPassword?: string
 
   // subscription
   maxSubscriptionBuffer?: number

--- a/packages/pds/src/mailer/index.ts
+++ b/packages/pds/src/mailer/index.ts
@@ -73,7 +73,7 @@ export class ServerMailer {
       from: mailOpts.from ?? this.config.email?.fromAddress,
       html,
     })
-    if (!this.config.email?.smtpUrl) {
+    if (!this.config.email) {
       mailerLogger.debug(
         'No SMTP URL has been configured. Intended to send email:\n' +
           JSON.stringify(res, null, 2),

--- a/packages/pds/src/mailer/moderation.ts
+++ b/packages/pds/src/mailer/moderation.ts
@@ -27,7 +27,7 @@ export class ModerationMailer {
 
     const res = await this.transporter.sendMail(mail)
 
-    if (!this.config.moderationEmail?.smtpUrl) {
+    if (!this.config.moderationEmail) {
       mailerLogger.debug(
         'Moderation email auth is not configured. Intended to send email:\n' +
           JSON.stringify(res, null, 2),


### PR DESCRIPTION
Enable configuring mail transports via host/port options in addition to a single SMTP URL.

- Add EmailConfig union (EmailUrlConfig | EmailHostConfig)
- Extend ServerEnvironment with SMTP host/port/pool/secure/auth fields for both normal and moderation email
- Build nodemailer transport from either smtpUrl or host/port options in AppContext for server and moderation mailers
- Disallow setting both emailSmtpUrl and emailSmtpHost to avoid ambiguity
- Default smtpHost to "localhost" and smtpPort to 25 when using host/port configuration
- Adjust mailer debug logging to check for overall email config presence

No behavior change for existing setups that use smtpUrl; new env vars are optional and only used when provided.