### PR TITLE
lexicon-resolver: don't require at:// handle for lexicon resoltion

### DIFF
--- a/.changeset/lazy-impalas-burn.md
+++ b/.changeset/lazy-impalas-burn.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lexicon-resolver': patch
+---
+
+Do not require at:// handle for lexicon resolution

--- a/packages/lexicon-resolver/src/record.ts
+++ b/packages/lexicon-resolver/src/record.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-deprecated */
 
 import { CID } from 'multiformats/cid'
-import { IdResolver } from '@atproto/identity'
+import { IdResolver, parseToAtprotoDocument } from '@atproto/identity'
 import { RepoRecord } from '@atproto/lexicon'
 import {
   Commit,
@@ -61,19 +61,30 @@ export function buildRecordResolver(
   ): Promise<RecordResolution> {
     const uri = typeof uriStr === 'string' ? new AtUri(uriStr) : uriStr
     const did = await getDidFromUri(uri, { idResolver })
-    const identity = await idResolver.did
-      .resolveAtprotoData(did, opts.forceRefresh)
+    const identityDoc = await idResolver.did
+      .ensureResolve(did, opts.forceRefresh)
       .catch((err) => {
         throw new RecordResolutionError('Could not resolve DID identity data', {
           cause: err,
         })
       })
+    const { pds, signingKey } = parseToAtprotoDocument(identityDoc)
+    if (!pds) {
+      throw new RecordResolutionError(
+        'Incomplete DID identity data: missing pds',
+      )
+    }
+    if (!signingKey) {
+      throw new RecordResolutionError(
+        'Incomplete DID identity data: missing signing key',
+      )
+    }
     const client = new Client(
       typeof rpc === 'function'
         ? rpc
         : {
             ...rpc,
-            service: rpc?.service ?? identity.pds,
+            service: rpc?.service ?? pds,
             fetch: rpc?.fetch ?? safeFetch,
           },
     )
@@ -90,7 +101,7 @@ export function buildRecordResolver(
       })
     const verified = await verifyRecordProof(proofBytes, {
       uri: AtUri.make(did, uri.collection, uri.rkey),
-      signingKey: identity.signingKey,
+      signingKey,
     })
     return verified
   }

--- a/packages/lexicon-resolver/tests/record.test.ts
+++ b/packages/lexicon-resolver/tests/record.test.ts
@@ -97,4 +97,96 @@ describe('Record resolution', () => {
       }),
     ).rejects.toThrow('Malformed record proof')
   })
+
+  it('does not resolve record with missing signing key.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post5')
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.verificationMethods = {
+          not_atproto: doc.verificationMethods.atproto,
+        }
+        return doc
+      },
+    )
+    await expect(
+      resolveRecord(post.ref.uri, {
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Incomplete DID identity data: missing signing key')
+    // reset alice's key
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.verificationMethods = {
+          atproto: doc.verificationMethods.not_atproto,
+        }
+        return doc
+      },
+    )
+  })
+
+  it('does not resolve record with missing pds.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post6')
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.services = {
+          not_atproto_pds: doc.services.atproto_pds,
+        }
+        return doc
+      },
+    )
+    await expect(
+      resolveRecord(post.ref.uri, {
+        forceRefresh: true,
+      }),
+    ).rejects.toThrow('Incomplete DID identity data: missing pds')
+    // reset alice's pds
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.services = {
+          atproto_pds: doc.services.not_atproto_pds,
+        }
+        return doc
+      },
+    )
+  })
+
+  it('resolves record despite missing at:// handle.', async () => {
+    const post = await sc.post(sc.dids.alice, 'post7')
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.alsoKnownAs = doc.alsoKnownAs.map((aka) =>
+          aka.replace('at://', 'notat://'),
+        )
+        return doc
+      },
+    )
+    const result = await resolveRecord(post.ref.uriStr, {
+      forceRefresh: true,
+    })
+    expect(result.commit.did).toEqual(sc.dids.alice)
+    expect(result.cid.toString()).toEqual(post.ref.cidStr)
+    expect(result.uri.toString()).toEqual(post.ref.uriStr)
+    expect(result.record.text).toEqual('post7')
+    // reset alice's handle
+    await network.pds.ctx.plcClient.updateData(
+      sc.dids.alice,
+      network.pds.ctx.plcRotationKey,
+      (doc) => {
+        doc.alsoKnownAs = doc.alsoKnownAs.map((aka) =>
+          aka.replace('notat://', 'at://'),
+        )
+        return doc
+      },
+    )
+  })
 })


### PR DESCRIPTION
The identity resolver's `resolveAtprotoData()` method ensures that there's a syntactically valid at:// handle in the DID document (in addition to a PDS endpoint and atproto signing key).  A handle isn't required for the purposes of lexicon resolution, so here we're loosening that constraint.