### PR TITLE
update group chat lexicons

### DIFF
--- a/.changeset/itchy-bars-relate.md
+++ b/.changeset/itchy-bars-relate.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Update chat lexicons

--- a/lexicons/chat/bsky/convo/defs.json
+++ b/lexicons/chat/bsky/convo/defs.json
@@ -288,7 +288,7 @@
         "id": { "type": "string" },
         "rev": { "type": "string" },
         "members": {
-          "description": "Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members.",
+          "description": "Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members.",
           "type": "array",
           "items": {
             "type": "ref",
@@ -325,13 +325,17 @@
     "groupConvo": {
       "description": "[NOTE: This is under active development and should be considered unstable while this note is here].",
       "type": "object",
-      "required": ["name", "lockStatus"],
+      "required": ["name", "lockStatus", "memberCount"],
       "properties": {
         "name": {
           "type": "string",
           "description": "The display name of the group conversation.",
           "maxGraphemes": 128,
           "maxLength": 1280
+        },
+        "memberCount": {
+          "type": "integer",
+          "description": "The total number of members in the group conversation."
         },
         "joinLink": {
           "type": "ref",
@@ -476,7 +480,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataAddMember" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataAddMember",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logRemoveMember": {
@@ -486,7 +494,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataRemoveMember" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataRemoveMember",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logMemberJoin": {
@@ -496,7 +508,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataMemberJoin" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataMemberJoin",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logMemberLeave": {
@@ -506,7 +522,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataMemberLeave" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataMemberLeave",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logLockConvo": {
@@ -516,7 +536,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataLockConvo" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataLockConvo",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logUnlockConvo": {
@@ -526,7 +550,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataUnlockConvo" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataUnlockConvo",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logLockConvoPermanently": {
@@ -537,8 +565,9 @@
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
         "message": {
+          "description": "A system message with data of type #systemMessageDataLockConvoPermanently",
           "type": "ref",
-          "ref": "#systemMessageDataLockConvoPermanently"
+          "ref": "#systemMessageView"
         }
       }
     },
@@ -549,7 +578,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataEditGroup" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEditGroup",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logCreateJoinLink": {
@@ -559,7 +592,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataCreateJoinLink" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataCreateJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logEditJoinLink": {
@@ -569,7 +606,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataEditJoinLink" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEditJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logEnableJoinLink": {
@@ -579,7 +620,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataEnableJoinLink" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataEnableJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logDisableJoinLink": {
@@ -589,7 +634,11 @@
       "properties": {
         "rev": { "type": "string" },
         "convoId": { "type": "string" },
-        "message": { "type": "ref", "ref": "#systemMessageDataDisableJoinLink" }
+        "message": {
+          "description": "A system message with data of type #systemMessageDataDisableJoinLink",
+          "type": "ref",
+          "ref": "#systemMessageView"
+        }
       }
     },
     "logIncomingJoinRequest": {

--- a/lexicons/chat/bsky/convo/getConvoMembers.json
+++ b/lexicons/chat/bsky/convo/getConvoMembers.json
@@ -1,0 +1,42 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.convo.getConvoMembers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Returns a paginated list of members from a conversation.",
+      "errors": [{ "name": "InvalidConvo" }],
+      "parameters": {
+        "type": "params",
+        "required": ["convoId"],
+        "properties": {
+          "convoId": { "type": "string" },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["members"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "chat.bsky.actor.defs#profileViewBasic"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/chat/bsky/group/addMembers.json
+++ b/lexicons/chat/bsky/group/addMembers.json
@@ -40,6 +40,13 @@
             "convo": {
               "type": "ref",
               "ref": "chat.bsky.convo.defs#convoView"
+            },
+            "addedMembers": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "chat.bsky.actor.defs#profileViewBasic"
+              }
             }
           }
         }

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -165,6 +165,7 @@ import * as ChatBskyConvoDeleteMessageForSelf from './types/chat/bsky/convo/dele
 import * as ChatBskyConvoGetConvo from './types/chat/bsky/convo/getConvo.js'
 import * as ChatBskyConvoGetConvoAvailability from './types/chat/bsky/convo/getConvoAvailability.js'
 import * as ChatBskyConvoGetConvoForMembers from './types/chat/bsky/convo/getConvoForMembers.js'
+import * as ChatBskyConvoGetConvoMembers from './types/chat/bsky/convo/getConvoMembers.js'
 import * as ChatBskyConvoGetLog from './types/chat/bsky/convo/getLog.js'
 import * as ChatBskyConvoGetMessages from './types/chat/bsky/convo/getMessages.js'
 import * as ChatBskyConvoLeaveConvo from './types/chat/bsky/convo/leaveConvo.js'
@@ -504,6 +505,7 @@ export * as ChatBskyConvoDeleteMessageForSelf from './types/chat/bsky/convo/dele
 export * as ChatBskyConvoGetConvo from './types/chat/bsky/convo/getConvo.js'
 export * as ChatBskyConvoGetConvoAvailability from './types/chat/bsky/convo/getConvoAvailability.js'
 export * as ChatBskyConvoGetConvoForMembers from './types/chat/bsky/convo/getConvoForMembers.js'
+export * as ChatBskyConvoGetConvoMembers from './types/chat/bsky/convo/getConvoMembers.js'
 export * as ChatBskyConvoGetLog from './types/chat/bsky/convo/getLog.js'
 export * as ChatBskyConvoGetMessages from './types/chat/bsky/convo/getMessages.js'
 export * as ChatBskyConvoLeaveConvo from './types/chat/bsky/convo/leaveConvo.js'
@@ -3845,6 +3847,17 @@ export class ChatBskyConvoNS {
       .call('chat.bsky.convo.getConvoForMembers', params, undefined, opts)
       .catch((e) => {
         throw ChatBskyConvoGetConvoForMembers.toKnownErr(e)
+      })
+  }
+
+  getConvoMembers(
+    params?: ChatBskyConvoGetConvoMembers.QueryParams,
+    opts?: ChatBskyConvoGetConvoMembers.CallOptions,
+  ): Promise<ChatBskyConvoGetConvoMembers.Response> {
+    return this._client
+      .call('chat.bsky.convo.getConvoMembers', params, undefined, opts)
+      .catch((e) => {
+        throw ChatBskyConvoGetConvoMembers.toKnownErr(e)
       })
   }
 

--- a/packages/api/src/client/lexicons.ts
+++ b/packages/api/src/client/lexicons.ts
@@ -10286,7 +10286,7 @@ export const schemaDict = {
           },
           members: {
             description:
-              'Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members.',
+              'Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members.',
             type: 'array',
             items: {
               type: 'ref',
@@ -10338,13 +10338,18 @@ export const schemaDict = {
         description:
           '[NOTE: This is under active development and should be considered unstable while this note is here].',
         type: 'object',
-        required: ['name', 'lockStatus'],
+        required: ['name', 'lockStatus', 'memberCount'],
         properties: {
           name: {
             type: 'string',
             description: 'The display name of the group conversation.',
             maxGraphemes: 128,
             maxLength: 1280,
+          },
+          memberCount: {
+            type: 'integer',
+            description:
+              'The total number of members in the group conversation.',
           },
           joinLink: {
             type: 'ref',
@@ -10574,8 +10579,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataAddMember',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataAddMember',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10592,8 +10599,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataRemoveMember',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataRemoveMember',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10610,8 +10619,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataMemberJoin',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataMemberJoin',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10628,8 +10639,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataMemberLeave',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataMemberLeave',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10646,8 +10659,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataLockConvo',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataLockConvo',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10664,8 +10679,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataUnlockConvo',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataUnlockConvo',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10682,8 +10699,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataLockConvoPermanently',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataLockConvoPermanently',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10700,8 +10719,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEditGroup',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEditGroup',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10718,8 +10739,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataCreateJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataCreateJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10736,8 +10759,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEditJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEditJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10754,8 +10779,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEnableJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEnableJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10772,8 +10799,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataDisableJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataDisableJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -11021,6 +11050,58 @@ export const schemaDict = {
               convo: {
                 type: 'ref',
                 ref: 'lex:chat.bsky.convo.defs#convoView',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ChatBskyConvoGetConvoMembers: {
+    lexicon: 1,
+    id: 'chat.bsky.convo.getConvoMembers',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Returns a paginated list of members from a conversation.',
+        errors: [
+          {
+            name: 'InvalidConvo',
+          },
+        ],
+        parameters: {
+          type: 'params',
+          required: ['convoId'],
+          properties: {
+            convoId: {
+              type: 'string',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['members'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              members: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:chat.bsky.actor.defs#profileViewBasic',
+                },
               },
             },
           },
@@ -11793,6 +11874,13 @@ export const schemaDict = {
               convo: {
                 type: 'ref',
                 ref: 'lex:chat.bsky.convo.defs#convoView',
+              },
+              addedMembers: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:chat.bsky.actor.defs#profileViewBasic',
+                },
               },
             },
           },
@@ -22988,6 +23076,7 @@ export const ids = {
   ChatBskyConvoGetConvo: 'chat.bsky.convo.getConvo',
   ChatBskyConvoGetConvoAvailability: 'chat.bsky.convo.getConvoAvailability',
   ChatBskyConvoGetConvoForMembers: 'chat.bsky.convo.getConvoForMembers',
+  ChatBskyConvoGetConvoMembers: 'chat.bsky.convo.getConvoMembers',
   ChatBskyConvoGetLog: 'chat.bsky.convo.getLog',
   ChatBskyConvoGetMessages: 'chat.bsky.convo.getMessages',
   ChatBskyConvoLeaveConvo: 'chat.bsky.convo.leaveConvo',

--- a/packages/api/src/client/types/chat/bsky/convo/defs.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/defs.ts
@@ -447,7 +447,7 @@ export interface ConvoView {
   $type?: 'chat.bsky.convo.defs#convoView'
   id: string
   rev: string
-  /** Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members. */
+  /** Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members. */
   members: ChatBskyActorDefs.ProfileViewBasic[]
   lastMessage?:
     | $Typed<MessageView>
@@ -491,6 +491,8 @@ export interface GroupConvo {
   $type?: 'chat.bsky.convo.defs#groupConvo'
   /** The display name of the group conversation. */
   name: string
+  /** The total number of members in the group conversation. */
+  memberCount: number
   joinLink?: ChatBskyGroupDefs.JoinLinkView
   lockStatus: ConvoLockStatus
 }
@@ -713,7 +715,7 @@ export interface LogAddMember {
   $type?: 'chat.bsky.convo.defs#logAddMember'
   rev: string
   convoId: string
-  message: SystemMessageDataAddMember
+  message: SystemMessageView
 }
 
 const hashLogAddMember = 'logAddMember'
@@ -731,7 +733,7 @@ export interface LogRemoveMember {
   $type?: 'chat.bsky.convo.defs#logRemoveMember'
   rev: string
   convoId: string
-  message: SystemMessageDataRemoveMember
+  message: SystemMessageView
 }
 
 const hashLogRemoveMember = 'logRemoveMember'
@@ -749,7 +751,7 @@ export interface LogMemberJoin {
   $type?: 'chat.bsky.convo.defs#logMemberJoin'
   rev: string
   convoId: string
-  message: SystemMessageDataMemberJoin
+  message: SystemMessageView
 }
 
 const hashLogMemberJoin = 'logMemberJoin'
@@ -767,7 +769,7 @@ export interface LogMemberLeave {
   $type?: 'chat.bsky.convo.defs#logMemberLeave'
   rev: string
   convoId: string
-  message: SystemMessageDataMemberLeave
+  message: SystemMessageView
 }
 
 const hashLogMemberLeave = 'logMemberLeave'
@@ -785,7 +787,7 @@ export interface LogLockConvo {
   $type?: 'chat.bsky.convo.defs#logLockConvo'
   rev: string
   convoId: string
-  message: SystemMessageDataLockConvo
+  message: SystemMessageView
 }
 
 const hashLogLockConvo = 'logLockConvo'
@@ -803,7 +805,7 @@ export interface LogUnlockConvo {
   $type?: 'chat.bsky.convo.defs#logUnlockConvo'
   rev: string
   convoId: string
-  message: SystemMessageDataUnlockConvo
+  message: SystemMessageView
 }
 
 const hashLogUnlockConvo = 'logUnlockConvo'
@@ -821,7 +823,7 @@ export interface LogLockConvoPermanently {
   $type?: 'chat.bsky.convo.defs#logLockConvoPermanently'
   rev: string
   convoId: string
-  message: SystemMessageDataLockConvoPermanently
+  message: SystemMessageView
 }
 
 const hashLogLockConvoPermanently = 'logLockConvoPermanently'
@@ -843,7 +845,7 @@ export interface LogEditGroup {
   $type?: 'chat.bsky.convo.defs#logEditGroup'
   rev: string
   convoId: string
-  message: SystemMessageDataEditGroup
+  message: SystemMessageView
 }
 
 const hashLogEditGroup = 'logEditGroup'
@@ -861,7 +863,7 @@ export interface LogCreateJoinLink {
   $type?: 'chat.bsky.convo.defs#logCreateJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataCreateJoinLink
+  message: SystemMessageView
 }
 
 const hashLogCreateJoinLink = 'logCreateJoinLink'
@@ -879,7 +881,7 @@ export interface LogEditJoinLink {
   $type?: 'chat.bsky.convo.defs#logEditJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataEditJoinLink
+  message: SystemMessageView
 }
 
 const hashLogEditJoinLink = 'logEditJoinLink'
@@ -897,7 +899,7 @@ export interface LogEnableJoinLink {
   $type?: 'chat.bsky.convo.defs#logEnableJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataEnableJoinLink
+  message: SystemMessageView
 }
 
 const hashLogEnableJoinLink = 'logEnableJoinLink'
@@ -915,7 +917,7 @@ export interface LogDisableJoinLink {
   $type?: 'chat.bsky.convo.defs#logDisableJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataDisableJoinLink
+  message: SystemMessageView
 }
 
 const hashLogDisableJoinLink = 'logDisableJoinLink'

--- a/packages/api/src/client/types/chat/bsky/convo/getConvoMembers.ts
+++ b/packages/api/src/client/types/chat/bsky/convo/getConvoMembers.ts
@@ -1,0 +1,54 @@
+/**
+ * GENERATED CODE - DO NOT MODIFY
+ */
+import { HeadersMap, XRPCError } from '@atproto/xrpc'
+import { type ValidationResult, BlobRef } from '@atproto/lexicon'
+import { CID } from 'multiformats/cid'
+import { validate as _validate } from '../../../../lexicons'
+import {
+  type $Typed,
+  is$typed as _is$typed,
+  type OmitKey,
+} from '../../../../util'
+import type * as ChatBskyActorDefs from '../actor/defs.js'
+
+const is$typed = _is$typed,
+  validate = _validate
+const id = 'chat.bsky.convo.getConvoMembers'
+
+export type QueryParams = {
+  convoId: string
+  limit?: number
+  cursor?: string
+}
+export type InputSchema = undefined
+
+export interface OutputSchema {
+  cursor?: string
+  members: ChatBskyActorDefs.ProfileViewBasic[]
+}
+
+export interface CallOptions {
+  signal?: AbortSignal
+  headers?: HeadersMap
+}
+
+export interface Response {
+  success: boolean
+  headers: HeadersMap
+  data: OutputSchema
+}
+
+export class InvalidConvoError extends XRPCError {
+  constructor(src: XRPCError) {
+    super(src.status, src.error, src.message, src.headers, { cause: src })
+  }
+}
+
+export function toKnownErr(e: any) {
+  if (e instanceof XRPCError) {
+    if (e.error === 'InvalidConvo') return new InvalidConvoError(e)
+  }
+
+  return e
+}

--- a/packages/api/src/client/types/chat/bsky/group/addMembers.ts
+++ b/packages/api/src/client/types/chat/bsky/group/addMembers.ts
@@ -11,6 +11,7 @@ import {
   type OmitKey,
 } from '../../../../util'
 import type * as ChatBskyConvoDefs from '../convo/defs.js'
+import type * as ChatBskyActorDefs from '../actor/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
@@ -25,6 +26,7 @@ export interface InputSchema {
 
 export interface OutputSchema {
   convo: ChatBskyConvoDefs.ConvoView
+  addedMembers?: ChatBskyActorDefs.ProfileViewBasic[]
 }
 
 export interface CallOptions {

--- a/packages/ozone/src/lexicon/index.ts
+++ b/packages/ozone/src/lexicon/index.ts
@@ -128,6 +128,7 @@ import * as ChatBskyConvoDeleteMessageForSelf from './types/chat/bsky/convo/dele
 import * as ChatBskyConvoGetConvo from './types/chat/bsky/convo/getConvo.js'
 import * as ChatBskyConvoGetConvoAvailability from './types/chat/bsky/convo/getConvoAvailability.js'
 import * as ChatBskyConvoGetConvoForMembers from './types/chat/bsky/convo/getConvoForMembers.js'
+import * as ChatBskyConvoGetConvoMembers from './types/chat/bsky/convo/getConvoMembers.js'
 import * as ChatBskyConvoGetLog from './types/chat/bsky/convo/getLog.js'
 import * as ChatBskyConvoGetMessages from './types/chat/bsky/convo/getMessages.js'
 import * as ChatBskyConvoLeaveConvo from './types/chat/bsky/convo/leaveConvo.js'
@@ -2021,6 +2022,18 @@ export class ChatBskyConvoNS {
     >,
   ) {
     const nsid = 'chat.bsky.convo.getConvoForMembers' // @ts-ignore
+    return this._server.xrpc.method(nsid, cfg)
+  }
+
+  getConvoMembers<A extends Auth = void>(
+    cfg: MethodConfigOrHandler<
+      A,
+      ChatBskyConvoGetConvoMembers.QueryParams,
+      ChatBskyConvoGetConvoMembers.HandlerInput,
+      ChatBskyConvoGetConvoMembers.HandlerOutput
+    >,
+  ) {
+    const nsid = 'chat.bsky.convo.getConvoMembers' // @ts-ignore
     return this._server.xrpc.method(nsid, cfg)
   }
 

--- a/packages/ozone/src/lexicon/lexicons.ts
+++ b/packages/ozone/src/lexicon/lexicons.ts
@@ -10286,7 +10286,7 @@ export const schemaDict = {
           },
           members: {
             description:
-              'Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members.',
+              'Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members.',
             type: 'array',
             items: {
               type: 'ref',
@@ -10338,13 +10338,18 @@ export const schemaDict = {
         description:
           '[NOTE: This is under active development and should be considered unstable while this note is here].',
         type: 'object',
-        required: ['name', 'lockStatus'],
+        required: ['name', 'lockStatus', 'memberCount'],
         properties: {
           name: {
             type: 'string',
             description: 'The display name of the group conversation.',
             maxGraphemes: 128,
             maxLength: 1280,
+          },
+          memberCount: {
+            type: 'integer',
+            description:
+              'The total number of members in the group conversation.',
           },
           joinLink: {
             type: 'ref',
@@ -10574,8 +10579,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataAddMember',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataAddMember',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10592,8 +10599,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataRemoveMember',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataRemoveMember',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10610,8 +10619,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataMemberJoin',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataMemberJoin',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10628,8 +10639,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataMemberLeave',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataMemberLeave',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10646,8 +10659,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataLockConvo',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataLockConvo',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10664,8 +10679,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataUnlockConvo',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataUnlockConvo',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10682,8 +10699,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataLockConvoPermanently',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataLockConvoPermanently',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10700,8 +10719,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEditGroup',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEditGroup',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10718,8 +10739,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataCreateJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataCreateJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10736,8 +10759,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEditJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEditJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10754,8 +10779,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataEnableJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataEnableJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -10772,8 +10799,10 @@ export const schemaDict = {
             type: 'string',
           },
           message: {
+            description:
+              'A system message with data of type #systemMessageDataDisableJoinLink',
             type: 'ref',
-            ref: 'lex:chat.bsky.convo.defs#systemMessageDataDisableJoinLink',
+            ref: 'lex:chat.bsky.convo.defs#systemMessageView',
           },
         },
       },
@@ -11021,6 +11050,58 @@ export const schemaDict = {
               convo: {
                 type: 'ref',
                 ref: 'lex:chat.bsky.convo.defs#convoView',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  ChatBskyConvoGetConvoMembers: {
+    lexicon: 1,
+    id: 'chat.bsky.convo.getConvoMembers',
+    defs: {
+      main: {
+        type: 'query',
+        description: 'Returns a paginated list of members from a conversation.',
+        errors: [
+          {
+            name: 'InvalidConvo',
+          },
+        ],
+        parameters: {
+          type: 'params',
+          required: ['convoId'],
+          properties: {
+            convoId: {
+              type: 'string',
+            },
+            limit: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              default: 50,
+            },
+            cursor: {
+              type: 'string',
+            },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['members'],
+            properties: {
+              cursor: {
+                type: 'string',
+              },
+              members: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:chat.bsky.actor.defs#profileViewBasic',
+                },
               },
             },
           },
@@ -11793,6 +11874,13 @@ export const schemaDict = {
               convo: {
                 type: 'ref',
                 ref: 'lex:chat.bsky.convo.defs#convoView',
+              },
+              addedMembers: {
+                type: 'array',
+                items: {
+                  type: 'ref',
+                  ref: 'lex:chat.bsky.actor.defs#profileViewBasic',
+                },
               },
             },
           },
@@ -22919,6 +23007,7 @@ export const ids = {
   ChatBskyConvoGetConvo: 'chat.bsky.convo.getConvo',
   ChatBskyConvoGetConvoAvailability: 'chat.bsky.convo.getConvoAvailability',
   ChatBskyConvoGetConvoForMembers: 'chat.bsky.convo.getConvoForMembers',
+  ChatBskyConvoGetConvoMembers: 'chat.bsky.convo.getConvoMembers',
   ChatBskyConvoGetLog: 'chat.bsky.convo.getLog',
   ChatBskyConvoGetMessages: 'chat.bsky.convo.getMessages',
   ChatBskyConvoLeaveConvo: 'chat.bsky.convo.leaveConvo',

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/defs.ts
@@ -447,7 +447,7 @@ export interface ConvoView {
   $type?: 'chat.bsky.convo.defs#convoView'
   id: string
   rev: string
-  /** Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. NOTE: TBD an endpoint to list all members. */
+  /** Members of this conversation. For direct convos, it will be an immutable list of the 2 members. For group convos, it will a list of important members (the first few members, the viewer, the member who invited the viewer, the member who sent the last message, the member who sent the last reaction), but will not contain the full list of members. Use chat.bsky.convo.getConvoMembers to list all members. */
   members: ChatBskyActorDefs.ProfileViewBasic[]
   lastMessage?:
     | $Typed<MessageView>
@@ -491,6 +491,8 @@ export interface GroupConvo {
   $type?: 'chat.bsky.convo.defs#groupConvo'
   /** The display name of the group conversation. */
   name: string
+  /** The total number of members in the group conversation. */
+  memberCount: number
   joinLink?: ChatBskyGroupDefs.JoinLinkView
   lockStatus: ConvoLockStatus
 }
@@ -713,7 +715,7 @@ export interface LogAddMember {
   $type?: 'chat.bsky.convo.defs#logAddMember'
   rev: string
   convoId: string
-  message: SystemMessageDataAddMember
+  message: SystemMessageView
 }
 
 const hashLogAddMember = 'logAddMember'
@@ -731,7 +733,7 @@ export interface LogRemoveMember {
   $type?: 'chat.bsky.convo.defs#logRemoveMember'
   rev: string
   convoId: string
-  message: SystemMessageDataRemoveMember
+  message: SystemMessageView
 }
 
 const hashLogRemoveMember = 'logRemoveMember'
@@ -749,7 +751,7 @@ export interface LogMemberJoin {
   $type?: 'chat.bsky.convo.defs#logMemberJoin'
   rev: string
   convoId: string
-  message: SystemMessageDataMemberJoin
+  message: SystemMessageView
 }
 
 const hashLogMemberJoin = 'logMemberJoin'
@@ -767,7 +769,7 @@ export interface LogMemberLeave {
   $type?: 'chat.bsky.convo.defs#logMemberLeave'
   rev: string
   convoId: string
-  message: SystemMessageDataMemberLeave
+  message: SystemMessageView
 }
 
 const hashLogMemberLeave = 'logMemberLeave'
@@ -785,7 +787,7 @@ export interface LogLockConvo {
   $type?: 'chat.bsky.convo.defs#logLockConvo'
   rev: string
   convoId: string
-  message: SystemMessageDataLockConvo
+  message: SystemMessageView
 }
 
 const hashLogLockConvo = 'logLockConvo'
@@ -803,7 +805,7 @@ export interface LogUnlockConvo {
   $type?: 'chat.bsky.convo.defs#logUnlockConvo'
   rev: string
   convoId: string
-  message: SystemMessageDataUnlockConvo
+  message: SystemMessageView
 }
 
 const hashLogUnlockConvo = 'logUnlockConvo'
@@ -821,7 +823,7 @@ export interface LogLockConvoPermanently {
   $type?: 'chat.bsky.convo.defs#logLockConvoPermanently'
   rev: string
   convoId: string
-  message: SystemMessageDataLockConvoPermanently
+  message: SystemMessageView
 }
 
 const hashLogLockConvoPermanently = 'logLockConvoPermanently'
@@ -843,7 +845,7 @@ export interface LogEditGroup {
   $type?: 'chat.bsky.convo.defs#logEditGroup'
   rev: string
   convoId: string
-  message: SystemMessageDataEditGroup
+  message: SystemMessageView
 }
 
 const hashLogEditGroup = 'logEditGroup'
@@ -861,7 +863,7 @@ export interface LogCreateJoinLink {
   $type?: 'chat.bsky.convo.defs#logCreateJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataCreateJoinLink
+  message: SystemMessageView
 }
 
 const hashLogCreateJoinLink = 'logCreateJoinLink'
@@ -879,7 +881,7 @@ export interface LogEditJoinLink {
   $type?: 'chat.bsky.convo.defs#logEditJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataEditJoinLink
+  message: SystemMessageView
 }
 
 const hashLogEditJoinLink = 'logEditJoinLink'
@@ -897,7 +899,7 @@ export interface LogEnableJoinLink {
   $type?: 'chat.bsky.convo.defs#logEnableJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataEnableJoinLink
+  message: SystemMessageView
 }
 
 const hashLogEnableJoinLink = 'logEnableJoinLink'
@@ -915,7 +917,7 @@ export interface LogDisableJoinLink {
   $type?: 'chat.bsky.convo.defs#logDisableJoinLink'
   rev: string
   convoId: string
-  message: SystemMessageDataDisableJoinLink
+  message: SystemMessageView
 }
 
 const hashLogDisableJoinLink = 'logDisableJoinLink'

--- a/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvoMembers.ts
+++ b/packages/ozone/src/lexicon/types/chat/bsky/convo/getConvoMembers.ts
@@ -9,29 +9,25 @@ import {
   is$typed as _is$typed,
   type OmitKey,
 } from '../../../../util'
-import type * as ChatBskyConvoDefs from '../convo/defs.js'
 import type * as ChatBskyActorDefs from '../actor/defs.js'
 
 const is$typed = _is$typed,
   validate = _validate
-const id = 'chat.bsky.group.addMembers'
+const id = 'chat.bsky.convo.getConvoMembers'
 
-export type QueryParams = {}
-
-export interface InputSchema {
+export type QueryParams = {
   convoId: string
-  members: string[]
+  limit: number
+  cursor?: string
 }
+export type InputSchema = undefined
 
 export interface OutputSchema {
-  convo: ChatBskyConvoDefs.ConvoView
-  addedMembers?: ChatBskyActorDefs.ProfileViewBasic[]
+  cursor?: string
+  members: ChatBskyActorDefs.ProfileViewBasic[]
 }
 
-export interface HandlerInput {
-  encoding: 'application/json'
-  body: InputSchema
-}
+export type HandlerInput = void
 
 export interface HandlerSuccess {
   encoding: 'application/json'
@@ -42,16 +38,7 @@ export interface HandlerSuccess {
 export interface HandlerError {
   status: number
   message?: string
-  error?:
-    | 'AccountSuspended'
-    | 'BlockedActor'
-    | 'GroupInvitesDisabled'
-    | 'ConvoLocked'
-    | 'InsufficientRole'
-    | 'InvalidConvo'
-    | 'MemberLimitReached'
-    | 'NotFollowedBySender'
-    | 'RecipientNotFound'
+  error?: 'InvalidConvo'
 }
 
 export type HandlerOutput = HandlerError | HandlerSuccess


### PR DESCRIPTION
Changing some object definitions related to the ongoing group chats work.

I did leave a note of `[NOTE: This is under active development and should be considered unstable while this note is here]` in all of those objects, so hopefully this won't break anyone downstream.