### PR TITLE
Disable strict mode parsing of records

### DIFF
--- a/.changeset/silly-cars-pick.md
+++ b/.changeset/silly-cars-pick.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Disable strict parsing of records

--- a/.changeset/violet-feet-thank.md
+++ b/.changeset/violet-feet-thank.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Allow specifying `ValidateOptions` to `matches()` and `ifMathces()` method, allowing disabling "strict" mode

--- a/packages/bsky/src/data-plane/server/routes/profile.ts
+++ b/packages/bsky/src/data-plane/server/routes/profile.ts
@@ -3,12 +3,9 @@ import { ServiceImpl } from '@connectrpc/connect'
 import { Selectable, sql } from 'kysely'
 import { keyBy } from '@atproto/common'
 import { parseJsonBytes } from '../../../hydration/util'
+import { app, chat } from '../../../lexicons/index.js'
 import { Service } from '../../../proto/bsky_connect'
 import { VerificationMeta } from '../../../proto/bsky_pb'
-import {
-  ChatDeclarationRecord,
-  NotificationDeclarationRecord,
-} from '../../../views/types'
 import { Database } from '../db'
 import { Verification } from '../db/tables/verification'
 import { getRecords } from './records'
@@ -96,7 +93,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
       const status = statuses.records[i]
 
