### PR TITLE
Sync: getCursor bugfix

### DIFF
--- a/.changeset/jolly-things-read.md
+++ b/.changeset/jolly-things-read.md
@@ -1,0 +1,5 @@
+---
+'@atproto/sync': patch
+---
+
+Fix getCursor invocation

--- a/packages/sync/src/firehose/index.ts
+++ b/packages/sync/src/firehose/index.ts
@@ -33,9 +33,9 @@ import { didAndSeqForEvt } from '../util.js'
 export type FirehoseOptions = ClientOptions & {
   idResolver: IdResolver
 
-  handleEvent: (evt: Event) => Awaited<void>
+  handleEvent: (evt: Event) => void | Promise<void>
   onError: (err: Error) => void
-  getCursor?: () => Awaited<number | undefined>
+  getCursor?: () => number | undefined | Promise<number | undefined>
 
   runner?: EventRunner // should only set getCursor *or* runner
 
@@ -89,13 +89,13 @@ export class Firehose {
       method: com.atproto.sync.subscribeRepos.$lxm,
       signal: this.abortController.signal,
       getParams: async () => {
-        const getCursorFn = () =>
-          this.opts.runner?.getCursor() ?? this.opts.getCursor
-        if (!getCursorFn) {
-          return undefined
+        let cursor: number | undefined
+        if (this.opts.runner) {
+          cursor = await this.opts.runner.getCursor()
+        } else if (this.opts.getCursor) {
+          cursor = await this.opts.getCursor()
         }
-        const cursor = await getCursorFn()
-        return { cursor }
+        return cursor === undefined ? undefined : { cursor }
       },
       validate: (value: unknown) => {
         const result = com.atproto.sync.subscribeRepos.$message.safeParse(value)

--- a/packages/sync/src/runner/types.ts
+++ b/packages/sync/src/runner/types.ts
@@ -1,5 +1,5 @@
 export interface EventRunner {
-  getCursor(): Awaited<number | undefined>
+  getCursor(): number | undefined | Promise<number | undefined>
   trackEvent(
     did: string,
     seq: number,


### PR DESCRIPTION
We weren't invoking firehose opts `getCursor` correctly.

Also fixed types to support sync & async getCursor functions.