### PR TITLE
fix(ozone/verification): revoke all URIs in batch instead of returning early

### DIFF
--- a/packages/ozone/src/verification/service.ts
+++ b/packages/ozone/src/verification/service.ts
@@ -54,8 +54,9 @@ export class VerificationService {
   }) {
     const now = new Date().toISOString()
     return this.db.transaction(async (tx) => {
+      let lastResult: unknown
       for (const uri of uris) {
-        return tx.db
+        lastResult = await tx.db
           .updateTable('verification')
           .set({
             revokeReason,
@@ -68,6 +69,7 @@ export class VerificationService {
           .where('revokedAt', 'is', null)
           .execute()
       }
+      return lastResult
     })
   }
 


### PR DESCRIPTION
Remove the early return inside markRevoked() loop so every URI in the input list is processed within the transaction.