### PR TITLE
Add documentation for requestLock throwing errors

### DIFF
--- a/packages/oauth/oauth-client-node/README.md
+++ b/packages/oauth/oauth-client-node/README.md
@@ -263,7 +263,8 @@ after a short period of time (one hour should be more than enough).
 #### `requestLock`
 
 When multiple instances of the client are running, this lock will prevent
-concurrent refreshes of the same session.
+concurrent refreshes of the same session. If the lock fails to be acquired an
+error should be thrown.
 
 Here is an example implementation based on [`redlock`](https://www.npmjs.com/package/redlock):
 


### PR DESCRIPTION
This was a question I had when reading about the runtime locks in the OAuth client: https://bsky.app/profile/thisismissem.social/post/3mjy4u3rdg22e

This wasn't entirely obvious from reading the existing documentation, and my lock implementation returns both whether the lock was acquired, and what the result was if the locked function ran: https://github.com/ThisIsMissEm/adonisjs-atproto-oauth/issues/42

cc @matthieusieben 