### PR TITLE
:sparkles: Add delayed takedown feature to ozone

### DIFF
--- a/lexicons/tools/ozone/moderation/cancelScheduledActions.json
+++ b/lexicons/tools/ozone/moderation/cancelScheduledActions.json
@@ -1,0 +1,60 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.moderation.cancelScheduledActions",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Cancel all pending scheduled moderation actions for specified subjects",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["subjects"],
+          "properties": {
+            "subjects": {
+              "type": "array",
+              "maxLength": 100,
+              "items": {
+                "type": "string",
+                "format": "did"
+              },
+              "description": "Array of DID subjects to cancel scheduled actions for"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "#cancellationResults"
+        }
+      }
+    },
+    "cancellationResults": {
+      "type": "object",
+      "required": ["succeeded", "failed"],
+      "properties": {
+        "succeeded": {
+          "type": "array",
+          "items": { "type": "string", "format": "did" },
+          "description": "DIDs for which all pending scheduled actions were successfully cancelled"
+        },
+        "failed": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#failedCancellation" },
+          "description": "DIDs for which cancellation failed with error details"
+        }
+      }
+    },
+    "failedCancellation": {
+      "type": "object",
+      "required": ["did", "error"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "error": { "type": "string" },
+        "errorCode": { "type": "string" }
+      }
+    }
+  }
+}

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -38,7 +38,9 @@
             "#modEventPriorityScore",
             "#ageAssuranceEvent",
             "#ageAssuranceOverrideEvent",
-            "#revokeAccountCredentialsEvent"
+            "#revokeAccountCredentialsEvent",
+            "#scheduleTakedownEvent",
+            "#cancelScheduledTakedownEvent"
           ]
         },
         "subject": {
@@ -93,7 +95,9 @@
             "#modEventPriorityScore",
             "#ageAssuranceEvent",
             "#ageAssuranceOverrideEvent",
-            "#revokeAccountCredentialsEvent"
+            "#revokeAccountCredentialsEvent",
+            "#scheduleTakedownEvent",
+            "#cancelScheduledTakedownEvent"
           ]
         },
         "subject": {
@@ -678,6 +682,16 @@
         "timestamp": { "type": "string", "format": "datetime" }
       }
     },
+    "scheduleTakedownEvent": {
+      "type": "object",
+      "description": "Logs a scheduled takedown action for an account.",
+      "properties": {}
+    },
+    "cancelScheduledTakedownEvent": {
+      "type": "object",
+      "description": "Logs cancellation of a scheduled takedown action for an account.",
+      "properties": {}
+    },
     "repoView": {
       "type": "object",
       "required": [
@@ -1003,6 +1017,83 @@
     "timelineEventPlcTombstone": {
       "type": "token",
       "description": "Moderation event timeline event for a PLC tombstone operation"
+    },
+    "scheduledActionView": {
+      "type": "object",
+      "description": "View of a scheduled moderation action",
+      "required": ["id", "action", "did", "createdBy", "createdAt", "status"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Auto-incrementing row ID"
+        },
+        "action": {
+          "type": "string",
+          "knownValues": ["takedown"],
+          "description": "Type of action to be executed"
+        },
+        "eventData": {
+          "type": "unknown",
+          "description": "Serialized event object that will be propagated to the event when performed"
+        },
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "Subject DID for the action"
+        },
+        "executeAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Exact time to execute the action"
+        },
+        "executeAfter": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Earliest time to execute the action (for randomized scheduling)"
+        },
+        "executeUntil": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Latest time to execute the action (for randomized scheduling)"
+        },
+        "randomizeExecution": {
+          "type": "boolean",
+          "description": "Whether execution time should be randomized within the specified range"
+        },
+        "createdBy": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the user who created this scheduled action"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the scheduled action was created"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the scheduled action was last updated"
+        },
+        "status": {
+          "type": "string",
+          "knownValues": ["pending", "executed", "cancelled", "failed"],
+          "description": "Current status of the scheduled action"
+        },
+        "lastExecutedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the action was last attempted to be executed"
+        },
+        "lastFailureReason": {
+          "type": "string",
+          "description": "Reason for the last execution failure"
+        },
+        "executionEventId": {
+          "type": "integer",
+          "description": "ID of the moderation event created when action was successfully executed"
+        }
+      }
     }
   }
 }

--- a/lexicons/tools/ozone/moderation/emitEvent.json
+++ b/lexicons/tools/ozone/moderation/emitEvent.json
@@ -35,7 +35,9 @@
                 "tools.ozone.moderation.defs#modEventPriorityScore",
                 "tools.ozone.moderation.defs#ageAssuranceEvent",
                 "tools.ozone.moderation.defs#ageAssuranceOverrideEvent",
-                "tools.ozone.moderation.defs#revokeAccountCredentialsEvent"
+                "tools.ozone.moderation.defs#revokeAccountCredentialsEvent",
+                "tools.ozone.moderation.defs#scheduleTakedownEvent",
+                "tools.ozone.moderation.defs#cancelScheduledTakedownEvent"
               ]
             },
             "subject": {

--- a/lexicons/tools/ozone/moderation/getAccountTimeline.json
+++ b/lexicons/tools/ozone/moderation/getAccountTimeline.json
@@ -92,7 +92,9 @@
             "tools.ozone.hosting.getAccountHistory#accountCreated",
             "tools.ozone.hosting.getAccountHistory#emailConfirmed",
             "tools.ozone.hosting.getAccountHistory#passwordUpdated",
-            "tools.ozone.hosting.getAccountHistory#handleUpdated"
+            "tools.ozone.hosting.getAccountHistory#handleUpdated",
+            "tools.ozone.moderation.defs#scheduleTakedownEvent",
+            "tools.ozone.moderation.defs#cancelScheduledTakedownEvent"
           ]
         },
         "count": {

--- a/lexicons/tools/ozone/moderation/listScheduledActions.json
+++ b/lexicons/tools/ozone/moderation/listScheduledActions.json
@@ -1,0 +1,76 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.moderation.listScheduledActions",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "List scheduled moderation actions with optional filtering",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "startTime": {
+              "type": "string",
+              "format": "datetime",
+              "description": "Filter actions scheduled to execute after this time"
+            },
+            "endTime": {
+              "type": "string",
+              "format": "datetime",
+              "description": "Filter actions scheduled to execute before this time"
+            },
+            "subjects": {
+              "type": "array",
+              "maxLength": 100,
+              "items": {
+                "type": "string",
+                "format": "did"
+              },
+              "description": "Filter actions for specific DID subjects"
+            },
+            "statuses": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "knownValues": ["pending", "executed", "cancelled", "failed"]
+              },
+              "description": "Filter actions by status"
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50,
+              "description": "Maximum number of results to return"
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Cursor for pagination"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["actions"],
+          "properties": {
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "tools.ozone.moderation.defs#scheduledActionView"
+              }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Cursor for next page of results"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/tools/ozone/moderation/scheduleAction.json
+++ b/lexicons/tools/ozone/moderation/scheduleAction.json
@@ -1,0 +1,134 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.moderation.scheduleAction",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Schedule a moderation action to be executed at a future time",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["action", "subjects", "createdBy", "scheduling"],
+          "properties": {
+            "action": {
+              "type": "union",
+              "refs": ["#takedown"]
+            },
+            "subjects": {
+              "type": "array",
+              "maxLength": 100,
+              "items": {
+                "type": "string",
+                "format": "did"
+              },
+              "description": "Array of DID subjects to schedule the action for"
+            },
+            "createdBy": {
+              "type": "string",
+              "format": "did"
+            },
+            "scheduling": {
+              "type": "ref",
+              "ref": "#schedulingConfig"
+            },
+            "modTool": {
+              "type": "ref",
+              "ref": "tools.ozone.moderation.defs#modTool",
+              "description": "This will be propagated to the moderation event when it is applied"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "#scheduledActionResults"
+        }
+      }
+    },
+    "takedown": {
+      "type": "object",
+      "description": "Schedule a takedown action",
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "durationInHours": {
+          "type": "integer",
+          "description": "Indicates how long the takedown should be in effect before automatically expiring."
+        },
+        "acknowledgeAccountSubjects": {
+          "type": "boolean",
+          "description": "If true, all other reports on content authored by this account will be resolved (acknowledged)."
+        },
+        "policies": {
+          "type": "array",
+          "maxLength": 5,
+          "items": {
+            "type": "string"
+          },
+          "description": "Names/Keywords of the policies that drove the decision."
+        }
+      }
+    },
+    "schedulingConfig": {
+      "type": "object",
+      "description": "Configuration for when the action should be executed",
+      "properties": {
+        "executeAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Exact time to execute the action"
+        },
+        "executeAfter": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Earliest time to execute the action (for randomized scheduling)"
+        },
+        "executeUntil": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Latest time to execute the action (for randomized scheduling)"
+        }
+      }
+    },
+    "scheduledActionResults": {
+      "type": "object",
+      "required": ["succeeded", "failed"],
+      "properties": {
+        "succeeded": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "did"
+          }
+        },
+        "failed": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#failedScheduling"
+          }
+        }
+      }
+    },
+    "failedScheduling": {
+      "type": "object",
+      "required": ["subject", "error"],
+      "properties": {
+        "subject": {
+          "type": "string",
+          "format": "did"
+        },
+        "error": {
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -251,6 +251,7 @@ import * as ToolsOzoneCommunicationDeleteTemplate from './types/tools/ozone/comm
 import * as ToolsOzoneCommunicationListTemplates from './types/tools/ozone/communication/listTemplates.js'
 import * as ToolsOzoneCommunicationUpdateTemplate from './types/tools/ozone/communication/updateTemplate.js'
 import * as ToolsOzoneHostingGetAccountHistory from './types/tools/ozone/hosting/getAccountHistory.js'
+import * as ToolsOzoneModerationCancelScheduledActions from './types/tools/ozone/moderation/cancelScheduledActions.js'
 import * as ToolsOzoneModerationDefs from './types/tools/ozone/moderation/defs.js'
 import * as ToolsOzoneModerationEmitEvent from './types/tools/ozone/moderation/emitEvent.js'
 import * as ToolsOzoneModerationGetAccountTimeline from './types/tools/ozone/moderation/getAccountTimeline.js'
@@ -261,8 +262,10 @@ import * as ToolsOzoneModerationGetRepo from './types/tools/ozone/moderation/get
 import * as ToolsOzoneModerationGetReporterStats from './types/tools/ozone/moderation/getReporterStats.js'
 import * as ToolsOzoneModerationGetRepos from './types/tools/ozone/moderation/getRepos.js'
 import * as ToolsOzoneModerationGetSubjects from './types/tools/ozone/moderation/getSubjects.js'
+import * as ToolsOzoneModerationListScheduledActions from './types/tools/ozone/moderation/listScheduledActions.js'
 import * as ToolsOzoneModerationQueryEvents from './types/tools/ozone/moderation/queryEvents.js'
 import * as ToolsOzoneModerationQueryStatuses from './types/tools/ozone/moderation/queryStatuses.js'
+import * as ToolsOzoneModerationScheduleAction from './types/tools/ozone/moderation/scheduleAction.js'
 import * as ToolsOzoneModerationSearchRepos from './types/tools/ozone/moderation/searchRepos.js'
 import * as ToolsOzoneReportDefs from './types/tools/ozone/report/defs.js'
 import * as ToolsOzoneSafelinkAddRule from './types/tools/ozone/safelink/addRule.js'
@@ -539,6 +542,7 @@ export * as ToolsOzoneCommunicationDeleteTemplate from './types/tools/ozone/comm
 export * as ToolsOzoneCommunicationListTemplates from './types/tools/ozone/communication/listTemplates.js'
 export * as ToolsOzoneCommunicationUpdateTemplate from './types/tools/ozone/communication/updateTemplate.js'
 export * as ToolsOzoneHostingGetAccountHistory from './types/tools/ozone/hosting/getAccountHistory.js'
+export * as ToolsOzoneModerationCancelScheduledActions from './types/tools/ozone/moderation/cancelScheduledActions.js'
 export * as ToolsOzoneModerationDefs from './types/tools/ozone/moderation/defs.js'
 export * as ToolsOzoneModerationEmitEvent from './types/tools/ozone/moderation/emitEvent.js'
 export * as ToolsOzoneModerationGetAccountTimeline from './types/tools/ozone/moderation/getAccountTimeline.js'
@@ -549,8 +553,10 @@ export * as ToolsOzoneModerationGetRepo from './types/tools/ozone/moderation/get
 export * as ToolsOzoneModerationGetReporterStats from './types/tools/ozone/moderation/getReporterStats.js'
 export * as ToolsOzoneModerationGetRepos from './types/tools/ozone/moderation/getRepos.js'
 export * as ToolsOzoneModerationGetSubjects from './types/tools/ozone/moderation/getSubjects.js'
+export * as ToolsOzoneModerationListScheduledActions from './types/tools/ozone/moderation/listScheduledActions.js'
 export * as ToolsOzoneModerationQueryEvents from './types/tools/ozone/moderation/queryEvents.js'
 export * as ToolsOzoneModerationQueryStatuses from './types/tools/ozone/moderation/queryStatuses.js'
+export * as ToolsOzoneModerationScheduleAction from './types/tools/ozone/moderation/scheduleAction.js'
 export * as ToolsOzoneModerationSearchRepos from './types/tools/ozone/moderation/searchRepos.js'
 export * as ToolsOzoneReportDefs from './types/tools/ozone/report/defs.js'
 export * as ToolsOzoneSafelinkAddRule from './types/tools/ozone/safelink/addRule.js'
@@ -4882,6 +4888,18 @@ export class ToolsOzoneModerationNS {
     this._client = client
   }
 
+  cancelScheduledActions(
+    data?: ToolsOzoneModerationCancelScheduledActions.InputSchema,
+    opts?: ToolsOzoneModerationCancelScheduledActions.CallOptions,
+  ): Promise<ToolsOzoneModerationCancelScheduledActions.Response> {
+    return this._client.call(
+      'tools.ozone.moderation.cancelScheduledActions',
+      opts?.qp,
+      data,
+      opts,
+    )
+  }
+
   emitEvent(
     data?: ToolsOzoneModerationEmitEvent.InputSchema,
     opts?: ToolsOzoneModerationEmitEvent.CallOptions,
@@ -4991,6 +5009,18 @@ export class ToolsOzoneModerationNS {
     )
   }
 
+  listScheduledActions(
+    data?: ToolsOzoneModerationListScheduledActions.InputSchema,
+    opts?: ToolsOzoneModerationListScheduledActions.CallOptions,
+  ): Promise<ToolsOzoneModerationListScheduledActions.Response> {
+    return this._client.call(
+      'tools.ozone.moderation.listScheduledActions',
+      opts?.qp,
+      data,
+      opts,
+    )
+  }
+
   queryEvents(
     params?: ToolsOzoneModerationQueryEvents.QueryParams,
     opts?: ToolsOzoneModerationQueryEvents.CallOptions,
@@ -5011,6 +5041,18 @@ export class ToolsOzoneModerationNS {
       'tools.ozone.moderation.queryStatuses',
       params,
       undefined,
+      opts,
+    )
+  }
+
+  scheduleAction(
+    data?: ToolsOzoneModerationScheduleAction.InputSchema,
+    opts?: ToolsOzoneModerationScheduleAction.CallOptions,
+  ): Promise<ToolsOzoneModerationScheduleAction.Response> {
+    return this._client.call(
+      'tools.ozone.moderation.scheduleAction',
+      opts?.qp,
+      data,
       opts,
     )
   }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -14181,6 +14181,83 @@ export const schemaDict = {
       },
     },
   },
+  ToolsOzoneModerationCancelScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.cancelScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Cancel all pending scheduled moderation actions for specified subjects',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['subjects'],
+            properties: {
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description:
+                  'Array of DID subjects to cancel scheduled actions for',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.cancelScheduledActions#cancellationResults',
+          },
+        },
+      },
+      cancellationResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+            description:
+              'DIDs for which all pending scheduled actions were successfully cancelled',
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.cancelScheduledActions#failedCancellation',
+            },
+            description:
+              'DIDs for which cancellation failed with error details',
+          },
+        },
+      },
+      failedCancellation: {
+        type: 'object',
+        required: ['did', 'error'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
   ToolsOzoneModerationDefs: {
     lexicon: 1,
     id: 'tools.ozone.moderation.defs',
@@ -14224,6 +14301,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14299,6 +14378,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14984,6 +15065,17 @@ export const schemaDict = {
           },
         },
       },
+      scheduleTakedownEvent: {
+        type: 'object',
+        description: 'Logs a scheduled takedown action for an account.',
+        properties: {},
+      },
+      cancelScheduledTakedownEvent: {
+        type: 'object',
+        description:
+          'Logs cancellation of a scheduled takedown action for an account.',
+        properties: {},
+      },
       repoView: {
         type: 'object',
         required: [
@@ -15457,6 +15549,88 @@ export const schemaDict = {
         description:
           'Moderation event timeline event for a PLC tombstone operation',
       },
+      scheduledActionView: {
+        type: 'object',
+        description: 'View of a scheduled moderation action',
+        required: ['id', 'action', 'did', 'createdBy', 'createdAt', 'status'],
+        properties: {
+          id: {
+            type: 'integer',
+            description: 'Auto-incrementing row ID',
+          },
+          action: {
+            type: 'string',
+            knownValues: ['takedown'],
+            description: 'Type of action to be executed',
+          },
+          eventData: {
+            type: 'unknown',
+            description:
+              'Serialized event object that will be propagated to the event when performed',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+            description: 'Subject DID for the action',
+          },
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+          randomizeExecution: {
+            type: 'boolean',
+            description:
+              'Whether execution time should be randomized within the specified range',
+          },
+          createdBy: {
+            type: 'string',
+            format: 'did',
+            description: 'DID of the user who created this scheduled action',
+          },
+          createdAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was created',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was last updated',
+          },
+          status: {
+            type: 'string',
+            knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+            description: 'Current status of the scheduled action',
+          },
+          lastExecutedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the action was last attempted to be executed',
+          },
+          lastFailureReason: {
+            type: 'string',
+            description: 'Reason for the last execution failure',
+          },
+          executionEventId: {
+            type: 'integer',
+            description:
+              'ID of the moderation event created when action was successfully executed',
+          },
+        },
+      },
     },
   },
   ToolsOzoneModerationEmitEvent: {
@@ -15497,6 +15671,8 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
                   'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
                   'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+                  'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+                  'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
                 ],
               },
               subject: {
@@ -15645,6 +15821,8 @@ export const schemaDict = {
               'tools.ozone.hosting.getAccountHistory#emailConfirmed',
               'tools.ozone.hosting.getAccountHistory#passwordUpdated',
               'tools.ozone.hosting.getAccountHistory#handleUpdated',
+              'tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           count: {
@@ -15907,6 +16085,85 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:tools.ozone.moderation.defs#subjectView',
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationListScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.listScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'List scheduled moderation actions with optional filtering',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              startTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute after this time',
+              },
+              endTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute before this time',
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Filter actions for specific DID subjects',
+              },
+              statuses: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+                },
+                description: 'Filter actions by status',
+              },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 100,
+                default: 50,
+                description: 'Maximum number of results to return',
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for pagination',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['actions'],
+            properties: {
+              actions: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:tools.ozone.moderation.defs#scheduledActionView',
+                },
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for next page of results',
               },
             },
           },
