### PR TITLE
lexicons: add 'bot' wellKnown label value

### DIFF
--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -140,16 +140,12 @@
       "type": "string",
       "knownValues": [
         "!hide",
-        "!no-promote",
         "!warn",
         "!no-unauthenticated",
-        "dmca-violation",
-        "doxxing",
         "porn",
         "sexual",
         "nudity",
-        "nsfl",
-        "gore",
+        "graphic-media",
         "bot"
       ]
     }


### PR DESCRIPTION
Sort of a minor thing, but related to recent self-labeling feature in bsky app. This `knownValues` list isn't binding, but it can help with dev tooling and understanding.

While I was at it, I also updated the other values to match the atproto docs. Eg, we never used things like "doxxing" as a global label, and instead of "gore" have "graphic-media": https://atproto.com/guides/labels#global-label-values

See also: https://github.com/bluesky-social/bsky-docs/pull/404