### PR TITLE
Improve support for `ArrayBufferLike`-backed `Uint8Array` data

### DIFF
--- a/.changeset/eighty-bars-cough.md
+++ b/.changeset/eighty-bars-cough.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-client': patch
+---
+
+Allow `SharedArrayBuffer`-backed `Uint8Array` to be used as `BinaryBodyInit` (used for binary request bodies and unknown response payloads)

--- a/.changeset/fresh-eggs-march.md
+++ b/.changeset/fresh-eggs-march.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-data': patch
+---
+
+Fix typing of internal NodeJS buffer

--- a/.changeset/neat-areas-rule.md
+++ b/.changeset/neat-areas-rule.md
@@ -1,0 +1,5 @@
+---
+'@atproto/common': patch
+---
+
+Add back support for any `Uint8Array` as input to the `ui8ToArrayBuffer` helper

--- a/.changeset/rare-beds-argue.md
+++ b/.changeset/rare-beds-argue.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Remove un-necessary type casting

--- a/.changeset/small-socks-raise.md
+++ b/.changeset/small-socks-raise.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-client': patch
+---
+
+Allow custom `RuntimeImplementation` to return a `SharedArrayBuffer`-backed `Uint8Array` from the `digest()` method. Input to this function will always be `Uint8Array<ArrayBuffer>`.

--- a/packages/common/src/buffers.ts
+++ b/packages/common/src/buffers.ts
@@ -2,9 +2,13 @@ export function ui8ToBuffer(bytes: Uint8Array): Buffer {
   return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
 }
 
-export function ui8ToArrayBuffer(bytes: Uint8Array<ArrayBuffer>): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteLength + bytes.byteOffset,
-  )
+export function ui8ToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  if (bytes.buffer instanceof ArrayBuffer) {
+    return bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteLength + bytes.byteOffset,
+    )
+  }
+
+  return new Uint8Array(bytes).buffer
 }

