### PR TITLE
Make `options` required for `Client.get`

### DIFF
--- a/.changeset/grumpy-memes-nail.md
+++ b/.changeset/grumpy-memes-nail.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-client': patch
+---
+
+Make `options` required for `Client.get` when the schema expects a `rkey` to fetch a record

--- a/packages/lex/lex-client/src/client.ts
+++ b/packages/lex/lex-client/src/client.ts
@@ -919,7 +919,7 @@ export class Client implements Agent {
   ): Promise<GetOutput<T>>
   public async get<const T extends RecordSchema>(
     ns: Main<T>,
-    options?: GetOptions<T>,
+    options: GetOptions<T>,
   ): Promise<GetOutput<T>>
   public async get<const T extends RecordSchema>(
     ns: Main<T>,


### PR DESCRIPTION
current implementation allows the following which is not correct (an `rkey` is needed so the TypeScript should reject this):

```ts
const response = await client.get(app.bsky.feed.post) // should error
const response = await client.get(app.bsky.feed.post, { rkey: '123' }) // ok
```
