### PR TITLE
Fix typo in chat.bsky.authFullChatClient lexicon

### DIFF
--- a/lexicons/chat/bsky/authFullChatClient.json
+++ b/lexicons/chat/bsky/authFullChatClient.json
@@ -17,10 +17,10 @@
           "inheritAud": true,
           "lxm": [
             "chat.bsky.actor.deleteAccount",
+            "chat.bsky.actor.exportAccountData",
             "chat.bsky.convo.acceptConvo",
             "chat.bsky.convo.addReaction",
             "chat.bsky.convo.deleteMessageForSelf",
-            "chat.bsky.convo.exportAccountData",
             "chat.bsky.convo.getConvo",
             "chat.bsky.convo.getConvoAvailability",
             "chat.bsky.convo.getConvoForMembers",


### PR DESCRIPTION
Change "chat.bsky.convo.exportAccountData" to
"chat.bsky.actor.exportAccountData" in an lxm of
chat.bsky.authFullChatClient#main's permission-set, as the former does not exist, but seems to be a typo of the latter.