### PR TITLE
pds: use entryway mock server for tests

### DIFF
--- a/.changeset/fancy-ears-train.md
+++ b/.changeset/fancy-ears-train.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Remove legacy JWT typ check.

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -83,7 +83,6 @@
     "@atproto/bsky": "workspace:^",
     "@atproto/lex-document": "workspace:^",
     "@atproto/oauth-client-browser-example": "workspace:^",
-    "@atproto/pds-entryway": "npm:@atproto/pds@0.3.0-entryway.3",
     "@did-plc/server": "^0.0.1",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -465,8 +465,8 @@ export class AuthVerifier {
       throw new AuthRequiredError(undefined, 'AuthMissing')
     }
 
-    const { payload, protectedHeader } = await jose
-      .jwtVerify(token, this._jwtKey, { ...options, typ: undefined })
+    const { payload } = await jose
+      .jwtVerify(token, this._jwtKey, options)
       .catch((cause) => {
         if (cause instanceof jose.errors.JWTExpired) {
           throw new InvalidRequestError('Token has expired', 'ExpiredToken', {
@@ -480,14 +480,6 @@ export class AuthVerifier {
           )
         }
       })
-
-    // @NOTE: the "typ" is now set in production environments, so we should be
-    // able to safely check it through jose.jwtVerify(). However, tests depend
-    // on @atproto/pds-entryway which does not set "typ" in the access tokens.
-    // For that reason, we still allow it to be missing.
-    if (protectedHeader.typ && options.typ !== protectedHeader.typ) {
-      throw new InvalidRequestError('Invalid token type', 'InvalidToken')
-    }
 
     const { sub, aud, scope, lxm, cnf, jti } = payload
 
@@ -634,7 +626,7 @@ const extractAuthType = (req: IncomingMessage): AuthType | null => {
   return type
 }
 
-const bearerTokenFromReq = (req: IncomingMessage) => {
+export const bearerTokenFromReq = (req: IncomingMessage) => {
   const [type, token] = parseAuthorizationHeader(req)
   return type === AuthType.BEARER ? token : null
 }

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -32,7 +32,11 @@ import compression from './util/compression'
 import * as wellKnown from './well-known'
 
 export * from './lexicons.js'
-export { createSecretKeyObject } from './auth-verifier'
+export {
+  bearerTokenFromReq,
+  createPublicKeyObject,
+  createSecretKeyObject,
+} from './auth-verifier'
 export * from './config'
 export { AppContext } from './context'
 export { Database } from './db'

--- a/packages/pds/tests/auth.test.ts
+++ b/packages/pds/tests/auth.test.ts
@@ -331,7 +331,9 @@ describe('auth', () => {
       password: 'password',
     })
     const refreshWithAccess = refreshSession(account.accessJwt)
-    await expect(refreshWithAccess).rejects.toThrow('Invalid token type')
+    await expect(refreshWithAccess).rejects.toThrow(
+      'Token could not be verified',
+    )
   })
 
   it('expired refresh token cannot be used to refresh a session.', async () => {

--- a/packages/pds/tests/entryway-mock.ts
+++ b/packages/pds/tests/entryway-mock.ts
@@ -10,13 +10,15 @@ import { AtpAgent } from '@atproto/api'
 import { getVerificationMaterial } from '@atproto/common'
 import { Secp256k1Keypair, randomStr } from '@atproto/crypto'
 import { IdResolver, getDidKeyFromMultibase } from '@atproto/identity'
+import { DidString, HandleString } from '@atproto/syntax'
 import {
   AuthRequiredError,
+  createServer,
   parseReqNsid,
   verifyJwt as verifyServiceJwt,
 } from '@atproto/xrpc-server'
 import { bearerTokenFromReq, createPublicKeyObject } from '../src/auth-verifier'
-import { createServer } from '../src/lexicon'
+import { com } from '../src/lexicons/index.js'
 
 interface Account {
   did: string
@@ -163,7 +165,7 @@ export class MockEntryway {
 
     const server = createServer()
 
-    server.com.atproto.server.createAccount({
+    server.add(com.atproto.server.createAccount, {
       handler: async ({ input }) => {
         const { email, handle } = input.body
 
@@ -222,7 +224,7 @@ export class MockEntryway {
         return {
           encoding: 'application/json' as const,
           body: {
-            did: plcCreate.did,
+            did: plcCreate.did as DidString,
             handle,
             accessJwt,
             refreshJwt,
@@ -231,7 +233,7 @@ export class MockEntryway {
       },
     })
 
-    server.com.atproto.server.getSession({
+    server.add(com.atproto.server.getSession, {
       auth: accessOrServiceAuth,
       handler: async ({ auth }) => {
         const account = accounts.get(auth.credentials.did)
@@ -243,8 +245,8 @@ export class MockEntryway {
         return {
           encoding: 'application/json' as const,
           body: {
-            did: account.did,
-            handle: account.handle,
+            did: account.did as DidString,
+            handle: account.handle as HandleString,
             email: account.email,
             emailConfirmed: false,
           },
@@ -252,47 +254,38 @@ export class MockEntryway {
       },
     })
 
-    server.com.atproto.identity.updateHandle({
+    server.add(com.atproto.identity.updateHandle, {
       auth: serviceAuth,
       handler: async ({ auth, input }) => {
         // The PDS sends { did, handle } where did is the target user
-        try {
-          const body = input.body as { did?: string; handle: string }
-          const targetDid = body.did || auth.credentials.did
-          const newHandle = body.handle
+        const body = input.body as { did?: string; handle: string }
+        const targetDid = body.did || auth.credentials.did
+        const newHandle = body.handle
 
-          // Update handle in PLC
-          await plcClient.updateHandle(
-            targetDid,
-            opts.plcRotationKey,
-            newHandle,
-          )
+        // Update handle in PLC
+        await plcClient.updateHandle(targetDid, opts.plcRotationKey, newHandle)
 
-          // Update in-memory account
-          const account = accounts.get(targetDid)
-          if (account) {
-            account.handle = newHandle
-          }
-
-          // Notify PDS via admin endpoint
-          const adminAuth = Buffer.from(`admin:${opts.adminPassword}`).toString(
-            'base64',
-          )
-          await pdsAgent.com.atproto.admin.updateAccountHandle(
-            { did: targetDid, handle: newHandle },
-            {
-              headers: { authorization: `Basic ${adminAuth}` },
-              encoding: 'application/json',
-            },
-          )
-        } catch (err) {
-          console.error(err)
-          throw err
+        // Update in-memory account
+        const account = accounts.get(targetDid)
+        if (account) {
+          account.handle = newHandle
         }
+
+        // Notify PDS via admin endpoint
+        const adminAuth = Buffer.from(`admin:${opts.adminPassword}`).toString(
+          'base64',
+        )
+        await pdsAgent.com.atproto.admin.updateAccountHandle(
+          { did: targetDid, handle: newHandle },
+          {
+            headers: { authorization: `Basic ${adminAuth}` },
+            encoding: 'application/json',
+          },
+        )
       },
     })
 
-    const httpServer = server.xrpc.listen(opts.port)
+    const httpServer = server.listen(opts.port)
     const terminator = createHttpTerminator({ server: httpServer })
 
     const instance = new MockEntryway(httpServer, terminator, idResolver, opts)

--- a/packages/pds/tests/entryway-mock.ts
+++ b/packages/pds/tests/entryway-mock.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert'
+import { createPrivateKey } from 'node:crypto'
+import * as http from 'node:http'
+import * as plcLib from '@did-plc/lib'
+import { HttpTerminator, createHttpTerminator } from 'http-terminator'
+import * as jose from 'jose'
+import KeyEncoder from 'key-encoder'
+import * as ui8 from 'uint8arrays'
+import { AtpAgent } from '@atproto/api'
+import { getVerificationMaterial } from '@atproto/common'
+import { Secp256k1Keypair, randomStr } from '@atproto/crypto'
+import { IdResolver, getDidKeyFromMultibase } from '@atproto/identity'
+import {
+  AuthRequiredError,
+  parseReqNsid,
+  verifyJwt as verifyServiceJwt,
+} from '@atproto/xrpc-server'
+import { bearerTokenFromReq, createPublicKeyObject } from '../src/auth-verifier'
+import { createServer } from '../src/lexicon'
+
+interface Account {
+  did: string
+  handle: string
+  email?: string
+}
+
+interface MockEntrywayOpts {
+  port: number
+  serviceDid: string
+  plcUrl: string
+  pdsUrl: string
+  pdsDid: string
+  adminPassword: string
+  jwtSigningKey: Secp256k1Keypair
+  plcRotationKey: Secp256k1Keypair
+}
+
+type AccessAuthResult = { credentials: { did: string; type: 'access' } }
+type ServiceAuthResult = { credentials: { did: string; type: 'service' } }
+
+export class MockEntryway {
+  public url: string
+  public serviceDid: string
+  public plcRotationKey: Secp256k1Keypair
+  public idResolver: IdResolver
+
+  private server: http.Server
+  private terminator: HttpTerminator
+  private accounts = new Map<string, Account>()
+
+  private constructor(
+    server: http.Server,
+    terminator: HttpTerminator,
+    idResolver: IdResolver,
+    opts: MockEntrywayOpts,
+  ) {
+    this.server = server
+    this.terminator = terminator
+    this.url = `http://localhost:${opts.port}`
+    this.serviceDid = opts.serviceDid
+    this.plcRotationKey = opts.plcRotationKey
+    this.idResolver = idResolver
+  }
+
+  static async create(opts: MockEntrywayOpts): Promise<MockEntryway> {
+    const keyEncoder = new KeyEncoder('secp256k1')
+    const privateKeyHex = ui8.toString(await opts.jwtSigningKey.export(), 'hex')
+    const privatePem = keyEncoder.encodePrivate(privateKeyHex, 'raw', 'pem')
+    const jwtPrivateKey = createPrivateKey({ format: 'pem', key: privatePem })
+    const jwtPublicKey = createPublicKeyObject(
+      opts.jwtSigningKey.publicKeyStr('hex'),
+    )
+
+    const plcClient = new plcLib.Client(opts.plcUrl)
+    const pdsAgent = new AtpAgent({ service: opts.pdsUrl })
+    const idResolver = new IdResolver({ plcUrl: opts.plcUrl })
+
+    const accounts = new Map<string, Account>()
+
+    const getSigningKey = async (
+      iss: string,
+      forceRefresh: boolean,
+    ): Promise<string> => {
+      const [did, serviceId] = iss.split('#')
+      assert(!serviceId, 'no service id expected in iss claim')
+      const didDoc = await idResolver.did.resolve(did, forceRefresh)
+      if (!didDoc) {
+        throw new AuthRequiredError(`could not resolve did: ${did}`)
+      }
+      const parsedKey = getVerificationMaterial(didDoc, 'atproto')
+      if (!parsedKey) {
+        throw new AuthRequiredError('missing or bad key in did doc')
+      }
+      const didKey = getDidKeyFromMultibase(parsedKey)
+      if (!didKey) {
+        throw new AuthRequiredError('missing or bad key in did doc')
+      }
+      return didKey
+    }
+
+    const bearerToken = (req: http.IncomingMessage): string => {
+      const token = bearerTokenFromReq(req)
+      if (!token) {
+        throw new AuthRequiredError('missing bearer token')
+      }
+      return token
+    }
+
+    // Auth: verify user access token (typ: 'at+jwt') signed by entryway
+    const accessAuth = async ({
+      req,
+    }: {
+      req: http.IncomingMessage
+    }): Promise<AccessAuthResult> => {
+      try {
+        const token = bearerToken(req)
+        const { payload } = await jose.jwtVerify(token, jwtPublicKey)
+        if (!payload.sub) {
+          throw new AuthRequiredError('missing sub in token')
+        }
+        return { credentials: { did: payload.sub, type: 'access' } }
+      } catch (err) {
+        console.log(err)
+        throw err
+      }
+    }
+
+    // Auth: verify service auth token from PDS (no typ / typ !== 'at+jwt')
+    const serviceAuth = async ({
+      req,
+    }: {
+      req: http.IncomingMessage
+    }): Promise<ServiceAuthResult> => {
+      try {
+        const token = bearerToken(req)
+        const nsid = parseReqNsid(req)
+        const payload = await verifyServiceJwt(
+          token,
+          opts.serviceDid,
+          nsid,
+          getSigningKey,
+        )
+        return { credentials: { did: payload.iss, type: 'service' } }
+      } catch (err) {
+        console.log(err)
+        throw err
+      }
+    }
+
+    // Auth: accept either access token or service auth
+    const accessOrServiceAuth = async ({
+      req,
+    }: {
+      req: http.IncomingMessage
+    }): Promise<AccessAuthResult | ServiceAuthResult> => {
+      const token = bearerToken(req)
+      const { typ } = jose.decodeProtectedHeader(token)
+      if (typ === 'at+jwt') {
+        return accessAuth({ req })
+      }
+      return serviceAuth({ req })
+    }
+
+    const server = createServer()
+
+    server.com.atproto.server.createAccount({
+      handler: async ({ input }) => {
+        const { email, handle } = input.body
+
+        // Reserve a signing key on the PDS
+        const {
+          data: { signingKey },
+        } = await pdsAgent.com.atproto.server.reserveSigningKey({})
+
+        // Create PLC operation
+        const plcCreate = await plcLib.createOp({
+          signingKey,
+          rotationKeys: [opts.plcRotationKey.did()],
+          handle,
+          pds: opts.pdsUrl,
+          signer: opts.plcRotationKey,
+        })
+
+        // Create account on PDS (no auth needed — userServiceAuthOptional)
+        await pdsAgent.com.atproto.server.createAccount({
+          did: plcCreate.did,
+          handle,
+          plcOp: plcCreate.op,
+        })
+
+        // Store account in memory
+        accounts.set(plcCreate.did, {
+          did: plcCreate.did,
+          handle,
+          email,
+        })
+
+        // Sign access + refresh JWTs
+        const now = Math.floor(Date.now() / 1000)
+        const accessJwt = await new jose.SignJWT({
+          scope: 'com.atproto.access',
+        })
+          .setProtectedHeader({ alg: 'ES256K', typ: 'at+jwt' })
+          .setSubject(plcCreate.did)
+          .setAudience(opts.pdsDid)
+          .setIssuedAt(now)
+          .setExpirationTime(now + 60 * 60)
+          .setJti(randomStr(16, 'base32'))
+          .sign(jwtPrivateKey)
+
+        const refreshJwt = await new jose.SignJWT({
+          scope: 'com.atproto.refresh',
+        })
+          .setProtectedHeader({ alg: 'ES256K', typ: 'at+jwt' })
+          .setSubject(plcCreate.did)
+          .setAudience(opts.pdsDid)
+          .setIssuedAt(now)
+          .setExpirationTime(now + 90 * 24 * 60 * 60)
+          .setJti(randomStr(16, 'base32'))
+          .sign(jwtPrivateKey)
+
+        return {
+          encoding: 'application/json' as const,
+          body: {
+            did: plcCreate.did,
+            handle,
+            accessJwt,
+            refreshJwt,
+          },
+        }
+      },
+    })
+
+    server.com.atproto.server.getSession({
+      auth: accessOrServiceAuth,
+      handler: async ({ auth }) => {
+        const account = accounts.get(auth.credentials.did)
+        if (!account) {
+          throw new Error(
+            `Could not find account for DID: ${auth.credentials.did}`,
+          )
+        }
+        return {
+          encoding: 'application/json' as const,
+          body: {
+            did: account.did,
+            handle: account.handle,
+            email: account.email,
+            emailConfirmed: false,
+          },
+        }
+      },
+    })
+
+    server.com.atproto.identity.updateHandle({
+      auth: serviceAuth,
+      handler: async ({ auth, input }) => {
+        // The PDS sends { did, handle } where did is the target user
+        try {
+          const body = input.body as { did?: string; handle: string }
+          const targetDid = body.did || auth.credentials.did
+          const newHandle = body.handle
+
+          // Update handle in PLC
+          await plcClient.updateHandle(
+            targetDid,
+            opts.plcRotationKey,
+            newHandle,
+          )
+
+          // Update in-memory account
+          const account = accounts.get(targetDid)
+          if (account) {
+            account.handle = newHandle
+          }
+
+          // Notify PDS via admin endpoint
+          const adminAuth = Buffer.from(`admin:${opts.adminPassword}`).toString(
+            'base64',
+          )
+          await pdsAgent.com.atproto.admin.updateAccountHandle(
+            { did: targetDid, handle: newHandle },
+            {
+              headers: { authorization: `Basic ${adminAuth}` },
+              encoding: 'application/json',
+            },
+          )
+        } catch (err) {
+          console.error(err)
+          throw err
+        }
+      },
+    })
+
+    const httpServer = server.xrpc.listen(opts.port)
+    const terminator = createHttpTerminator({ server: httpServer })
+
+    const instance = new MockEntryway(httpServer, terminator, idResolver, opts)
+    instance.accounts = accounts
+
+    return instance
+  }
+
+  getAccount(did: string): Account | undefined {
+    return this.accounts.get(did)
+  }
+
+  async destroy(): Promise<void> {
+    await this.terminator.terminate()
+  }
+}

--- a/packages/pds/tests/entryway-mock.ts
+++ b/packages/pds/tests/entryway-mock.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { createPrivateKey } from 'node:crypto'
 import * as http from 'node:http'
 import * as plcLib from '@did-plc/lib'
@@ -21,8 +20,8 @@ import { bearerTokenFromReq, createPublicKeyObject } from '../src/auth-verifier'
 import { com } from '../src/lexicons/index.js'
 
 interface Account {
-  did: string
-  handle: string
+  did: DidString
+  handle: HandleString
   email?: string
 }
 
@@ -84,7 +83,9 @@ export class MockEntryway {
       forceRefresh: boolean,
     ): Promise<string> => {
       const [did, serviceId] = iss.split('#')
-      assert(!serviceId, 'no service id expected in iss claim')
+      if (serviceId) {
+        throw new AuthRequiredError('no service id expected in iss claim')
+      }
       const didDoc = await idResolver.did.resolve(did, forceRefresh)
       if (!didDoc) {
         throw new AuthRequiredError(`could not resolve did: ${did}`)
@@ -116,7 +117,13 @@ export class MockEntryway {
     }): Promise<AccessAuthResult> => {
       try {
         const token = bearerToken(req)
-        const { payload } = await jose.jwtVerify(token, jwtPublicKey)
+        const { protectedHeader, payload } = await jose.jwtVerify(
+          token,
+          jwtPublicKey,
+        )
+        if (protectedHeader.typ !== 'at+jwt') {
+          throw new AuthRequiredError('expected typ: at+jwt')
+        }
         if (!payload.sub) {
           throw new AuthRequiredError('missing sub in token')
         }
@@ -135,6 +142,12 @@ export class MockEntryway {
     }): Promise<ServiceAuthResult> => {
       try {
         const token = bearerToken(req)
+        const { typ } = jose.decodeProtectedHeader(token)
+        if (typ === 'at+jwt') {
+          throw new AuthRequiredError(
+            'expected service auth: typ must not be at+jwt',
+          )
+        }
         const nsid = parseReqNsid(req)
         const payload = await verifyServiceJwt(
           token,
@@ -192,7 +205,7 @@ export class MockEntryway {
 
         // Store account in memory
         accounts.set(plcCreate.did, {
-          did: plcCreate.did,
+          did: plcCreate.did as DidString,
           handle,
           email,
         })
@@ -245,8 +258,8 @@ export class MockEntryway {
         return {
           encoding: 'application/json' as const,
           body: {
-            did: account.did as DidString,
-            handle: account.handle as HandleString,
+            did: account.did,
+            handle: account.handle,
             email: account.email,
             emailConfirmed: false,
           },
@@ -258,7 +271,7 @@ export class MockEntryway {
       auth: serviceAuth,
       handler: async ({ auth, input }) => {
         // The PDS sends { did, handle } where did is the target user
-        const body = input.body as { did?: string; handle: string }
+        const body = input.body as typeof input.body & { did?: string }
         const targetDid = body.did || auth.credentials.did
         const newHandle = body.handle
 

--- a/packages/pds/tests/entryway.test.ts
+++ b/packages/pds/tests/entryway.test.ts
@@ -1,22 +1,17 @@
 import assert from 'node:assert'
-import * as os from 'node:os'
-import * as path from 'node:path'
 import * as plcLib from '@did-plc/lib'
 import getPort from 'get-port'
-import { decodeJwt } from 'jose'
-import * as ui8 from 'uint8arrays'
 import { AtpAgent } from '@atproto/api'
-import { Secp256k1Keypair, randomStr } from '@atproto/crypto'
+import { Secp256k1Keypair } from '@atproto/crypto'
 import { SeedClient, TestPds, TestPlc, mockResolvers } from '@atproto/dev-env'
 import { isDidString } from '@atproto/lex'
-import * as pdsEntryway from '@atproto/pds-entryway'
 import { DidString } from '@atproto/syntax'
-import { parseReqNsid } from '@atproto/xrpc-server'
+import { MockEntryway } from './entryway-mock'
 
 describe('entryway', () => {
   let plc: TestPlc
   let pds: TestPds
-  let entryway: pdsEntryway.PDS
+  let entryway: MockEntryway
   let pdsAgent: AtpAgent
   let entrywayAgent: AtpAgent
   let alice: DidString
@@ -30,7 +25,7 @@ describe('entryway', () => {
     pds = await TestPds.create({
       entrywayUrl: `http://localhost:${entrywayPort}`,
       entrywayDid: 'did:example:entryway',
-      entrywayJwtVerifyKeyK256PublicKeyHex: getPublicHex(jwtSigningKey),
+      entrywayJwtVerifyKeyK256PublicKeyHex: jwtSigningKey.publicKeyStr('hex'),
       entrywayPlcRotationKey: plcRotationKey.did(),
       adminPassword: 'admin-pass',
       serviceHandleDomains: [],
@@ -38,29 +33,21 @@ describe('entryway', () => {
       serviceDid: 'did:example:pds',
       inviteRequired: false,
     })
-    entryway = await createEntryway({
-      dbPostgresSchema: 'entryway',
+    entryway = await MockEntryway.create({
       port: entrywayPort,
-      adminPassword: 'admin-pass',
-      jwtSigningKeyK256PrivateKeyHex: await getPrivateHex(jwtSigningKey),
-      plcRotationKeyK256PrivateKeyHex: await getPrivateHex(plcRotationKey),
-      inviteRequired: false,
       serviceDid: 'did:example:entryway',
-      didPlcUrl: plc.url,
+      plcUrl: plc.url,
+      pdsUrl: pds.url,
+      pdsDid: 'did:example:pds',
+      adminPassword: 'admin-pass',
+      jwtSigningKey,
+      plcRotationKey,
     })
     mockResolvers(pds.ctx.idResolver, pds)
-    mockResolvers(entryway.ctx.idResolver, pds)
-    await entryway.ctx.db.db
-      .insertInto('pds')
-      .values({
-        did: pds.ctx.cfg.service.did,
-        host: new URL(pds.ctx.cfg.service.publicUrl).host,
-        weight: 1,
-      })
-      .execute()
+    mockResolvers(entryway.idResolver, pds)
     pdsAgent = pds.getAgent()
     entrywayAgent = new AtpAgent({
-      service: entryway.ctx.cfg.service.publicUrl,
+      service: entryway.url,
     })
   })
 
@@ -110,9 +97,7 @@ describe('entryway', () => {
     const doc = await pds.ctx.idResolver.did.resolve(alice)
     const handleToDid = await pds.ctx.idResolver.handle.resolve('alice2.test')
     const accountFromPds = await pds.ctx.accountManager.getAccount(alice)
-    const accountFromEntryway = await entryway.ctx.services
-      .account(entryway.ctx.db)
-      .getAccount(alice)
+    const accountFromEntryway = entryway.getAccount(alice)
     expect(doc?.alsoKnownAs).toEqual(['at://alice2.test'])
     expect(handleToDid).toEqual(alice)
     expect(accountFromPds?.handle).toEqual('alice2.test')
@@ -128,13 +113,10 @@ describe('entryway', () => {
         'com.atproto.identity.updateHandle',
       ),
     )
-    const doc = await entryway.ctx.idResolver.did.resolve(alice)
-    const handleToDid =
-      await entryway.ctx.idResolver.handle.resolve('alice3.test')
+    const doc = await entryway.idResolver.did.resolve(alice)
+    const handleToDid = await entryway.idResolver.handle.resolve('alice3.test')
     const accountFromPds = await pds.ctx.accountManager.getAccount(alice)
-    const accountFromEntryway = await entryway.ctx.services
-      .account(entryway.ctx.db)
-      .getAccount(alice)
+    const accountFromEntryway = entryway.getAccount(alice)
     expect(doc?.alsoKnownAs).toEqual(['at://alice3.test'])
     expect(handleToDid).toEqual(alice)
     expect(accountFromPds?.handle).toEqual('alice3.test')
@@ -148,7 +130,7 @@ describe('entryway', () => {
     const rotationKey = await Secp256k1Keypair.create()
     const plcCreate = await plcLib.createOp({
       signingKey,
-      rotationKeys: [rotationKey.did(), entryway.ctx.plcRotationKey.did()],
+      rotationKeys: [rotationKey.did(), entryway.plcRotationKey.did()],
       handle: 'weirdalice.test',
       pds: pds.ctx.cfg.service.publicUrl,
       signer: rotationKey,
@@ -161,67 +143,3 @@ describe('entryway', () => {
     await expect(tryCreateAccount).rejects.toThrow('invalid plc operation')
   })
 })
-
-const createEntryway = async (
-  config: pdsEntryway.ServerEnvironment & {
-    adminPassword: string
-    jwtSigningKeyK256PrivateKeyHex: string
-    plcRotationKeyK256PrivateKeyHex: string
-  },
-) => {
-  const signingKey = await Secp256k1Keypair.create({ exportable: true })
-  const recoveryKey = await Secp256k1Keypair.create({ exportable: true })
-  const env: pdsEntryway.ServerEnvironment = {
-    isEntryway: true,
-    recoveryDidKey: recoveryKey.did(),
-    serviceHandleDomains: ['.test'],
-    dbPostgresUrl: process.env.DB_POSTGRES_URL,
-    blobstoreDiskLocation: path.join(os.tmpdir(), randomStr(8, 'base32')),
-    bskyAppViewUrl: 'https://appview.invalid',
-    bskyAppViewDid: 'did:example:invalid',
-    bskyAppViewCdnUrlPattern: 'http://cdn.appview.com/%s/%s/%s',
-    jwtSecret: randomStr(8, 'base32'),
-    repoSigningKeyK256PrivateKeyHex: await getPrivateHex(signingKey),
-    modServiceUrl: 'https://mod.invalid',
-    modServiceDid: 'did:example:invalid',
-    ...config,
-  }
-  const cfg = pdsEntryway.envToCfg(env)
-  const secrets = pdsEntryway.envToSecrets(env)
-  const server = await pdsEntryway.PDS.create(cfg, secrets)
-  await server.ctx.db.migrateToLatestOrThrow()
-  await server.start()
-  // patch entryway access token verification to handle internal service auth pds -> entryway
-  const origValidateAccessToken =
-    server.ctx.authVerifier.validateAccessToken.bind(server.ctx.authVerifier)
-  server.ctx.authVerifier.validateAccessToken = async (req, scopes) => {
-    const jwt = req.headers.authorization?.replace('Bearer ', '') ?? ''
-    const claims = decodeJwt(jwt)
-    if (claims.aud === 'did:example:entryway') {
-      assert(claims.lxm === parseReqNsid(req), 'bad lxm claim in service auth')
-      assert(claims.aud, 'missing aud claim in service auth')
-      assert(claims.iss, 'missing iss claim in service auth')
-      return {
-        artifacts: jwt,
-        credentials: {
-          type: 'access',
-          scope: 'com.atproto.access' as any,
-          audience: claims.aud,
-          did: claims.iss,
-        },
-      }
-    }
-    return origValidateAccessToken(req, scopes)
-  }
-  // @TODO temp hack because entryway teardown calls signupActivator.run() by mistake
-  server.ctx.signupActivator.run = server.ctx.signupActivator.destroy
-  return server
-}
-
-const getPublicHex = (key: Secp256k1Keypair) => {
-  return key.publicKeyStr('hex')
-}
-
-const getPrivateHex = async (key: Secp256k1Keypair) => {
-  return ui8.toString(await key.export(), 'hex')
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1904,9 +1904,6 @@ importers:
       '@atproto/oauth-client-browser-example':
         specifier: workspace:^
         version: link:../oauth/oauth-client-browser-example
-      '@atproto/pds-entryway':
-        specifier: npm:@atproto/pds@0.3.0-entryway.3
-        version: /@atproto/pds@0.3.0-entryway.3
       '@did-plc/server':
         specifier: ^0.0.1
         version: 0.0.1
@@ -2289,59 +2286,6 @@ packages:
       multiformats: 9.9.0
       one-webcrypto: 1.0.3
       uint8arrays: 3.0.0
-
-  /@atproto/pds@0.3.0-entryway.3:
-    resolution: {integrity: sha512-hc/KcBgFjSfrnNgrc9vx/QaCov79cXbRRQEWrAt/rdMLhcFEGCydN7ukddjOiLkLdhDqywSHrLOEbqg+MReQXw==}
-    dependencies:
-      '@atproto/api': link:packages/api
-      '@atproto/aws': link:packages/aws
-      '@atproto/common': link:packages/common
-      '@atproto/crypto': link:packages/crypto
-      '@atproto/identity': link:packages/identity
-      '@atproto/lexicon': link:packages/lexicon
-      '@atproto/repo': link:packages/repo
-      '@atproto/syntax': link:packages/syntax
-      '@atproto/xrpc': link:packages/xrpc
-      '@atproto/xrpc-server': link:packages/xrpc-server
-      '@bufbuild/protobuf': 1.6.0
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect-node': 1.3.0(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@did-plc/lib': 0.0.1
-      better-sqlite3: 9.6.0
-      bytes: 3.1.2
-      compression: 1.7.4
-      cors: 2.8.5
-      disposable-email: 0.2.3
-      express: 4.18.2
-      express-async-errors: 3.1.1(express@4.18.2)
-      file-type: 16.5.4
-      form-data: 4.0.0
-      handlebars: 4.7.8
-      http-errors: 2.0.0
-      http-terminator: 3.2.0
-      ioredis: 5.3.2
-      jose: 4.15.4
-      key-encoder: 2.0.3
-      kysely: 0.22.0
-      multiformats: 9.9.0
-      nodemailer: 6.8.0
-      nodemailer-html-to-text: 3.2.0
-      p-queue: 6.6.2
-      pg: 8.10.0
-      pino: 8.21.0
-      pino-http: 8.6.1
-      rate-limiter-flexible: 2.4.1
-      sharp: 0.32.6
-      twilio: 4.21.0
-      typed-emitter: 2.1.0
-      uint8arrays: 3.0.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - debug
-      - pg-native
-      - supports-color
-    dev: true
 
   /@aws-crypto/crc32@5.2.0:
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -3344,7 +3288,6 @@ packages:
   /@babel/helper-validator-identifier@7.28.5:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.25.9:
     resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
@@ -3400,7 +3343,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.28.5
-    dev: true
 
   /@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.26.9):
     resolution: {integrity: sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==}
@@ -4222,9 +4164,9 @@ packages:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.4
+      '@babel/types': 7.28.5
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4249,7 +4191,6 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -4581,6 +4522,7 @@ packages:
       '@bufbuild/protobuf': 1.6.0
       '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
       undici: 5.28.4
+    dev: false
 
   /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.6.0):
     resolution: {integrity: sha512-kTeWxJnLLtxKc2ZSDN0rIBgwfP8RwcLknthX4AKlIAmN9ZC4gGnCbwp+3BKcP/WH5c8zGBAWqSY3zeqCM+ah7w==}
@@ -5634,6 +5576,7 @@ packages:
   /@fastify/busboy@2.1.0:
     resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
     engines: {node: '>=14'}
+    dev: false
 
   /@fastify/deepmerge@1.3.0:
     resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
@@ -5962,6 +5905,7 @@ packages:
 
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: false
 
   /@ipld/dag-cbor@7.0.3:
     resolution: {integrity: sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==}
@@ -8582,6 +8526,7 @@ packages:
 
   /@tokenizer/token@0.3.0:
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+    dev: false
 
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -9784,12 +9729,6 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  /bare-events@2.5.0:
-    resolution: {integrity: sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     requiresBuild: true
@@ -9798,18 +9737,6 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
-    dev: true
-    optional: true
-
-  /bare-fs@2.3.5:
-    resolution: {integrity: sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==}
-    requiresBuild: true
-    dependencies:
-      bare-events: 2.5.0
-      bare-path: 2.1.3
-      bare-stream: 2.3.0
-    transitivePeerDependencies:
-      - bare-abort-controller
     dev: true
     optional: true
 
@@ -9833,24 +9760,10 @@ packages:
     dev: true
     optional: true
 
-  /bare-os@2.4.4:
-    resolution: {integrity: sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /bare-os@3.6.2:
     resolution: {integrity: sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==}
     engines: {bare: '>=1.14.0'}
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /bare-path@2.1.3:
-    resolution: {integrity: sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==}
-    requiresBuild: true
-    dependencies:
-      bare-os: 2.4.4
     dev: true
     optional: true
 
@@ -9859,17 +9772,6 @@ packages:
     requiresBuild: true
     dependencies:
       bare-os: 3.6.2
-    dev: true
-    optional: true
-
-  /bare-stream@2.3.0:
-    resolution: {integrity: sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==}
-    requiresBuild: true
-    dependencies:
-      b4a: 1.6.7
-      streamx: 2.20.1
-    transitivePeerDependencies:
-      - bare-abort-controller
     dev: true
     optional: true
 
@@ -9945,6 +9847,7 @@ packages:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2
+    dev: false
 
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -9963,6 +9866,7 @@ packages:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
     dependencies:
       file-uri-to-path: 1.0.0
+    dev: false
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -10077,10 +9981,6 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
 
-  /buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-    dev: true
-
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -10110,6 +10010,7 @@ packages:
   /bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -10268,6 +10169,7 @@ packages:
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: false
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -10381,6 +10283,7 @@ packages:
   /cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -10422,6 +10325,7 @@ packages:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
+    dev: false
 
   /color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -10434,6 +10338,7 @@ packages:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+    dev: false
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -10484,6 +10389,7 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /compression@1.7.4:
     resolution: {integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==}
@@ -10498,6 +10404,7 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -10704,10 +10611,6 @@ packages:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
     dev: true
 
-  /dayjs@1.11.10:
-    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
-    dev: true
-
   /dc-polyfill@0.1.3:
     resolution: {integrity: sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==}
     engines: {node: '>=12.17'}
@@ -10846,6 +10749,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       mimic-response: 3.1.0
+    dev: false
 
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -10854,6 +10758,7 @@ packages:
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+    dev: false
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -10921,6 +10826,7 @@ packages:
   /denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+    dev: false
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -10982,10 +10888,6 @@ packages:
     resolution: {integrity: sha512-L1cn+cZhKmxUwixH8n+n0HG+WbCz+LF4coyT6yMh930tpkD90ZWFx3A9dHIdFMVM745saaeNGYScIEstm3Y3yg==}
     dev: false
 
-  /disposable-email@0.2.3:
-    resolution: {integrity: sha512-gkBQQ5Res431ZXqLlAafrXHizG7/1FWmi8U2RTtriD78Vc10HhBUvdJun3R4eSF0KRIQQJs+wHlxjkED/Hr1EQ==}
-    dev: true
-
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -11011,15 +10913,18 @@ packages:
       domelementtype: 2.3.0
       domhandler: 4.3.1
       entities: 2.2.0
+    dev: false
 
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
 
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
+    dev: false
 
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -11027,6 +10932,7 @@ packages:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+    dev: false
 
   /dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -11067,12 +10973,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  /ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: true
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -11153,6 +11053,7 @@ packages:
 
   /entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: false
 
   /env-editor@0.4.2:
     resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
@@ -11950,6 +11851,7 @@ packages:
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
 
   /events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -11992,6 +11894,7 @@ packages:
   /expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+    dev: false
 
   /expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -12389,9 +12292,11 @@ packages:
       readable-web-to-node-stream: 3.0.2
       strtok3: 6.3.0
       token-types: 4.2.1
+    dev: false
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    dev: false
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -12544,6 +12449,7 @@ packages:
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    dev: false
 
   /fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
@@ -12746,6 +12652,7 @@ packages:
 
   /github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -12992,6 +12899,7 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: false
 
   /help-me@4.2.0:
     resolution: {integrity: sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==}
@@ -13047,6 +12955,7 @@ packages:
       he: 1.2.0
       htmlparser2: 6.1.0
       minimist: 1.2.8
+    dev: false
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -13055,6 +12964,7 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
+    dev: false
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -13245,6 +13155,7 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: false
 
   /inquirer@7.3.3:
     resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
@@ -13308,6 +13219,7 @@ packages:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -13351,6 +13263,7 @@ packages:
 
   /is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
 
   /is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -14350,37 +14263,6 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
-    engines: {node: '>=12', npm: '>=6'}
-    dependencies:
-      jws: 3.2.2
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.6.3
-    dev: true
-
-  /jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    dev: true
-
-  /jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
-    dependencies:
-      jwa: 1.4.1
-      safe-buffer: 5.2.1
-    dev: true
-
   /key-encoder@2.0.3:
     resolution: {integrity: sha512-fgBtpAGIr/Fy5/+ZLQZIPPhsZEcbSlYu/Wu96tNDFNSjSACw5lEIOFeaVdQ/iwrb8oxjlWi6wmWdH76hV6GZjg==}
     dependencies:
@@ -14401,6 +14283,7 @@ packages:
   /kysely@0.22.0:
     resolution: {integrity: sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==}
     engines: {node: '>=14.0.0'}
+    dev: false
 
   /kysely@0.23.5:
     resolution: {integrity: sha512-TH+b56pVXQq0tsyooYLeNfV11j6ih7D50dyN8tkM0e7ndiUH28Nziojiog3qRFlmEj9XePYdZUrNJ2079Qjdow==}
@@ -14712,6 +14595,7 @@ packages:
 
   /lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
 
   /lodash.flow@3.5.0:
     resolution: {integrity: sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==}
@@ -14722,32 +14606,9 @@ packages:
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
     dev: true
 
-  /lodash.includes@4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-    dev: true
-
   /lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
-
-  /lodash.isboolean@3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-    dev: true
-
-  /lodash.isinteger@4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-    dev: true
-
-  /lodash.isnumber@3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-    dev: true
-
-  /lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-    dev: true
-
-  /lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-    dev: true
+    dev: false
 
   /lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
@@ -14755,10 +14616,6 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
-
-  /lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
     dev: true
 
   /lodash.pick@4.4.0:
@@ -15407,6 +15264,7 @@ packages:
   /mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+    dev: false
 
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -15522,6 +15380,7 @@ packages:
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: false
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -15593,6 +15452,7 @@ packages:
 
   /napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -15619,6 +15479,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.6.3
+    dev: false
 
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -15626,6 +15487,7 @@ packages:
 
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+    dev: false
 
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -15688,10 +15550,12 @@ packages:
     engines: {node: '>= 10.23.0'}
     dependencies:
       html-to-text: 7.1.1
+    dev: false
 
   /nodemailer@6.8.0:
     resolution: {integrity: sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==}
     engines: {node: '>=6.0.0'}
+    dev: false
 
   /nopt@6.0.0:
     resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
@@ -15837,6 +15701,7 @@ packages:
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -16004,6 +15869,7 @@ packages:
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
+    dev: false
 
   /p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -16159,6 +16025,7 @@ packages:
   /peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
     engines: {node: '>=8'}
+    dev: false
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -16414,6 +16281,7 @@ packages:
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -16707,10 +16575,6 @@ packages:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
     dev: true
 
-  /querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: true
-
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
@@ -16734,6 +16598,7 @@ packages:
 
   /rate-limiter-flexible@2.4.1:
     resolution: {integrity: sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g==}
+    dev: false
 
   /raw-body@2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -16752,6 +16617,7 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    dev: false
 
   /react-base16-styling@0.6.0:
     resolution: {integrity: sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==}
@@ -17001,6 +16867,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       readable-stream: 3.6.2
+    dev: false
 
   /readdirp@3.5.0:
     resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
@@ -17016,12 +16883,14 @@ packages:
   /redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
+    dev: false
 
   /redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
     dependencies:
       redis-errors: 1.2.0
+    dev: false
 
   /reflect.getprototypeof@1.0.8:
     resolution: {integrity: sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==}
@@ -17124,10 +16993,6 @@ packages:
       rc: 1.2.8
       resolve: 1.7.1
     dev: false
-
-  /requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: true
 
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -17314,6 +17179,7 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
+    dev: false
     optional: true
 
   /safe-array-concat@1.0.1:
@@ -17338,6 +17204,7 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    dev: false
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -17378,10 +17245,6 @@ packages:
   /scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
     dev: false
-
-  /scmp@2.1.0:
-    resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}
-    dev: true
 
   /secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
@@ -17539,23 +17402,6 @@ packages:
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  /sharp@0.32.6:
-    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
-    engines: {node: '>=14.15.0'}
-    requiresBuild: true
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.3
-      node-addon-api: 6.1.0
-      prebuild-install: 7.1.2
-      semver: 7.6.3
-      simple-get: 4.0.1
-      tar-fs: 3.0.6
-      tunnel-agent: 0.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-    dev: true
-
   /sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -17625,6 +17471,7 @@ packages:
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    dev: false
 
   /simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
@@ -17632,6 +17479,7 @@ packages:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    dev: false
 
   /simple-plist@1.3.1:
     resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
@@ -17645,6 +17493,7 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
+    dev: false
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -17815,6 +17664,7 @@ packages:
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -17984,6 +17834,7 @@ packages:
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -18000,6 +17851,7 @@ packages:
     dependencies:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
+    dev: false
 
   /structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
@@ -18077,18 +17929,7 @@ packages:
       mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 2.2.0
-
-  /tar-fs@3.0.6:
-    resolution: {integrity: sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==}
-    dependencies:
-      pump: 3.0.0
-      tar-stream: 3.1.6
-    optionalDependencies:
-      bare-fs: 2.3.5
-      bare-path: 2.1.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-    dev: true
+    dev: false
 
   /tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
@@ -18112,6 +17953,7 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    dev: false
 
   /tar-stream@3.1.6:
     resolution: {integrity: sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==}
@@ -18296,6 +18138,7 @@ packages:
     dependencies:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+    dev: false
 
   /toygrad@2.6.0:
     resolution: {integrity: sha512-g4zBmlSbvzOE5FOILxYkAybTSxijKLkj1WoNqVGnbMcWDyj4wWQ+eYSr3ik7XOpIgMq/7eBcPRTJX3DM2E0YMg==}
@@ -18391,23 +18234,7 @@ packages:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
       safe-buffer: 5.2.1
-
-  /twilio@4.21.0:
-    resolution: {integrity: sha512-+meDbJPOxs6vEysJ7xX7XMn6FLKmZFSeVzMKjzN9NWgDXssp713Kf1ukteZlXhnhd7/NtNiUv5OU17qVgBb/BQ==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      axios: 1.6.7
-      dayjs: 1.11.10
-      https-proxy-agent: 5.0.1
-      jsonwebtoken: 9.0.2
-      qs: 6.11.0
-      scmp: 2.1.0
-      url-parse: 1.5.10
-      xmlbuilder: 13.0.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
+    dev: false
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -18532,6 +18359,7 @@ packages:
     resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
     optionalDependencies:
       rxjs: 7.8.2
+    dev: false
 
   /typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
@@ -18612,6 +18440,7 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.0
+    dev: false
 
   /undici@6.19.8:
     resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
@@ -18708,13 +18537,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-
-  /url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-    dev: true
 
   /use-callback-ref@1.3.3(@types/react@19.0.10)(react@19.0.0):
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -19210,11 +19032,6 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
     dev: false
-
-  /xmlbuilder@13.0.2:
-    resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
-    engines: {node: '>=6.0'}
-    dev: true
 
   /xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}


### PR DESCRIPTION
This replaces a stale dependency on legacy entryway code with a mock entryway server for the @atproto/pds package tests.  As a result we also no longer reference a problematic, old version of sharp.  Should help to unstick future nodejs upgrades.

Probably want to hold off on merging until #4408 lands to avoid unnecessary conflicts.