### PR TITLE
Begin implementing authorization_management_uri

### DIFF
--- a/.changeset/young-trainers-think.md
+++ b/.changeset/young-trainers-think.md
@@ -1,0 +1,10 @@
+---
+"@atproto/oauth-provider": patch
+"@atproto/oauth-types": patch
+---
+
+Implement authorization_management_uri for discovery of Authorization Server account page
+
+This implements the following internet draft for exposing an `authorization_management_uri` from the Authorization Server Metadata response. This allows client applications to provide a link to the management UI on the Authorization Server to manage their OAuth clients, sessions and account credentials.
+
+https://datatracker.ietf.org/doc/draft-emelia-oauth-authorization-management-uri/

--- a/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
+++ b/packages/oauth/oauth-provider/src/metadata/build-metadata.ts
@@ -127,5 +127,9 @@ export function buildMetadata(
 
     // https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html
     client_id_metadata_document_supported: true,
+
+    // https://datatracker.ietf.org/doc/draft-emelia-oauth-authorization-management-uri/
+    // URL is serviced by createAccountPageMiddleware
+    authorization_management_uri: new URL('/account', issuer).href,
   })
 }

--- a/packages/oauth/oauth-types/src/oauth-authorization-server-metadata.ts
+++ b/packages/oauth/oauth-types/src/oauth-authorization-server-metadata.ts
@@ -72,6 +72,9 @@ export const oauthAuthorizationServerMetadataSchema = z.object({
 
   // https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html
   client_id_metadata_document_supported: z.boolean().optional(),
+
+  // https://datatracker.ietf.org/doc/draft-emelia-oauth-authorization-management-uri/
+  authorization_management_uri: webUriSchema.optional(),
 })
 
 export type OAuthAuthorizationServerMetadata = z.infer<


### PR DESCRIPTION
- https://datatracker.ietf.org/doc/draft-emelia-oauth-authorization-management-uri/
- https://github.com/bluesky-social/social-app/issues/9403

This just implements support for authorization_management_uri in the oauth packages. We should probably expose an API from something like `@atproto/api` that provides this URI to the client, but I can't see a clear way to implement that.