### PR TITLE
Remove introspection endpoint from oauth server metadata

### DIFF
--- a/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
+++ b/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
@@ -106,7 +106,7 @@ export function buildMetadata(
 
     revocation_endpoint: new URL('/oauth/revoke', issuer).href,
 
-    introspection_endpoint: new URL('/oauth/introspect', issuer).href,
+    // introspection_endpoint: new URL('/oauth/introspect', issuer).href,
 
     // end_session_endpoint: new URL('/oauth/logout', issuer).href,
 


### PR DESCRIPTION
We don't (currently) implement this endpoint, so we shouldn't advertise it in the metadata document.