### PR TITLE
Avoid too much drift in generated TIDs

### DIFF
--- a/.changeset/healthy-dolls-lay.md
+++ b/.changeset/healthy-dolls-lay.md
@@ -1,0 +1,5 @@
+---
+"@atproto/common-web": patch
+---
+
+Avoid too much drift in generated TIDs


### PR DESCRIPTION
In the current implementation, every time more than one TID is generated within a single millisecond, a counter is increased and used to in create a global counter. That global counter does not get reset afterwards. This means that for every ms during which more than one TID is generated, the TID generator clock drifts for 1/1000 of a second.

If two TIDs are generated during the same second, once per minute, this results in a "drift" of about 1.44 second per day. Since servers are typically running for weeks, this can amount to a non negligeable amount of drift.

This change fixes that by:
1) Resetting the count when more than one second after the previously generated TID
2) Avoids drifting too much under heavy load, by re-using unused TIDs from the elapsed second
3) Throws an error if the load caused the drift to reach 1 minute (because the load caused the generation of 1_000_000 TIDs per second, sustained for 1 minute)