### PR TITLE
Fix `Client.call` options for XRPC queries

### DIFF
--- a/packages/lex/lex-client/src/client.ts
+++ b/packages/lex/lex-client/src/client.ts
@@ -753,7 +753,7 @@ export class Client implements Agent {
       : T extends Procedure
         ? Omit<XrpcOptions<T>, 'body'>
         : T extends Query
-          ? Omit<XrpcOptions<T>, 'param'>
+          ? Omit<XrpcOptions<T>, 'params'>
           : never,
   ): Promise<
     T extends Action


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/bluesky-social/atproto/pull/4761