### PR TITLE
bsky: improve error messaging for DPoP bound access tokens

### DIFF
--- a/.changeset/eleven-eagles-cry.md
+++ b/.changeset/eleven-eagles-cry.md
@@ -1,0 +1,14 @@
+---
+"@atproto/bsky": patch
+---
+
+Prevent usage of DPoP bound access tokens with bsky.social
+
+Using DPoP bound access tokens against the bsky server would already fail, but
+it would fail with a rather misleading error: "InvalidToken: Bad token scope",
+because the `scope` on a DPoP bound access token is the actual OAuth scopes, not
+the expected `com.atproto.access` string.
+
+This change means the entryway explicit checks if the token is a DPoP bound
+access token, and if it is, then it fails with an error "Malformed token: DPoP
+not supported". A similar check is also done with Bearer tokens in the PDS.

--- a/packages/bsky/src/auth-verifier.ts
+++ b/packages/bsky/src/auth-verifier.ts
@@ -234,7 +234,15 @@ export class AuthVerifier {
         )
       })
 
-    const { sub, aud, scope } = res.payload
+    const { sub, aud, scope, cnf } = res.payload
+    if (typeof cnf !== 'undefined') {
+      // Proof-of-Possession (PoP) tokens are not allowed here
+      // https://www.rfc-editor.org/rfc/rfc7800.html
+      throw new AuthRequiredError(
+        'Malformed token: DPoP not supported',
+        'InvalidToken',
+      )
+    }
     if (typeof sub !== 'string' || !sub.startsWith('did:')) {
       throw new AuthRequiredError('Malformed token', 'InvalidToken')
     } else if (


### PR DESCRIPTION
See the changeset for the details, I discovered whilst helping someone in the AT Protocol Touchers discord that the bsky.social server will accept DPoP bound access tokens sent as `Bearer <dpop-access-token>` instead of `DPoP <dpop-access-token>` (a fairly easy developer mistake), but the server misdirects the developer with the error "Bad token scope", because the `scope` on a DPoP bound access token is the actual oauth scopes like `atproto transition:generic`, when the bsky.social server expects `com.atproto.access` or similar.

This change just makes that error a little bit more visible to a developer. cc @matthieusieben 