### PR TITLE
Update com.germnetwork.declaration lexicon from their published lexicon

### DIFF
--- a/.changeset/afraid-pens-vanish.md
+++ b/.changeset/afraid-pens-vanish.md
@@ -1,0 +1,6 @@
+---
+'@atproto/bsky': patch
+'@atproto/api': patch
+---
+
+Update Germ Network lexicon from source

--- a/lexicons/com/germnetwork/declaration.json
+++ b/lexicons/com/germnetwork/declaration.json
@@ -1,45 +1,73 @@
 {
-  "lexicon": 1,
-  "id": "com.germnetwork.declaration",
   "defs": {
     "main": {
-      "type": "record",
-      "description": "A delegate messaging id",
+      "description": "A declaration of a Germ Network account",
       "key": "literal:self",
       "record": {
-        "type": "object",
-        "required": ["version", "currentKey"],
         "properties": {
-          "version": {
-            "type": "string"
+          "continuityProofs": {
+            "description": "Array of opaque values to allow for key rolling",
+            "items": {
+              "type": "bytes"
+            },
+            "maxLength": 1000,
+            "type": "array"
           },
           "currentKey": {
+            "description": "Opaque value, an ed25519 public key prefixed with a byte enum",
             "type": "bytes"
           },
-          "messageMe": { "type": "ref", "ref": "#messageMe" },
           "keyPackage": {
+            "description": "Opaque value, contains MLS KeyPackage(s), and other signature data, and is signed by the currentKey",
             "type": "bytes"
           },
-          "continuityProofs": {
-            "type": "array",
-            "items": { "type": "bytes" }
+          "messageMe": {
+            "description": "Controls who can message this account",
+            "ref": "#messageMe",
+            "type": "ref"
+          },
+          "version": {
+            "description": "Semver version number, without pre-release or build information, for the format of opaque content",
+            "maxLength": 14,
+            "minLength": 5,
+            "type": "string"
           }
-        }
-      }
+        },
+        "required": [
+          "version",
+          "currentKey"
+        ],
+        "type": "object"
+      },
+      "type": "record"
     },
     "messageMe": {
-      "type": "object",
-      "required": ["showButtonTo", "messageMeUrl"],
       "properties": {
         "messageMeUrl": {
-          "type": "string",
-          "format": "uri"
+          "description": "A URL to present to an account that does not have its own com.germnetwork.declaration record, must have an empty fragment component, where the app should fill in the fragment component with the DIDs of the two accounts who wish to message each other",
+          "format": "uri",
+          "maxLength": 2047,
+          "minLength": 1,
+          "type": "string"
         },
         "showButtonTo": {
-          "type": "string",
-          "knownValues": ["usersIFollow", "everyone"]
+          "description": "The policy of who can message the account, this value is included in the keyPackage, but is duplicated here to allow applications to decide if they should show a 'Message on Germ' button to the viewer.",
+          "knownValues": [
+            "usersIFollow",
+            "everyone"
+          ],
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "showButtonTo",
+        "messageMeUrl"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "id": "com.germnetwork.declaration",
+  "lexicon": 1
 }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -15341,54 +15341,73 @@ export const schemaDict = {
     },
   },
   ComGermnetworkDeclaration: {
-    lexicon: 1,
-    id: 'com.germnetwork.declaration',
     defs: {
       main: {
-        type: 'record',
-        description: 'A delegate messaging id',
+        description: 'A declaration of a Germ Network account',
         key: 'literal:self',
         record: {
-          type: 'object',
-          required: ['version', 'currentKey'],
           properties: {
-            version: {
-              type: 'string',
-            },
-            currentKey: {
-              type: 'bytes',
-            },
-            messageMe: {
-              type: 'ref',
-              ref: 'lex:com.germnetwork.declaration#messageMe',
-            },
-            keyPackage: {
-              type: 'bytes',
-            },
             continuityProofs: {
-              type: 'array',
+              description: 'Array of opaque values to allow for key rolling',
               items: {
                 type: 'bytes',
               },
+              maxLength: 1000,
+              type: 'array',
+            },
+            currentKey: {
+              description:
+                'Opaque value, an ed25519 public key prefixed with a byte enum',
+              type: 'bytes',
+            },
+            keyPackage: {
+              description:
+                'Opaque value, contains MLS KeyPackage(s), and other signature data, and is signed by the currentKey',
+              type: 'bytes',
+            },
+            messageMe: {
+              description: 'Controls who can message this account',
+              ref: 'lex:com.germnetwork.declaration#messageMe',
+              type: 'ref',
+            },
+            version: {
+              description:
+                'Semver version number, without pre-release or build information, for the format of opaque content',
+              maxLength: 14,
+              minLength: 5,
+              type: 'string',
             },
           },
+          required: ['version', 'currentKey'],
+          type: 'object',
         },
+        type: 'record',
       },
       messageMe: {
-        type: 'object',
-        required: ['showButtonTo', 'messageMeUrl'],
         properties: {
           messageMeUrl: {
-            type: 'string',
+            description:
+              'A URL to present to an account that does not have its own com.germnetwork.declaration record, must have an empty fragment component, where the app should fill in the fragment component with the DIDs of the two accounts who wish to message each other',
             format: 'uri',
+            maxLength: 2047,
+            minLength: 1,
+            type: 'string',
           },
           showButtonTo: {
-            type: 'string',
+            description:
+              "The policy of who can message the account, this value is included in the keyPackage, but is duplicated here to allow applications to decide if they should show a 'Message on Germ' button to the viewer.",
             knownValues: ['usersIFollow', 'everyone'],
+            maxLength: 100,
+            minLength: 1,
+            type: 'string',
           },
         },
+        required: ['showButtonTo', 'messageMeUrl'],
+        type: 'object',
       },
     },
+    id: 'com.germnetwork.declaration',
+    lexicon: 1,
   },
   ToolsOzoneCommunicationCreateTemplate: {
     lexicon: 1,

--- a/packages/api/src/client/types/com/germnetwork/declaration.ts
+++ b/packages/api/src/client/types/com/germnetwork/declaration.ts
@@ -12,11 +12,15 @@ const id = 'com.germnetwork.declaration'
 
 export interface Main {
   $type: 'com.germnetwork.declaration'
-  version: string
-  currentKey: Uint8Array
-  messageMe?: MessageMe
-  keyPackage?: Uint8Array
+  /** Array of opaque values to allow for key rolling */
   continuityProofs?: Uint8Array[]
+  /** Opaque value, an ed25519 public key prefixed with a byte enum */
+  currentKey: Uint8Array
+  /** Opaque value, contains MLS KeyPackage(s), and other signature data, and is signed by the currentKey */
+  keyPackage?: Uint8Array
+  messageMe?: MessageMe
+  /** Semver version number, without pre-release or build information, for the format of opaque content */
+  version: string
   [k: string]: unknown
 }
 
@@ -38,7 +42,9 @@ export {
 
 export interface MessageMe {
   $type?: 'com.germnetwork.declaration#messageMe'
+  /** A URL to present to an account that does not have its own com.germnetwork.declaration record, must have an empty fragment component, where the app should fill in the fragment component with the DIDs of the two accounts who wish to message each other */
   messageMeUrl: string
+  /** The policy of who can message the account, this value is included in the keyPackage, but is duplicated here to allow applications to decide if they should show a 'Message on Germ' button to the viewer. */
   showButtonTo: 'usersIFollow' | 'everyone' | (string & {})
 }
 

--- a/packages/bsky/src/lexicon/lexicons.ts
+++ b/packages/bsky/src/lexicon/lexicons.ts
@@ -15341,54 +15341,73 @@ export const schemaDict = {
     },
   },
   ComGermnetworkDeclaration: {
-    lexicon: 1,
-    id: 'com.germnetwork.declaration',
     defs: {
       main: {
-        type: 'record',
-        description: 'A delegate messaging id',
+        description: 'A declaration of a Germ Network account',
         key: 'literal:self',
         record: {
-          type: 'object',
-          required: ['version', 'currentKey'],
           properties: {
-            version: {
-              type: 'string',
-            },
-            currentKey: {
-              type: 'bytes',
-            },
-            messageMe: {
-              type: 'ref',
-              ref: 'lex:com.germnetwork.declaration#messageMe',
-            },
-            keyPackage: {
-              type: 'bytes',
-            },
             continuityProofs: {
-              type: 'array',
+              description: 'Array of opaque values to allow for key rolling',
               items: {
                 type: 'bytes',
               },
+              maxLength: 1000,
+              type: 'array',
+            },
+            currentKey: {
+              description:
+                'Opaque value, an ed25519 public key prefixed with a byte enum',
+              type: 'bytes',
+            },
+            keyPackage: {
+              description:
+                'Opaque value, contains MLS KeyPackage(s), and other signature data, and is signed by the currentKey',
+              type: 'bytes',
+            },
+            messageMe: {
+              description: 'Controls who can message this account',
+              ref: 'lex:com.germnetwork.declaration#messageMe',
+              type: 'ref',
+            },
+            version: {
+              description:
+                'Semver version number, without pre-release or build information, for the format of opaque content',
+              maxLength: 14,
+              minLength: 5,
+              type: 'string',
             },
           },
+          required: ['version', 'currentKey'],
+          type: 'object',
         },
+        type: 'record',
       },
       messageMe: {
-        type: 'object',
-        required: ['showButtonTo', 'messageMeUrl'],
         properties: {
           messageMeUrl: {
-            type: 'string',
+            description:
+              'A URL to present to an account that does not have its own com.germnetwork.declaration record, must have an empty fragment component, where the app should fill in the fragment component with the DIDs of the two accounts who wish to message each other',
             format: 'uri',
+            maxLength: 2047,
+            minLength: 1,
+            type: 'string',
           },
           showButtonTo: {
-            type: 'string',
+            description:
+              "The policy of who can message the account, this value is included in the keyPackage, but is duplicated here to allow applications to decide if they should show a 'Message on Germ' button to the viewer.",
             knownValues: ['usersIFollow', 'everyone'],
+            maxLength: 100,
+            minLength: 1,
+            type: 'string',
           },
         },
+        required: ['showButtonTo', 'messageMeUrl'],
+        type: 'object',
       },
     },
+    id: 'com.germnetwork.declaration',
+    lexicon: 1,
   },
 } as const satisfies Record<string, LexiconDoc>
 export const schemas = Object.values(schemaDict) satisfies LexiconDoc[]

--- a/packages/bsky/src/lexicon/types/com/germnetwork/declaration.ts
+++ b/packages/bsky/src/lexicon/types/com/germnetwork/declaration.ts
@@ -12,11 +12,15 @@ const id = 'com.germnetwork.declaration'
 
 export interface Main {
   $type: 'com.germnetwork.declaration'
-  version: string
-  currentKey: Uint8Array
-  messageMe?: MessageMe
-  keyPackage?: Uint8Array
+  /** Array of opaque values to allow for key rolling */
   continuityProofs?: Uint8Array[]
+  /** Opaque value, an ed25519 public key prefixed with a byte enum */
+  currentKey: Uint8Array
+  /** Opaque value, contains MLS KeyPackage(s), and other signature data, and is signed by the currentKey */
+  keyPackage?: Uint8Array
+  messageMe?: MessageMe
+  /** Semver version number, without pre-release or build information, for the format of opaque content */
+  version: string
   [k: string]: unknown
 }
 
@@ -38,7 +42,9 @@ export {
 
 export interface MessageMe {
   $type?: 'com.germnetwork.declaration#messageMe'
+  /** A URL to present to an account that does not have its own com.germnetwork.declaration record, must have an empty fragment component, where the app should fill in the fragment component with the DIDs of the two accounts who wish to message each other */
   messageMeUrl: string
+  /** The policy of who can message the account, this value is included in the keyPackage, but is duplicated here to allow applications to decide if they should show a 'Message on Germ' button to the viewer. */
   showButtonTo: 'usersIFollow' | 'everyone' | (string & {})
 }
 


### PR DESCRIPTION
@bnewbold I noticed the Germ Network lexicon was slightly out of date with the version that's published now, so this just runs `goat lex pull com.germnetwork.declaration -u` and `pnpm codegen`.

The main changes are just upper limits on values and some better documentation. These changes were made upstream in https://github.com/germ-network/lexicon/pull/1 