### PR TITLE
Enforce Max Depth on lexToIpld

### DIFF
--- a/.changeset/fix-lextoipld-stack-overflow.md
+++ b/.changeset/fix-lextoipld-stack-overflow.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lexicon': patch
+---
+
+Add depth limit to lexToIpld to prevent stack overflow on pathologically nested record data

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -32,7 +32,7 @@ export const lexToIpld = (val: LexValue, depth = 0): IpldValue => {
     // Prevent stack overflow on pathologically nested data (e.g. malicious
     // records with thousands of nested arrays/objects). Values beyond this
     // depth are dropped to avoid crashing the process.
-    return undefined
+    return null
   }
   // walk arrays
   if (Array.isArray(val)) {

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -25,10 +25,18 @@ export type RepoRecord = Record<string, LexValue>
 /**
  * @deprecated Use `LexValue` from `@atproto/lex-data` instead (which doesn't need conversion to IPLD).
  */
-export const lexToIpld = (val: LexValue): IpldValue => {
+const MAX_LEX_DEPTH = 128
+
+export const lexToIpld = (val: LexValue, depth = 0): IpldValue => {
+  if (depth > MAX_LEX_DEPTH) {
+    // Prevent stack overflow on pathologically nested data (e.g. malicious
+    // records with thousands of nested arrays/objects). Values beyond this
+    // depth are dropped to avoid crashing the process.
+    return undefined
+  }
   // walk arrays
   if (Array.isArray(val)) {
-    return val.map((item) => lexToIpld(item))
+    return val.map((item) => lexToIpld(item, depth + 1))
   }
   // objects
   if (val && typeof val === 'object') {
@@ -43,7 +51,7 @@ export const lexToIpld = (val: LexValue): IpldValue => {
     // walk plain objects
     const toReturn = {}
     for (const key of Object.keys(val)) {
-      toReturn[key] = lexToIpld(val[key])
+      toReturn[key] = lexToIpld(val[key], depth + 1)
     }
     return toReturn
   }

--- a/packages/lexicon/tests/serialize.test.ts
+++ b/packages/lexicon/tests/serialize.test.ts
@@ -1,32 +1,63 @@
 import { lexToIpld } from '../src/serialize'
 
 describe('lexToIpld', () => {
-  it('does not stack overflow on deeply nested arrays', () => {
+  it('truncates deeply nested arrays at depth limit', () => {
     // Reproduces a real-world crash: a malicious profile record contained a
     // field with thousands of nested CBOR arrays ([[[[...]]]]), causing
     // lexToIpld to overflow the call stack during response serialization.
     let val: unknown = 'leaf'
-    for (let i = 0; i < 10_000; i++) {
+    for (let i = 0; i < 200; i++) {
       val = [val]
     }
 
-    expect(() => lexToIpld(val)).not.toThrow()
+    // Should not throw (previously would stack overflow on production
+    // containers with smaller stacks)
+    const result = lexToIpld(val)
+
+    // Walk the result to verify: valid structure down to the depth limit,
+    // then null beyond it
+    let current = result
+    let depth = 0
+    while (Array.isArray(current) && current.length === 1) {
+      current = current[0]
+      depth++
+    }
+    // Should have stopped recursing at the depth limit (128), replacing
+    // deeper values with null
+    expect(current).toBeNull()
+    expect(depth).toBe(129)
   })
 
-  it('does not stack overflow on deeply nested objects', () => {
+  it('truncates deeply nested objects at depth limit', () => {
     let val: unknown = 'leaf'
-    for (let i = 0; i < 10_000; i++) {
+    for (let i = 0; i < 200; i++) {
       val = { nested: val }
     }
 
-    expect(() => lexToIpld(val)).not.toThrow()
+    const result = lexToIpld(val)
+
+    let current = result as Record<string, unknown>
+    let depth = 0
+    while (
+      current !== null &&
+      typeof current === 'object' &&
+      'nested' in current
+    ) {
+      current = current.nested as Record<string, unknown>
+      depth++
+    }
+    expect(current).toBeNull()
+    expect(depth).toBe(129)
   })
 
-  it('still converts shallow values correctly', () => {
+  it('preserves structure below the depth limit', () => {
     expect(lexToIpld('hello')).toBe('hello')
     expect(lexToIpld(42)).toBe(42)
     expect(lexToIpld(null)).toBe(null)
     expect(lexToIpld([1, 2, 3])).toEqual([1, 2, 3])
     expect(lexToIpld({ a: 1, b: 'two' })).toEqual({ a: 1, b: 'two' })
+    expect(lexToIpld({ nested: { deep: [1] } })).toEqual({
+      nested: { deep: [1] },
+    })
   })
 })

--- a/packages/lexicon/tests/serialize.test.ts
+++ b/packages/lexicon/tests/serialize.test.ts
@@ -1,0 +1,32 @@
+import { lexToIpld } from '../src/serialize'
+
+describe('lexToIpld', () => {
+  it('does not stack overflow on deeply nested arrays', () => {
+    // Reproduces a real-world crash: a malicious profile record contained a
+    // field with thousands of nested CBOR arrays ([[[[...]]]]), causing
+    // lexToIpld to overflow the call stack during response serialization.
+    let val: unknown = 'leaf'
+    for (let i = 0; i < 10_000; i++) {
+      val = [val]
+    }
+
+    expect(() => lexToIpld(val)).not.toThrow()
+  })
+
+  it('does not stack overflow on deeply nested objects', () => {
+    let val: unknown = 'leaf'
+    for (let i = 0; i < 10_000; i++) {
+      val = { nested: val }
+    }
+
+    expect(() => lexToIpld(val)).not.toThrow()
+  })
+
+  it('still converts shallow values correctly', () => {
+    expect(lexToIpld('hello')).toBe('hello')
+    expect(lexToIpld(42)).toBe(42)
+    expect(lexToIpld(null)).toBe(null)
+    expect(lexToIpld([1, 2, 3])).toEqual([1, 2, 3])
+    expect(lexToIpld({ a: 1, b: 'two' })).toEqual({ a: 1, b: 'two' })
+  })
+})


### PR DESCRIPTION
I'm unsure that this is actual root cause fix of this issue. Definitely want review from @matthieusieben before this goes out

This was suggested by claude for fixing this user's issues https://bsky.app/profile/did:plc:rhzwcsk5kcoidziamyopsjez

as suggested by this log line:

> "payload":{"error":"InternalServerError","message":"Internal Server Error"},"name":"xrpc-server","msg":"unhandled exception in xrpc method app.bsky.feed.getAuthorFeed"}

<img width="1181" height="656" alt="Screenshot 2026-04-14 at 19 35 07" src="https://github.com/user-attachments/assets/cc2132ce-267a-4481-b075-5b3b8b947385" />


It seems to be caused by this repo?

```
$ atp repo export did:plc:b2wskpxho4srwilqyssafllz
wrote did:plc:b2wskpxho4srwilqyssafllz.car (5375403 bytes)

$ atp repo inspect did\:plc\:b2wskpxho4srwilqyssafllz.car
DID:  did:plc:b2wskpxho4srwilqyssafllz
Rev:  3mckxtl4azw22
Version:  3
Records:  9417

  app.bsky.actor.profile                   1
  app.bsky.actor.status                    1
  app.bsky.feed.like                       36
  app.bsky.feed.post                       9366
  app.bsky.feed.repost                     1
  app.bsky.graph.block                     1
  app.bsky.graph.follow                    1
  com.example.blob                         8
  com.example.htmlblob                     2

$ atp resolve did:plc:b2wskpxho4srwilqyssafllz
DID:  did:plc:b2wskpxho4srwilqyssafllz
Handle:  test142342.bsky.social
PDS:  https://inkcap.us-east.host.bsky.network
Signing:  did:key:zQ3shVja3jn4uK62iaLrhBeESaqeQCSr2BGfFGrXXfJ1Ndr5J  (K-256)
```