### PR TITLE
Validate verification methods in signPlcOperation

### DIFF
--- a/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
+++ b/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
@@ -44,6 +44,63 @@ export default function (server: Server, ctx: AppContext) {
         token,
       )
 
+      if (input.body.verificationMethods !== undefined) {
+        if (
+          typeof input.body.verificationMethods !== 'object' ||
+          input.body.verificationMethods === null ||
+          Array.isArray(input.body.verificationMethods)
+        ) {
+          throw new InvalidRequestError(
+            'verificationMethods must be an object',
+          )
+        }
+        for (const [key, value] of Object.entries(
+          input.body.verificationMethods,
+        )) {
+          if (typeof value !== 'string') {
+            throw new InvalidRequestError(
+              `verificationMethods.${key} must be a string`,
+            )
+          }
+          if (!value.startsWith('did:key:')) {
+            throw new InvalidRequestError(
+              `verificationMethods.${key} must start with "did:key:"`,
+            )
+          }
+        }
+      }
+
+      if (input.body.services !== undefined) {
+        if (
+          typeof input.body.services !== 'object' ||
+          input.body.services === null ||
+          Array.isArray(input.body.services)
+        ) {
+          throw new InvalidRequestError('services must be an object')
+        }
+        for (const [key, value] of Object.entries(input.body.services)) {
+          if (
+            typeof value !== 'object' ||
+            value === null ||
+            Array.isArray(value)
+          ) {
+            throw new InvalidRequestError(
+              `services.${key} must be an object`,
+            )
+          }
+          if (typeof value.type !== 'string') {
+            throw new InvalidRequestError(
+              `services.${key}.type must be a string`,
+            )
+          }
+          if (typeof value.endpoint !== 'string') {
+            throw new InvalidRequestError(
+              `services.${key}.endpoint must be a string`,
+            )
+          }
+        }
+      }
+
       const lastOp = await ctx.plcClient.getLastOp(did)
       if (check.is(lastOp, plc.def.tombstone)) {
         throw new InvalidRequestError('Did is tombstoned')
@@ -56,12 +113,10 @@ export default function (server: Server, ctx: AppContext) {
           rotationKeys: input.body.rotationKeys ?? lastOp.rotationKeys,
           alsoKnownAs: input.body.alsoKnownAs ?? lastOp.alsoKnownAs,
           verificationMethods:
-            // @TODO: actually validate instead of type casting
             (input.body.verificationMethods as
               | undefined
               | Record<string, string>) ?? lastOp.verificationMethods,
           services:
-            // @TODO: actually validate instead of type casting
             (input.body.services as
               | undefined
               | Record<string, { type: string; endpoint: string }>) ??


### PR DESCRIPTION
Fixes #4402

Adds validation for `verificationMethods` and `services` in `com.atproto.identity.signPlcOperation` to reject invalid inputs before consuming the email confirmation token.

The endpoint now validates that:
- `verificationMethods` values must start with `did:key:` prefix
- `services` objects must have `type` and `endpoint` string properties

This prevents users from wasting their email confirmation token on operations that would fail when submitted to the PLC server.