### PR TITLE
Fix queryLabels cursor pagination by adding missing ORDER BY

### DIFF
--- a/packages/ozone/src/api/label/queryLabels.ts
+++ b/packages/ozone/src/api/label/queryLabels.ts
@@ -6,7 +6,11 @@ import { Server } from '../../lexicon'
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.label.queryLabels(async ({ params }) => {
     const { uriPatterns, sources, limit, cursor } = params
-    let builder = ctx.db.db.selectFrom('label').selectAll().limit(limit)
+    let builder = ctx.db.db
+      .selectFrom('label')
+      .selectAll()
+      .orderBy('id', 'asc')
+      .limit(limit)
     // if includes '*', then we don't need a where clause
     if (!uriPatterns.includes('*')) {
       builder = builder.where((qb) => {


### PR DESCRIPTION
Fixes #4328

The `queryLabels` endpoint uses cursor-based pagination with `where('id', '>', cursorId)`, but was missing an `ORDER BY` clause. This caused inconsistent results across queries and unreliable pagination.

Added `.orderBy('id', 'asc')` to ensure deterministic ordering.