### PR TITLE
Ensure scoped checkGates merges outer user context

### DIFF
--- a/.changeset/rich-bikes-peel.md
+++ b/.changeset/rich-bikes-peel.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Ensure scoped `checkGates` merges outer context

--- a/packages/bsky/src/feature-gates/index.ts
+++ b/packages/bsky/src/feature-gates/index.ts
@@ -190,17 +190,12 @@ export class FeatureGatesClient {
         gates: Gate[],
         userContextOverrides?: Pick<UserContext, 'did'>,
       ) => {
-        /*
-         * Merge the base user context with any overrides provided at check time. This
-         * allows us to set a base context for the request, but also override or add
-         * properties for specific gate checks if needed.
-         */
         const userContext = mergeUserContexts(base, userContextOverrides)
         return this.checkGates(gates, userContext)
       },
       checkGate: (gate: Gate, userContextOverrides?: UserContext) => {
-        const gatesMap = this.checkGates([gate], userContextOverrides || {})
-        return gatesMap.get(gate) || false
+        const userContext = mergeUserContexts(base, userContextOverrides)
+        return this.checkGates([gate], userContext).get(gate) || false
       },
     }
   }

--- a/packages/bsky/src/feature-gates/utils.ts
+++ b/packages/bsky/src/feature-gates/utils.ts
@@ -37,6 +37,11 @@ export function normalizeUserContext(
   }
 }
 
+/**
+ * Merge the base user context with any overrides provided at check time. This
+ * allows us to set a base context for the request, but also override or add
+ * properties for specific gate checks if needed.
+ */
 export function mergeUserContexts(
   base: NormalizedUserContext,
   overrides?: UserContext,


### PR DESCRIPTION
Without merging in `base` from the `scope` closure, calls [like this one](https://github.com/bluesky-social/atproto/blob/fix-gb/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts#L113-L115) are supplying `{}` as the `userContext` to `private checkGates`