### PR TITLE
Make sure to always trigger `refreshSession` when resuming sessions

### DIFF
--- a/.changeset/sixty-moments-cross.md
+++ b/.changeset/sixty-moments-cross.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Make sure to always trigger a `refreshSession` when `resumeSession()` is called

--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -159,7 +159,7 @@ export class AtpAgent extends Agent {
 export class CredentialSession implements SessionManager {
   public pdsUrl?: URL // The PDS URL, driven by the did doc
   public session?: AtpSessionData
-  public refreshSessionPromise: Promise<void> | undefined
+  public refreshSessionPromise?: Promise<ComAtprotoServerRefreshSession.Response>
 
   /**
    * Private {@link ComAtprotoServerNS} used to perform session management API
@@ -372,47 +372,28 @@ export class CredentialSession implements SessionManager {
    */
   async resumeSession(
     session: AtpSessionData,
-  ): Promise<
-    | ComAtprotoServerGetSession.Response
-    | ComAtprotoServerRefreshSession.Response
-  > {
+  ): Promise<ComAtprotoServerRefreshSession.Response> {
     // Protect against multiple calls to resumeSession that would trigger a
     // refresh for the same session simultaneously.
     // Ideally, this check would be based on a session identifier, but since
     // we don't have one, we will just check the refresh token.
-    if (session.refreshJwt === this.session?.refreshJwt) {
-      // Protect against refreshes in progress
-      await this.refreshSessionPromise
-
-      // Another concurrent operation may have replaced the session while we
-      // were waiting for the refresh to complete.
-      if (session.did !== this.session?.did) {
-        throw new Error('DID mismatch on resumeSession')
-      }
-
-      return this.server.getSession(undefined, {
-        headers: { authorization: `Bearer ${this.session.accessJwt}` },
-      })
+    if (session.refreshJwt !== this.session?.refreshJwt) {
+      // Set the current session, and discard any pending refresh operation..
+      this.session = session
+      this.refreshSessionPromise = undefined
     }
 
-    // Set the current session, then force a refresh, replacing any pending
-    // refresh operation.
-    this.session = session
-    this.refreshSessionPromise = undefined
+    // Ensure that the session is still valid by forcing a refresh. This will
+    // also ensure that persistSession handler is called.
+    const result = await this.refreshSession()
 
-    const promise = this._refreshSessionInner()
+    // Fool-proofing: another concurrent operation may have replaced the session
+    // while we were waiting for the refresh to complete.
+    if (session.did !== this.session?.did) {
+      throw new Error('DID mismatch on resumeSession')
+    }
 
-    // Discard any concurrent refresh, replacing it with this one.
-    this.refreshSessionPromise = promise
-      .then(
-        (): void => {},
-        (): void => {},
-      )
-      .finally(() => {
-        this.refreshSessionPromise = undefined
-      })
-
-    return promise
+    return result
   }
 
   /**
@@ -420,18 +401,23 @@ export class CredentialSession implements SessionManager {
    * - Wraps the actual implementation in a promise-guard to ensure only
    *   one refresh is attempted at a time.
    */
-  async refreshSession(): Promise<void> {
-    if (!this.session) return
+  async refreshSession(): Promise<ComAtprotoServerRefreshSession.Response> {
+    if (!this.session) {
+      throw new Error('Unexpected state: no session to refresh')
+    }
 
     // Do not refresh if we already have a refresh in progress
-    return (this.refreshSessionPromise ||= this._refreshSessionInner()
-      .then(
-        (): void => {},
-        (): void => {},
-      )
-      .finally(() => {
+    if (this.refreshSessionPromise) return this.refreshSessionPromise
+
+    const promise = this._refreshSessionInner().finally(() => {
+      if (this.refreshSessionPromise === promise) {
         this.refreshSessionPromise = undefined
-      }))
+      }
+    })
+
+    this.refreshSessionPromise = promise
+
+    return promise
   }
 
   /**


### PR DESCRIPTION
This change attempts to fix a regression introduced by https://github.com/bluesky-social/atproto/pull/4470

It takes a different approach than #4711 by always calling `refreshSession()`, which should ensure that `persistSession('update', session)` gets called as part of the resume process.

This also fixes a potential issue where a long lasting refresh operation (e.g. due to network timeouts) could override the concurrency guard (`refreshSessionPromise`) set by another operation.