### PR TITLE
Rewrite of aturi tests

### DIFF
--- a/.changeset/smart-boats-hope.md
+++ b/.changeset/smart-boats-hope.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Rewrite of tests

--- a/packages/syntax/tests/aturi-string.test.ts
+++ b/packages/syntax/tests/aturi-string.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+import { ensureValidAtUri, isValidAtUri } from '../src'
+
+describe('valid interop', () => {
+  for (const value of readLines(
+    `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_valid.txt`,
+  )) {
+    testValid(value)
+  }
+})
+
+// describe('invalid interop', () => {
+//   for (const value of readLines(
+//     `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_invalid.txt`,
+//   )) {
+//     testInvalid(value)
+//   }
+// })
+
+describe('custom cases', () => {
+  describe('valid spec basics', () => {
+    testValid('at://did:plc:asdf123')
+    testValid('at://user.bsky.social')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/record')
+
+    testValid('at://did:plc:asdf123#/frag')
+    testValid('at://user.bsky.social#/frag')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post#/frag')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/record#/frag')
+  })
+
+  describe('invalid spec basics', () => {
+    testInvalid('a://did:plc:asdf123')
+    testInvalid('at//did:plc:asdf123')
+    testInvalid('at:/a/did:plc:asdf123')
+    testInvalid('at:/did:plc:asdf123')
+    testInvalid('AT://did:plc:asdf123')
+    testInvalid('http://did:plc:asdf123')
+    testInvalid('://did:plc:asdf123')
+    testInvalid('at:did:plc:asdf123')
+    testInvalid('at:/did:plc:asdf123')
+    testInvalid('at:///did:plc:asdf123')
+    testInvalid('at://:/did:plc:asdf123')
+    testInvalid('at:/ /did:plc:asdf123')
+    testInvalid('at://did:plc:asdf123 ')
+    testInvalid('at://did:plc:asdf123/ ')
+    testInvalid(' at://did:plc:asdf123')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post ')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post# ')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post#/ ')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post#/frag ')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post#fr ag')
+    testInvalid('//did:plc:asdf123')
+    testInvalid('at://name')
+    testInvalid('at://name.0')
+    testInvalid('at://diD:plc:asdf123')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.p@st')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.p$st')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.p%st')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.p&st')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.p()t')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed_post')
+    testInvalid('at://did:plc:asdf123/-com.atproto.feed.post')
+    testInvalid('at://did:plc:asdf@123/com.atproto.feed.post')
+
+    testInvalid('at://DID:plc:asdf123')
+    testInvalid('at://user.bsky.123')
+    testInvalid('at://bsky')
+    testInvalid('at://did:plc:')
+    testInvalid('at://did:plc:')
+    testInvalid('at://frag')
+  })
+
+  describe('very long strings', () => {
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/' + 'o'.repeat(800))
+    testInvalid(`at://did:plc:${'o'.repeat(8200)}/com.atproto.feed.post/record`)
+  })
+
+  describe('invalid collection', () => {
+    testInvalid('at://did:plc:asdf123/short/stuff')
+    testInvalid('at://did:plc:asdf123/12345')
+  })
+
+  describe('invalid repeated slashes', () => {
+    testInvalid('at://user.bsky.social//')
+    testInvalid('at://user.bsky.social//com.atproto.feed.post')
+    testInvalid('at://user.bsky.social/com.atproto.feed.post//')
+  })
+
+  describe('invalid trailing slashes', () => {
+    testInvalid('at://did:plc:asdf123/')
+    testInvalid('at://user.bsky.social/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/#/frag')
+  })
+
+  describe('invalid segment count', () => {
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/asdf123/asdf')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/asdf123/more/more')
+  })
+
+  describe('valid record key', () => {
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/a')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/asdf123')
+  })
+
+  describe('invalid trailing slash', () => {
+    testInvalid('at://did:plc:asdf123/')
+    testInvalid('at://user.bsky.social/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/')
+    testInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/#/frag')
+  })
+
+  describe('invalid record keys', () => {
+    // is probably too permissive about URL encoding
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%30')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%3')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%zz')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%%%')
+
+    // is very permissive about fragments
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/%23')
+
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/$@!*)(:,;~.sdf123')
+    testValid("at://did:plc:asdf123/com.atproto.feed.post/~'sdf123")
+
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/$')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/@')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/!')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/*')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/(')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/,')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/;')
+    testValid('at://did:plc:asdf123/com.atproto.feed.post/abc%30123')
+  })
+
+  describe('valid fragment', () => {
+    testValid('at://did:plc:asdf123#/frac')
+  })
+
+  describe('invalid fragment', () => {
+    testValid('at://did:plc:asdf123#/com.atproto.feed.post')
+    testValid('at://did:plc:asdf123#/com.atproto.feed.post/')
+    testValid('at://did:plc:asdf123#/asdf/')
+
+    testValid('at://did:plc:asdf123/com.atproto.feed.post#/$@!*():,;~.sdf123')
+    testValid('at://did:plc:asdf123#/[asfd]')
+
+    testValid('at://did:plc:asdf123#/$')
+    testValid('at://did:plc:asdf123#/*')
+    testValid('at://did:plc:asdf123#/;')
+    testValid('at://did:plc:asdf123#/,')
+
+    testInvalid('at://did:plc:asdf123#')
+    testInvalid('at://did:plc:asdf123##')
+    testInvalid('#at://did:plc:asdf123')
+    testInvalid('at://did:plc:asdf123#/asdf#/asdf')
+  })
+})
+
+function testValid(value: string) {
+  test(value, () => {
+    expect(isValidAtUri(value)).toBe(true)
+    expect(() => ensureValidAtUri(value)).not.toThrow()
+  })
+}
+
+function testInvalid(value: string) {
+  test(value, () => {
+    expect(isValidAtUri(value)).toBe(false)
+  })
+}
+
+function readLines(filePath: string): string[] {
+  return readFileSync(filePath, 'utf-8')
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('#') && line.length > 0)
+}

