### PR TITLE
Fix scope `aud` param

### DIFF
--- a/.changeset/cozy-bears-serve.md
+++ b/.changeset/cozy-bears-serve.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Allow `DidString` helpers to be call with any value (not only strings)

--- a/.changeset/fresh-yaks-watch.md
+++ b/.changeset/fresh-yaks-watch.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-scopes': patch
+---
+
+Fix `include:` and `rpc:` scope to expect `Did` values as `aud` parameter

--- a/.changeset/lucky-hands-wave.md
+++ b/.changeset/lucky-hands-wave.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Make `parseReqNsid` stronly typed

--- a/.changeset/orange-pianos-jump.md
+++ b/.changeset/orange-pianos-jump.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Allow `NsidString` helpers to be call with any value (not only strings)

--- a/packages/oauth/oauth-provider/src/lexicon/lexicon-getter.ts
+++ b/packages/oauth/oauth-provider/src/lexicon/lexicon-getter.ts
@@ -1,5 +1,5 @@
 import { LexResolver, LexResolverError } from '@atproto/lex-resolver'
-import { Nsid } from '@atproto/oauth-scopes'
+import { NsidString } from '@atproto/oauth-scopes'
 import { CachedGetter } from '@atproto-labs/simple-store'
 import { LEXICON_REFRESH_FREQUENCY } from '../constants.js'
 import { LexiconData, LexiconStore } from './lexicon-store.js'
@@ -11,7 +11,7 @@ import { LexiconData, LexiconStore } from './lexicon-store.js'
  *
  * @private
  */
