### PR TITLE
Restore session on network error

### DIFF
--- a/.changeset/fast-monkeys-punch.md
+++ b/.changeset/fast-monkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": minor
+---
+
+Don't clear session in resumeSession on transient network errors

--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -418,8 +418,9 @@ export class CredentialSession implements SessionManager {
           this.session = undefined
           this.persistSession?.('expired', undefined)
         } else {
-          this.session = undefined
-          this.persistSession?.('network-error', undefined)
+          // Assume the problem is transient and the session can be reused later.
+          this.session = session
+          this.persistSession?.('network-error', session)
         }
       }
 

--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -411,14 +411,16 @@ export class CredentialSession implements SessionManager {
     } catch (err) {
       // protect against concurrent session updates
       if (this.session === session) {
-        this.session = undefined
-        this.persistSession?.(
+        if (
           err instanceof XRPCError &&
-            ['ExpiredToken', 'InvalidToken'].includes(err.error)
-            ? 'expired'
-            : 'network-error',
-          undefined,
-        )
+          ['ExpiredToken', 'InvalidToken'].includes(err.error)
+        ) {
+          this.session = undefined
+          this.persistSession?.('expired', undefined)
+        } else {
+          this.session = undefined
+          this.persistSession?.('network-error', undefined)
+        }
       }
 
       throw err


### PR DESCRIPTION
Currently, if `resumeSession` fails with `network-error`, `this.session` gets cleared out. However, that's actually extremely unhelpful and used to be (in a more distant past) one of the causes of "random logouts" in the flagship atproto app, Bluesky.

The official Bluesky client already includes a hack to work around this:

https://github.com/bluesky-social/social-app/blob/7f4e3091f792963114dc8f11e246744b51127bf1/src/state/session/agent.ts#L324-L331

```js
    let lastSession = this.sessionManager.session
    this.persistSessionHandler = event => {
      if (this.sessionManager.session) {
        lastSession = this.sessionManager.session
      } else if (event === 'network-error') {
        // Put it back, we'll try again later.
        this.sessionManager.session = lastSession
      }
```

If the error is `network-error`, the Bluesky app simply patches the `.session` back to what it was.

That hack is unfortunate, complicates the logic, doesn't work for anyone else, and is also probably subtly buggy. In particular, it can in theory [cause an old session to revive](https://bsky.app/profile/mackuba.eu/post/3luecguaugc2h). I don't know if that can actually happen but I'd like to rip out the hack in favor of this fix upstream.

## Test Plan

I split the change in two commits: the first one just splits existing logic in two cases, and the second one is the intended change. I'd suggest reading the `social-app` code above to verify that this is equivalent to what we're already doing.

You may also want to rip out the above hack from the `social-app` and verify that network failures still don't cause a logout. In particular, verify that the test plan from https://github.com/bluesky-social/social-app/pull/4911 (when I added the hack) still passes.