### PR TITLE
Avoid buffering of large payloads during read-after-write

### DIFF
--- a/.changeset/green-pens-judge.md
+++ b/.changeset/green-pens-judge.md
@@ -2,4 +2,4 @@
 '@atproto/pds': patch
 ---
 
-Avoid i/o during read after write munging transaction
+Avoid buffering or large payloads during read-after-write

--- a/.changeset/green-pens-judge.md
+++ b/.changeset/green-pens-judge.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Avoid i/o during read after write munging transaction

--- a/.changeset/green-pens-judge.md
+++ b/.changeset/green-pens-judge.md
@@ -2,4 +2,4 @@
 '@atproto/pds': patch
 ---
 
-Avoid buffering or large payloads during read-after-write
+Avoid buffering of large payloads during read-after-write

--- a/.changeset/vast-suits-taste.md
+++ b/.changeset/vast-suits-taste.md
@@ -1,0 +1,5 @@
+---
+'@atproto/common': patch
+---
+
+Add `maxSize` option to `streamToNodeBuffer` utility

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -32,11 +32,14 @@ export const streamSize = async (stream: Readable): Promise<number> => {
   return size
 }
 
-export const streamToBytes = async (stream: AsyncIterable<Uint8Array>) =>
+export const streamToBytes = async (
+  stream: AsyncIterable<Uint8Array>,
+  maxSize?: number,
+) =>
   // @NOTE Though Buffer is a sub-class of Uint8Array, we have observed
   // inconsistencies when using a Buffer in place of Uint8Array. For this
   // reason, we convert the Buffer to a Uint8Array.
