### PR TITLE
bsky: Don't base status takedown on actor takedown

### DIFF
--- a/packages/bsky/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getProfile.ts
@@ -62,6 +62,7 @@ const hydration = async (input: {
     [skeleton.did],
     params.hydrateCtx.copy({
       includeActorTakedowns: true,
+      includeTakedowns: params.hydrateCtx.includeTakedowns,
     }),
   )
 }

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -35,6 +35,7 @@ export default function (server: Server, ctx: AppContext) {
         labelers,
         viewer,
         includeTakedowns,
+        includeActorTakedowns: includeTakedowns,
       })
 
       const result = await getAuthorFeed({ ...params, hydrateCtx }, ctx)
@@ -71,6 +72,7 @@ export const skeleton = async (inputs: {
     throw new InvalidRequestError('Profile not found')
   }
   const actors = await ctx.hydrator.actor.getActors([did], {
+    includeActorTakedowns: params.hydrateCtx.includeActorTakedowns,
     includeTakedowns: params.hydrateCtx.includeTakedowns,
     skipCacheForDids: params.hydrateCtx.skipCacheForViewer,
   })

--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -11,6 +11,7 @@ export default function (server: Server, ctx: AppContext) {
       const { includeTakedowns } = ctx.authVerifier.parseCreds(auth)
 
       const actors = await ctx.hydrator.actor.getActors(dids, {
+        includeActorTakedowns: true,
         includeTakedowns: true,
         skipCacheForDids: dids,
       })

--- a/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getSubjectStatus.ts
@@ -49,6 +49,7 @@ export default function (server: Server, ctx: AppContext) {
       } else if (did) {
         const res = (
           await ctx.hydrator.actor.getActors([did], {
+            includeActorTakedowns: true,
             includeTakedowns: true,
             skipCacheForDids: [did],
           })

--- a/packages/bsky/src/api/com/atproto/repo/getRecord.ts
+++ b/packages/bsky/src/api/com/atproto/repo/getRecord.ts
@@ -15,6 +15,7 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const actors = await ctx.hydrator.actor.getActors([did], {
+        includeActorTakedowns: includeTakedowns,
         includeTakedowns,
       })
       if (!actors.get(did)) {

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -159,11 +159,16 @@ export class ActorHydrator {
   async getActors(
     dids: string[],
     opts: {
+      includeActorTakedowns?: boolean
       includeTakedowns?: boolean
       skipCacheForDids?: string[]
     } = {},
   ): Promise<Actors> {
-    const { includeTakedowns = false, skipCacheForDids } = opts
+    const {
+      includeActorTakedowns = false,
+      includeTakedowns = false,
+      skipCacheForDids,
+    } = opts
     if (!dids.length) return new HydrationMap<Actor>()
     const res = await this.dataplane.getActors({ dids, skipCacheForDids })
     return dids.reduce((acc, did, i) => {
@@ -173,14 +178,14 @@ export class ActorHydrator {
         (actor.upstreamStatus && actor.upstreamStatus !== 'active')
       if (
         !actor.exists ||
-        (isNoHosted && !includeTakedowns) ||
+        (isNoHosted && !includeActorTakedowns) ||
         !!actor.tombstonedAt
       ) {
         return acc.set(did, null)
       }
 
       const profile = actor.profile?.record
-        ? parseRecord<ProfileRecord>(actor.profile, includeTakedowns)
+        ? parseRecord<ProfileRecord>(actor.profile, includeActorTakedowns)
         : undefined
 
       const status = actor.statusRecord

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -228,16 +228,16 @@ export class Hydrator {
     dids: string[],
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
-    const includeTakedowns = ctx.includeTakedowns || ctx.includeActorTakedowns
     const [actors, labels, profileViewersState] = await Promise.all([
       this.actor.getActors(dids, {
-        includeTakedowns,
+        includeActorTakedowns: ctx.includeActorTakedowns,
+        includeTakedowns: ctx.includeTakedowns,
         skipCacheForDids: ctx.skipCacheForViewer,
       }),
       this.label.getLabelsForSubjects(labelSubjectsForDid(dids), ctx.labelers),
       this.hydrateProfileViewers(dids, ctx),
     ])
-    if (!includeTakedowns) {
+    if (!ctx.includeActorTakedowns) {
       actionTakedownLabels(dids, actors, labels)
     }
     return mergeStates(profileViewersState ?? {}, {
@@ -1316,6 +1316,7 @@ export class Hydrator {
     return new HydrateCtx({
       labelers: availableLabelers,
       viewer: vals.viewer,
+      includeActorTakedowns: vals.includeActorTakedowns,
       includeTakedowns: vals.includeTakedowns,
       include3pBlocks: vals.include3pBlocks,
       includeDebugField,


### PR DESCRIPTION
This is in the context of allowing Ozone to take down "live now" records upon abuse reports.

1. In `ActorHydrator#getActors`, there was a single option `includeTakedowns` to control whether takedown actors and takedown actor status records should be included.
2. `app.bsky.actor.getProfile` forced `includeActorTakedowns: true` (I don't know why). But I believe it only wanted to force the inclusion of the taken-down actors, not the status record.
3. It ended up getting to `Hydrator#hydrateProfiles`, where any take-down (actor or general) was translated as a single take-down to `ActorHydrator#getActors`.
4. With these changes, when `Hydrator#hydrateProfiles` is calling `ActorHydrator#getActors`, it correctly separates what is actor takedown option and what is the general takedown option.

Related past changes: https://github.com/bluesky-social/atproto/pull/3108