### PR TITLE
Workaround missing dependency when installing npm@latest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,10 @@ jobs:
           cache: pnpm
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+      # Temporary workaround for an issue with Node.js v22
+      # https://github.com/npm/cli/issues/9151
+      # https://github.com/npm/cli/pull/9152
+      - run: npm install --global npm@11.11.1
       - run: npm install --global npm@latest
       - run: pnpm install --frozen-lockfile
         env:


### PR DESCRIPTION
This is causing deployments to fail, e.g., https://github.com/bluesky-social/atproto/actions/runs/23920326164/attempts/1

See issues linked in comments for more context:
* https://github.com/npm/cli/issues/9151
* https://github.com/npm/cli/pull/9152