### PR TITLE
Upgrade packages to node v22+

### DIFF
--- a/.changeset/drop-node-18-20.md
+++ b/.changeset/drop-node-18-20.md
@@ -1,0 +1,65 @@
+---
+'@atproto/bsky': patch
+'@atproto/bsync': patch
+'@atproto/ozone': patch
+'@atproto/pds': patch
+'@atproto/api': minor
+'@atproto/aws': minor
+'@atproto/common': minor
+'@atproto/common-web': minor
+'@atproto/crypto': minor
+'@atproto/dev-env': minor
+'@atproto/did': minor
+'@atproto/identity': minor
+'@atproto/jwk': minor
+'@atproto/jwk-jose': minor
+'@atproto/jwk-webcrypto': minor
+'@atproto/lex': minor
+'@atproto/lex-builder': minor
+'@atproto/lex-cbor': minor
+'@atproto/lex-cli': minor
+'@atproto/lex-client': minor
+'@atproto/lex-data': minor
+'@atproto/lex-document': minor
+'@atproto/lex-installer': minor
+'@atproto/lex-json': minor
+'@atproto/lex-password-session': minor
+'@atproto/lex-resolver': minor
+'@atproto/lex-schema': minor
+'@atproto/lex-server': minor
+'@atproto/lexicon': minor
+'@atproto/lexicon-resolver': minor
+'@atproto/oauth-client': minor
+'@atproto/oauth-client-browser': minor
+'@atproto/oauth-client-browser-example': minor
+'@atproto/oauth-client-expo': minor
+'@atproto/oauth-client-node': minor
+'@atproto/oauth-provider': minor
+'@atproto/oauth-provider-api': minor
+'@atproto/oauth-provider-ui': minor
+'@atproto/oauth-scopes': minor
+'@atproto/oauth-types': minor
+'@atproto/repo': minor
+'@atproto/sync': minor
+'@atproto/syntax': minor
+'@atproto/tap': minor
+'@atproto/ws-client': minor
+'@atproto/xrpc': minor
+'@atproto/xrpc-server': minor
+'@atproto-labs/did-resolver': minor
+'@atproto-labs/fetch': minor
+'@atproto-labs/fetch-node': minor
+'@atproto-labs/handle-resolver': minor
+'@atproto-labs/handle-resolver-node': minor
+'@atproto-labs/identity-resolver': minor
+'@atproto-labs/pipe': minor
+'@atproto-labs/rollup-plugin-bundle-manifest': minor
+'@atproto-labs/simple-store': minor
+'@atproto-labs/simple-store-memory': minor
+'@atproto-labs/simple-store-redis': minor
+'@atproto-labs/xrpc-utils': minor
+---
+
+Drop support for Node.js 18 and 20. Node.js 22 is now the minimum supported version. Docker images now use `node:22-alpine3.23`.
+
+`@atproto-labs/fetch-node`: `unicastFetchWrap` and `safeFetchWrap` no longer accept `dangerouslyForceKeepAliveAgent` — on Node.js 22+ the keep-alive dispatcher is always used via `new Request(input, { dispatcher })`, so the option was a no-op.

--- a/.changeset/drop-node-18-20.md
+++ b/.changeset/drop-node-18-20.md
@@ -60,6 +60,4 @@
 '@atproto-labs/xrpc-utils': minor
 ---
 
-Drop support for Node.js 18 and 20. Node.js 22 is now the minimum supported version. Docker images now use `node:22-alpine3.23`.
-
-`@atproto-labs/fetch-node`: `unicastFetchWrap` and `safeFetchWrap` no longer accept `dangerouslyForceKeepAliveAgent` — on Node.js 22+ the keep-alive dispatcher is always used via `new Request(input, { dispatcher })`, so the option was a no-op.
+**BREAKING:** Drop support for Node.js 18 and 20. Node.js 22 is now the minimum supported version. Docker images now use Node.js 24.

--- a/.changeset/fetch-node-drop-keepalive-option.md
+++ b/.changeset/fetch-node-drop-keepalive-option.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': minor
+---
+
+**BREAKING:** `unicastFetchWrap` and `safeFetchWrap` no longer accept `dangerouslyForceKeepAliveAgent` — on Node.js 22+ the keep-alive dispatcher is always used via `new Request(input, { dispatcher })`, so the option was a no-op.

--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - '*'
-  push:
-    branches:
-      - divy/node-22-24
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'

