### PR TITLE
permission-set for deleting public content

### DIFF
--- a/lexicons/app/bsky/authDeleteContent.json
+++ b/lexicons/app/bsky/authDeleteContent.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.authDeleteContent",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Delete Bluesky Content",
+      "title:lang": {},
+      "detail": "Clean up public account history: posts, reposts, and likes.",
+      "detail:lang": {},
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "repo",
+          "action": ["delete"],
+          "collection": [
+            "app.bsky.feed.like",
+            "app.bsky.feed.post",
+            "app.bsky.feed.postgate",
+            "app.bsky.feed.repost",
+            "app.bsky.feed.threadgate"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I thought that "authDeletePosts" would cover this use-case, but I checked some actual tools that might use this scope:

- https://bsky.jazco.dev/cleanup
- https://github.com/Gorcenski/skeeter-deleter
- https://bskydelete.com/
- https://redact.dev/services/bluesky

and they basically all delete reposts and likes as well. This is a permission set for that specific use-case.