### PR TITLE
add script for publishing lexicons

### DIFF
--- a/publish_lexicons.sh
+++ b/publish_lexicons.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+echo "### tools.ozone.*"
+GOAT_PASSWORD=`pass bsky/bsky.social/ozone-lexicons | head -n1` GOAT_USERNAME=ozone-lexicons.bsky.social goat lex publish --update lexicons/tools/ozone/
+
+echo "### chat.bsky.*"
+GOAT_PASSWORD=`pass bsky/bsky.social/bsky-lexicons | head -n1` GOAT_USERNAME=bsky-lexicons.bsky.social goat lex publish --update lexicons/chat/bsky
+
+echo "### app.bsky.*"
+GOAT_PASSWORD=`pass bsky/bsky.social/bsky-lexicons | head -n1` GOAT_USERNAME=bsky-lexicons.bsky.social goat lex publish --update lexicons/app/bsky
+
+echo "### com.atproto.*"
+GOAT_PASSWORD=`pass bsky/bsky.social/atproto-lexicons | head -n1` GOAT_USERNAME=atproto-lexicons.bsky.social goat lex publish --update lexicons/com/atproto


### PR DESCRIPTION
This script is how I have been publishing lexicons from this repo. It is a bit idiosyncratic to my dev machine: eg, I use `pass` as a password manager most of the time. It should be possible to update this to use the 1password CLI tool (`op`) instead.

Could probably get integrated in to the `Makefile` instead of being a separate script.

We've had conversations about setting up CI (github actions) that use `goat` to do linting, check for breaking changes, and even auto-publish after merging to main. I think having a manual script is a good start, and something we will want documented/easy even if we mostly rely on automation (aka, we always need a documented manual "break glass" option).

I don't have a strong feeling about whether to merge this as-is (so we have some option), or leave this PR open as documentation until a better workflow is available.