### PR TITLE
Fix invalid handle showing verification

### DIFF
--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -503,7 +503,10 @@ export class Views {
   ): VerificationState | undefined {
     const actor = state.actors?.get(did)
     if (!actor) return
-    if (actor.handle === INVALID_HANDLE) return
+
+    // Currently, the handle comes as "handle.invalid" from the production dataplane.
+    // But the contract allows for empty handle, so we cover both cases.
+    if (!actor.handle || actor.handle === INVALID_HANDLE) return
 
     const isImpersonation = state.labels?.get(did)?.isImpersonation
 

--- a/packages/bsky/tests/views/verification.test.ts
+++ b/packages/bsky/tests/views/verification.test.ts
@@ -32,6 +32,7 @@ describe('verification views', () => {
   let verifier2: string
   let verifier3: string
   let handleinvalid: string
+  let handleempty: string
 
   beforeAll(async () => {
     network = await TestNetwork.create({
@@ -56,6 +57,7 @@ describe('verification views', () => {
     verifier2 = sc.dids.verifier2
     verifier3 = sc.dids.verifier3
     handleinvalid = sc.dids.handleinvalid
+    handleempty = sc.dids.handleempty
 
     await network.bsky.db.db
       .updateTable('actor')
@@ -234,6 +236,12 @@ describe('verification views', () => {
         description:
           'returns undefined for user with invalid handle even if they have verifications',
         getDid: () => handleinvalid,
+        getExpected: () => undefined,
+      },
+      {
+        description:
+          'returns undefined for user with empty handle even if they have verifications',
+        getDid: () => handleempty,
         getExpected: () => undefined,
       },
     ]

--- a/packages/dev-env/src/seed/verifications.ts
+++ b/packages/dev-env/src/seed/verifications.ts
@@ -26,6 +26,7 @@ export default async (sc: SeedClient<TestNetwork>) => {
   await sc.createAccount('verifier3', users.verifier3)
 
   await sc.createAccount('handleinvalid', users.handleinvalid)
+  await sc.createAccount('handleempty', users.handleempty)
 
   for (const name in sc.dids) {
     await sc.createProfile(sc.dids[name], `display-${name}`, `descript-${name}`)
@@ -145,6 +146,11 @@ export default async (sc: SeedClient<TestNetwork>) => {
     .set({ handle: INVALID_HANDLE })
     .where('did', '=', sc.dids.handleinvalid)
     .execute()
+  await sc.network.bsky.db.db
+    .updateTable('actor')
+    .set({ handle: null })
+    .where('did', '=', sc.dids.handleempty)
+    .execute()
 
   return sc
 }
@@ -214,6 +220,11 @@ const users = {
     email: 'handleinvalid@test.com',
     handle: 'handleinvalid.test',
     password: 'handleinvalid-pass',
+  },
+  handleempty: {
+    email: 'handleempty@test.com',
+    handle: 'handleempty.test',
+    password: 'handleempty-pass',
   },
 }
 


### PR DESCRIPTION
Context:

1. We were returning `handle.invalid` as the handle for a specific profile.
2. While that was going on, someone from the bsky team verified that profile, and then `handle.invalid` got into the verification record.
3. The profile was showing as verified while having the invalid handle badge.

This prevents showing any verification while the handle is invalid (failing bidirectional resolution).
