### PR TITLE
com.atproto.lexicon.validateLexicon lexicon method

### DIFF
--- a/lexicons/com/atproto/lexicon/validateLexicon.json
+++ b/lexicons/com/atproto/lexicon/validateLexicon.json
@@ -1,0 +1,113 @@
+{
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "id": "com.atproto.lexicon.validateLexicon",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Validates a lexicon schema, and optionally validates data against it. If data is omitted, only validates the schema structure.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "schema"
+          ],
+          "properties": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "lexicon"
+              ],
+              "properties": {
+                "lexicon": {
+                  "type": "integer",
+                  "description": "Indicates the 'version' of the Lexicon language. Must be '1' for the current atproto/Lexicon schema system."
+                }
+              },
+              "description": "The lexicon schema to validate (as JSON object)."
+            },
+            "data": {
+              "type": "unknown",
+              "description": "The data to validate against the schema. If omitted, only validates the schema structure."
+            },
+            "flags": {
+              "type": "ref",
+              "ref": "#validateFlags",
+              "description": "Optional flags for validation behavior."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "valid"
+          ],
+          "properties": {
+            "valid": {
+              "type": "boolean",
+              "description": "Whether the schema (and data, if provided) is valid."
+            },
+            "errors": {
+              "type": "array",
+              "description": "Validation errors, if any.",
+              "items": {
+                "type": "ref",
+                "ref": "#validationError"
+              }
+            }
+          }
+        }
+      }
+    },
+    "validateFlags": {
+      "type": "object",
+      "description": "Optional flags to control validation behavior.",
+      "properties": {
+        "allowLegacyBlob": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow legacy blob format (cid field instead of ref)."
+        },
+        "allowLenientDatetime": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow lenient datetime parsing."
+        },
+        "skipExternalRefs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip validation of external references (treat them as valid)."
+        },
+        "externalSchemas": {
+          "type": "array",
+          "default": [],
+          "description": "External schemas to use for validation (as JSON objects).",
+          "items": {
+            "type": "unknown"
+          }
+        }
+      }
+    },
+    "validationError": {
+      "type": "object",
+      "description": "A validation error with message and optional path.",
+      "required": [
+        "message"
+      ],
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "The error message describing what validation failed."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path to the error location in the data (if applicable)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the `com.atproto.lexicon.validateLexicon` lexicon method that performs lexicon schema and optional record validation.

# Rationale

Lexicon validation is a complex and important facet of lexicon schema development that can vary widely in implementation and use. Tooling has generally been made available for local execution, but that has trade-offs. By allowing validation to occur over API calls, multiple implementations of validation can be used without increasing local development or continuous integration dependencies.

This PR does not endorse any specific implementation of validation or linting and leaves that entirely to the discretion of the implementor of this XRPC method. The inputs can be flexibly used to support additional flags and options.

***Caching***: This XRPC method is compatible with HTTP caching. For example, creating a CID of the incoming request body and caching the result of validation with that key can produce content (`Etag`) and time-based caching artifacts.

## Example Schema Validation

**Request**

```
POST /xrpc/com.atproto.lexicon.validate
Host: lexicon.garden
Content-Type: application/json
Content-Length: 216

{
    "schema": {
        "id": "garden.lexicon.stunning-leafcutter.example",
        "defs": {
            "main": {
                "key": "tid",
                "type": "record",
                "record": {
                    "type": "object",
                    "required": [],
                    "properties": {}
                },
                "description": "My lexicon description"
            }
        },
        "lexicon": 1
    }
}
```

**Response**

```
HTTP/2 200
Date: Wed, 07 Jan 2026 13:27:52 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 14

{"valid":true}
```

## Example Schema and Record Validation

**Request**

```
POST /xrpc/com.atproto.lexicon.validate
Host: lexicon.garden
Content-Type: application/json
Content-Length: 278

{
    "schema": {
        "id": "garden.lexicon.stunning-leafcutter.example",
        "defs": {
            "main": {
                "key": "tid",
                "type": "record",
                "record": {
                    "type": "object",
                    "required": [],
                    "properties": {}
                },
                "description": "My lexicon description"
            }
        },
        "lexicon": 1
    },
    "data": {
        "$type": "garden.lexicon.stunning-leafcutter.example"
    }
}
```

**Response**

```
HTTP/2 200
Date: Wed, 07 Jan 2026 13:31:04 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 14

{"valid":true}
```

## Example Provided External References

The external references component allows for a catalog to be provided. This catalog can be used for override lexicon resolution components.

**Request**

```
POST /xrpc/com.atproto.lexicon.validate
Host: lexicon.garden
Content-Type: application/json
Content-Length: 612

{
    "schema": {
        "id": "garden.lexicon.stunning-leafcutter.example",
        "defs": {
            "main": {
                "key": "tid",
                "type": "record",
                "record": {
                    "type": "object",
                    "required": [
                        "external"
                    ],
                    "properties": {
                        "external": {
                            "type": "ref",
                            "ref": "garden.lexicon.stunning-leafcutter.externalExample"
                        }
                    }
                },
                "description": "My lexicon description"
            }
        },
        "lexicon": 1
    },
    "data": {
        "$type": "garden.lexicon.stunning-leafcutter.example",
        "external": {
            "$type": "garden.lexicon.stunning-leafcutter.externalExample"
        }
    },
    "flags": {
        "externalSchemas": [
            {
                "id": "garden.lexicon.stunning-leafcutter.externalExample",
                "defs": {
                    "main": {
                        "type": "object",
                        "required": [],
                        "properties": {}
                    }
                },
                "lexicon": 1
            }
        ]
    }
}
```

**Response**

```
HTTP/2 200
Date: Wed, 07 Jan 2026 13:34:33 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 14

{"valid":true}
```

# Prior Art

This builds off of the precedent of having XRPC methods provide core protocol functionality helpers for applications to use. Examples include the `com.atproto.identity.resolveHandle` and `com.atproto.identity.resolveDid` XRPC methods.

# Disclosures

I, Nick Gerakines ( @ngerakines ), make this contribution with the intention of it being licensed as part of the project as a whole and make no claims once it is merged into and incorporated into this project.

No artificial intelligence tooling was used in the creation of the code or source files in this pull request.