### PR TITLE
Add errors property to app.bsky.actor.getProfile

### DIFF
--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -23,7 +23,7 @@
           "ref": "app.bsky.actor.defs#profileViewDetailed"
         }
       },
-      "errors": [{ "name": "InvalidRequest" }]
+      "errors": [{ "name": "InvalidRequest" }, { "name": "AccountDeactivated" }]
     }
   }
 }

--- a/lexicons/app/bsky/actor/getProfile.json
+++ b/lexicons/app/bsky/actor/getProfile.json
@@ -22,7 +22,8 @@
           "type": "ref",
           "ref": "app.bsky.actor.defs#profileViewDetailed"
         }
-      }
+      },
+      "errors": [{ "name": "InvalidRequest" }]
     }
   }
 }


### PR DESCRIPTION
This was causing `@atproto/lex` to fail parsing the response for when a profile is not found.

Arguably this should be a more explicit error, but that's what the bsky appview returns at the moment, e.g., https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=did:plc:a2amvy3onlpobuzi3dspka7b

```
{"error":"InvalidRequest","message":"Profile not found"}
```

There's probably other cases where this occurs too.

cc @matthieusieben 