### PR TITLE
feat: change the uploadBlob endpoint to use both the ip and did

### DIFF
--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -14,6 +14,7 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
+      calcKey: ({ auth, req }) => `${auth.credentials.did}-${req.ip}`,
       durationMs: DAY,
       points: 1000,
     },


### PR DESCRIPTION
Since the uploadBlob endpoint is an authenticated endpoint we have access to the user's did and can use that as a key along with the ip for rate limits. This would help with backends that do large amounts of blob uploads on behalf of users, like PDS migration tools to help limit them being blocked globally for all users by ip to a single PDS

There is some concerns that an attacker could just rotate through did's to attack the server, but ideally registration is locked down by invite codes or a captcha to hopefully make it a bit harder for an attacker to leverage that. 