### PR TITLE
Clarify that dev env requires docker and jq to be installed on system and not npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make build
 make test
 
 # run a local PDS and AppView with fake test accounts and data
-# (this requires a global installation of `jq` and `docker`)
+# (this requires a global installation of `jq` and `docker` using your system's package manager)
 make run-dev-env
 
 # show all other commands


### PR DESCRIPTION
In the dev quickstart section of the readme file, it says "this requires a global installation of `jq` and `docker`" which could be misread as "this requires a installation of jq and docker in npm with the --global flag" which can be confusing, since npm **does** have two packages named jq and docker, but they are completely different packages from the actual jq and docker that the dev environment depends on. Trying to run the dev environment with these incorrect packages results in errors that aren't easily resolvable unless you already know that npm has different packages by the same name. This line should be updated to clarify that jq and docker need to be installed through the system package manager and not npm.