### PR TITLE
fix(clean): use find to recursively remove dist and node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ deps: ## Installs dependent libs using 'pnpm install'
 
 .PHONY: clean
 clean: ## Deletes all 'dist' and 'node_modules' directories (including nested)
-	rm -rf **/dist **/node_modules
+	find . -type d \( -name "dist" -o -name "node_modules" \) -prune -exec rm -rf {} +
 
 .PHONY: nvm-setup
 nvm-setup: ## Use NVM to install and activate node+pnpm

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ deps: ## Installs dependent libs using 'pnpm install'
 	pnpm install --frozen-lockfile
 
 .PHONY: clean
-clean: ## Deletes all 'dist' and 'node_package' directories (including nested)
-	rm -rf **/dist **/node_packages
+clean: ## Deletes all 'dist' and 'node_modules' directories (including nested)
+	rm -rf **/dist **/node_modules
 
 .PHONY: nvm-setup
 nvm-setup: ## Use NVM to install and activate node+pnpm


### PR DESCRIPTION
## Summary

This PR fixes the behavior of the `make clean` target in the Makefile.
Previously, `make clean` used:
```
rm -rf **/dist **/node_packages
```

However:

* The pattern did *not* consistently match nested `dist` and `node_modules` directories across environments and shells (e.g., shells without `globstar` enabled).
* There is no directory named `node_packages` in this repository — the intended directory is `node_modules`. A quick `find . -type d -name "node_packages"` returned no results.

As a result, `make clean` did not remove many of the expected build artifacts as intended.

## What Changed

* Replaced the glob-based removal with a `find` command that reliably locates all matching directories and deletes them:

```
find . -type d \( -name "dist" -o -name "node_modules" \) -prune -exec rm -rf {} +
```

* Verified with `find` that the expected directories (`dist` and `node_modules`, including nested ones) are identified before deletion.

## Why This Matters

* The glob pattern previously used depends on shell configuration (e.g., `globstar`) and may silently fail in some environments.
* The earlier pattern also referenced a non-existent directory (`node_packages`), meaning some intended removals were never happening.
* The new implementation works consistently across shells and ensures that all intended `dist` and `node_modules` dirs are cleaned.

## Verification

Before applying the change, the set of directories reported by:

```
find . -type d \( -name "dist" -o -name "node_modules" \) -prune -print
```

matched expectations in workspace layouts with nested packages. After removal, those directories are indeed deleted.

Additionally, running:

```
find . -type d -name "node_packages"
```

returned no results, confirming that the previous pattern was referring to a non-existent directory.

## Impact

This only affects the `make clean` target: no other build behavior or code functionality is affected.