### PR TITLE
dev-env: fix flaky handle resolutions in tests

### DIFF
--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -90,6 +90,9 @@ export class TestNetwork extends TestNetworkNoAppView {
       ...params.pds,
     })
 
+    // mock before any events start flowing from pds so that we don't miss e.g. any handle resolutions.
+    mockNetworkUtilities(pds, bsky)
+
     const ozone = await TestOzone.create({
       port: ozonePort,
       plcUrl: plc.url,
@@ -116,7 +119,6 @@ export class TestNetwork extends TestNetworkNoAppView {
 
     await ozone.addAdminDid(ozoneServiceProfile.did)
 
-    mockNetworkUtilities(pds, bsky)
     await thirdPartyPds.processAll()
     await pds.processAll()
     await ozone.processAll()


### PR DESCRIPTION
By placing network mocks before data is flowing, we should be able to avoid invalid handles appearing in the tests due to missed handle resolutions.