### PR TITLE
Optimize counting of graphemes when validating strings

### DIFF
--- a/.changeset/plenty-masks-marry.md
+++ b/.changeset/plenty-masks-marry.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Optimize counting of graphemes when validating strings

--- a/packages/lex/lex-schema/src/schema/string.ts
+++ b/packages/lex/lex-schema/src/schema/string.ts
@@ -99,12 +99,15 @@ export class StringSchema<
       }
     }
 
+    // Optimization: count graphemes once
     let lazyGraphLen: number
 
     const minGraphemes = this.options.minGraphemes
     if (minGraphemes != null) {
-      // Optimization: avoid counting graphemes if the length check already fails
       if (str.length < minGraphemes) {
+        // If the JavaScript string length (UTF-16) is below the minimal limit,
+        // its grapheme length (which <= .length) will also be below.
+        // Fail early.
         return ctx.issueTooSmall(str, 'grapheme', minGraphemes, str.length)
       } else if ((lazyGraphLen ??= graphemeLen(str)) < minGraphemes) {
         return ctx.issueTooSmall(str, 'grapheme', minGraphemes, lazyGraphLen)
@@ -113,7 +116,10 @@ export class StringSchema<
 
     const maxGraphemes = this.options.maxGraphemes
     if (maxGraphemes != null) {
-      if ((lazyGraphLen ??= graphemeLen(str)) > maxGraphemes) {
+      if (str.length <= maxGraphemes) {
+        // If the JavaScript string length (UTF-16) is within the maximum limit,
+        // its grapheme length (which <= .length) will also be within.
+      } else if ((lazyGraphLen ??= graphemeLen(str)) > maxGraphemes) {
         return ctx.issueTooBig(str, 'grapheme', maxGraphemes, lazyGraphLen)
       }
     }


### PR DESCRIPTION
Lex SDK string validation in un-necessarily counting graphemes characters. This optimizes that behavior by not counting graphemes if the string length cannot possibly exceed the grapheme length.


Based on:

https://github.com/bluesky-social/atproto/blob/9b610dc54cd6be9145e9c36980fb5ac4ae30337b/packages/lexicon/src/validators/primitives.ts#L252-L312