### PR TITLE
Update com.atproto.label defintions to give clearer descriptions

### DIFF
--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -29,6 +29,7 @@
         "val": {
           "type": "string",
           "maxLength": 128,
+          "maxGraphemes": 128,
           "description": "The identifier for this label, see labelValueDefintion's identifier property."
         },
         "neg": {
@@ -71,6 +72,7 @@
         "val": {
           "type": "string",
           "maxLength": 128,
+          "maxGraphemes": 128,
           "description": "The identifier for this label, see labelValueDefintion's identifier property."
         }
       }
@@ -83,8 +85,8 @@
         "identifier": {
           "type": "string",
           "description": "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).",
-          "maxLength": 100,
-          "maxGraphemes": 100
+          "maxLength": 128,
+          "maxGraphemes": 128,
         },
         "severity": {
           "type": "string",


### PR DESCRIPTION
The `val` property appears a few times, but from what I can tell, this should be the `identifier` in the `labelValueDefinition`, but may be an arbitrary string, if no definition exists?