@@ -16326,6 +16583,147 @@ export const schemaDict = {
                 },
               },
             },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationScheduleAction: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.scheduleAction',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Schedule a moderation action to be executed at a future time',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['action', 'subjects', 'createdBy', 'scheduling'],
+            properties: {
+              action: {
+                type: 'union',
+                refs: ['lex:tools.ozone.moderation.scheduleAction#takedown'],
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Array of DID subjects to schedule the action for',
+              },
+              createdBy: {
+                type: 'string',
+                format: 'did',
+              },
+              scheduling: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.scheduleAction#schedulingConfig',
+              },
+              modTool: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.defs#modTool',
+                description:
+                  'This will be propagated to the moderation event when it is applied',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.scheduleAction#scheduledActionResults',
+          },
+        },
+      },
+      takedown: {
+        type: 'object',
+        description: 'Schedule a takedown action',
+        properties: {
+          comment: {
+            type: 'string',
+          },
+          durationInHours: {
+            type: 'integer',
+            description:
+              'Indicates how long the takedown should be in effect before automatically expiring.',
+          },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
+          },
+        },
+      },
+      schedulingConfig: {
+        type: 'object',
+        description: 'Configuration for when the action should be executed',
+        properties: {
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+        },
+      },
+      scheduledActionResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.scheduleAction#failedScheduling',
+            },
+          },
+        },
+      },
+      failedScheduling: {
+        type: 'object',
+        required: ['subject', 'error'],
+        properties: {
+          subject: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
           },
         },
       },
@@ -18726,6 +19124,8 @@ export const ids = {
   ToolsOzoneCommunicationUpdateTemplate:
     'tools.ozone.communication.updateTemplate',
   ToolsOzoneHostingGetAccountHistory: 'tools.ozone.hosting.getAccountHistory',
+  ToolsOzoneModerationCancelScheduledActions:
+    'tools.ozone.moderation.cancelScheduledActions',
   ToolsOzoneModerationDefs: 'tools.ozone.moderation.defs',
   ToolsOzoneModerationEmitEvent: 'tools.ozone.moderation.emitEvent',
   ToolsOzoneModerationGetAccountTimeline:
@@ -18738,8 +19138,11 @@ export const ids = {
     'tools.ozone.moderation.getReporterStats',
   ToolsOzoneModerationGetRepos: 'tools.ozone.moderation.getRepos',
   ToolsOzoneModerationGetSubjects: 'tools.ozone.moderation.getSubjects',
+  ToolsOzoneModerationListScheduledActions:
+    'tools.ozone.moderation.listScheduledActions',
   ToolsOzoneModerationQueryEvents: 'tools.ozone.moderation.queryEvents',
   ToolsOzoneModerationQueryStatuses: 'tools.ozone.moderation.queryStatuses',
+  ToolsOzoneModerationScheduleAction: 'tools.ozone.moderation.scheduleAction',
   ToolsOzoneModerationSearchRepos: 'tools.ozone.moderation.searchRepos',
   ToolsOzoneReportDefs: 'tools.ozone.report.defs',
   ToolsOzoneSafelinkAddRule: 'tools.ozone.safelink.addRule',

--- a/packages/api/src/client/types/tools/ozone/moderation/cancelScheduledActions.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/cancelScheduledActions.ts
@@ -1,0 +1,77 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.cancelScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Array of DID subjects to cancel scheduled actions for */
+  subjects: string[]
+}
+
+export type OutputSchema = CancellationResults
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+  qp?: QueryParams
+  encoding?: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}
+
+export interface CancellationResults {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#cancellationResults'
+  /** DIDs for which all pending scheduled actions were successfully cancelled */
+  succeeded: string[]
+  /** DIDs for which cancellation failed with error details */
+  failed: FailedCancellation[]
+}
+
+const hashCancellationResults = 'cancellationResults'
+
+export function isCancellationResults<V>(v: V) {
+  return is$typed(v, id, hashCancellationResults)
+}
+
+export function validateCancellationResults<V>(v: V) {
+  return validate<CancellationResults & V>(v, id, hashCancellationResults)
+}
+
+export interface FailedCancellation {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#failedCancellation'
+  did: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedCancellation = 'failedCancellation'
+
+export function isFailedCancellation<V>(v: V) {
+  return is$typed(v, id, hashFailedCancellation)
+}
+
+export function validateFailedCancellation<V>(v: V) {
+  return validate<FailedCancellation & V>(v, id, hashFailedCancellation)
+}

--- a/packages/api/src/client/types/tools/ozone/moderation/defs.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/defs.ts
@@ -46,6 +46,8 @@ export interface ModEventView {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>
@@ -96,6 +98,8 @@ export interface ModEventViewDetail {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<RepoView>
@@ -701,6 +705,40 @@ export function validateRecordEvent<V>(v: V) {
   return validate<RecordEvent & V>(v, id, hashRecordEvent)
 }
 
+/** Logs a scheduled takedown action for an account. */
+export interface ScheduleTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+}
+
+const hashScheduleTakedownEvent = 'scheduleTakedownEvent'
+
+export function isScheduleTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashScheduleTakedownEvent)
+}
+
+export function validateScheduleTakedownEvent<V>(v: V) {
+  return validate<ScheduleTakedownEvent & V>(v, id, hashScheduleTakedownEvent)
+}
+
+/** Logs cancellation of a scheduled takedown action for an account. */
+export interface CancelScheduledTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
+}
+
+const hashCancelScheduledTakedownEvent = 'cancelScheduledTakedownEvent'
+
+export function isCancelScheduledTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashCancelScheduledTakedownEvent)
+}
+
+export function validateCancelScheduledTakedownEvent<V>(v: V) {
+  return validate<CancelScheduledTakedownEvent & V>(
+    v,
+    id,
+    hashCancelScheduledTakedownEvent,
+  )
+}
+
 export interface RepoView {
   $type?: 'tools.ozone.moderation.defs#repoView'
   did: string
@@ -1010,3 +1048,48 @@ export const TIMELINEEVENTPLCCREATE = `${id}#timelineEventPlcCreate`
 export const TIMELINEEVENTPLCOPERATION = `${id}#timelineEventPlcOperation`
 /** Moderation event timeline event for a PLC tombstone operation */
 export const TIMELINEEVENTPLCTOMBSTONE = `${id}#timelineEventPlcTombstone`
+
+/** View of a scheduled moderation action */
+export interface ScheduledActionView {
+  $type?: 'tools.ozone.moderation.defs#scheduledActionView'
+  /** Auto-incrementing row ID */
+  id: number
+  /** Type of action to be executed */
+  action: 'takedown' | (string & {})
+  /** Serialized event object that will be propagated to the event when performed */
+  eventData?: { [_ in string]: unknown }
+  /** Subject DID for the action */
+  did: string
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+  /** Whether execution time should be randomized within the specified range */
+  randomizeExecution?: boolean
+  /** DID of the user who created this scheduled action */
+  createdBy: string
+  /** When the scheduled action was created */
+  createdAt: string
+  /** When the scheduled action was last updated */
+  updatedAt?: string
+  /** Current status of the scheduled action */
+  status: 'pending' | 'executed' | 'cancelled' | 'failed' | (string & {})
+  /** When the action was last attempted to be executed */
+  lastExecutedAt?: string
+  /** Reason for the last execution failure */
+  lastFailureReason?: string
+  /** ID of the moderation event created when action was successfully executed */
+  executionEventId?: number
+}
+
+const hashScheduledActionView = 'scheduledActionView'
+
+export function isScheduledActionView<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionView)
+}
+
+export function validateScheduledActionView<V>(v: V) {
+  return validate<ScheduledActionView & V>(v, id, hashScheduledActionView)
+}

--- a/packages/api/src/client/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/emitEvent.ts
@@ -44,6 +44,8 @@ export interface InputSchema {
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceEvent>
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceOverrideEvent>
     | $Typed<ToolsOzoneModerationDefs.RevokeAccountCredentialsEvent>
+    | $Typed<ToolsOzoneModerationDefs.ScheduleTakedownEvent>
+    | $Typed<ToolsOzoneModerationDefs.CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>

--- a/packages/api/src/client/types/tools/ozone/moderation/getAccountTimeline.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/getAccountTimeline.ts
@@ -98,6 +98,8 @@ export interface TimelineItemSummary {
     | 'tools.ozone.hosting.getAccountHistory#emailConfirmed'
     | 'tools.ozone.hosting.getAccountHistory#passwordUpdated'
     | 'tools.ozone.hosting.getAccountHistory#handleUpdated'
+    | 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+    | 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
     | (string & {})
   count: number
 }

--- a/packages/api/src/client/types/tools/ozone/moderation/listScheduledActions.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/listScheduledActions.ts
@@ -1,0 +1,57 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.listScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Filter actions scheduled to execute after this time */
+  startTime?: string
+  /** Filter actions scheduled to execute before this time */
+  endTime?: string
+  /** Filter actions for specific DID subjects */
+  subjects?: string[]
+  /** Filter actions by status */
+  statuses?: ('pending' | 'executed' | 'cancelled' | 'failed' | (string & {}))[]
+  /** Maximum number of results to return */
+  limit?: number
+  /** Cursor for pagination */
+  cursor?: string
+}
+
+export interface OutputSchema {
+  actions: ToolsOzoneModerationDefs.ScheduledActionView[]
+  /** Cursor for next page of results */
+  cursor?: string
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+  qp?: QueryParams
+  encoding?: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}

