### PR TITLE
Fix imports from `iso-datestring-validator`

### DIFF
--- a/.changeset/afraid-islands-swim.md
+++ b/.changeset/afraid-islands-swim.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Fixes a bug that would reject valid `datetime` atproto strings in non-strict validation

--- a/.changeset/goofy-pans-hang.md
+++ b/.changeset/goofy-pans-hang.md
@@ -1,0 +1,6 @@
+---
+'@atproto/lex-schema': patch
+'@atproto/lexicon': patch
+---
+
+Use datetime validation utility from `@atproto/syntax`

--- a/.changeset/khaki-socks-worry.md
+++ b/.changeset/khaki-socks-worry.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lexicon': patch
+---
+
+Fix datetime validation that would reject valid atproto datetime strings (e.g. `1985-04-12T23:20:50.1234567890Z` & `1985-04-12T23:20:50.123+01:45`)

--- a/.changeset/salty-flies-sleep.md
+++ b/.changeset/salty-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lexicon': patch
+---
+
+Improve performances of string validation utilities (and drop use of deprecated functions)

--- a/.changeset/true-carpets-grab.md
+++ b/.changeset/true-carpets-grab.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Add `isDatetimeStringLenient` datetime validation utility

--- a/packages/lex/lex-schema/package.json
+++ b/packages/lex/lex-schema/package.json
@@ -37,7 +37,6 @@
     "@atproto/syntax": "workspace:^",
     "@atproto/lex-data": "workspace:^",
     "@standard-schema/spec": "^1.1.0",