--- a/packages/syntax/tests/aturi.test.ts
+++ b/packages/syntax/tests/aturi.test.ts
@@ -1,12 +1,26 @@
-import * as fs from 'node:fs'
-import * as readline from 'node:readline'
-import { describe, expect, it } from 'vitest'
-import { AtUri, ensureValidAtUri, ensureValidAtUriRegex } from '../src'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it, test } from 'vitest'
+import { AtUri } from '../src'
 
 describe(AtUri, () => {
-  it('parses valid at uris', () => {
-    //                 input   host    path    query   hash
-    type AtUriTest = [string, string, string, string, string]
+  describe('parses valid interop', () => {
+    for (const value of readLines(
+      `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_valid.txt`,
+    )) {
+      test(value, () => {
+        expect(() => new AtUri(value)).not.toThrow()
+      })
+    }
+  })
+
+  describe('valid at uris', () => {
+    type AtUriTest = [
+      input: string,
+      host: string,
+      path: string,
+      query: string,
+      hash: string,
+    ]
     const TESTS: AtUriTest[] = [
       ['foo.com', 'foo.com', '', '', ''],
       ['at://foo.com', 'foo.com', '', '', ''],
@@ -246,15 +260,17 @@ describe(AtUri, () => {
         '',
       ],
     ]
-    for (const [uri, hostname, pathname, search, hash] of TESTS) {
-      const urip = new AtUri(uri)
-      expect(urip.protocol).toBe('at:')
-      expect(urip.host).toBe(hostname)
-      expect(urip.hostname).toBe(hostname)
-      expect(urip.origin).toBe(`at://${hostname}`)
-      expect(urip.pathname).toBe(pathname)
-      expect(urip.search).toBe(search)
-      expect(urip.hash).toBe(hash)
+    for (const [input, host, path, search, hash] of TESTS) {
+      test(input, () => {
+        const urip = new AtUri(input)
+        expect(urip.protocol).toBe('at:')
+        expect(urip.host).toBe(host)
+        expect(urip.hostname).toBe(host)
+        expect(urip.origin).toBe(`at://${host}`)
+        expect(urip.pathname).toBe(path)
+        expect(urip.search).toBe(search)
+        expect(urip.hash).toBe(hash)
+      })
     }
   })
 
@@ -316,11 +332,9 @@ describe(AtUri, () => {
     expect(urip.toString()).toBe('at://foo.com/foo?foo=bar&baz=buux#hash')
   })
 
-  it('supports relative URIs', () => {
-    //                 input   path    query   hash
-    type AtUriTest = [string, string, string, string]
+  describe('relative URIs', () => {
+    type AtUriTest = [input: string, path: string, search: string, hash: string]
     const TESTS: AtUriTest[] = [
-      // input hostname pathname query hash
       ['', '', '', ''],
       ['/', '/', '', ''],
       ['/foo', '/foo', '', ''],
@@ -347,179 +361,22 @@ describe(AtUri, () => {
     ]
 
     for (const base of BASES) {
-      const basep = new AtUri(base)
-      for (const [relative, pathname, search, hash] of TESTS) {
-        const urip = new AtUri(relative, base)
-        expect(urip.protocol).toBe('at:')
-        expect(urip.host).toBe(basep.host)
-        expect(urip.hostname).toBe(basep.hostname)
-        expect(urip.origin).toBe(basep.origin)
-        expect(urip.pathname).toBe(pathname)
-        expect(urip.search).toBe(search)
-        expect(urip.hash).toBe(hash)
-      }
+      describe(base, () => {
+        for (const [input, path, search, hash] of TESTS) {
+          test(input, () => {
+            const baseUri = new AtUri(base)
+            const uri = new AtUri(input, base)
+            expect(uri.protocol).toBe('at:')
+            expect(uri.host).toBe(baseUri.host)
+            expect(uri.hostname).toBe(baseUri.hostname)
+            expect(uri.origin).toBe(baseUri.origin)
+            expect(uri.pathname).toBe(path)
+            expect(uri.search).toBe(search)
+            expect(uri.hash).toBe(hash)
+          })
+        }
+      })
     }
-  })
-})
-
-describe('AtUri validation', () => {
-  const expectValid = (h: string) => {
-    ensureValidAtUri(h)
-    ensureValidAtUriRegex(h)
-  }
-  const expectInvalid = (h: string) => {
-    expect(() => ensureValidAtUri(h)).toThrow()
-    expect(() => ensureValidAtUriRegex(h)).toThrow()
-  }
-
-  it('enforces spec basics', () => {
-    expectValid('at://did:plc:asdf123')
-    expectValid('at://user.bsky.social')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/record')
-
-    expectValid('at://did:plc:asdf123#/frag')
-    expectValid('at://user.bsky.social#/frag')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post#/frag')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/record#/frag')
-
-    expectInvalid('a://did:plc:asdf123')
-    expectInvalid('at//did:plc:asdf123')
-    expectInvalid('at:/a/did:plc:asdf123')
-    expectInvalid('at:/did:plc:asdf123')
-    expectInvalid('AT://did:plc:asdf123')
-    expectInvalid('http://did:plc:asdf123')
-    expectInvalid('://did:plc:asdf123')
-    expectInvalid('at:did:plc:asdf123')
-    expectInvalid('at:/did:plc:asdf123')
-    expectInvalid('at:///did:plc:asdf123')
-    expectInvalid('at://:/did:plc:asdf123')
-    expectInvalid('at:/ /did:plc:asdf123')
-    expectInvalid('at://did:plc:asdf123 ')
-    expectInvalid('at://did:plc:asdf123/ ')
-    expectInvalid(' at://did:plc:asdf123')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post ')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post# ')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post#/ ')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post#/frag ')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post#fr ag')
-    expectInvalid('//did:plc:asdf123')
-    expectInvalid('at://name')
-    expectInvalid('at://name.0')
-    expectInvalid('at://diD:plc:asdf123')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.p@st')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.p$st')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.p%st')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.p&st')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.p()t')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed_post')
-    expectInvalid('at://did:plc:asdf123/-com.atproto.feed.post')
-    expectInvalid('at://did:plc:asdf@123/com.atproto.feed.post')
-
-    expectInvalid('at://DID:plc:asdf123')
-    expectInvalid('at://user.bsky.123')
-    expectInvalid('at://bsky')
-    expectInvalid('at://did:plc:')
-    expectInvalid('at://did:plc:')
-    expectInvalid('at://frag')
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/' + 'o'.repeat(800))
-    expectInvalid(
-      'at://did:plc:asdf123/com.atproto.feed.post/' + 'o'.repeat(8200),
-    )
-  })
-
-  it('has specified behavior on edge cases', () => {
-    expectInvalid('at://user.bsky.social//')
-    expectInvalid('at://user.bsky.social//com.atproto.feed.post')
-    expectInvalid('at://user.bsky.social/com.atproto.feed.post//')
-    expectInvalid(
-      'at://did:plc:asdf123/com.atproto.feed.post/asdf123/more/more',
-    )
-    expectInvalid('at://did:plc:asdf123/short/stuff')
-    expectInvalid('at://did:plc:asdf123/12345')
-  })
-
-  it('enforces no trailing slashes', () => {
-    expectValid('at://did:plc:asdf123')
-    expectInvalid('at://did:plc:asdf123/')
-
-    expectValid('at://user.bsky.social')
-    expectInvalid('at://user.bsky.social/')
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post/')
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/record')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post/record/#/frag')
-  })
-
-  it('enforces strict paths', () => {
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/asdf123')
-    expectInvalid('at://did:plc:asdf123/com.atproto.feed.post/asdf123/asdf')
-  })
-
-  it('is very permissive about record keys', () => {
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/asdf123')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/a')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%23')
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/$@!*)(:,;~.sdf123')
-    expectValid("at://did:plc:asdf123/com.atproto.feed.post/~'sdf123")
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/$')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/@')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/!')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/*')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/(')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/,')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/;')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/abc%30123')
-  })
-
-  it('is probably too permissive about URL encoding', () => {
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%30')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%3')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%zz')
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post/%%%')
-  })
-
-  it('is very permissive about fragments', () => {
-    expectValid('at://did:plc:asdf123#/frac')
-
-    expectInvalid('at://did:plc:asdf123#')
-    expectInvalid('at://did:plc:asdf123##')
-    expectInvalid('#at://did:plc:asdf123')
-    expectInvalid('at://did:plc:asdf123#/asdf#/asdf')
-
-    expectValid('at://did:plc:asdf123#/com.atproto.feed.post')
-    expectValid('at://did:plc:asdf123#/com.atproto.feed.post/')
-    expectValid('at://did:plc:asdf123#/asdf/')
-
-    expectValid('at://did:plc:asdf123/com.atproto.feed.post#/$@!*():,;~.sdf123')
-    expectValid('at://did:plc:asdf123#/[asfd]')
-
-    expectValid('at://did:plc:asdf123#/$')
-    expectValid('at://did:plc:asdf123#/*')
-    expectValid('at://did:plc:asdf123#/;')
-    expectValid('at://did:plc:asdf123#/,')
-  })
-
-  it('conforms to interop valid ATURIs', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/aturi_syntax_valid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectValid(line)
-    })
   })
 
   it('properly checks that the did property is a valid did', () => {
@@ -568,6 +425,10 @@ describe('AtUri validation', () => {
     expect(urip.rkey).toBe('not a valid rkey')
     expect(() => urip.rkeySafe).toThrow()
   })
-
-  // NOTE: this package is currently more permissive than spec about AT URIs, so invalid cases are not errors
 })
+
+function readLines(filePath: string): string[] {
+  return readFileSync(filePath, 'utf-8')
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('#') && line.length > 0)
+}

--- a/packages/syntax/tests/interop-files/aturi_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/aturi_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/aturi_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/aturi_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/aturi_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/aturi_syntax_valid.txt


### PR DESCRIPTION
This is a priliminary work aimed at making at-uri validation actually spec compliant. There are two changes here:

- Split `aturi_validation.ts` tests in separate file
- Ensure that  `new AtUri` works with valid interop data

I also added a commented version of `aturi_syntax_invalid.txt` as the current validation allows actually invalid uris

The main work is to make the https://github.com/bluesky-social/atproto/pull/4806 diff more legible.