### PR TITLE
Drops `recId` from user suggestions

### DIFF
--- a/.changeset/frank-bats-hope.md
+++ b/.changeset/frank-bats-hope.md
@@ -1,0 +1,6 @@
+---
+'@atproto/api': minor
+'@atproto/bsky': minor
+---
+
+Removes `recId` from suggested users — we need at as string, so we're gonna re-add it as string (instead of integer) later.

--- a/lexicons/app/bsky/unspecced/getSuggestedUsers.json
+++ b/lexicons/app/bsky/unspecced/getSuggestedUsers.json
@@ -32,10 +32,6 @@
                 "type": "ref",
                 "ref": "app.bsky.actor.defs#profileView"
               }
-            },
-            "recId": {
-              "type": "integer",
-              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }

--- a/lexicons/app/bsky/unspecced/getSuggestedUsersSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getSuggestedUsersSkeleton.json
@@ -37,10 +37,6 @@
                 "type": "string",
                 "format": "did"
               }
-            },
-            "recId": {
-              "type": "integer",
-              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -8030,11 +8030,6 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
-              },
             },
           },
         },
@@ -8082,11 +8077,6 @@ export const schemaDict = {
                   type: 'string',
                   format: 'did',
                 },
-              },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
               },
             },
           },

--- a/packages/api/src/client/types/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getSuggestedUsers.ts
@@ -25,8 +25,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   actors: AppBskyActorDefs.ProfileView[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export interface CallOptions {

--- a/packages/api/src/client/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
+++ b/packages/api/src/client/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
@@ -26,8 +26,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   dids: string[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export interface CallOptions {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
@@ -145,7 +145,6 @@ const presentation = (
 ) => {
   const { ctx, skeleton, hydration } = input
   return {
-    recId: skeleton.recId,
     actors: mapDefined(skeleton.dids, (did) =>
       ctx.views.profile(did, hydration),
     ),
@@ -168,5 +167,4 @@ type Params = QueryParams & {
 
 type SkeletonState = {
   dids: string[]
-  recId?: number
 }

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -8030,11 +8030,6 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
-              },
             },
           },
         },
@@ -8082,11 +8077,6 @@ export const schemaDict = {
                   type: 'string',
                   format: 'did',
                 },
-              },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
               },
             },
           },

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
@@ -24,8 +24,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   actors: AppBskyActorDefs.ProfileView[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void

--- a/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
+++ b/packages/bsky/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
@@ -25,8 +25,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   dids: string[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -8030,11 +8030,6 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
-              },
             },
           },
         },
@@ -8082,11 +8077,6 @@ export const schemaDict = {
                   type: 'string',
                   format: 'did',
                 },
-              },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
               },
             },
           },

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
@@ -24,8 +24,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   actors: AppBskyActorDefs.ProfileView[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void

--- a/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
+++ b/packages/ozone/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
@@ -25,8 +25,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   dids: string[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void

--- a/packages/pds/src/lexicon/lexicons.ts
+++ b/packages/pds/src/lexicon/lexicons.ts
@@ -8030,11 +8030,6 @@ export const schemaDict = {
                   ref: 'lex:app.bsky.actor.defs#profileView',
                 },
               },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
-              },
             },
           },
         },
@@ -8082,11 +8077,6 @@ export const schemaDict = {
                   type: 'string',
                   format: 'did',
                 },
-              },
-              recId: {
-                type: 'integer',
-                description:
-                  'Snowflake for this recommendation, use when submitting recommendation events.',
               },
             },
           },

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestedUsers.ts
@@ -24,8 +24,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   actors: AppBskyActorDefs.ProfileView[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void

--- a/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
+++ b/packages/pds/src/lexicon/types/app/bsky/unspecced/getSuggestedUsersSkeleton.ts
@@ -25,8 +25,6 @@ export type InputSchema = undefined
 
 export interface OutputSchema {
   dids: string[]
-  /** Snowflake for this recommendation, use when submitting recommendation events. */
-  recId?: number
 }
 
 export type HandlerInput = void


### PR DESCRIPTION
We need to remove this field, deploy without it, and then re-add it as string.

Long story short: `recId` is an `int64` and TS/JS cannot get the machine ID out of it because it can't handle big integers unless with explicity `BigInt` — which is not the case in our stack. So we're gonna pass it ias string instead.