-    "iso-datestring-validator": "^2.2.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/lex/lex-schema/src/core/string-format.ts
+++ b/packages/lex/lex-schema/src/core/string-format.ts
@@ -1,5 +1,3 @@
-import isoDatestringValidator from 'iso-datestring-validator'
-const { isValidISODateString } = isoDatestringValidator
 import { validateCidString } from '@atproto/lex-data'
 import {
   AtIdentifierString,
@@ -14,6 +12,7 @@ import {
   isAtIdentifierString,
   isAtUriString,
   isDatetimeString,
+  isDatetimeStringLenient,
   isValidDid,
   isValidHandle,
   isValidLanguage,
@@ -50,27 +49,8 @@ export {
   assertDatetimeString,
   ifDatetimeString,
   isDatetimeString,
+  isDatetimeStringLenient,
 } from '@atproto/syntax'
-
-/**
- * Matches any ISO-ish datetime string. This is a more lenient check than
- * the strict {@link isDatetimeString} guard, which only allows datetimes that
- * fully conform to the AT Protocol specification (e.g. must include timezone).
- */
-export function isDatetimeStringLenient<I>(
-  input: I,
-): input is I & DatetimeString {
-  // @NOTE the returned type assertion is inaccurate wrt. the DatetimeString
-  // type definition. A more accurate solution would be to use a branded type
-  // instead of a template literal for the "datetime" format
-  if (typeof input !== 'string') return false
-  try {
-    return isValidISODateString(input)
-  } catch {
-    // @NOTE isValidISODateString throws on some inputs
-    return false
-  }
-}
 
 // DatetimeString utilities
 export { currentDatetimeString, toDatetimeString } from '@atproto/syntax'

--- a/packages/lexicon/package.json
+++ b/packages/lexicon/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@atproto/common-web": "workspace:^",
     "@atproto/syntax": "workspace:^",
-    "iso-datestring-validator": "^2.2.2",
     "multiformats": "^13.0.0",
     "zod": "^3.23.8"
   },

--- a/packages/lexicon/src/validators/formats.ts
+++ b/packages/lexicon/src/validators/formats.ts
@@ -1,157 +1,72 @@
-import isoDatestringValidator from 'iso-datestring-validator'
-const { isValidISODateString } = isoDatestringValidator
 import { CID } from 'multiformats/cid'
-import { validateLanguage } from '@atproto/common-web'
 import {
-  ensureValidAtUri,
-  ensureValidDid,
-  ensureValidHandle,
-  ensureValidRecordKey,
+  isAtIdentifierString,
+  isAtUriString,
+  isDatetimeStringLenient,
+  isValidDid,
+  isValidHandle,
+  isValidLanguage,
   isValidNsid,
+  isValidRecordKey,
   isValidTid,
   isValidUri,
 } from '@atproto/syntax'
 import { ValidationError, ValidationResult } from '../types.js'
 
-export function datetime(path: string, value: string): ValidationResult {
+export const datetime = createValidator(
+  isDatetimeStringLenient,
+  'must be an valid atproto datetime (both RFC-3339 and ISO-8601)',
+)
+export const uri = createValidator(isValidUri, 'must be a uri')
+export const atUri = createValidator(isAtUriString, 'must be a valid at-uri')
+export const did = createValidator(isValidDid, 'must be a valid did')
+export const handle = createValidator(isValidHandle, 'must be a valid handle')
+export const atIdentifier = createValidator(
+  isAtIdentifierString,
+  'must be a valid did or a handle',
+)
+export const nsid = createValidator(isValidNsid, 'must be a valid nsid')
+export const cid = createValidator(isCidString, 'must be a cid string')
+export const language = createValidator(
+  isValidLanguage,
+  'must be a well-formed BCP 47 language tag',
+)
+export const tid = createValidator(isValidTid, 'must be a valid TID')
+export const recordKey = createValidator(
+  isValidRecordKey,
+  'must be a valid Record Key',
+)
+
+// Internal helpers
+
+function createValidator<T extends string>(
+  assertionFn: (value: string) => value is T,
+  errorMessage: string,
+): <V extends string>(path: string, value: V) => ValidationResult<V & T>
+function createValidator(
+  assertionFn: (value: string) => boolean,
+  errorMessage: string,
+): (path: string, value: string) => ValidationResult<string>
+function createValidator(
+  assertionFn: (value: string) => boolean,
+  errorMessage: string,
+) {
+  return (path: string, value: string): ValidationResult => {
+    if (assertionFn(value)) {
+      return { success: true, value }
+    }
+    return {
+      success: false,
+      error: new ValidationError(`${path} ${errorMessage}`),
+    }
+  }
+}
+
+function isCidString(v: string): v is string {
   try {
-    if (!isValidISODateString(value)) {
-      throw new Error()
-    }
+    CID.parse(v)
+    return true
   } catch {
-    return {
-      success: false,
-      error: new ValidationError(
-        `${path} must be an valid atproto datetime (both RFC-3339 and ISO-8601)`,
-      ),
-    }
+    return false
   }
-  return { success: true, value }
-}
-
-export function uri(path: string, value: string): ValidationResult {
-  if (!isValidUri(value)) {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a uri`),
-    }
-  }
-  return { success: true, value }
-}
-
-export function atUri(path: string, value: string): ValidationResult {
-  try {
-    ensureValidAtUri(value)
-  } catch {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a valid at-uri`),
-    }
-  }
-
-  return { success: true, value }
-}
-
-export function did(path: string, value: string): ValidationResult {
-  try {
-    ensureValidDid(value)
-  } catch {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a valid did`),
-    }
-  }
-
-  return { success: true, value }
-}
-
-export function handle(path: string, value: string): ValidationResult {
-  try {
-    ensureValidHandle(value)
-  } catch {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a valid handle`),
-    }
-  }
-
-  return { success: true, value }
-}
-
-export function atIdentifier(path: string, value: string): ValidationResult {
-  // We can discriminate based on the "did:" prefix
-  if (value.startsWith('did:')) {
-    const didResult = did(path, value)
-    if (didResult.success) return didResult
-  } else {
-    const handleResult = handle(path, value)
-    if (handleResult.success) return handleResult
-  }
-
-  return {
-    success: false,
-    error: new ValidationError(`${path} must be a valid did or a handle`),
-  }
-}
-
-export function nsid(path: string, value: string): ValidationResult {
-  if (isValidNsid(value)) {
-    return {
-      success: true,
-      value,
-    }
-  } else {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a valid nsid`),
-    }
-  }
-}
-
-export function cid(path: string, value: string): ValidationResult {
-  try {
-    CID.parse(value)
-  } catch {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a cid string`),
-    }
-  }
-  return { success: true, value }
-}
-
-// The language format validates well-formed BCP 47 language tags: https://www.rfc-editor.org/info/bcp47
-export function language(path: string, value: string): ValidationResult {
-  if (validateLanguage(value)) {
-    return { success: true, value }
-  }
-  return {
-    success: false,
-    error: new ValidationError(
-      `${path} must be a well-formed BCP 47 language tag`,
-    ),
-  }
-}
-
-export function tid(path: string, value: string): ValidationResult {
-  if (isValidTid(value)) {
-    return { success: true, value }
-  }
-
-  return {
-    success: false,
-    error: new ValidationError(`${path} must be a valid TID`),
-  }
-}
-
-export function recordKey(path: string, value: string): ValidationResult {
-  try {
-    ensureValidRecordKey(value)
-  } catch {
-    return {
-      success: false,
-      error: new ValidationError(`${path} must be a valid Record Key`),
-    }
-  }
-  return { success: true, value }
 }

