### PR TITLE
Remove path prefix for XRPC router in README and nodejs files

### DIFF
--- a/packages/lex/lex-server/README.md
+++ b/packages/lex/lex-server/README.md
@@ -524,7 +524,7 @@ import { toRequestListener } from '@atproto/lex-server/nodejs'
 const app = express()
 
 // Mount the XRPC router
-app.use('/xrpc', toRequestListener(router.fetch))
+app.use(toRequestListener(router.fetch))
 
 app.listen(3000)
 ```

--- a/packages/lex/lex-server/src/nodejs.ts
+++ b/packages/lex/lex-server/src/nodejs.ts
@@ -397,7 +397,7 @@ function toConnectionInfo(req: IncomingMessage): NodeConnectionInfo {
  * const app = express()
  *
  * // Mount the XRPC router
- * app.use('/xrpc', toRequestListener(router.fetch))
+ * app.use(toRequestListener(router.fetch))
  * ```
  */
 export function toRequestListener<


### PR DESCRIPTION
The instructions to use `Express` with `lex-server` suggest mounting the routes at `/xrpc`, which instead results in routes being mounted under `/xrpc/xrpc`.