### PR TITLE
fix: preserve service fragment in pipethrough audience for scope checks

### DIFF
--- a/.changeset/fix-pipethrough-scope-audience.md
+++ b/.changeset/fix-pipethrough-scope-audience.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Fix scope check 403s for OAuth tokens using `include:` permission-set scopes with `inheritAud`. The pipethrough now preserves the service fragment (e.g. `#bsky_appview`) in the audience for scope matching, while stripping it from the JWT audience sent to the receiving service.

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -3,7 +3,11 @@ import { AuthScope } from '../../../../auth-scope'
 import { AppContext } from '../../../../context'
 import { Server } from '../../../../lexicon'
 import { ids } from '../../../../lexicon/lexicons'
-import { computeProxyTo, parseProxyInfo } from '../../../../pipethrough'
+import {
+  computeProxyTo,
+  parseProxyInfo,
+  stripFragment,
+} from '../../../../pipethrough'
 
 export default function (server: Server, ctx: AppContext) {
   server.com.atproto.moderation.createReport({
@@ -24,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
       const agent = new AtpAgent({ service: url })
       const serviceAuth = await ctx.serviceAuthHeaders(
         auth.credentials.did,
-        aud,
+        stripFragment(aud),
         ids.ComAtprotoModerationCreateReport,
       )
       const res = await agent.com.atproto.moderation.createReport(input.body, {

--- a/packages/pds/tests/proxied/proxy-header.test.ts
+++ b/packages/pds/tests/proxied/proxy-header.test.ts
@@ -72,10 +72,13 @@ describe('proxy header', () => {
       'Poorly formatted DID: foo',
     )
 
+    // The service fragment (e.g. #bsky_appview) must be preserved in the
+    // returned `did` so that scope checks match the audience from `include:`
+    // permission-set scopes using `inheritAud`.
     expect(
       parseProxyHeader(network.pds.ctx, `${proxyServer.did}#atproto_test`),
     ).resolves.toEqual({
-      did: proxyServer.did,
+      did: `${proxyServer.did}#atproto_test`,
       url: proxyServer.url,
     })
   })


### PR DESCRIPTION
## overview

if this PR is applied `parseProxyInfo` and `parseProxyHeader` now return the full service ID (`did:web:api.bsky.app#bsky_appview`) instead of the bare DID. This preserves the fragment for fine-grained oauth scoping.

notes: 
- `stripFragment` was added in order to preserve the way JWTs are passed to receiving services (bare DIDs expected)
- `createReport` need to strip the `fragment` since is also passes `parseProxyInfo`'s `aud` to `serviceAuthHeaders` 

## background

this PR came about when attempting to create fine grained scopes in favor of `transition:generic` in a [client](https://protoimsg.app) i'm working on. i noticed 403s coming back for scopes i requested and dug in to find the discrepancy in the `serviceInfo` return in the `pipethrough.ts` file. 


note: this same convention can be found in `computeProxyTo`  and where my inspiration came from 


## how to test

- `pnpm --filter @atproto/pds test -- --testPathPattern proxy-header`
  - **`parses proxy header`** — verifies `parseProxyHeader` returns `did` with fragment
  - **`proxies requests based on header`** — verifies the JWT `aud` is the bare DID (no fragment)


## screengrabs

- Verified locally against a self-hosted PDS: `getMutes`, on  other proxied appview calls return 200 with `include:` scopes (previously 403)

### proto IM PDS (with fix):
<img width="671" height="174" alt="getMinutes-pds-cahnge" src="https://github.com/user-attachments/assets/db15b946-324d-41da-bb42-aa7d875f4d42" />

### Bluesky PDS:
<img width="609" height="188" alt="getMutes-bsky" src="https://github.com/user-attachments/assets/23a1b4fb-46d8-403b-be17-4204100e0de2" />

