### PR TITLE
Data Plane Caller Interceptor

### DIFF
--- a/.changeset/easy-insects-dress.md
+++ b/.changeset/easy-insects-dress.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add interceptor to dataplane GRPC client

--- a/packages/bsky/src/data-plane/client/index.ts
+++ b/packages/bsky/src/data-plane/client/index.ts
@@ -10,6 +10,7 @@ import {
 import { createGrpcTransport } from '@connectrpc/connect-node'
 import { Service } from '../../proto/bsky_connect'
 import { HostList } from './hosts'
+import { callerInterceptor } from './util'
 
 export * from './hosts'
 export * from './util'
@@ -105,6 +106,7 @@ const createBaseClient = (
     httpVersion,
     acceptCompression: [],
     nodeOptions: { rejectUnauthorized },
+    interceptors: [callerInterceptor('appview')],
   })
   return createPromiseClient(Service, transport)
 }

--- a/packages/bsky/src/data-plane/client/util.test.ts
+++ b/packages/bsky/src/data-plane/client/util.test.ts
@@ -1,0 +1,39 @@
+/// <reference types="jest" />
+import { callerInterceptor } from './util'
+
+describe('callerInterceptor', () => {
+  it('sets x-atlantis-caller header on the request', async () => {
+    const interceptor = callerInterceptor('appview')
+    const expectedResponse = { status: 'ok' }
+    const next = jest.fn().mockResolvedValue(expectedResponse)
+
+    const req = { header: new Headers() }
+    const handler = interceptor(next)
+    const res = await handler(req as any)
+
+    expect(req.header.get('x-atlantis-caller')).toBe('appview')
+    expect(next).toHaveBeenCalledWith(req)
+    expect(res).toBe(expectedResponse)
+  })
+
+  it('uses the provided caller value', async () => {
+    const interceptor = callerInterceptor('feed-generator')
+    const next = jest.fn().mockResolvedValue({})
+
+    const req = { header: new Headers() }
+    await interceptor(next)(req as any)
+
+    expect(req.header.get('x-atlantis-caller')).toBe('feed-generator')
+  })
+
+  it('does not overwrite other existing headers', async () => {
+    const interceptor = callerInterceptor('appview')
+    const next = jest.fn().mockResolvedValue({})
+
+    const req = { header: new Headers({ 'x-other': 'value' }) }
+    await interceptor(next)(req as any)
+
+    expect(req.header.get('x-atlantis-caller')).toBe('appview')
+    expect(req.header.get('x-other')).toBe('value')
+  })
+})

--- a/packages/bsky/src/data-plane/client/util.ts
+++ b/packages/bsky/src/data-plane/client/util.ts
@@ -1,6 +1,14 @@
-import { Code, ConnectError } from '@connectrpc/connect'
+import { Code, ConnectError, Interceptor } from '@connectrpc/connect'
 import * as ui8 from 'uint8arrays'
 import { getDidKeyFromMultibase } from '@atproto/identity'
+
+export const callerInterceptor =
+  (caller: string): Interceptor =>
+  (next) =>
+  (req) => {
+    req.header.set('x-atlantis-caller', caller)
+    return next(req)
+  }
 
 export const isDataplaneError = (
   err: unknown,


### PR DESCRIPTION
Similar to the changes we've made in Discover and elsewhere, this enables the AppView to self-identify when calling the data plane so we can track it nicely in metrics.

This would have been useful in debugging last weeks' major incident.

Note that this was written by claude; I'm not super familiar with this code base, but a quick interceptor that sets this header seems reasonable?