### PR TITLE
Remove account status fallback to stale value

### DIFF
--- a/.changeset/five-chefs-cheer.md
+++ b/.changeset/five-chefs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Trust `status` returned from `refreshSession` and do not fall back to a potentially stale value from `this.session`.

--- a/packages/api/src/atp-agent.ts
+++ b/packages/api/src/atp-agent.ts
@@ -480,7 +480,7 @@ export class CredentialSession implements SessionManager {
         emailConfirmed: data.emailConfirmed ?? session.emailConfirmed,
         emailAuthFactor: data.emailAuthFactor ?? session.emailAuthFactor,
         active: data.active ?? session.active ?? true,
-        status: data.status ?? session.status,
+        status: data.status,
       }
 
       this._updateApiEndpoint(res.data.didDoc)


### PR DESCRIPTION
We were not clearing the stale status in this case, `status: undefined ?? session.status` was resolving to `session.status`, which was the old value.