### PR TITLE
trigger actions

### DIFF
--- a/.changeset/happy-taxis-smoke.md
+++ b/.changeset/happy-taxis-smoke.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+trigger build after github actions previously disabled


### PR DESCRIPTION
We disabled GH actions a few hours ago. As a result, https://github.com/bluesky-social/atproto/pull/4932 didn't trigger the "version packages" PR.

Trying to make it trigger with this change.