### PR TITLE
Fix comment and error message for pipethrough bug

### DIFF
--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -143,14 +143,14 @@ export async function pipethrough(
   }
 > {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
-    // pipethrough() is used from within xrpcServer handlers, which means that
-    // the request body either has been parsed or is a readable stream that has
-    // been piped for decoding & size limiting. Because of this, forwarding the
-    // request body requires re-encoding it. Since we currently do not use
-    // pipethrough() with procedures, proxying of request body is not
+    // pipethrough() is used from within some app.bsky xrpcServer handlers,
+    // which means that the request body either has been parsed or is a readable
+    // stream that has been piped for decoding & size limiting. Because of this,
+    // forwarding the request body requires re-encoding it. Since we currently
+    // do not use pipethrough() with procedures, proxying of request body is not
     // implemented.
     throw new InternalServerError(
-      `Proxying of ${req.method} requests is not supported`,
+      `[BUG, #4193] Proxying of ${req.method} requests is currently not supported for ${req.path}`,
     )
   }
 


### PR DESCRIPTION
Does not fix, but improves the situation for #4193 by providing an more accurate error message when the bug is encountered, and clarifying the associated code comment.

Support for proxying of `app.bsky.*` rpcs was added as part of [OAuth Scopes](https://github.com/bluesky-social/atproto/pull/3806) four months ago.

Pretty quickly [#4193], multiple devs in the ecosystem ran into issues with proxying *procedures* specifically. Code comments in the PR [explicitly indicate that they are supposed to work](https://github.com/bluesky-social/atproto/pull/3806/files#diff-4e013f56d905f7aceac269bef7caf77417ea32715138bb25360c602baefbda1fR25-R27). However unfortunately the pipethrough method as used will always reject them for those app.bsky procedures.

What has made this bug worse is that the error message [currently claims that proxying POST requests is not supported at all!](https://bsky.app/profile/nel.pet/post/3m76ffqnhok2y)

It's pretty painful to encounter the bug, and the misleading error message adds general proxying misinfo to the sting, so this change updates the message to at least be a bit more clear about the scope of the issue encountered, as a stop-gap until the underlying proxying problem is fixed.