### PR TITLE
pds & lexicon: explicit error when record exists during creation

### DIFF
--- a/.changeset/eighty-items-dig.md
+++ b/.changeset/eighty-items-dig.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Add RecordAlreadyExists error for record creation.

--- a/.changeset/loud-moose-hear.md
+++ b/.changeset/loud-moose-hear.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Handle case where record already exists during creation.

--- a/lexicons/com/atproto/repo/applyWrites.json
+++ b/lexicons/com/atproto/repo/applyWrites.json
@@ -61,6 +61,10 @@
         {
           "name": "InvalidSwap",
           "description": "Indicates that the 'swapCommit' parameter did not match current commit."
+        },
+        {
+          "name": "RecordAlreadyExists",
+          "description": "Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created."
         }
       ]
     },

--- a/lexicons/com/atproto/repo/createRecord.json
+++ b/lexicons/com/atproto/repo/createRecord.json
@@ -66,6 +66,10 @@
         {
           "name": "InvalidSwap",
           "description": "Indicates that 'swapCommit' didn't match current repo commit."
+        },
+        {
+          "name": "RecordAlreadyExists",
+          "description": "Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created."
         }
       ]
     }

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -14611,6 +14611,11 @@ export const schemaDict = {
             description:
               "Indicates that the 'swapCommit' parameter did not match current commit.",
           },
+          {
+            name: 'RecordAlreadyExists',
+            description:
+              'Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created.',
+          },
         ],
       },
       create: {
@@ -14789,6 +14794,11 @@ export const schemaDict = {
             name: 'InvalidSwap',
             description:
               "Indicates that 'swapCommit' didn't match current repo commit.",
+          },
+          {
+            name: 'RecordAlreadyExists',
+            description:
+              'Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created.',
           },
         ],
       },

--- a/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
+++ b/packages/api/src/client/types/com/atproto/repo/applyWrites.ts
@@ -56,9 +56,17 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export class RecordAlreadyExistsError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
     if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === 'RecordAlreadyExists')
+      return new RecordAlreadyExistsError(e)
   }
 
   return e

--- a/packages/api/src/client/types/com/atproto/repo/createRecord.ts
+++ b/packages/api/src/client/types/com/atproto/repo/createRecord.ts
@@ -59,9 +59,17 @@ export class InvalidSwapError extends XRPCError {
   }
 }
 
+export class RecordAlreadyExistsError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
 export function toKnownErr(e: any) {
   if (e instanceof XRPCError) {
     if (e.error === 'InvalidSwap') return new InvalidSwapError(e)
+    if (e.error === 'RecordAlreadyExists')
+      return new RecordAlreadyExistsError(e)
   }
 
   return e

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -14611,6 +14611,11 @@ export const schemaDict = {
             description:
               "Indicates that the 'swapCommit' parameter did not match current commit.",
           },
+          {
+            name: 'RecordAlreadyExists',
+            description:
+              'Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created.',
+          },
         ],
       },
       create: {
@@ -14789,6 +14794,11 @@ export const schemaDict = {
             name: 'InvalidSwap',
             description:
               "Indicates that 'swapCommit' didn't match current repo commit.",
+          },
+          {
+            name: 'RecordAlreadyExists',
+            description:
+              'Indicates that a record already exists in this repo with the given collection and rkey, so it cannot be created.',
           },
         ],
       },

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/applyWrites.ts
@@ -50,7 +50,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'InvalidSwap'
+  error?: 'InvalidSwap' | 'RecordAlreadyExists'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
+++ b/packages/ozone/src/lexicon/types/com/atproto/repo/createRecord.ts
@@ -53,7 +53,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?: 'InvalidSwap'
+  error?: 'InvalidSwap' | 'RecordAlreadyExists'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess

--- a/packages/pds/src/actor-store/repo/transactor.ts
+++ b/packages/pds/src/actor-store/repo/transactor.ts
@@ -12,6 +12,7 @@ import {
   CommitOp,
   PreparedCreate,
   PreparedWrite,
+  RecordAlreadyExistsError,
 } from '../../repo/types'
 import { BlobTransactor } from '../blob/transactor'
 import { ActorDb } from '../db'
@@ -134,6 +135,9 @@ export class RepoTransactor extends RepoReader {
         op.prev = currRecord
       }
       commitOps.push(op)