--- a/packages/lexicon/src/validators/primitives.ts
+++ b/packages/lexicon/src/validators/primitives.ts
@@ -156,7 +156,7 @@ function string(
   path: string,
   def: LexUserType,
   value: unknown,
-): ValidationResult {
+): ValidationResult<string> {
   def = def as LexString
 
   // type

--- a/packages/syntax/package.json
+++ b/packages/syntax/package.json
@@ -23,6 +23,7 @@
     "build": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
+    "iso-datestring-validator": "^2.2.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/syntax/src/datetime.ts
+++ b/packages/syntax/src/datetime.ts
@@ -136,13 +136,22 @@ export function isDatetimeStringLenient<I>(
   // @NOTE the returned type assertion is inaccurate wrt. the DatetimeString
   // type definition. A more accurate solution would be to use a branded type
   // instead of a template literal for the "datetime" format
+
   if (typeof input !== 'string') return false
+
   try {
-    return isValidISODateString(input)
+    if (isValidISODateString(input)) return true
   } catch {
-    // @NOTE isValidISODateString throws on some inputs
-    return false
+    // isValidISODateString can throw on some inputs.
   }
+
+  // @NOTE The "iso-datestring-validator" implementation is *not* compliant with
+  // the AT Protocol datetime specification. In particular, it rejects some
+  // valid AT Protocol datetimes (eg: "1985-04-12T23:20:50.1235678912345Z",
+  // "1985-04-12T23:20:50.123+01:45", "1985-04-12T23:20:50.1234567890Z"). For
+  // this reason, we run "isDatetimeString" validation if "isValidISODateString"
+  // does not return true.
+  return isDatetimeString(input)
 }
 
 /**

--- a/packages/syntax/src/datetime.ts
+++ b/packages/syntax/src/datetime.ts
@@ -1,3 +1,9 @@
+import * as isoDatestringValidator from 'iso-datestring-validator'
+
+// Node ESM interop wraps "iso-datestring-validator" as { default: { ... } }
+// @TODO Remove "iso-datestring-validator" dependency
+const { isValidISODateString } = ((m) => m.default ?? m)(isoDatestringValidator)
+
 /**
  * Indicates a date or string is not a valid representation of a datetime
  * according to the atproto
@@ -117,6 +123,26 @@ export function asDatetimeString<I>(input: I): I & DatetimeString {
  */
 export function isDatetimeString<I>(input: I): input is I & DatetimeString {
   return parseString(input).success
+}
+
+/**
+ * Matches any ISO-ish datetime string. This is a more lenient check than
+ * the strict {@link isDatetimeString} guard, which only allows datetimes that
+ * fully conform to the AT Protocol specification (e.g. must include timezone).
+ */
+export function isDatetimeStringLenient<I>(
+  input: I,
+): input is I & DatetimeString {
+  // @NOTE the returned type assertion is inaccurate wrt. the DatetimeString
+  // type definition. A more accurate solution would be to use a branded type
+  // instead of a template literal for the "datetime" format
+  if (typeof input !== 'string') return false
+  try {
+    return isValidISODateString(input)
+  } catch {
+    // @NOTE isValidISODateString throws on some inputs
+    return false
+  }
 }
 
 /**

--- a/packages/syntax/tests/datetime.test.ts
+++ b/packages/syntax/tests/datetime.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, test } from 'vitest'
 import {
   InvalidDatetimeError,
   ensureValidDatetime,
-  isValidDatetime,
+  isDatetimeString,
+  isDatetimeStringLenient,
   normalizeDatetime,
   normalizeDatetimeAlways,
 } from '../src/index.js'
@@ -18,29 +19,38 @@ const interopInvalidParse = readLines(
   `${__dirname}/interop-files/datetime_parse_invalid.txt`,
 )
 
+// These strings come from the test suite in "@atproto/lexicon", kept around
+// to ensure compatibility with legacy implementation.
+const legacyValid = [
+  '2022-12-12T00:50:36.809Z',
+  '2022-12-12T00:50:36Z',
+  '2022-12-12T00:50:36.8Z',
+  '2022-12-12T00:50:36.80Z',
+  '2022-12-12T00:50:36+00:00',
+  '2022-12-12T00:50:36.8+00:00',
+  '2022-12-11T19:50:36-05:00',
+  '2022-12-11T19:50:36.8-05:00',
+  '2022-12-11T19:50:36.80-05:00',
+  '2022-12-11T19:50:36.809-05:00',
+]
+
 describe(ensureValidDatetime, () => {
-  describe('valid interop', () => {
-    for (const dt of interopValid) {
-      test(dt, () => {
-        expect(() => ensureValidDatetime(dt)).not.toThrow()
-      })
-    }
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (dt) => {
+      expect(() => ensureValidDatetime(dt)).not.toThrow()
+    })
   })
 
-  describe('fails on interop (invalid syntax)', () => {
-    for (const dt of interopInvalidSyntax) {
-      test(dt, () => {
-        expect(() => ensureValidDatetime(dt)).toThrow(InvalidDatetimeError)
-      })
-    }
+  describe('Interop invalid syntax', () => {
+    test.each(interopInvalidSyntax)('%s', (dt) => {
+      expect(() => ensureValidDatetime(dt)).toThrow(InvalidDatetimeError)
+    })
   })
 
-  describe('fails on interop (invalid parse)', () => {
-    for (const dt of interopInvalidParse) {
-      test(dt, () => {
-        expect(() => ensureValidDatetime(dt)).toThrow(InvalidDatetimeError)
-      })
-    }
+  describe('Interop invalid parse', () => {
+    test.each(interopInvalidParse)('%s', (dt) => {
+      expect(() => ensureValidDatetime(dt)).toThrow(InvalidDatetimeError)
+    })
   })
 
   it('rejects datetime that normalizes past year 9999 due to negative offset', () => {
@@ -52,64 +62,85 @@ describe(ensureValidDatetime, () => {
   })
 })
 
-describe(isValidDatetime, () => {
-  describe('valid interop', () => {
-    for (const dt of interopValid) {
-      test(dt, () => {
-        expect(isValidDatetime(dt)).toBe(true)
-      })
-    }
+describe(isDatetimeString, () => {
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (dt) => {
+      expect(isDatetimeString(dt)).toBe(true)
+    })
   })
 
-  describe('fails on interop (invalid syntax)', () => {
-    for (const dt of interopInvalidSyntax) {
-      test(dt, () => {
-        expect(isValidDatetime(dt)).toBe(false)
-      })
-    }
+  describe('Interop invalid syntax', () => {
+    test.each(interopInvalidSyntax)('%s', (dt) => {
+      expect(isDatetimeString(dt)).toBe(false)
+    })
   })
 
-  describe('fails on interop (invalid parse)', () => {
-    for (const dt of interopInvalidParse) {
-      test(dt, () => {
-        expect(isValidDatetime(dt)).toBe(false)
-      })
-    }
+  describe('Interop invalid parse', () => {
+    test.each(interopInvalidParse)('%s', (dt) => {
+      expect(isDatetimeString(dt)).toBe(false)
+    })
+  })
+
+  describe('succeeds on legacy valid', () => {
+    test.each(legacyValid)('%s', (dt) => {
+      expect(isDatetimeString(dt)).toBe(true)
+    })
   })
 
   it('rejects datetime that normalizes past year 9999 due to negative offset', () => {
     // 9999-12-31T23:59:00-00:01 is syntactically valid, but normalizing to
     // UTC advances it to 10000-01-01T00:00:00Z, which is out of range
-    expect(isValidDatetime('9999-12-31T23:59:00-00:01')).toBe(false)
+    expect(isDatetimeString('9999-12-31T23:59:00-00:01')).toBe(false)
+  })
+})
+
+describe(isDatetimeStringLenient, () => {
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (dt) => {
+      expect(isDatetimeStringLenient(dt)).toBe(true)
+    })
+  })
+
+  // Because of it leniency, the "isDatetimeStringLenient" implementation does
+  // not fail on some of the invalid syntax cases, so these tests are skipped.
+  describe.skip('Interop invalid syntax', () => {
+    test.each(interopInvalidSyntax)('%s', (dt) => {
+      expect(isDatetimeStringLenient(dt)).toBe(false)
+    })
+  })
+
+  describe('Interop invalid parse', () => {
+    test.each(interopInvalidParse)('%s', (dt) => {
+      expect(isDatetimeStringLenient(dt)).toBe(false)
+    })
+  })
+
+  describe('Legacy valid', () => {
+    test.each(legacyValid)('%s', (dt) => {
+      expect(isDatetimeStringLenient(dt)).toBe(true)
+    })
   })
 })
 
 describe(normalizeDatetime, () => {
-  describe('valid interop', () => {
-    for (const dt of interopValid) {
-      test(dt, () => {
-        expect(() => normalizeDatetime(dt)).not.toThrow()
-      })
-    }
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (dt) => {
+      expect(() => normalizeDatetime(dt)).not.toThrow()
+    })
   })
 
   // @NOTE Normalize will actually succeed on some of the invalid syntax cases,
   // because it is more lenient than the regex validation.
+  describe.skip('Interop invalid syntax', () => {
+    test.each(interopInvalidSyntax)('%s', (dt) => {
+      expect(() => normalizeDatetime(dt)).toThrow(InvalidDatetimeError)
+    })
+  })
 
-  // describe('fails on interop (invalid syntax)', () => {
-  //   for (const dt of interopInvalidSyntax) {
-  //     test(dt, () => {
-  //       expect(() => normalizeDatetime(dt)).toThrow(InvalidDatetimeError)
-  //     })
-  //   }
-  // })
-
-  describe('fails on interop (invalid parse)', () => {
-    for (const dt of interopInvalidParse) {
-      test(dt, () => {
-        expect(() => normalizeDatetime(dt)).toThrow(InvalidDatetimeError)
-      })
-    }
+  describe('Interop invalid parse', () => {
+    test.each(interopInvalidParse)('%s', (dt) => {
+      expect(() => normalizeDatetime(dt)).toThrow(InvalidDatetimeError)
+    })
   })
 
   it('normalizes valid input', () => {
@@ -220,30 +251,24 @@ describe(normalizeDatetimeAlways, () => {
     )
   })
 
-  describe('valid interop', () => {
-    for (const dt of interopValid) {
-      test(dt, () => {
-        // @NOTE we can't test the returned value as some will normalize while others won't.
-        expect(() => normalizeDatetimeAlways(dt)).not.toThrow()
-      })
-    }
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (dt) => {
+      // @NOTE we can't test the returned value as some will normalize while others won't.
+      expect(() => normalizeDatetimeAlways(dt)).not.toThrow()
+    })
   })
 
-  describe('succeeds on interop (invalid syntax)', () => {
-    for (const dt of interopInvalidSyntax) {
-      test(dt, () => {
-        // @NOTE we can't test the returned value as some will normalize while others won't.
-        expect(() => normalizeDatetimeAlways(dt)).not.toThrow()
-      })
-    }
+  describe('Interop invalid syntax', () => {
+    test.each(interopInvalidSyntax)('%s', (dt) => {
+      // @NOTE we can't test the returned value as some will normalize while others won't.
+      expect(() => normalizeDatetimeAlways(dt)).not.toThrow()
+    })
   })
 
-  describe('succeeds on interop invalid parse', () => {
-    for (const dt of interopInvalidParse) {
-      test(dt, () => {
-        expect(normalizeDatetimeAlways(dt)).toEqual('1970-01-01T00:00:00.000Z')
-      })
-    }
+  describe('Interop invalid parse', () => {
+    test.each(interopInvalidParse)('%s', (dt) => {
+      expect(normalizeDatetimeAlways(dt)).toEqual('1970-01-01T00:00:00.000Z')
+    })
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1062,9 +1062,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
-      iso-datestring-validator:
-        specifier: ^2.2.2
-        version: 2.2.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -1130,9 +1127,6 @@ importers:
       '@atproto/syntax':
         specifier: workspace:^
         version: link:../syntax
-      iso-datestring-validator:
-        specifier: ^2.2.2
-        version: 2.2.2
       multiformats:
         specifier: ^13.0.0
         version: 13.4.2
@@ -2032,6 +2026,9 @@ importers:
 
   packages/syntax:
     dependencies:
+      iso-datestring-validator:
+        specifier: ^2.2.2
+        version: 2.2.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1


### PR DESCRIPTION
This fixes import from `iso-datestring-validator` that are causing build failures in dependents packages (like the [Bluesky social app](https://github.com/bluesky-social/social-app/pull/10543/)).

The issue is that bundlers and Node's ESM/CJS compatibility layer have different behaviors.

Bundlers want:
```ts
import { isValidISODateString } from 'iso-datestring-validator';
```

While NodeJS wants:
```ts
import isoDatestringValidator from 'iso-datestring-validator'
const { isValidISODateString } = isoDatestringValidator
```

This change adopts an hybrid approach that works in both environments:
```ts
import * as isoDatestringValidator from 'iso-datestring-validator'
const { isValidISODateString } = ((m) => m.default ?? m)(isoDatestringValidator)
```

Since this package is used from both `lex-schema` and `lexicon` in order to validate the `datetime` atproto string format, this PR also moves the validation logic (and dependency) to `@atproto/syntax`.

In addition to this, this PR takes the opportunity to remove the use of some deprecated and un-necessary `try/catch` ways of validating string formats in `@atproto/lexicon`.