--- a/packages/lex/lex-client/src/types.ts
+++ b/packages/lex/lex-client/src/types.ts
@@ -46,18 +46,14 @@ export type Service = `${DidString}#${DidServiceIdentifier}`
  * const file: BinaryBodyInit = fileInput.files[0]
  * await client.xrpc(uploadMethod, { body: file })
  * ```
- *
- * @note Uint8Array is parameterized with ArrayBuffer (not ArrayBufferLike)
- * because fetch's BodyInit requires ArrayBuffer-backed views —
- * SharedArrayBuffer is not supported for network I/O.
  */
 export type BinaryBodyInit =
-  | Uint8Array<ArrayBuffer>
-  | ArrayBuffer
-  | Blob
-  | ReadableStream<Uint8Array<ArrayBuffer>>
-  | AsyncIterable<Uint8Array<ArrayBuffer>>
   | string
+  | Blob
+  | Uint8Array
+  | ArrayBuffer
+  | ReadableStream<Uint8Array>
+  | AsyncIterable<Uint8Array>
 
 export type EncodingString = `${string}/${string}`
 
@@ -68,7 +64,7 @@ export function isEncodingString(
 }
 
 export type XrpcUnknownResponsePayload<
-  TBinary extends BinaryBodyInit = Uint8Array<ArrayBuffer>,
+  TBinary extends BinaryBodyInit = Uint8Array,
 > = {
   encoding: EncodingString
   body: LexValue | TBinary

--- a/packages/lex/lex-client/src/util.ts
+++ b/packages/lex/lex-client/src/util.ts
@@ -55,6 +55,19 @@ export function isAsyncIterable<T>(
   )
 }
 
+export function asUint8ArrayArrayBuffer(
+  bytes: Uint8Array,
+): Uint8Array<ArrayBuffer> {
+  // If the Uint8Array is already backed by a non-shared ArrayBuffer, we can use
+  // it directly.
+  if (bytes.buffer instanceof ArrayBuffer) {
+    return bytes as Uint8Array<ArrayBuffer>
+  }
+
+  // Otherwise, we need to create a new ArrayBuffer and copy the data.
+  return new Uint8Array(bytes)
+}
+
 export type XrpcRequestHeadersOptions = {
   /** Additional HTTP headers to include in the request. */
   headers?: HeadersInit
@@ -115,7 +128,7 @@ export function toReadableStreamPonyfill(
   data: AsyncIterable<Uint8Array>,
 ): ReadableStream<Uint8Array> {
   let iterator: AsyncIterator<Uint8Array> | undefined
-  return new ReadableStream({
+  return new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         iterator ??= data[Symbol.asyncIterator]()

--- a/packages/lex/lex-client/src/xrpc.ts
+++ b/packages/lex/lex-client/src/xrpc.ts
@@ -19,6 +19,7 @@ import { XrpcResponse, XrpcResponseOptions } from './response.js'
 import { BinaryBodyInit } from './types.js'
 import {
   XrpcRequestHeadersOptions,
+  asUint8ArrayArrayBuffer,
   buildXrpcRequestHeaders,
   isAsyncIterable,
   isBlobLike,
@@ -336,17 +337,16 @@ function xrpcProcedureInput(
     case 'object': {
       if (body === null) break
       if (ArrayBuffer.isView(body)) {
-        return buildPayload(
-          input,
-          body as Uint8Array<ArrayBuffer>,
-          encodingHint,
-        )
+        return buildPayload(input, asUint8ArrayArrayBuffer(body), encodingHint)
       } else if (
         body instanceof ArrayBuffer ||
         body instanceof ReadableStream
       ) {
         return buildPayload(input, body, encodingHint)
       } else if (isAsyncIterable(body)) {
+        // @NOTE While fetch() does not allow SharedArrayBuffer-backed
+        // Uint8Arrays as "body", it **does** allow using ReadableStreams made
+        // of Uint8Arrays<SharedArrayBuffer> (tested on NodeJS 22) as "body".
         return buildPayload(input, toReadableStream(body), encodingHint)
       } else if (isBlobLike(body)) {
         return buildPayload(input, body, encodingHint || body.type)

--- a/packages/lex/lex-data/src/lib/nodejs-buffer.ts
+++ b/packages/lex/lex-data/src/lib/nodejs-buffer.ts
@@ -9,20 +9,28 @@ interface NodeJSBuffer<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
   extends Uint8Array<TArrayBuffer> {
   byteLength: number
   toString(encoding?: Encoding): string
+  slice(start?: number, end?: number): NodeJSBuffer<ArrayBuffer>
+  subarray(start?: number, end?: number): NodeJSBuffer<TArrayBuffer>
 }
 
 interface NodeJSBufferConstructor {
   new (input: string, encoding?: Encoding): NodeJSBuffer
   from(
-    input: Uint8Array | ArrayBuffer | ArrayBufferView,
+    string: WithImplicitCoercion<string>,
+    encoding?: BufferEncoding,
   ): NodeJSBuffer<ArrayBuffer>
-  from(input: string, encoding?: Encoding): NodeJSBuffer<ArrayBuffer>
+  from(
+    arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
+  ): NodeJSBuffer<ArrayBuffer>
   from<TArrayBuffer extends ArrayBufferLike>(
     arrayBuffer: WithImplicitCoercion<TArrayBuffer>,
     byteOffset?: number,
     length?: number,
-  ): Buffer<TArrayBuffer>
-  concat(list: readonly Uint8Array[], totalLength?: number): NodeJSBuffer
+  ): NodeJSBuffer<TArrayBuffer>
+  concat(
+    list: readonly Uint8Array[],
+    totalLength?: number,
+  ): NodeJSBuffer<ArrayBuffer>
   byteLength(input: string, encoding?: Encoding): number
   prototype: NodeJSBuffer
 }

--- a/packages/lex/lex-data/src/uint8array-concat.ts
+++ b/packages/lex/lex-data/src/uint8array-concat.ts
@@ -6,7 +6,7 @@ export const ui8ConcatNode = Buffer
   ? function ui8ConcatNode(
       array: readonly Uint8Array[],
     ): Uint8Array<ArrayBuffer> {
-      return Buffer.concat(array) as Uint8Array<ArrayBuffer>
+      return Buffer.concat(array)
     }
   : /* v8 ignore next -- @preserve */ null
 

--- a/packages/oauth/oauth-client-browser/src/browser-runtime-implementation.ts
+++ b/packages/oauth/oauth-client-browser/src/browser-runtime-implementation.ts
@@ -46,7 +46,7 @@ export class BrowserRuntimeImplementation implements RuntimeImplementation {
   async digest(
     data: Uint8Array<ArrayBuffer>,
     { name }: DigestAlgorithm,
-  ): Promise<Uint8Array<ArrayBuffer>> {
+  ): Promise<Uint8Array> {
     switch (name) {
       case 'sha256':
       case 'sha384':

--- a/packages/oauth/oauth-client/src/runtime-implementation.ts
+++ b/packages/oauth/oauth-client/src/runtime-implementation.ts
@@ -10,7 +10,7 @@ export type DigestAlgorithm = { name: 'sha256' | 'sha384' | 'sha512' }
 export type RuntimeDigest = (
   data: Uint8Array<ArrayBuffer>,
   alg: DigestAlgorithm,
-) => Awaitable<Uint8Array<ArrayBuffer>>
+) => Awaitable<Uint8Array>
 
 export type RuntimeLock = <T>(
   name: string,

--- a/packages/pds/tests/sync/invertible-ops.test.ts
+++ b/packages/pds/tests/sync/invertible-ops.test.ts
@@ -65,9 +65,7 @@ describe('invertible ops', () => {
       const { prevData } = evt
       if (!prevData) continue
 
-      const { blocks, root } = await repo.readCarWithRoot(
-        evt.blocks as Uint8Array,
-      )
+      const { blocks, root } = await repo.readCarWithRoot(evt.blocks)
       const storage = new repo.MemoryBlockstore(blocks)
       const slice = await repo.Repo.load(storage, root)
 


### PR DESCRIPTION
This relaxes some of the constraints introduced by the recent TypeScript 6 migration (and release through #4952)