### PR TITLE
Downgrade devEngines onFail to warn until we can upgrade pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "onFail": "error"
+      "onFail": "warn"
     }
   },
   "pnpm": {


### PR DESCRIPTION
It seems pnpm prior to v11 calls `npm` under the hood for some operations, so we need to downgrade from `"onFail": "error"` to `"onFail": "warn"` until we can upgrade pnpm.

Confirmed by running `pnpm info @atproto/aws` locally:

* Fails with v8.15.9
* Succeeds with v11.1.1

Related GitHub issue: https://github.com/pnpm/pnpm/issues/9924#issuecomment-4297229243