### PR TITLE
Fix `@atproto/sync` test flakyness

### DIFF
--- a/.changeset/social-mice-relate.md
+++ b/.changeset/social-mice-relate.md
@@ -1,0 +1,5 @@
+---
+'@atproto/sync': patch
+---
+
+Fix test flakiness

--- a/packages/sync/tests/runner.test.ts
+++ b/packages/sync/tests/runner.test.ts
@@ -107,7 +107,7 @@ describe('EventRunner utils', () => {
           complete.push({ partition, id: i })
         })
       }
-      expect(runner.partitions.size).toEqual(partitions.size)
+      expect(runner.partitions.size).toBeLessThanOrEqual(partitions.size)
       await runner.mainQueue.onIdle()
       expect(complete.length).toEqual(500)
       for (const partition of partitions) {


### PR DESCRIPTION
The `settles with many items` test in `@atproto/sync` sometimes results in the following error:

```sh
pnpm exec jest -t 'settles with many items' -- tests/runner.test.ts
```

```
 FAIL   Sync  tests/runner.test.ts
  EventRunner utils
    ConsecutiveList
      ○ skipped tracks consecutive complete items.
    MemoryRunner
      ✕ settles with many items. (17 ms)
      ○ skipped performs work in parallel across partitions, serial within a partition.
      ○ skipped limits overall concurrency.

  ● EventRunner utils › MemoryRunner › settles with many items.

    expect(received).toEqual(expected)

    Expected: 16
    Received: 15

    > 110 |       expect(runner.partitions.size).toEqual(partitions.size)
          |                                      ^
      111 |       await runner.mainQueue.onIdle()
      112 |       expect(complete.length).toEqual(500)
      113 |       for (const partition of partitions) {

      at Object.toEqual (tests/runner.test.ts:110:38)
```

The reason we run into this is that the `MemoryRunner` relies on two queuing systems internally.

If, during the test's 100 first iterations (100 corresponds to the `MemoryRunner`'s "main" concurrency processor), the random value does not take all 16 values ([0;15]) at least once, the assertion does not hold. Here is how to adapt the test's code so that it always fails:

```ts
      const runner = new MemoryRunner({ concurrency: 100 })
      const complete: { partition: number; id: number }[] = []
      const partitions = new Set<number>()
      for (let i = 0; i < 500; ++i) {
        const partition =
          i < 100 // Makes sure that value 15 is never set at beginning:
            ? Math.floor(Math.random() * 15)
            : Math.floor(Math.random() * 16)
        partitions.add(partition)
        runner.addTask(partition.toString(10), async () => {
          await wait((i % 2) * 2)
          complete.push({ partition, id: i })
        })
      }
      expect(runner.partitions.size).toEqual(partitions.size)
```

