### PR TITLE
Use workspace dictionary in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.language": "en,en-US",
-  "cSpell.userWords": [
+  "cSpell.words": [
     "algs",
     "appview",
     "atproto",


### PR DESCRIPTION
I was wondering why words in my user dictionary were still being flagged as misspelled.

<img width="530" height="116" alt="cspell" src="https://github.com/user-attachments/assets/911ebc25-8d1d-4e2b-af0d-e3b55ca92b54" />
