### PR TITLE
PDS: fix rpc audience check for service proxying

### DIFF
--- a/.changeset/plenty-mangos-do.md
+++ b/.changeset/plenty-mangos-do.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Fix rpc audience check for service proxying.

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -3,7 +3,11 @@ import { AuthScope } from '../../../../auth-scope'
 import { AppContext } from '../../../../context'
 import { Server } from '../../../../lexicon'
 import { ids } from '../../../../lexicon/lexicons'
-import { computeProxyTo, parseProxyInfo } from '../../../../pipethrough'
+import {
+  computeProxyTo,
+  parseProxyInfo,
+  serviceJwtAud,
+} from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.moderation.createReport({
@@ -16,15 +20,15 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     handler: async ({ auth, input, req }) => {
-      const { url, did: aud } = await parseProxyInfo(
+      const proxy = await parseProxyInfo(
         ctx,
         req,
         ids.ComAtprotoModerationCreateReport,
       )
-      const agent = new AtpAgent({ service: url })
+      const agent = new AtpAgent({ service: proxy.serviceInfo.url })
       const serviceAuth = await ctx.serviceAuthHeaders(
         auth.credentials.did,
-        aud,
+        serviceJwtAud(proxy),
         ids.ComAtprotoModerationCreateReport,
       )
       const res = await agent.com.atproto.moderation.createReport(input.body, {

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -262,13 +262,10 @@ export const parseProxyHeader = async (
   }
 
   const did = proxyTo.slice(0, hashIndex)
-  const serviceId = proxyTo.slice(hashIndex)
+  const serviceId = proxyTo.slice(hashIndex + 1)
 
   // Special case a configured appview, while still proxying correctly any other appview
-  if (
-    ctx.cfg.bskyAppView &&
-    proxyTo === `${ctx.cfg.bskyAppView.did}#bsky_appview`
-  ) {
+  if (serviceId === 'bsky_appview' && did === ctx.cfg.bskyAppView?.did) {
     return { serviceId, serviceInfo: ctx.cfg.bskyAppView }
   }
 


### PR DESCRIPTION
Fixes an issue where the rpc scope audience checks weren't properly taking into account the service id when service proxying.