### PR TITLE
Age Assurance V2

### DIFF
--- a/.changeset/silent-cougars-tie.md
+++ b/.changeset/silent-cougars-tie.md
@@ -1,0 +1,7 @@
+---
+"@atproto/bsky": patch
+"@atproto/api": patch
+"@atproto/ozone": patch
+---
+
+Adds ageassurance namespace, methods, and utils for Age Assurance V2

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@atproto/lex-cli": "workspace:^",
+    "@jest/globals": "^28.1.3",
     "jest": "^28.1.2",
     "prettier": "^3.2.5",
     "typescript": "^5.6.3"

--- a/packages/api/src/age-assurance.test.ts
+++ b/packages/api/src/age-assurance.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  ageAssuranceRuleIDs,
+  computeAgeAssuranceRegionAccess,
+  getAgeAssuranceRegionConfig,
+} from './age-assurance'
+import { AppBskyAgeassuranceDefs } from './client'
+
+describe('age-assurance', () => {
+  describe('getAgeAssuranceRegionConfig', () => {
+    const config: AppBskyAgeassuranceDefs.Config = {
+      regions: [
+        {
+          countryCode: 'US',
+          regionCode: 'CA',
+          rules: [],
+        },
+        {
+          countryCode: 'US',
+          rules: [],
+        },
+      ],
+    }
+
+    it('should find region by country code only', () => {
+      const result = getAgeAssuranceRegionConfig(config, {
+        countryCode: 'US',
+      })
+
+      expect(result).toEqual({
+        countryCode: 'US',
+        rules: [],
+      })
+    })
+
+    it('should find region by country code and region code', () => {
+      const result = getAgeAssuranceRegionConfig(config, {
+        countryCode: 'US',
+        regionCode: 'CA',
+      })
+
+      expect(result).toEqual({
+        countryCode: 'US',
+        regionCode: 'CA',
+        rules: [],
+      })
+    })
+
+    it('should return undefined when no matching region found', () => {
+      const result = getAgeAssuranceRegionConfig(config, {
+        countryCode: 'GB',
+      })
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('computeAgeAssuranceRegionAccess', () => {
+    const region: AppBskyAgeassuranceDefs.ConfigRegion = {
+      countryCode: 'US',
+      rules: [
+        {
+          $type: ageAssuranceRuleIDs.IfAccountNewerThan,
+          date: '2025-12-10T00:00:00Z',
+          access: 'none',
+        },
+        {
+          $type: ageAssuranceRuleIDs.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ageAssuranceRuleIDs.IfAssuredOverAge,
+          age: 16,
+          access: 'safe',
+        },
+        {
+          $type: ageAssuranceRuleIDs.IfDeclaredOverAge,
+          age: 16,
+          access: 'safe',
+        },
+        {
+          $type: ageAssuranceRuleIDs.Default,
+          access: 'none',
+        },
+      ],
+    }
+
+    it('should apply default if no data provided', () => {
+      const result = computeAgeAssuranceRegionAccess(region, {})
+
+      expect(result).toEqual({
+        access: 'none',
+        reason: ageAssuranceRuleIDs.Default,
+      })
+    })
+
+    describe('IfAccountNewerThan', () => {
+      it('should block accounts created after threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          accountCreatedAt: new Date(2025, 11, 15).toISOString(),
+          declaredAge: 18,
+        })
+        expect(result).toEqual({
+          access: 'none',
+          reason: ageAssuranceRuleIDs.IfAccountNewerThan,
+        })
+      })
+
+      it('should allow accounts created before threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          accountCreatedAt: new Date(2025, 10, 1).toISOString(),
+          declaredAge: 18,
+        })
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfDeclaredOverAge,
+        })
+      })
+
+      it('should allow accounts created exactly at threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          accountCreatedAt: new Date(2025, 11, 1).toISOString(),
+          declaredAge: 18,
+        })
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfDeclaredOverAge,
+        })
+      })
+
+      it('should not apply rule when accountCreatedAt is not provided', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          declaredAge: 15,
+        })
+        expect(result).toEqual({
+          access: 'none',
+          reason: ageAssuranceRuleIDs.Default,
+        })
+      })
+
+      it('should not apply rule when assuredAge is present', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          accountCreatedAt: new Date(2025, 11, 15).toISOString(),
+          assuredAge: 20,
+        })
+        expect(result).toEqual({
+          access: 'full',
+          reason: ageAssuranceRuleIDs.IfAssuredOverAge,
+        })
+      })
+    })
+
+    describe('IfDeclaredOverAge rule', () => {
+      it('should allow users at or above age threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          declaredAge: 18,
+        })
+
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfDeclaredOverAge,
+        })
+      })
+
+      it('should allow users above age threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          declaredAge: 25,
+        })
+
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfDeclaredOverAge,
+        })
+      })
+
+      it('should not allow users below age threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          declaredAge: 17,
+        })
+
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfDeclaredOverAge,
+        })
+      })
+    })
+
+    describe('IfAssuredOverAge rule', () => {
+      it('should allow users at or above assured age threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          assuredAge: 18,
+        })
+
+        expect(result).toEqual({
+          access: 'full',
+          reason: ageAssuranceRuleIDs.IfAssuredOverAge,
+        })
+      })
+
+      it('should not allow users below assured age threshold', () => {
+        const result = computeAgeAssuranceRegionAccess(region, {
+          assuredAge: 17,
+        })
+
+        expect(result).toEqual({
+          access: 'safe',
+          reason: ageAssuranceRuleIDs.IfAssuredOverAge,
+        })
+      })
+    })
+  })
+})

