### PR TITLE
lex: more flexible 'aud' for getServiceAuth

### DIFF
--- a/lexicons/com/atproto/server/getServiceAuth.json
+++ b/lexicons/com/atproto/server/getServiceAuth.json
@@ -4,15 +4,14 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Get a signed token on behalf of the requesting DID for the requested service.",
+      "description": "Get a signed token on behalf of the requesting DID for the requested service, which can be used to make an authenticated XRPC HTTP API request. Implemented by PDS, requires authentication, and constrained by session permissions.",
       "parameters": {
         "type": "params",
         "required": ["aud"],
         "properties": {
           "aud": {
             "type": "string",
-            "format": "did",
-            "description": "The DID of the service that the token will be used to authenticate with"
+            "description": "The DID (and optional service ID as a fragment) of the recipient service for this request (the \"audience\")."
           },
           "exp": {
             "type": "integer",

--- a/lexicons/com/atproto/server/getServiceAuth.json
+++ b/lexicons/com/atproto/server/getServiceAuth.json
@@ -11,7 +11,7 @@
         "properties": {
           "aud": {
             "type": "string",
-            "description": "The DID (and optional service ID as a fragment) of the recipient service for this request (the \"audience\")."
+            "description": "The \"audience\" DID service reference for the intended recipient of the request. Syntax is a DID with a service endpoint id, separated by a hash (eg 'did:web:example.com#app_svc'). For OAuth clients, this field must exactly match the 'aud' granted via permission. Use of a bare DID (with no hash or service id) is deprecated, and does not work with OAuth clients."
           },
           "exp": {
             "type": "integer",
@@ -20,7 +20,7 @@
           "lxm": {
             "type": "string",
             "format": "nsid",
-            "description": "Lexicon (XRPC) method to bind the requested token to"
+            "description": "Lexicon (XRPC) method to bind the requested token to. This field is effectively required."
           }
         }
       },


### PR DESCRIPTION
Updates `getServiceAuth` to support single-string `aud` syntax.

Background/motivation is described in https://github.com/bluesky-social/proposals/tree/main/0013-service-auth-refs; this is a revised/alternative proposal, which matches the spec updates proposed in https://github.com/bluesky-social/atproto-website/pull/616

Before merging:
- [ ] run codegen
- [ ] fix any build errors (eg, in PDS/entryway implementation)
- [ ] create a changeset