### PR TITLE
Add import settings to server description

### DIFF
--- a/packages/pds/src/api/com/atproto/server/describeServer.ts
+++ b/packages/pds/src/api/com/atproto/server/describeServer.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
           email: contactEmailAddress,
         },
         imports: {
-          aceepted: acceptingImports,
+          accepted: acceptingImports,
           maxSize: maxImportSize,
         },
       },


### PR DESCRIPTION
I was originally going to add something to expose if registration was at all enabled (i.e., a friends & family PDS would indicate "no", since invites won't be given out to anyone), but as we don't have that sort of configuration, I added in details relating to imports, which would allow tools like PDS Moover to maintain a list of servers you can migrate to.

cc @fatfingers23

i know the commit message is messed up and we should probably add test coverage. Hence draft status.