### PR TITLE
Implement generic feeds lexicon

### DIFF
--- a/lexicons/com/atproto/feed/defs.json
+++ b/lexicons/com/atproto/feed/defs.json
@@ -46,7 +46,7 @@
         "like": { "type": "string", "format": "at-uri" }
       }
     },
-    "skeletonFeedPost": {
+    "skeletonFeedItem": {
       "type": "object",
       "required": ["record"],
       "properties": {

--- a/lexicons/com/atproto/feed/defs.json
+++ b/lexicons/com/atproto/feed/defs.json
@@ -120,11 +120,15 @@
     },
     "contentModeUnspecified": {
       "type": "token",
-      "description": "Declares the feed generator returns any types of posts."
+      "description": "Declares the feed generator returns any types of items."
     },
     "contentModeVideo": {
       "type": "token",
-      "description": "Declares the feed generator returns posts containing video embeds."
+      "description": "Declares the feed generator returns items containing video embeds."
+    },
+    "contentModeMedia": {
+      "type": "token",
+      "description": "Declares the feed generator returns items containing media (images, videos, audio, etc)."
     },
     "interactionSeen": {
       "type": "token",

--- a/lexicons/com/atproto/feed/defs.json
+++ b/lexicons/com/atproto/feed/defs.json
@@ -1,0 +1,146 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.defs",
+  "defs": {
+    "generatorView": {
+      "type": "object",
+      "required": ["uri", "cid", "did", "creator", "displayName", "indexedAt"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "did": { "type": "string", "format": "did" },
+        "creator": { "type": "string", "format": "did" },
+        "displayName": {
+          "type": "string",
+          "maxGraphemes": 64,
+          "maxLength": 640
+        },
+        "description": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000
+        },
+        "avatar": { "type": "string", "format": "uri" },
+        "likeCount": { "type": "integer", "minimum": 0 },
+        "acceptsInteractions": { "type": "boolean" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+        },
+        "viewer": { "type": "ref", "ref": "#generatorViewerState" },
+        "contentMode": {
+          "type": "string",
+          "knownValues": [
+            "com.atproto.feed.defs#contentModeUnspecified",
+            "com.atproto.feed.defs#contentModeVideo",
+            "com.atproto.feed.defs#contentModeMedia"
+          ],
+          "maxLength": 300
+        },
+        "indexedAt": { "type": "string", "format": "datetime" }
+      }
+    },
+    "generatorViewerState": {
+      "type": "object",
+      "properties": {
+        "like": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "skeletonFeedPost": {
+      "type": "object",
+      "required": ["record"],
+      "properties": {
+        "record": { "type": "string", "format": "at-uri" },
+        "reason": {
+          "type": "union",
+          "refs": ["#skeletonReasonPin"]
+        },
+        "feedContext": {
+          "type": "string",
+          "description": "Context that will be passed through to client and may be passed to feed generator back alongside interactions.",
+          "maxLength": 2000
+        }
+      }
+    },
+    "skeletonReasonPin": {
+      "type": "object",
+      "description": "This record is pinned to the top of the Feed",
+      "properties": {}
+    },
+    "interaction": {
+      "type": "object",
+      "properties": {
+        "item": { "type": "string", "format": "at-uri" },
+        "event": {
+          "type": "string",
+          "knownValues": [
+            "com.atproto.feed.defs#requestLess",
+            "com.atproto.feed.defs#requestMore",
+            "com.atproto.feed.defs#clickthroughItem",
+            "com.atproto.feed.defs#clickthroughAuthor",
+            "com.atproto.feed.defs#clickthroughEmbed",
+            "com.atproto.feed.defs#interactionSeen",
+            "com.atproto.feed.defs#interactionLike",
+            "com.atproto.feed.defs#interactionReply",
+            "com.atproto.feed.defs#interactionShare"
+          ],
+          "maxLength": 300
+        },
+        "feedContext": {
+          "type": "string",
+          "description": "Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.",
+          "maxLength": 2000
+        },
+        "reqId": {
+          "type": "string",
+          "description": "Unique identifier per request that may be passed back alongside interactions.",
+          "maxLength": 100
+        }
+      }
+    },
+    "requestLess": {
+      "type": "token",
+      "description": "Request that less content like the given feed item be shown in the feed"
+    },
+    "requestMore": {
+      "type": "token",
+      "description": "Request that more content like the given feed item be shown in the feed"
+    },
+    "clickthroughItem": {
+      "type": "token",
+      "description": "User clicked through to the feed item"
+    },
+    "clickthroughAuthor": {
+      "type": "token",
+      "description": "User clicked through to the author of the feed item"
+    },
+    "clickthroughEmbed": {
+      "type": "token",
+      "description": "User clicked through to the embedded content of the feed item"
+    },
+    "contentModeUnspecified": {
+      "type": "token",
+      "description": "Declares the feed generator returns any types of posts."
+    },
+    "contentModeVideo": {
+      "type": "token",
+      "description": "Declares the feed generator returns posts containing video embeds."
+    },
+    "interactionSeen": {
+      "type": "token",
+      "description": "Feed item was seen by user"
+    },
+    "interactionLike": {
+      "type": "token",
+      "description": "User liked the feed item"
+    },
+    "interactionReply": {
+      "type": "token",
+      "description": "User replied to the feed item"
+    },
+    "interactionShare": {
+      "type": "token",
+      "description": "User shared the feed item"
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/describeFeedGenerator.json
+++ b/lexicons/com/atproto/feed/describeFeedGenerator.json
@@ -1,0 +1,40 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.describeFeedGenerator",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get information about a feed generator, including policies and offered feed URIs. Does not require auth; implemented by Feed Generator services (not App View).",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "feeds"],
+          "properties": {
+            "did": { "type": "string", "format": "did" },
+            "feeds": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#feed" }
+            },
+            "links": { "type": "ref", "ref": "#links" }
+          }
+        }
+      }
+    },
+    "feed": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" }
+      }
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "documentation": { "type": "string", "maxLength": 8000 },
+        "privacyPolicy": { "type": "string", "maxLength": 8000 },
+        "termsOfService": { "type": "string", "maxLength": 8000 }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/generator.json
+++ b/lexicons/com/atproto/feed/generator.json
@@ -39,7 +39,8 @@
             "type": "string",
             "knownValues": [
               "com.atproto.feed.defs#contentModeUnspecified",
-              "com.atproto.feed.defs#contentModeVideo"
+              "com.atproto.feed.defs#contentModeVideo",
+              "com.atproto.feed.defs#contentModeMedia"
             ],
             "maxLength": 300
           },

