### PR TITLE
Ensure service entrypoints are copied into docker containers

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -46,6 +46,8 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc-server ./packages/xrpc-server
 COPY ./packages/xrpc ./packages/xrpc
 
+COPY ./services/bsky ./services/bsky
+
 # install all deps
 RUN PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile
 # build all packages with external node_modules

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -21,6 +21,8 @@ COPY ./packages/lex/lex-data ./packages/lex/lex-data
 COPY ./packages/lex/lex-json ./packages/lex/lex-json
 COPY ./packages/syntax ./packages/syntax
 
+COPY ./services/bsync ./services/bsync
+
 # install all deps
 RUN PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile
 # build all packages with external node_modules

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -47,6 +47,8 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc ./packages/xrpc
 COPY ./packages/xrpc-server ./packages/xrpc-server
 
+COPY ./services/ozone ./services/ozone
+
 # install all deps
 RUN PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile
 # build all packages with external node_modules

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -47,6 +47,8 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc-server ./packages/xrpc-server
 COPY ./packages/xrpc ./packages/xrpc
 
+COPY ./services/pds ./services/pds
+
 # install all deps
 RUN PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile
 # build all packages with external node_modules


### PR DESCRIPTION
These were removed in #4652 which is causing a `Error: Cannot find module '/app/services/bsky/api.js'` error in deploys