+      if (action === WriteOpAction.Create && currRecord) {
+        throw new RecordAlreadyExistsError(op.path)
+      }
       if (swapCid !== undefined) {
         if (action === WriteOpAction.Create && swapCid !== null) {
           throw new BadRecordSwapError(currRecord) // There should be no current record for a create

--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -12,6 +12,7 @@ import {
   BadCommitSwapError,
   InvalidRecordError,
   PreparedWrite,
+  RecordAlreadyExistsError,
   prepareCreate,
   prepareDelete,
   prepareUpdate,
@@ -168,9 +169,11 @@ export default function (server: Server, ctx: AppContext) {
           .catch((err) => {
             if (err instanceof BadCommitSwapError) {
               throw new InvalidRequestError(err.message, 'InvalidSwap')
-            } else {
-              throw err
             }
+            if (err instanceof RecordAlreadyExistsError) {
+              throw new InvalidRequestError(err.message, 'RecordAlreadyExists')
+            }
+            throw err
           })
 
         await ctx.sequencer.sequenceCommit(did, commit)

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -12,6 +12,7 @@ import {
   BadCommitSwapError,
   InvalidRecordError,
   PreparedCreate,
+  RecordAlreadyExistsError,
   prepareCreate,
   prepareDelete,
 } from '../../../../repo'
@@ -107,6 +108,9 @@ export default function (server: Server, ctx: AppContext) {
           .catch((err) => {
             if (err instanceof BadCommitSwapError) {
               throw new InvalidRequestError(err.message, 'InvalidSwap')
+            }
+            if (err instanceof RecordAlreadyExistsError) {
+              throw new InvalidRequestError(err.message, 'RecordAlreadyExists')
             }
             throw err
           })

--- a/packages/pds/src/repo/types.ts
+++ b/packages/pds/src/repo/types.ts
@@ -63,3 +63,9 @@ export class BadRecordSwapError extends Error {
     super(`Record was at ${cid?.toString() ?? 'null'}`)
   }
 }
+
+export class RecordAlreadyExistsError extends Error {
+  constructor(public path: string) {
+    super(`Record already exists: ${path}`)
+  }
+}

--- a/packages/pds/tests/crud.test.ts
+++ b/packages/pds/tests/crud.test.ts
@@ -394,6 +394,68 @@ describe('crud operations', () => {
     })
   })
 
+  describe('createRecord', () => {
+    it("creates a new record if it doesn't already exist", async () => {
+      const { repo } = bobAgent.api.com.atproto
+      const exists = repo.getRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.a.collection',
+        rkey: 'fresh-key',
+      })
+      await expect(exists).rejects.toThrow('Could not locate record')
+
+      const { data: create } = await repo.createRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.a.collection',
+        rkey: 'self',
+        record: {},
+      })
+      expect(create.uri).toEqual(
+        `at://${bobAgent.assertDid}/example.a.collection/self`,
+      )
+
+      const existsAfterWrite = await repo.getRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.a.collection',
+        rkey: 'self',
+      })
+      expect(existsAfterWrite.data.uri).toEqual(
+        `at://${bobAgent.assertDid}/example.a.collection/self`,
+      )
+    })
+
+    it('fails if a record already exists', async () => {
+      const { repo } = bobAgent.api.com.atproto
+      const exists = repo.getRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.b.collection',
+        rkey: 'self',
+      })
+      await expect(exists).rejects.toThrow('Could not locate record')
+
+      const { data: create } = await repo.createRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.b.collection',
+        rkey: 'self',
+        record: { value: 'before' },
+      })
+      expect(create.uri).toEqual(
+        `at://${bobAgent.assertDid}/example.b.collection/self`,
+      )
+
+      const createAfterExists = repo.createRecord({
+        repo: bobAgent.assertDid,
+        collection: 'example.b.collection',
+        rkey: 'self',
+        record: { value: 'after' },
+      })
+      await expect(createAfterExists).rejects.toMatchObject({
+        error: 'RecordAlreadyExists',
+        message: 'Record already exists: example.b.collection/self',
+      })
+    })
+  })
+
   describe('putRecord', () => {
     const profilePath = {
       collection: 'app.bsky.actor.profile',


### PR DESCRIPTION
When a record already exists during record creation (i.e. `com.atproto.repo.createRecord`) the PDS currently serves a 500.  With this change the PDS will serve an XRPC error newly specified by the `com.atproto.repo.createRecord` and `com.atproto.repo.applyWrites` lexicons.