-      const chatDeclaration = parseJsonBytes<ChatDeclarationRecord>(
+      const chatDeclaration = parseJsonBytes(
+        chat.bsky.actor.declaration.main,
         chatDeclarations.records[i].record,
       )
 
@@ -115,7 +113,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       const ageAssuranceForDids = new Set(returnAgeAssuranceForDids)
 
       const activitySubscription = () => {
-        const record = parseJsonBytes<NotificationDeclarationRecord>(
+        const record = parseJsonBytes(
+          app.bsky.notification.declaration.main,
           notifDeclarations.records[i].record,
         )
 

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -10,7 +10,7 @@ import {
   normalizeHandle,
 } from '@atproto/syntax'
 import { DataPlaneClient } from '../data-plane/client'
-import { app } from '../lexicons'
+import { app, chat, com } from '../lexicons/index.js'
 import { ActivitySubscription, VerificationMeta } from '../proto/bsky_pb'
 import {
   ChatDeclarationRecord,
@@ -215,11 +215,16 @@ export class ActorHydrator {
       }
 
       const profile = actor.profile?.record
-        ? parseRecord<ProfileRecord>(actor.profile, includeTakedowns)
+        ? parseRecord(
+            app.bsky.actor.profile.main,
+            actor.profile,
+            includeTakedowns,
+          )
         : undefined
 
       const status = actor.statusRecord
-        ? parseRecord<StatusRecord>(
+        ? parseRecord(
+            app.bsky.actor.status.main,
             actor.statusRecord,
             /*
              * Always true, we filter this out in the `Views.status()`. If we
@@ -230,7 +235,11 @@ export class ActorHydrator {
         : undefined
 
       const germ = actor.germRecord
-        ? parseRecord<GermDeclarationRecord>(actor.germRecord, includeTakedowns)
+        ? parseRecord(
+            com.germnetwork.declaration.main,
+            actor.germRecord,
+            includeTakedowns,
+          )
         : undefined
 
       const verifications = mapDefined(
@@ -316,7 +325,8 @@ export class ActorHydrator {
     const res = await this.dataplane.getActorChatDeclarationRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<ChatDeclarationRecord>(
+      const record = parseRecord(
+        chat.bsky.actor.declaration.main,
         res.records[i],
         includeTakedowns,
       )
@@ -335,7 +345,8 @@ export class ActorHydrator {
 
     const res = await this.dataplane.getGermDeclarationRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<GermDeclarationRecord>(
+      const record = parseRecord(
+        com.germnetwork.declaration.main,
         res.records[i],
         includeTakedowns,
       )
@@ -357,7 +368,8 @@ export class ActorHydrator {
     })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<NotificationDeclarationRecord>(
+      const record = parseRecord(
+        app.bsky.notification.declaration.main,
         res.records[i],
         includeTakedowns,
       )
@@ -377,7 +389,11 @@ export class ActorHydrator {
     const res = await this.dataplane.getStatusRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<StatusRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.actor.status.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uri, record ?? null)
     }
 

--- a/packages/bsky/src/hydration/feed.ts
+++ b/packages/bsky/src/hydration/feed.ts
@@ -1,6 +1,7 @@
 import { dedupeStrs } from '@atproto/common'
 import { AtUriString, DidString } from '@atproto/syntax'
 import { DataPlaneClient } from '../data-plane/client'
+import { app } from '../lexicons/index.js'
 import {
   postUriToPostgateUri,
   postUriToThreadgateUri,
@@ -140,7 +141,11 @@ export class FeedHydrator {
       )
 
       for (let i = 0; i < need.length; i++) {
-        const record = parseRecord<PostRecord>(res.records[i], includeTakedowns)
+        const record = parseRecord(
+          app.bsky.feed.post.main,
+          res.records[i],
+          includeTakedowns,
+        )
         const violatesThreadGate = res.meta[i].violatesThreadGate
         const violatesEmbeddingRules = res.meta[i].violatesEmbeddingRules
         const hasThreadGate = res.meta[i].hasThreadGate
@@ -304,7 +309,8 @@ export class FeedHydrator {
 
     const res = await this.dataplane.getFeedGeneratorRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<FeedGenRecord>(
+      const record = parseRecord(
+        app.bsky.feed.generator.main,
         res.records[i],
         includeTakedowns,
       )
@@ -369,7 +375,11 @@ export class FeedHydrator {
 
     const res = await this.dataplane.getThreadGateRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<GateRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.feed.threadgate.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uris[i], record ?? null)
     }
 
@@ -393,7 +403,8 @@ export class FeedHydrator {
 
     const res = await this.dataplane.getPostgateRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<PostgateRecord>(
+      const record = parseRecord(
+        app.bsky.feed.postgate.main,
         res.records[i],
         includeTakedowns,
       )
@@ -412,7 +423,11 @@ export class FeedHydrator {
 
     const res = await this.dataplane.getLikeRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<LikeRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.feed.like.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uris[i], record ?? null)
     }
 
@@ -428,7 +443,11 @@ export class FeedHydrator {
 
     const res = await this.dataplane.getRepostRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<RepostRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.feed.repost.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uris[i], record ?? null)
     }
 

--- a/packages/bsky/src/hydration/graph.ts
+++ b/packages/bsky/src/hydration/graph.ts
@@ -1,5 +1,6 @@
 import { AtUriString, DidString } from '@atproto/syntax'
 import { DataPlaneClient } from '../data-plane/client'
+import { app } from '../lexicons/index.js'
 import { FollowInfo } from '../proto/bsky_pb'
 import {
   BlockRecord,
@@ -115,7 +116,11 @@ export class GraphHydrator {
 
     const res = await this.dataplane.getListRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<ListRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.graph.list.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uris[i], record ?? null)
     }
 
@@ -131,7 +136,8 @@ export class GraphHydrator {
 
     const res = await this.dataplane.getListItemRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
-      const record = parseRecord<ListItemRecord>(
+      const record = parseRecord(
+        app.bsky.graph.listitem.main,
         res.records[i],
         includeTakedowns,
       )
@@ -214,7 +220,11 @@ export class GraphHydrator {
     const res = await this.dataplane.getFollowRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<FollowRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.graph.follow.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uri, record ?? null)
     }
 
@@ -231,7 +241,8 @@ export class GraphHydrator {
     const res = await this.dataplane.getVerificationRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<VerificationRecord>(
+      const record = parseRecord(
+        app.bsky.graph.verification.main,
         res.records[i],
         includeTakedowns,
       )
@@ -251,7 +262,11 @@ export class GraphHydrator {
     const res = await this.dataplane.getBlockRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<BlockRecord>(res.records[i], includeTakedowns)
+      const record = parseRecord(
+        app.bsky.graph.block.main,
+        res.records[i],
+        includeTakedowns,
+      )
       map.set(uri, record ?? null)
     }
 
@@ -296,7 +311,8 @@ export class GraphHydrator {
     const res = await this.dataplane.getStarterPackRecords({ uris })
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
-      const record = parseRecord<StarterPackRecord>(
+      const record = parseRecord(
+        app.bsky.graph.starterpack.main,
         res.records[i],
         includeTakedowns,
       )

--- a/packages/bsky/src/hydration/label.ts
+++ b/packages/bsky/src/hydration/label.ts
@@ -1,6 +1,6 @@
 import { AtUri, AtUriString, DidString, UriString } from '@atproto/syntax'
 import { DataPlaneClient } from '../data-plane/client'
-import { app } from '../lexicons/index.js'
+import { app, com } from '../lexicons/index.js'
 import { ParsedLabelers } from '../util'
 import { Label, LabelerRecord } from '../views/types.js'
 import {
@@ -84,7 +84,7 @@ export class LabelHydrator {
     })
 
     for (const cur of res.labels) {
-      const parsed = parseJsonBytes(cur) as Label | undefined
+      const parsed = parseJsonBytes(com.atproto.label.defs.label, cur)
       if (!parsed || parsed.neg) continue
       const { sig: _, ...label } = parsed
       let entry = map.get(label.uri)
@@ -142,7 +142,8 @@ export class LabelHydrator {
     })
     for (let i = 0; i < dids.length; i++) {
       const did = dids[i]
-      const record = parseRecord<LabelerRecord>(
+      const record = parseRecord(
+        app.bsky.labeler.service.main,
         res.records[i],
         includeTakedowns,
       )

--- a/packages/bsky/src/hydration/util.ts
+++ b/packages/bsky/src/hydration/util.ts
@@ -1,18 +1,19 @@
 import { Timestamp } from '@bufbuild/protobuf'
-import * as ui8 from 'uint8arrays'
 import {
   AtUriString,
   Cid,
+  Infer,
+  LexParseOptions,
   LexValue,
+  RecordSchema,
+  Schema,
   TypedLexMap,
-  isPlainObject,
-  l,
+  ValidateOptions,
   lexParse,
   parseCidSafe,
 } from '@atproto/lex'
 import { AtUri } from '@atproto/syntax'
-import * as lexicons from '../lexicons/index.js'
-import { Record } from '../proto/bsky_pb'
+import { Record as RecordEntry } from '../proto/bsky_pb'
 
 export class HydrationMap<K, T> extends Map<K, T | null> implements Merges {
   merge(map: HydrationMap<K, T>): this {
@@ -65,73 +66,49 @@ export const mergeManyMaps = <K, T>(...maps: HydrationMap<K, T>[]) => {
 
 export type ItemRef = { uri: AtUriString; cid?: string }
 
-export const parseRecord = <T extends { $type: string }>(
-  entry: Record,
+export function parseRecord<TSchema extends RecordSchema>(
+  recordSchema: TSchema,
+  recordEntry: RecordEntry,
   includeTakedowns: boolean,
-): RecordInfo<T> | undefined => {
-  if (!includeTakedowns && entry.takenDown) {
+): RecordInfo<Infer<TSchema>> | undefined {
+  if (!includeTakedowns && recordEntry.takenDown) {
     return undefined
   }
 
-  const cid = entry.cid
+  const cid = recordEntry.cid
   if (!cid) return
 
-  const record = parseJsonBytes<T>(entry.record)
-  if (!record || !isValidRecord(record)) return
+  const record = parseJsonBytes(recordSchema, recordEntry.record)
+  if (!record) {
+    return
+  }
 
   return {
     record,
     cid,
-    sortedAt: parseDate(entry.sortedAt) ?? new Date(0),
-    indexedAt: parseDate(entry.indexedAt) ?? new Date(0),
-    takedownRef: safeTakedownRef(entry),
+    sortedAt: parseDate(recordEntry.sortedAt) ?? new Date(0),
+    indexedAt: parseDate(recordEntry.indexedAt) ?? new Date(0),
+    takedownRef: safeTakedownRef(recordEntry),
   }
 }
 
-/**
- * Recursively enumerate all RecordSchemas in a namespace.
- */
-function* enumerateRecordSchemas(namespace: {
-  [key: string]: unknown
-}): Generator<l.RecordSchema> {
-  for (const key of Object.keys(namespace)) {
-    if (key === '$defs') {
-      const { main } = (namespace as { $defs: { main?: unknown } })[key]
-      if (main && main instanceof l.RecordSchema) {
-        yield main
-      }
-    } else if (key.charCodeAt(0) !== 36) {
-      // skip keys starting with '$' (generated utils)
-      const val = namespace[key]
-      if (val && typeof val === 'object') {
-        yield* enumerateRecordSchemas(val as { [key: string]: unknown })
-      }
-    }
-  }
-}
-
-const KNOWN_RECORD_TYPES = new Map<string, l.RecordSchema>(
-  Array.from(enumerateRecordSchemas(lexicons), (s) => [s.$type, s]),
-)
-
-const isValidRecord = (value: LexValue): boolean => {
-  if (!isPlainObject(value) || typeof value.$type !== 'string') {
-    return false
-  }
-
-  const schema = KNOWN_RECORD_TYPES.get(value.$type)
-  if (!schema) {
-    return false
-  }
-
-  return schema.matches(value)
-}
-
-export const parseJsonBytes = <T extends LexValue = LexValue>(
+export const parseJsonBytes = <TSchema extends Schema<LexValue>>(
+  schema: TSchema,
   bytes: Uint8Array | undefined,
-): T | undefined => {
+  options: LexParseOptions & ValidateOptions = { strict: false },
+): Infer<TSchema> | undefined => {
   if (!bytes || bytes.byteLength === 0) return undefined
-  return lexParse<T>(ui8.toString(bytes, 'utf8'))
+
+  // @NOTE Buffer.from(bytes) creates a copy of the ArrayBuffer
+  const jsonBuffer = Buffer.from(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  )
+  const jsonString = jsonBuffer.toString('utf8')
+
+  const value = lexParse(jsonString, options)
+  return schema.ifMatches(value, options)
 }
 
 export const parseString = <T extends string | undefined>(

--- a/packages/lex/lex-schema/src/core/schema.ts
+++ b/packages/lex/lex-schema/src/core/schema.ts
@@ -120,8 +120,11 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    * will typically arise in generic contexts, where the narrowed type is not
    * needed.
    */
-  assert(input: unknown): asserts input is InferInput<this> {
-    const result = ValidationContext.validate(input, this)
+  assert(
+    input: unknown,
+    options?: ValidateOptions,
+  ): asserts input is InferInput<this> {
+    const result = this.safeValidate(input, options)
     if (!result.success) throw result.reason
   }
 
@@ -131,8 +134,8 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    * every name in the call target to be declared with an explicit type
    * annotation. ts(2775)_" errors.
    */
-  check(input: unknown): void {
-    this.assert(input)
+  check(input: unknown, options?: ValidateOptions): void {
+    this.assert(input, options)
   }
 
   /**
@@ -140,17 +143,14 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    * schema, otherwise throws. This is the same as calling {@link parse}() with
    * `mode: "validate"`.
    */
-  cast<I>(input: I): I & InferInput<this> {
-    const result = ValidationContext.validate(input, this)
+  cast<I>(input: I, options?: ValidateOptions): I & InferInput<this> {
+    const result = this.safeValidate(input, options)
     if (result.success) return result.value
     throw result.reason
   }
 
   /**
    * Type guard that checks if the input matches this schema.
-   *
-   * @param input - The value to check
-   * @returns `true` if the input is valid according to this schema
    *
    * @example
    * ```typescript
@@ -160,8 +160,11 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    * }
    * ```
    */
-  matches<I>(input: I): input is I & InferInput<this> {
-    const result = ValidationContext.validate(input, this)
+  matches<I>(
+    input: I,
+    options?: ValidateOptions,
+  ): input is I & InferInput<this> {
+    const result = this.safeValidate(input, options)
     return result.success
   }
 
@@ -170,9 +173,6 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    *
    * This is useful for optional filtering operations where you want to
    * conditionally extract values that match a schema.
-   *
-   * @param input - The value to check
-   * @returns The input value with narrowed type if valid, otherwise `undefined`
    *
    * @example
    * ```typescript
@@ -183,8 +183,11 @@ export abstract class Schema<out TInput = unknown, out TOutput = TInput>
    * }
    * ```
    */
-  ifMatches<I>(input: I): (I & InferInput<this>) | undefined {
-    return this.matches(input) ? input : undefined
+  ifMatches<I>(
+    input: I,
+    options?: ValidateOptions,
+  ): (I & InferInput<this>) | undefined {
+    return this.matches(input, options) ? input : undefined
   }
 
   /**


### PR DESCRIPTION
When we released https://github.com/bluesky-social/atproto/pull/4408, users [reported](https://bsky.app/profile/snarfed.org/post/3mhqqhldank2f) that their profile would not show up in the app anymore.

This change fixes that by disabling strict record validation.

I was also able to replace type-casting of validation result by actual schema based validation.