### PR TITLE
feat(pds): allow override plcRotationKey

### DIFF
--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -243,7 +243,7 @@ export class AppContext {
     )
     await accountManager.migrateOrThrow()
 
-    const plcRotationKey =
+    const plcRotationKey = overrides?.plcRotationKey || (
       secrets.plcRotationKey.provider === 'kms'
         ? await KmsKeypair.load({
             keyId: secrets.plcRotationKey.keyId,
@@ -251,6 +251,7 @@ export class AppContext {
         : await crypto.Secp256k1Keypair.import(
             secrets.plcRotationKey.privateKeyHex,
           )
+    )
 
     const localViewer = LocalViewer.creator(
       accountManager,


### PR DESCRIPTION
Because environment variables are indeed not secure enough, I'm developing an alternative to the existing AWS KMS-based plcRotationKey for my own PDS, using a custom Hashicorp Vault plugin ([source](https://github.com/rdp-studio/vault-plugin-atcrypto), [Keypair implementation](https://gist.github.com/rdp-studio/dc217d70f8f8b318462138fe3bd5bf90)). During testing, I encountered an issue where the rotationKey used in the OAuth account creation process was inconsistent with my custom keypair.

This patch ensures that when plcRotationKey is overridden, it will also be correctly overridden in the AccountManager's OAuthStore.

By the way, I think this integration might make sense for people who want full self-hosting, and it would be even better if it could be integrated into PDS.