### PR TITLE
increase string preview in validation error

### DIFF
--- a/.changeset/olive-bottles-jog.md
+++ b/.changeset/olive-bottles-jog.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Increase string preview validation error

--- a/packages/lex/lex-schema/src/core/validation-issue.ts
+++ b/packages/lex/lex-schema/src/core/validation-issue.ts
@@ -1,6 +1,6 @@
 import { ifCid, isLegacyBlobRef, isPlainObject } from '@atproto/lex-data'
 
-const STRING_PREVIEW_MAX_LENGTH = 48
+const STRING_PREVIEW_MAX_LENGTH = 256
 const STRING_PREVIEW_TRUNCATED_SUFFIX = '…'
 
 /**


### PR DESCRIPTION
48 is usually not enough for ATURIs. And it is pretty useful to get full ATURIs in investigations, etc.