-  new Uint8Array(await streamToNodeBuffer(stream))
+  new Uint8Array(await streamToNodeBuffer(stream, maxSize))
 
 // streamToBuffer identifier name already taken by @atproto/common-web
 export const streamToNodeBuffer = async (

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -41,9 +41,10 @@ export const streamToBytes = async (stream: AsyncIterable<Uint8Array>) =>
 // streamToBuffer identifier name already taken by @atproto/common-web
 export const streamToNodeBuffer = async (
   stream: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  maxSize = Infinity,
 ): Promise<Buffer> => {
   const chunks: Uint8Array[] = []
-  let totalLength = 0 // keep track of total length for Buffer.concat
+  let totalLength = 0
   for await (const chunk of stream) {
     if (chunk instanceof Uint8Array) {
       chunks.push(chunk)
@@ -51,8 +52,13 @@ export const streamToNodeBuffer = async (
     } else {
       throw new TypeError('expected Uint8Array')
     }
+    if (totalLength > maxSize) {
+      throw new Error('Stream exceeds maximum size')
+    }
   }
-  return Buffer.concat(chunks, totalLength)
+  return chunks.length === 1
+    ? Buffer.from(chunks[0].buffer, chunks[0].byteOffset, chunks[0].byteLength)
+    : Buffer.concat(chunks, totalLength)
 }
 
 export const byteIterableToStream = (

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -97,6 +97,13 @@ describe('streams', () => {
         'expected Uint8Array',
       )
     })
+
+    it('respects maxSize', async () => {
+      const stream = Readable.from(Buffer.from('foo'))
+      await expect(streams.streamToNodeBuffer(stream, 2)).rejects.toThrow(
+        'Stream exceeds maximum size',
+      )
+    })
   })
 
   describe('byteIterableToStream', () => {

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -428,11 +428,12 @@ function asDecodedStream(
   } catch (cause) {
     // content encoding not supported
     if (!readable.destroyed) readable.destroy()
+
+    const reason = cause instanceof TypeError ? cause.message : undefined
+
     throw new XRPCServerError(
       ResponseType.UpstreamFailure,
-      cause instanceof TypeError
-        ? cause.message
-        : 'unable to decode response body',
+      `Unable to decode "${contentEncoding}"${reason ? `: ${reason}` : ''}`,
       undefined,
       { cause },
     )

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -529,7 +529,7 @@ async function bufferIterable(
             await it.return?.()
           } catch (err) {
             // Should never happen. Prevent server from crashing if it does.
-            httpLogger.error({ err }, 'Error closing pipethrough stream')
+            httpLogger.warn({ err }, 'Error closing pipethrough stream')
           }
         })
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -168,10 +168,13 @@ export async function pipethrough(
       'x-bsky-topics': req.headers['x-bsky-topics'],
 
       // Because we sometimes need to interpret the response (e.g. during
-      // read-after-write, through asPipeThroughBuffer()), we need to ask the
-      // upstream server for an encoding that both the requester and the PDS can
-      // understand. Since we might have to do the decoding ourselves, we will
-      // use our own preferences (and weight) to negotiate the encoding.
+      // read-after-write), we need to ask the upstream server for an encoding
+      // that both the requester and the PDS can understand. Since we might have
+      // to do the decoding ourselves, we will use our own preferences (and
+      // weight) to negotiate the encoding.
+
+      // @TODO We should make this configurable through pipethrough options,
+      // allowing to opt-in the the negociated encodings on a per-request basis.
       'accept-encoding': buildProxiedContentEncoding(
         req.headers['accept-encoding'],
         ctx.cfg.proxy.preferCompressed,
@@ -406,10 +409,7 @@ async function tryParsingError(
   }
 
   try {
-    const buffer = await bufferUpstreamResponse(
-      readable,
-      headers['content-encoding'],
-    )
+    const buffer = await streamToNodeBuffer(asDecodedStream(readable, headers))
 
     const errInfo: unknown = JSON.parse(buffer.toString('utf8'))
     return {
@@ -422,34 +422,104 @@ async function tryParsingError(
   }
 }
 
-async function bufferUpstreamResponse(
+function asDecodedStream(
   readable: Readable,
-  contentEncoding?: string | string[],
-): Promise<Buffer> {
+  headers?: IncomingHttpHeaders,
+): Readable {
+  const contentEncoding = headers?.['content-encoding']
   try {
-    return await streamToNodeBuffer(decodeStream(readable, contentEncoding))
+    return decodeStream(readable, contentEncoding)
   } catch (err) {
     if (!readable.destroyed) readable.destroy()
+    throw err
+  }
+}
 
+/**
+ * Attempt to bufferize a pipethrough stream response into a
+ * {@link HandlerPipeThroughBuffer}, falling back to a stream if the response is
+ * bigger than {@link maxBufferSize}.
+ */
+export async function bufferUpstreamResponseMaybe(
+  streamRes: HandlerPipeThroughStream,
+  maxBufferSize = 10 * 1024 * 1024, // 10MB
+): Promise<HandlerPipeThroughBuffer | HandlerPipeThroughStream> {
+  const buffered = await bufferReadableMaybe(
+    asDecodedStream(streamRes.stream, streamRes.headers),
+    maxBufferSize,
+  ).catch((err) => {
     throw new XRPCServerError(
       ResponseType.UpstreamFailure,
       err instanceof TypeError ? err.message : 'unable to decode request body',
       undefined,
       { cause: err },
     )
-  }
+  })
+
+  const headers = omit(streamRes.headers, [
+    'content-encoding',
+    'content-length',
+  ])
+
+  return buffered.type === 'stream'
+    ? {
+        encoding: streamRes.encoding,
+        stream: buffered.stream,
+        headers,
+      }
+    : {
+        encoding: streamRes.encoding,
+        buffer: buffered.buffer,
+        headers,
+      }
 }
 
-export async function asPipeThroughBuffer(
-  input: HandlerPipeThroughStream,
-): Promise<HandlerPipeThroughBuffer> {
-  return {
-    buffer: await bufferUpstreamResponse(
-      input.stream,
-      input.headers?.['content-encoding'],
-    ),
-    headers: omit(input.headers, ['content-encoding', 'content-length']),
-    encoding: input.encoding,
+async function bufferReadableMaybe(
+  iterable: AsyncIterable<Uint8Array>,
+  maxBufferSize = 10 * 1024 * 1024, // 10MB
+): Promise<
+  { type: 'buffer'; buffer: Buffer } | { type: 'stream'; stream: Readable }
+> {
+  const chunks: Uint8Array[] = []
+  let totalLength = 0
+
+  const it: AsyncIterator<Uint8Array> = iterable[Symbol.asyncIterator]()
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value: chunk, done } = await it.next()
+    if (done) break
+
+    if (chunk instanceof Uint8Array) {
+      chunks.push(chunk)
+      totalLength += Buffer.byteLength(chunk)
+    } else {
+      throw new TypeError('expected Uint8Array')
+    }
+
+    // Response is too big, abort buffering and return a stream
+    if (totalLength > maxBufferSize) {
+      const stream = Readable.from(combine(chunks, it))
+      return { type: 'stream', stream }
+    }
+  }
+
+  const buffer = Buffer.concat(chunks, totalLength)
+  return { type: 'buffer', buffer }
+}
+
+async function* combine(
+  chunks: Iterable<Uint8Array>,
+  iterator: AsyncIterator<Uint8Array>,
+) {
+  try {
+    yield* chunks
+    while (true) {
+      const { value: chunk, done } = await iterator.next()
+      if (done) break
+      else yield chunk
+    }
+  } finally {
+    await iterator.return?.()
   }
 }
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -506,10 +506,8 @@ async function bufferIterable(
   let totalLength = 0
 
   const it: AsyncIterator<Uint8Array> = iterable[Symbol.asyncIterator]()
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { value: chunk, done } = await it.next()
-    if (done) break
+  for (let result = await it.next(); !result.done; result = await it.next()) {
+    const chunk = result.value
 
     try {
       // @NOTE next line will throw if chunk is not a Uint8Array

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -135,13 +135,7 @@ export async function pipethrough(
   ctx: AppContext,
   req: Request,
   options?: PipethroughOptions,
-): Promise<
-  HandlerPipeThroughStream & {
-    stream: Readable
-    headers: Record<string, string>
-    encoding: string
-  }
-> {
+): Promise<HandlerPipeThroughStream> {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     // pipethrough() is used from within xrpcServer handlers, which means that
     // the request body either has been parsed or is a readable stream that has
@@ -430,53 +424,77 @@ function asDecodedStream(
   try {
     return decodeStream(readable, contentEncoding)
   } catch (err) {
+    // content encoding not supported
     if (!readable.destroyed) readable.destroy()
     throw err
   }
 }
 
 /**
- * Attempt to bufferize a pipethrough stream response into a
+ * Attempts to bufferize a pipethrough stream response into a
  * {@link HandlerPipeThroughBuffer}, falling back to a stream if the response is
  * bigger than {@link maxBufferSize}.
+ *
+ * If no {@link maxBufferSize} is provided, the whole response will be buffered,
+ * which could lead to high memory usage or OOM crashes if the response is too
+ * big. It is recommended to provide a reasonable {@link maxBufferSize} based on
+ * the expected response sizes.
  */
-export async function bufferUpstreamResponseMaybe(
+export async function asPipeThroughBuffer(
   streamRes: HandlerPipeThroughStream,
-  maxBufferSize = 10 * 1024 * 1024, // 10MB
+  maxBufferSize?: undefined,
+): Promise<HandlerPipeThroughBuffer>
+export async function asPipeThroughBuffer(
+  streamRes: HandlerPipeThroughStream,
+  maxBufferSize: number | undefined,
+): Promise<HandlerPipeThroughBuffer | HandlerPipeThroughStream>
+export async function asPipeThroughBuffer(
+  streamRes: HandlerPipeThroughStream,
+  maxBufferSize?: number,
 ): Promise<HandlerPipeThroughBuffer | HandlerPipeThroughStream> {
-  const buffered = await bufferReadableMaybe(
-    asDecodedStream(streamRes.stream, streamRes.headers),
-    maxBufferSize,
-  ).catch((err) => {
-    throw new XRPCServerError(
-      ResponseType.UpstreamFailure,
-      err instanceof TypeError ? err.message : 'unable to decode request body',
-      undefined,
-      { cause: err },
-    )
-  })
+  const decodedStream = asDecodedStream(streamRes.stream, streamRes.headers)
+
+  const buffered = await bufferizeIterable(decodedStream, maxBufferSize).catch(
+    (err) => {
+      throw new XRPCServerError(
+        ResponseType.UpstreamFailure,
+        err instanceof TypeError
+          ? err.message
+          : 'unable to decode request body',
+        undefined,
+        { cause: err },
+      )
+    },
+  )
 
   const headers = omit(streamRes.headers, [
     'content-encoding',
     'content-length',
   ])
 
-  return buffered.type === 'stream'
-    ? {
-        encoding: streamRes.encoding,
-        stream: buffered.stream,
-        headers,
-      }
-    : {
-        encoding: streamRes.encoding,
-        buffer: buffered.buffer,
-        headers,
-      }
+  return buffered.type === 'buffer'
+    ? { encoding: streamRes.encoding, headers, buffer: buffered.buffer }
+    : { encoding: streamRes.encoding, headers, stream: buffered.stream }
 }
 
-async function bufferReadableMaybe(
+/**
+ * Buffers an async iterable of Uint8Arrays into a single Buffer, unless the
+ * total size exceeds a specified limit, in which case it returns a Readable
+ * stream of the data instead.
+ */
+async function bufferizeIterable(
   iterable: AsyncIterable<Uint8Array>,
-  maxBufferSize = 10 * 1024 * 1024, // 10MB
+  maxBufferSize?: undefined,
+): Promise<{ type: 'buffer'; buffer: Buffer }>
+async function bufferizeIterable(
+  iterable: AsyncIterable<Uint8Array>,
+  maxBufferSize: number | undefined,
+): Promise<
+  { type: 'buffer'; buffer: Buffer } | { type: 'stream'; stream: Readable }
+>
+async function bufferizeIterable(
+  iterable: AsyncIterable<Uint8Array>,
+  maxBufferSize?: number,
 ): Promise<
   { type: 'buffer'; buffer: Buffer } | { type: 'stream'; stream: Readable }
 > {
@@ -489,34 +507,67 @@ async function bufferReadableMaybe(
     const { value: chunk, done } = await it.next()
     if (done) break
 
-    if (chunk instanceof Uint8Array) {
-      chunks.push(chunk)
+    try {
+      // @NOTE next line will throw if chunk is not a Uint8Array
       totalLength += Buffer.byteLength(chunk)
-    } else {
-      throw new TypeError('expected Uint8Array')
-    }
+      chunks.push(chunk)
 
-    // Response is too big, abort buffering and return a stream
-    if (totalLength > maxBufferSize) {
-      const stream = Readable.from(combine(chunks, it))
-      return { type: 'stream', stream }
+      // Response is too big, abort buffering and return a stream
+      if (maxBufferSize !== undefined && totalLength > maxBufferSize) {
+        const stream = Readable.from(combineWithIterator(chunks, it))
+
+        // Because we've already started consuming the input iterator, we need
+        // to make sure that that iterator gets return()'ed. Since a generator
+        // function's "finally" block will only be executed if the generator
+        // actually started iterating (by calling next() at least once), the
+        // "finally" block in combineWithIterator() might not be executed if
+        // Readable.from() did not start consuming the combined iterator (eg. if
+        // it gets destroyed during the current event loop). In order to avoid
+        // any leak we ensure that closing the stream will also close the input
+        // iterator.
+        const cleanup = finished(stream, async () => {
+          cleanup()
+          try {
+            await it.return?.()
+          } catch (err) {
+            // Should never happen. Prevent server from crashing if it does.
+            httpLogger.error({ err }, 'Error closing pipethrough stream')
+          }
+        })
+
+        return { type: 'stream', stream }
+      }
+    } catch (err) {
+      await it.throw?.(err)
+      throw err
     }
   }
 
-  const buffer = Buffer.concat(chunks, totalLength)
+  // All chunks buffered successfully, concatenate into a single Buffer
+  const buffer =
+    // Avoid unnecessary copy if there's only one chunk
+    chunks.length === 1
+      ? Buffer.from(
+          chunks[0].buffer,
+          chunks[0].byteOffset,
+          chunks[0].byteLength,
+        )
+      : Buffer.concat(chunks, totalLength)
   return { type: 'buffer', buffer }
 }
 
-async function* combine(
-  chunks: Iterable<Uint8Array>,
-  iterator: AsyncIterator<Uint8Array>,
-) {
+async function* combineWithIterator(
+  chunks: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  iterator: Iterator<Uint8Array> | AsyncIterator<Uint8Array>,
+): AsyncGenerator<Uint8Array, void, unknown> {
   try {
     yield* chunks
-    while (true) {
-      const { value: chunk, done } = await iterator.next()
-      if (done) break
-      else yield chunk
+    for (
+      let result = await iterator.next();
+      !result.done;
+      result = await iterator.next()
+    ) {
+      yield result.value
     }
   } finally {
     await iterator.return?.()

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -168,7 +168,7 @@ export async function pipethrough(
       // weight) to negotiate the encoding.
 
       // @TODO We should make this configurable through pipethrough options,
-      // allowing to opt-in the the negociated encodings on a per-request basis.
+      // allowing opting in to the negotiated encodings on a per-request basis.
       'accept-encoding': buildProxiedContentEncoding(
         req.headers['accept-encoding'],
         ctx.cfg.proxy.preferCompressed,
@@ -462,7 +462,7 @@ export async function asPipeThroughBuffer(
         ResponseType.UpstreamFailure,
         err instanceof TypeError
           ? err.message
-          : 'unable to decode request body',
+          : 'unable to decode response body',
         undefined,
         { cause: err },
       )
@@ -512,7 +512,9 @@ async function bufferIterable(
 
       // Response is too big, abort buffering and return a stream
       if (maxBufferSize !== undefined && totalLength > maxBufferSize) {
-        const stream = Readable.from(combineWithIterator(chunks, it))
+        const stream = Readable.from(combineWithIterator(chunks, it), {
+          objectMode: false,
+        })
 
         // Because we've already started consuming the input iterator, we need
         // to make sure that that iterator gets return()'ed. Since a generator

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -425,10 +425,17 @@ function asDecodedStream(
   const contentEncoding = headers?.['content-encoding']
   try {
     return decodeStream(readable, contentEncoding)
-  } catch (err) {
+  } catch (cause) {
     // content encoding not supported
     if (!readable.destroyed) readable.destroy()
-    throw err
+    throw new XRPCServerError(
+      ResponseType.UpstreamFailure,
+      cause instanceof TypeError
+        ? cause.message
+        : 'unable to decode response body',
+      undefined,
+      { cause },
+    )
   }
 }
 
@@ -457,14 +464,12 @@ export async function asPipeThroughBuffer(
   const decodedStream = asDecodedStream(streamRes.stream, streamRes.headers)
 
   const buffered = await bufferIterable(decodedStream, maxBufferSize).catch(
-    (err) => {
+    (cause) => {
       throw new XRPCServerError(
         ResponseType.UpstreamFailure,
-        err instanceof TypeError
-          ? err.message
-          : 'unable to decode response body',
+        'unable to read response body',
         undefined,
-        { cause: err },
+        { cause },
       )
     },
   )

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -403,7 +403,9 @@ async function tryParsingError(
   }
 
   try {
-    const buffer = await streamToNodeBuffer(asDecodedStream(readable, headers))
+    const decodedStream = asDecodedStream(readable, headers)
+    // Read no more than 1mb of error response body, to avoid OOM crashes
+    const buffer = await streamToNodeBuffer(decodedStream, 1024 * 1024)
 
     const errInfo: unknown = JSON.parse(buffer.toString('utf8'))
     return {
@@ -454,7 +456,7 @@ export async function asPipeThroughBuffer(
 ): Promise<HandlerPipeThroughBuffer | HandlerPipeThroughStream> {
   const decodedStream = asDecodedStream(streamRes.stream, streamRes.headers)
 
-  const buffered = await bufferizeIterable(decodedStream, maxBufferSize).catch(
+  const buffered = await bufferIterable(decodedStream, maxBufferSize).catch(
     (err) => {
       throw new XRPCServerError(
         ResponseType.UpstreamFailure,
@@ -472,9 +474,9 @@ export async function asPipeThroughBuffer(
     'content-length',
   ])
 
-  return buffered.type === 'buffer'
-    ? { encoding: streamRes.encoding, headers, buffer: buffered.buffer }
-    : { encoding: streamRes.encoding, headers, stream: buffered.stream }
+  return buffered instanceof Readable
+    ? { encoding: streamRes.encoding, headers, stream: buffered }
+    : { encoding: streamRes.encoding, headers, buffer: buffered }
 }
 
 /**
@@ -482,22 +484,18 @@ export async function asPipeThroughBuffer(
  * total size exceeds a specified limit, in which case it returns a Readable
  * stream of the data instead.
  */
-async function bufferizeIterable(
+async function bufferIterable(
   iterable: AsyncIterable<Uint8Array>,
   maxBufferSize?: undefined,
-): Promise<{ type: 'buffer'; buffer: Buffer }>
-async function bufferizeIterable(
+): Promise<Buffer>
+async function bufferIterable(
   iterable: AsyncIterable<Uint8Array>,
   maxBufferSize: number | undefined,
-): Promise<
-  { type: 'buffer'; buffer: Buffer } | { type: 'stream'; stream: Readable }
->
-async function bufferizeIterable(
+): Promise<Buffer | Readable>
+async function bufferIterable(
   iterable: AsyncIterable<Uint8Array>,
   maxBufferSize?: number,
-): Promise<
-  { type: 'buffer'; buffer: Buffer } | { type: 'stream'; stream: Readable }
-> {
+): Promise<Buffer | Readable> {
   const chunks: Uint8Array[] = []
   let totalLength = 0
 
@@ -535,7 +533,7 @@ async function bufferizeIterable(
           }
         })
 
-        return { type: 'stream', stream }
+        return stream
       }
     } catch (err) {
       await it.throw?.(err)
@@ -553,7 +551,7 @@ async function bufferizeIterable(
           chunks[0].byteLength,
         )
       : Buffer.concat(chunks, totalLength)
-  return { type: 'buffer', buffer }
+  return buffer
 }
 
 async function* combineWithIterator(

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -42,54 +42,46 @@ export const pipethroughReadAfterWrite = async <
   const requester = auth.credentials.did
   const method = l.getMain(ns)
 
-  let streamRes: HandlerPipeThroughBuffer | HandlerPipeThroughStream =
+  let result: HandlerPipeThroughBuffer | HandlerPipeThroughStream =
     await pipethrough(ctx, req, { iss: requester })
 
-  // Only json responses can be parsed for munging
-  if (!isJsonContentType(streamRes.encoding)) {
-    return streamRes
-  }
+  const rev = result.headers?.['atproto-repo-rev']
+  if (!rev) return result
 
-  // Check that the rev is one that we can munge against, if not we return the
-  // stream directly without buffering since we won't be doing a munge and want
-  // to avoid unnecessary memory usage.
-  const rev = streamRes.headers?.['atproto-repo-rev']
-  if (!rev) {
-    return streamRes
+  // Only json responses can be parsed for munging
+  if (!isJsonContentType(result.encoding)) {
+    return result
   }
 
   try {
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)
+      if (local.count === 0) return result
 
-      if (local.count === 0) {
-        return streamRes
-      }
-
-      // @NOTE we replace streamRes to avoid accidentally using the stream after
-      // it's been consumed by asPipeThroughBuffer, which would cause an error. By
-      // replacing it with the buffered version, we ensure that any further use of
-      // streamRes is safe.
-      streamRes = await asPipeThroughBuffer(
-        streamRes as HandlerPipeThroughStream,
+      // @NOTE we replace "result" to avoid accidentally using the stream after
+      // it's been consumed by asPipeThroughBuffer, which would cause an error.
+      // By replacing it with the buffered version, we ensure that any further
+      // use of "result" is safe.
+      result = await asPipeThroughBuffer(
+        result as HandlerPipeThroughStream,
         10 * 1024 * 1024,
       )
 
-      // response was too big to buffer, skip munge
-      if (!('buffer' in streamRes)) {
-        return streamRes
+      // result was too big to buffer, skip munge
+      if (!('buffer' in result)) {
+        return result
       }
 
-      const lex = lexParse(streamRes.buffer.toString('utf8'), { strict: false })
+      const lex = lexParse(result.buffer.toString('utf8'), {
+        strict: false,
+      })
 
-      const result = method.output.schema.safeValidate(lex, { strict: false })
+      const parsed = method.output.schema.safeValidate(lex, { strict: false })
 
-      // Upstream payload does not conform to schema, skip munge
-      if (!result.success) {
-        return streamRes
-      }
+      // We won't perform munging with invalid upstream data
+      if (!parsed.success) return result
 
-      const parsedRes = result.value as l.InferMethodOutputBody<M, never>
+      const parsedRes = parsed.value as l.InferMethodOutputBody<M, never>
 
       const localViewer = ctx.localViewer(store)
 
@@ -100,7 +92,7 @@ export const pipethroughReadAfterWrite = async <
   } catch (err) {
     log.warn({ err, requester }, 'error in read after write munge')
 
-    return streamRes
+    return result
   }
 }
 

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -48,13 +48,13 @@ export const pipethroughReadAfterWrite = async <
     return streamRes
   }
 
-  const buffered = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024) // 10mb max buffer size
+  const bufferRes = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024) // 10mb max buffer size
 
   // response is too big to buffer, skip munge and return the stream
-  if (!('buffer' in buffered)) return buffered
+  if (!('buffer' in bufferRes)) return bufferRes
 
   try {
-    const lex = lexParse(buffered.buffer.toString('utf8'), { strict: false })
+    const lex = lexParse(bufferRes.buffer.toString('utf8'), { strict: false })
 
     const parsedRes = method.output.schema.validate(lex, {
       strict: false,
@@ -62,18 +62,17 @@ export const pipethroughReadAfterWrite = async <
 
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)
-      if (local.count === 0) return buffered
+      if (local.count === 0) return bufferRes
 
       const localViewer = ctx.localViewer(store)
 
       const data = await munge(localViewer, parsedRes, local, requester)
-
       return formatMungedResponse(data, getLocalLag(local))
     })
   } catch (err) {
     log.warn({ err, requester }, 'error in read after write munge')
 
-    return buffered
+    return bufferRes
   }
 }
 

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -1,13 +1,7 @@
-import { Readable } from 'node:stream'
 import express from 'express'
-import { decodeStream, omit } from '@atproto/common'
 import { LexValue, l } from '@atproto/lex'
 import { lexParse } from '@atproto/lex-json'
-import {
-  HandlerPipeThrough,
-  HandlerPipeThroughBuffer,
-  HandlerPipeThroughStream,
-} from '@atproto/xrpc-server'
+import { HandlerPipeThrough } from '@atproto/xrpc-server'
 import { AppContext } from '../context'
 import { readStickyLogger as log } from '../logger'
 import {

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -15,6 +15,8 @@ import {
 } from '../pipethrough'
 import { HandlerResponse, LocalRecords, MungeFn } from './types'
 
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024
+
 export const getLocalLag = (local: LocalRecords): number | undefined => {
   let oldest: string | undefined = local.profile?.indexedAt
   for (const post of local.posts) {
@@ -53,6 +55,14 @@ export const pipethroughReadAfterWrite = async <
     return result
   }
 
+  // IF the response is not chunked, we can determine that the content is too
+  // large to buffer without consuming the stream, so we skip munge in that case
+  // to avoid breaking the stream.
+  const contentLength = result.headers?.['content-length']
+  if (contentLength && Number(contentLength) > MAX_BUFFER_SIZE) {
+    return result
+  }
+
   try {
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)
@@ -64,7 +74,7 @@ export const pipethroughReadAfterWrite = async <
       // use of "result" is safe.
       result = await asPipeThroughBuffer(
         result as HandlerPipeThroughStream,
-        10 * 1024 * 1024,
+        MAX_BUFFER_SIZE,
       )
 
       // result was too big to buffer, skip munge

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -1,14 +1,17 @@
+import { Readable } from 'node:stream'
 import express from 'express'
+import { decodeStream, omit } from '@atproto/common'
 import { LexValue, l } from '@atproto/lex'
 import { lexParse } from '@atproto/lex-json'
 import {
   HandlerPipeThrough,
   HandlerPipeThroughBuffer,
+  HandlerPipeThroughStream,
 } from '@atproto/xrpc-server'
 import { AppContext } from '../context'
 import { readStickyLogger as log } from '../logger'
 import {
-  asPipeThroughBuffer,
+  bufferUpstreamResponseMaybe,
   isJsonContentType,
   pipethrough,
 } from '../pipethrough'
@@ -51,38 +54,32 @@ export const pipethroughReadAfterWrite = async <
     return streamRes
   }
 
-  // if the munging fails, we can't return the original response because the
-  // stream will already have been read. If we end-up buffering the response,
-  // we'll return the buffered response in case of an error.
-  let bufferRes: HandlerPipeThroughBuffer | undefined
+  const buffered = await bufferUpstreamResponseMaybe(streamRes)
+
+  // response is too big to buffer, skip munge and return the stream
+  if ('stream' in buffered) return buffered
 
   try {
+    const lex = lexParse(buffered.buffer.toString('utf8'), { strict: false })
+
+    const original = method.output.schema.validate(lex, {
+      strict: false,
+    }) as l.InferMethodOutputBody<M, never>
+
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)
-      if (local.count === 0) return streamRes
-
-      const { buffer } = (bufferRes = await asPipeThroughBuffer(streamRes))
-
-      const lex = lexParse(buffer.toString('utf8'), { strict: false })
-
-      const result = method.output.schema.safeValidate(lex, { strict: false })
-
-      // We won't perform munging with invalid upstream data
-      if (!result.success) return bufferRes
-
-      const parsedRes = result.value as l.InferMethodOutputBody<M, never>
+      if (local.count === 0) return buffered
 
       const localViewer = ctx.localViewer(store)
 
-      const data = await munge(localViewer, parsedRes, local, requester)
+      const data = await munge(localViewer, original, local, requester)
+
       return formatMungedResponse(data, getLocalLag(local))
     })
   } catch (err) {
-    // The error occurred while reading the stream, this is non-recoverable
-    if (!bufferRes && !streamRes.stream.readable) throw err
-
     log.warn({ err, requester }, 'error in read after write munge')
-    return bufferRes ?? streamRes
+
+    return buffered
   }
 }
 

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -81,9 +81,7 @@ export const pipethroughReadAfterWrite = async <
         return result
       }
 
-      const lex = lexParse(result.buffer.toString('utf8'), {
-        strict: false,
-      })
+      const lex = lexParse(result.buffer.toString('utf8'), { strict: false })
 
       const parsed = method.output.schema.safeValidate(lex, { strict: false })
 

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -5,7 +5,7 @@ import { HandlerPipeThrough } from '@atproto/xrpc-server'
 import { AppContext } from '../context'
 import { readStickyLogger as log } from '../logger'
 import {
-  bufferUpstreamResponseMaybe,
+  asPipeThroughBuffer,
   isJsonContentType,
   pipethrough,
 } from '../pipethrough'
@@ -40,18 +40,18 @@ export const pipethroughReadAfterWrite = async <
 
   const streamRes = await pipethrough(ctx, req, { iss: requester })
 
-  const rev = streamRes.headers['atproto-repo-rev']
+  const rev = streamRes.headers?.['atproto-repo-rev']
   if (!rev) return streamRes
 
-  if (isJsonContentType(streamRes.headers['content-type']) === false) {
+  if (isJsonContentType(streamRes.headers?.['content-type']) === false) {
     // content-type is present but not JSON, we can't munge this
     return streamRes
   }
 
-  const buffered = await bufferUpstreamResponseMaybe(streamRes)
+  const buffered = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024) // 10mb max buffer size
 
   // response is too big to buffer, skip munge and return the stream
-  if ('stream' in buffered) return buffered
+  if (!('buffer' in buffered)) return buffered
 
   try {
     const lex = lexParse(buffered.buffer.toString('utf8'), { strict: false })

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -62,7 +62,7 @@ export const pipethroughReadAfterWrite = async <
   try {
     const lex = lexParse(buffered.buffer.toString('utf8'), { strict: false })
 
-    const original = method.output.schema.validate(lex, {
+    const parsedRes = method.output.schema.validate(lex, {
       strict: false,
     }) as l.InferMethodOutputBody<M, never>
 
@@ -72,7 +72,7 @@ export const pipethroughReadAfterWrite = async <
 
       const localViewer = ctx.localViewer(store)
 
-      const data = await munge(localViewer, original, local, requester)
+      const data = await munge(localViewer, parsedRes, local, requester)
 
       return formatMungedResponse(data, getLocalLag(local))
     })

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -1,7 +1,11 @@
 import express from 'express'
 import { LexValue, l } from '@atproto/lex'
 import { lexParse } from '@atproto/lex-json'
-import { HandlerPipeThrough } from '@atproto/xrpc-server'
+import {
+  HandlerPipeThrough,
+  HandlerPipeThroughBuffer,
+  HandlerPipeThroughStream,
+} from '@atproto/xrpc-server'
 import { AppContext } from '../context'
 import { readStickyLogger as log } from '../logger'
 import {
@@ -38,47 +42,65 @@ export const pipethroughReadAfterWrite = async <
   const requester = auth.credentials.did
   const method = l.getMain(ns)
 
-  const streamRes = await pipethrough(ctx, req, { iss: requester })
+  let streamRes: HandlerPipeThroughBuffer | HandlerPipeThroughStream =
+    await pipethrough(ctx, req, { iss: requester })
 
-  const rev = streamRes.headers?.['atproto-repo-rev']
-  if (!rev) return streamRes
-
-  if (isJsonContentType(streamRes.headers?.['content-type']) === false) {
-    // content-type is present but not JSON, we can't munge this
+  // Only json responses can be parsed for munging
+  if (!isJsonContentType(streamRes.encoding)) {
     return streamRes
   }
 
-  // Buffer up to 10mb of response body for munge, if larger we skip munge and
-  // return the stream directly to avoid OOM crashes
-  const bufferRes = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024)
-
-  // response is too big to buffer, skip munge and return the stream
-  if (!('buffer' in bufferRes)) return bufferRes
+  // Check that the rev is one that we can munge against, if not we return the
+  // stream directly without buffering since we won't be doing a munge and want
+  // to avoid unnecessary memory usage.
+  const rev = streamRes.headers?.['atproto-repo-rev']
+  if (!rev) {
+    return streamRes
+  }
 
   try {
-    const lex = lexParse(bufferRes.buffer.toString('utf8'), { strict: false })
-
-    const result = method.output.schema.safeValidate(lex, { strict: false })
-
-    // Upstream payload does not conform to schema, skip munge and return the
-    // buffered response as-is
-    if (!result.success) return bufferRes
-
-    const parsedRes = result.value as l.InferMethodOutputBody<M, never>
-
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)
-      if (local.count === 0) return bufferRes
+
+      if (local.count === 0) {
+        return streamRes
+      }
+
+      // @NOTE we replace streamRes to avoid accidentally using the stream after
+      // it's been consumed by asPipeThroughBuffer, which would cause an error. By
+      // replacing it with the buffered version, we ensure that any further use of
+      // streamRes is safe.
+      streamRes = await asPipeThroughBuffer(
+        streamRes as HandlerPipeThroughStream,
+        10 * 1024 * 1024,
+      )
+
+      // response was too big to buffer, skip munge
+      if (!('buffer' in streamRes)) {
+        return streamRes
+      }
+
+      const lex = lexParse(streamRes.buffer.toString('utf8'), { strict: false })
+
+      const result = method.output.schema.safeValidate(lex, { strict: false })
+
+      // Upstream payload does not conform to schema, skip munge
+      if (!result.success) {
+        return streamRes
+      }
+
+      const parsedRes = result.value as l.InferMethodOutputBody<M, never>
 
       const localViewer = ctx.localViewer(store)
 
       const data = await munge(localViewer, parsedRes, local, requester)
+
       return formatMungedResponse(data, getLocalLag(local))
     })
   } catch (err) {
     log.warn({ err, requester }, 'error in read after write munge')
 
-    return bufferRes
+    return streamRes
   }
 }
 

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -48,7 +48,9 @@ export const pipethroughReadAfterWrite = async <
     return streamRes
   }
 
-  const bufferRes = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024) // 10mb max buffer size
+  // Buffer up to 10mb of response body for munge, if larger we skip munge and
+  // return the stream directly to avoid OOM crashes
+  const bufferRes = await asPipeThroughBuffer(streamRes, 10 * 1024 * 1024)
 
   // response is too big to buffer, skip munge and return the stream
   if (!('buffer' in bufferRes)) return bufferRes
@@ -56,9 +58,13 @@ export const pipethroughReadAfterWrite = async <
   try {
     const lex = lexParse(bufferRes.buffer.toString('utf8'), { strict: false })
 
-    const parsedRes = method.output.schema.validate(lex, {
-      strict: false,
-    }) as l.InferMethodOutputBody<M, never>
+    const result = method.output.schema.safeValidate(lex, { strict: false })
+
+    // Upstream payload does not conform to schema, skip munge and return the
+    // original response
+    if (!result.success) return bufferRes
+
+    const parsedRes = result.value as l.InferMethodOutputBody<M, never>
 
     return await ctx.actorStore.read(requester, async (store) => {
       const local = await store.record.getRecordsSinceRev(rev)

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -61,7 +61,7 @@ export const pipethroughReadAfterWrite = async <
     const result = method.output.schema.safeValidate(lex, { strict: false })
 
     // Upstream payload does not conform to schema, skip munge and return the
-    // original response
+    // buffered response as-is
     if (!result.success) return bufferRes
 
     const parsedRes = result.value as l.InferMethodOutputBody<M, never>

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -55,9 +55,8 @@ export const pipethroughReadAfterWrite = async <
     return result
   }
 
-  // IF the response is not chunked, we can determine that the content is too
-  // large to buffer without consuming the stream, so we skip munge in that case
-  // to avoid breaking the stream.
+  // If the response is not chunked, we can determine that the content is too
+  // large to buffer without consuming the stream
   const contentLength = result.headers?.['content-length']
   if (contentLength && Number(contentLength) > MAX_BUFFER_SIZE) {
     return result


### PR DESCRIPTION
This change avoids un-necessary buffering of data.