### PR TITLE
remove docker compose version

### DIFF
--- a/packages/dev-infra/docker-compose.yaml
+++ b/packages/dev-infra/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   # An ephermerally-stored postgres database for single-use test runs
   db_test: &db_test


### PR DESCRIPTION
This keeps giving some warnings: `WARN[0000] .../atproto/packages/dev-infra/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`