--- a/packages/api/src/client/types/tools/ozone/moderation/scheduleAction.ts
+++ b/packages/api/src/client/types/tools/ozone/moderation/scheduleAction.ts
@@ -1,0 +1,123 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.scheduleAction'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  action: $Typed<Takedown> | { $type: string }
+  /** Array of DID subjects to schedule the action for */
+  subjects: string[]
+  createdBy: string
+  scheduling: SchedulingConfig
+  modTool?: ToolsOzoneModerationDefs.ModTool
+}
+
+export type OutputSchema = ScheduledActionResults
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+  qp?: QueryParams
+  encoding?: 'application/json'
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export function toKnownErr(e: any) {
+  return e
+}
+
+/** Schedule a takedown action */
+export interface Takedown {
+  $type?: 'tools.ozone.moderation.scheduleAction#takedown'
+  comment?: string
+  /** Indicates how long the takedown should be in effect before automatically expiring. */
+  durationInHours?: number
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
+}
+
+const hashTakedown = 'takedown'
+
+export function isTakedown<V>(v: V) {
+  return is$typed(v, id, hashTakedown)
+}
+
+export function validateTakedown<V>(v: V) {
+  return validate<Takedown & V>(v, id, hashTakedown)
+}
+
+/** Configuration for when the action should be executed */
+export interface SchedulingConfig {
+  $type?: 'tools.ozone.moderation.scheduleAction#schedulingConfig'
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+}
+
+const hashSchedulingConfig = 'schedulingConfig'
+
+export function isSchedulingConfig<V>(v: V) {
+  return is$typed(v, id, hashSchedulingConfig)
+}
+
+export function validateSchedulingConfig<V>(v: V) {
+  return validate<SchedulingConfig & V>(v, id, hashSchedulingConfig)
+}
+
+export interface ScheduledActionResults {
+  $type?: 'tools.ozone.moderation.scheduleAction#scheduledActionResults'
+  succeeded: string[]
+  failed: FailedScheduling[]
+}
+
+const hashScheduledActionResults = 'scheduledActionResults'
+
+export function isScheduledActionResults<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionResults)
+}
+
+export function validateScheduledActionResults<V>(v: V) {
+  return validate<ScheduledActionResults & V>(v, id, hashScheduledActionResults)
+}
+
+export interface FailedScheduling {
+  $type?: 'tools.ozone.moderation.scheduleAction#failedScheduling'
+  subject: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedScheduling = 'failedScheduling'
+
+export function isFailedScheduling<V>(v: V) {
+  return is$typed(v, id, hashFailedScheduling)
+}
+
+export function validateFailedScheduling<V>(v: V) {
+  return validate<FailedScheduling & V>(v, id, hashFailedScheduling)
+}

--- a/packages/ozone/src/api/index.ts
+++ b/packages/ozone/src/api/index.ts
@@ -8,6 +8,7 @@ import updateTemplate from './communication/updateTemplate'
 import fetchLabels from './label/fetchLabels'
 import queryLabels from './label/queryLabels'
 import subscribeLabels from './label/subscribeLabels'
+import cancelScheduledActions from './moderation/cancelScheduledActions'
 import emitEvent from './moderation/emitEvent'
 import getAccountTimeline from './moderation/getAccountTimeline'
 import getEvent from './moderation/getEvent'
@@ -17,8 +18,10 @@ import getRepo from './moderation/getRepo'
 import getReporterStats from './moderation/getReporterStats'
 import getRepos from './moderation/getRepos'
 import getSubjects from './moderation/getSubjects'
+import listScheduledActions from './moderation/listScheduledActions'
 import queryEvents from './moderation/queryEvents'
 import queryStatuses from './moderation/queryStatuses'
+import scheduleAction from './moderation/scheduleAction'
 import searchRepos from './moderation/searchRepos'
 import proxied from './proxied'
 import createReport from './report/createReport'
@@ -94,5 +97,8 @@ export default function (server: Server, ctx: AppContext) {
   querySafelinkEvents(server, ctx)
   querySafelinkRules(server, ctx)
   getAccountTimeline(server, ctx)
+  scheduleAction(server, ctx)
+  listScheduledActions(server, ctx)
+  cancelScheduledActions(server, ctx)
   return server
 }

--- a/packages/ozone/src/api/moderation/cancelScheduledActions.ts
+++ b/packages/ozone/src/api/moderation/cancelScheduledActions.ts
@@ -1,0 +1,57 @@
+import { AuthRequiredError } from '@atproto/xrpc-server'
+import { AppContext } from '../../context'
+import { Server } from '../../lexicon'
+import { subjectFromInput } from '../../mod-service/subject'
+
+export default function (server: Server, ctx: AppContext) {
+  server.tools.ozone.moderation.cancelScheduledActions({
+    auth: ctx.authVerifier.modOrAdminToken,
+    handler: async ({ input, auth }) => {
+      const access = auth.credentials
+      const db = ctx.db
+      const { subjects } = input.body
+
+      if (!access.isModerator) {
+        throw new AuthRequiredError(
+          'Must be a moderator to cancel scheduled actions',
+        )
+      }
+
+      const createdBy =
+        access.type === 'admin_token' ? ctx.cfg.service.did : access.iss
+      const now = new Date()
+
+      const result = await db.transaction(async (tx) => {
+        const scheduledActionService = ctx.scheduledActionService(tx)
+        const modService = ctx.modService(tx)
+
+        const cancellations =
+          await scheduledActionService.cancelScheduledActions(subjects)
+
+        for (const subject of cancellations.succeeded) {
+          await modService.logEvent({
+            event: {
+              $type: 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
+            },
+            subject: subjectFromInput({
+              did: subject,
+              $type: 'com.atproto.admin.defs#repoRef',
+            }),
+            createdBy,
+            createdAt: now,
+          })
+        }
+
+        return cancellations
+      })
+
+      return {
+        encoding: 'application/json',
+        body: {
+          succeeded: result.succeeded,
+          failed: result.failed,
+        },
+      }
+    },
+  })
+}

--- a/packages/ozone/src/api/moderation/listScheduledActions.ts
+++ b/packages/ozone/src/api/moderation/listScheduledActions.ts
@@ -1,4 +1,3 @@
-import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import { AppContext } from '../../context'
 import { Server } from '../../lexicon'
 import { getScheduledActionStatus } from '../util'

--- a/packages/ozone/src/api/moderation/listScheduledActions.ts
+++ b/packages/ozone/src/api/moderation/listScheduledActions.ts
@@ -1,0 +1,46 @@
+import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
+import { AppContext } from '../../context'
+import { Server } from '../../lexicon'
+import { getScheduledActionStatus } from '../util'
+
+export default function (server: Server, ctx: AppContext) {
+  server.tools.ozone.moderation.listScheduledActions({
+    auth: ctx.authVerifier.modOrAdminToken,
+    handler: async ({ input }) => {
+      const db = ctx.db
+      const {
+        startTime,
+        endTime,
+        subjects,
+        statuses,
+        limit = 50,
+        cursor,
+      } = input.body
+
+      const scheduledActionService = ctx.scheduledActionService(db)
+
+      const parsedStatuses = statuses?.map((status) =>
+        getScheduledActionStatus(status),
+      )
+
+      const result = await scheduledActionService.listScheduledActions({
+        cursor,
+        limit,
+        startTime: startTime ? new Date(startTime) : undefined,
+        endTime: endTime ? new Date(endTime) : undefined,
+        subjects,
+        statuses: parsedStatuses,
+      })
+
+      return {
+        encoding: 'application/json',
+        body: {
+          actions: result.actions.map((action) =>
+            scheduledActionService.formatScheduledAction(action),
+          ),
+          cursor: result.cursor,
+        },
+      }
+    },
+  })
+}

--- a/packages/ozone/src/api/moderation/scheduleAction.ts
+++ b/packages/ozone/src/api/moderation/scheduleAction.ts
@@ -1,0 +1,111 @@
+import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
+import { AppContext } from '../../context'
+import { Server } from '../../lexicon'
+import { subjectFromInput } from '../../mod-service/subject'
+import { ExecutionSchedule } from '../../scheduled-action/types'
+import { getScheduledActionType } from '../util'
+
+export default function (server: Server, ctx: AppContext) {
+  server.tools.ozone.moderation.scheduleAction({
+    auth: ctx.authVerifier.modOrAdminToken,
+    handler: async ({ input, auth }) => {
+      const access = auth.credentials
+      const db = ctx.db
+      const { action, subjects, createdBy, scheduling, modTool } = input.body
+
+      if (!access.isModerator) {
+        throw new AuthRequiredError('Must be a moderator to schedule actions')
+      }
+
+      if (access.type === 'admin_token' && !createdBy) {
+        throw new AuthRequiredError(
+          'Must specify createdBy when using admin auth',
+        )
+      }
+
+      const actionType = getScheduledActionType(
+        action.$type?.split('#')[1] || '',
+      )
+
+      const succeeded: string[] = []
+      const failed: { subject: string; error: string; errorCode?: string }[] =
+        []
+
+      // Defining alternatively required fields is not supported by lexicons so we need to manually validate here
+      if (!scheduling.executeAt && !scheduling.executeAfter) {
+        throw new InvalidRequestError('Must specify an execution schedule')
+      }
+
+      const executionSchedule: ExecutionSchedule = scheduling.executeAt
+        ? { executeAt: new Date(scheduling.executeAt) }
+        : {
+            executeAfter: new Date(scheduling.executeAfter!),
+            executeUntil: scheduling.executeUntil
+              ? new Date(scheduling.executeUntil)
+              : undefined,
+          }
+
+      const eventData = { ...action, modTool }
+      const actualCreatedBy =
+        access.type === 'admin_token'
+          ? createdBy || ctx.cfg.service.did
+          : access.iss
+
+      const now = new Date()
+      for (const subject of subjects) {
+        try {
+          await db.transaction(async (tx) => {
+            const modService = ctx.modService(tx)
+            const scheduledActionService = ctx.scheduledActionService(tx)
+            // register the action in database
+            await scheduledActionService.scheduleAction({
+              action: actionType,
+              eventData,
+              did: subject,
+              createdBy: actualCreatedBy,
+              ...executionSchedule,
+            })
+            // log an event in the mod event stream
+            await modService.logEvent({
+              event: {
+                $type: 'tools.ozone.moderation.defs#scheduleTakedownEvent',
+              },
+              subject: subjectFromInput({
+                did: subject,
+                $type: 'com.atproto.admin.defs#repoRef',
+              }),
+              createdBy: actualCreatedBy,
+              createdAt: now,
+              modTool,
+            })
+            succeeded.push(subject)
+          })
+        } catch (error) {
+          let errorMessage = 'Unknown error'
+          let errorCode: string | undefined
+
+          if (error instanceof InvalidRequestError) {
+            errorMessage = error.message
+            errorCode = 'InvalidRequest'
+          } else if (error instanceof Error) {
+            errorMessage = error.message
+          }
+
+          failed.push({
+            subject,
+            error: errorMessage,
+            errorCode,
+          })
+        }
+      }
+
+      return {
+        encoding: 'application/json',
+        body: {
+          succeeded,
+          failed,
+        },
+      }
+    },
+  })
+}

--- a/packages/ozone/src/api/moderation/util.ts
+++ b/packages/ozone/src/api/moderation/util.ts
@@ -1,0 +1,94 @@
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { ProtectedTagSettingKey } from '../../setting/constants'
+import { SettingService } from '../../setting/service'
+import { ProtectedTagSetting } from '../../setting/types'
+
+export const getProtectedTags = async (
+  settingService: SettingService,
+  serviceDid: string,
+) => {
+  const protectedTagSetting = await settingService.query({
+    keys: [ProtectedTagSettingKey],
+    scope: 'instance',
+    did: serviceDid,
+    limit: 1,
+  })
+
+  // if no protected tags are configured, then no need to do further check
+  if (!protectedTagSetting.options.length) {
+    return
+  }
+
+  return protectedTagSetting.options[0].value as ProtectedTagSetting
+}
+
+export const assertProtectedTagAction = ({
+  protectedTags,
+  subjectTags,
+  actionAuthor,
+  isModerator,
+  isAdmin,
+  isTriage,
+}: {
+  protectedTags: ProtectedTagSetting
+  subjectTags: string[]
+  actionAuthor: string
+  isModerator: boolean
+  isAdmin: boolean
+  isTriage: boolean
+}) => {
+  subjectTags.forEach((tag) => {
+    if (!Object.hasOwn(protectedTags, tag)) return
+    if (
+      protectedTags[tag]['moderators'] &&
+      !protectedTags[tag]['moderators'].includes(actionAuthor)
+    ) {
+      throw new InvalidRequestError(
+        `Not allowed to action on protected tag: ${tag}`,
+      )
+    }
+
+    if (protectedTags[tag]['roles']) {
+      if (isAdmin) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleAdmin',
+          )
+        ) {
+          return
+        }
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+
+      if (isModerator) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleModerator',
+          )
+        ) {
+          return
+        }
+
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+
+      if (isTriage) {
+        if (
+          protectedTags[tag]['roles'].includes(
+            'tools.ozone.team.defs#roleTriage',
+          )
+        ) {
+          return
+        }
+
+        throw new InvalidRequestError(
+          `Not allowed to action on protected tag: ${tag}`,
+        )
+      }
+    }
+  })
+}

