### PR TITLE
Prevent verification of handle.invalid

### DIFF
--- a/.changeset/blue-baboons-peel.md
+++ b/.changeset/blue-baboons-peel.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Prevent tools.ozone.verification.grantVerification from verifying handle.invalid

--- a/packages/ozone/tests/verification.test.ts
+++ b/packages/ozone/tests/verification.test.ts
@@ -132,6 +132,26 @@ describe('verification', () => {
         'Must be an admin or verifier to grant verifications',
       )
     })
+
+    it('fails if the handle is invalid', async () => {
+      const {
+        data: { verifications, failedVerifications },
+      } = await adminAgent.tools.ozone.verification.grantVerifications({
+        verifications: [
+          {
+            subject: sc.dids.dan,
+            handle: 'handle.invalid',
+            displayName: 'Bob',
+          },
+        ],
+      })
+
+      expect(verifications.length).toEqual(0)
+      expect(failedVerifications.length).toEqual(1)
+      const failed = failedVerifications.at(0)
+      expect(failed!.error).toEqual('Cannot verify with invalid handle')
+      expect(failed!.subject).toEqual(sc.dids.dan)
+    })
   })
 
   it('does not publish record if a valid one already exists', async () => {


### PR DESCRIPTION
I think this change should prevent this:
<img width="595" height="205" alt="Screenshot 2026-02-04 at 02 21 39" src="https://github.com/user-attachments/assets/7e1f9a35-b1d8-4c3c-849f-927a28925dc3" />

Though, it may actually be worth that endpoint doing a completely fresh resolution for the subject, just to really assert that the handle is definitely valid at that given point in time and that the handle value matches the supplied did.

The account in question above was: https://bsky.app/profile/did:plc:bo44s3mpcgypge54ao5i43w2
Although, I don't see a verification record from bsky.app — I'm guessing it was deleted by something?

cc @foysalit 