### PR TITLE
Use pnpm publish in CI to avoid devEngines conflict with npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,11 +26,6 @@ jobs:
           cache: pnpm
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
-      # Temporary workaround for an issue with Node.js v22
-      # https://github.com/npm/cli/issues/9151
-      # https://github.com/npm/cli/pull/9152
-      - run: npm install --global npm@11.11.1
-      - run: npm install --global npm@latest
       - run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
@@ -38,7 +33,7 @@ jobs:
         uses: changesets/action@v1
         id: changesets
         with:
-          publish: pnpm release
+          publish: pnpm run publish:ci
           version: pnpm run version-packages
           commit: 'Version packages'
           title: 'Version packages'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:withFlags": "pnpm run test --",
     "bench": "vitest bench --run",
     "changeset": "changeset",
-    "release": "pnpm build && changeset publish",
+    "publish:ci": "pnpm run build && changeset tag && pnpm publish -r --no-git-checks --access public",
     "version-packages": "changeset version && git add ."
   },
   "devDependencies": {


### PR DESCRIPTION
Changeset publish uses npm internally for registry checks, which fails because `devEngines.packageManager` requires pnpm as of #4905. So here we switch to `pnpm publish -r` which handles registry interaction.