### PR TITLE
Fix: Label creation notification race condition

### DIFF
--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -1329,7 +1329,6 @@ export class ModerationService {
     )
     const dbVals = signedLabels.map((l) => formatLabelRow(l, this.signingKeyId))
     const { ref } = this.db.db.dynamic
-    await sql`notify ${ref(LabelChannel)}`.execute(this.db.db)
     const excluded = (col: string) => ref(`excluded.${col}`)
     const res = await this.db.db
       .insertInto('label')
@@ -1346,6 +1345,7 @@ export class ModerationService {
       )
       .returningAll()
       .execute()
+    await sql`notify ${ref(LabelChannel)}`.execute(this.db.db)
     return res.map((row) => formatLabel(row))
   }
 


### PR DESCRIPTION
Previously the notification for the label creation was dispatched before the label was actually inserted into the database. In all other cases where we use postgresql's `notify`, we do it after the `insertInto`, such that the listener is guaranteed to receive the newly created record when querying.

Noticed this by chance whilst looking into the whole [ghosts in the labeler service definition](https://bsky.app/profile/thisismissem.social/post/3m3xd75n4zk2n) thread.