### PR TITLE
Remove non-existing `reporter_stats` from materliaziled view to refresh

### DIFF
--- a/.changeset/shy-dogs-kick.md
+++ b/.changeset/shy-dogs-kick.md
@@ -1,0 +1,5 @@
+---
+"@atproto/ozone": patch
+---
+
+Remove non-existing `reporter_stats` from materliaziled view to refresh

--- a/packages/ozone/src/daemon/materialized-view-refresher.ts
+++ b/packages/ozone/src/daemon/materialized-view-refresher.ts
@@ -10,7 +10,6 @@ export class MaterializedViewRefresher extends PeriodicBackgroundTask {
         'record_events_stats',
         'account_record_events_stats',
         'account_record_status_stats',
-        'reporter_stats',
       ]) {
         if (signal.aborted) break
 


### PR DESCRIPTION
Looks like this is a left over from the time we developped this. 