--- a/packages/ozone/src/api/util.ts
+++ b/packages/ozone/src/api/util.ts
@@ -152,6 +152,8 @@ const eventTypes = new Set([
   'tools.ozone.moderation.defs#ageAssuranceEvent',
   'tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
   'tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+  'tools.ozone.moderation.defs#scheduleTakedownEvent',
+  'tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
 ])
 
 export const getMemberRole = (role: string) => {
@@ -211,3 +213,34 @@ const safelinkPatterns = new Set(['domain', 'url'])
 const safelinkActions = new Set(['block', 'warn', 'whitelist'])
 const safelinkReasons = new Set(['csam', 'spam', 'phishing', 'none'])
 const safelinkEventTypes = new Set(['addRule', 'updateRule', 'removeRule'])
+
+export const getScheduledActionType = (action: string): ScheduledActionType => {
+  if (scheduledActionTypes.has(action)) {
+    return action as ScheduledActionType
+  }
+  throw new InvalidRequestError('Invalid scheduled action type')
+}
+
+export const getScheduledActionStatus = (
+  status: string,
+): ScheduledActionStatus => {
+  if (scheduledActionStatuses.has(status)) {
+    return status as ScheduledActionStatus
+  }
+  throw new InvalidRequestError('Invalid scheduled action status')
+}
+
+export type ScheduledActionType = 'takedown'
+export type ScheduledActionStatus =
+  | 'pending'
+  | 'executed'
+  | 'cancelled'
+  | 'failed'
+
+const scheduledActionTypes = new Set(['takedown'])
+const scheduledActionStatuses = new Set([
+  'pending',
+  'executed',
+  'cancelled',
+  'failed',
+])

--- a/packages/ozone/src/context.ts
+++ b/packages/ozone/src/context.ts
@@ -25,6 +25,10 @@ import {
   SafelinkRuleService,
   SafelinkRuleServiceCreator,
 } from './safelink/service'
+import {
+  ScheduledActionService,
+  ScheduledActionServiceCreator,
+} from './scheduled-action/service'
 import { Sequencer } from './sequencer/sequencer'
 import { SetService, SetServiceCreator } from './set/service'
 import { SettingService, SettingServiceCreator } from './setting/service'
@@ -52,6 +56,7 @@ export type AppContextOptions = {
   moderationServiceProfile: ModerationServiceProfileCreator
   communicationTemplateService: CommunicationTemplateServiceCreator
   safelinkRuleService: SafelinkRuleServiceCreator
+  scheduledActionService: ScheduledActionServiceCreator
   setService: SetServiceCreator
   settingService: SettingServiceCreator
   teamService: TeamServiceCreator
@@ -141,6 +146,7 @@ export class AppContext {
 
     const communicationTemplateService = CommunicationTemplateService.creator()
     const safelinkRuleService = SafelinkRuleService.creator()
+    const scheduledActionService = ScheduledActionService.creator()
     const teamService = TeamService.creator(
       appviewAgent,
       cfg.appview.did,
@@ -171,6 +177,7 @@ export class AppContext {
         moderationServiceProfile,
         communicationTemplateService,
         safelinkRuleService,
+        scheduledActionService,
         teamService,
         setService,
         settingService,
@@ -223,6 +230,10 @@ export class AppContext {
 
   get safelinkRuleService(): SafelinkRuleServiceCreator {
     return this.opts.safelinkRuleService
+  }
+
+  get scheduledActionService(): ScheduledActionServiceCreator {
+    return this.opts.scheduledActionService
   }
 
   get teamService(): TeamServiceCreator {

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -8,6 +8,7 @@ import { OzoneConfig, OzoneSecrets } from '../config'
 import { Database } from '../db'
 import { ModerationService } from '../mod-service'
 import { ScheduledActionService } from '../scheduled-action/service'
+import { SettingService } from '../setting/service'
 import { TeamService } from '../team'
 import { getSigningKeyId } from '../util'
 import { EventPusher } from './event-pusher'
@@ -75,6 +76,7 @@ export class DaemonContext {
       appviewAgent,
       createAuthHeaders,
     )
+    const settingService = SettingService.creator()
     const scheduledActionService = ScheduledActionService.creator()
     const teamService = TeamService.creator(
       appviewAgent,
@@ -96,6 +98,8 @@ export class DaemonContext {
 
     const scheduledActionProcessor = new ScheduledActionProcessor(
       db,
+      cfg.service.did,
+      settingService,
       modService,
       scheduledActionService,
     )

--- a/packages/ozone/src/daemon/index.ts
+++ b/packages/ozone/src/daemon/index.ts
@@ -5,6 +5,7 @@ import { DaemonContext } from './context'
 export { EventPusher } from './event-pusher'
 export { BlobDiverter } from './blob-diverter'
 export { EventReverser } from './event-reverser'
+export { ScheduledActionProcessor } from './scheduled-action-processor'
 
 export class OzoneDaemon {
   constructor(public ctx: DaemonContext) {}

--- a/packages/ozone/src/daemon/scheduled-action-processor.ts
+++ b/packages/ozone/src/daemon/scheduled-action-processor.ts
@@ -1,0 +1,182 @@
+import { MINUTE, SECOND } from '@atproto/common'
+import { Database } from '../db'
+import {
+  ModEventTakedown,
+  ModTool,
+} from '../lexicon/types/tools/ozone/moderation/defs'
+import { dbLogger } from '../logger'
+import { ModerationServiceCreator } from '../mod-service'
+import { subjectFromInput } from '../mod-service/subject'
+import { ModEventType } from '../mod-service/types'
+import { ScheduledActionServiceCreator } from '../scheduled-action/service'
+
+export class ScheduledActionProcessor {
+  destroyed = false
+  processingPromise: Promise<void> = Promise.resolve()
+  timer?: NodeJS.Timeout
+
+  constructor(
+    private db: Database,
+    private modService: ModerationServiceCreator,
+    private scheduledActionService: ScheduledActionServiceCreator,
+  ) {}
+
+  start() {
+    this.poll()
+  }
+
+  poll() {
+    if (this.destroyed) return
+    this.processingPromise = this.findAndExecuteScheduledActions()
+      .catch((err) =>
+        dbLogger.error({ err }, 'scheduled action processing errored'),
+      )
+      .finally(() => {
+        this.timer = setTimeout(() => this.poll(), getInterval())
+      })
+  }
+
+  async destroy() {
+    this.destroyed = true
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    await this.processingPromise
+  }
+
+  async executeScheduledAction(actionId: number) {
+    await this.db.transaction(async (dbTxn) => {
+      const moderationTxn = this.modService(dbTxn)
+      const scheduledActionTxn = this.scheduledActionService(dbTxn)
+
+      try {
+        // maybe overfetching here to get the action again within the transaction to ensure it's still pending
+        const action = await dbTxn.db
+          .selectFrom('scheduled_action')
+          .selectAll()
+          .where('id', '=', actionId)
+          .where('status', '=', 'pending')
+          .executeTakeFirst()
+
+        if (!action) {
+          // already processed or cancelled
+          return
+        }
+
+        let event: ModEventType
+        let modTool: ModTool | undefined
+
+        // Create the appropriate moderation action based on the scheduled action type
+        switch (action.action) {
+          case 'takedown':
+            {
+              const eventData = action.eventData as ModEventTakedown & {
+                modTool?: ModTool
+              }
+              modTool = eventData.modTool
+              event = {
+                $type: 'tools.ozone.moderation.defs#modEventTakedown',
+                comment: `[SCHEDULED_ACTION] ${eventData.comment || 'Scheduled takedown executed'}`,
+                durationInHours: eventData.durationInHours,
+                acknowledgeAccountSubjects:
+                  eventData.acknowledgeAccountSubjects,
+                policies: eventData.policies,
+              }
+            }
+            break
+          default:
+            throw new Error(
+              `Unsupported scheduled action type: ${action.action}`,
+            )
+        }
+
+        // Execute the moderation action
+        const moderationEvent = await moderationTxn.logEvent({
+          event,
+          subject: subjectFromInput({
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: action.did,
+          }),
+          createdBy: action.createdBy,
+          modTool,
+        })
+
+        // Mark the scheduled action as executed
+        await scheduledActionTxn.markActionAsExecuted(
+          actionId,
+          moderationEvent.event.id,
+        )
+
+        dbLogger.info(
+          {
+            scheduledActionId: actionId,
+            moderationEventId: moderationEvent.event.id,
+            did: action.did,
+          },
+          'executed scheduled action',
+        )
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error'
+
+        // mark as failed
+        await scheduledActionTxn.markActionAsFailed(actionId, errorMessage)
+
+        dbLogger.error(
+          {
+            scheduledActionId: actionId,
+            error: errorMessage,
+          },
+          'failed to execute scheduled action',
+        )
+      }
+    })
+  }
+
+  async findAndExecuteScheduledActions() {
+    const scheduledActionService = this.scheduledActionService(this.db)
+    const now = new Date()
+
+    const actionsToExecute =
+      await scheduledActionService.getPendingActionsToExecute(now)
+
+    for (const action of actionsToExecute) {
+      // For randomized execution, check if we should execute now or wait
+      if (action.randomizeExecution && action.executeAfter) {
+        const executeAfter = new Date(action.executeAfter)
+        // Default to a 30 second window for execution
+        const executeUntil = action.executeUntil
+          ? new Date(action.executeUntil)
+          : new Date(executeAfter.getTime() + 30 * SECOND)
+
+        // Only execute if we're past the earliest time
+        if (now < executeAfter) {
+          continue
+        }
+
+        // For randomized scheduling, randomly decide whether to execute now
+        // The probability increases as we get closer to the deadline
+        const timeRange = executeUntil.getTime() - executeAfter.getTime()
+        const timeElapsed = now.getTime() - executeAfter.getTime()
+        const executeProb = Math.min(timeElapsed / timeRange, 1)
+
+        // Execute with increasing probability as we approach the deadline
+        // Always execute if we're at or past the deadline
+        if (now < executeUntil && Math.random() > executeProb * 0.1) {
+          continue
+        }
+      }
+
+      await this.executeScheduledAction(action.id)
+    }
+  }
+}
+
+const getInterval = (): number => {
+  // Process scheduled actions every minute
+  const now = Date.now()
+  const intervalMs = MINUTE
+  const nextIteration = Math.ceil(now / intervalMs)
+  return nextIteration * intervalMs - now
+}

--- a/packages/ozone/src/db/migrations/20250923T000000000Z-scheduled-actions.ts
+++ b/packages/ozone/src/db/migrations/20250923T000000000Z-scheduled-actions.ts
@@ -1,0 +1,62 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('scheduled_action')
+    .addColumn('id', 'bigserial', (col) => col.primaryKey())
+    .addColumn('action', 'varchar', (col) => col.notNull())
+    .addColumn('eventData', 'jsonb')
+    .addColumn('did', 'varchar', (col) => col.notNull())
+    .addColumn('executeAt', 'timestamptz')
+    .addColumn('executeAfter', 'timestamptz')
+    .addColumn('executeUntil', 'timestamptz')
+    .addColumn('randomizeExecution', 'boolean', (col) => col.defaultTo(false))
+    .addColumn('createdBy', 'varchar', (col) => col.notNull())
+    .addColumn('createdAt', 'timestamptz', (col) => col.defaultTo('now()'))
+    .addColumn('updatedAt', 'timestamptz', (col) => col.defaultTo('now()'))
+    .addColumn('status', 'varchar', (col) => col.defaultTo('pending'))
+    .addColumn('lastExecutedAt', 'timestamptz')
+    .addColumn('lastFailureReason', 'text')
+    .addColumn('executionEventId', 'bigint')
+    .execute()
+
+  // Unique constraint to prevent multiple pending actions for the same subject
+  await db.schema
+    .createIndex('scheduled_action_unique_pending_subject')
+    .unique()
+    .on('scheduled_action')
+    .columns(['did', 'action', 'status'])
+    .execute()
+
+  // for task runner to query pending actions efficiently
+  await db.schema
+    .createIndex('scheduled_action_execute_time_idx')
+    .on('scheduled_action')
+    .columns(['executeAt', 'executeAfter', 'status'])
+    .execute()
+
+  // for querying actions by subject
+  await db.schema
+    .createIndex('scheduled_action_did_idx')
+    .on('scheduled_action')
+    .column('did')
+    .execute()
+
+  // for querying actions by status
+  await db.schema
+    .createIndex('scheduled_action_status_idx')
+    .on('scheduled_action')
+    .column('status')
+    .execute()
+
+  // for querying actions by creation time for pagination
+  await db.schema
+    .createIndex('scheduled_action_created_at_idx')
+    .on('scheduled_action')
+    .column('createdAt')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('scheduled_action').execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -30,3 +30,5 @@ export * as _20250618T180246000Z from './20250618T180246000Z-add-mod-tool-to-mod
 export * as _20250701T000000000Z from './20250701T000000000Z-add-age-assurance-state'
 export * as _20250715T000000000Z from './20250715T000000000Z-add-mod-event-external-id'
 export * as _20250718T150931000Z from './20250718T150931000Z-update-appeal-reason-stats'
+export * as _20250813T000000000Z from './20250813T000000000Z-mod-tool-batch-id-index'
+export * as _20250923T000000000Z from './20250923T000000000Z-scheduled-actions'

--- a/packages/ozone/src/db/schema/index.ts
+++ b/packages/ozone/src/db/schema/index.ts
@@ -14,6 +14,7 @@ import * as recordEventsStats from './record_events_stats'
 import * as recordPushEvent from './record_push_event'
 import * as repoPushEvent from './repo_push_event'
 import * as safelink from './safelink'
+import * as scheduledAction from './scheduled-action'
 import * as setting from './setting'
 import * as signingKey from './signing_key'
 import * as verification from './verification'
@@ -35,7 +36,8 @@ export type DatabaseSchemaType = modEvent.PartialDB &
   accountRecordStatusStats.PartialDB &
   verification.PartialDB &
   firehoseCursor.PartialDB &
-  safelink.PartialDB
+  safelink.PartialDB &
+  scheduledAction.PartialDB
 
 export type DatabaseSchema = Kysely<DatabaseSchemaType>
 

--- a/packages/ozone/src/db/schema/scheduled-action.ts
+++ b/packages/ozone/src/db/schema/scheduled-action.ts
@@ -1,0 +1,25 @@
+import { GeneratedAlways } from 'kysely'
+
+export const scheduledActionTableName = 'scheduled_action'
+
+export interface ScheduledAction {
+  id: GeneratedAlways<number>
+  action: string
+  eventData: unknown | null
+  did: string
+  executeAt: string | null
+  executeAfter: string | null
+  executeUntil: string | null
+  randomizeExecution: boolean
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+  status: string
+  lastExecutedAt: string | null
+  lastFailureReason: string | null
+  executionEventId: number | null
+}
+
+export type PartialDB = {
+  [scheduledActionTableName]: ScheduledAction
+}

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -207,6 +207,7 @@ import * as ToolsOzoneCommunicationDeleteTemplate from './types/tools/ozone/comm
 import * as ToolsOzoneCommunicationListTemplates from './types/tools/ozone/communication/listTemplates.js'
 import * as ToolsOzoneCommunicationUpdateTemplate from './types/tools/ozone/communication/updateTemplate.js'
 import * as ToolsOzoneHostingGetAccountHistory from './types/tools/ozone/hosting/getAccountHistory.js'
+import * as ToolsOzoneModerationCancelScheduledActions from './types/tools/ozone/moderation/cancelScheduledActions.js'
 import * as ToolsOzoneModerationEmitEvent from './types/tools/ozone/moderation/emitEvent.js'
 import * as ToolsOzoneModerationGetAccountTimeline from './types/tools/ozone/moderation/getAccountTimeline.js'
 import * as ToolsOzoneModerationGetEvent from './types/tools/ozone/moderation/getEvent.js'
@@ -216,8 +217,10 @@ import * as ToolsOzoneModerationGetRepo from './types/tools/ozone/moderation/get
 import * as ToolsOzoneModerationGetReporterStats from './types/tools/ozone/moderation/getReporterStats.js'
 import * as ToolsOzoneModerationGetRepos from './types/tools/ozone/moderation/getRepos.js'
 import * as ToolsOzoneModerationGetSubjects from './types/tools/ozone/moderation/getSubjects.js'
+import * as ToolsOzoneModerationListScheduledActions from './types/tools/ozone/moderation/listScheduledActions.js'
 import * as ToolsOzoneModerationQueryEvents from './types/tools/ozone/moderation/queryEvents.js'
 import * as ToolsOzoneModerationQueryStatuses from './types/tools/ozone/moderation/queryStatuses.js'
+import * as ToolsOzoneModerationScheduleAction from './types/tools/ozone/moderation/scheduleAction.js'
 import * as ToolsOzoneModerationSearchRepos from './types/tools/ozone/moderation/searchRepos.js'
 import * as ToolsOzoneSafelinkAddRule from './types/tools/ozone/safelink/addRule.js'
 import * as ToolsOzoneSafelinkQueryEvents from './types/tools/ozone/safelink/queryEvents.js'
@@ -3083,6 +3086,18 @@ export class ToolsOzoneModerationNS {
     this._server = server
   }
 
+  cancelScheduledActions<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationCancelScheduledActions.QueryParams,
+      ToolsOzoneModerationCancelScheduledActions.HandlerInput,
+      ToolsOzoneModerationCancelScheduledActions.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.cancelScheduledActions' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   emitEvent<A extends Auth = void>(
     cfg: MethodConfigOrHandler<
       A,
@@ -3191,6 +3206,18 @@ export class ToolsOzoneModerationNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
+  listScheduledActions<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationListScheduledActions.QueryParams,
+      ToolsOzoneModerationListScheduledActions.HandlerInput,
+      ToolsOzoneModerationListScheduledActions.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.listScheduledActions' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   queryEvents<A extends Auth = void>(
     cfg: MethodConfigOrHandler<
       A,
@@ -3212,6 +3239,18 @@ export class ToolsOzoneModerationNS {
     >,
   ) {
     const nsid = 'tools.ozone.moderation.queryStatuses' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  scheduleAction<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationScheduleAction.QueryParams,
+      ToolsOzoneModerationScheduleAction.HandlerInput,
+      ToolsOzoneModerationScheduleAction.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.scheduleAction' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -14181,6 +14181,83 @@ export const schemaDict = {
       },
     },
   },
+  ToolsOzoneModerationCancelScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.cancelScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Cancel all pending scheduled moderation actions for specified subjects',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['subjects'],
+            properties: {
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description:
+                  'Array of DID subjects to cancel scheduled actions for',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.cancelScheduledActions#cancellationResults',
+          },
+        },
+      },
+      cancellationResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+            description:
+              'DIDs for which all pending scheduled actions were successfully cancelled',
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.cancelScheduledActions#failedCancellation',
+            },
+            description:
+              'DIDs for which cancellation failed with error details',
+          },
+        },
+      },
+      failedCancellation: {
+        type: 'object',
+        required: ['did', 'error'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
   ToolsOzoneModerationDefs: {
     lexicon: 1,
     id: 'tools.ozone.moderation.defs',
@@ -14224,6 +14301,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14299,6 +14378,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14984,6 +15065,17 @@ export const schemaDict = {
           },
         },
       },
+      scheduleTakedownEvent: {
+        type: 'object',
+        description: 'Logs a scheduled takedown action for an account.',
+        properties: {},
+      },
+      cancelScheduledTakedownEvent: {
+        type: 'object',
+        description:
+          'Logs cancellation of a scheduled takedown action for an account.',
+        properties: {},
+      },
       repoView: {
         type: 'object',
         required: [
@@ -15457,6 +15549,88 @@ export const schemaDict = {
         description:
           'Moderation event timeline event for a PLC tombstone operation',
       },
+      scheduledActionView: {
+        type: 'object',
+        description: 'View of a scheduled moderation action',
+        required: ['id', 'action', 'did', 'createdBy', 'createdAt', 'status'],
+        properties: {
+          id: {
+            type: 'integer',
+            description: 'Auto-incrementing row ID',
+          },
+          action: {
+            type: 'string',
+            knownValues: ['takedown'],
+            description: 'Type of action to be executed',
+          },
+          eventData: {
+            type: 'unknown',
+            description:
+              'Serialized event object that will be propagated to the event when performed',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+            description: 'Subject DID for the action',
+          },
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+          randomizeExecution: {
+            type: 'boolean',
+            description:
+              'Whether execution time should be randomized within the specified range',
+          },
+          createdBy: {
+            type: 'string',
+            format: 'did',
+            description: 'DID of the user who created this scheduled action',
+          },
+          createdAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was created',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was last updated',
+          },
+          status: {
+            type: 'string',
+            knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+            description: 'Current status of the scheduled action',
+          },
+          lastExecutedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the action was last attempted to be executed',
+          },
+          lastFailureReason: {
+            type: 'string',
+            description: 'Reason for the last execution failure',
+          },
+          executionEventId: {
+            type: 'integer',
+            description:
+              'ID of the moderation event created when action was successfully executed',
+          },
+        },
+      },
     },
   },
   ToolsOzoneModerationEmitEvent: {
@@ -15497,6 +15671,8 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
                   'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
                   'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+                  'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+                  'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
                 ],
               },
               subject: {
@@ -15645,6 +15821,8 @@ export const schemaDict = {
               'tools.ozone.hosting.getAccountHistory#emailConfirmed',
               'tools.ozone.hosting.getAccountHistory#passwordUpdated',
               'tools.ozone.hosting.getAccountHistory#handleUpdated',
+              'tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           count: {
@@ -15907,6 +16085,85 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:tools.ozone.moderation.defs#subjectView',
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationListScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.listScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'List scheduled moderation actions with optional filtering',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              startTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute after this time',
+              },
+              endTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute before this time',
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Filter actions for specific DID subjects',
+              },
+              statuses: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+                },
+                description: 'Filter actions by status',
+              },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 100,
+                default: 50,
+                description: 'Maximum number of results to return',
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for pagination',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['actions'],
+            properties: {
+              actions: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:tools.ozone.moderation.defs#scheduledActionView',
+                },
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for next page of results',
               },
             },
           },
@@ -16326,6 +16583,147 @@ export const schemaDict = {
                 },
               },
             },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationScheduleAction: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.scheduleAction',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Schedule a moderation action to be executed at a future time',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['action', 'subjects', 'createdBy', 'scheduling'],
+            properties: {
+              action: {
+                type: 'union',
+                refs: ['lex:tools.ozone.moderation.scheduleAction#takedown'],
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Array of DID subjects to schedule the action for',
+              },
+              createdBy: {
+                type: 'string',
+                format: 'did',
+              },
+              scheduling: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.scheduleAction#schedulingConfig',
+              },
+              modTool: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.defs#modTool',
+                description:
+                  'This will be propagated to the moderation event when it is applied',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.scheduleAction#scheduledActionResults',
+          },
+        },
+      },
+      takedown: {
+        type: 'object',
+        description: 'Schedule a takedown action',
+        properties: {
+          comment: {
+            type: 'string',
+          },
+          durationInHours: {
+            type: 'integer',
+            description:
+              'Indicates how long the takedown should be in effect before automatically expiring.',
+          },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
+          },
+        },
+      },
+      schedulingConfig: {
+        type: 'object',
+        description: 'Configuration for when the action should be executed',
+        properties: {
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+        },
+      },
+      scheduledActionResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.scheduleAction#failedScheduling',
+            },
+          },
+        },
+      },
+      failedScheduling: {
+        type: 'object',
+        required: ['subject', 'error'],
+        properties: {
+          subject: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
           },
         },
       },
