### PR TITLE
Multi pds dev-env

### DIFF
--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "start": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps dist/bin.js",
-    "dev": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps --watch dist/bin.js"
+    "dev": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps --watch dist/bin.js",
+    "start:multi-pds": "node --enable-source-maps dist/bin-multi-pds.js"
   },
   "engines": {
     "node": ">=18.7.0"

--- a/packages/dev-env/src/bin-multi-pds.ts
+++ b/packages/dev-env/src/bin-multi-pds.ts
@@ -1,0 +1,81 @@
+import './env'
+import { TestNetworkNoAppView } from './network-no-appview'
+import { TestPds } from './pds'
+import { mockMailer } from './util'
+
+const parsePdsCount = (): number => {
+  const arg = process.argv[2]
+  if (arg === undefined) return 3
+  const n = Number.parseInt(arg, 10)
+  if (!Number.isFinite(n) || n < 1) {
+    throw new Error(`Invalid PDS count "${arg}": must be an integer >= 1`)
+  }
+  return n
+}
+
+const run = async () => {
+  const totalPdsCount = parsePdsCount()
+  const extraPdsCount = totalPdsCount - 1
+
+  console.log(`
+██████╗
+██╔═══██╗
+██║██╗██║
+██║██║██║
+╚█║████╔╝
+ ╚╝╚═══╝  protocol
+
+[ created by Bluesky ]`)
+
+  const network = await TestNetworkNoAppView.create({
+    pds: {
+      port: 2583,
+      hostname: 'localhost',
+      enableDidDocWithSession: true,
+    },
+    plc: { port: 2582 },
+    extraPdses: extraPdsCount,
+  })
+  mockMailer(network.pds)
+  for (const extra of network.extraPdses) {
+    mockMailer(extra)
+  }
+
+  console.log(`👤 DID Placeholder server http://localhost:${network.plc.port}`)
+
+  const allPdses: { label: string; pds: TestPds; domain: string }[] = [
+    { label: 'pds1 (primary)', pds: network.pds, domain: 'test' },
+    ...network.extraPdses.map((pds, i) => ({
+      label: `pds${i + 2}`,
+      pds,
+      domain: `test${i + 2}`,
+    })),
+  ]
+
+  for (const { label, pds } of allPdses) {
+    console.log(`🌞 ${label} http://localhost:${pds.port}`)
+  }
+
+  // Seed one account per PDS so each has data that's reachable cross-PDS.
+  const seeded: { handle: string; did: string; pds: string }[] = []
+  for (const { label, pds, domain } of allPdses) {
+    const agent = pds.getAgent()
+    const handle = `alice.${domain}`
+    const res = await agent.com.atproto.server.createAccount({
+      handle,
+      email: `alice-${domain}@test.com`,
+      password: 'alice-pass',
+    })
+    seeded.push({ handle, did: res.data.did, pds: label })
+  }
+
+  console.log('\n👥 Seeded accounts:')
+  for (const acct of seeded) {
+    console.log(
+      `  ${acct.pds.padEnd(16)} handle=${acct.handle.padEnd(20)} did=${acct.did}`,
+    )
+  }
+  console.log('  (password for all: alice-pass)')
+}
+
+run()

--- a/packages/dev-env/src/bin-multi-pds.ts
+++ b/packages/dev-env/src/bin-multi-pds.ts
@@ -1,7 +1,10 @@
 import './env'
+import { IntrospectServer } from './introspect'
 import { TestNetworkNoAppView } from './network-no-appview'
 import { TestPds } from './pds'
 import { mockMailer } from './util'
+
+const INTROSPECT_PORT = 2581
 
 const parsePdsCount = (): number => {
   const arg = process.argv[2]
@@ -41,6 +44,12 @@ const run = async () => {
     mockMailer(extra)
   }
 
+  const introspect = await IntrospectServer.start(INTROSPECT_PORT, network.plc, [
+    network.pds,
+    ...network.extraPdses,
+  ])
+
+  console.log(`🔍 Introspection server http://localhost:${introspect.port}`)
   console.log(`👤 DID Placeholder server http://localhost:${network.plc.port}`)
 
   const allPdses: { label: string; pds: TestPds; domain: string }[] = [

--- a/packages/dev-env/src/bin-multi-pds.ts
+++ b/packages/dev-env/src/bin-multi-pds.ts
@@ -65,17 +65,20 @@ const run = async () => {
     console.log(`🌞 ${label} http://localhost:${pds.port}`)
   }
 
-  // Seed one account per PDS so each has data that's reachable cross-PDS.
+  // Seed alice/bob/carol on each PDS so each has data that's reachable cross-PDS.
+  const seedNames = ['alice', 'bob', 'carol']
   const seeded: { handle: string; did: string; pds: string }[] = []
   for (const { label, pds, domain } of allPdses) {
     const agent = pds.getAgent()
-    const handle = `alice.${domain}`
-    const res = await agent.com.atproto.server.createAccount({
-      handle,
-      email: `alice-${domain}@test.com`,
-      password: 'alice-pass',
-    })
-    seeded.push({ handle, did: res.data.did, pds: label })
+    for (const name of seedNames) {
+      const handle = `${name}.${domain}`
+      const res = await agent.com.atproto.server.createAccount({
+        handle,
+        email: `${name}-${domain}@test.com`,
+        password: `${name}-pass`,
+      })
+      seeded.push({ handle, did: res.data.did, pds: label })
+    }
   }
 
   console.log('\n👥 Seeded accounts:')
@@ -84,7 +87,7 @@ const run = async () => {
       `  ${acct.pds.padEnd(16)} handle=${acct.handle.padEnd(20)} did=${acct.did}`,
     )
   }
-  console.log('  (password for all: alice-pass)')
+  console.log('  (passwords: alice-pass / bob-pass / carol-pass)')
 }
 
 run()

--- a/packages/dev-env/src/introspect.ts
+++ b/packages/dev-env/src/introspect.ts
@@ -15,31 +15,45 @@ export class IntrospectServer {
   static async start(
     port: number,
     plc: TestPlc,
-    pds: TestPds,
-    bsky: TestBsky,
-    ozone: TestOzone,
+    pds: TestPds | TestPds[],
+    bsky?: TestBsky,
+    ozone?: TestOzone,
   ) {
+    const pdses = Array.isArray(pds) ? pds : [pds]
     const app = express()
     app.get('/', (_req, res) => {
       res.status(200).send({
         plc: {
           url: plc.url,
         },
+        // For backwards compat the first PDS is exposed at "pds"; all PDSes
+        // (including the first) are exposed at "pdses".
         pds: {
-          url: pds.url,
-          did: pds.ctx.cfg.service.did,
+          url: pdses[0].url,
+          did: pdses[0].ctx.cfg.service.did,
         },
-        bsky: {
-          url: bsky.url,
-          did: bsky.ctx.cfg.serverDid,
-        },
-        ozone: {
-          url: ozone.url,
-          did: ozone.ctx.cfg.service.did,
-        },
-        db: {
-          url: ozone.ctx.cfg.db.postgresUrl,
-        },
+        pdses: pdses.map((p) => ({
+          url: p.url,
+          did: p.ctx.cfg.service.did,
+          handleDomains: p.ctx.cfg.identity.serviceHandleDomains,
+        })),
+        bsky: bsky
+          ? {
+              url: bsky.url,
+              did: bsky.ctx.cfg.serverDid,
+            }
+          : undefined,
+        ozone: ozone
+          ? {
+              url: ozone.url,
+              did: ozone.ctx.cfg.service.did,
+            }
+          : undefined,
+        db: ozone
+          ? {
+              url: ozone.ctx.cfg.db.postgresUrl,
+            }
+          : undefined,
       })
     })
     const server = app.listen(port)

--- a/packages/dev-env/src/network-no-appview.ts
+++ b/packages/dev-env/src/network-no-appview.ts
@@ -1,3 +1,4 @@
+import getPort from 'get-port'
 import { SkeletonHandler } from '@atproto/pds'
 import { TestFeedGen } from './feed-gen'
 import { TestPds } from './pds'
@@ -11,6 +12,7 @@ export class TestNetworkNoAppView {
   constructor(
     public plc: TestPlc,
     public pds: TestPds,
+    public extraPdses: TestPds[] = [],
   ) {}
 
   static async create(
@@ -22,9 +24,26 @@ export class TestNetworkNoAppView {
       ...params.pds,
     })
 
-    mockNetworkUtilities(pds)
+    const extraPdsCount = params.extraPdses ?? 0
+    const extraPdses: TestPds[] = []
+    for (let i = 0; i < extraPdsCount; i++) {
+      // Extra PDSes get their own non-overlapping handle domain (.test2, .test3, ...)
+      // to avoid colliding with the primary PDS's .test.
+      const domain = `.test${i + 2}`
+      const extra = await TestPds.create({
+        didPlcUrl: plc.url,
+        ...params.pds,
+        // Override after spreading so each extra PDS gets a unique port and
+        // its own handle domain (rather than inheriting the primary's).
+        port: await getPort(),
+        serviceHandleDomains: [domain],
+      })
+      extraPdses.push(extra)
+    }
 
-    return new TestNetworkNoAppView(plc, pds)
+    mockNetworkUtilities([pds, ...extraPdses])
+
+    return new TestNetworkNoAppView(plc, pds, extraPdses)
   }
 
   async createFeedGen(
@@ -43,11 +62,13 @@ export class TestNetworkNoAppView {
 
   async processAll() {
     await this.pds.processAll()
+    await Promise.all(this.extraPdses.map((p) => p.processAll()))
   }
 
   async close() {
     await Promise.all(this.feedGens.map((fg) => fg.close()))
     await this.pds.close()
+    await Promise.all(this.extraPdses.map((p) => p.close()))
     await this.plc.close()
   }
 }

--- a/packages/dev-env/src/types.ts
+++ b/packages/dev-env/src/types.ts
@@ -51,6 +51,7 @@ export type TestServerParams = {
   bsky: Partial<BskyConfig>
   ozone: Partial<OzoneConfig>
   introspect: Partial<IntrospectConfig>
+  extraPdses: number
 }
 
 export type DidAndKey = {

--- a/packages/dev-env/src/util.ts
+++ b/packages/dev-env/src/util.ts
@@ -6,15 +6,26 @@ import { TestBsky } from './bsky'
 import { TestPds } from './pds'
 import { DidAndKey } from './types'
 
-export const mockNetworkUtilities = (pds: TestPds, bsky?: TestBsky) => {
-  mockResolvers(pds.ctx.idResolver, pds)
+export const mockNetworkUtilities = (
+  pds: TestPds | TestPds[],
+  bsky?: TestBsky,
+) => {
+  const pdses = Array.isArray(pds) ? pds : [pds]
+  for (const p of pdses) {
+    mockResolvers(p.ctx.idResolver, pdses)
+  }
   if (bsky) {
-    mockResolvers(bsky.ctx.idResolver, pds)
-    mockResolvers(bsky.dataplane.idResolver, pds)
+    mockResolvers(bsky.ctx.idResolver, pdses)
+    mockResolvers(bsky.dataplane.idResolver, pdses)
   }
 }
 
-export const mockResolvers = (idResolver: IdResolver, pds: TestPds) => {
+export const mockResolvers = (
+  idResolver: IdResolver,
+  pds: TestPds | TestPds[],
+) => {
+  const pdses = Array.isArray(pds) ? pds : [pds]
+
   // Map pds public url to its local url when resolving from plc
   const origResolveDid = idResolver.did.resolveNoCache
   idResolver.did.resolveNoCache = async (did: string) => {
@@ -24,24 +35,28 @@ export const mockResolvers = (idResolver: IdResolver, pds: TestPds) => {
     ) as ReturnType<typeof origResolveDid>)
     const service = result?.service?.find((svc) => svc.id === '#atproto_pds')
     if (typeof service?.serviceEndpoint === 'string') {
-      service.serviceEndpoint = service.serviceEndpoint.replace(
-        pds.ctx.cfg.service.publicUrl,
-        `http://localhost:${pds.port}`,
-      )
+      for (const p of pdses) {
+        service.serviceEndpoint = service.serviceEndpoint.replace(
+          p.ctx.cfg.service.publicUrl,
+          `http://localhost:${p.port}`,
+        )
+      }
     }
     return result
   }
 
   const origResolveHandleDns = idResolver.handle.resolveDns
   idResolver.handle.resolve = async (handle: string) => {
-    const isPdsHandle = pds.ctx.cfg.identity.serviceHandleDomains.some(
-      (domain) => handle.endsWith(domain),
+    // Handle domains across PDSes are disjoint suffixes (.test, .test2, ...);
+    // first match wins.
+    const match = pdses.find((p) =>
+      p.ctx.cfg.identity.serviceHandleDomains.some((d) => handle.endsWith(d)),
     )
-    if (!isPdsHandle) {
+    if (!match) {
       return origResolveHandleDns.call(idResolver.handle, handle)
     }
 
-    const url = new URL(`/.well-known/atproto-did`, pds.url)
+    const url = new URL(`/.well-known/atproto-did`, match.url)
     try {
       const res = await request(url, { headers: { host: handle } })
       if (res.statusCode !== 200) {


### PR DESCRIPTION
Adds the ability to run a local multi-PDS dev-env for testing federated features.

This runs without an appview/ozone/feedgen and so does not require docker/postgres/redis. This is mainly owing to the fact that we don't have a relay implementation that we can run in-process. 

### Usage
```bash
pnpm start:multi-pds       # 3 PDSes (default
pnpm start:multi-pds 5    # 5 PDSes 
```

Primary PDS gets the `.test` TLD, the extras get `.test2`, `.test3`, etc. 

Setup script creates an account on each PDS: `alice.${PDS_DOMAIN}` with the password `alice-pass`.