### PR TITLE
fix: implement com.atproto.admin.searchAccounts handler

### DIFF
--- a/packages/pds/src/account-manager/account-manager.ts
+++ b/packages/pds/src/account-manager/account-manager.ts
@@ -83,6 +83,13 @@ export class AccountManager {
     return account.getAccountByEmail(this.db, email, flags)
   }
 
+  async searchAccounts(
+    opts: { email?: string; cursor?: string; limit: number },
+    flags?: account.AvailabilityFlags,
+  ): Promise<ActorAccount[]> {
+    return account.searchAccounts(this.db, opts, flags)
+  }
+
   async isAccountActivated(did: DidString): Promise<boolean> {
     const account = await this.getAccount(did, { includeDeactivated: true })
     if (!account) return false

--- a/packages/pds/src/account-manager/helpers/account.ts
+++ b/packages/pds/src/account-manager/helpers/account.ts
@@ -105,6 +105,28 @@ export const getAccountByEmail = async (
   return found || null
 }
 
+export const searchAccounts = async (
+  db: AccountDb,
+  opts: {
+    email?: string
+    cursor?: string
+    limit: number
+  },
+  flags?: AvailabilityFlags,
+): Promise<ActorAccount[]> => {
+  const { email, cursor, limit } = opts
+  let builder = selectAccountQB(db, flags)
+    .orderBy('actor.did', 'asc')
+    .limit(limit)
+  if (email) {
+    builder = builder.where('account.email', 'like', `%${email.toLowerCase()}%`)
+  }
+  if (cursor) {
+    builder = builder.where('actor.did', '>', cursor as DidString)
+  }
+  return builder.execute()
+}
+
 export const registerActor = async (
   db: AccountDb,
   opts: {

--- a/packages/pds/src/api/com/atproto/admin/index.ts
+++ b/packages/pds/src/api/com/atproto/admin/index.ts
@@ -8,6 +8,7 @@ import getAccountInfo from './getAccountInfo'
 import getAccountInfos from './getAccountInfos'
 import getInviteCodes from './getInviteCodes'
 import getSubjectStatus from './getSubjectStatus'
+import searchAccounts from './searchAccounts'
 import sendEmail from './sendEmail'
 import updateAccountEmail from './updateAccountEmail'
 import updateAccountHandle from './updateAccountHandle'
@@ -28,4 +29,5 @@ export default function (server: Server, ctx: AppContext) {
   updateAccountPassword(server, ctx)
   sendEmail(server, ctx)
   deleteAccount(server, ctx)
+  searchAccounts(server, ctx)
 }

--- a/packages/pds/src/api/com/atproto/admin/searchAccounts.ts
+++ b/packages/pds/src/api/com/atproto/admin/searchAccounts.ts
@@ -1,0 +1,41 @@
+import { Server } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context'
+import { com } from '../../../../lexicons/index.js'
+import { formatAccountInfo } from './util'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(com.atproto.admin.searchAccounts, {
+    auth: ctx.authVerifier.moderator,
+    handler: async ({ params }) => {
+      const { email, cursor, limit = 50 } = params
+      const accounts = await ctx.accountManager.searchAccounts(
+        { email, cursor, limit },
+        { includeDeactivated: true, includeTakenDown: true },
+      )
+
+      const dids = accounts.map((a) => a.did)
+      const [invites, invitedBy] = await Promise.all([
+        ctx.accountManager.getAccountsInvitesCodes(dids),
+        ctx.accountManager.getInvitedByForAccounts(dids),
+      ])
+
+      const managesOwnInvites = !ctx.cfg.entryway
+      const accountViews = accounts.map((account) =>
+        formatAccountInfo(account, { managesOwnInvites, invites, invitedBy }),
+      )
+
+      const nextCursor =
+        accounts.length === limit
+          ? accounts[accounts.length - 1].did
+          : undefined
+
+      return {
+        encoding: 'application/json' as const,
+        body: {
+          cursor: nextCursor,
+          accounts: accountViews,
+        },
+      }
+    },
+  })
+}

--- a/packages/pds/tests/admin-search-accounts.test.ts
+++ b/packages/pds/tests/admin-search-accounts.test.ts
@@ -1,0 +1,123 @@
+import { AtpAgent } from '@atproto/api'
+import { SeedClient, TestNetworkNoAppView } from '@atproto/dev-env'
+import usersSeed, { users } from './seeds/users'
+
+describe('com.atproto.admin.searchAccounts', () => {
+  let network: TestNetworkNoAppView
+  let agent: AtpAgent
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'pds_admin_search_accounts',
+    })
+    agent = network.pds.getAgent()
+    sc = network.getSeedClient()
+    await usersSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('returns all accounts when no filter is provided', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      {},
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(res.data.accounts.length).toBeGreaterThanOrEqual(4)
+    const handles = res.data.accounts.map((a) => a.handle)
+    expect(handles).toContain('alice.test')
+    expect(handles).toContain('bob.test')
+    expect(handles).toContain('carol.test')
+    expect(handles).toContain('dan.test')
+  })
+
+  it('filters accounts by exact email', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      { email: 'alice@test.com' },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(res.data.accounts.length).toBe(1)
+    expect(res.data.accounts[0].handle).toBe('alice.test')
+    expect(res.data.accounts[0].email).toBe('alice@test.com')
+  })
+
+  it('filters accounts by partial email', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      { email: 'test.com' },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(res.data.accounts.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('returns empty list when email does not match', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      { email: 'doesnotexist@nowhere.com' },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(res.data.accounts).toHaveLength(0)
+    expect(res.data.cursor).toBeUndefined()
+  })
+
+  it('returns account fields: did, handle, email, indexedAt', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      { email: 'bob@test.com' },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    const account = res.data.accounts[0]
+    expect(account.did).toMatch(/^did:/)
+    expect(account.handle).toBe('bob.test')
+    expect(account.email).toBe('bob@test.com')
+    expect(account.indexedAt).toBeDefined()
+  })
+
+  it('paginates results using limit and cursor', async () => {
+    const page1 = await agent.api.com.atproto.admin.searchAccounts(
+      { limit: 2 },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(page1.data.accounts).toHaveLength(2)
+    expect(page1.data.cursor).toBeDefined()
+
+    const page2 = await agent.api.com.atproto.admin.searchAccounts(
+      { limit: 2, cursor: page1.data.cursor },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(page2.data.accounts.length).toBeGreaterThanOrEqual(2)
+
+    const page1Dids = page1.data.accounts.map((a) => a.did)
+    const page2Dids = page2.data.accounts.map((a) => a.did)
+    const overlap = page1Dids.filter((did) => page2Dids.includes(did))
+    expect(overlap).toHaveLength(0)
+  })
+
+  it('returns no cursor when results are exhausted', async () => {
+    const res = await agent.api.com.atproto.admin.searchAccounts(
+      { limit: 100 },
+      { headers: network.pds.adminAuthHeaders() },
+    )
+    expect(res.data.cursor).toBeUndefined()
+  })
+
+  it('rejects requests without auth', async () => {
+    await expect(
+      agent.api.com.atproto.admin.searchAccounts({}),
+    ).rejects.toThrow()
+  })
+
+  it('rejects requests with user access token instead of admin auth', async () => {
+    const { data: session } =
+      await agent.api.com.atproto.server.createSession({
+        identifier: users.alice.handle,
+        password: users.alice.password,
+      })
+    await expect(
+      agent.api.com.atproto.admin.searchAccounts(
+        {},
+        { headers: { authorization: `Bearer ${session.accessJwt}` } },
+      ),
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Problem

`com.atproto.admin.searchAccounts` was defined in the lexicon but had no
backend implementation. Any request to this endpoint returned:

```json
{"error":"MethodNotImplemented","message":"Method Not Implemented"}
```

## Root Cause
The lexicon schema existed at:
lexicons/com/atproto/admin/searchAccounts.json

But the route handler was never registered in the PDS. The endpoint was
visible to clients but completely unimplemented on the server side.


## Solution
- `account-manager/helpers/account.ts` -> Added searchAccounts DB
query function with email filtering and cursor-based pagination

- `account-manager/account-manager.ts` -> Added searchAccounts
method to the AccountManager class to expose the query

- `api/com/atproto/admin/searchAccounts.ts`-> Created the missing
route handler with moderator auth, account fetching, invite data, and
pagination

-  `api/com/atproto/admin/index.ts`-> Registered the new handler

Closes #4736 


##Test Cases Added
Added tests/admin-search-accounts.test.ts covering:

- Returns all accounts when no filter is provided
- Filters accounts by exact email
- Filters accounts by partial email
- Returns empty list when email does not match
- Returns correct account fields (did, handle, email, indexedAt)
- Paginates results using limit and cursor
- Returns no cursor when results are exhausted
- Rejects requests without auth
- Rejects requests with user access token instead of admin auth


##Test Plan
-  Start the dev environment
`make run-dev-env`

- In a new terminal — call the endpoint with admin credentials
`curl -X GET "http://localhost:2583/xrpc/com.atproto.admin.searchAccounts" \
  -H "Authorization: Basic $(echo -n 'admin:admin-pass' | base64)"`

- Filter by email
`curl -X GET "http://localhost:2583/xrpc/com.atproto.admin.searchAccounts?email=alice" \
  -H "Authorization: Basic $(echo -n 'admin:admin-pass' | base64)"`