### PR TITLE
Improve error reporting

### DIFF
--- a/.changeset/fluffy-insects-move.md
+++ b/.changeset/fluffy-insects-move.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-client': patch
+---
+
+On NodeJS, improve error reporting by unwrapping undici errors

--- a/.changeset/violet-bats-talk.md
+++ b/.changeset/violet-bats-talk.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Use request logger instead of global one when performing service proxying

--- a/packages/lex/lex-client/src/xrpc.ts
+++ b/packages/lex/lex-client/src/xrpc.ts
@@ -218,7 +218,8 @@ export async function xrpcSafe<const M extends Query | Procedure>(
     const agent = buildAgent(agentOpts)
     const url = xrpcRequestUrl(method, options)
     const request = xrpcRequestInit(method, options)
-    const response = await agent.fetchHandler(url, request).catch((cause) => {
+    const response = await agent.fetchHandler(url, request).catch((err) => {
+      const cause = extractFetchErrorCause(err)
       throw new XrpcFetchError(method, cause)
     })
     return await XrpcResponse.fromFetchResponse<M>(method, response, options)
@@ -411,4 +412,30 @@ function buildEncoding(schema: Payload, encodingHint?: string): string {
   throw new TypeError(
     `Unable to determine payload encoding. Please provide a 'content-type' header matching ${schema.encoding}.`,
   )
+}
+
+/**
+ * Extracts the root cause from an error, unwrapping common fetch-related errors
+ * such as those from undici (Node's internal fetch implementation).
+ *
+ * @param err - The error to extract the root cause from
+ * @returns The root cause error, or the original error if no specific pattern is matched
+ * @remarks This is useful for getting more specific error information from fetch-related failures, especially in Node environments using undici.
+ */
+export function extractFetchErrorCause(err: unknown): unknown {
+  // Unwrap the Network error from undici (i.e. Node's internal fetch() implementation)
+  // https://github.com/nodejs/undici/blob/04cb77327f7ada95c2e5b67424cddcb22d7bf882/lib/web/fetch/index.js#L234-L239
+  if (
+    err instanceof TypeError &&
+    err.message === 'fetch failed' &&
+    err.cause !== undefined
+  ) {
+    return err.cause
+  }
+
+  // @TODO Add other unwrap patterns here as needed (e.g. for other fetch
+  // implementations or common network libraries, like "node:http", or in other
+  // environments like React Native, Deno, Bun, Browser, etc.)
+
+  return err
 }

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -91,7 +91,7 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         headers,
       }
 
-      await pipethroughStream(ctx, dispatchOptions, (upstream) => {
+      await pipethroughStream(ctx, req, dispatchOptions, (upstream) => {
         res.status(upstream.statusCode)
 
         for (const [name, val] of responseHeaders(upstream.headers)) {
@@ -188,7 +188,7 @@ export async function pipethrough(
     highWaterMark: 2 * 65536, // twice the default (64KiB)
   }
 
-  const { headers, body } = await pipethroughRequest(ctx, dispatchOptions)
+  const { headers, body } = await pipethroughRequest(ctx, req, dispatchOptions)
 
   return {
     encoding: safeString(headers['content-type']) ?? 'application/json',
@@ -291,6 +291,7 @@ export const parseProxyHeader = async (
  */
 async function pipethroughStream(
   ctx: AppContext,
+  req: Request,
   dispatchOptions: Dispatcher.RequestOptions,
   successStreamFactory: Dispatcher.StreamFactory,
 ): Promise<void> {
@@ -327,7 +328,7 @@ async function pipethroughStream(
       // or writable stream errors. In the latter case, the promise will already
       // be resolved, and reject()ing it there after will have no effect. Those
       // error would still be logged by the successStreamFactory() function.
-      .catch(handleUpstreamRequestError)
+      .catch(handleUpstreamRequestError.bind(req))
       .catch(reject)
   })
 }
@@ -338,6 +339,7 @@ async function pipethroughStream(
  */
 async function pipethroughRequest(
   ctx: AppContext,
+  req: Request,
   dispatchOptions: Dispatcher.RequestOptions,
 ) {
   // HandlerPipeThroughStream requires a readable stream to be returned, so we
@@ -345,7 +347,7 @@ async function pipethroughRequest(
 
   const upstream = await ctx.proxyAgent
     .request(dispatchOptions)
-    .catch(handleUpstreamRequestError)
+    .catch(handleUpstreamRequestError.bind(req))
 
   if (upstream.statusCode >= 400) {
     const parsed = await tryParsingError(upstream.headers, upstream.body)
@@ -359,13 +361,21 @@ async function pipethroughRequest(
 }
 
 function handleUpstreamRequestError(
+  this: Request,
   err: unknown,
   message = 'Upstream service unreachable',
 ): never {
-  httpLogger.error({ err }, message)
+  const logger = isPinoHttpRequest(this) ? this.log : httpLogger
+  logger.error({ err }, message)
   throw new XRPCServerError(ResponseType.UpstreamFailure, message, undefined, {
     cause: err,
   })
+}
+
+function isPinoHttpRequest(req: Request): req is Request & {
+  log: { error: (obj: unknown, msg: string) => void }
+} {
+  return typeof (req as { log?: any }).log?.error === 'function'
 }
 
 // Request parsing/forwarding


### PR DESCRIPTION
This change aims at providing better stack traces in logs:
- By using the `req.log` instead of the global logger
- By extracting undici's inner error when `fetch()` causes an error