--- a/packages/api/src/age-assurance.ts
+++ b/packages/api/src/age-assurance.ts
@@ -1,0 +1,137 @@
+import { AppBskyAgeassuranceDefs } from './client'
+import { ids } from './client/lexicons'
+
+export type AgeAssuranceRuleID = Exclude<
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleDefault['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfDeclaredOverAge['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfDeclaredUnderAge['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfAssuredOverAge['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfAssuredUnderAge['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfAccountNewerThan['$type']
+  | AppBskyAgeassuranceDefs.ConfigRegionRuleIfAccountOlderThan['$type'],
+  undefined
+>
+
+export const ageAssuranceRuleIDs: Record<string, AgeAssuranceRuleID> = {
+  Default: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleDefault`,
+  IfDeclaredOverAge: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfDeclaredOverAge`,
+  IfDeclaredUnderAge: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfDeclaredUnderAge`,
+  IfAssuredOverAge: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfAssuredOverAge`,
+  IfAssuredUnderAge: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfAssuredUnderAge`,
+  IfAccountNewerThan: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfAccountNewerThan`,
+  IfAccountOlderThan: `${ids.AppBskyAgeassuranceDefs}#configRegionRuleIfAccountOlderThan`,
+}
+
+/**
+ * Returns the first matched region configuration based on the provided geolocation.
+ */
+export function getAgeAssuranceRegionConfig(
+  config: AppBskyAgeassuranceDefs.Config,
+  geolocation: {
+    countryCode: string
+    regionCode?: string
+  },
+): AppBskyAgeassuranceDefs.ConfigRegion | undefined {
+  const { regions } = config
+  return regions.find(({ countryCode, regionCode }) => {
+    if (countryCode === geolocation.countryCode) {
+      return !regionCode || regionCode === geolocation.regionCode
+    }
+  })
+}
+
+export function computeAgeAssuranceRegionAccess(
+  region: AppBskyAgeassuranceDefs.ConfigRegion,
+  data:
+    | {
+        /**
+         * The account creation date in ISO 8601 format. Only checked if we
+         * don't have an assured age, such as on the client.
+         */
+        accountCreatedAt?: string
+        /**
+         * The user's declared age
+         */
+        declaredAge?: number
+        /**
+         * The user's minimum age as assured by a trusted third party.
+         */
+        assuredAge?: number
+      }
+    | undefined,
+):
+  | {
+      access: AppBskyAgeassuranceDefs.Access
+      reason: AgeAssuranceRuleID
+    }
+  | undefined {
+  // first match wins
+  for (const rule of region.rules) {
+    if (AppBskyAgeassuranceDefs.isConfigRegionRuleIfAccountNewerThan(rule)) {
+      if (data?.accountCreatedAt && !data?.assuredAge) {
+        const accountCreatedAt = new Date(data.accountCreatedAt)
+        const threshold = new Date(rule.date)
+        if (accountCreatedAt >= threshold) {
+          return {
+            access: rule.access,
+            reason: rule.$type,
+          }
+        }
+      }
+    } else if (
+      AppBskyAgeassuranceDefs.isConfigRegionRuleIfAccountOlderThan(rule)
+    ) {
+      if (data?.accountCreatedAt && !data?.assuredAge) {
+        const accountCreatedAt = new Date(data.accountCreatedAt)
+        const threshold = new Date(rule.date)
+        if (accountCreatedAt < threshold) {
+          return {
+            access: rule.access,
+            reason: rule.$type,
+          }
+        }
+      }
+    } else if (
+      AppBskyAgeassuranceDefs.isConfigRegionRuleIfDeclaredOverAge(rule)
+    ) {
+      if (data?.declaredAge !== undefined && data.declaredAge >= rule.age) {
+        return {
+          access: rule.access,
+          reason: rule.$type,
+        }
+      }
+    } else if (
+      AppBskyAgeassuranceDefs.isConfigRegionRuleIfDeclaredUnderAge(rule)
+    ) {
+      if (data?.declaredAge !== undefined && data.declaredAge < rule.age) {
+        return {
+          access: rule.access,
+          reason: rule.$type,
+        }
+      }
+    } else if (
+      AppBskyAgeassuranceDefs.isConfigRegionRuleIfAssuredOverAge(rule)
+    ) {
+      if (data?.assuredAge && data.assuredAge >= rule.age) {
+        return {
+          access: rule.access,
+          reason: rule.$type,
+        }
+      }
+    } else if (
+      AppBskyAgeassuranceDefs.isConfigRegionRuleIfAssuredUnderAge(rule)
+    ) {
+      if (data?.assuredAge && data.assuredAge < rule.age) {
+        return {
+          access: rule.access,
+          reason: rule.$type,
+        }
+      }
+    } else if (AppBskyAgeassuranceDefs.isConfigRegionRuleDefault(rule)) {
+      return {
+        access: rule.access,
+        reason: rule.$type,
+      }
+    }
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -24,6 +24,7 @@ export * from './rich-text/util'
 export * from './moderation'
 export * from './moderation/types'
 export * from './mocker'
+export * from './age-assurance'
 export { DEFAULT_LABEL_SETTINGS, LABELS } from './moderation/const/labels'
 export { Agent } from './agent'
 

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -83,6 +83,7 @@
     "@bufbuild/protoc-gen-es": "^1.5.0",
     "@connectrpc/protoc-gen-connect-es": "^1.1.4",
     "@did-plc/server": "^0.0.1",
+    "@jest/globals": "28",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/express-serve-static-core": "^4.17.36",

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -493,6 +493,7 @@ message AgeAssuranceStatus {
   string status = 1;
   google.protobuf.Timestamp last_initiated_at = 2;
   bool override_applied = 3;
+  string access = 4;
 }
 
 message GetActorsResponse {

--- a/packages/bsky/src/api/age-assurance/const.ts
+++ b/packages/bsky/src/api/age-assurance/const.ts
@@ -1,0 +1,142 @@
+import {
+  AppBskyAgeassuranceDefs,
+  ageAssuranceRuleIDs as ids,
+} from '@atproto/api'
+
+/**
+ * Age assurance configuration defining rules for various regions.
+ *
+ * NOTE: These rules are matched in order, and the first matching rule
+ * determines the access level granted.
+ *
+ * NOTE: all regions MUST have a default rule as the last rule.
+ */
+export const AGE_ASSURANCE_CONFIG: AppBskyAgeassuranceDefs.Config = {
+  regions: [
+    {
+      countryCode: 'GB',
+      regionCode: undefined,
+      rules: [
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.IfDeclaredOverAge,
+          age: 13,
+          access: 'safe',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+    {
+      countryCode: 'AU',
+      regionCode: undefined,
+      rules: [
+        {
+          $type: ids.IfAccountNewerThan,
+          date: '2025-12-10T00:00:00Z',
+          access: 'none',
+        },
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 16,
+          access: 'safe',
+        },
+        {
+          $type: ids.IfDeclaredOverAge,
+          age: 16,
+          access: 'safe',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+    {
+      countryCode: 'US',
+      regionCode: 'SD',
+      rules: [
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.IfDeclaredOverAge,
+          age: 13,
+          access: 'safe',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+    {
+      countryCode: 'US',
+      regionCode: 'WY',
+      rules: [
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.IfDeclaredOverAge,
+          age: 13,
+          access: 'safe',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+    {
+      countryCode: 'US',
+      regionCode: 'OH',
+      rules: [
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.IfDeclaredOverAge,
+          age: 13,
+          access: 'safe',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+    {
+      countryCode: 'US',
+      regionCode: 'MS',
+      rules: [
+        {
+          $type: ids.IfAssuredOverAge,
+          age: 18,
+          access: 'full',
+        },
+        {
+          $type: ids.Default,
+          access: 'none',
+        },
+      ],
+    },
+  ],
+}

--- a/packages/bsky/src/api/age-assurance/index.ts
+++ b/packages/bsky/src/api/age-assurance/index.ts
@@ -1,0 +1,34 @@
+import { Router, raw } from 'express'
+import { AppContext } from '../../context'
+import { webhookAuth } from '../kws/webhook'
+import { handler as ageVerifiedRedirect } from './redirects/kws-age-verified'
+import { AppContextWithAA } from './types'
+import { handler as ageVerifiedWebhook } from './webhooks/kws-age-verified'
+
+export const createRouter = (ctx: AppContext): Router => {
+  assertAppContextWithAgeAssuranceClient(ctx)
+
+  const router = Router()
+  router.use(raw({ type: 'application/json' }))
+  router.post(
+    '/age-assurance/webhooks/kws-age-verified',
+    webhookAuth({
+      secret: ctx.cfg.kws.ageVerifiedWebhookSecret,
+    }),
+    ageVerifiedWebhook(ctx),
+  )
+  router.get(
+    '/age-assurance/redirects/kws-age-verified',
+    ageVerifiedRedirect(ctx),
+  )
+
+  return router
+}
+
+const assertAppContextWithAgeAssuranceClient: (
+  ctx: AppContext,
+) => asserts ctx is AppContextWithAA = (ctx: AppContext) => {
+  if (!ctx.kwsClient) {
+    throw new Error('Tried to set up KWS router without kwsClient configured.')
+  }
+}

--- a/packages/bsky/src/api/age-assurance/kws/age-verified.ts
+++ b/packages/bsky/src/api/age-assurance/kws/age-verified.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+
+/**
+ * Schema for KWS the `status` object on `age-verified` payloads.
+ */
+export const KWSAgeVerifiedStatusSchema = z.object({
+  verified: z.boolean(),
+  verifiedMinimumAge: z.number(),
+  transactionId: z.string().optional(),
+})
+
+/**
+ * The KWS `status` object on `age-verified` payloads.
+ */
+export type KWSAgeVerifiedStatus = z.infer<typeof KWSAgeVerifiedStatusSchema>
+
+export function serializeKWSAgeVerifiedStatus(
+  status: KWSAgeVerifiedStatus,
+): string {
+  return JSON.stringify(KWSAgeVerifiedStatusSchema.parse(status))
+}
+
+/**
+ * Parse KWS `age-verified` status object.
+ */
+export const parseKWSAgeVerifiedStatus = (
+  raw: string,
+): KWSAgeVerifiedStatus => {
+  try {
+    const value = JSON.parse(raw)
+    return KWSAgeVerifiedStatusSchema.parse(value)
+  } catch (err) {
+    throw new Error(`Invalid KWS age-verified status: ${raw}`, {
+      cause: err,
+    })
+  }
+}
+
+/**
+ * Schema for KWS `age-verified` webhooks.
+ *
+ * Note: we don't use `.strict()` here so that we avoid breaking if KWS adds
+ * fields, and some fields below are not strictly typed since we're not using
+ * them.
+ */
+export const KWSAgeVerifiedWebhookSchema = z.object({
+  name: z.string(),
+  time: z.string(), // ISO8601 timestamp, but don't validate here
+  orgId: z.string().uuid().optional(),
+  productId: z.string().uuid().optional(),
+  payload: z.object({
+    email: z.string(), // no need to validate here
+    externalPayload: z.string(),
+    status: KWSAgeVerifiedStatusSchema,
+  }),
+})
+
+/**
+ * The raw KWS `age-verified` webhook body
+ */
+export type KWSWebhookAgeVerified = z.infer<typeof KWSAgeVerifiedWebhookSchema>
+
+/**
+ * Parse KWS `age-verified` webhook body and its external payload.
+ */
+export const parseKWSAgeVerifiedWebhook = (
+  raw: string,
+): KWSWebhookAgeVerified => {
+  try {
+    const value: unknown = JSON.parse(raw)
+    return KWSAgeVerifiedWebhookSchema.parse(value)
+  } catch (err) {
+    throw new Error(`Invalid webhook body: ${raw}`, { cause: err })
+  }
+}

--- a/packages/bsky/src/api/age-assurance/kws/const.ts
+++ b/packages/bsky/src/api/age-assurance/kws/const.ts
@@ -1,0 +1,33 @@
+/**
+ * Supported languages for KWS Adult Verification. This list comes from KWS's
+ * Age Verification Developer Guide PDF doc.
+ */
+export const KWS_SUPPORTED_LANGUAGES = new Set([
+  'en',
+  'ar',
+  'zh-Hans',
+  'nl',
+  'tl',
+  'fr',
+  'de',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'pl',
+  'pt-BR',
+  'pt',
+  'ru',
+  'es',
+  'th',
+  'tr',
+  'vi',
+])
+
+/**
+ * Regions where our "version 2" using the `age-verified` KWS flow is
+ * available. In these regions, we'll use a different KWS flow from the
+ * existing `adult-verified` flow, pass along a different external payload, and
+ * handle webhooks/redirects differently in the appview.
+ */
+export const KWS_V2_COUNTRIES = new Set(['AU'])

--- a/packages/bsky/src/api/age-assurance/kws/external-payload.test.ts
+++ b/packages/bsky/src/api/age-assurance/kws/external-payload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  KWSExternalPayloadVersion,
+  parseKWSExternalPayloadV1WithV2Compat,
+  parseKWSExternalPayloadV2,
+  parseKWSExternalPayloadVersion,
+  serializeKWSExternalPayloadV1,
+  serializeKWSExternalPayloadV2,
+} from './external-payload'
+
+describe('parseKWSExternalPayloadVersion', () => {
+  it('should return V2 for "2"', () => {
+    const result = parseKWSExternalPayloadVersion('2')
+    expect(result).toBe('2')
+  })
+  it('should return V1 for unknown versions', () => {
+    const result = parseKWSExternalPayloadVersion('unknown')
+    expect(result).toBe('1')
+  })
+})
+
+describe('parseKWSExternalPayloadV1WithV2Compat', () => {
+  it('should parse V1 payload correctly', () => {
+    const payload = {
+      attemptId: '123',
+      actorDid: 'did:plc:123',
+    }
+    const serialized = serializeKWSExternalPayloadV1(payload)
+    const result = parseKWSExternalPayloadV1WithV2Compat(serialized)
+    expect(result).toEqual({
+      version: KWSExternalPayloadVersion.V1,
+      ...payload,
+    })
+  })
+  it('should parse V2 payload correctly', () => {
+    const payload = {
+      version: KWSExternalPayloadVersion.V2 as const,
+      attemptId: '123',
+      actorDid: 'did:plc:123',
+      countryCode: 'US',
+    }
+    const serialized = serializeKWSExternalPayloadV2(payload)
+    const result = parseKWSExternalPayloadV1WithV2Compat(serialized)
+    expect(result).toEqual(payload)
+  })
+})
+
+describe('serializeKWSExternalPayloadV2 & parseKWSExternalPayloadV2', () => {
+  const payload = {
+    version: KWSExternalPayloadVersion.V2 as const,
+    attemptId: '123',
+    actorDid: 'did:plc:123',
+    countryCode: 'US',
+    regionCode: 'CA',
+  }
+  it('compresses when serializing', () => {
+    const serialized = serializeKWSExternalPayloadV2(payload)
+    const comparison = JSON.stringify({
+      v: KWSExternalPayloadVersion.V2,
+      id: payload.attemptId,
+      did: payload.actorDid,
+      gc: payload.countryCode,
+      gr: payload.regionCode,
+    })
+    expect(serialized).toEqual(comparison)
+  })
+  it('decompresses when parsing', () => {
+    const serialized = serializeKWSExternalPayloadV2(payload)
+    const deserialized = parseKWSExternalPayloadV2(serialized)
+    expect(deserialized).toEqual(payload)
+  })
+})

--- a/packages/bsky/src/api/age-assurance/kws/external-payload.ts
+++ b/packages/bsky/src/api/age-assurance/kws/external-payload.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+
+export const KWS_EXTERNAL_PAYLOAD_CHAR_LIMIT = 250
+
+/**
+ * Thrown when the provided external payload exceeds KWS's character limit.
+ *
+ * This is most commonly caused by DIDs that are too long, such as for
+ * `did:web` DIDs. But it's very rare, and the client has special handling for
+ * this case.
+ */
+export class KWSExternalPayloadTooLargeError extends Error {}
+
+export enum KWSExternalPayloadVersion {
+  V1 = '1',
+  V2 = '2',
+}
+
+export function parseKWSExternalPayloadVersion(raw: string) {
+  switch (raw) {
+    case KWSExternalPayloadVersion.V2:
+      return KWSExternalPayloadVersion.V2
+    default:
+      return KWSExternalPayloadVersion.V1
+  }
+}
+
+export type KWSExternalPayloadV1 = {
+  actorDid: string
+  attemptId: string
+}
+
+export const KWSExternalPayloadV1Schema = z.object({
+  actorDid: z.string(),
+  attemptId: z.string(),
+})
+
+export function parseKWSExternalPayloadV1(raw: string): KWSExternalPayloadV1 {
+  try {
+    const value: unknown = JSON.parse(raw)
+    return KWSExternalPayloadV1Schema.parse(value)
+  } catch (err) {
+    throw new Error(`Failed to parse KWSExternalPayloadV1`, {
+      cause: err,
+    })
+  }
+}
+
+export function serializeKWSExternalPayloadV1(
+  payload: KWSExternalPayloadV1,
+): string {
+  try {
+    return JSON.stringify(KWSExternalPayloadV1Schema.parse(payload))
+  } catch (err) {
+    throw new Error('Failed to serialize KWSExternalPayloadV1', { cause: err })
+  }
+}
+
+/**
+ * During our migration from v1 to v2 of the KWS external payload, we'll be
+ * sending v2 payloads on the v1 flow (the `adult-verified` email flow). We use
+ * this utility to parse either v1 or v2 payloads in that flow.
+ *
+ * Check for the `version` field on the output of this method to discriminate
+ * between the two types and handle them differently.
+ */
+export function parseKWSExternalPayloadV1WithV2Compat(
+  raw: string,
+):
+  | (KWSExternalPayloadV1 & { version: KWSExternalPayloadVersion.V1 })
+  | KWSExternalPayloadV2 {
+  const deserialized = JSON.parse(raw)
+  const v2 = deserialized.v === KWSExternalPayloadVersion.V2
+
+  if (v2) {
+    return parseKWSExternalPayloadV2(raw)
+  } else {
+    return {
+      ...parseKWSExternalPayloadV1(raw),
+      version: KWSExternalPayloadVersion.V1,
+    }
+  }
+}
+
+/***************************
+ * KWS External Payload V2 *
+ ***************************/
+
+export type KWSExternalPayloadV2 = {
+  version: KWSExternalPayloadVersion.V2
+  attemptId: string
+  actorDid: string
+  countryCode: string
+  regionCode?: string
+}
+
+export const KWSExternalPayloadV2Schema = z.object({
+  v: z.string(),
+  id: z.string(),
+  did: z.string(),
+  gc: z.string().length(2),
+  gr: z.string().optional(),
+})
+
+export function serializeKWSExternalPayloadV2(
+  payload: KWSExternalPayloadV2,
+): string {
+  let compressed: z.infer<typeof KWSExternalPayloadV2Schema>
+  try {
+    compressed = KWSExternalPayloadV2Schema.parse({
+      v: KWSExternalPayloadVersion.V2, // version
+      id: payload.attemptId,
+      did: payload.actorDid,
+      gc: payload.countryCode, // geolocation country
+      gr: payload.regionCode, // geolocation region
+    })
+  } catch (err) {
+    throw new Error('Failed to serialize KWSExternalPayloadV2', { cause: err })
+  }
+
+  const serialized = JSON.stringify(compressed)
+
+  if (serialized.length > KWS_EXTERNAL_PAYLOAD_CHAR_LIMIT) {
+    throw new KWSExternalPayloadTooLargeError(
+      `Serialized external payload size ${serialized.length} exceeds limit of ${KWS_EXTERNAL_PAYLOAD_CHAR_LIMIT}`,
+    )
+  }
+
+  return serialized
+}
+
+export function parseKWSExternalPayloadV2(raw: string): KWSExternalPayloadV2 {
+  try {
+    const deserialized = JSON.parse(raw)
+    const parsed = KWSExternalPayloadV2Schema.parse(deserialized)
+
+    return {
+      version: KWSExternalPayloadVersion.V2,
+      attemptId: parsed.id,
+      actorDid: parsed.did,
+      countryCode: parsed.gc,
+      regionCode: parsed.gr,
+    }
+  } catch (err) {
+    throw new Error(`Failed to parse KWSExternalPayloadV2`, {
+      cause: err,
+    })
+  }
+}

--- a/packages/bsky/src/api/age-assurance/redirects/kws-age-verified.ts
+++ b/packages/bsky/src/api/age-assurance/redirects/kws-age-verified.ts
@@ -1,0 +1,107 @@
+import express, { RequestHandler } from 'express'
+import { ageAssuranceLogger as logger } from '../../../logger'
+import { getClientUa, validateSignature } from '../../kws/util'
+import { AGE_ASSURANCE_CONFIG } from '../const'
+import { parseKWSAgeVerifiedStatus } from '../kws/age-verified'
+import {
+  type KWSExternalPayloadV2,
+  parseKWSExternalPayloadV2,
+} from '../kws/external-payload'
+import { createEvent } from '../stash'
+import { AppContextWithAA } from '../types'
+import { computeAgeAssuranceAccessOrThrow } from '../util'
+
+function parseQueryParams(
+  ctx: AppContextWithAA,
+  req: express.Request,
+): {
+  status: string
+  externalPayload: string
+} {
+  try {
+    const status = String(req.query.status)
+    const externalPayload = String(req.query.externalPayload)
+    const signature = String(req.query.signature)
+
+    validateSignature(
+      ctx.cfg.kws.ageVerifiedRedirectSecret,
+      `${status}:${externalPayload}`,
+      signature,
+    )
+
+    return {
+      status,
+      externalPayload,
+    }
+  } catch (err) {
+    throw new Error('Invalid KWS API request', { cause: err })
+  }
+}
+
+export const handler =
+  (ctx: AppContextWithAA): RequestHandler =>
+  async (req: express.Request, res: express.Response) => {
+    let externalPayload: KWSExternalPayloadV2 | undefined
+
+    try {
+      const query = parseQueryParams(ctx, req)
+      const { verified, verifiedMinimumAge } = parseKWSAgeVerifiedStatus(
+        query.status,
+      )
+      externalPayload = parseKWSExternalPayloadV2(query.externalPayload)
+      const { actorDid, attemptId, countryCode, regionCode } = externalPayload
+
+      /*
+       * KWS does not send unverified webhooks for age verification, so we
+       * expect all webhooks to be verified. This is just a sanity check.
+       */
+      if (!verified) {
+        const message =
+          'Expected KWS verification redirect to have verified status'
+        logger.error({}, message)
+        throw new Error(message)
+      }
+
+      const { access } = computeAgeAssuranceAccessOrThrow(
+        AGE_ASSURANCE_CONFIG,
+        {
+          countryCode,
+          regionCode,
+          verifiedMinimumAge,
+        },
+      )
+
+      await createEvent(ctx, actorDid, {
+        attemptId,
+        // Assumes `app.set('trust proxy', ...)` configured with `true` or specific values.
+        completeIp: req.ip,
+        completeUa: getClientUa(req),
+        countryCode,
+        regionCode,
+        status: 'assured',
+        access,
+      })
+
+      const q = new URLSearchParams({ actorDid, result: 'success' })
+
+      return res
+        .status(302)
+        .setHeader('Location', `${ctx.cfg.kws.redirectUrl}?${q}`)
+        .end()
+    } catch (err) {
+      logger.error(
+        { err, ...externalPayload },
+        'Failed to handle KWS verification redirect',
+      )
+
+      const q = new URLSearchParams({
+        ...(externalPayload ? { actorDid: externalPayload.actorDid } : {}),
+        result: 'unknown',
+      })
+
+      return res
+        .status(302)
+        .setHeader('Location', `${ctx.cfg.kws.redirectUrl}?${q}`)
+        .end()
+    }
+  }

--- a/packages/bsky/src/api/age-assurance/stash.ts
+++ b/packages/bsky/src/api/age-assurance/stash.ts
@@ -1,0 +1,22 @@
+import { TID } from '@atproto/common'
+import { AppContext } from '../../context'
+import { Event as AgeAssuranceEvent } from '../../lexicon/types/app/bsky/ageassurance/defs'
+import { Namespaces } from '../../stash'
+
+export async function createEvent(
+  ctx: AppContext,
+  actorDid: string,
+  event: Omit<AgeAssuranceEvent, 'createdAt'>,
+) {
+  const payload: AgeAssuranceEvent = {
+    createdAt: new Date().toISOString(),
+    ...event,
+  }
+  await ctx.stashClient.create({
+    actorDid: actorDid,
+    namespace: Namespaces.AppBskyAgeassuranceDefsEvent,
+    key: TID.nextStr(),
+    payload,
+  })
+  return payload
+}

--- a/packages/bsky/src/api/age-assurance/types.ts
+++ b/packages/bsky/src/api/age-assurance/types.ts
@@ -1,0 +1,10 @@
+import { KwsConfig, ServerConfig } from '../../config'
+import { AppContext } from '../../context'
+import { KwsClient } from '../../kws'
+
+export type AppContextWithAA = AppContext & {
+  kwsClient: KwsClient
+  cfg: ServerConfig & {
+    kws: KwsConfig
+  }
+}

--- a/packages/bsky/src/api/age-assurance/util.ts
+++ b/packages/bsky/src/api/age-assurance/util.ts
@@ -1,0 +1,66 @@
+import {
+  type AppBskyAgeassuranceDefs,
+  computeAgeAssuranceRegionAccess,
+  getAgeAssuranceRegionConfig,
+} from '@atproto/api'
+
+/**
+ * Compute age assurance access based on verified minimum age. Thrown errors
+ * are internal errors, so handle them accordingly.
+ */
+export function computeAgeAssuranceAccessOrThrow(
+  config: AppBskyAgeassuranceDefs.Config,
+  {
+    countryCode,
+    regionCode,
+    verifiedMinimumAge,
+  }: {
+    countryCode: string
+    regionCode?: string
+    verifiedMinimumAge: number
+  },
+) {
+  const region = getAgeAssuranceRegionConfig(config, {
+    countryCode,
+    regionCode,
+  })
+
+  if (region) {
+    const result = computeAgeAssuranceRegionAccess(region, {
+      assuredAge: verifiedMinimumAge,
+      /*
+       * We don't care about this here, this is a client-only rule. If we have
+       * verified data, we can use that, and the account creation date is
+       * irrelevant.
+       */
+      accountCreatedAt: undefined,
+    })
+
+    if (result) {
+      return result
+    } else {
+      /*
+       * If we don't get a result, it's because none of the rules matched,
+       * which is a configuration error: there should always be a default
+       * rule.
+       */
+      throw new Error('Cound not compute age assurance region access')
+    }
+  } else {
+    /**
+     * If we had geolocation data, but we don't have a region config for this
+     * geolocation, then it means a user outside of our configured regions
+     * has completed age verification. In this case, we can't determine their
+     * access level, so we throw an error.
+     *
+     * This case is also guarded in `app.bsky.ageassurance.begin`.
+     */
+    throw new Error('Could not get config for region')
+  }
+}
+
+export function createLocationString(countryCode: string, regionCode?: string) {
+  return regionCode
+    ? `${countryCode.toUpperCase()}-${regionCode.toUpperCase()}`
+    : countryCode.toUpperCase()
+}

--- a/packages/bsky/src/api/age-assurance/webhooks/kws-age-verified.ts
+++ b/packages/bsky/src/api/age-assurance/webhooks/kws-age-verified.ts
@@ -1,0 +1,75 @@
+import express, { RequestHandler } from 'express'
+import { ageAssuranceLogger as logger } from '../../../logger'
+import { AGE_ASSURANCE_CONFIG } from '../const'
+import {
+  type KWSWebhookAgeVerified,
+  parseKWSAgeVerifiedWebhook,
+} from '../kws/age-verified'
+import { parseKWSExternalPayloadV2 } from '../kws/external-payload'
+import { createEvent } from '../stash'
+import { type AppContextWithAA } from '../types'
+import { computeAgeAssuranceAccessOrThrow } from '../util'
+
+export const handler =
+  (ctx: AppContextWithAA): RequestHandler =>
+  async (req: express.Request, res: express.Response) => {
+    let body: KWSWebhookAgeVerified
+    try {
+      body = parseKWSAgeVerifiedWebhook(req.body)
+    } catch (err) {
+      const message = 'Failed to parse KWS webhook body'
+      logger.error({ err }, message)
+      return res.status(400).json({ error: message })
+    }
+
+    const { status, externalPayload } = body.payload
+    const { verified, verifiedMinimumAge } = status
+    const { actorDid, countryCode, regionCode, attemptId } =
+      parseKWSExternalPayloadV2(externalPayload)
+
+    /*
+     * KWS does not send unverified webhooks for age verification, so we
+     * expect all webhooks to be verified. This is just a sanity check.
+     */
+    if (!verified) {
+      const message = 'Expected KWS webhook to have verified status'
+      logger.error({}, message)
+      return res.status(400).json({ error: message })
+    }
+
+    let result: ReturnType<typeof computeAgeAssuranceAccessOrThrow> | undefined
+    try {
+      result = computeAgeAssuranceAccessOrThrow(AGE_ASSURANCE_CONFIG, {
+        countryCode,
+        regionCode,
+        verifiedMinimumAge,
+      })
+    } catch (err) {
+      // internal errors
+      logger.error(
+        { err, attemptId, actorDid, countryCode, regionCode },
+        'Failed to compute age assurance access',
+      )
+    }
+
+    try {
+      if (result) {
+        await createEvent(ctx, actorDid, {
+          attemptId,
+          countryCode,
+          regionCode,
+          status: 'assured',
+          access: result.access,
+        })
+      }
+
+      return res.status(200).end()
+    } catch (err) {
+      const message = 'Failed to handle KWS webhook'
+      logger.error(
+        { err, attemptId, actorDid, countryCode, regionCode },
+        message,
+      )
+      return res.status(500).json({ error: message })
+    }
+  }

--- a/packages/bsky/src/api/app/bsky/ageassurance/begin.ts
+++ b/packages/bsky/src/api/app/bsky/ageassurance/begin.ts
@@ -1,0 +1,167 @@
+import crypto from 'node:crypto'
+import { isEmailValid } from '@hapi/address'
+import { isDisposableEmail } from 'disposable-email-domains-js'
+import { getAgeAssuranceRegionConfig } from '@atproto/api'
+import {
+  InvalidRequestError,
+  MethodNotImplementedError,
+} from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context'
+import { Server } from '../../../../lexicon'
+import { InputSchema } from '../../../../lexicon/types/app/bsky/ageassurance/begin'
+import { httpLogger as log } from '../../../../logger'
+import { ActorInfo } from '../../../../proto/bsky_pb'
+import { AGE_ASSURANCE_CONFIG } from '../../../age-assurance/const'
+import {
+  KWS_SUPPORTED_LANGUAGES,
+  KWS_V2_COUNTRIES,
+} from '../../../age-assurance/kws/const'
+import {
+  KWSExternalPayloadTooLargeError,
+  KWSExternalPayloadVersion,
+  serializeKWSExternalPayloadV2,
+} from '../../../age-assurance/kws/external-payload'
+import { createEvent } from '../../../age-assurance/stash'
+import { createLocationString } from '../../../age-assurance/util'
+import { getClientUa } from '../../../kws/util'
+
+export default function (server: Server, ctx: AppContext) {
+  server.app.bsky.ageassurance.begin({
+    auth: ctx.authVerifier.standard,
+    handler: async ({ auth, input, req }) => {
+      if (!ctx.kwsClient) {
+        throw new MethodNotImplementedError(
+          'This service is not configured to support age assurance.',
+        )
+      }
+
+      const actorDid = auth.credentials.iss
+      const actorInfo = await getAgeVerificationState(ctx, actorDid)
+
+      if (actorInfo?.ageAssuranceStatus) {
+        if (
+          actorInfo.ageAssuranceStatus.status !== 'unknown' &&
+          actorInfo.ageAssuranceStatus.status !== 'pending'
+        ) {
+          throw new InvalidRequestError(
+            `Cannot initiate age assurance flow from current state: ${actorInfo.ageAssuranceStatus.status}`,
+            'InvalidInitiation',
+          )
+        }
+      }
+
+      const attemptId = crypto.randomUUID()
+      const { email, language, countryCode, regionCode } = validateInput(
+        input.body,
+      )
+
+      let externalPayload: string
+      try {
+        externalPayload = serializeKWSExternalPayloadV2({
+          version: KWSExternalPayloadVersion.V2,
+          actorDid,
+          attemptId,
+          countryCode,
+          regionCode,
+        })
+      } catch (err) {
+        if (err instanceof KWSExternalPayloadTooLargeError) {
+          log.error({ err, actorDid }, err.message)
+          throw new InvalidRequestError(
+            'Age Assurance flow failed because DID is too long',
+            'DidTooLong',
+          )
+        }
+        throw err
+      }
+
+      /*
+       * Determine if age assurance config exists for this region. The calling
+       * application should already have checked for this, so this is just a
+       * safeguard.
+       */
+      const region = getAgeAssuranceRegionConfig(AGE_ASSURANCE_CONFIG, {
+        countryCode,
+        regionCode,
+      })
+      if (!region) {
+        const message = 'Age Assurance is not required in this region'
+        log.error({ actorDid, countryCode, regionCode }, message)
+        throw new InvalidRequestError(message, 'RegionNotSupported')
+      }
+
+      const location = createLocationString(countryCode, regionCode)
+
+      if (KWS_V2_COUNTRIES.has(region.countryCode)) {
+        // `age-verified` flow
+        await ctx.kwsClient.sendAgeVerifiedFlowEmail({
+          location,
+          email,
+          externalPayload,
+          language,
+        })
+      } else {
+        // `adult-verified` flow is what we've been using prior to `age-verified`
+        await ctx.kwsClient.sendAdultVerifiedFlowEmail({
+          location,
+          email,
+          externalPayload,
+          language,
+        })
+      }
+
+      const event = await createEvent(ctx, actorDid, {
+        attemptId,
+        email,
+        // Assumes `app.set('trust proxy', ...)` configured with `true` or specific values.
+        initIp: req.ip,
+        initUa: getClientUa(req),
+        status: 'pending',
+        access: 'unknown',
+        countryCode,
+        regionCode,
+      })
+
+      return {
+        encoding: 'application/json',
+        body: {
+          lastInitiatedAt: event.createdAt,
+          status: 'pending',
+          access: 'unknown',
+        },
+      }
+    },
+  })
+}
+
+function validateInput({ email, language, ...rest }: InputSchema): InputSchema {
+  if (!isEmailValid(email) || isDisposableEmail(email)) {
+    throw new InvalidRequestError(
+      'This email address is not supported, please use a different email.',
+      'InvalidEmail',
+    )
+  }
+
+  return {
+    email,
+    language: KWS_SUPPORTED_LANGUAGES.has(language) ? language : 'en',
+    ...rest,
+  }
+}
+
+async function getAgeVerificationState(
+  ctx: AppContext,
+  actorDid: string,
+): Promise<ActorInfo | undefined> {
+  try {
+    const res = await ctx.dataplane.getActors({
+      dids: [actorDid],
+      returnAgeAssuranceForDids: [actorDid],
+      skipCacheForDids: [actorDid],
+    })
+
+    return res.actors[0]
+  } catch (err) {
+    return undefined
+  }
+}

--- a/packages/bsky/src/api/app/bsky/ageassurance/getConfig.ts
+++ b/packages/bsky/src/api/app/bsky/ageassurance/getConfig.ts
@@ -1,0 +1,15 @@
+import { AGE_ASSURANCE_CONFIG } from '../../../../api/age-assurance/const'
+import { AppContext } from '../../../../context'
+import { Server } from '../../../../lexicon'
+
+export default function (server: Server, ctx: AppContext) {
+  server.app.bsky.ageassurance.getConfig({
+    auth: ctx.authVerifier.standardOptional,
+    handler: async () => {
+      return {
+        encoding: 'application/json',
+        body: AGE_ASSURANCE_CONFIG,
+      }
+    },
+  })
+}

--- a/packages/bsky/src/api/app/bsky/ageassurance/getState.ts
+++ b/packages/bsky/src/api/app/bsky/ageassurance/getState.ts
@@ -1,0 +1,53 @@
+import { UpstreamFailureError } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context'
+import { Server } from '../../../../lexicon'
+import { ActorInfo } from '../../../../proto/bsky_pb'
+
+export default function (server: Server, ctx: AppContext) {
+  server.app.bsky.ageassurance.getState({
+    auth: ctx.authVerifier.standard,
+    handler: async ({ auth }) => {
+      const viewer = auth.credentials.iss
+      const actor = await getActorInfo(ctx, viewer)
+
+      return {
+        encoding: 'application/json',
+        body: {
+          state: {
+            lastInitiatedAt:
+              actor.ageAssuranceStatus?.lastInitiatedAt
+                ?.toDate()
+                .toISOString() || undefined,
+            status: actor.ageAssuranceStatus?.status || 'unknown',
+            access: actor.ageAssuranceStatus?.access || 'unknown',
+          },
+          metadata: {
+            accountCreatedAt:
+              actor.createdAt?.toDate().toISOString() || undefined,
+          },
+        },
+      }
+    },
+  })
+}
+
+const getActorInfo = async (
+  ctx: AppContext,
+  actorDid: string,
+): Promise<ActorInfo> => {
+  try {
+    const res = await ctx.dataplane.getActors({
+      dids: [actorDid],
+      returnAgeAssuranceForDids: [actorDid],
+      skipCacheForDids: [actorDid],
+    })
+
+    return res.actors[0]
+  } catch (err) {
+    throw new UpstreamFailureError(
+      'Cannot get current age assurance state',
+      'GetAgeAssuranceStateFailed',
+      { cause: err },
+    )
+  }
+}

--- a/packages/bsky/src/api/external.ts
+++ b/packages/bsky/src/api/external.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { AppContext } from '../context'
+import * as aaApi from './age-assurance'
 import * as kwsApi from './kws'
 
 export const createRouter = (ctx: AppContext): Router => {
@@ -7,6 +8,7 @@ export const createRouter = (ctx: AppContext): Router => {
 
   if (ctx.kwsClient) {
     router.use('/kws', kwsApi.createRouter(ctx))
+    router.use(aaApi.createRouter(ctx))
   }
 
   return router

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -5,6 +5,9 @@ import getProfiles from './app/bsky/actor/getProfiles'
 import getSuggestions from './app/bsky/actor/getSuggestions'
 import searchActors from './app/bsky/actor/searchActors'
 import searchActorsTypeahead from './app/bsky/actor/searchActorsTypeahead'
+import aaBegin from './app/bsky/ageassurance/begin'
+import aaGetConfig from './app/bsky/ageassurance/getConfig'
+import aaGetState from './app/bsky/ageassurance/getState'
 import createBookmark from './app/bsky/bookmark/createBookmark'
 import deleteBookmark from './app/bsky/bookmark/deleteBookmark'
 import getBookmarks from './app/bsky/bookmark/getBookmarks'
@@ -156,6 +159,9 @@ export default function (server: Server, ctx: AppContext) {
   getTaggedSuggestions(server, ctx)
   getAgeAssuranceState(server, ctx)
   initAgeAssurance(server, ctx)
+  aaGetConfig(server, ctx)
+  aaGetState(server, ctx)
+  aaBegin(server, ctx)
   // com.atproto
   getSubjectStatus(server, ctx)
   updateSubjectStatus(server, ctx)

--- a/packages/bsky/src/api/kws/index.ts
+++ b/packages/bsky/src/api/kws/index.ts
@@ -9,7 +9,13 @@ export const createRouter = (ctx: AppContext): Router => {
 
   const router = Router()
   router.use(raw({ type: 'application/json' }))
-  router.post('/age-assurance-webhook', webhookAuth(ctx), webhookHandler(ctx))
+  router.post(
+    '/age-assurance-webhook',
+    webhookAuth({
+      secret: ctx.cfg.kws.webhookSecret,
+    }),
+    webhookHandler(ctx),
+  )
   router.get('/age-assurance-verification', verificationHandler(ctx))
   return router
 }

--- a/packages/bsky/src/api/kws/webhook.ts
+++ b/packages/bsky/src/api/kws/webhook.ts
@@ -1,19 +1,21 @@
 import express, { RequestHandler } from 'express'
 import { httpLogger as log } from '../../logger'
+import { AGE_ASSURANCE_CONFIG } from '../age-assurance/const'
+import {
+  KWSExternalPayloadVersion,
+  parseKWSExternalPayloadV1WithV2Compat,
+} from '../age-assurance/kws/external-payload'
+import { createEvent } from '../age-assurance/stash'
+import { computeAgeAssuranceAccessOrThrow } from '../age-assurance/util'
 import {
   AppContextWithKwsClient,
   KwsWebhookBody,
   webhookBodyIntermediateSchema,
 } from './types'
-import {
-  createStashEvent,
-  kwsWwwAuthenticate,
-  parseExternalPayload,
-  validateSignature,
-} from './util'
+import { createStashEvent, kwsWwwAuthenticate, validateSignature } from './util'
 
 export const webhookAuth =
-  (ctx: AppContextWithKwsClient): RequestHandler =>
+  ({ secret }: { secret: string }): RequestHandler =>
   (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const body: Buffer = req.body
     const sigHeader = req.headers['x-kws-signature']
@@ -34,7 +36,7 @@ export const webhookAuth =
       }
 
       const data = `${timestamp}.${body}`
-      validateSignature(ctx.cfg.kws.webhookSecret, data, signature)
+      validateSignature(secret, data, signature)
       next()
     } catch (err) {
       log.error({ err }, 'Invalid KWS webhook signature')
@@ -51,21 +53,10 @@ type AgeAssuranceWebhookIntermediateBody = {
   }
 }
 
-const parseBody = (serialized: string): KwsWebhookBody => {
+const parseBody = (serialized: string): AgeAssuranceWebhookIntermediateBody => {
   try {
     const value: unknown = JSON.parse(serialized)
-    const intermediate: AgeAssuranceWebhookIntermediateBody =
-      webhookBodyIntermediateSchema.parse(value)
-
-    return {
-      ...intermediate,
-      payload: {
-        ...intermediate.payload,
-        externalPayload: parseExternalPayload(
-          intermediate.payload.externalPayload,
-        ),
-      },
-    }
+    return webhookBodyIntermediateSchema.parse(value)
   } catch (err) {
     throw new Error(`Invalid webhook body: ${serialized}`, { cause: err })
   }
@@ -74,7 +65,7 @@ const parseBody = (serialized: string): KwsWebhookBody => {
 export const webhookHandler =
   (ctx: AppContextWithKwsClient): RequestHandler =>
   async (req: express.Request, res: express.Response) => {
-    let body: KwsWebhookBody
+    let body: AgeAssuranceWebhookIntermediateBody
     try {
       body = parseBody(req.body)
     } catch (err) {
@@ -82,23 +73,55 @@ export const webhookHandler =
       return res.status(400).json(err)
     }
 
-    const {
-      payload: {
-        status: { verified },
-        externalPayload,
-      },
-    } = body
-    const { actorDid, attemptId } = externalPayload
+    const { verified } = body.payload.status
     if (!verified) {
       throw new Error('Unexpected KWS webhook call with unverified status')
     }
 
+    const externalPayload = parseKWSExternalPayloadV1WithV2Compat(
+      body.payload.externalPayload,
+    )
+    const isV2 = externalPayload.version === KWSExternalPayloadVersion.V2
+
+    let result: ReturnType<typeof computeAgeAssuranceAccessOrThrow> | undefined
+    if (isV2) {
+      const { attemptId, actorDid, countryCode, regionCode } = externalPayload
+      try {
+        result = computeAgeAssuranceAccessOrThrow(AGE_ASSURANCE_CONFIG, {
+          countryCode: countryCode,
+          regionCode: regionCode,
+          verifiedMinimumAge: 18, // `adult-verified` is 18+ only
+        })
+      } catch (err) {
+        // internal errors
+        log.error(
+          { err, attemptId, actorDid, countryCode, regionCode },
+          'Failed to compute age assurance access',
+        )
+      }
+    }
+
     try {
-      await createStashEvent(ctx, {
-        actorDid,
-        attemptId,
-        status: 'assured',
-      })
+      if (isV2) {
+        if (result) {
+          const { attemptId, actorDid, countryCode, regionCode } =
+            externalPayload
+          await createEvent(ctx, actorDid, {
+            attemptId,
+            status: 'assured',
+            access: result.access,
+            countryCode,
+            regionCode,
+          })
+        } // else do nothing
+      } else {
+        const { attemptId, actorDid } = externalPayload
+        await createStashEvent(ctx, {
+          attemptId: attemptId,
+          actorDid: actorDid,
+          status: 'assured',
+        })
+      }
       return res.status(200).end()
     } catch (err) {
       log.error({ err }, 'Failed to handle KWS webhook')

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -13,8 +13,22 @@ export interface KwsConfig {
   clientId: string
   redirectUrl: string
   userAgent: string
+  /**
+   * V1 secret used to validate `adult-verifieid` redirects
+   */
   verificationSecret: string
+  /**
+   * V1 secret used to validate `adult-verified` webhooks
+   */
   webhookSecret: string
+  /**
+   * V2 secret used to validate `age-verified` webhooks
+   */
+  ageVerifiedWebhookSecret: string
+  /**
+   * V2 secret used to validate `age-verified` redirects
+   */
+  ageVerifiedRedirectSecret: string
 }
 
 export interface ServerConfigValues {
@@ -251,6 +265,10 @@ export class ServerConfig {
     const kwsUserAgent = process.env.BSKY_KWS_USER_AGENT
     const kwsVerificationSecret = process.env.BSKY_KWS_VERIFICATION_SECRET
     const kwsWebhookSecret = process.env.BSKY_KWS_WEBHOOK_SECRET
+    const kwsAgeVerifiedWebhookSecret =
+      process.env.BSKY_KWS_AGE_VERIFIED_WEBHOOK_SECRET
+    const kwsAgeVerifiedRedirectSecret =
+      process.env.BSKY_KWS_AGE_VERIFIED_REDIRECT_SECRET
     if (
       kwsApiKey ||
       kwsApiOrigin ||
@@ -259,7 +277,9 @@ export class ServerConfig {
       kwsRedirectUrl ||
       kwsUserAgent ||
       kwsVerificationSecret ||
-      kwsWebhookSecret
+      kwsWebhookSecret ||
+      kwsAgeVerifiedWebhookSecret ||
+      kwsAgeVerifiedRedirectSecret
     ) {
       assert(
         kwsApiOrigin &&
@@ -269,7 +289,9 @@ export class ServerConfig {
           kwsUserAgent &&
           kwsVerificationSecret &&
           kwsWebhookSecret &&
-          kwsApiKey,
+          kwsApiKey &&
+          kwsAgeVerifiedWebhookSecret &&
+          kwsAgeVerifiedRedirectSecret,
         'all KWS environment variables must be set if any are set',
       )
       kws = {
@@ -281,6 +303,8 @@ export class ServerConfig {
         userAgent: kwsUserAgent,
         verificationSecret: kwsVerificationSecret,
         webhookSecret: kwsWebhookSecret,
+        ageVerifiedWebhookSecret: kwsAgeVerifiedWebhookSecret,
+        ageVerifiedRedirectSecret: kwsAgeVerifiedRedirectSecret,
       }
     }
 

--- a/packages/bsky/src/data-plane/server/db/migrations/20251120T004738098Z-update-actor-age-assurance-v2.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/20251120T004738098Z-update-actor-age-assurance-v2.ts
@@ -1,0 +1,28 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('actor')
+    .addColumn('ageAssuranceAccess', 'text')
+    .execute()
+  await db.schema
+    .alterTable('actor')
+    .addColumn('ageAssuranceCountryCode', 'text')
+    .execute()
+  await db.schema
+    .alterTable('actor')
+    .addColumn('ageAssuranceRegionCode', 'text')
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('actor').dropColumn('ageAssuranceAccess').execute()
+  await db.schema
+    .alterTable('actor')
+    .dropColumn('ageAssuranceCountryCode')
+    .execute()
+  await db.schema
+    .alterTable('actor')
+    .dropColumn('ageAssuranceRegionCode')
+    .execute()
+}

--- a/packages/bsky/src/data-plane/server/db/migrations/index.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/index.ts
@@ -55,3 +55,4 @@ export * as _20250611T140649895Z from './20250611T140649895Z-add-activity-subscr
 export * as _20250627T025331240Z from './20250627T025331240Z-add-actor-age-assurance-columns'
 export * as _20250812T183735692Z from './20250812T183735692Z-add-bookmarks'
 export * as _20250813T174955711Z from './20250813T174955711Z-add-post-agg-bookmarks'
+export * as _20251120T004738098Z from './20251120T004738098Z-update-actor-age-assurance-v2'

--- a/packages/bsky/src/data-plane/server/db/tables/actor.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/actor.ts
@@ -9,6 +9,9 @@ export interface Actor {
   trustedVerifier: Generated<boolean>
   ageAssuranceStatus: string | null
   ageAssuranceLastInitiatedAt: string | null
+  ageAssuranceAccess: string | null
+  ageAssuranceCountryCode: string | null
+  ageAssuranceRegionCode: string | null
 }
 
 export const tableName = 'actor'

--- a/packages/bsky/src/data-plane/server/routes/profile.ts
+++ b/packages/bsky/src/data-plane/server/routes/profile.ts
@@ -134,11 +134,22 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
           return undefined
         }
 
+        const status = row?.ageAssuranceStatus ?? 'unknown'
+        let access = row?.ageAssuranceAccess
+        if (status === 'assured') {
+          access = 'full'
+        } else if (status === 'blocked') {
+          access = 'none'
+        } else {
+          access = 'unknown'
+        }
+
         return {
-          status: row?.ageAssuranceStatus ?? 'unknown',
           lastInitiatedAt: row?.ageAssuranceLastInitiatedAt
             ? Timestamp.fromDate(new Date(row?.ageAssuranceLastInitiatedAt))
             : undefined,
+          status,
+          access,
         }
       }
 

--- a/packages/bsky/src/logger.ts
+++ b/packages/bsky/src/logger.ts
@@ -17,6 +17,8 @@ export const featureGatesLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky:featuregates')
 export const dataplaneLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky:dp')
+export const ageAssuranceLogger: ReturnType<typeof subsystemLogger> =
+  subsystemLogger('bsky:aa')
 export const httpLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky')
 

--- a/packages/bsky/src/proto/bsky_pb.ts
+++ b/packages/bsky/src/proto/bsky_pb.ts
@@ -3856,6 +3856,16 @@ export class AgeAssuranceStatus extends Message<AgeAssuranceStatus> {
    */
   overrideApplied = false;
 
+  /**
+   * @generated from field: string access = 4;
+   */
+  access = "";
+
+  /**
+   * @generated from field: string access_reason = 5;
+   */
+  accessReason = "";
+
   constructor(data?: PartialMessage<AgeAssuranceStatus>) {
     super();
     proto3.util.initPartial(data, this);
@@ -3867,6 +3877,8 @@ export class AgeAssuranceStatus extends Message<AgeAssuranceStatus> {
     { no: 1, name: "status", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "last_initiated_at", kind: "message", T: Timestamp },
     { no: 3, name: "override_applied", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 4, name: "access", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "access_reason", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AgeAssuranceStatus {

--- a/packages/bsky/src/stash.ts
+++ b/packages/bsky/src/stash.ts
@@ -3,6 +3,7 @@
 import { LexValue, stringifyLex } from '@atproto/lexicon'
 import { BsyncClient } from './bsync'
 import { lexicons } from './lexicon/lexicons'
+import { Event as AgeAssuranceEventV2 } from './lexicon/types/app/bsky/ageassurance/defs'
 import { Bookmark } from './lexicon/types/app/bsky/bookmark/defs'
 import {
   Preferences,
@@ -22,6 +23,8 @@ export const Namespaces = {
     'app.bsky.notification.defs#subjectActivitySubscription' satisfies PickNSID<SubjectActivitySubscription>,
   AppBskyUnspeccedDefsAgeAssuranceEvent:
     'app.bsky.unspecced.defs#ageAssuranceEvent' satisfies PickNSID<AgeAssuranceEvent>,
+  AppBskyAgeassuranceDefsEvent:
+    'app.bsky.ageassurance.defs#event' satisfies PickNSID<AgeAssuranceEventV2>,
 }
 
 export type Namespace = (typeof Namespaces)[keyof typeof Namespaces]

--- a/packages/bsky/tests/views/age-assurance-v2.test.ts
+++ b/packages/bsky/tests/views/age-assurance-v2.test.ts
@@ -1,0 +1,745 @@
+import crypto from 'node:crypto'
+import { once } from 'node:events'
+import { Server, createServer } from 'node:http'
+import { AddressInfo } from 'node:net'
+import express, { Application } from 'express'
+import {
+  AppBskyAgeassuranceDefs,
+  AtpAgent,
+  ageAssuranceRuleIDs as ruleIds,
+} from '@atproto/api'
+import { SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
+import {
+  type KWSWebhookAgeVerified,
+  serializeKWSAgeVerifiedStatus,
+} from '../../src/api/age-assurance/kws/age-verified'
+import {
+  KWSExternalPayloadVersion,
+  serializeKWSExternalPayloadV1,
+  serializeKWSExternalPayloadV2,
+} from '../../src/api/age-assurance/kws/external-payload'
+import { KwsWebhookBody } from '../../src/api/kws/types'
+import { ids } from '../../src/lexicon/lexicons'
+import * as AppBskyAgeassuranceBegin from '../../src/lexicon/types/app/bsky/ageassurance/begin'
+import * as AppBskyAgeassuranceGetState from '../../src/lexicon/types/app/bsky/ageassurance/getState'
+
+type Database = TestNetwork['bsky']['db']
+
+const BSKY_REDIRECT_URL = 'http://bsky'
+
+jest.mock('../../dist/api/age-assurance/const.js', () => {
+  const AGE_ASSURANCE_CONFIG: AppBskyAgeassuranceDefs.Config = {
+    regions: [
+      {
+        countryCode: 'AA',
+        regionCode: undefined,
+        rules: [
+          {
+            $type: ruleIds.IfAssuredOverAge,
+            age: 18,
+            access: 'full',
+          },
+          {
+            $type: ruleIds.Default,
+            access: 'safe',
+          },
+        ],
+      },
+      {
+        countryCode: 'BB',
+        regionCode: undefined,
+        rules: [
+          {
+            $type: ruleIds.IfAssuredOverAge,
+            age: 18,
+            access: 'full',
+          },
+          {
+            $type: ruleIds.Default,
+            access: 'safe',
+          },
+        ],
+      },
+    ],
+  }
+  return {
+    AGE_ASSURANCE_CONFIG,
+  }
+})
+
+jest.mock('../../dist/api/age-assurance/kws/const.js', () => {
+  const actual = jest.requireActual('../../dist/api/age-assurance/kws/const.js')
+  const KWS_V2_COUNTRIES = new Set(['AA'])
+  return {
+    ...actual,
+    KWS_V2_COUNTRIES,
+  }
+})
+
+describe('age assurance v2 views', () => {
+  let network: TestNetwork
+  let db: Database
+  let agent: AtpAgent
+  let sc: SeedClient
+  let kws: MockKwsServer
+
+  const kwsOauthMock = jest.fn()
+  const kwsSendAgeVerifiedFlowEmailMock = jest.fn()
+  const kwsSendAdultVerifiedFlowEmailMock = jest.fn()
+  const actor = {
+    did: '',
+    email: '',
+  }
+
+  beforeAll(async () => {
+    kws = new MockKwsServer({
+      oauthMock: kwsOauthMock,
+      sendAgeVerifiedFlowEmailMock: kwsSendAgeVerifiedFlowEmailMock,
+      sendAdultVerifiedFlowEmailMock: kwsSendAdultVerifiedFlowEmailMock,
+    })
+    await kws.listen()
+
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_age_assurance_v_two',
+      bsky: {
+        statsigEnv: 'test',
+        statsigKey: 'secret-key',
+        kws: {
+          apiKey: 'apiKey',
+          apiOrigin: kws.url,
+          authOrigin: kws.url,
+          clientId: 'clientId',
+          redirectUrl: BSKY_REDIRECT_URL,
+          userAgent: 'userAgent',
+          verificationSecret: kws.verificationSecret,
+          webhookSecret: kws.webhookSecret,
+          ageVerifiedWebhookSecret: kws.ageVerifiedWebhookSecret,
+          ageVerifiedRedirectSecret: kws.ageVerifiedRedirectSecret,
+        },
+      },
+    })
+
+    kws.setBskyBaseUrl(network.bsky.url)
+
+    db = network.bsky.db
+    agent = network.bsky.getClient()
+    sc = network.getSeedClient()
+
+    await basicSeed(sc)
+    await network.processAll()
+
+    actor.did = sc.dids.alice
+    actor.email = sc.accounts[actor.did].email
+  })
+
+  beforeEach(async () => {
+    // Default mocks for KWS endpoints.
+    kwsOauthMock.mockImplementation(
+      (_req: express.Request, res: express.Response) =>
+        res.json({
+          access_token:
+            'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.INVALID',
+          expires_in: 3600,
+        }),
+    )
+    kwsSendAgeVerifiedFlowEmailMock.mockImplementation(
+      (_req: express.Request, res: express.Response) => {
+        res.json({})
+      },
+    )
+    kwsSendAdultVerifiedFlowEmailMock.mockImplementation(
+      (_req: express.Request, res: express.Response) => {
+        res.json({})
+      },
+    )
+  })
+
+  afterEach(async () => {
+    jest.resetAllMocks()
+    await clearPrivateData(db)
+    await clearActorAgeAssurance(db)
+  })
+
+  afterAll(async () => {
+    await network.close()
+    await kws.stop()
+  })
+
+  const getState = async (params: AppBskyAgeassuranceGetState.QueryParams) => {
+    const { data } = await agent.app.bsky.ageassurance.getState(params, {
+      headers: await network.serviceHeaders(
+        actor.did,
+        ids.AppBskyAgeassuranceGetState,
+      ),
+    })
+    return data
+  }
+
+  const beginAgeAssurance = async (
+    params: Omit<AppBskyAgeassuranceBegin.InputSchema, 'email' | 'language'> & {
+      email?: string
+    },
+  ) => {
+    const { data } = await agent.app.bsky.ageassurance.begin(
+      {
+        ...params,
+        email: params.email || sc.accounts[actor.did].email,
+        language: 'en',
+      },
+      {
+        headers: await network.serviceHeaders(
+          actor.did,
+          ids.AppBskyAgeassuranceBegin,
+        ),
+      },
+    )
+    return data
+  }
+
+  describe('app.bsky.ageassurance.getState', () => {
+    it('initially returns defaults', async () => {
+      const { state, metadata } = await getState({
+        countryCode: 'US',
+        regionCode: undefined,
+      })
+      expect(metadata.accountCreatedAt).toBeDefined()
+      expect(state).toEqual({
+        lastInitatedAt: undefined,
+        status: 'unknown',
+        access: 'unknown',
+      })
+    })
+  })
+
+  describe('app.bsky.ageassurance.begin', () => {
+    it('fails if region not supported', async () => {
+      const call = beginAgeAssurance({
+        countryCode: 'XX',
+      })
+      await expect(call).rejects.toHaveProperty('error', 'RegionNotSupported')
+    })
+
+    it('fails if email is invalid', async () => {
+      const call = beginAgeAssurance({
+        email: 'invalid-email',
+        countryCode: 'XX',
+      })
+      await expect(call).rejects.toHaveProperty('error', 'InvalidEmail')
+    })
+
+    it('succeeds for V2 country', async () => {
+      const res = await beginAgeAssurance({
+        countryCode: 'AA',
+      })
+      await network.processAll()
+      const { state } = await getState({
+        countryCode: 'AA',
+      })
+      expect(kwsSendAgeVerifiedFlowEmailMock).toHaveBeenCalledTimes(1)
+      expect(res).toEqual(state)
+      expect(state.lastInitiatedAt).toBeDefined()
+      expect(state.status).toEqual('pending')
+      expect(state.access).toEqual('unknown')
+    })
+
+    it('succeeds for V1 country', async () => {
+      const res = await beginAgeAssurance({
+        countryCode: 'BB',
+      })
+      await network.processAll()
+      const { state } = await getState({
+        countryCode: 'BB',
+      })
+      expect(kwsSendAdultVerifiedFlowEmailMock).toHaveBeenCalledTimes(1)
+      expect(res).toEqual(state)
+      expect(state.lastInitiatedAt).toBeDefined()
+      expect(state.status).toEqual('pending')
+      expect(state.access).toEqual('unknown')
+    })
+  })
+
+  describe('external handlers', () => {
+    describe('V2 redirects', () => {
+      it('redirects with result=unknown if we fail to parse the status object', async () => {
+        const res = await kws.redirectV2({
+          externalPayload: serializeKWSExternalPayloadV2({
+            version: KWSExternalPayloadVersion.V2,
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+            countryCode: 'AA',
+          }),
+          status: JSON.stringify({
+            verified: true,
+            verifiedMinimumAge: '18', // will fail parsing
+          }),
+        })
+        expect(res.status).toBe(302)
+        expect(res.headers.get('Location')).toBe(
+          `${BSKY_REDIRECT_URL}?result=unknown`,
+        )
+      })
+
+      it('redirects with result=unknown if status is not verified', async () => {
+        const res = await kws.redirectV2({
+          externalPayload: serializeKWSExternalPayloadV2({
+            version: KWSExternalPayloadVersion.V2,
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+            countryCode: 'AA',
+          }),
+          status: serializeKWSAgeVerifiedStatus({
+            verified: false,
+            verifiedMinimumAge: 18,
+          }),
+        })
+        expect(res.status).toBe(302)
+        expect(res.headers.get('Location')).toBe(
+          `${BSKY_REDIRECT_URL}?actorDid=${encodeURIComponent(actor.did)}&result=unknown`,
+        )
+      })
+
+      // this also covers any other thrown errors
+      it('redirects with result=unknown if access check throws', async () => {
+        const res = await kws.redirectV2({
+          externalPayload: serializeKWSExternalPayloadV2({
+            version: KWSExternalPayloadVersion.V2,
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+            countryCode: 'XX', // should never reach KWS anyway
+          }),
+          status: serializeKWSAgeVerifiedStatus({
+            verified: true,
+            verifiedMinimumAge: 18,
+          }),
+        })
+        expect(res.status).toBe(302)
+        expect(res.headers.get('Location')).toBe(
+          `${BSKY_REDIRECT_URL}?actorDid=${encodeURIComponent(actor.did)}&result=unknown`,
+        )
+      })
+
+      it('success', async () => {
+        await beginAgeAssurance({
+          countryCode: 'AA',
+        })
+        await network.processAll()
+        await kws.redirectV2({
+          externalPayload: serializeKWSExternalPayloadV2({
+            version: KWSExternalPayloadVersion.V2,
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+            countryCode: 'AA',
+          }),
+          status: serializeKWSAgeVerifiedStatus({
+            verified: true,
+            verifiedMinimumAge: 18,
+          }),
+        })
+        await network.processAll()
+        const { state } = await getState({
+          countryCode: 'AA',
+        })
+        expect(state.lastInitiatedAt).toBeDefined()
+        expect(state.status).toEqual('assured')
+        expect(state.access).toEqual('full')
+      })
+    })
+
+    describe('V2 webhooks', () => {
+      it('returns 400 if we fail to parse the external payload', async () => {
+        const res = await kws.webhookV2({
+          name: 'age-verified',
+          time: new Date().toISOString(),
+          orgId: crypto.randomUUID(),
+          productId: crypto.randomUUID(),
+          payload: {
+            email: actor.email,
+            externalPayload: serializeKWSExternalPayloadV2({
+              version: KWSExternalPayloadVersion.V2,
+              actorDid: actor.did,
+              attemptId: crypto.randomUUID(),
+              countryCode: 'AA',
+            }),
+            status: {
+              verified: true,
+              // @ts-ignore testing invalid payload
+              verifiedMinimumAge: '18',
+            },
+          },
+        })
+        expect(res.status).toBe(400)
+        await expect(res.json()).resolves.toHaveProperty(
+          'error',
+          'Failed to parse KWS webhook body',
+        )
+      })
+
+      it('returns 400 if status is not verified', async () => {
+        const res = await kws.webhookV2({
+          name: 'age-verified',
+          time: new Date().toISOString(),
+          orgId: crypto.randomUUID(),
+          productId: crypto.randomUUID(),
+          payload: {
+            email: actor.email,
+            externalPayload: serializeKWSExternalPayloadV2({
+              version: KWSExternalPayloadVersion.V2,
+              actorDid: actor.did,
+              attemptId: crypto.randomUUID(),
+              countryCode: 'AA',
+            }),
+            status: {
+              verified: false,
+              verifiedMinimumAge: 18,
+            },
+          },
+        })
+        expect(res.status).toBe(400)
+        await expect(res.json()).resolves.toHaveProperty(
+          'error',
+          'Expected KWS webhook to have verified status',
+        )
+      })
+
+      it('returns 200, but AA state unchanged due to invalid region', async () => {
+        const res = await kws.webhookV2({
+          name: 'age-verified',
+          time: new Date().toISOString(),
+          orgId: crypto.randomUUID(),
+          productId: crypto.randomUUID(),
+          payload: {
+            email: actor.email,
+            externalPayload: serializeKWSExternalPayloadV2({
+              version: KWSExternalPayloadVersion.V2,
+              actorDid: actor.did,
+              attemptId: crypto.randomUUID(),
+              countryCode: 'XX',
+            }),
+            status: {
+              verified: true,
+              verifiedMinimumAge: 18,
+            },
+          },
+        })
+        await network.processAll()
+        expect(res.status).toBe(200)
+        const { state } = await getState({
+          countryCode: 'XX',
+        })
+        expect(state.status).toEqual('unknown') // we never began, so it's still unknown
+      })
+
+      it('success', async () => {
+        await beginAgeAssurance({
+          countryCode: 'AA',
+        })
+        await network.processAll()
+        await kws.webhookV2({
+          name: 'age-verified',
+          time: new Date().toISOString(),
+          orgId: crypto.randomUUID(),
+          productId: crypto.randomUUID(),
+          payload: {
+            email: actor.email,
+            externalPayload: serializeKWSExternalPayloadV2({
+              version: KWSExternalPayloadVersion.V2,
+              actorDid: actor.did,
+              attemptId: crypto.randomUUID(),
+              countryCode: 'AA',
+            }),
+            status: {
+              verified: true,
+              verifiedMinimumAge: 18,
+            },
+          },
+        })
+        await network.processAll()
+        const { state } = await getState({
+          countryCode: 'AA',
+        })
+        expect(state.lastInitiatedAt).toBeDefined()
+        expect(state.status).toEqual('assured')
+        expect(state.access).toEqual('full')
+      })
+    })
+
+    describe('V1 compat', () => {
+      it('works via webhook', async () => {
+        await beginAgeAssurance({
+          countryCode: 'BB',
+        })
+        await network.processAll()
+        await kws.webhookV1({
+          payload: {
+            externalPayload: serializeKWSExternalPayloadV2({
+              version: KWSExternalPayloadVersion.V2,
+              actorDid: actor.did,
+              attemptId: crypto.randomUUID(),
+              countryCode: 'BB',
+            }),
+            status: {
+              verified: true,
+            },
+          },
+        })
+        await network.processAll()
+        const { state } = await getState({
+          countryCode: 'BB',
+        })
+        expect(state.lastInitiatedAt).toBeDefined()
+        expect(state.status).toEqual('assured')
+        expect(state.access).toEqual('full')
+      })
+
+      it('works via redirect', async () => {
+        await beginAgeAssurance({
+          countryCode: 'BB',
+        })
+        await network.processAll()
+        await kws.redirectV1({
+          externalPayload: serializeKWSExternalPayloadV2({
+            version: KWSExternalPayloadVersion.V2,
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+            countryCode: 'BB',
+          }),
+          status: JSON.stringify({
+            verified: true,
+          }),
+        })
+        await network.processAll()
+        const { state } = await getState({
+          countryCode: 'BB',
+        })
+        expect(state.lastInitiatedAt).toBeDefined()
+        expect(state.status).toEqual('assured')
+        expect(state.access).toEqual('full')
+      })
+    })
+  })
+
+  describe('misc', () => {
+    it('cannot re-init from terminal state', async () => {
+      await kws.redirectV2({
+        externalPayload: serializeKWSExternalPayloadV2({
+          version: KWSExternalPayloadVersion.V2,
+          actorDid: actor.did,
+          attemptId: crypto.randomUUID(),
+          countryCode: 'AA',
+        }),
+        status: serializeKWSAgeVerifiedStatus({
+          verified: true,
+          verifiedMinimumAge: 18,
+        }),
+      })
+      await network.processAll()
+      const call = beginAgeAssurance({
+        countryCode: 'AA',
+      })
+      await expect(call).rejects.toHaveProperty('error', 'InvalidInitiation')
+    })
+
+    /*
+     * This tests local dataplane behavior, but the actual prod implementation
+     * lives in the dataplane repo, obviously.
+     */
+    it('dataplane converts v1 to v2 state at read time', async () => {
+      await beginAgeAssurance({
+        countryCode: 'BB',
+      })
+      await network.processAll()
+      await kws.webhookV1({
+        payload: {
+          externalPayload: serializeKWSExternalPayloadV1({
+            actorDid: actor.did,
+            attemptId: crypto.randomUUID(),
+          }),
+          status: {
+            verified: true,
+          },
+        },
+      })
+      await network.processAll()
+      const { state } = await getState({
+        countryCode: 'BB',
+      })
+      expect(state.lastInitiatedAt).toBeDefined()
+      expect(state.status).toEqual('assured')
+      expect(state.access).toEqual('full')
+    })
+  })
+})
+
+const clearPrivateData = async (db: Database) => {
+  await db.db.deleteFrom('private_data').execute()
+}
+
+const clearActorAgeAssurance = async (db: Database) => {
+  await db.db
+    .updateTable('actor')
+    .set({
+      ageAssuranceStatus: null,
+      ageAssuranceLastInitiatedAt: null,
+      ageAssuranceAccess: null,
+      ageAssuranceCountryCode: null,
+      ageAssuranceRegionCode: null,
+    })
+    .execute()
+}
+
+class MockKwsServer {
+  verificationSecret = 'verificationSecret' // unused here
+  webhookSecret = 'webhookSecret' // unused here
+  ageVerifiedWebhookSecret = 'ageVerifiedWebhookSecret'
+  ageVerifiedRedirectSecret = 'ageVerifiedRedirectSecret'
+
+  private app: Application
+  private server: Server
+  private bskyUrlBase = ''
+
+  constructor({
+    oauthMock,
+    sendAgeVerifiedFlowEmailMock,
+    sendAdultVerifiedFlowEmailMock,
+  }: {
+    oauthMock: jest.Mock
+    sendAgeVerifiedFlowEmailMock: jest.Mock
+    sendAdultVerifiedFlowEmailMock: jest.Mock
+  }) {
+    this.app = express()
+      .use(express.json())
+      .post('/auth/realms/kws/protocol/openid-connect/token', (_, res) =>
+        oauthMock(_, res),
+      )
+      .post('/v1/verifications/send-email', (req, res) => {
+        const body = req.body
+        if (body.userContext === 'age') {
+          return sendAgeVerifiedFlowEmailMock(req, res)
+        } else if (body.userContext === 'adult') {
+          return sendAdultVerifiedFlowEmailMock(req, res)
+        }
+      })
+
+    this.server = createServer(this.app)
+  }
+
+  async listen(port?: number) {
+    this.server.listen(port)
+    await once(this.server, 'listening')
+  }
+
+  async stop() {
+    this.server.close()
+    await once(this.server, 'close')
+  }
+
+  setBskyBaseUrl(url: string) {
+    this.bskyUrlBase = url
+  }
+
+  redirectV1({
+    externalPayload,
+    status,
+  }: {
+    externalPayload: string
+    status: string
+  }) {
+    const sig = crypto
+      .createHmac('sha256', this.verificationSecret)
+      .update(`${status}:${externalPayload}`)
+      .digest('hex')
+
+    const queryString = new URLSearchParams({
+      externalPayload,
+      signature: sig,
+      status,
+    }).toString()
+
+    return fetch(
+      `${this.bskyUrlBase}/external/kws/age-assurance-verification?${queryString}`,
+      {
+        method: 'GET',
+        redirect: 'manual',
+      },
+    )
+  }
+
+  redirectV2({
+    externalPayload,
+    status,
+  }: {
+    externalPayload: string
+    status: string
+  }) {
+    const sig = crypto
+      .createHmac('sha256', this.ageVerifiedRedirectSecret)
+      .update(`${status}:${externalPayload}`)
+      .digest('hex')
+
+    const queryString = new URLSearchParams({
+      externalPayload,
+      signature: sig,
+      status,
+    }).toString()
+
+    return fetch(
+      `${this.bskyUrlBase}/external/age-assurance/redirects/kws-age-verified?${queryString}`,
+      {
+        method: 'GET',
+        redirect: 'manual',
+      },
+    )
+  }
+
+  webhookV1(
+    body: Omit<KwsWebhookBody, 'payload'> & {
+      payload: Omit<KwsWebhookBody['payload'], 'externalPayload'> & {
+        externalPayload: string
+      }
+    },
+  ): Promise<Response> {
+    const bodyBuffer = Buffer.from(JSON.stringify(body))
+
+    const timestamp = new Date().valueOf()
+    const sig = crypto
+      .createHmac('sha256', this.webhookSecret)
+      .update(`${timestamp}.${bodyBuffer}`)
+      .digest('hex')
+
+    return fetch(`${this.bskyUrlBase}/external/kws/age-assurance-webhook`, {
+      method: 'POST',
+      body: bodyBuffer,
+      headers: {
+        'x-kws-signature': `t=${timestamp},v1=${sig}`,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  webhookV2(body: KWSWebhookAgeVerified): Promise<Response> {
+    const bodyBuffer = Buffer.from(JSON.stringify(body))
+
+    const timestamp = new Date().valueOf()
+    const sig = crypto
+      .createHmac('sha256', this.ageVerifiedWebhookSecret)
+      .update(`${timestamp}.${bodyBuffer}`)
+      .digest('hex')
+
+    return fetch(
+      `${this.bskyUrlBase}/external/age-assurance/webhooks/kws-age-verified`,
+      {
+        method: 'POST',
+        body: bodyBuffer,
+        headers: {
+          'x-kws-signature': `t=${timestamp},v1=${sig}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }
+
+  get url() {
+    const address = this.server.address() as AddressInfo
+    return `http://localhost:${address.port}`
+  }
+}

--- a/packages/bsky/tests/views/age-assurance.test.ts
+++ b/packages/bsky/tests/views/age-assurance.test.ts
@@ -58,6 +58,8 @@ describe('age assurance views', () => {
           userAgent: 'userAgent',
           verificationSecret,
           webhookSecret,
+          ageVerifiedWebhookSecret: 'ageVerifiedWebhookSecret',
+          ageVerifiedRedirectSecret: 'ageVerifiedRedirectSecret',
         },
       },
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@atproto/lex-cli':
         specifier: workspace:^
         version: link:../lex-cli
+      '@jest/globals':
+        specifier: ^28.1.3
+        version: 28.1.3
       jest:
         specifier: ^28.1.2
         version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
@@ -320,6 +323,9 @@ importers:
       '@did-plc/server':
         specifier: ^0.0.1
         version: 0.0.1
+      '@jest/globals':
+        specifier: '28'
+        version: 28.1.3
       '@types/cors':
         specifier: ^2.8.12
         version: 2.8.12


### PR DESCRIPTION
Since adding Age Assurance and regional access controls earlier this year, more countries and jurisdictions have enacted Age Assurance laws that Bluesky must follow in order to remain legally compliant. For example, Australia and Virginia both have new requirements on the horizon that our V1 implementation cannot account for. And previously, we made the difficult decision to block Mississippi entirely due to the additional complexity required to support that region at the time.

Because of these new requirements, and with the prospect of more to come in the future, we've decided to dedicate some time to building out a V2 of Age Assurance, which can handled these more complex rulesets.

This PR unifies the separate systems we have been using into a single "V2" system that will work for all regions. This includes Australia, Virginia, and even Mississippi.