### PR TITLE
Lexicon blobref fix

### DIFF
--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "@atproto/common-web": "workspace:^",
+    "@atproto/lex-data": "workspace:^",
     "@atproto/syntax": "workspace:^",
     "iso-datestring-validator": "^2.2.2",
-    "multiformats": "^9.9.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/lexicon/src/blob-refs.ts
+++ b/packages/lexicon/src/blob-refs.ts
@@ -1,11 +1,16 @@
-import { CID } from 'multiformats/cid'
 import { z } from 'zod'
 import { check, ipldToJson, schema } from '@atproto/common-web'
+import { CID } from '@atproto/lex-data'
 
 export const typedJsonBlobRef = z
   .object({
     $type: z.literal('blob'),
-    ref: schema.cid,
+    ref: z.union([
+      schema.cid,
+      z.object({
+        $link: schema.cid
+      }).transform(({ $link }) => $link)
+    ]),
     mimeType: z.string(),
     size: z.number(),
   })
@@ -41,8 +46,9 @@ export class BlobRef {
   }
 
   static asBlobRef(obj: unknown): BlobRef | null {
-    if (check.is(obj, jsonBlobRef)) {
-      return BlobRef.fromJsonRef(obj)
+    const result = jsonBlobRef.safeParse(obj)
+    if (result.success) {
+      return BlobRef.fromJsonRef(result.data)
     }
     return null
   }

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -1,4 +1,3 @@
-import { CID } from 'multiformats/cid'
 import {
   IpldValue,
   JsonValue,
@@ -6,6 +5,7 @@ import {
   ipldToJson,
   jsonToIpld,
 } from '@atproto/common-web'
+import { isCid } from '@atproto/lex-data'
 import { BlobRef, jsonBlobRef } from './blob-refs'
 
 /**
@@ -37,7 +37,7 @@ export const lexToIpld = (val: LexValue): IpldValue => {
       return val.original
     }
     // retain cids & bytes
-    if (CID.asCID(val) || val instanceof Uint8Array) {
+    if (isCid(val) || val instanceof Uint8Array) {
       return val
     }
     // walk plain objects
@@ -65,13 +65,16 @@ export const ipldToLex = (val: IpldValue): LexValue => {
     if (
       (val['$type'] === 'blob' ||
         (typeof val['cid'] === 'string' &&
-          typeof val['mimeType'] === 'string')) &&
-      check.is(val, jsonBlobRef)
+          typeof val['mimeType'] === 'string'))
     ) {
+      const result = jsonBlobRef.safeParse(val)
+      if (result.success) {
+        return BlobRef.fromJsonRef(result.data)
+      }
       return BlobRef.fromJsonRef(val)
     }
     // retain cids, bytes
-    if (CID.asCID(val) || val instanceof Uint8Array) {
+    if (isCid(val) || val instanceof Uint8Array) {
       return val
     }
     // map plain objects

--- a/packages/lexicon/src/serialize.ts
+++ b/packages/lexicon/src/serialize.ts
@@ -71,7 +71,6 @@ export const ipldToLex = (val: IpldValue): LexValue => {
       if (result.success) {
         return BlobRef.fromJsonRef(result.data)
       }
-      return BlobRef.fromJsonRef(val)
     }
     // retain cids, bytes
     if (isCid(val) || val instanceof Uint8Array) {

--- a/packages/lexicon/src/validators/blob.ts
+++ b/packages/lexicon/src/validators/blob.ts
@@ -1,4 +1,4 @@
-import { BlobRef } from '../blob-refs'
+import { jsonBlobRef, BlobRef } from '../blob-refs'
 import { Lexicons } from '../lexicons'
 import { LexUserType, ValidationError, ValidationResult } from '../types'
 
@@ -9,11 +9,16 @@ export function blob(
   value: unknown,
 ): ValidationResult {
   // check
-  if (!value || !(value instanceof BlobRef)) {
-    return {
-      success: false,
-      error: new ValidationError(`${path} should be a blob ref`),
-    }
+  if (value instanceof BlobRef) {
+    return { success: true, value }
   }
-  return { success: true, value }
+
+  if (jsonBlobRef.safeParse(value).success) {
+    return { success: true, value }
+  }
+
+  return {
+    success: false,
+    error: new ValidationError(`${path} should be a blob ref`),
+  }
 }

--- a/packages/lexicon/src/validators/formats.ts
+++ b/packages/lexicon/src/validators/formats.ts
@@ -1,6 +1,6 @@
 import { isValidISODateString } from 'iso-datestring-validator'
-import { CID } from 'multiformats/cid'
 import { validateLanguage } from '@atproto/common-web'
+import { parseCid } from '@atproto/lex-data'
 import {
   ensureValidAtUri,
   ensureValidDid,
@@ -109,7 +109,7 @@ export function nsid(path: string, value: string): ValidationResult {
 
 export function cid(path: string, value: string): ValidationResult {
   try {
-    CID.parse(value)
+    parseCid(value)
   } catch {
     return {
       success: false,

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -1,5 +1,5 @@
-import { CID } from 'multiformats/cid'
 import { graphemeLen, utf8Len } from '@atproto/common-web'
+import { ifCid } from '@atproto/lex-data'
 import { Lexicons } from '../lexicons'
 import {
   LexBoolean,
@@ -388,7 +388,7 @@ function cidLink(
   def: LexUserType,
   value: unknown,
 ): ValidationResult {
-  if (CID.asCID(value) === null) {
+  if (ifCid(value) === null) {
     return {
       success: false,
       error: new ValidationError(`${path} must be a CID`),


### PR DESCRIPTION
- Added transform to `typedJsonBlobRef` to handle `{$link: string}`
- Replaced `check.is` with `safeParse`. The type assertion returned by `check.is` is incorrect because of the transform in `cidSchema` (`@atproto/common-web`)
- Replaced `multiformats/cid` with `@atproto/lex-data` (see CID deprecation in `@atproto/lex-data`)
- Added JSON support to blob validator (bluesky-social/atproto#3866)