### PR TITLE
Add bsync protos to pds, bsky, ozone service dockerfiles to fix build

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -20,6 +20,7 @@ COPY ./packages/lex ./packages/lex
 COPY ./packages/api ./packages/api
 COPY ./packages/aws ./packages/aws
 COPY ./packages/bsky ./packages/bsky
+COPY ./packages/bsync ./packages/bsync
 COPY ./packages/common-web ./packages/common-web
 COPY ./packages/common ./packages/common
 COPY ./packages/crypto ./packages/crypto

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -20,6 +20,7 @@ COPY ./packages/lex ./packages/lex
 COPY ./packages/api ./packages/api
 COPY ./packages/aws ./packages/aws
 COPY ./packages/bsky ./packages/bsky
+COPY ./packages/bsync ./packages/bsync
 COPY ./packages/common ./packages/common
 COPY ./packages/common-web ./packages/common-web
 COPY ./packages/crypto ./packages/crypto

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -21,6 +21,7 @@ COPY ./packages/lex ./packages/lex
 COPY ./packages/api ./packages/api
 COPY ./packages/aws ./packages/aws
 COPY ./packages/bsky ./packages/bsky
+COPY ./packages/bsync ./packages/bsync
 COPY ./packages/common-web ./packages/common-web
 COPY ./packages/common ./packages/common
 COPY ./packages/crypto ./packages/crypto


### PR DESCRIPTION
Followup to #4960 to fix docker builds.  Bsync package is now needed for builds in order to grab its protos.