### PR TITLE
lexicons: Change threadgateView record type from 'unknown' to 'app.bsky.feed.threadgate'

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -231,7 +231,7 @@
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
         "cid": { "type": "string", "format": "cid" },
-        "record": { "type": "unknown" },
+        "record": { "type": "ref", "ref": "app.bsky.feed.threadgate" },
         "lists": {
           "type": "array",
           "items": { "type": "ref", "ref": "app.bsky.graph.defs#listViewBasic" }


### PR DESCRIPTION
The type is already well known and defined, it just wasn't specified.