### PR TITLE
Fix conflicting identifier for generated type utilities

### DIFF
--- a/.changeset/thirty-ducks-return.md
+++ b/.changeset/thirty-ducks-return.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-builder': patch
+---
+
+Add a `$` in front of the method type utilities to prevent name conflicts with local definitions

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -278,7 +278,7 @@ export class LexDefBuilder {
   ) {
     this.file.addTypeAlias({
       isExported: true,
-      name: 'Params',
+      name: '$Params',
       type: `l.InferMethodParams<typeof ${ref.varName}>`,
       docs: compileDocs(def.parameters?.description),
     })
@@ -286,14 +286,14 @@ export class LexDefBuilder {
     if (def.type === 'procedure') {
       this.file.addTypeAlias({
         isExported: true,
-        name: 'Input',
+        name: '$Input',
         type: `l.InferMethodInput<typeof ${ref.varName}>`,
         docs: compileDocs(def.input?.description),
       })
 
       this.file.addTypeAlias({
         isExported: true,
-        name: 'InputBody',
+        name: '$InputBody',
         type: `l.InferMethodInputBody<typeof ${ref.varName}>`,
         docs: compileDocs(def.input?.description),
       })
@@ -302,14 +302,14 @@ export class LexDefBuilder {
     if (def.type === 'procedure' || def.type === 'query') {
       this.file.addTypeAlias({
         isExported: true,
-        name: 'Output',
+        name: '$Output',
         type: `l.InferMethodOutput<typeof ${ref.varName}>`,
         docs: compileDocs(def.output?.description),
       })
 
       this.file.addTypeAlias({
         isExported: true,
-        name: 'OutputBody',
+        name: '$OutputBody',
         type: `l.InferMethodOutputBody<typeof ${ref.varName}>`,
         docs: compileDocs(def.output?.description),
       })
@@ -318,7 +318,7 @@ export class LexDefBuilder {
     if (def.type === 'subscription') {
       this.file.addTypeAlias({
         isExported: true,
-        name: 'Message',
+        name: '$Message',
         type: `l.InferSubscriptionMessage<typeof ${ref.varName}>`,
         docs: compileDocs(def.message?.description),
       })

--- a/packages/lex/lex-client/tests/client.test.ts
+++ b/packages/lex/lex-client/tests/client.test.ts
@@ -390,7 +390,7 @@ describe('Client', () => {
         const rkey = payload.rkey || nextTid()
         const cid = await cidForLex(payload.record as LexValue)
 
-        const responseBody: com.atproto.repo.createRecord.OutputBody = {
+        const responseBody: com.atproto.repo.createRecord.$OutputBody = {
           cid: cid.toString(),
           uri: `at://${payload.repo}/${payload.collection}/${rkey}`,
         }
@@ -490,7 +490,7 @@ describe('Client', () => {
 
         const cid = await cidForLex(record)
 
-        const responseBody: com.atproto.repo.getRecord.OutputBody = {
+        const responseBody: com.atproto.repo.getRecord.$OutputBody = {
           cid: cid.toString(),
           uri: `at://${repo!}/${collection!}/${rkey!}` as any,
           value: record,
@@ -536,7 +536,7 @@ describe('Client', () => {
 
         const bytes = new Uint8Array(await blob.arrayBuffer())
 
-        const responseBody: com.atproto.repo.uploadBlob.OutputBody = {
+        const responseBody: com.atproto.repo.uploadBlob.$OutputBody = {
           blob: {
             $type: 'blob',
             ref: await cidForRawBytes(bytes),

--- a/packages/lex/lex-password-session/src/password-session.test.ts
+++ b/packages/lex/lex-password-session/src/password-session.test.ts
@@ -62,7 +62,7 @@ describe(PasswordSession, () => {
       .add(com.atproto.server.createSession, async ({ input }) => {
         const session = await authVerifier.create(input.body)
 
-        const body: com.atproto.server.createSession.OutputBody = {
+        const body: com.atproto.server.createSession.$OutputBody = {
           accessJwt: session.accessJwt,
           refreshJwt: session.refreshJwt,
 
@@ -86,7 +86,7 @@ describe(PasswordSession, () => {
       .add(com.atproto.server.getSession, {
         auth: authVerifier.accessStrategy,
         handler: async ({ credentials: { session } }) => {
-          const body: com.atproto.server.getSession.OutputBody = {
+          const body: com.atproto.server.getSession.$OutputBody = {
             did: session.did,
             didDoc: {
               '@context': 'https://w3.org/ns/did/v1',
@@ -117,7 +117,7 @@ describe(PasswordSession, () => {
 
           // Note, we omit email and didDoc here to test that they are properly
           // fetched via getSession in the agent
-          const body: com.atproto.server.refreshSession.OutputBody = {
+          const body: com.atproto.server.refreshSession.$OutputBody = {
             accessJwt: session.accessJwt,
             refreshJwt: session.refreshJwt,
 

--- a/packages/lex/lex-password-session/src/password-session.ts
+++ b/packages/lex/lex-password-session/src/password-session.ts
@@ -38,7 +38,7 @@ export type DeleteFailure = XrpcFailure<
  * service URL used for authentication. Store this data securely to resume sessions
  * later without re-authenticating.
  */
-export type SessionData = com.atproto.server.createSession.OutputBody & {
+export type SessionData = com.atproto.server.createSession.$OutputBody & {
   service: string
 }
 
@@ -442,7 +442,7 @@ export class PasswordSession implements Agent {
    * ```
    */
   static async createAccount(
-    body: com.atproto.server.createAccount.InputBody,
+    body: com.atproto.server.createAccount.$InputBody,
     {
       service,
       headers,

--- a/packages/lex/lex/lexicons/com/example/subscription.json
+++ b/packages/lex/lex/lexicons/com/example/subscription.json
@@ -1,0 +1,32 @@
+{
+  "lexicon": 1,
+  "id": "com.example.subscription",
+  "defs": {
+    "main": {
+      "type": "subscription",
+      "description": "A subscription",
+      "message": {
+        "schema": {
+          "type": "union",
+          "refs": ["#message", "#params"]
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "description": "A definition with a name (message) that might cause conflict with generated utility types for subscriptions",
+      "required": ["string"],
+      "properties": {
+        "string": { "type": "string" }
+      }
+    },
+    "params": {
+      "type": "object",
+      "description": "A definition with a name (params) that might cause conflict with generated utility types for methods",
+      "required": ["integer"],
+      "properties": {
+        "integer": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/packages/lex/lex/tests/query.test.ts
+++ b/packages/lex/lex/tests/query.test.ts
@@ -104,7 +104,7 @@ describe('com.example.query', () => {
     })
 
     it('properly infers the type of default parameters', () => {
-      function returnDef(params: com.example.query.Params): number {
+      function returnDef(params: com.example.query.$Params): number {
         return params.def
       }
 


### PR DESCRIPTION
`lex-builder` will export type utilities for methods (`Params`, `Input`, `InputBody`, `Output`, `OutputBody`, `Message`) that might conflict with locally defined "defs":

<img width="574" height="441" alt="Capture d’écran 2026-02-19 à 12 29 26" src="https://github.com/user-attachments/assets/d1c45695-3a58-4582-aa6a-87d768082bcb" />

In order to avoid that situation, type utils need to be prefixed with `$`. This also allows the naming of these utilities to be consistent with other utils (like `$nsid`, `$lxm`, etc.)