--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - '*'
+  push:
+    branches:
+      - divy/node-22-24
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Go programming language source code is in [bluesky-social/indigo](https://github
 
 ## Developer Quickstart
 
-We recommend [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js installs. This project requires Node.js version 18. `pnpm` is used to manage the workspace of multiple packages. You can install it with `npm install --global pnpm`.
+We recommend [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js installs. This project requires Node.js version 22 or later. `pnpm` is used to manage the workspace of multiple packages. You can install it with `npm install --global pnpm`.
 
 There is a Makefile which can help with basic development tasks:
 
 ```shell
-# use existing nvm to install node 18 and pnpm
+# use existing nvm to install node 22 and pnpm
 make nvm-setup
 
 # pull dependencies and build all local packages

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81",
   "devEngines": {
@@ -17,10 +17,11 @@
   },
   "pnpm": {
     "executionEnv": {
-      "nodeVersion": ">=18.7.0"
+      "nodeVersion": ">=22"
     },
     "overrides": {
-      "cookie": "^0.7.2"
+      "cookie": "^0.7.2",
+      "opentelemetry-plugin-better-sqlite3>@opentelemetry/core": "^1.30.0"
     }
   },
   "scripts": {
@@ -53,7 +54,7 @@
     "@swc/core": "^1.3.42",
     "@swc/jest": "^0.2.24",
     "@types/jest": "^28.1.4",
-    "@types/node": "^18.19.67",
+    "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vitest/coverage-v8": "4.0.16",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/api",
   "version": "0.19.17",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Client library for atproto and Bluesky",
   "keywords": [

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -19,7 +19,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/common": "workspace:^",

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -27,7 +27,7 @@
     "buf:gen": "buf generate ../bsync/proto && buf generate ./proto"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto-labs/fetch-node": "workspace:^",

--- a/packages/bsync/package.json
+++ b/packages/bsync/package.json
@@ -25,7 +25,7 @@
     "buf:gen": "buf generate proto"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/common": "workspace:^",

--- a/packages/common-web/package.json
+++ b/packages/common-web/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/common-web",
   "version": "0.4.21",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Shared web-platform-friendly code for atproto libraries",
   "keywords": [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/common-web": "workspace:^",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -20,7 +20,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@noble/curves": "^1.7.0",

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -21,7 +21,7 @@
     "dev": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps --watch dist/bin.js"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/api": "workspace:^",

--- a/packages/did/package.json
+++ b/packages/did/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/did",
   "version": "0.3.0",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "DID resolution and verification library",
   "keywords": [

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -22,7 +22,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/common-web": "workspace:^",

--- a/packages/internal/did-resolver/package.json
+++ b/packages/internal/did-resolver/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/did-resolver",
   "version": "0.2.6",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "DID resolution and verification library",
   "keywords": [

--- a/packages/internal/fetch-node/package.json
+++ b/packages/internal/fetch-node/package.json
@@ -24,7 +24,7 @@
     }
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto-labs/fetch": "workspace:^",

--- a/packages/internal/fetch-node/src/safe.ts
+++ b/packages/internal/fetch-node/src/safe.ts
@@ -52,7 +52,6 @@ export type SafeFetchWrapOptions<C> = UnicastFetchWrapOptions<C> & {
  */
 export function safeFetchWrap<C>({
   fetch = globalThis.fetch as Fetch<C>,
-  dangerouslyForceKeepAliveAgent = false,
   responseMaxSize = 512 * 1024, // 512kB
   ssrfProtection = true,
   allowCustomPort = !ssrfProtection,
@@ -106,9 +105,7 @@ export function safeFetchWrap<C>({
        * input, we need to make sure that the request is not vulnerable to SSRF
        * attacks.
        */
-      allowPrivateIps
-        ? fetch
-        : unicastFetchWrap({ fetch, dangerouslyForceKeepAliveAgent }),
+      allowPrivateIps ? fetch : unicastFetchWrap({ fetch }),
     ),
 
     /**

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -17,12 +17,21 @@ export type UnicastFetchWrapOptions<C = FetchContext> = {
   fetch?: Fetch<C>
 }
 
+const SUPPORTS_REQUEST_INIT_DISPATCHER =
+  Number(process.versions.node.split('.')[0]) >= 20
+
 /**
  * @see {@link https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/}
  */
 export function unicastFetchWrap<C = FetchContext>({
   fetch = globalThis.fetch,
 }: UnicastFetchWrapOptions<C>): Fetch<C> {
+  if (!SUPPORTS_REQUEST_INIT_DISPATCHER) {
+    throw new Error(
+      'Unicast SSRF protection unavailable on your platform. Update to Node.js 22+.',
+    )
+  }
+
   const dispatcher = new Agent({
     connect: { lookup: unicastLookup },
   })

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -1,7 +1,7 @@
 import dns, { LookupAddress } from 'node:dns'
 import { LookupFunction } from 'node:net'
 import ipaddr from 'ipaddr.js'
-import { Agent, Client } from 'undici'
+import { Agent } from 'undici'
 import {
   Fetch,
   FetchContext,
@@ -15,181 +15,40 @@ const { IPv4, IPv6 } = ipaddr
 
 export type UnicastFetchWrapOptions<C = FetchContext> = {
   fetch?: Fetch<C>
-
-  /**
-   * ## ‼️ important security feature use with care
-   *
-   * On older NodeJS version, the `dispatcher` init option is ignored when
-   * creating a new Request instance. It can only be passed through the fetch
-   * function directly.
-   *
-   * Since this is a security feature, we need to ensure that the unicastLookup
-   * function is called to resolve the hostname to a unicast IP address.
-   *
-   * However, in the case a custom "fetch" function is passed here (fetch !==
-   * globalThis.fetch), we have no guarantee that the dispatcher will be used to
-   * make the request. Because of this, in such a case, we will use a one-time
-   * use dispatcher that checks that the provided fetch function indeed made use
-   * of the "unicastLookup" when a custom dispatch init function is used.
-   *
-   * Sadly, this means that we cannot use "keepAlive" connections, as the method
-   * used to ensure that "unicastLookup" gets called requires to create a new
-   * dispatcher for each request.
-   *
-   * If you can guarantee that the provided fetch function will make use of the
-   * "dispatcher" init option, you can set this flag to true, which will enable
-   * the use of a single agent (with keep-alive) for all requests.
-   *
-   * @default false
-   * @note This option has no effect on Node.js versions >= 20
-   */
-  dangerouslyForceKeepAliveAgent?: boolean
 }
-
-// @TODO support other runtimes ?
-const SUPPORTS_REQUEST_INIT_DISPATCHER =
-  Number(process.versions.node.split('.')[0]) >= 20
 
 /**
  * @see {@link https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/}
  */
 export function unicastFetchWrap<C = FetchContext>({
   fetch = globalThis.fetch,
-  dangerouslyForceKeepAliveAgent = false,
 }: UnicastFetchWrapOptions<C>): Fetch<C> {
-  if (
-    SUPPORTS_REQUEST_INIT_DISPATCHER ||
-    dangerouslyForceKeepAliveAgent ||
-    fetch === globalThis.fetch
-  ) {
-    const dispatcher = new Agent({
-      connect: { lookup: unicastLookup },
-    })
+  const dispatcher = new Agent({
+    connect: { lookup: unicastLookup },
+  })
 
-    return async function (input, init): Promise<Response> {
-      if (init?.dispatcher) {
-        throw new FetchRequestError(
-          asRequest(input, init),
-          500,
-          'SSRF protection cannot be used with a custom request dispatcher',
-        )
-      }
-
-      const url = extractUrl(input)
-
-      if (url.hostname && isUnicastIp(url.hostname) === false) {
-        throw new FetchRequestError(
-          asRequest(input, init),
-          400,
-          'Hostname is a non-unicast address',
-        )
-      }
-
-      if (SUPPORTS_REQUEST_INIT_DISPATCHER) {
-        // @ts-expect-error non-standard option
-        const request = new Request(input, { ...init, dispatcher })
-        return fetch.call(this, request)
-      } else {
-        // @ts-expect-error non-standard option
-        return fetch.call(this, input, { ...init, dispatcher })
-      }
+  return async function (input, init): Promise<Response> {
+    if (init?.dispatcher) {
+      throw new FetchRequestError(
+        asRequest(input, init),
+        500,
+        'SSRF protection cannot be used with a custom request dispatcher',
+      )
     }
-  } else {
-    return async function (input, init): Promise<Response> {
-      if (init?.dispatcher) {
-        throw new FetchRequestError(
-          asRequest(input, init),
-          500,
-          'SSRF protection cannot be used with a custom request dispatcher',
-        )
-      }
 
-      const url = extractUrl(input)
+    const url = extractUrl(input)
 
-      if (!url.hostname) {
-        return fetch.call(this, input, init)
-      }
-
-      switch (isUnicastIp(url.hostname)) {
-        case true: {
-          // hostname is a unicast address, safe to proceed.
-          return fetch.call(this, input, init)
-        }
-
-        case false: {
-          throw new FetchRequestError(
-            asRequest(input, init),
-            400,
-            'Hostname is a non-unicast address',
-          )
-        }
-
-        case undefined: {
-          // hostname is a domain name, let's create a new dispatcher that
-          // will 1) use the unicastLookup function to resolve the hostname
-          // and 2) allow us to check that the lookup function was indeed
-          // called.
-
-          let didLookup = false
-          const dispatcher = new Client(url.origin, {
-            // Do *not* enable H2 here, as it will cause an error (the
-            // client will terminate the connection before the response is
-            // consumed).
-            // https://github.com/nodejs/undici/issues/3671
-            connect: {
-              keepAlive: false, // Client will be used once
-              lookup(...args) {
-                didLookup = true
-                unicastLookup(...args)
-              },
-            },
-          })
-
-          try {
-            const headers = new Headers(init?.headers)
-            headers.set('connection', 'close') // Proactively close the connection
-
-            const response = await fetch.call(this, input, {
-              ...init,
-              headers,
-              // @ts-expect-error non-standard option
-              dispatcher,
-            })
-
-            if (!didLookup) {
-              // We need to ensure that the body is discarded. We can either
-              // consume the whole body (for await loop) in order to keep the
-              // socket alive, or cancel the request. Since we sent "connection:
-              // close", there is no point in consuming the whole response
-              // (which would cause un-necessary bandwidth).
-              //
-              // https://undici.nodejs.org/#/?id=garbage-collection
-              await response.body?.cancel()
-
-              // If you encounter this error, either upgrade to Node.js >=21 or
-              // make sure that the dispatcher passed through the requestInit
-              // object ends up being used to make the request.
-
-              // eslint-disable-next-line no-unsafe-finally
-              throw new FetchRequestError(
-                asRequest(input, init),
-                500,
-                'Unable to enforce SSRF protection',
-              )
-            }
-
-            return response
-          } finally {
-            // Free resources (we cannot await here since the response was not
-            // consumed yet).
-            void dispatcher.close().catch((err) => {
-              // No biggie, but let's still log it
-              console.warn('Failed to close dispatcher', err)
-            })
-          }
-        }
-      }
+    if (url.hostname && isUnicastIp(url.hostname) === false) {
+      throw new FetchRequestError(
+        asRequest(input, init),
+        400,
+        'Hostname is a non-unicast address',
+      )
     }
+
+    // @ts-expect-error non-standard option
+    const request = new Request(input, { ...init, dispatcher })
+    return fetch.call(this, request)
   }
 }
 

--- a/packages/internal/fetch/package.json
+++ b/packages/internal/fetch/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/fetch",
   "version": "0.2.3",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Isomorphic wrapper utilities for fetch API",
   "keywords": [

--- a/packages/internal/handle-resolver-node/package.json
+++ b/packages/internal/handle-resolver-node/package.json
@@ -26,7 +26,7 @@
     }
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto-labs/fetch-node": "workspace:^",

--- a/packages/internal/handle-resolver/package.json
+++ b/packages/internal/handle-resolver/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/handle-resolver",
   "version": "0.3.6",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Isomorphic ATProto handle to DID resolver",
   "keywords": [

--- a/packages/internal/identity-resolver/package.json
+++ b/packages/internal/identity-resolver/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/identity-resolver",
   "version": "0.3.6",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "A library resolving ATPROTO identities",
   "keywords": [

--- a/packages/internal/pipe/package.json
+++ b/packages/internal/pipe/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/pipe",
   "version": "0.1.1",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Library for combining multiple functions into a single function.",
   "keywords": [

--- a/packages/internal/rollup-plugin-bundle-manifest/package.json
+++ b/packages/internal/rollup-plugin-bundle-manifest/package.json
@@ -24,7 +24,7 @@
     }
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "files": [
     "dist"

--- a/packages/internal/simple-store-memory/package.json
+++ b/packages/internal/simple-store-memory/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/simple-store-memory",
   "version": "0.1.4",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Memory based simple-store implementation",
   "keywords": [

--- a/packages/internal/simple-store-redis/package.json
+++ b/packages/internal/simple-store-redis/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/simple-store-redis",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Redis based simple-store implementation",
   "keywords": [

--- a/packages/internal/simple-store/package.json
+++ b/packages/internal/simple-store/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/simple-store",
   "version": "0.3.0",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Simple store interfaces & utilities",
   "keywords": [

--- a/packages/internal/xrpc-utils/package.json
+++ b/packages/internal/xrpc-utils/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto-labs/xrpc-utils",
   "version": "0.0.24",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "XRPC server utilities for Node.JS",
   "keywords": [

--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -22,7 +22,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/lexicon": "workspace:^",

--- a/packages/lex/lex-builder/package.json
+++ b/packages/lex/lex-builder/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-builder",
   "version": "0.0.23",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "TypeScript schema builder for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-cbor/package.json
+++ b/packages/lex/lex-cbor/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-cbor",
   "version": "0.0.16",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon encoding utilities for AT Lexicon data in CBOR format",
   "keywords": [

--- a/packages/lex/lex-client/package.json
+++ b/packages/lex/lex-client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-client",
   "version": "0.0.21",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "HTTP client for interacting with Lexicon based APIs",
   "keywords": [

--- a/packages/lex/lex-data/package.json
+++ b/packages/lex/lex-data/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-data",
   "version": "0.0.15",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Core utilities for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-data/src/lib/nodejs-buffer.ts
+++ b/packages/lex/lex-data/src/lib/nodejs-buffer.ts
@@ -1,5 +1,10 @@
 type Encoding = 'utf8' | 'base64' | 'base64url'
 
+// Node's buffer module declares this type internally, but referencing it here
+// would couple this file to @types/node. Local copy keeps this module
+// standalone so it compiles in any environment.
+type WithImplicitCoercion<T> = T | { valueOf(): T }
+
 interface NodeJSBuffer<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
   extends Uint8Array<TArrayBuffer> {
   byteLength: number

--- a/packages/lex/lex-data/src/lib/nodejs-buffer.ts
+++ b/packages/lex/lex-data/src/lib/nodejs-buffer.ts
@@ -2,7 +2,7 @@ type Encoding = 'utf8' | 'base64' | 'base64url'
 
 // Node's buffer module declares this type internally, but referencing it here
 // would couple this file to @types/node. Local copy keeps this module
-// standalone so it compiles in any environment.
+// standalone so it compiles in any environment (see tsconfig/isomorphic.json).
 type WithImplicitCoercion<T> = T | { valueOf(): T }
 
 interface NodeJSBuffer<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>

--- a/packages/lex/lex-document/package.json
+++ b/packages/lex/lex-document/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-document",
   "version": "0.0.21",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon document validation tools for AT",
   "keywords": [

--- a/packages/lex/lex-installer/package.json
+++ b/packages/lex/lex-installer/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-installer",
   "version": "0.0.26",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon document packet manager for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-json/package.json
+++ b/packages/lex/lex-json/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-json",
   "version": "0.0.16",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon encoding utilities for AT Lexicon data in JSON format",
   "keywords": [

--- a/packages/lex/lex-password-session/package.json
+++ b/packages/lex/lex-password-session/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-password-session",
   "version": "0.0.14",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Password based client authentication for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-resolver/package.json
+++ b/packages/lex/lex-resolver/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-resolver",
   "version": "0.0.23",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon document resolver utility for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-schema/package.json
+++ b/packages/lex/lex-schema/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-schema",
   "version": "0.0.20",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon schema system for AT Lexicons",
   "keywords": [

--- a/packages/lex/lex-server/package.json
+++ b/packages/lex/lex-server/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex-server",
   "version": "0.0.18",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Request router for Atproto Lexicon protocols and schemas",
   "keywords": [

--- a/packages/lex/lex/package.json
+++ b/packages/lex/lex/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lex",
   "version": "0.0.26",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Lexicon tooling for AT",
   "keywords": [

--- a/packages/lexicon-resolver/package.json
+++ b/packages/lexicon-resolver/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lexicon-resolver",
   "version": "0.3.6",
+  "engines": {
+    "node": ">=22"
+  },
   "type": "commonjs",
   "license": "MIT",
   "description": "ATProto Lexicon resolution",

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/lexicon",
   "version": "0.6.2",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "atproto Lexicon schema language library",
   "keywords": [

--- a/packages/oauth/jwk-jose/package.json
+++ b/packages/oauth/jwk-jose/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/jwk-jose",
   "version": "0.1.11",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "`jose` based implementation of @atproto/jwk Key's",
   "keywords": [

--- a/packages/oauth/jwk-webcrypto/package.json
+++ b/packages/oauth/jwk-webcrypto/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/jwk-webcrypto",
   "version": "0.2.0",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Webcrypto based implementation of @atproto/jwk Key's",
   "keywords": [

--- a/packages/oauth/jwk/package.json
+++ b/packages/oauth/jwk/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/jwk",
   "version": "0.6.0",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "A library for working with JSON Web Keys (JWKs) in TypeScript. This is meant to be extended by environment-specific libraries like @atproto/jwk-jose.",
   "keywords": [

--- a/packages/oauth/oauth-client-browser-example/package.json
+++ b/packages/oauth/oauth-client-browser-example/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-client-browser-example",
   "version": "0.0.10",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Example single page application app using ATPROTO OAuth",
   "keywords": [

--- a/packages/oauth/oauth-client-browser/package.json
+++ b/packages/oauth/oauth-client-browser/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-client-browser",
   "version": "0.3.42",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "ATPROTO OAuth client for the browser (relies on WebCrypto & Indexed DB)",
   "keywords": [

--- a/packages/oauth/oauth-client-expo/package.json
+++ b/packages/oauth/oauth-client-expo/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-client-expo",
   "version": "0.0.10",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "ATPROTO OAuth client for Expo applications",
   "authors": [

--- a/packages/oauth/oauth-client-node/package.json
+++ b/packages/oauth/oauth-client-node/package.json
@@ -25,7 +25,7 @@
     }
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "files": [
     "dist"

--- a/packages/oauth/oauth-client/package.json
+++ b/packages/oauth/oauth-client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-client",
   "version": "0.6.1",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "OAuth client for ATPROTO PDS. This package serves as common base for environment-specific implementations (NodeJS, Browser, React-Native).",
   "keywords": [

--- a/packages/oauth/oauth-provider-api/package.json
+++ b/packages/oauth/oauth-provider-api/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-provider-api",
   "version": "0.4.0",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Shared data types for the @atproto/oauth-provider and @atproto/oauth-provider-ui packages",
   "keywords": [

--- a/packages/oauth/oauth-provider-ui/package.json
+++ b/packages/oauth/oauth-provider-ui/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/oauth/oauth-provider-ui"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "type": "commonjs",
   "exports": {

--- a/packages/oauth/oauth-provider/package.json
+++ b/packages/oauth/oauth-provider/package.json
@@ -28,7 +28,7 @@
     }
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto-labs/fetch": "workspace:^",

--- a/packages/oauth/oauth-scopes/package.json
+++ b/packages/oauth/oauth-scopes/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-scopes",
   "version": "0.3.2",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "A library for manipulating and validating ATproto OAuth scopes in TypeScript.",
   "keywords": [

--- a/packages/oauth/oauth-types/package.json
+++ b/packages/oauth/oauth-types/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/oauth-types",
   "version": "0.6.3",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "OAuth typing & validation library",
   "keywords": [

--- a/packages/ozone/package.json
+++ b/packages/ozone/package.json
@@ -25,7 +25,7 @@
     "migration:create": "ts-node ./bin/migration-create.ts"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@atproto/api": "workspace:^",

--- a/packages/ozone/src/background.ts
+++ b/packages/ozone/src/background.ts
@@ -12,7 +12,7 @@ export class BackgroundQueue {
   private abortController = new AbortController()
   private queue: PQueue
 
-  public get signal() {
+  public get signal(): AbortSignal {
     return this.abortController.signal
   }
 
@@ -99,7 +99,7 @@ export class PeriodicBackgroundTask {
   private intervalPromise?: Promise<void>
   private runningPromise?: Promise<void>
 
-  public get signal() {
+  public get signal(): AbortSignal {
     return this.abortController.signal
   }
 

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -16,7 +16,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "scripts": {
     "codegen": "lex build --override --indexFile --lexicons ../../lexicons",
@@ -54,7 +54,7 @@
     "@atproto/xrpc-server": "workspace:^",
     "@did-plc/lib": "^0.0.4",
     "@hapi/address": "^5.1.1",
-    "better-sqlite3": "^10.0.0",
+    "better-sqlite3": "^12.0.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "disposable-email-domains-js": "^1.5.0",

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -338,15 +338,6 @@ export class AppContext {
       responseMaxSize: cfg.fetch.maxResponseSize,
       ssrfProtection: !cfg.fetch.disableSsrfProtection,
 
-      // @NOTE Since we are using NodeJS <= 20, unicastFetchWrap would normally
-      // *not* be using a keep-alive agent if it we are providing a fetch
-      // function that is different from `globalThis.fetch`. However, since the
-      // fetch function below is indeed calling `globalThis.fetch` without
-      // altering any argument, we can safely force the use of the keep-alive
-      // agent. This would not be the case if we used "loggedFetch" as that
-      // function does wrap the input & init arguments into a Request object,
-      // which, on NodeJS<=20, results in init.dispatcher *not* being used.
-      dangerouslyForceKeepAliveAgent: true,
       fetch: function (input, init) {
         const method =
           init?.method ?? (input instanceof Request ? input.method : 'GET')

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -8,7 +8,7 @@
     "mst"
   ],
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "homepage": "https://atproto.com",
   "repository": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/sync"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/syntax/package.json
+++ b/packages/syntax/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/syntax",
   "version": "0.5.4",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "Validation for atproto identifiers and formats: DID, handle, NSID, AT URI, etc",
   "keywords": [

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/tap"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/ws-client"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/xrpc-server/package.json
+++ b/packages/xrpc-server/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/xrpc-server"
   },
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/xrpc/package.json
+++ b/packages/xrpc/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@atproto/xrpc",
   "version": "0.7.7",
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "description": "atproto HTTP API (XRPC) client library",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cookie: ^0.7.2
+  opentelemetry-plugin-better-sqlite3>@opentelemetry/core: ^1.30.0
 
 importers:
 
@@ -19,7 +20,7 @@ importers:
         version: 0.5.1
       '@changesets/cli':
         specifier: ^2.29.7
-        version: 2.29.7(@types/node@18.19.67)
+        version: 2.29.7(@types/node@22.19.17)
       '@swc/core':
         specifier: ^1.3.42
         version: 1.11.18
@@ -30,8 +31,8 @@ importers:
         specifier: ^28.1.4
         version: 28.1.4
       '@types/node':
-        specifier: ^18.19.67
-        version: 18.19.67
+        specifier: ^22.0.0
+        version: 22.19.17
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.4.0
         version: 7.4.0(@typescript-eslint/parser@7.4.0)(eslint@8.57.0)(typescript@5.8.3)
@@ -64,7 +65,7 @@ importers:
         version: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       node-gyp:
         specifier: ^9.3.1
         version: 9.3.1
@@ -85,7 +86,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/api:
     dependencies:
@@ -122,7 +123,7 @@ importers:
         version: 28.1.3
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -340,10 +341,10 @@ importers:
         version: 6.9.7
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       ts-node:
         specifier: ^10.8.2
-        version: 10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2)
+        version: 10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -398,10 +399,10 @@ importers:
         version: 5.1.1
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       ts-node:
         specifier: ^10.8.2
-        version: 10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2)
+        version: 10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -426,7 +427,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -451,7 +452,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -473,7 +474,7 @@ importers:
         version: link:../common
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -562,7 +563,7 @@ importers:
         version: 0.2.24(@swc/core@1.13.3)
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -593,7 +594,7 @@ importers:
         version: 6.1.2
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -827,7 +828,7 @@ importers:
         version: 17.0.35
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-builder:
     dependencies:
@@ -852,7 +853,7 @@ importers:
         version: 0.28.1
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-cbor:
     dependencies:
@@ -871,10 +872,10 @@ importers:
         version: 4.5.8
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@18.19.67)
+        version: 6.2.0(@types/node@22.19.17)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-client:
     dependencies:
@@ -899,7 +900,7 @@ importers:
         version: link:../lex-cbor
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-data:
     dependencies:
@@ -921,7 +922,7 @@ importers:
         version: 3.45.1
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-document:
     dependencies:
@@ -940,7 +941,7 @@ importers:
         version: link:../lex-data
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-installer:
     dependencies:
@@ -971,7 +972,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-json:
     dependencies:
@@ -984,7 +985,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-password-session:
     dependencies:
@@ -1006,7 +1007,7 @@ importers:
         version: link:../lex-server
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-resolver:
     dependencies:
@@ -1043,7 +1044,7 @@ importers:
         version: link:../lex-builder
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-schema:
     dependencies:
@@ -1065,7 +1066,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lex/lex-server:
     dependencies:
@@ -1114,7 +1115,7 @@ importers:
         version: 4.0.16(vitest@4.0.16)
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/lexicon:
     dependencies:
@@ -1136,7 +1137,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -1167,7 +1168,7 @@ importers:
         version: link:../lex/lex-cbor
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.3
@@ -1334,7 +1335,7 @@ importers:
         version: 4.1.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@18.19.67)
+        version: 6.2.0(@types/node@22.19.17)
 
   packages/oauth/oauth-client-expo:
     dependencies:
@@ -1608,7 +1609,7 @@ importers:
         version: 2.0.3
       vite:
         specifier: ^6.2.0
-        version: 6.2.0(@types/node@18.19.67)
+        version: 6.2.0(@types/node@22.19.17)
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -1624,7 +1625,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.3
@@ -1749,10 +1750,10 @@ importers:
         version: 6.9.7
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       ts-node:
         specifier: ^10.8.2
-        version: 10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2)
+        version: 10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -1823,8 +1824,8 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1
       better-sqlite3:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^12.0.0
+        version: 12.9.0
       compression:
         specifier: ^1.7.4
         version: 1.7.4
@@ -1933,13 +1934,13 @@ importers:
         version: 6.1.2
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       puppeteer:
         specifier: ^23.11.1
         version: 23.11.1(typescript@5.8.2)
       ts-node:
         specifier: ^10.8.2
-        version: 10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2)
+        version: 10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -1976,7 +1977,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -2013,7 +2014,7 @@ importers:
         version: 8.5.4
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -2029,7 +2030,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/tap:
     dependencies:
@@ -2066,7 +2067,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@18.19.67)
+        version: 4.0.16(@types/node@22.19.17)
 
   packages/ws-client:
     dependencies:
@@ -2085,7 +2086,7 @@ importers:
         version: 6.1.2
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.8.3
@@ -2177,7 +2178,7 @@ importers:
         version: 6.1.2
       jest:
         specifier: ^28.1.2
-        version: 28.1.2(@types/node@18.19.67)(ts-node@10.8.2)
+        version: 28.1.2(@types/node@22.19.17)(ts-node@10.8.2)
       jose:
         specifier: ^4.15.4
         version: 4.15.4
@@ -2236,8 +2237,8 @@ importers:
         specifier: ^4.18.0
         version: 4.20.0
       opentelemetry-plugin-better-sqlite3:
-        specifier: ^1.1.0
-        version: 1.1.0(better-sqlite3@9.6.0)
+        specifier: ^1.13.0
+        version: 1.13.0(better-sqlite3@12.9.0)
 
 packages:
 
@@ -4343,7 +4344,7 @@ packages:
       - encoding
     dev: true
 
-  /@changesets/cli@2.29.7(@types/node@18.19.67):
+  /@changesets/cli@2.29.7(@types/node@22.19.17):
     resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
     hasBin: true
     dependencies:
@@ -4361,7 +4362,7 @@ packages:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@18.19.67)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.8.0
@@ -5889,7 +5890,7 @@ packages:
     dev: false
     optional: true
 
-  /@inquirer/external-editor@1.0.3(@types/node@18.19.67):
+  /@inquirer/external-editor@1.0.3(@types/node@22.19.17):
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -5898,7 +5899,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chardet: 2.1.1
       iconv-lite: 0.7.0
     dev: true
@@ -5955,7 +5956,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -5976,14 +5977,14 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@18.19.67)(ts-node@10.8.2)
+      jest-config: 28.1.3(@types/node@22.19.17)(ts-node@10.8.2)
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -6025,7 +6026,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-mock: 28.1.3
     dev: true
 
@@ -6035,7 +6036,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-mock: 29.7.0
     dev: false
 
@@ -6062,7 +6063,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
@@ -6074,7 +6075,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6106,7 +6107,7 @@ packages:
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -6223,7 +6224,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -6235,7 +6236,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       '@types/yargs': 17.0.35
       chalk: 4.1.2
     dev: true
@@ -6247,7 +6248,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6492,7 +6493,7 @@ packages:
     dependencies:
       '@lingui/cli': 5.2.0(typescript@5.8.2)
       '@lingui/conf': 5.2.0(typescript@5.8.2)
-      vite: 6.2.0(@types/node@18.19.67)
+      vite: 6.2.0(@types/node@22.19.17)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6582,6 +6583,13 @@ packages:
       rimraf: 3.0.2
     dev: true
 
+  /@opentelemetry/api-logs@0.208.0:
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+    dev: false
+
   /@opentelemetry/api@1.7.0:
     resolution: {integrity: sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==}
     engines: {node: '>=8.0.0'}
@@ -6602,18 +6610,26 @@ packages:
       '@opentelemetry/semantic-conventions': 1.18.1
     dev: false
 
-  /@opentelemetry/instrumentation@0.44.0(@opentelemetry/api@1.7.0):
-    resolution: {integrity: sha512-B6OxJTRRCceAhhnPDBshyQO7K07/ltX3quOLu0icEvPK9QZ7r9P1y0RQX8O5DxB4vTv4URRkxkg+aFU/plNtQw==}
+  /@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0):
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.28.0
+    dev: false
+
+  /@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0):
+    resolution: {integrity: sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
     dependencies:
-      '@opentelemetry/api': 1.7.0
-      '@types/shimmer': 1.0.5
-      import-in-the-middle: 1.4.2
-      require-in-the-middle: 7.2.0
-      semver: 7.5.4
-      shimmer: 1.2.1
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6636,6 +6652,16 @@ packages:
 
   /@opentelemetry/semantic-conventions@1.18.1:
     resolution: {integrity: sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@opentelemetry/semantic-conventions@1.28.0:
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@opentelemetry/semantic-conventions@1.40.0:
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
     dev: false
 
@@ -8457,7 +8483,7 @@ packages:
       '@tailwindcss/node': 4.1.3
       '@tailwindcss/oxide': 4.1.3
       tailwindcss: 4.1.3
-      vite: 6.2.0(@types/node@18.19.67)
+      vite: 6.2.0(@types/node@22.19.17)
     dev: true
 
   /@tanstack/history@1.115.0:
@@ -8596,13 +8622,13 @@ packages:
   /@types/bn.js@5.1.1:
     resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/chai@5.2.3:
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -8614,7 +8640,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/cookie@0.6.0:
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -8671,7 +8697,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/http-errors@2.0.4:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
@@ -8717,7 +8743,7 @@ packages:
   /@types/node-fetch@2.6.12:
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       form-data: 4.0.0
     dev: true
 
@@ -8734,6 +8760,12 @@ packages:
     resolution: {integrity: sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
+
+  /@types/node@22.19.17:
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+    dependencies:
+      undici-types: 6.21.0
 
   /@types/nodemailer@6.4.6:
     resolution: {integrity: sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==}
@@ -8785,7 +8817,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/send@0.17.4:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -8799,7 +8831,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.1
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
 
   /@types/shimmer@1.0.5:
     resolution: {integrity: sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww==}
@@ -8842,7 +8874,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
     dev: true
     optional: true
 
@@ -9018,7 +9050,7 @@ packages:
       vite: ^4 || ^5 || ^6
     dependencies:
       '@swc/core': 1.13.3
-      vite: 6.2.0(@types/node@18.19.67)
+      vite: 6.2.0(@types/node@22.19.17)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -9043,7 +9075,7 @@ packages:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@18.19.67)
+      vitest: 4.0.16(@types/node@22.19.17)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9073,7 +9105,7 @@ packages:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.2.0(@types/node@18.19.67)
+      vite: 6.2.0(@types/node@22.19.17)
     dev: true
 
   /@vitest/pretty-format@4.0.16:
@@ -9136,6 +9168,14 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.10.0
+    dev: false
+
+  /acorn-import-attributes@1.9.5(acorn@8.15.0):
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.15.0
     dev: false
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
@@ -9833,16 +9873,9 @@ packages:
       is-windows: 1.0.2
     dev: true
 
-  /better-sqlite3@10.0.0:
-    resolution: {integrity: sha512-rOz0JY8bt9oMgrFssP7GnvA5R3yln73y/NizzWqy3WlFth8Ux8+g4r/N9fjX97nn4X1YX6MTER2doNpTu5pqiA==}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.2
-    dev: false
-
-  /better-sqlite3@9.6.0:
-    resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
+  /better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -10186,7 +10219,7 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -10207,7 +10240,7 @@ packages:
   /chromium-edge-launcher@0.2.0:
     resolution: {integrity: sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -10227,6 +10260,10 @@ packages:
 
   /cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
+  /cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+    dev: false
 
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -13122,6 +13159,15 @@ packages:
       module-details-from-path: 1.0.3
     dev: false
 
+  /import-in-the-middle@2.0.6:
+    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
+    dependencies:
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+    dev: false
+
   /import-local@3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
     engines: {node: '>=8'}
@@ -13651,7 +13697,7 @@ packages:
       '@jest/expect': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -13670,7 +13716,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@28.1.3(@types/node@18.19.67)(ts-node@10.8.2):
+  /jest-cli@28.1.3(@types/node@22.19.17)(ts-node@10.8.2):
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -13687,7 +13733,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 28.1.3(@types/node@18.19.67)(ts-node@10.8.2)
+      jest-config: 28.1.3(@types/node@22.19.17)(ts-node@10.8.2)
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -13698,7 +13744,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@28.1.3(@types/node@18.19.67)(ts-node@10.8.2):
+  /jest-config@28.1.3(@types/node@22.19.17)(ts-node@10.8.2):
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -13713,7 +13759,7 @@ packages:
       '@babel/core': 7.18.6
       '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       babel-jest: 28.1.3(@babel/core@7.18.6)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -13733,7 +13779,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2)
+      ts-node: 10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13780,7 +13826,7 @@ packages:
       '@jest/environment': 28.1.3
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-mock: 28.1.3
       jest-util: 28.1.3
     dev: true
@@ -13792,7 +13838,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: false
@@ -13812,7 +13858,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13831,7 +13877,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13897,7 +13943,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
     dev: true
 
   /jest-mock@29.7.0:
@@ -13905,7 +13951,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-util: 29.7.0
     dev: false
 
@@ -13965,7 +14011,7 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.11
@@ -14051,7 +14097,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -14063,7 +14109,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -14099,7 +14145,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -14111,7 +14157,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -14120,13 +14166,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
 
-  /jest@28.1.2(@types/node@18.19.67)(ts-node@10.8.2):
+  /jest@28.1.2(@types/node@22.19.17)(ts-node@10.8.2):
     resolution: {integrity: sha512-Tuf05DwLeCh2cfWCQbcz9UxldoDyiR1E9Igaei5khjonKncYdc6LDfynKCEWozK0oLE3GD+xKAo2u8x/0s6GOg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -14139,7 +14185,7 @@ packages:
       '@jest/core': 28.1.3(ts-node@10.8.2)
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3(@types/node@18.19.67)(ts-node@10.8.2)
+      jest-cli: 28.1.3(@types/node@22.19.17)(ts-node@10.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -15391,6 +15437,10 @@ packages:
     resolution: {integrity: sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==}
     dev: false
 
+  /module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+    dev: false
+
   /moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
     dev: true
@@ -15478,7 +15528,7 @@ packages:
     resolution: {integrity: sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.4
     dev: false
 
   /node-abort-controller@3.1.1:
@@ -15742,16 +15792,16 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /opentelemetry-plugin-better-sqlite3@1.1.0(better-sqlite3@9.6.0):
-    resolution: {integrity: sha512-yd+mgaB5W5JxzcQt9TvX1VIrusqtbbeuxSoZ6KQe4Ra0J/Kqkp6kz7dg0VQUU5+cenOWkza6xtvsT0KGXI03HA==}
+  /opentelemetry-plugin-better-sqlite3@1.13.0(better-sqlite3@12.9.0):
+    resolution: {integrity: sha512-JHRGpq1KyTdlt50XmWCZ6P7nxEMGmn/EvdJKFPkZAnVtk9pQDnDwYobX/L/xeRkriihRKwHQ3UWoeIGUeolNtQ==}
     peerDependencies:
-      better-sqlite3: ^7.1.1 || ^8.0.0 || ^9.0.0
+      better-sqlite3: ^7.1.1 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
     dependencies:
-      '@opentelemetry/api': 1.7.0
-      '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
-      '@opentelemetry/instrumentation': 0.44.0(@opentelemetry/api@1.7.0)
-      '@opentelemetry/semantic-conventions': 1.18.1
-      better-sqlite3: 9.6.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      better-sqlite3: 12.9.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -16267,6 +16317,7 @@ packages:
   /prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
     dependencies:
       detect-libc: 2.0.3
@@ -16468,7 +16519,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       long: 5.2.3
     dev: false
 
@@ -16985,6 +17036,16 @@ packages:
       - supports-color
     dev: false
 
+  /require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /requireg@0.2.2:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
@@ -17278,7 +17339,6 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -18181,7 +18241,7 @@ packages:
       code-block-writer: 13.0.3
     dev: false
 
-  /ts-node@10.8.2(@swc/core@1.11.18)(@types/node@18.19.67)(typescript@5.8.2):
+  /ts-node@10.8.2(@swc/core@1.11.18)(@types/node@22.19.17)(typescript@5.8.2):
     resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
     hasBin: true
     peerDependencies:
@@ -18201,7 +18261,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -18435,6 +18495,9 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   /undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
@@ -18660,7 +18723,7 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite@6.2.0(@types/node@18.19.67):
+  /vite@6.2.0(@types/node@22.19.17):
     resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -18700,7 +18763,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       esbuild: 0.25.0
       postcss: 8.5.3
       rollup: 4.34.9
@@ -18708,7 +18771,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@4.0.16(@types/node@18.19.67):
+  /vitest@4.0.16(@types/node@22.19.17):
     resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -18742,7 +18805,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 22.19.17
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(vite@6.2.0)
       '@vitest/pretty-format': 4.0.16
@@ -18761,7 +18824,7 @@ packages:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.2.0(@types/node@18.19.67)
+      vite: 6.2.0(@types/node@22.19.17)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY ./package.json ./
-RUN corepack prepare --activate
+RUN corepack install
 
 # Move files into the image and install
 COPY ./*.* ./

--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.20-alpine AS build
+FROM node:22-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/bsky
 
 # Uses assets from build stage to reduce build size
-FROM node:20.20-alpine
+FROM node:22-alpine3.23
 
 # dumb-init is used to handle signals properly.
 # runit is installed so it can be (optionally) used for logging via svlogd.

--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.23 AS build
+FROM node:24.15-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/bsky
 
 # Uses assets from build stage to reduce build size
-FROM node:22-alpine3.23
+FROM node:24.15-alpine3.23
 
 # dumb-init is used to handle signals properly.
 # runit is installed so it can be (optionally) used for logging via svlogd.

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY ./package.json ./
-RUN corepack prepare --activate
+RUN corepack install
 
 # Move files into the image and install
 COPY ./*.* ./

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.23 AS build
+FROM node:24.15-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -33,7 +33,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/bsync
 
 # Uses assets from build stage to reduce build size
-FROM node:22-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:22-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -33,7 +33,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/bsync
 
 # Uses assets from build stage to reduce build size
-FROM node:18-alpine
+FROM node:22-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY ./package.json ./
-RUN corepack prepare --activate
+RUN corepack install
 
 # Move files into the image and install
 COPY ./*.* ./

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:22-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/ozone
 
 # Uses assets from build stage to reduce build size
-FROM node:18-alpine
+FROM node:22-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.23 AS build
+FROM node:24.15-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/ozone
 
 # Uses assets from build stage to reduce build size
-FROM node:22-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE there is an additional build stage below that should match
-FROM node:20.20-alpine3.23 AS build
+FROM node:22-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/pds
 
 # Uses assets from build stage to reduce build size
-FROM node:20.20-alpine3.23
+FROM node:22-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY ./package.json ./
-RUN corepack prepare --activate
+RUN corepack install
 
 # Move files into the image and install
 COPY ./*.* ./

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE there is an additional build stage below that should match
-FROM node:22-alpine3.23 AS build
+FROM node:24.15-alpine3.23 AS build
 
 RUN corepack enable
 
@@ -58,7 +58,7 @@ RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --
 WORKDIR services/pds
 
 # Uses assets from build stage to reduce build size
-FROM node:22-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/pds/package.json
+++ b/services/pds/package.json
@@ -6,6 +6,6 @@
     "@atproto/pds": "workspace:^",
     "@opentelemetry/instrumentation": "^0.45.0",
     "dd-trace": "^4.18.0",
-    "opentelemetry-plugin-better-sqlite3": "^1.1.0"
+    "opentelemetry-plugin-better-sqlite3": "^1.13.0"
   }
 }


### PR DESCRIPTION
This is the first in a suite of PRs to get us on node v22+, TypeScript 6, and with ESM-only packages.  Here's an overview of this PR:

  - Drop support for Node.js 18 and 20 across all packages. Node.js 22 is now the minimum supported version.
  - Docker images bumped to `node:24.15-alpine3.23`.
  - Upgrade `@types/node` from `^18` to `^22`.
  - Upgrade `better-sqlite3` from `^10` to `^12` (ships prebuilt binaries for Node 22/24, eliminates native compile dependency).
  - Upgrade `opentelemetry-plugin-better-sqlite3` to `^1.13` (widens peer range for better-sqlite3@12).
  - Simplify `@atproto-labs/fetch-node`: remove the `dangerouslyForceKeepAliveAgent` option and the Node <20 compatibility branch from `unicastFetchWrap` — on Node 22+ the dispatcher init is always supported. A runtime guard remains as a safety net.
  - Replace deprecated `corepack prepare --activate` with `corepack install` in Dockerfiles.
  - Add `"engines": { "node": ">=22" }` to every published package so consumers see warnings on unsupported versions.
  - Fix `WithImplicitCoercion` type in `@atproto/lex-data` — `@types/node@22` scoped this type inside `declare module "buffer"` rather than leaking it globally.

  ### Breaking changes

  - All packages now declare `engines.node >= 22`. Consumers on Node 18/20 will see npm/pnpm engine
  warnings.
  - `@atproto-labs/fetch-node`: `unicastFetchWrap` and `safeFetchWrap` no longer accept `dangerouslyForceKeepAliveAgent`.