### PR TITLE
Match report reason mapping to RFC-0009

### DIFF
--- a/.changeset/young-cherries-worry.md
+++ b/.changeset/young-cherries-worry.md
@@ -1,0 +1,5 @@
+---
+"@atproto/ozone": patch
+---
+
+Map new `#reasonRuleOther` to old `#reasonOther` to mirror the recommendation laid out in RFC 0009

--- a/packages/ozone/src/mod-service/profile.ts
+++ b/packages/ozone/src/mod-service/profile.ts
@@ -8,13 +8,14 @@ import {
   REASONSEXUAL,
   REASONSPAM,
   REASONVIOLATION,
+  REASONOTHER,
 } from '../lexicon/types/com/atproto/moderation/defs'
 import { httpLogger } from '../logger'
 
 // Reverse mapping from new ozone namespaced reason types to old com.atproto namespaced reason types
 export const NEW_TO_OLD_REASON_MAPPING: Record<string, string> = {
   'tools.ozone.report.defs#reasonMisleadingSpam': REASONSPAM,
-  'tools.ozone.report.defs#reasonRuleOther': REASONVIOLATION,
+  'tools.ozone.report.defs#reasonRuleOther': REASONOTHER,
   'tools.ozone.report.defs#reasonMisleadingOther': REASONMISLEADING,
   'tools.ozone.report.defs#reasonSexualUnlabeled': REASONSEXUAL,
   'tools.ozone.report.defs#reasonHarassmentOther': REASONRUDE,


### PR DESCRIPTION
In [RFC-0009](https://github.com/bluesky-social/proposals/tree/main/0009-mod-report-granularity#backwards-compatibility), we recommended mapping `#reasonRuleOther` to `#reasonOther`. In order for this to function correctly, I think we should mirror this relationship in the opposite direction.

This way, if a labeler only supports `#reasonOther`, the user is still able to submit reports to that labeler using `#reasonOther`.