### PR TITLE
Clarify applyWrites commit behaviour

### DIFF
--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Apply a batch transaction of repository creates, updates, and deletes. Requires auth, implemented by PDS.",
+      "description": "Apply a batch transaction of repository creates, updates, and deletes, in a single commit. Requires auth, implemented by PDS.",
       "input": {
         "encoding": "application/json",
         "schema": {


### PR DESCRIPTION
`applyWrites` was always strongly implied to produce a single commit (and this is what the reference implementation does), but it wasn't explicitly stated - now it is.