### PR TITLE
add 'app.bsky.actor.getPreferences' to authViewAll

### DIFF
--- a/lexicons/app/bsky/authViewAll.json
+++ b/lexicons/app/bsky/authViewAll.json
@@ -14,6 +14,7 @@
           "resource": "rpc",
           "inheritAud": true,
           "lxm": [
+            "app.bsky.actor.getPreferences",
             "app.bsky.actor.getProfile",
             "app.bsky.actor.getProfiles",
             "app.bsky.actor.getSuggestions",


### PR DESCRIPTION
The motivation for this is to for read-only apps to display lists and feeds which have been pinned/followed by the user. Presumably the prefs could also be used by read-only apps to apply labeling configuration.

Note that `app.bsky.notification.getPreferences` is already included in this permission set.

See: https://github.com/bluesky-social/atproto/discussions/4437#discussioncomment-16042897