### PR TITLE
Modify parsing URLs and hashtags

### DIFF
--- a/packages/api/src/rich-text/util.ts
+++ b/packages/api/src/rich-text/util.ts
@@ -1,6 +1,6 @@
 export const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 export const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+  /(^|[^a-zA-Z0-9])((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
 export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
 
 /**
@@ -9,4 +9,4 @@ export const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
  */
 export const TAG_REGEX =
   // eslint-disable-next-line no-misleading-character-class
-  /(^|\s)[#＃]((?!\ufe0f)[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*[^\d\s\p{P}\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]+[^\s\u00AD\u2060\u200A\u200B\u200C\u200D\u20e2]*)?/gu
+  /(^|[^a-zA-Z0-9])[#＃][\p{L}0-9_-]+/gu


### PR DESCRIPTION
This is re-fix version of https://github.com/bluesky-social/atproto/pull/3942
To parse in non-English languages, replace `\s|\(` to `[^a-zA-Z0-9]` and use `\p{L}` to simplify.
This is related to https://github.com/bluesky-social/atproto/pull/3142