### PR TITLE
relax `sync.listReposByCollection` to accept zero or multiple collections

### DIFF
--- a/lexicons/com/atproto/sync/listReposByCollection.json
+++ b/lexicons/com/atproto/sync/listReposByCollection.json
@@ -4,12 +4,18 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Enumerates all the DIDs which have records with the given collection NSID.",
+      "description": "Enumerates all the active DIDs which have records in any of the given collection NSIDs. If omitted, active DIDs from all collections are returned.",
       "parameters": {
         "type": "params",
-        "required": ["collection"],
+        "required": [],
         "properties": {
-          "collection": { "type": "string", "format": "nsid" },
+          "collection": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "nsid"
+            }
+          },
           "limit": {
             "type": "integer",
             "description": "Maximum size of response set. Recommend setting a large maximum (1000+) when enumerating large DID lists.",


### PR DESCRIPTION
`goat lex lint` complains with only the two (pre-existing) missing max string length warnings.

context: https://bsky.app/profile/bnewbold.net/post/3mgikph3pws27

compatibility:

- this change is api-backwards-compatible for clients: querying for a single collection has the same syntax and expected behaviour
- the semantics are clarified: `inactive` accounts are excluded from the list (not sure if collectiondir does this? it wasn't specified previously, but that might imply *all* identities)
- no maximum number of collections is defined, which could lead to incompatibilities between implementations. there are practical limits from URL length limitations, but we could probably pick a reasonable number.


motivation:

1. ability to get the full set of `active` accounts.

   sync tools like Tap periodically rescan for new repos for eventual consistency. when operating in full-network mode, Tap currently can't use the same accounts index as it does when using a signal collection to enumerate accounts.

   with this change, Tap and similar tools could get the complete list of DIDs known to the index by calling `listReposByCollection` with zero `collection` param keys.


2. ability to get a unified set of accounts from a logical `OR` of multiple signal collections.

   an app that wishes to backfill accounts based on presence in multiple different signal collections currently has to page through `listReposByCollection` once for each collection. this is annoying, and if there is signficant overlap between the sets of users, wasteful.

   with this change, mult-collection-signal tools can get a unified, deduplicated single list of active DIDs by passing multiple `collection` param keys.


downsides:

- collectiondir may not be well-positioned to implement the multi-collection case, as it orders its collection-to-DID keys by time-of-index, not by DID. (lightrail currently emits identities ordered by DID, so multiple collections can be scanned in parallel and deduplicated)


alternatives:

- make the `collection` param **optional** instead of an array; so zero-or-one collections can be specified. this would serve motivation 1 and not 2.
- make this a new query instead of changing `sync.listReposByCollection`. existing `collectiondir` instances would keep serving the existing query. at least [one](https://relay.waow.tech/xrpc/com.atproto.sync.listReposByCollection?collection=app.blento.card) non-Bluesky-operated instance of collectiondir is known to be running.
- use a magic `internal.some.nsid.for.wildcard` collection to request a wilcard (no-filter) listing of all active repos. to me this is surprising behaviour, and while nobody can claim authority over an `internal.*` NSID, you [*can* create records](https://atproto.at/viewer?uri=did%3Aplc%3A7hptvnhdyeu53xp6rz7e42iy%2Finternal.test.collection%2F3mgndglxad32t) in a PDS under them.

cc @bnewbold 