### PR TITLE
feat(oauth): add domain_handle oauth parameter for sign up

### DIFF
--- a/packages/oauth/oauth-provider-ui/hydration-data.d.ts
+++ b/packages/oauth/oauth-provider-ui/hydration-data.d.ts
@@ -17,6 +17,7 @@ export type AuthorizeData = {
   loginHint?: string
   uiLocales?: string
   promptMode?: OAuthPromptMode
+  domainHandle?: string
   permissionSets: PermissionSets
 }
 

--- a/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
@@ -22,9 +22,13 @@ if (
   url.pathname === '/oauth/authorize' &&
   !url.searchParams.has('request_uri')
 ) {
+  const domainHandle = url.searchParams.get('domain_handle')
   url.search = ''
   url.searchParams.set('client_id', authorizeData.clientId)
   url.searchParams.set('request_uri', authorizeData.requestUri)
+  if (domainHandle) {
+    url.searchParams.set('domain_handle', domainHandle)
+  }
   window.history.replaceState(history.state, '', url.pathname + url.search)
 }
 

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/authorize-view.tsx
@@ -144,6 +144,7 @@ export function AuthorizeView({
       <SignUpView
         {...props}
         customizationData={customizationData}
+        domainHandle={authorizeData.domainHandle}
         onValidateNewHandle={doValidateNewHandle}
         onBack={showHome}
         onDone={doSignUp}

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-handle-form.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-handle-form.tsx
@@ -74,6 +74,7 @@ export type SignUpHandleFormProps = Override<
   >,
   {
     domains: string[]
+    domainHandle?: string
 
     onNext: (signal: AbortSignal) => void | PromiseLike<void>
     nextLabel?: ReactNode
@@ -88,6 +89,7 @@ export type SignUpHandleFormProps = Override<
 
 export function SignUpHandleForm({
   domains: availableDomains,
+  domainHandle,
 
   onNext,
   nextLabel,
@@ -111,7 +113,13 @@ export function SignUpHandleForm({
 
   const [domainIdx, setDomainIdx] = useState(() => {
     const idx = domains.findIndex((d) => handleInit?.endsWith(d))
-    return idx === -1 ? 0 : idx
+    if (idx !== -1) return idx
+
+    const normalized = domainHandle?.toLowerCase()
+    const preferredIdx =
+      normalized != null ? domains.findIndex((d) => d === normalized) : -1
+
+    return preferredIdx === -1 ? 0 : preferredIdx
   })
   const [segment, setSegment] = useState(() => handleInit?.split('.')[0] || '')
 

--- a/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/views/authorize/sign-up/sign-up-view.tsx
@@ -21,6 +21,8 @@ export type SignUpViewProps = Override<
   {
     customizationData?: CustomizationData
 
+    domainHandle?: string
+
     onBack?: () => void
     backLabel?: ReactNode
     onValidateNewHandle: (
@@ -45,6 +47,7 @@ export function SignUpView({
     links,
   } = {},
 
+  domainHandle,
   onValidateNewHandle,
   onDone,
   onBack,
@@ -102,6 +105,7 @@ export function SignUpView({
                 className="grow"
                 invalid={invalid}
                 domains={availableUserDomains}
+                domainHandle={domainHandle}
                 handle={handle}
                 onHandle={setHandle}
                 prevLabel={prevLabel}

--- a/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
+++ b/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
@@ -33,6 +33,11 @@ export function sendAuthorizePageFactory(customization: Customization) {
   ): Promise<void> {
     await setupCsrfToken(req, res)
 
+    const domainHandle = getDomainHandle(
+      data.parameters.domain_handle,
+      customizationData.availableUserDomains,
+    )
+
     const script = declareHydrationData<HydrationData['authorization-page']>({
       __customizationData: customizationData,
       __authorizeData: {
@@ -47,6 +52,7 @@ export function sendAuthorizePageFactory(customization: Customization) {
         uiLocales: data.parameters.ui_locales,
         loginHint: data.parameters.login_hint,
         promptMode: data.parameters.prompt,
+        domainHandle,
         permissionSets: Object.fromEntries(data.permissionSets),
       },
       __sessions: data.sessions,
@@ -64,4 +70,17 @@ export function sendAuthorizePageFactory(customization: Customization) {
       styles: [...styles, customizationCss],
     })
   }
+}
+
+function getDomainHandle(
+  domainHandle: string | undefined,
+  availableDomains?: readonly string[],
+): string | undefined {
+  const value = domainHandle?.toLowerCase()
+
+  if (!value || !value.startsWith('.') || value.endsWith('.')) return undefined
+  if (!availableDomains?.length) return undefined
+  if (!availableDomains.includes(value)) return undefined
+
+  return value
 }

--- a/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
+++ b/packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts
@@ -86,6 +86,12 @@ export const oauthAuthorizationRequestParametersSchema = z.object({
   // How the AS should prompt the user for authorization:
   prompt: oauthPromptModeSchema.optional(),
 
+  // atproto extension: preferred handle domain for account creation
+  domain_handle: z
+    .string()
+    .regex(/^\.[a-z0-9-]+(\.[a-z0-9-]+)*$/)
+    .optional(),
+
   // https://datatracker.ietf.org/doc/html/rfc9396
   authorization_details: z
     .preprocess(jsonObjectPreprocess, oauthAuthorizationDetailsSchema)


### PR DESCRIPTION
(authored with codex)

this makes it so applications with a PDS with multiple available user domains can choose which domain handle to use as default at sign up.

not too sure about putting it in `packages/oauth/oauth-types/src/oauth-authorization-request-parameters.ts` with the oauth spec stuff, but can pull that out if needed. figured I'd go ahead and make the PR to get opinions.

granted this is a problem and solution to something that [only I](https://bsky.app/profile/mmatt.net/post/3me34qpvotc2e) may care about, so if this is out of scope just let me know :^)