### PR TITLE
oauth-scopes: allow wildcard audience in include scope

### DIFF
--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.test.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.test.ts
@@ -58,6 +58,15 @@ describe('IncludeScope', () => {
             aud: 'did:web:example.com#my_service',
           })
         })
+
+        it('parsing of wildcard aud', () => {
+          expect(
+            IncludeScope.fromString('include:com.example.baz?aud=*'),
+          ).toMatchObject({
+            nsid: 'com.example.baz',
+            aud: '*',
+          })
+        })
       })
 
       describe('rejects', () => {
@@ -109,6 +118,11 @@ describe('IncludeScope', () => {
             ).toString(),
           ).toEqual(
             'include:com.example.foo?aud=did:web:example.com%23my_service',
+          )
+        })
+        it('formating of scope with wildcard aud', () => {
+          expect(new IncludeScope('com.example.foo', '*').toString()).toEqual(
+            'include:com.example.foo?aud=*',
           )
         })
       })
@@ -259,6 +273,22 @@ describe('IncludeScope', () => {
               'rpc:com.example.calendar.listEvents?aud=did:web:example.com%23foo',
               'rpc:com.example.calendar.getEventDetails?aud=did:web:example.com%23foo',
             ])
+          })
+
+          it('inherits wildcard aud', () => {
+            expect(
+              compilePermissions('include:com.example.calendar.auth?aud=*', {
+                type: 'permission-set',
+                permissions: [
+                  {
+                    type: 'permission',
+                    resource: 'rpc',
+                    inheritAud: true,
+                    lxm: ['com.example.calendar.listEvents'],
+                  },
+                ],
+              }),
+            ).toEqual(['rpc:com.example.calendar.listEvents?aud=*'])
           })
         })
 

--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
@@ -1,4 +1,3 @@
-import { AtprotoAudience, isAtprotoAudience } from '@atproto/did'
 import { LexiconPermission, LexiconPermissionSet } from '../lib/lexicon.js'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
@@ -11,7 +10,7 @@ import {
   isScopeSyntaxFor,
 } from '../lib/syntax.js'
 import { RepoPermission } from './repo-permission.js'
-import { RpcPermission } from './rpc-permission.js'
+import { AudParam, isAudParam, RpcPermission } from './rpc-permission.js'
 
 export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
 
@@ -23,7 +22,7 @@ export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
 export class IncludeScope {
   constructor(
     public readonly nsid: Nsid,
-    public readonly aud: undefined | AtprotoAudience = undefined,
+    public readonly aud: undefined | AudParam = undefined,
   ) {}
 
   toString() {
@@ -166,7 +165,7 @@ export class IncludeScope {
       aud: {
         multiple: false,
         required: false,
-        validate: isAtprotoAudience,
+        validate: isAudParam,
       },
     },
     'nsid',


### PR DESCRIPTION
Fixes #4490

The `include:` scope parser was rejecting `aud=*` because it only accepted `AtprotoAudience` (DID with fragment). This change reuses the existing `AudParam` type and `isAudParam` validator from `rpc-permission.ts` which correctly handles `'*' | AtprotoAudience`.