### PR TITLE
Statsig FF to get user sugg from discover vs topic

### DIFF
--- a/packages/bsky/src/feature-gates.ts
+++ b/packages/bsky/src/feature-gates.ts
@@ -12,6 +12,7 @@ export enum FeatureGateID {
    * appease TS
    */
   _ = '',
+  SuggestedUsersFromDiscover = 'disc_onboarding_follow_suggest',
   ThreadsV2ReplyRankingExploration = 'threads_v2_reply_ranking_exploration',
   SearchFilteringExploration = 'search_filtering_exploration',
 }


### PR DESCRIPTION
This is related to https://github.com/bluesky-social/atproto/pull/4526.
There, we were doing 2 things:
1. Adding this new feature flag to get suggested users from discover vs topic.
2. Switching FF service from Statsig to Growthbook.

Turns out we can't wait for `2` to be done and need to release `1` first. That's what this PR is for. I just copied the relevant change in the endpoint from #4526.