@@ -18726,6 +19124,8 @@ export const ids = {
   ToolsOzoneCommunicationUpdateTemplate:
     'tools.ozone.communication.updateTemplate',
   ToolsOzoneHostingGetAccountHistory: 'tools.ozone.hosting.getAccountHistory',
+  ToolsOzoneModerationCancelScheduledActions:
+    'tools.ozone.moderation.cancelScheduledActions',
   ToolsOzoneModerationDefs: 'tools.ozone.moderation.defs',
   ToolsOzoneModerationEmitEvent: 'tools.ozone.moderation.emitEvent',
   ToolsOzoneModerationGetAccountTimeline:
@@ -18738,8 +19138,11 @@ export const ids = {
     'tools.ozone.moderation.getReporterStats',
   ToolsOzoneModerationGetRepos: 'tools.ozone.moderation.getRepos',
   ToolsOzoneModerationGetSubjects: 'tools.ozone.moderation.getSubjects',
+  ToolsOzoneModerationListScheduledActions:
+    'tools.ozone.moderation.listScheduledActions',
   ToolsOzoneModerationQueryEvents: 'tools.ozone.moderation.queryEvents',
   ToolsOzoneModerationQueryStatuses: 'tools.ozone.moderation.queryStatuses',
+  ToolsOzoneModerationScheduleAction: 'tools.ozone.moderation.scheduleAction',
   ToolsOzoneModerationSearchRepos: 'tools.ozone.moderation.searchRepos',
   ToolsOzoneReportDefs: 'tools.ozone.report.defs',
   ToolsOzoneSafelinkAddRule: 'tools.ozone.safelink.addRule',

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/cancelScheduledActions.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/cancelScheduledActions.ts
@@ -1,0 +1,77 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.cancelScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Array of DID subjects to cancel scheduled actions for */
+  subjects: string[]
+}
+
+export type OutputSchema = CancellationResults
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export interface CancellationResults {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#cancellationResults'
+  /** DIDs for which all pending scheduled actions were successfully cancelled */
+  succeeded: string[]
+  /** DIDs for which cancellation failed with error details */
+  failed: FailedCancellation[]
+}
+
+const hashCancellationResults = 'cancellationResults'
+
+export function isCancellationResults<V>(v: V) {
+  return is$typed(v, id, hashCancellationResults)
+}
+
+export function validateCancellationResults<V>(v: V) {
+  return validate<CancellationResults & V>(v, id, hashCancellationResults)
+}
+
+export interface FailedCancellation {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#failedCancellation'
+  did: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedCancellation = 'failedCancellation'
+
+export function isFailedCancellation<V>(v: V) {
+  return is$typed(v, id, hashFailedCancellation)
+}
+
+export function validateFailedCancellation<V>(v: V) {
+  return validate<FailedCancellation & V>(v, id, hashFailedCancellation)
+}

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -46,6 +46,8 @@ export interface ModEventView {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>
@@ -96,6 +98,8 @@ export interface ModEventViewDetail {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<RepoView>
@@ -701,6 +705,40 @@ export function validateRecordEvent<V>(v: V) {
   return validate<RecordEvent & V>(v, id, hashRecordEvent)
 }
 
+/** Logs a scheduled takedown action for an account. */
+export interface ScheduleTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+}
+
+const hashScheduleTakedownEvent = 'scheduleTakedownEvent'
+
+export function isScheduleTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashScheduleTakedownEvent)
+}
+
+export function validateScheduleTakedownEvent<V>(v: V) {
+  return validate<ScheduleTakedownEvent & V>(v, id, hashScheduleTakedownEvent)
+}
+
+/** Logs cancellation of a scheduled takedown action for an account. */
+export interface CancelScheduledTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
+}
+
+const hashCancelScheduledTakedownEvent = 'cancelScheduledTakedownEvent'
+
+export function isCancelScheduledTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashCancelScheduledTakedownEvent)
+}
+
+export function validateCancelScheduledTakedownEvent<V>(v: V) {
+  return validate<CancelScheduledTakedownEvent & V>(
+    v,
+    id,
+    hashCancelScheduledTakedownEvent,
+  )
+}
+
 export interface RepoView {
   $type?: 'tools.ozone.moderation.defs#repoView'
   did: string
@@ -1010,3 +1048,48 @@ export const TIMELINEEVENTPLCCREATE = `${id}#timelineEventPlcCreate`
 export const TIMELINEEVENTPLCOPERATION = `${id}#timelineEventPlcOperation`
 /** Moderation event timeline event for a PLC tombstone operation */
 export const TIMELINEEVENTPLCTOMBSTONE = `${id}#timelineEventPlcTombstone`
+
+/** View of a scheduled moderation action */
+export interface ScheduledActionView {
+  $type?: 'tools.ozone.moderation.defs#scheduledActionView'
+  /** Auto-incrementing row ID */
+  id: number
+  /** Type of action to be executed */
+  action: 'takedown' | (string & {})
+  /** Serialized event object that will be propagated to the event when performed */
+  eventData?: { [_ in string]: unknown }
+  /** Subject DID for the action */
+  did: string
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+  /** Whether execution time should be randomized within the specified range */
+  randomizeExecution?: boolean
+  /** DID of the user who created this scheduled action */
+  createdBy: string
+  /** When the scheduled action was created */
+  createdAt: string
+  /** When the scheduled action was last updated */
+  updatedAt?: string
+  /** Current status of the scheduled action */
+  status: 'pending' | 'executed' | 'cancelled' | 'failed' | (string & {})
+  /** When the action was last attempted to be executed */
+  lastExecutedAt?: string
+  /** Reason for the last execution failure */
+  lastFailureReason?: string
+  /** ID of the moderation event created when action was successfully executed */
+  executionEventId?: number
+}
+
+const hashScheduledActionView = 'scheduledActionView'
+
+export function isScheduledActionView<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionView)
+}
+
+export function validateScheduledActionView<V>(v: V) {
+  return validate<ScheduledActionView & V>(v, id, hashScheduledActionView)
+}

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -43,6 +43,8 @@ export interface InputSchema {
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceEvent>
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceOverrideEvent>
     | $Typed<ToolsOzoneModerationDefs.RevokeAccountCredentialsEvent>
+    | $Typed<ToolsOzoneModerationDefs.ScheduleTakedownEvent>
+    | $Typed<ToolsOzoneModerationDefs.CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/getAccountTimeline.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/getAccountTimeline.ts
@@ -88,6 +88,8 @@ export interface TimelineItemSummary {
     | 'tools.ozone.hosting.getAccountHistory#emailConfirmed'
     | 'tools.ozone.hosting.getAccountHistory#passwordUpdated'
     | 'tools.ozone.hosting.getAccountHistory#handleUpdated'
+    | 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+    | 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
     | (string & {})
   count: number
 }

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/listScheduledActions.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/listScheduledActions.ts
@@ -1,0 +1,57 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.listScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Filter actions scheduled to execute after this time */
+  startTime?: string
+  /** Filter actions scheduled to execute before this time */
+  endTime?: string
+  /** Filter actions for specific DID subjects */
+  subjects?: string[]
+  /** Filter actions by status */
+  statuses?: ('pending' | 'executed' | 'cancelled' | 'failed' | (string & {}))[]
+  /** Maximum number of results to return */
+  limit: number
+  /** Cursor for pagination */
+  cursor?: string
+}
+
+export interface OutputSchema {
+  actions: ToolsOzoneModerationDefs.ScheduledActionView[]
+  /** Cursor for next page of results */
+  cursor?: string
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/ozone/src/lexicon/types/tools/ozone/moderation/scheduleAction.ts
+++ b/packages/ozone/src/lexicon/types/tools/ozone/moderation/scheduleAction.ts
@@ -1,0 +1,123 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.scheduleAction'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  action: $Typed<Takedown> | { $type: string }
+  /** Array of DID subjects to schedule the action for */
+  subjects: string[]
+  createdBy: string
+  scheduling: SchedulingConfig
+  modTool?: ToolsOzoneModerationDefs.ModTool
+}
+
+export type OutputSchema = ScheduledActionResults
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** Schedule a takedown action */
+export interface Takedown {
+  $type?: 'tools.ozone.moderation.scheduleAction#takedown'
+  comment?: string
+  /** Indicates how long the takedown should be in effect before automatically expiring. */
+  durationInHours?: number
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
+}
+
+const hashTakedown = 'takedown'
+
+export function isTakedown<V>(v: V) {
+  return is$typed(v, id, hashTakedown)
+}
+
+export function validateTakedown<V>(v: V) {
+  return validate<Takedown & V>(v, id, hashTakedown)
+}
+
+/** Configuration for when the action should be executed */
+export interface SchedulingConfig {
+  $type?: 'tools.ozone.moderation.scheduleAction#schedulingConfig'
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+}
+
+const hashSchedulingConfig = 'schedulingConfig'
+
+export function isSchedulingConfig<V>(v: V) {
+  return is$typed(v, id, hashSchedulingConfig)
+}
+
+export function validateSchedulingConfig<V>(v: V) {
+  return validate<SchedulingConfig & V>(v, id, hashSchedulingConfig)
+}
+
+export interface ScheduledActionResults {
+  $type?: 'tools.ozone.moderation.scheduleAction#scheduledActionResults'
+  succeeded: string[]
+  failed: FailedScheduling[]
+}
+
+const hashScheduledActionResults = 'scheduledActionResults'
+
+export function isScheduledActionResults<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionResults)
+}
+
+export function validateScheduledActionResults<V>(v: V) {
+  return validate<ScheduledActionResults & V>(v, id, hashScheduledActionResults)
+}
+
+export interface FailedScheduling {
+  $type?: 'tools.ozone.moderation.scheduleAction#failedScheduling'
+  subject: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedScheduling = 'failedScheduling'
+
+export function isFailedScheduling<V>(v: V) {
+  return is$typed(v, id, hashFailedScheduling)
+}
+
+export function validateFailedScheduling<V>(v: V) {
+  return validate<FailedScheduling & V>(v, id, hashFailedScheduling)
+}

--- a/packages/ozone/src/scheduled-action/service.ts
+++ b/packages/ozone/src/scheduled-action/service.ts
@@ -1,0 +1,276 @@
+import { Selectable } from 'kysely'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import { ScheduledActionStatus, ScheduledActionType } from '../api/util'
+import { Database } from '../db'
+import { ScheduledAction } from '../db/schema/scheduled-action'
+import { ScheduledActionView } from '../lexicon/types/tools/ozone/moderation/defs'
+import { SchedulingParams } from './types'
+
+export type ScheduledActionServiceCreator = (
+  db: Database,
+) => ScheduledActionService
+
+export class ScheduledActionService {
+  constructor(public db: Database) {}
+
+  static creator() {
+    return (db: Database) => new ScheduledActionService(db)
+  }
+
+  formatScheduledAction(
+    action: Selectable<ScheduledAction>,
+  ): ScheduledActionView {
+    return {
+      id: action.id,
+      action: action.action,
+      eventData: action.eventData as { [x: string]: unknown } | undefined,
+      did: action.did,
+      executeAt: action.executeAt
+        ? new Date(action.executeAt).toISOString()
+        : undefined,
+      executeAfter: action.executeAfter
+        ? new Date(action.executeAfter).toISOString()
+        : undefined,
+      executeUntil: action.executeUntil
+        ? new Date(action.executeUntil).toISOString()
+        : undefined,
+      randomizeExecution: action.randomizeExecution,
+      createdBy: action.createdBy,
+      createdAt: new Date(action.createdAt).toISOString(),
+      updatedAt: new Date(action.updatedAt).toISOString(),
+      status: action.status,
+      lastExecutedAt: action.lastExecutedAt
+        ? new Date(action.lastExecutedAt).toISOString()
+        : undefined,
+      lastFailureReason: action.lastFailureReason || undefined,
+      executionEventId: action.executionEventId || undefined,
+    }
+  }
+
+  async scheduleAction(
+    schedulingParams: SchedulingParams,
+  ): Promise<Selectable<ScheduledAction>> {
+    const { action, eventData, did, createdBy } = schedulingParams
+
+    // Only allow one pending action at a time for a given subject and action type
+    const existingAction = await this.getPendingActionForSubject(did, action)
+    if (existingAction) {
+      throw new InvalidRequestError(
+        'A pending scheduled action already exists for this subject',
+        'ActionAlreadyExists',
+      )
+    }
+
+    // When a time-range for action is specified, ensure that the range is valid
+    if (
+      'executeAfter' in schedulingParams &&
+      schedulingParams.executeAfter &&
+      schedulingParams.executeUntil &&
+      schedulingParams.executeAfter >= schedulingParams.executeUntil
+    ) {
+      throw new InvalidRequestError(
+        'executeAfter must be before executeUntil',
+        'InvalidScheduling',
+      )
+    }
+
+    const now = new Date().toISOString()
+    const randomizeExecution =
+      !('executeAt' in schedulingParams) && 'executeAfter' in schedulingParams
+
+    const scheduledAction = await this.db.db
+      .insertInto('scheduled_action')
+      .values({
+        action,
+        eventData: JSON.stringify(eventData),
+        did,
+        executeAt: randomizeExecution
+          ? null
+          : schedulingParams.executeAt?.toISOString(),
+        executeAfter: randomizeExecution
+          ? schedulingParams.executeAfter?.toISOString()
+          : null,
+        executeUntil: randomizeExecution
+          ? schedulingParams.executeUntil?.toISOString()
+          : null,
+        randomizeExecution,
+        createdBy,
+        createdAt: now,
+        updatedAt: now,
+        status: 'pending',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    return scheduledAction
+  }
+
+  async getPendingActionForSubject(
+    did: string,
+    action: ScheduledActionType,
+  ): Promise<Selectable<ScheduledAction> | null> {
+    const scheduledAction = await this.db.db
+      .selectFrom('scheduled_action')
+      .selectAll()
+      .where('did', '=', did)
+      .where('action', '=', action)
+      .where('status', '=', 'pending')
+      .executeTakeFirst()
+
+    return scheduledAction || null
+  }
+
+  async listScheduledActions({
+    cursor,
+    limit = 50,
+    startTime,
+    endTime,
+    subjects,
+    statuses,
+    direction = 'desc',
+  }: {
+    cursor?: string
+    limit?: number
+    startTime?: Date
+    endTime?: Date
+    subjects?: string[]
+    statuses?: ScheduledActionStatus[]
+    direction?: 'asc' | 'desc'
+  } = {}): Promise<{
+    actions: Selectable<ScheduledAction>[]
+    cursor?: string
+  }> {
+    let query = this.db.db.selectFrom('scheduled_action').selectAll()
+
+    if (subjects && subjects.length > 0) {
+      query = query.where('did', 'in', subjects)
+    }
+
+    if (statuses && statuses.length > 0) {
+      query = query.where('status', 'in', statuses)
+    }
+
+    if (startTime) {
+      query = query.where((qb) => {
+        return qb
+          .orWhere('executeAt', '>=', startTime.toISOString())
+          .orWhere('executeAfter', '>=', startTime.toISOString())
+      })
+    }
+
+    if (endTime) {
+      query = query.where((qb) => {
+        return qb
+          .orWhere('executeAt', '<=', endTime.toISOString())
+          .orWhere('executeUntil', '<=', endTime.toISOString())
+          .orWhere((sqb) => {
+            return sqb
+              .where('executeUntil', 'is', null)
+              .where('executeAfter', '<=', endTime.toISOString())
+          })
+      })
+    }
+
+    if (cursor) {
+      query = query.where(
+        'id',
+        direction === 'asc' ? '>' : '<',
+        parseInt(cursor, 10),
+      )
+    }
+
+    const actions = await query.orderBy('id', direction).limit(limit).execute()
+
+    return {
+      actions,
+      cursor: actions.at(-1)?.id?.toString(),
+    }
+  }
+
+  async cancelScheduledActions(subjects: string[]): Promise<{
+    succeeded: string[]
+    failed: { did: string; error: string; errorCode?: string }[]
+  }> {
+    const succeeded: string[] = []
+    const failed: { did: string; error: string; errorCode?: string }[] = []
+
+    for (const did of subjects) {
+      try {
+        const result = await this.db.db
+          .updateTable('scheduled_action')
+          .set({
+            status: 'cancelled',
+            updatedAt: new Date().toISOString(),
+          })
+          .where('did', '=', did)
+          .where('status', '=', 'pending')
+          .executeTakeFirst()
+
+        if (result.numUpdatedRows && result.numUpdatedRows > 0) {
+          succeeded.push(did)
+        } else {
+          failed.push({
+            did,
+            error: 'No pending scheduled actions found for subject',
+            errorCode: 'NoPendingActions',
+          })
+        }
+      } catch (error) {
+        failed.push({
+          did,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          errorCode: 'DatabaseError',
+        })
+      }
+    }
+
+    return { succeeded, failed }
+  }
+
+  async getPendingActionsToExecute(
+    now: Date,
+  ): Promise<Selectable<ScheduledAction>[]> {
+    return await this.db.db
+      .selectFrom('scheduled_action')
+      .selectAll()
+      .where('status', '=', 'pending')
+      .where((qb) => {
+        return qb
+          .orWhere('executeAfter', '<=', now.toISOString())
+          .orWhere('executeAt', '<=', now.toISOString())
+      })
+      .execute()
+  }
+
+  async markActionAsExecuted(
+    actionId: number,
+    executionEventId: number,
+  ): Promise<void> {
+    await this.db.db
+      .updateTable('scheduled_action')
+      .set({
+        status: 'executed',
+        lastExecutedAt: new Date().toISOString(),
+        executionEventId,
+        updatedAt: new Date().toISOString(),
+      })
+      .where('id', '=', actionId)
+      .execute()
+  }
+
+  async markActionAsFailed(
+    actionId: number,
+    failureReason: string,
+  ): Promise<void> {
+    await this.db.db
+      .updateTable('scheduled_action')
+      .set({
+        status: 'failed',
+        lastExecutedAt: new Date().toISOString(),
+        lastFailureReason: failureReason,
+        updatedAt: new Date().toISOString(),
+      })
+      .where('id', '=', actionId)
+      .execute()
+  }
+}

--- a/packages/ozone/src/scheduled-action/types.ts
+++ b/packages/ozone/src/scheduled-action/types.ts
@@ -1,0 +1,17 @@
+import { ScheduledActionType } from '../api/util'
+
+export type ExecutionSchedule =
+  | {
+      executeAt: Date
+    }
+  | {
+      executeAfter: Date
+      executeUntil?: Date
+    }
+
+export type SchedulingParams = {
+  action: ScheduledActionType
+  eventData: unknown
+  did: string
+  createdBy: string
+} & ExecutionSchedule

--- a/packages/ozone/tests/__snapshots__/scheduled-action.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/scheduled-action.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scheduled action management listScheduledActions allows moderators to list all scheduled actions 1`] = `
+Array [
+  Object {
+    "action": "takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "did": "user(0)",
+    "eventData": Object {
+      "$type": "tools.ozone.moderation.scheduleAction#takedown",
+      "comment": "test",
+      "policies": Array [
+        "spam",
+      ],
+    },
+    "executeAfter": "1970-01-01T00:00:00.000Z",
+    "executeUntil": "1970-01-01T00:00:00.000Z",
+    "id": 3,
+    "randomizeExecution": true,
+    "status": "pending",
+    "updatedAt": "1970-01-01T00:00:00.000Z",
+  },
+  Object {
+    "action": "takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "did": "user(2)",
+    "eventData": Object {
+      "$type": "tools.ozone.moderation.scheduleAction#takedown",
+      "comment": "test",
+      "policies": Array [
+        "spam",
+      ],
+    },
+    "executeAt": "1970-01-01T00:00:00.000Z",
+    "id": 2,
+    "randomizeExecution": false,
+    "status": "pending",
+    "updatedAt": "1970-01-01T00:00:00.000Z",
+  },
+  Object {
+    "action": "takedown",
+    "createdAt": "1970-01-01T00:00:00.000Z",
+    "createdBy": "user(1)",
+    "did": "user(3)",
+    "eventData": Object {
+      "$type": "tools.ozone.moderation.scheduleAction#takedown",
+      "comment": "test",
+      "policies": Array [
+        "spam",
+      ],
+    },
+    "executeAt": "1970-01-01T00:00:00.000Z",
+    "id": 1,
+    "randomizeExecution": false,
+    "status": "pending",
+    "updatedAt": "1970-01-01T00:00:00.000Z",
+  },
+]
+`;

--- a/packages/ozone/tests/scheduled-action-processor.test.ts
+++ b/packages/ozone/tests/scheduled-action-processor.test.ts
@@ -1,0 +1,326 @@
+import { AtpAgent } from '@atproto/api'
+import { HOUR, MINUTE } from '@atproto/common'
+import { SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
+import { ModEventTakedown } from '../dist/lexicon/types/tools/ozone/moderation/defs'
+import { ids } from '../src/lexicon/lexicons'
+
+describe('scheduled action processor', () => {
+  let network: TestNetwork
+  let adminAgent: AtpAgent
+  let sc: SeedClient
+
+  const getAdminHeaders = async (route: string) => {
+    return {
+      headers: await network.ozone.modHeaders(route, 'admin'),
+    }
+  }
+
+  const scheduleTestAction = async (subject: string, scheduling: any) => {
+    return await adminAgent.tools.ozone.moderation.scheduleAction(
+      {
+        action: {
+          $type: 'tools.ozone.moderation.scheduleAction#takedown',
+          comment: 'Test scheduled takedown',
+          policies: ['spam'],
+        },
+        subjects: [subject],
+        createdBy: 'did:plc:moderator',
+        scheduling,
+      },
+      await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+    )
+  }
+
+  const getScheduledActions = async (
+    subjects?: string[],
+    statuses?: string[],
+  ) => {
+    const { data } =
+      await adminAgent.tools.ozone.moderation.listScheduledActions(
+        { subjects, statuses },
+        await getAdminHeaders(ids.ToolsOzoneModerationListScheduledActions),
+      )
+    return data.actions
+  }
+
+  const getModerationEvents = async (subject: string, types?: string[]) => {
+    const { data } = await adminAgent.tools.ozone.moderation.queryEvents(
+      { subject, types },
+      await getAdminHeaders(ids.ToolsOzoneModerationQueryEvents),
+    )
+    return data.events
+  }
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_scheduled_action_processor_test',
+    })
+    adminAgent = network.ozone.getClient()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  describe('findAndExecuteScheduledActions', () => {
+    it('processes actions scheduled for immediate execution', async () => {
+      const testSubject = sc.dids.alice
+
+      const pastTime = new Date(Date.now() - 1000).toISOString()
+      await scheduleTestAction(testSubject, { executeAt: pastTime })
+
+      const pendingActions = await getScheduledActions(
+        [testSubject],
+        ['pending'],
+      )
+      expect(pendingActions.length).toBe(1)
+
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      const executedActions = await getScheduledActions(
+        [testSubject],
+        ['executed'],
+      )
+      expect(executedActions.length).toBe(1)
+      expect(executedActions[0].status).toBe('executed')
+      expect(executedActions[0].executionEventId).toBeDefined()
+
+      const modEvents = await getModerationEvents(testSubject, [
+        'tools.ozone.moderation.defs#modEventTakedown',
+      ])
+      expect(modEvents.length).toBe(1)
+
+      expect(modEvents[0].event['comment']).toContain(
+        '[SCHEDULED_ACTION] Test scheduled takedown',
+      )
+    })
+
+    it('skips actions scheduled for future execution', async () => {
+      const testSubject = sc.dids.bob
+
+      // Schedule an action for future execution (1 hour from now)
+      const futureTime = new Date(Date.now() + HOUR).toISOString()
+      await scheduleTestAction(testSubject, { executeAt: futureTime })
+
+      // Process scheduled actions
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      // Verify action is still pending
+      const pendingActions = await getScheduledActions(
+        [testSubject],
+        ['pending'],
+      )
+      expect(pendingActions.length).toBe(1)
+
+      const executedActions = await getScheduledActions(
+        [testSubject],
+        ['executed'],
+      )
+      expect(executedActions.length).toBe(0)
+    })
+
+    it('processes randomized scheduling actions within time window', async () => {
+      const testSubject = sc.dids.carol
+
+      // Schedule an action with time range (past executeAfter, future executeUntil)
+      const pastTime = new Date(Date.now() - 30 * MINUTE).toISOString()
+      const futureTime = new Date(Date.now() + 30 * MINUTE).toISOString()
+      await scheduleTestAction(testSubject, {
+        executeAfter: pastTime,
+        executeUntil: futureTime,
+      })
+
+      // Process multiple times to account for randomization
+      let executed = false
+      for (let i = 0; i < 20 && !executed; i++) {
+        await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+        const executedActions = await getScheduledActions(
+          [testSubject],
+          ['executed'],
+        )
+        if (executedActions.length > 0) {
+          executed = true
+          expect(executedActions[0].status).toBe('executed')
+        }
+      }
+
+      // At least verify the action is eligible for processing
+      const actions = await getScheduledActions([testSubject])
+      expect(actions.length).toBe(1)
+      expect(actions[0].randomizeExecution).toBe(true)
+    })
+
+    it('skips randomized actions before executeAfter time', async () => {
+      const testSubject = 'did:plc:future_randomized'
+
+      // Schedule an action with future executeAfter
+      const futureAfter = new Date(Date.now() + 30 * MINUTE).toISOString()
+      const futureUntil = new Date(Date.now() + HOUR).toISOString()
+      await scheduleTestAction(testSubject, {
+        executeAfter: futureAfter,
+        executeUntil: futureUntil,
+      })
+
+      // Process scheduled actions
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      // Verify action is still pending
+      const pendingActions = await getScheduledActions(
+        [testSubject],
+        ['pending'],
+      )
+      expect(pendingActions.length).toBe(1)
+    })
+
+    it('always executes randomized actions past executeUntil deadline', async () => {
+      const testSubject = 'did:plc:overdue_randomized'
+
+      // Schedule an action that's past its deadline
+      const pastAfter = new Date(Date.now() - HOUR).toISOString()
+      const pastUntil = new Date(Date.now() - 30 * MINUTE).toISOString()
+      await scheduleTestAction(testSubject, {
+        executeAfter: pastAfter,
+        executeUntil: pastUntil,
+      })
+
+      // Process scheduled actions
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      // Verify action is executed (should always execute past deadline)
+      const executedActions = await getScheduledActions(
+        [testSubject],
+        ['executed'],
+      )
+      expect(executedActions.length).toBe(1)
+      expect(executedActions[0].status).toBe('executed')
+    })
+  })
+
+  describe('executeScheduledAction', () => {
+    it('handles takedown actions with all properties', async () => {
+      const testSubject = 'did:plc:detailed_takedown'
+
+      // Schedule a detailed takedown action
+      await adminAgent.tools.ozone.moderation.scheduleAction(
+        {
+          action: {
+            $type: 'tools.ozone.moderation.scheduleAction#takedown',
+            comment: 'Detailed takedown test',
+            durationInHours: 24,
+            acknowledgeAccountSubjects: true,
+            policies: ['spam', 'harassment'],
+          },
+          subjects: [testSubject],
+          createdBy: 'did:plc:moderator',
+          scheduling: {
+            executeAt: new Date(Date.now() - 1000).toISOString(),
+          },
+          modTool: { name: 'test-tool' },
+        },
+        await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+      )
+
+      // Process the action
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      // Verify the moderation event has all properties
+      const modEvents = await getModerationEvents(testSubject, [
+        'tools.ozone.moderation.defs#modEventTakedown',
+      ])
+      expect(modEvents.length).toBe(1)
+
+      const takedownEvent = modEvents[0].event as ModEventTakedown
+      expect(takedownEvent.comment).toContain('[SCHEDULED_ACTION]')
+      expect(takedownEvent.comment).toContain('Detailed takedown test')
+      expect(takedownEvent.durationInHours).toBe(24)
+      expect(takedownEvent.acknowledgeAccountSubjects).toBe(true)
+      expect(takedownEvent.policies).toEqual(['spam', 'harassment'])
+    })
+
+    it('marks action as failed when moderation event creation fails', async () => {
+      const testSubject = 'did:plc:invalid_subject'
+
+      await scheduleTestAction(testSubject, {
+        executeAt: new Date(Date.now() - 1000).toISOString(),
+      })
+
+      const pendingActions = await getScheduledActions(
+        [testSubject],
+        ['pending'],
+      )
+      expect(pendingActions.length).toBe(1)
+      const actionId = pendingActions[0].id
+
+      // Manually update the action type to trigger error in processing
+      await network.ozone.ctx.db.db
+        .updateTable('scheduled_action')
+        .set({ action: 'unknown' })
+        .where('id', '=', actionId)
+        .execute()
+
+      await network.ozone.daemon.ctx.scheduledActionProcessor.executeScheduledAction(
+        actionId,
+      )
+
+      const failedActions = await getScheduledActions([testSubject], ['failed'])
+      expect(failedActions.length).toBe(1)
+      expect(failedActions[0].status).toBe('failed')
+      expect(failedActions[0].lastFailureReason).toBeDefined()
+    })
+
+    it('skips actions that are no longer pending', async () => {
+      const testSubject = 'did:plc:already_processed'
+
+      // Schedule and then cancel an action
+      await scheduleTestAction(testSubject, {
+        executeAt: new Date(Date.now() - 1000).toISOString(),
+      })
+
+      await adminAgent.tools.ozone.moderation.cancelScheduledActions(
+        { subjects: [testSubject] },
+        await getAdminHeaders(ids.ToolsOzoneModerationCancelScheduledActions),
+      )
+
+      const cancelledActions = await getScheduledActions(
+        [testSubject],
+        ['cancelled'],
+      )
+      expect(cancelledActions.length).toBe(1)
+      const actionId = cancelledActions[0].id
+
+      await network.ozone.daemon.ctx.scheduledActionProcessor.executeScheduledAction(
+        actionId,
+      )
+
+      const modEvents = await getModerationEvents(testSubject)
+      const takedownEvents = modEvents.filter(
+        (e) => e.event.$type === 'tools.ozone.moderation.defs#modEventTakedown',
+      )
+      expect(takedownEvents.length).toBe(0)
+    })
+
+    it('processes multiple actions in batch', async () => {
+      const subjects = ['did:plc:batch1', 'did:plc:batch2', 'did:plc:batch3']
+      const pastTime = new Date(Date.now() - 1000).toISOString()
+
+      for (const subject of subjects) {
+        await scheduleTestAction(subject, { executeAt: pastTime })
+      }
+
+      await network.ozone.daemon.ctx.scheduledActionProcessor.findAndExecuteScheduledActions()
+
+      const executedActions = await getScheduledActions(subjects, ['executed'])
+      expect(executedActions.length).toBe(3)
+
+      for (const subject of subjects) {
+        const modEvents = await getModerationEvents(subject, [
+          'tools.ozone.moderation.defs#modEventTakedown',
+        ])
+        expect(modEvents.length).toBe(1)
+      }
+    })
+  })
+})

--- a/packages/ozone/tests/scheduled-action-processor.test.ts
+++ b/packages/ozone/tests/scheduled-action-processor.test.ts
@@ -362,7 +362,7 @@ describe('scheduled action processor', () => {
       )
     })
 
-    it.only('enforces protected tag restrictions when account has protected tags', async () => {
+    it('enforces protected tag restrictions when account has protected tags', async () => {
       const testSubject = 'did:plc:protected_tag_test'
 
       // add the protected tag to the account

--- a/packages/ozone/tests/scheduled-action.test.ts
+++ b/packages/ozone/tests/scheduled-action.test.ts
@@ -1,0 +1,328 @@
+import { AtpAgent } from '@atproto/api'
+import { SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
+import { ids } from '../src/lexicon/lexicons'
+import { forSnapshot } from './_util'
+
+describe('scheduled action management', () => {
+  let network: TestNetwork
+  let adminAgent: AtpAgent
+  let modAgent: AtpAgent
+  let triageAgent: AtpAgent
+  let sc: SeedClient
+
+  const getAdminHeaders = async (route: string) => {
+    return {
+      headers: await network.ozone.modHeaders(route, 'admin'),
+    }
+  }
+
+  const getModHeaders = async (route: string) => {
+    return {
+      headers: await network.ozone.modHeaders(route, 'moderator'),
+    }
+  }
+
+  const getModEvent = async (params: {
+    subject: string
+    cancellation?: boolean
+  }) => {
+    const {
+      data: { events },
+    } = await adminAgent.tools.ozone.moderation.queryEvents(
+      {
+        subject: params.subject,
+        types: [
+          params.cancellation
+            ? 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
+            : 'tools.ozone.moderation.defs#scheduleTakedownEvent',
+        ],
+      },
+      await getAdminHeaders(ids.ToolsOzoneModerationQueryEvents),
+    )
+    return events
+  }
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_scheduled_action_test',
+    })
+    adminAgent = network.ozone.getClient()
+    modAgent = network.ozone.getClient()
+    triageAgent = network.ozone.getClient()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  describe('scheduleAction', () => {
+    const getTestAction = () => ({
+      action: {
+        $type: 'tools.ozone.moderation.scheduleAction#takedown',
+        comment: 'test',
+        policies: ['spam'],
+      },
+      subjects: [sc.dids.carol, sc.dids.bob],
+      createdBy: 'did:plc:moderator',
+      scheduling: {
+        executeAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(), // 1 hour from now
+      },
+    })
+
+    it('allows admins to schedule actions', async () => {
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.scheduleAction(
+          getTestAction(),
+          await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+        )
+      const bobsModEvents = await getModEvent({ subject: sc.dids.bob })
+
+      expect(result.succeeded.length).toBe(2)
+      expect(result.failed.length).toBe(0)
+      expect(result.succeeded).toContain(sc.dids.carol)
+      expect(result.succeeded).toContain(sc.dids.bob)
+      expect(bobsModEvents.length).toBe(1)
+    })
+
+    it('rejects triage role from scheduling actions', async () => {
+      await expect(
+        triageAgent.tools.ozone.moderation.scheduleAction(getTestAction(), {
+          headers: await network.ozone.modHeaders(
+            ids.ToolsOzoneModerationScheduleAction,
+            'triage',
+          ),
+        }),
+      ).rejects.toThrow('Must be a moderator to schedule actions')
+    })
+
+    it('supports scheduling with time range (executeAfter/executeUntil)', async () => {
+      const rangeAction = {
+        ...getTestAction(),
+        subjects: [sc.dids.alice],
+        scheduling: {
+          executeAfter: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // 30 min from now
+          executeUntil: new Date(Date.now() + 90 * 60 * 1000).toISOString(), // 90 min from now
+        },
+      }
+
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.scheduleAction(
+          rangeAction,
+          await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+        )
+      expect(result.succeeded.length).toBe(1)
+      expect(result.succeeded).toContain(sc.dids.alice)
+    })
+
+    it('prevents scheduling multiple actions for same subject', async () => {
+      const duplicateAction = {
+        ...getTestAction(),
+        subjects: [sc.dids.carol],
+        scheduling: {
+          executeAt: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        },
+      }
+
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.scheduleAction(
+          duplicateAction,
+          await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+        )
+      expect(result.succeeded.length).toBe(0)
+      expect(result.failed.length).toBe(1)
+      expect(result.failed[0].subject).toBe(sc.dids.carol)
+      expect(result.failed[0].error).toContain(
+        'A pending scheduled action already exists',
+      )
+    })
+
+    it('validates scheduling parameters', async () => {
+      const invalidAction = {
+        ...getTestAction(),
+        subjects: ['did:plc:test_invalid'],
+        scheduling: {
+          executeAfter: new Date(Date.now() + 90 * 60 * 1000).toISOString(),
+          executeUntil: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // executeUntil before executeAfter
+        },
+      }
+
+      const { data } = await adminAgent.tools.ozone.moderation.scheduleAction(
+        invalidAction,
+        await getAdminHeaders(ids.ToolsOzoneModerationScheduleAction),
+      )
+
+      expect(data.failed.length).toBe(1)
+      expect(data.failed[0].subject).toBe('did:plc:test_invalid')
+      expect(data.failed[0].error).toContain(
+        'executeAfter must be before executeUntil',
+      )
+    })
+  })
+
+  describe('listScheduledActions', () => {
+    it('allows moderators to list all scheduled actions', async () => {
+      const { data: result } =
+        await modAgent.tools.ozone.moderation.listScheduledActions(
+          {},
+          await getModHeaders(ids.ToolsOzoneModerationListScheduledActions),
+        )
+
+      expect(result.actions.length).toBeGreaterThan(0)
+      expect(forSnapshot(result.actions)).toMatchSnapshot()
+    })
+
+    it('allows filtering by subjects', async () => {
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.listScheduledActions(
+          {
+            subjects: [sc.dids.carol],
+          },
+          await getAdminHeaders(ids.ToolsOzoneModerationListScheduledActions),
+        )
+
+      expect(result.actions.length).toBeGreaterThan(0)
+      result.actions.forEach((action) => {
+        expect(action.did).toBe(sc.dids.carol)
+      })
+    })
+
+    it('allows filtering by status', async () => {
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.listScheduledActions(
+          {
+            statuses: ['pending'],
+          },
+          await getAdminHeaders(ids.ToolsOzoneModerationListScheduledActions),
+        )
+
+      expect(result.actions.length).toBeGreaterThan(0)
+      result.actions.forEach((action) => {
+        expect(action.status).toBe('pending')
+      })
+    })
+
+    it('supports time range filtering', async () => {
+      const now = new Date()
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+      const twoHoursFromNow = new Date(now.getTime() + 2 * 60 * 60 * 1000)
+
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.listScheduledActions(
+          {
+            startTime: oneHourAgo.toISOString(),
+            endTime: twoHoursFromNow.toISOString(),
+          },
+          await getAdminHeaders(ids.ToolsOzoneModerationListScheduledActions),
+        )
+
+      expect(result.actions.length).toBeGreaterThan(0)
+    })
+
+    it('supports pagination', async () => {
+      const headers = await getAdminHeaders(
+        ids.ToolsOzoneModerationListScheduledActions,
+      )
+      const { data: page1 } =
+        await adminAgent.tools.ozone.moderation.listScheduledActions(
+          { limit: 2 },
+          headers,
+        )
+
+      expect(page1.actions.length).toBe(2)
+      expect(page1.cursor).toBeDefined()
+
+      const { data: page2 } =
+        await adminAgent.tools.ozone.moderation.listScheduledActions(
+          {
+            limit: 2,
+            cursor: page1.cursor,
+          },
+          headers,
+        )
+
+      expect(page2.actions.length).toBeGreaterThan(0)
+      expect(page1.actions.map((a) => a.did)).not.toContain(
+        page2.actions[0].did,
+      )
+    })
+  })
+
+  describe('cancelScheduledActions', () => {
+    it('allows moderators to cancel scheduled actions', async () => {
+      const { data: result } =
+        await modAgent.tools.ozone.moderation.cancelScheduledActions(
+          {
+            subjects: [sc.dids.bob],
+          },
+          await getModHeaders(ids.ToolsOzoneModerationCancelScheduledActions),
+        )
+      const bobsModEvents = await getModEvent({
+        subject: sc.dids.bob,
+        cancellation: true,
+      })
+      expect(result.succeeded.length).toBe(1)
+      expect(result.failed.length).toBe(0)
+      expect(result.succeeded).toContain(sc.dids.bob)
+      expect(bobsModEvents.length).toBe(1)
+    })
+
+    it('allows admins to cancel scheduled actions', async () => {
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.cancelScheduledActions(
+          {
+            subjects: [sc.dids.carol],
+          },
+          await getAdminHeaders(ids.ToolsOzoneModerationCancelScheduledActions),
+        )
+
+      expect(result.succeeded.length).toBe(1)
+      expect(result.failed.length).toBe(0)
+      expect(result.succeeded).toContain(sc.dids.carol)
+
+      const {
+        data: { actions },
+      } = await adminAgent.tools.ozone.moderation.listScheduledActions(
+        {
+          subjects: [sc.dids.carol],
+        },
+        await getAdminHeaders(ids.ToolsOzoneModerationListScheduledActions),
+      )
+
+      expect(actions[0].status).toBe('cancelled')
+    })
+
+    it('handles cancellation of non-existent actions', async () => {
+      const { data: result } =
+        await adminAgent.tools.ozone.moderation.cancelScheduledActions(
+          {
+            subjects: ['did:plc:nonexistent'],
+          },
+          await getAdminHeaders(ids.ToolsOzoneModerationCancelScheduledActions),
+        )
+
+      expect(result.succeeded.length).toBe(0)
+      expect(result.failed.length).toBe(1)
+      expect(result.failed[0].did).toBe('did:plc:nonexistent')
+      expect(result.failed[0].error).toContain(
+        'No pending scheduled actions found',
+      )
+    })
+
+    it('rejects triage moderators from cancelling actions', async () => {
+      await expect(
+        triageAgent.tools.ozone.moderation.cancelScheduledActions(
+          { subjects: [sc.dids.carol] },
+          {
+            headers: await network.ozone.modHeaders(
+              ids.ToolsOzoneModerationCancelScheduledActions,
+              'triage',
+            ),
+          },
+        ),
+      ).rejects.toThrow('Must be a moderator to cancel scheduled actions')
+    })
+  })
+})

--- a/packages/pds/src/lexicon/index.ts
+++ b/packages/pds/src/lexicon/index.ts
@@ -207,6 +207,7 @@ import * as ToolsOzoneCommunicationDeleteTemplate from './types/tools/ozone/comm
 import * as ToolsOzoneCommunicationListTemplates from './types/tools/ozone/communication/listTemplates.js'
 import * as ToolsOzoneCommunicationUpdateTemplate from './types/tools/ozone/communication/updateTemplate.js'
 import * as ToolsOzoneHostingGetAccountHistory from './types/tools/ozone/hosting/getAccountHistory.js'
+import * as ToolsOzoneModerationCancelScheduledActions from './types/tools/ozone/moderation/cancelScheduledActions.js'
 import * as ToolsOzoneModerationEmitEvent from './types/tools/ozone/moderation/emitEvent.js'
 import * as ToolsOzoneModerationGetAccountTimeline from './types/tools/ozone/moderation/getAccountTimeline.js'
 import * as ToolsOzoneModerationGetEvent from './types/tools/ozone/moderation/getEvent.js'
@@ -216,8 +217,10 @@ import * as ToolsOzoneModerationGetRepo from './types/tools/ozone/moderation/get
 import * as ToolsOzoneModerationGetReporterStats from './types/tools/ozone/moderation/getReporterStats.js'
 import * as ToolsOzoneModerationGetRepos from './types/tools/ozone/moderation/getRepos.js'
 import * as ToolsOzoneModerationGetSubjects from './types/tools/ozone/moderation/getSubjects.js'
+import * as ToolsOzoneModerationListScheduledActions from './types/tools/ozone/moderation/listScheduledActions.js'
 import * as ToolsOzoneModerationQueryEvents from './types/tools/ozone/moderation/queryEvents.js'
 import * as ToolsOzoneModerationQueryStatuses from './types/tools/ozone/moderation/queryStatuses.js'
+import * as ToolsOzoneModerationScheduleAction from './types/tools/ozone/moderation/scheduleAction.js'
 import * as ToolsOzoneModerationSearchRepos from './types/tools/ozone/moderation/searchRepos.js'
 import * as ToolsOzoneSafelinkAddRule from './types/tools/ozone/safelink/addRule.js'
 import * as ToolsOzoneSafelinkQueryEvents from './types/tools/ozone/safelink/queryEvents.js'
@@ -3083,6 +3086,18 @@ export class ToolsOzoneModerationNS {
     this._server = server
   }
 
+  cancelScheduledActions<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationCancelScheduledActions.QueryParams,
+      ToolsOzoneModerationCancelScheduledActions.HandlerInput,
+      ToolsOzoneModerationCancelScheduledActions.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.cancelScheduledActions' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   emitEvent<A extends Auth = void>(
     cfg: MethodConfigOrHandler<
       A,
@@ -3191,6 +3206,18 @@ export class ToolsOzoneModerationNS {
     return this._server.xrpc.method(nsid, cfg)
   }
 
+  listScheduledActions<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationListScheduledActions.QueryParams,
+      ToolsOzoneModerationListScheduledActions.HandlerInput,
+      ToolsOzoneModerationListScheduledActions.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.listScheduledActions' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
   queryEvents<A extends Auth = void>(
     cfg: MethodConfigOrHandler<
       A,
@@ -3212,6 +3239,18 @@ export class ToolsOzoneModerationNS {
     >,
   ) {
     const nsid = 'tools.ozone.moderation.queryStatuses' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  scheduleAction<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ToolsOzoneModerationScheduleAction.QueryParams,
+      ToolsOzoneModerationScheduleAction.HandlerInput,
+      ToolsOzoneModerationScheduleAction.HandlerOutput
+    >,
+  ) {
+    const nsid = 'tools.ozone.moderation.scheduleAction' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -14181,6 +14181,83 @@ export const schemaDict = {
       },
     },
   },
+  ToolsOzoneModerationCancelScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.cancelScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Cancel all pending scheduled moderation actions for specified subjects',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['subjects'],
+            properties: {
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description:
+                  'Array of DID subjects to cancel scheduled actions for',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.cancelScheduledActions#cancellationResults',
+          },
+        },
+      },
+      cancellationResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+            description:
+              'DIDs for which all pending scheduled actions were successfully cancelled',
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.cancelScheduledActions#failedCancellation',
+            },
+            description:
+              'DIDs for which cancellation failed with error details',
+          },
+        },
+      },
+      failedCancellation: {
+        type: 'object',
+        required: ['did', 'error'],
+        properties: {
+          did: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
   ToolsOzoneModerationDefs: {
     lexicon: 1,
     id: 'tools.ozone.moderation.defs',
@@ -14224,6 +14301,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14299,6 +14378,8 @@ export const schemaDict = {
               'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
               'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
               'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+              'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           subject: {
@@ -14984,6 +15065,17 @@ export const schemaDict = {
           },
         },
       },
+      scheduleTakedownEvent: {
+        type: 'object',
+        description: 'Logs a scheduled takedown action for an account.',
+        properties: {},
+      },
+      cancelScheduledTakedownEvent: {
+        type: 'object',
+        description:
+          'Logs cancellation of a scheduled takedown action for an account.',
+        properties: {},
+      },
       repoView: {
         type: 'object',
         required: [
@@ -15457,6 +15549,88 @@ export const schemaDict = {
         description:
           'Moderation event timeline event for a PLC tombstone operation',
       },
+      scheduledActionView: {
+        type: 'object',
+        description: 'View of a scheduled moderation action',
+        required: ['id', 'action', 'did', 'createdBy', 'createdAt', 'status'],
+        properties: {
+          id: {
+            type: 'integer',
+            description: 'Auto-incrementing row ID',
+          },
+          action: {
+            type: 'string',
+            knownValues: ['takedown'],
+            description: 'Type of action to be executed',
+          },
+          eventData: {
+            type: 'unknown',
+            description:
+              'Serialized event object that will be propagated to the event when performed',
+          },
+          did: {
+            type: 'string',
+            format: 'did',
+            description: 'Subject DID for the action',
+          },
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+          randomizeExecution: {
+            type: 'boolean',
+            description:
+              'Whether execution time should be randomized within the specified range',
+          },
+          createdBy: {
+            type: 'string',
+            format: 'did',
+            description: 'DID of the user who created this scheduled action',
+          },
+          createdAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was created',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the scheduled action was last updated',
+          },
+          status: {
+            type: 'string',
+            knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+            description: 'Current status of the scheduled action',
+          },
+          lastExecutedAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'When the action was last attempted to be executed',
+          },
+          lastFailureReason: {
+            type: 'string',
+            description: 'Reason for the last execution failure',
+          },
+          executionEventId: {
+            type: 'integer',
+            description:
+              'ID of the moderation event created when action was successfully executed',
+          },
+        },
+      },
     },
   },
   ToolsOzoneModerationEmitEvent: {
@@ -15497,6 +15671,8 @@ export const schemaDict = {
                   'lex:tools.ozone.moderation.defs#ageAssuranceEvent',
                   'lex:tools.ozone.moderation.defs#ageAssuranceOverrideEvent',
                   'lex:tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+                  'lex:tools.ozone.moderation.defs#scheduleTakedownEvent',
+                  'lex:tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
                 ],
               },
               subject: {
@@ -15645,6 +15821,8 @@ export const schemaDict = {
               'tools.ozone.hosting.getAccountHistory#emailConfirmed',
               'tools.ozone.hosting.getAccountHistory#passwordUpdated',
               'tools.ozone.hosting.getAccountHistory#handleUpdated',
+              'tools.ozone.moderation.defs#scheduleTakedownEvent',
+              'tools.ozone.moderation.defs#cancelScheduledTakedownEvent',
             ],
           },
           count: {
@@ -15907,6 +16085,85 @@ export const schemaDict = {
                   type: 'ref',
                   ref: 'lex:tools.ozone.moderation.defs#subjectView',
                 },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationListScheduledActions: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.listScheduledActions',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'List scheduled moderation actions with optional filtering',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              startTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute after this time',
+              },
+              endTime: {
+                type: 'string',
+                format: 'datetime',
+                description:
+                  'Filter actions scheduled to execute before this time',
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Filter actions for specific DID subjects',
+              },
+              statuses: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  knownValues: ['pending', 'executed', 'cancelled', 'failed'],
+                },
+                description: 'Filter actions by status',
+              },
+              limit: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 100,
+                default: 50,
+                description: 'Maximum number of results to return',
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for pagination',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['actions'],
+            properties: {
+              actions: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:tools.ozone.moderation.defs#scheduledActionView',
+                },
+              },
+              cursor: {
+                type: 'string',
+                description: 'Cursor for next page of results',
               },
             },
           },
@@ -16326,6 +16583,147 @@ export const schemaDict = {
                 },
               },
             },
+          },
+        },
+      },
+    },
+  },
+  ToolsOzoneModerationScheduleAction: {
+    lexicon: 1,
+    id: 'tools.ozone.moderation.scheduleAction',
+    defs: {
+      main: {
+        type: 'procedure',
+        description:
+          'Schedule a moderation action to be executed at a future time',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['action', 'subjects', 'createdBy', 'scheduling'],
+            properties: {
+              action: {
+                type: 'union',
+                refs: ['lex:tools.ozone.moderation.scheduleAction#takedown'],
+              },
+              subjects: {
+                type: 'array',
+                maxLength: 100,
+                items: {
+                  type: 'string',
+                  format: 'did',
+                },
+                description: 'Array of DID subjects to schedule the action for',
+              },
+              createdBy: {
+                type: 'string',
+                format: 'did',
+              },
+              scheduling: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.scheduleAction#schedulingConfig',
+              },
+              modTool: {
+                type: 'ref',
+                ref: 'lex:tools.ozone.moderation.defs#modTool',
+                description:
+                  'This will be propagated to the moderation event when it is applied',
+              },
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'ref',
+            ref: 'lex:tools.ozone.moderation.scheduleAction#scheduledActionResults',
+          },
+        },
+      },
+      takedown: {
+        type: 'object',
+        description: 'Schedule a takedown action',
+        properties: {
+          comment: {
+            type: 'string',
+          },
+          durationInHours: {
+            type: 'integer',
+            description:
+              'Indicates how long the takedown should be in effect before automatically expiring.',
+          },
+          acknowledgeAccountSubjects: {
+            type: 'boolean',
+            description:
+              'If true, all other reports on content authored by this account will be resolved (acknowledged).',
+          },
+          policies: {
+            type: 'array',
+            maxLength: 5,
+            items: {
+              type: 'string',
+            },
+            description:
+              'Names/Keywords of the policies that drove the decision.',
+          },
+        },
+      },
+      schedulingConfig: {
+        type: 'object',
+        description: 'Configuration for when the action should be executed',
+        properties: {
+          executeAt: {
+            type: 'string',
+            format: 'datetime',
+            description: 'Exact time to execute the action',
+          },
+          executeAfter: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Earliest time to execute the action (for randomized scheduling)',
+          },
+          executeUntil: {
+            type: 'string',
+            format: 'datetime',
+            description:
+              'Latest time to execute the action (for randomized scheduling)',
+          },
+        },
+      },
+      scheduledActionResults: {
+        type: 'object',
+        required: ['succeeded', 'failed'],
+        properties: {
+          succeeded: {
+            type: 'array',
+            items: {
+              type: 'string',
+              format: 'did',
+            },
+          },
+          failed: {
+            type: 'array',
+            items: {
+              type: 'ref',
+              ref: 'lex:tools.ozone.moderation.scheduleAction#failedScheduling',
+            },
+          },
+        },
+      },
+      failedScheduling: {
+        type: 'object',
+        required: ['subject', 'error'],
+        properties: {
+          subject: {
+            type: 'string',
+            format: 'did',
+          },
+          error: {
+            type: 'string',
+          },
+          errorCode: {
+            type: 'string',
           },
         },
       },
@@ -18726,6 +19124,8 @@ export const ids = {
   ToolsOzoneCommunicationUpdateTemplate:
     'tools.ozone.communication.updateTemplate',
   ToolsOzoneHostingGetAccountHistory: 'tools.ozone.hosting.getAccountHistory',
+  ToolsOzoneModerationCancelScheduledActions:
+    'tools.ozone.moderation.cancelScheduledActions',
   ToolsOzoneModerationDefs: 'tools.ozone.moderation.defs',
   ToolsOzoneModerationEmitEvent: 'tools.ozone.moderation.emitEvent',
   ToolsOzoneModerationGetAccountTimeline:
@@ -18738,8 +19138,11 @@ export const ids = {
     'tools.ozone.moderation.getReporterStats',
   ToolsOzoneModerationGetRepos: 'tools.ozone.moderation.getRepos',
   ToolsOzoneModerationGetSubjects: 'tools.ozone.moderation.getSubjects',
+  ToolsOzoneModerationListScheduledActions:
+    'tools.ozone.moderation.listScheduledActions',
   ToolsOzoneModerationQueryEvents: 'tools.ozone.moderation.queryEvents',
   ToolsOzoneModerationQueryStatuses: 'tools.ozone.moderation.queryStatuses',
+  ToolsOzoneModerationScheduleAction: 'tools.ozone.moderation.scheduleAction',
   ToolsOzoneModerationSearchRepos: 'tools.ozone.moderation.searchRepos',
   ToolsOzoneReportDefs: 'tools.ozone.report.defs',
   ToolsOzoneSafelinkAddRule: 'tools.ozone.safelink.addRule',

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/cancelScheduledActions.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/cancelScheduledActions.ts
@@ -1,0 +1,77 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.cancelScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Array of DID subjects to cancel scheduled actions for */
+  subjects: string[]
+}
+
+export type OutputSchema = CancellationResults
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+export interface CancellationResults {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#cancellationResults'
+  /** DIDs for which all pending scheduled actions were successfully cancelled */
+  succeeded: string[]
+  /** DIDs for which cancellation failed with error details */
+  failed: FailedCancellation[]
+}
+
+const hashCancellationResults = 'cancellationResults'
+
+export function isCancellationResults<V>(v: V) {
+  return is$typed(v, id, hashCancellationResults)
+}
+
+export function validateCancellationResults<V>(v: V) {
+  return validate<CancellationResults & V>(v, id, hashCancellationResults)
+}
+
+export interface FailedCancellation {
+  $type?: 'tools.ozone.moderation.cancelScheduledActions#failedCancellation'
+  did: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedCancellation = 'failedCancellation'
+
+export function isFailedCancellation<V>(v: V) {
+  return is$typed(v, id, hashFailedCancellation)
+}
+
+export function validateFailedCancellation<V>(v: V) {
+  return validate<FailedCancellation & V>(v, id, hashFailedCancellation)
+}

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/defs.ts
@@ -46,6 +46,8 @@ export interface ModEventView {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>
@@ -96,6 +98,8 @@ export interface ModEventViewDetail {
     | $Typed<AgeAssuranceEvent>
     | $Typed<AgeAssuranceOverrideEvent>
     | $Typed<RevokeAccountCredentialsEvent>
+    | $Typed<ScheduleTakedownEvent>
+    | $Typed<CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<RepoView>
@@ -701,6 +705,40 @@ export function validateRecordEvent<V>(v: V) {
   return validate<RecordEvent & V>(v, id, hashRecordEvent)
 }
 
+/** Logs a scheduled takedown action for an account. */
+export interface ScheduleTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+}
+
+const hashScheduleTakedownEvent = 'scheduleTakedownEvent'
+
+export function isScheduleTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashScheduleTakedownEvent)
+}
+
+export function validateScheduleTakedownEvent<V>(v: V) {
+  return validate<ScheduleTakedownEvent & V>(v, id, hashScheduleTakedownEvent)
+}
+
+/** Logs cancellation of a scheduled takedown action for an account. */
+export interface CancelScheduledTakedownEvent {
+  $type?: 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
+}
+
+const hashCancelScheduledTakedownEvent = 'cancelScheduledTakedownEvent'
+
+export function isCancelScheduledTakedownEvent<V>(v: V) {
+  return is$typed(v, id, hashCancelScheduledTakedownEvent)
+}
+
+export function validateCancelScheduledTakedownEvent<V>(v: V) {
+  return validate<CancelScheduledTakedownEvent & V>(
+    v,
+    id,
+    hashCancelScheduledTakedownEvent,
+  )
+}
+
 export interface RepoView {
   $type?: 'tools.ozone.moderation.defs#repoView'
   did: string
@@ -1010,3 +1048,48 @@ export const TIMELINEEVENTPLCCREATE = `${id}#timelineEventPlcCreate`
 export const TIMELINEEVENTPLCOPERATION = `${id}#timelineEventPlcOperation`
 /** Moderation event timeline event for a PLC tombstone operation */
 export const TIMELINEEVENTPLCTOMBSTONE = `${id}#timelineEventPlcTombstone`
+
+/** View of a scheduled moderation action */
+export interface ScheduledActionView {
+  $type?: 'tools.ozone.moderation.defs#scheduledActionView'
+  /** Auto-incrementing row ID */
+  id: number
+  /** Type of action to be executed */
+  action: 'takedown' | (string & {})
+  /** Serialized event object that will be propagated to the event when performed */
+  eventData?: { [_ in string]: unknown }
+  /** Subject DID for the action */
+  did: string
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+  /** Whether execution time should be randomized within the specified range */
+  randomizeExecution?: boolean
+  /** DID of the user who created this scheduled action */
+  createdBy: string
+  /** When the scheduled action was created */
+  createdAt: string
+  /** When the scheduled action was last updated */
+  updatedAt?: string
+  /** Current status of the scheduled action */
+  status: 'pending' | 'executed' | 'cancelled' | 'failed' | (string & {})
+  /** When the action was last attempted to be executed */
+  lastExecutedAt?: string
+  /** Reason for the last execution failure */
+  lastFailureReason?: string
+  /** ID of the moderation event created when action was successfully executed */
+  executionEventId?: number
+}
+
+const hashScheduledActionView = 'scheduledActionView'
+
+export function isScheduledActionView<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionView)
+}
+
+export function validateScheduledActionView<V>(v: V) {
+  return validate<ScheduledActionView & V>(v, id, hashScheduledActionView)
+}

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/emitEvent.ts
@@ -43,6 +43,8 @@ export interface InputSchema {
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceEvent>
     | $Typed<ToolsOzoneModerationDefs.AgeAssuranceOverrideEvent>
     | $Typed<ToolsOzoneModerationDefs.RevokeAccountCredentialsEvent>
+    | $Typed<ToolsOzoneModerationDefs.ScheduleTakedownEvent>
+    | $Typed<ToolsOzoneModerationDefs.CancelScheduledTakedownEvent>
     | { $type: string }
   subject:
     | $Typed<ComAtprotoAdminDefs.RepoRef>

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/getAccountTimeline.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/getAccountTimeline.ts
@@ -88,6 +88,8 @@ export interface TimelineItemSummary {
     | 'tools.ozone.hosting.getAccountHistory#emailConfirmed'
     | 'tools.ozone.hosting.getAccountHistory#passwordUpdated'
     | 'tools.ozone.hosting.getAccountHistory#handleUpdated'
+    | 'tools.ozone.moderation.defs#scheduleTakedownEvent'
+    | 'tools.ozone.moderation.defs#cancelScheduledTakedownEvent'
     | (string & {})
   count: number
 }

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/listScheduledActions.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/listScheduledActions.ts
@@ -1,0 +1,57 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.listScheduledActions'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  /** Filter actions scheduled to execute after this time */
+  startTime?: string
+  /** Filter actions scheduled to execute before this time */
+  endTime?: string
+  /** Filter actions for specific DID subjects */
+  subjects?: string[]
+  /** Filter actions by status */
+  statuses?: ('pending' | 'executed' | 'cancelled' | 'failed' | (string & {}))[]
+  /** Maximum number of results to return */
+  limit: number
+  /** Cursor for pagination */
+  cursor?: string
+}
+
+export interface OutputSchema {
+  actions: ToolsOzoneModerationDefs.ScheduledActionView[]
+  /** Cursor for next page of results */
+  cursor?: string
+}
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/lexicon/types/tools/ozone/moderation/scheduleAction.ts
+++ b/packages/pds/src/lexicon/types/tools/ozone/moderation/scheduleAction.ts
@@ -1,0 +1,123 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ToolsOzoneModerationDefs from './defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'tools.ozone.moderation.scheduleAction'
+
+export type QueryParams = {}
+
+export interface InputSchema {
+  action: $Typed<Takedown> | { $type: string }
+  /** Array of DID subjects to schedule the action for */
+  subjects: string[]
+  createdBy: string
+  scheduling: SchedulingConfig
+  modTool?: ToolsOzoneModerationDefs.ModTool
+}
+
+export type OutputSchema = ScheduledActionResults
+
+export interface HandlerInput {
+  encoding: 'application/json'
+  body: InputSchema
+}
+
+export interface HandlerSuccess {
+  encoding: 'application/json'
+  body: OutputSchema
+  headers?: { [key: string]: string }
+}
+
+export interface HandlerError {
+  status: number
+  message?: string
+}
+
+export type HandlerOutput = HandlerError | HandlerSuccess
+
+/** Schedule a takedown action */
+export interface Takedown {
+  $type?: 'tools.ozone.moderation.scheduleAction#takedown'
+  comment?: string
+  /** Indicates how long the takedown should be in effect before automatically expiring. */
+  durationInHours?: number
+  /** If true, all other reports on content authored by this account will be resolved (acknowledged). */
+  acknowledgeAccountSubjects?: boolean
+  /** Names/Keywords of the policies that drove the decision. */
+  policies?: string[]
+}
+
+const hashTakedown = 'takedown'
+
+export function isTakedown<V>(v: V) {
+  return is$typed(v, id, hashTakedown)
+}
+
+export function validateTakedown<V>(v: V) {
+  return validate<Takedown & V>(v, id, hashTakedown)
+}
+
+/** Configuration for when the action should be executed */
+export interface SchedulingConfig {
+  $type?: 'tools.ozone.moderation.scheduleAction#schedulingConfig'
+  /** Exact time to execute the action */
+  executeAt?: string
+  /** Earliest time to execute the action (for randomized scheduling) */
+  executeAfter?: string
+  /** Latest time to execute the action (for randomized scheduling) */
+  executeUntil?: string
+}
+
+const hashSchedulingConfig = 'schedulingConfig'
+
+export function isSchedulingConfig<V>(v: V) {
+  return is$typed(v, id, hashSchedulingConfig)
+}
+
+export function validateSchedulingConfig<V>(v: V) {
+  return validate<SchedulingConfig & V>(v, id, hashSchedulingConfig)
+}
+
+export interface ScheduledActionResults {
+  $type?: 'tools.ozone.moderation.scheduleAction#scheduledActionResults'
+  succeeded: string[]
+  failed: FailedScheduling[]
+}
+
+const hashScheduledActionResults = 'scheduledActionResults'
+
+export function isScheduledActionResults<V>(v: V) {
+  return is$typed(v, id, hashScheduledActionResults)
+}
+
+export function validateScheduledActionResults<V>(v: V) {
+  return validate<ScheduledActionResults & V>(v, id, hashScheduledActionResults)
+}
+
+export interface FailedScheduling {
+  $type?: 'tools.ozone.moderation.scheduleAction#failedScheduling'
+  subject: string
+  error: string
+  errorCode?: string
+}
+
+const hashFailedScheduling = 'failedScheduling'
+
+export function isFailedScheduling<V>(v: V) {
+  return is$typed(v, id, hashFailedScheduling)
+}
+
+export function validateFailedScheduling<V>(v: V) {
+  return validate<FailedScheduling & V>(v, id, hashFailedScheduling)
+}


### PR DESCRIPTION
This PR adds a new module to ozone for scheduling account takedowns. When takedowns are scheduled or a scheduled takedown is cancelled, 2 new and different events are logged in the mod event stream for the subject.