### PR TITLE
Support configurable S3 key prefixes for blob store

### DIFF
--- a/packages/aws/src/s3.ts
+++ b/packages/aws/src/s3.ts
@@ -8,6 +8,8 @@ import { BlobNotFoundError, BlobStore } from '@atproto/repo'
 
 export type S3Config = {
   bucket: string
+  /** Optional prefix for S3 keys */
+  keyPrefix?: string
   /**
    * The maximum time any request to S3 (including individual blob chunks
    * uploads) can take, in milliseconds.
@@ -22,6 +24,7 @@ export type S3Config = {
 export class S3BlobStore implements BlobStore {
   private client: S3
   private bucket: string
+  private keyPrefix: string
   private uploadTimeoutMs: number
 
   constructor(
@@ -30,11 +33,13 @@ export class S3BlobStore implements BlobStore {
   ) {
     const {
       bucket,
+      keyPrefix,
       uploadTimeoutMs = 10 * SECOND,
       requestTimeoutMs = uploadTimeoutMs,
       ...rest
     } = cfg
     this.bucket = bucket
+    this.keyPrefix = keyPrefix ?? ''
     this.uploadTimeoutMs = uploadTimeoutMs
     this.client = new S3({
       ...rest,
@@ -87,7 +92,7 @@ export class S3BlobStore implements BlobStore {
       params: {
         Bucket: this.bucket,
         Body: bytes,
-        Key: path,
+        Key: this.keyPrefix + path,
       },
       // @ts-ignore native implementation fine in node >=15
       abortController,

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -58,6 +58,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     blobstoreCfg = {
       provider: 's3',
       bucket: env.blobstoreS3Bucket,
+      keyPrefix: env.blobstoreS3KeyPrefix,
       uploadTimeoutMs: env.blobstoreS3UploadTimeoutMs || 20000,
       region: env.blobstoreS3Region,
       endpoint: env.blobstoreS3Endpoint,
@@ -406,6 +407,7 @@ export type ActorStoreConfig = {
 export type S3BlobstoreConfig = {
   provider: 's3'
   bucket: string
+  keyPrefix?: string
   region?: string
   endpoint?: string
   forcePathStyle?: boolean

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -57,6 +57,7 @@ export function readEnv() {
     // blobstore: one required
     // s3
     blobstoreS3Bucket: envStr('PDS_BLOBSTORE_S3_BUCKET'),
+    blobstoreS3KeyPrefix: envStr('PDS_BLOBSTORE_S3_KEY_PREFIX'),
     blobstoreS3Region: envStr('PDS_BLOBSTORE_S3_REGION'),
     blobstoreS3Endpoint: envStr('PDS_BLOBSTORE_S3_ENDPOINT'),
     blobstoreS3ForcePathStyle: envBool('PDS_BLOBSTORE_S3_FORCE_PATH_STYLE'),


### PR DESCRIPTION
Pretty simple bit of additional bit of config - does what it says on the tin, just prefixes S3 keys when using S3 as the blob store.