### PR TITLE
Allow `[]` query params syntax with `app.bsky.feed.getPostThread` end…

### DIFF
--- a/.changeset/dry-teeth-travel.md
+++ b/.changeset/dry-teeth-travel.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Allow `[]` query params syntax with `app.bsky.feed.getPostThread` endpoint

--- a/packages/pds/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPostThread.ts
@@ -28,6 +28,11 @@ export default function (server: Server, ctx: AppContext) {
         permissions.assertRpc({ aud, lxm })
       },
     }),
+    opts: {
+      // @TODO remove after grace period has passed, behavior is non-standard.
+      // temporarily added for compat w/ previous version of xrpc-server to avoid breakage of a few specified parties.
+      paramsParseLoose: true,
+    },
     handler: async (reqCtx) => {
       try {
         return await pipethroughReadAfterWrite(


### PR DESCRIPTION
…point