### PR TITLE
fix(xrpc): always set Content-Type for POST procedures

### DIFF
--- a/packages/xrpc/src/util.ts
+++ b/packages/xrpc/src/util.ts
@@ -140,9 +140,14 @@ export function constructMethodCallHeaders(
   if (schema.type === 'procedure') {
     if (opts?.encoding) {
       headers.set('content-type', opts.encoding)
-    } else if (!headers.has('content-type') && typeof data !== 'undefined') {
-      // Special handling of BodyInit types before falling back to JSON encoding
-      if (
+    } else if (!headers.has('content-type')) {
+      // Always set Content-Type for procedures, even with no body.
+      // Some proxies (e.g. Cloudflare) block POST requests without Content-Type
+      // as "cross-site form submissions".
+      if (typeof data === 'undefined') {
+        headers.set('content-type', 'application/json')
+      } else if (
+        // Special handling of BodyInit types before falling back to JSON encoding
         data instanceof ArrayBuffer ||
         data instanceof ReadableStream ||
         ArrayBuffer.isView(data)


### PR DESCRIPTION
Fixes HTTP 403 errors when XRPC requests pass through Cloudflare.

## Problem

When making POST requests to XRPC procedures that have no request body (e.g., `com.atproto.server.refreshSession`), the client was not setting a Content-Type header. Cloudflare's cross-site POST protection blocks such requests, returning:

  "Cross-site POST form submissions are forbidden"

This caused cryptic errors like:
  XRPC ERROR 403: failed to decode xrpc error message: invalid character 'C'

The 'C' is from "Cross-site POST form submissions..." being parsed as JSON.

## Root Cause

In `constructMethodCallHeaders()`, Content-Type was only set when `data !== undefined`. For procedures with no body, no header was set, triggering Cloudflare's security rule.

## Solution

Always set `Content-Type: application/json` for procedure calls, even when there's no request body. This satisfies Cloudflare's requirements while maintaining correct behavior - empty-body POSTs with JSON content-type are valid HTTP.

## Testing

Verified with curl:
- Without Content-Type: 403 "Cross-site POST form submissions..."
- With Content-Type: application/json: Proper JSON response