### PR TITLE
Allow mime type in a record to not match the detected mime type.

### DIFF
--- a/packages/pds/src/actor-store/blob/transactor.ts
+++ b/packages/pds/src/actor-store/blob/transactor.ts
@@ -377,12 +377,6 @@ function verifyBlob(
       'BlobTooLarge',
     )
   }
-  if (blob.mimeType !== found.mimeType) {
-    throwInvalid(
-      `Referenced Mimetype does not match stored blob. Expected: ${found.mimeType}, Got: ${blob.mimeType}`,
-      'InvalidMimeType',
-    )
-  }
   if (
     blob.constraints.accept &&
     !acceptedMime(blob.mimeType, blob.constraints.accept)


### PR DESCRIPTION
Resolves #4322.

Removes the code that checks that the mime type in the record is the same as the detected mime type thats stored in the database. 

Does not solve the issue with `<svg`. See #3249 