### PR TITLE
Always add `#__PURE__` annotations to function calls

### DIFF
--- a/.changeset/polite-goats-brush.md
+++ b/.changeset/polite-goats-brush.md
@@ -1,0 +1,6 @@
+---
+'@atproto/lex-builder': patch
+'@atproto/lex': patch
+---
+
+Always add `#__PURE__` annotations to function calls

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -50,15 +50,6 @@ export type LexDefBuilderOptions = RefResolverOptions & {
    * @default '@atproto/lex-schema'
    */
   lib?: string
-  /**
-   * Whether to add `#__PURE__` annotations to function calls.
-   *
-   * These annotations help bundlers with tree-shaking by marking
-   * side-effect-free function calls.
-   *
-   * @default false
-   */
-  pureAnnotations?: boolean
 }
 
 /**
@@ -84,10 +75,6 @@ export class LexDefBuilder {
     indexer: LexiconIndexer,
   ) {
     this.refResolver = new RefResolver(doc, file, indexer, options)
-  }
-
-  private pure(code: string) {
-    return this.options.pureAnnotations ? markPure(code) : code
   }
 
   async build() {
@@ -160,7 +147,7 @@ export class LexDefBuilder {
   private async addPermissionSet(hash: string, def: LexiconPermissionSet) {
     const permission = def.permissions.map((def) => {
       const options = stringifyOptions(def, undefined, ['resource', 'type'])
-      return this.pure(
+      return markPure(
         `l.permission(${JSON.stringify(def.resource)}, ${options})`,
       )
     })
@@ -173,7 +160,7 @@ export class LexDefBuilder {
     ] satisfies (keyof l.PermissionSetOptions)[])
 
     await this.addSchema(hash, def, {
-      schema: this.pure(
+      schema: markPure(
         `l.permissionSet($nsid, [${permission.join(',')}], ${options})`,
       ),
     })
@@ -198,7 +185,7 @@ export class LexDefBuilder {
     })
 
     const ref = await this.addSchema(hash, def, {
-      schema: this.pure(
+      schema: markPure(
         `l.procedure($nsid, $params, $input, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
@@ -220,7 +207,7 @@ export class LexDefBuilder {
     })
 
     const ref = await this.addSchema(hash, def, {
-      schema: this.pure(
+      schema: markPure(
         `l.query($nsid, $params, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
@@ -242,7 +229,7 @@ export class LexDefBuilder {
     })
 
     const ref = await this.addSchema(hash, def, {
-      schema: this.pure(
+      schema: markPure(
         `l.subscription($nsid, $params, $message${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
@@ -317,7 +304,7 @@ export class LexDefBuilder {
     await this.addSchema(hash, def, {
       type: `{ ${properties.join(';')} }`,
       schema: (ref) =>
-        this.pure(
+        markPure(
           `l.record<${key}, ${ref.typeName}>(${key}, $nsid, ${objectSchema})`,
         ),
       objectUtils: true,
@@ -334,7 +321,7 @@ export class LexDefBuilder {
     await this.addSchema(hash, def, {
       type: `{ ${properties.join(';')} }`,
       schema: (ref) =>
-        this.pure(
+        markPure(
           `l.typedObject<${ref.typeName}>($nsid, ${JSON.stringify(hash)}, ${objectSchema})`,
         ),
       objectUtils: true,
@@ -344,7 +331,7 @@ export class LexDefBuilder {
 
   private async addToken(hash: string, def: LexiconToken) {
     await this.addSchema(hash, def, {
-      schema: this.pure(`l.token($nsid, ${JSON.stringify(hash)})`),
+      schema: markPure(`l.token($nsid, ${JSON.stringify(hash)})`),
       type: JSON.stringify(l.$type(this.doc.id, hash)),
       validationUtils: true,
     })
@@ -366,9 +353,7 @@ export class LexDefBuilder {
       // @NOTE Not using compileArraySchema to allow specifying the generic
       // parameter to l.array<>.
       schema: (ref) =>
-        this.pure(
-          `l.array<${ref.typeName}[number]>(${itemSchema}, ${options})`,
-        ),
+        markPure(`l.array<${ref.typeName}[number]>(${itemSchema}, ${options})`),
       validationUtils: true,
     })
   }
@@ -439,9 +424,9 @@ export class LexDefBuilder {
 
     if (hash === 'main' && objectUtils) {
       this.addUtils({
+        $type: `$nsid`,
         $isTypeOf: markPure(`${ref.varName}.isTypeOf.bind(${ref.varName})`),
         $build: markPure(`${ref.varName}.build.bind(${ref.varName})`),
-        $type: `${ref.varName}.$type`,
       })
     }
 
@@ -465,20 +450,20 @@ export class LexDefBuilder {
   }
 
   private async compilePayload(def: LexiconPayload | undefined) {
-    if (!def) return this.pure(`l.payload()`)
+    if (!def) return markPure(`l.payload()`)
 
     // Special case for JSON object payloads
     if (def.encoding === 'application/json' && def.schema?.type === 'object') {
       const properties = await this.compilePropertiesSchemas(def.schema)
-      return this.pure(`l.jsonPayload({${properties.join(',')}})`)
+      return markPure(`l.jsonPayload({${properties.join(',')}})`)
     }
 
     const encodedEncoding = JSON.stringify(def.encoding)
     if (def.schema) {
       const bodySchema = await this.compileBodySchema(def.schema)
-      return this.pure(`l.payload(${encodedEncoding}, ${bodySchema})`)
+      return markPure(`l.payload(${encodedEncoding}, ${bodySchema})`)
     } else {
-      return this.pure(`l.payload(${encodedEncoding})`)
+      return markPure(`l.payload(${encodedEncoding})`)
     }
   }
 
@@ -491,10 +476,10 @@ export class LexDefBuilder {
   }
 
   private async compileParamsSchema(def: undefined | LexiconParameters) {
-    if (!def) return this.pure(`l.params()`)
+    if (!def) return markPure(`l.params()`)
 
     const properties = await this.compilePropertiesSchemas(def)
-    return this.pure(
+    return markPure(
       properties.length === 0
         ? `l.params()`
         : `l.params({${properties.join(',')}})`,
@@ -508,7 +493,7 @@ export class LexDefBuilder {
 
   private async compileObjectSchema(def: LexiconObject): Promise<string> {
     const properties = await this.compilePropertiesSchemas(def)
-    return this.pure(`l.object({${properties.join(',')}})`)
+    return markPure(`l.object({${properties.join(',')}})`)
   }
 
   private async compilePropertiesSchemas(options: {
@@ -558,11 +543,11 @@ export class LexDefBuilder {
     let schema = await this.compileContainedSchema(def)
 
     if (isNullable) {
-      schema = this.pure(`l.nullable(${schema})`)
+      schema = markPure(`l.nullable(${schema})`)
     }
 
     if (!isRequired) {
-      schema = this.pure(`l.optional(${schema})`)
+      schema = markPure(`l.optional(${schema})`)
     }
 
     return `${JSON.stringify(key)}:${schema}`
@@ -654,7 +639,7 @@ export class LexDefBuilder {
       'minLength',
       'maxLength',
     ] satisfies (keyof l.ArraySchemaOptions)[])
-    return this.pure(`l.array(${itemSchema}, ${options})`)
+    return markPure(`l.array(${itemSchema}, ${options})`)
   }
 
   private async compileArrayType(def: LexiconArray): Promise<string> {
@@ -662,7 +647,7 @@ export class LexDefBuilder {
   }
 
   private async compileUnknownSchema(_def: LexiconUnknown): Promise<string> {
-    return this.pure(`l.lexMap()`)
+    return markPure(`l.lexMap()`)
   }
 
   private async compileUnknownType(_def: LexiconUnknown): Promise<string> {
@@ -672,9 +657,7 @@ export class LexDefBuilder {
   private withDefault(schema: string, defaultValue: unknown) {
     if (defaultValue === undefined) return schema
 
-    return this.pure(
-      `l.withDefault(${schema}, ${JSON.stringify(defaultValue)})`,
-    )
+    return markPure(`l.withDefault(${schema}, ${JSON.stringify(defaultValue)})`)
   }
 
   private async compileBooleanSchema(def: LexiconBoolean): Promise<string> {
@@ -686,7 +669,7 @@ export class LexDefBuilder {
 
     if (hasConst(def)) return this.compileConstSchema(def)
 
-    return this.withDefault(this.pure(`l.boolean()`), def.default)
+    return this.withDefault(markPure(`l.boolean()`), def.default)
   }
 
   private async compileBooleanType(def: LexiconBoolean): Promise<string> {
@@ -717,7 +700,7 @@ export class LexDefBuilder {
       'minimum',
     ] satisfies (keyof l.IntegerSchemaOptions)[])
 
-    return this.withDefault(this.pure(`l.integer(${options})`), def.default)
+    return this.withDefault(markPure(`l.integer(${options})`), def.default)
   }
 
   private async compileIntegerType(def: LexiconInteger): Promise<string> {
@@ -769,7 +752,7 @@ export class LexDefBuilder {
       : undefined
 
     return this.withDefault(
-      this.pure(`l.string${generic ? `<${generic}>` : ''}(${options})`),
+      markPure(`l.string${generic ? `<${generic}>` : ''}(${options})`),
       def.default,
     )
   }
@@ -822,7 +805,7 @@ export class LexDefBuilder {
       'minLength',
       'maxLength',
     ] satisfies (keyof l.BytesSchemaOptions)[])
-    return this.pure(`l.bytes(${options})`)
+    return markPure(`l.bytes(${options})`)
   }
 
   private async compileBytesType(_def: LexiconBytes): Promise<string> {
@@ -834,7 +817,7 @@ export class LexDefBuilder {
       'maxSize',
       'accept',
     ] satisfies (keyof l.BlobSchemaOptions)[])
-    return this.pure(`l.blob(${options})`)
+    return markPure(`l.blob(${options})`)
   }
 
   private async compileBlobType(_def: LexiconBlob): Promise<string> {
@@ -842,7 +825,7 @@ export class LexDefBuilder {
   }
 
   private async compileCidLinkSchema(_def: LexiconCid): Promise<string> {
-    return this.pure(`l.cid()`)
+    return markPure(`l.cid()`)
   }
 
   private async compileCidLinkType(_def: LexiconCid): Promise<string> {
@@ -853,7 +836,7 @@ export class LexDefBuilder {
     const { varName, typeName } = await this.refResolver.resolve(def.ref)
     // @NOTE "as any" is needed in schemas with circular refs as TypeScript
     // cannot infer the type of a value that depends on its initializer type
-    return this.pure(`l.ref<${typeName}>((() => ${varName}) as any)`)
+    return markPure(`l.ref<${typeName}>((() => ${varName}) as any)`)
   }
 
   private async compileRefType(def: LexiconRef): Promise<string> {
@@ -863,7 +846,7 @@ export class LexDefBuilder {
 
   private async compileRefUnionSchema(def: LexiconRefUnion): Promise<string> {
     if (def.refs.length === 0 && def.closed) {
-      return this.pure(`l.never()`)
+      return markPure(`l.never()`)
     }
 
     const refs = await Promise.all(
@@ -871,13 +854,11 @@ export class LexDefBuilder {
         const { varName, typeName } = await this.refResolver.resolve(ref)
         // @NOTE "as any" is needed in schemas with circular refs as TypeScript
         // cannot infer the type of a value that depends on its initializer type
-        return this.pure(`l.typedRef<${typeName}>((() => ${varName}) as any)`)
+        return markPure(`l.typedRef<${typeName}>((() => ${varName}) as any)`)
       }),
     )
 
-    return this.pure(
-      `l.typedUnion([${refs.join(',')}], ${def.closed ?? false})`,
-    )
+    return markPure(`l.typedUnion([${refs.join(',')}], ${def.closed ?? false})`)
   }
 
   private async compileRefUnionType(def: LexiconRefUnion): Promise<string> {
@@ -895,10 +876,10 @@ export class LexDefBuilder {
     T extends null | number | string | boolean,
   >(def: { const: T; enum?: readonly T[]; default?: T }): Promise<string> {
     if (hasEnum(def) && !def.enum.includes(def.const)) {
-      return this.pure(`l.never()`)
+      return markPure(`l.never()`)
     }
 
-    const result = this.pure(`l.literal(${JSON.stringify(def.const)})`)
+    const result = markPure(`l.literal(${JSON.stringify(def.const)})`)
 
     return this.withDefault(result, def.default)
   }
@@ -917,13 +898,13 @@ export class LexDefBuilder {
     default?: T
   }): Promise<string> {
     if (def.enum.length === 0) {
-      return this.pure(`l.never()`)
+      return markPure(`l.never()`)
     }
 
     const result =
       def.enum.length === 1
-        ? this.pure(`l.literal(${JSON.stringify(def.enum[0])})`)
-        : this.pure(`l.enum(${JSON.stringify(def.enum)})`)
+        ? markPure(`l.literal(${JSON.stringify(def.enum[0])})`)
+        : markPure(`l.enum(${JSON.stringify(def.enum)})`)
 
     return this.withDefault(result, def.default)
   }

--- a/packages/lex/lex-client/scripts/lex-build.mjs
+++ b/packages/lex/lex-client/scripts/lex-build.mjs
@@ -24,7 +24,6 @@ Promise.all([
     ],
     lib: '@atproto/lex-schema',
     pretty: true,
-    pureAnnotations: true,
     indexFile: true,
   }),
 

--- a/packages/lex/lex-password-session/scripts/lex-build.mjs
+++ b/packages/lex/lex-password-session/scripts/lex-build.mjs
@@ -19,7 +19,6 @@ build({
   ],
   lib: '@atproto/lex-schema',
   pretty: true,
-  pureAnnotations: true,
   indexFile: true,
 }).catch((err) => {
   console.error('Error building lexicon schemas:', err)

--- a/packages/lex/lex-resolver/scripts/lex-build.mjs
+++ b/packages/lex/lex-resolver/scripts/lex-build.mjs
@@ -13,7 +13,6 @@ build({
   include: ['com.atproto.sync.getRecord'],
   lib: '@atproto/lex-schema',
   pretty: true,
-  pureAnnotations: true,
   indexFile: true,
 }).catch((err) => {
   console.error('Error building lexicon schemas:', err)

--- a/packages/lex/lex/README.md
+++ b/packages/lex/lex/README.md
@@ -1075,14 +1075,6 @@ import { getProfile } from './lexicons/app/bsky/actor/getProfile.js'
 import * as app from './lexicons/app.js'
 ```
 
-For library authors, use `--pure-annotations` when building:
-
-```bash
-lex build --pure-annotations
-```
-
-This will make the generated code more easily tree-shakeable from places that import your library.
-
 ### Blob references
 
 In AT Protocol, binary data (blobs) are referenced using blob references, which include metadata like MIME type and size. These references allow PDSs to determine which binary data ("files") is referenced by records.

--- a/packages/lex/lex/bin/lex
+++ b/packages/lex/lex/bin/lex
@@ -51,12 +51,6 @@ yargs(hideBin(process.argv))
           default: false,
           describe: 'how to handle errors when processing input files',
         },
-        'pure-annotations': {
-          type: 'boolean',
-          default: false,
-          describe:
-            'adds `/*#__PURE__*/` annotations for tree-shaking tools. Set this to true if you are using generated lexicons in a library.',
-        },
         exclude: {
           array: true,
           type: 'string',


### PR DESCRIPTION
It turns out that not adding `#__PURE__` annotations to function calls is a mistake as it impacts the ability of bundlers (vite) to tree-shake the code properly, especially in code-bases that have side effects (as is typically the case for front-end app that embed CSS files).

This PR removes the option and always adds the annotations.