--- a/lexicons/com/atproto/feed/generator.json
+++ b/lexicons/com/atproto/feed/generator.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.generator",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring of the existence of a feed generator, and containing metadata about it. The record can exist in any repository.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["did", "displayName", "createdAt"],
+        "properties": {
+          "did": { "type": "string", "format": "did" },
+          "displayName": {
+            "type": "string",
+            "maxGraphemes": 24,
+            "maxLength": 240
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 300,
+            "maxLength": 3000
+          },
+          "avatar": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000
+          },
+          "acceptsInteractions": {
+            "type": "boolean",
+            "description": "Declaration that a feed accepts feedback interactions from a client through com.atproto.feed.sendInteractions"
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "contentMode": {
+            "type": "string",
+            "knownValues": [
+              "com.atproto.feed.defs#contentModeUnspecified",
+              "com.atproto.feed.defs#contentModeVideo"
+            ],
+            "maxLength": 300
+          },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/getFeedGenerator.json
+++ b/lexicons/com/atproto/feed/getFeedGenerator.json
@@ -1,0 +1,42 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.getFeedGenerator",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get information about a feed generator. Implemented by AppView.",
+      "parameters": {
+        "type": "params",
+        "required": ["feed"],
+        "properties": {
+          "feed": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the feed generator record."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["view", "isOnline", "isValid"],
+          "properties": {
+            "view": {
+              "type": "ref",
+              "ref": "com.atproto.feed.defs#generatorView"
+            },
+            "isOnline": {
+              "type": "boolean",
+              "description": "Indicates whether the feed generator service has been online recently, or else seems to be inactive."
+            },
+            "isValid": {
+              "type": "boolean",
+              "description": "Indicates whether the feed generator service is compatible with the record declaration."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/getFeedGenerators.json
+++ b/lexicons/com/atproto/feed/getFeedGenerators.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.getFeedGenerators",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get information about a list of feed generators.",
+      "parameters": {
+        "type": "params",
+        "required": ["feeds"],
+        "properties": {
+          "feeds": {
+            "type": "array",
+            "items": { "type": "string", "format": "at-uri" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["feeds"],
+          "properties": {
+            "feeds": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.feed.defs#generatorView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/getFeedSkeleton.json
+++ b/lexicons/com/atproto/feed/getFeedSkeleton.json
@@ -34,7 +34,7 @@
               "type": "array",
               "items": {
                 "type": "ref",
-                "ref": "com.atproto.feed.defs#skeletonFeedPost"
+                "ref": "com.atproto.feed.defs#skeletonFeedItem"
               }
             },
             "reqId": {

--- a/lexicons/com/atproto/feed/getFeedSkeleton.json
+++ b/lexicons/com/atproto/feed/getFeedSkeleton.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.getFeedSkeleton",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get a skeleton of a feed provided by a feed generator. Auth is optional, depending on provider requirements, and provides the DID of the requester. Implemented by Feed Generator Service.",
+      "parameters": {
+        "type": "params",
+        "required": ["feed"],
+        "properties": {
+          "feed": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Reference to feed generator record describing the specific feed being requested."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string", "maxLength": 1000 }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["feed"],
+          "properties": {
+            "cursor": { "type": "string", "maxLength": 1000 },
+            "feed": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.feed.defs#skeletonFeedPost"
+              }
+            },
+            "reqId": {
+              "type": "string",
+              "description": "Unique identifier per request that may be passed back alongside interactions.",
+              "maxLength": 100
+            }
+          }
+        }
+      },
+      "errors": [{ "name": "UnknownFeed" }]
+    }
+  }
+}

--- a/lexicons/com/atproto/feed/sendInteractions.json
+++ b/lexicons/com/atproto/feed/sendInteractions.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "com.atproto.feed.sendInteractions",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Send information about interactions with feed items back to the feed generator that served them.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["interactions"],
+          "properties": {
+            "feed": { "type": "string", "format": "at-uri" },
+            "interactions": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.feed.defs#interaction"
+              }
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Let's make feeds truly generic and a reusable concept across the protocol. This feels like the next step of moving the feed documentation into the [atproto.com website](https://atproto.com/guides/feeds), and I hope this provides a pathway for more applications and lexicons to experiment with custom feeds

I did run `goat lex lint` on this, but couldn't run `goat lex validate` as it was saying `error: expected NSID, got empty string` or `error: read ./lexicons/com/atproto/feed/: is a directory`