-export class LexiconGetter extends CachedGetter<Nsid, LexiconData> {
+export class LexiconGetter extends CachedGetter<NsidString, LexiconData> {
   constructor(store: LexiconStore, lexResolver: LexResolver) {
     super(
       async (input, options, storedData) => {

--- a/packages/oauth/oauth-provider/src/lexicon/lexicon-manager.ts
+++ b/packages/oauth/oauth-provider/src/lexicon/lexicon-manager.ts
@@ -1,6 +1,6 @@
 import { LexiconPermissionSet } from '@atproto/lex-document'
 import { LexResolver, LexResolverError } from '@atproto/lex-resolver'
-import { IncludeScope, Nsid } from '@atproto/oauth-scopes'
+import { IncludeScope, NsidString } from '@atproto/oauth-scopes'
 import { LexiconGetter } from './lexicon-getter.js'
 import { LexiconStore } from './lexicon-store.js'
 
@@ -46,20 +46,22 @@ export class LexiconManager {
     return this.getPermissionSets(nsids)
   }
 
-  protected async getPermissionSets(nsids: Set<Nsid>) {
+  protected async getPermissionSets(nsids: Set<NsidString>) {
     return new Map<string, LexiconPermissionSet>(
       await Promise.all(Array.from(nsids, this.getPermissionSetEntry, this)),
     )
   }
 
   protected async getPermissionSetEntry(
-    nsid: Nsid,
-  ): Promise<[nsid: Nsid, permissionSet: LexiconPermissionSet]> {
+    nsid: NsidString,
+  ): Promise<[nsid: NsidString, permissionSet: LexiconPermissionSet]> {
     const permissionSet = await this.getPermissionSet(nsid)
     return [nsid, permissionSet]
   }
 
-  protected async getPermissionSet(nsid: Nsid): Promise<LexiconPermissionSet> {
+  protected async getPermissionSet(
+    nsid: NsidString,
+  ): Promise<LexiconPermissionSet> {
     const { lexicon } = await this.lexiconGetter.get(nsid)
 
     if (!lexicon) {
@@ -96,11 +98,11 @@ function parseScope(scope?: string) {
   }
 }
 
-function extractNsids(includeScopes: IncludeScope[]): Set<Nsid> {
+function extractNsids(includeScopes: IncludeScope[]): Set<NsidString> {
   return new Set(Array.from(includeScopes, extractNsid))
 }
 
-function extractNsid(nsidScope: IncludeScope): Nsid {
+function extractNsid(nsidScope: IncludeScope): NsidString {
   return nsidScope.nsid
 }
 

--- a/packages/oauth/oauth-scopes/package.json
+++ b/packages/oauth/oauth-scopes/package.json
@@ -25,7 +25,6 @@
     }
   },
   "dependencies": {
-    "@atproto/did": "workspace:^",
     "@atproto/syntax": "workspace:^"
   },
   "devDependencies": {

--- a/packages/oauth/oauth-scopes/src/index.ts
+++ b/packages/oauth/oauth-scopes/src/index.ts
@@ -11,3 +11,11 @@ export * from './scopes/identity-permission.js'
 export * from './scopes/include-scope.js'
 export * from './scopes/repo-permission.js'
 export * from './scopes/rpc-permission.js'
+
+// Legacy
+export type {
+  /** @deprecated use {@link NsidString} instead */
+  NsidString as Nsid,
+  /** @deprecated use {@link isValidNsid} instead */
+  isValidNsid as isNsid,
+} from '@atproto/syntax'

--- a/packages/oauth/oauth-scopes/src/lib/nsid.ts
+++ b/packages/oauth/oauth-scopes/src/lib/nsid.ts
@@ -1,5 +1,0 @@
-import { isValidNsid } from '@atproto/syntax'
-
-export type Nsid = `${string}.${string}.${string}`
-export const isNsid = (v: unknown): v is Nsid =>
-  typeof v === 'string' && isValidNsid(v)

--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
@@ -1,6 +1,5 @@
-import { AtprotoAudience, isAtprotoAudience } from '@atproto/did'
+import { DidString, NsidString, isValidDid, isValidNsid } from '@atproto/syntax'
 import { LexiconPermission, LexiconPermissionSet } from '../lib/lexicon.js'
-import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
 import { LexPermissionSyntax } from '../lib/syntax-lexicon.js'
 import { ScopeStringSyntax } from '../lib/syntax-string.js'
@@ -13,7 +12,14 @@ import {
 import { RepoPermission } from './repo-permission.js'
 import { RpcPermission } from './rpc-permission.js'
 
-export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
+export {
+  type DidString,
+  type LexiconPermission,
+  type LexiconPermissionSet,
+  type NsidString,
+  isValidDid,
+  isValidNsid,
+}
 
 /**
  * This is used to handle "include:" oauth scope values, used to include
@@ -22,8 +28,8 @@ export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
  */
 export class IncludeScope {
   constructor(
-    public readonly nsid: Nsid,
-    public readonly aud: undefined | AtprotoAudience = undefined,
+    public readonly nsid: NsidString,
+    public readonly aud: undefined | DidString = undefined,
   ) {}
 
   toString() {
@@ -123,7 +129,7 @@ export class IncludeScope {
    * nsid of the lexicon itself (which is the same as the nsid of the `include:`
    * scope).
    */
-  public isParentAuthorityOf(otherNsid: '*' | Nsid) {
+  public isParentAuthorityOf(otherNsid: '*' | NsidString) {
     if (otherNsid === '*') {
       return false
     }
@@ -161,12 +167,12 @@ export class IncludeScope {
       nsid: {
         multiple: false,
         required: true,
-        validate: isNsid,
+        validate: isValidNsid,
       },
       aud: {
         multiple: false,
         required: false,
-        validate: isAtprotoAudience,
+        validate: isValidDid,
       },
     },
     'nsid',

--- a/packages/oauth/oauth-scopes/src/scopes/repo-permission.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/repo-permission.ts
@@ -1,4 +1,4 @@
-import { Nsid, isNsid } from '../lib/nsid.js'
+import { NsidString, isValidNsid } from '@atproto/syntax'
 import { Parser } from '../lib/parser.js'
 import { ResourcePermission } from '../lib/resource-permission.js'
 import { ScopeStringSyntax } from '../lib/syntax-string.js'
@@ -10,7 +10,7 @@ import {
 } from '../lib/syntax.js'
 import { knownValuesValidator } from '../lib/util.js'
 
-export { type Nsid, isNsid }
+export { type NsidString, isValidNsid }
 
 export const REPO_ACTIONS = Object.freeze([
   'create',
@@ -20,9 +20,9 @@ export const REPO_ACTIONS = Object.freeze([
 export type RepoAction = (typeof REPO_ACTIONS)[number]
 export const isRepoAction = knownValuesValidator(REPO_ACTIONS)
 
-export type CollectionParam = '*' | Nsid
+export type CollectionParam = '*' | NsidString
 export const isCollectionParam = (value: unknown): value is CollectionParam =>
-  value === '*' || isNsid(value)
+  value === '*' || isValidNsid(value)
 
 export type RepoPermissionMatch = {
   collection: string
@@ -33,7 +33,7 @@ export class RepoPermission
   implements ResourcePermission<'repo', RepoPermissionMatch>
 {
   constructor(
-    public readonly collection: NeRoArray<'*' | Nsid>,
+    public readonly collection: NeRoArray<'*' | NsidString>,
     public readonly action: NeRoArray<RepoAction>,
   ) {}
 
@@ -59,9 +59,9 @@ export class RepoPermission
         normalize: (value) => {
           if (value.length > 1) {
             if (value.includes('*')) return ['*'] as const
-            return [...new Set(value)].sort() as NeArray<Nsid>
+            return [...new Set(value)].sort() as NeArray<NsidString>
           }
-          return value as ['*' | Nsid]
+          return value as ['*' | NsidString]
         },
       },
       action: {
@@ -94,7 +94,7 @@ export class RepoPermission
 
   static scopeNeededFor(options: RepoPermissionMatch): string {
     return RepoPermission.parser.format({
-      collection: [options.collection as '*' | Nsid],
+      collection: [options.collection as '*' | NsidString],
       action: [options.action],
     })
   }

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -14,7 +14,7 @@ export default function (server: Server, ctx: AppContext) {
       authorize: (permissions, { req }) => {
         const lxm = ids.AppBskyActorGetPreferences
         const aud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud, lxm })
+        permissions.assertRpc({ lxm, aud })
       },
     }),
     handler: async ({ auth, req }) => {
@@ -25,7 +25,7 @@ export default function (server: Server, ctx: AppContext) {
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = ids.AppBskyActorGetPreferences
       const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
+      if (aud !== bskyAppView.did) {
         return pipethrough(ctx, req, { iss: did, aud, lxm })
       }
 

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -27,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = ids.AppBskyActorPutPreferences
       const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
+      if (aud !== bskyAppView.did) {
         return pipethrough(ctx, req, { iss: did, aud, lxm })
       }
 

--- a/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
@@ -1,4 +1,5 @@
 import { HOUR, MINUTE } from '@atproto/common'
+import { DidString, NsidString } from '@atproto/syntax'
 import { InvalidRequestError, createServiceJwt } from '@atproto/xrpc-server'
 import {
   AuthScope,
@@ -15,8 +16,11 @@ export default function (server: Server, ctx: AppContext) {
     auth: ctx.authVerifier.authorization({
       additional: [AuthScope.Takendown],
       authorize: (permissions, ctx) => {
-        const { aud, lxm = '*' } = ctx.params
-        permissions.assertRpc({ aud, lxm })
+        const { aud, lxm } = ctx.params
+        permissions.assertRpc({
+          aud: aud as DidString, // Validated by lexicon
+          lxm: lxm == null ? '*' : (lxm as NsidString),
+        })
       },
     }),
     handler: async ({ params, auth }) => {

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert'
 import path from 'node:path'
 import { DAY, HOUR, SECOND } from '@atproto/common'
 import { BrandingInput, HcaptchaConfig } from '@atproto/oauth-provider'
-import { ensureValidDid } from '@atproto/syntax'
+import { DidString, ensureValidDid, isValidDid } from '@atproto/syntax'
 import { ServerEnvironment } from './env'
 
 // off-config but still from env:
@@ -178,7 +178,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
   let bskyAppViewCfg: ServerConfig['bskyAppView'] = null
   if (env.bskyAppViewUrl) {
     assert(
-      env.bskyAppViewDid,
+      isValidDid(env.bskyAppViewDid),
       'if bsky appview service url is configured, must configure its did as well.',
     )
     bskyAppViewCfg = {
@@ -191,9 +191,10 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
   let modServiceCfg: ServerConfig['modService'] = null
   if (env.modServiceUrl) {
     assert(
-      env.modServiceDid,
+      isValidDid(env.modServiceDid),
       'if mod service url is configured, must configure its did as well.',
     )
+
     modServiceCfg = {
       url: env.modServiceUrl,
       did: env.modServiceDid,
@@ -203,7 +204,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
   let reportServiceCfg: ServerConfig['reportService'] = null
   if (env.reportServiceUrl) {
     assert(
-      env.reportServiceDid,
+      isValidDid(env.reportServiceDid),
       'if report service url is configured, must configure its did as well.',
     )
     reportServiceCfg = {
@@ -511,16 +512,16 @@ export type RateLimitsConfig =
 
 export type BksyAppViewConfig = {
   url: string
-  did: string
+  did: DidString
   cdnUrlPattern?: string
 }
 
 export type ModServiceConfig = {
   url: string
-  did: string
+  did: DidString
 }
 
 export type ReportServiceConfig = {
   url: string
-  did: string
+  did: DidString
 }

--- a/packages/syntax/src/did.ts
+++ b/packages/syntax/src/did.ts
@@ -14,9 +14,11 @@
 
 export type DidString<M extends string = string> = `did:${M}:${string}`
 
-export function ensureValidDid<I extends string>(
-  input: I,
-): asserts input is I & DidString {
+export function ensureValidDid<I>(input: I): asserts input is I & DidString {
+  if (typeof input !== 'string') {
+    throw new InvalidDidError('DID must be a string')
+  }
+
   if (!input.startsWith('did:')) {
     throw new InvalidDidError('DID requires "did:" prefix')
   }
@@ -50,9 +52,13 @@ export function ensureValidDid<I extends string>(
 
 const DID_REGEX = /^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$/
 
-export function ensureValidDidRegex<I extends string>(
+export function ensureValidDidRegex<I>(
   input: I,
 ): asserts input is I & DidString {
+  if (typeof input !== 'string') {
+    throw new InvalidDidError('DID must be a string')
+  }
+
   // simple regex to enforce most constraints via just regex and length.
   // hand wrote this regex based on above constraints
   if (!DID_REGEX.test(input)) {
@@ -64,8 +70,10 @@ export function ensureValidDidRegex<I extends string>(
   }
 }
 
-export function isValidDid<I extends string>(input: I): input is I & DidString {
-  return input.length <= 2048 && DID_REGEX.test(input)
+export function isValidDid<I>(input: I): input is I & DidString {
+  return (
+    typeof input === 'string' && input.length <= 2048 && DID_REGEX.test(input)
+  )
 }
 
 export class InvalidDidError extends Error {}

--- a/packages/syntax/src/nsid.ts
+++ b/packages/syntax/src/nsid.ts
@@ -60,22 +60,18 @@ export class NSID {
   }
 }
 
-export function ensureValidNsid<I extends string>(
-  input: I,
-): asserts input is I & NsidString {
+export function ensureValidNsid<I>(input: I): asserts input is I & NsidString {
   const result = validateNsid(input)
   if (!result.success) throw new InvalidNsidError(result.message)
 }
 
-export function parseNsid(nsid: string): string[] {
+export function parseNsid(nsid: unknown): string[] {
   const result = validateNsid(nsid)
   if (!result.success) throw new InvalidNsidError(result.message)
   return result.value
 }
 
-export function isValidNsid<I extends string>(
-  input: I,
-): input is I & NsidString {
+export function isValidNsid<I>(input: I): input is I & NsidString {
   // Since the regex version is more performant for valid NSIDs, we use it when
   // we don't care about error details.
   return validateNsidRegex(input).success
@@ -88,7 +84,14 @@ type ValidateResult<T> =
 // Human readable constraints on NSID:
 // - a valid domain in reversed notation
 // - followed by an additional period-separated name, which is camel-case letters
-export function validateNsid(input: string): ValidateResult<string[]> {
+export function validateNsid(input: unknown): ValidateResult<string[]> {
+  if (typeof input !== 'string') {
+    return {
+      success: false,
+      message: 'NSID must be a string',
+    }
+  }
+
   if (input.length > 253 + 1 + 63) {
     return {
       success: false,
@@ -179,7 +182,9 @@ function isValidIdentifier(v: string) {
  * {@link parseNsid}/{@link NSID.parse} if you need the parsed segments, or
  * {@link isValidNsid} if you just want a boolean.
  */
-export function ensureValidNsidRegex(nsid: string): asserts nsid is NsidString {
+export function ensureValidNsidRegex(
+  nsid: unknown,
+): asserts nsid is NsidString {
   const result = validateNsidRegex(nsid)
   if (!result.success) throw new InvalidNsidError(result.message)
 }
@@ -188,7 +193,14 @@ export function ensureValidNsidRegex(nsid: string): asserts nsid is NsidString {
  * Regexp based validation that behaves identically to the previous code but
  * provides less detailed error messages (while being 20% to 50% faster).
  */
-export function validateNsidRegex(value: string): ValidateResult<NsidString> {
+export function validateNsidRegex(value: unknown): ValidateResult<NsidString> {
+  if (typeof value !== 'string') {
+    return {
+      success: false,
+      message: 'NSID must be a string',
+    }
+  }
+
   if (value.length > 253 + 1 + 63) {
     return {
       success: false,

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -13,6 +13,7 @@ import {
   jsonToLex,
 } from '@atproto/lexicon'
 import { ResponseType } from '@atproto/xrpc'
+import { NsidString } from '../../syntax/dist'
 import { InternalServerError, InvalidRequestError, XRPCError } from './errors'
 import {
   Awaitable,
@@ -383,13 +384,13 @@ export const parseReqNsid = (req: Request | IncomingMessage) =>
 /**
  * Validates and extracts the nsid from an xrpc path
  */
-export const parseUrlNsid = (url: string): string => {
+export const parseUrlNsid = (url: string): NsidString => {
   const nsid = extractUrlNsid(url)
   if (nsid) return nsid
   throw new InvalidRequestError('invalid xrpc path')
 }
 
-export const extractUrlNsid = (url: string): string | undefined => {
+export const extractUrlNsid = (url: string): NsidString | undefined => {
   // /!\ Hot path
 
   if (
@@ -448,5 +449,5 @@ export const extractUrlNsid = (url: string): string | undefined => {
 
   // @TODO check max length of nsid
 
-  return url.slice(startOfNsid, curr)
+  return url.slice(startOfNsid, curr) as NsidString
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1697,9 +1697,6 @@ importers:
 
   packages/oauth/oauth-scopes:
     dependencies:
-      '@atproto/did':
-        specifier: workspace:^
-        version: link:../../did
       '@atproto/syntax':
         specifier: workspace:^
         version: link:../../syntax


### PR DESCRIPTION
POC for fixing request proxying with oauth credentials. On hold as there is an issue with the OAuth spec of the `rpc:` scope that needs to be tackled first.