### PR TITLE
Fix broken lxm method binding check in service JWT validation

### DIFF
--- a/packages/lex/lex-server/src/service-auth.ts
+++ b/packages/lex/lex-server/src/service-auth.ts
@@ -300,7 +300,7 @@ async function parseJwt(
     )
   }
 
-  if (payload.lxm != null && typeof payload.lxm !== options.lxm) {
+  if (payload.lxm != null && payload.lxm !== options.lxm) {
     throw new LexServerAuthError(
       'AuthenticationRequired',
       'Invalid JWT lexicon method ("lxm")',


### PR DESCRIPTION
The verifier compared typeof payload.lxm (always "string") to the expected NSID, causing any token that includes lxm to be rejected. Compare the claim value to the expected method NSID so method binding works when lxm is present.