### PR TITLE
Fix CI publish devEngines conflict with changeset publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: changesets/action@v1
         id: changesets
         with:
-          publish: pnpm release
+          publish: pnpm run publish:ci
           version: pnpm run version-packages
           commit: 'Version packages'
           title: 'Version packages'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,11 @@ jobs:
           cache: pnpm
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+      # Temporary workaround for an issue with Node.js v22
+      # https://github.com/npm/cli/issues/9151
+      # https://github.com/npm/cli/pull/9152
+      - run: npm install --global npm@11.11.1
+      - run: npm install --global npm@latest
       - run: pnpm install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
@@ -33,7 +38,7 @@ jobs:
         uses: changesets/action@v1
         id: changesets
         with:
-          publish: pnpm run publish:ci
+          publish: pnpm release
           version: pnpm run version-packages
           commit: 'Version packages'
           title: 'Version packages'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:withFlags": "pnpm run test --",
     "bench": "vitest bench --run",
     "changeset": "changeset",
-    "release": "pnpm build && changeset publish",
+    "publish:ci": "pnpm build && jq '.devEngines.packageManager.onFail = \"warn\"' package.json > package.json.tmp && mv package.json.tmp package.json && changeset publish",
     "version-packages": "changeset version && git add ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:withFlags": "pnpm run test --",
     "bench": "vitest bench --run",
     "changeset": "changeset",
-    "publish:ci": "pnpm run build && changeset tag && pnpm publish -r --no-git-checks --access public",
+    "release": "pnpm build && changeset publish",
     "version-packages": "changeset version && git add ."
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts #4928 which switched to `pnpm publish -r` (that broke due to missing OIDC auth).

Instead, relaxes `devEngines.packageManager.onFail` to `"warn"` via jq right before `changeset publish` runs. This allows npm (called internally by changeset) to proceed without erroring on the pnpm requirement, while keeping strict enforcement for local dev.

`changeset publish` uses npm internally. Since #4905 added `devEngines.packageManager` with `onFail: "error"`, npm refuses to run because it's not pnpm. The fix in #4928 tried switching to `pnpm publish -r` directly, but that broke because pnpm 8.x doesn't support npm's OIDC-based registry auth.