### PR TITLE
Remove impossible RecordNotFound error

### DIFF
--- a/lexicons/com/atproto/sync/getRecord.json
+++ b/lexicons/com/atproto/sync/getRecord.json
@@ -26,7 +26,6 @@
         "encoding": "application/vnd.ipld.car"
       },
       "errors": [
-        { "name": "RecordNotFound" },
         { "name": "RepoNotFound" },
         { "name": "RepoTakendown" },
         { "name": "RepoSuspended" },


### PR DESCRIPTION
`com.atproto.sync.getRecord` must prove the non-existence of a record when it's not found, which requires returning a CAR slice, so it cannot return an XRPC-shaped error body, so `RecordNotFound` can't be a compliant response. I think.

the description of this endpoint itself says

> Get data blocks needed to prove the existence **or non-existence** of record in the current version of repo. Does not require auth.

(emphasis added)