### PR TITLE
Fix lint warning in `@atproto/identity`

### DIFF
--- a/.changeset/witty-pianos-sin.md
+++ b/.changeset/witty-pianos-sin.md
@@ -1,0 +1,5 @@
+---
+'@atproto/identity': patch
+---
+
+Fix lint warning

--- a/packages/identity/tests/web/server.ts
+++ b/packages/identity/tests/web/server.ts
@@ -1,12 +1,12 @@
 import http from 'node:http'
 import cors from 'cors'
-import express from 'express'
+import express, { Router, json } from 'express'
 import { DidDocument } from '../../src'
 import { DidWebDb } from './db'
 
 const DOC_PATH = '/.well-known/did.json'
 
-const routes = express.Router()
+const routes = Router()
 
 // Get DID Doc
 routes.get('/*', async (req, res) => {
@@ -60,7 +60,7 @@ export class DidWebServer {
     const app = express()
 
     app.use(cors())
-    app.use(express.json())
+    app.use(json())
     app.use((_req, res, next) => {
       res.locals.db = db
       next()


### PR DESCRIPTION
Fixes the two warnings from the lint

```
. verify:lint: /Users/msi/Github/bluesky-social/atproto/packages/identity/tests/web/server.ts
. verify:lint:    9:16  warning  Caution: `express` also has a named export `Router`. Check if you meant to write `import {Router} from 'express'` instead  import/no-named-as-default-member
. verify:lint:   63:13  warning  Caution: `express` also has a named export `json`. Check if you meant to write `import {json} from 'express'` instead      import/no-named-as-default-member
. verify:lint: ✖ 2 problems (0 errors, 2 warnings)
```