### PR TITLE
Improve bundling size of lex-client

### DIFF
--- a/.changeset/clever-pugs-jog.md
+++ b/.changeset/clever-pugs-jog.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-client-browser-example': patch
+---
+
+Improve bundle size

--- a/.changeset/wicked-peaches-cover.md
+++ b/.changeset/wicked-peaches-cover.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-client': patch
+---
+
+Improve bundling size of lex-client

--- a/packages/lex/lex-client/src/client.ts
+++ b/packages/lex/lex-client/src/client.ts
@@ -1,6 +1,7 @@
 import { LexMap, LexValue, TypedLexMap } from '@atproto/lex-data'
 import {
   AtIdentifierString,
+  AtUriString,
   CidString,
   DidString,
   Infer,
@@ -19,7 +20,17 @@ import {
 } from '@atproto/lex-schema'
 import { Agent, AgentOptions, buildAgent } from './agent.js'
 import { XrpcFailure } from './errors.js'
-import { com } from './lexicons/index.js'
+// @NOTE We could use import { com } from "./lexicons/index.js" here, but some
+// consumers might not know how to properly tree-shake that, so we import only
+// the needed lexicons directly.
+import { main as applyWrites } from './lexicons/com/atproto/repo/applyWrites.js'
+import { main as createRecord } from './lexicons/com/atproto/repo/createRecord.js'
+import { main as deleteRecord } from './lexicons/com/atproto/repo/deleteRecord.js'
+import { main as getRecord } from './lexicons/com/atproto/repo/getRecord.js'
+import { main as listRecords } from './lexicons/com/atproto/repo/listRecords.js'
+import { main as putRecord } from './lexicons/com/atproto/repo/putRecord.js'
+import { main as uploadBlob } from './lexicons/com/atproto/repo/uploadBlob.js'
+import { main as getBlob } from './lexicons/com/atproto/sync/getBlob.js'
 import {
   XrpcResponse,
   XrpcResponseBody,
@@ -155,7 +166,7 @@ export type InferActionOutput<A extends Action> =
  * @see {@link Client.createRecord}
  */
 export type CreateRecordOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.createRecord.main>,
+  XrpcOptions<typeof createRecord>,
   'body'
 > & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
@@ -172,7 +183,7 @@ export type CreateRecordOptions = Omit<
  * @see {@link Client.deleteRecord}
  */
 export type DeleteRecordOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.deleteRecord.main>,
+  XrpcOptions<typeof deleteRecord>,
   'body'
 > & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
@@ -188,10 +199,7 @@ export type DeleteRecordOptions = Omit<
  *
  * @see {@link Client.getRecord}
  */
-export type GetRecordOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.getRecord.main>,
-  'params'
-> & {
+export type GetRecordOptions = Omit<XrpcOptions<typeof getRecord>, 'params'> & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
   repo?: AtIdentifierString
 }
@@ -201,10 +209,7 @@ export type GetRecordOptions = Omit<
  *
  * @see {@link Client.putRecord}
  */
-export type PutRecordOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.putRecord.main>,
-  'body'
-> & {
+export type PutRecordOptions = Omit<XrpcOptions<typeof putRecord>, 'body'> & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
   repo?: AtIdentifierString
   /** Compare-and-swap on the repo commit. If specified, must match current commit. */
@@ -221,7 +226,7 @@ export type PutRecordOptions = Omit<
  * @see {@link Client.listRecords}
  */
 export type ListRecordsOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.listRecords.main>,
+  XrpcOptions<typeof listRecords>,
   'params'
 > & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
@@ -240,7 +245,7 @@ export type ListRecordsOptions = Omit<
  * @see {@link Client.applyWrites}
  */
 export type ApplyWritesOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.applyWrites.main>,
+  XrpcOptions<typeof applyWrites>,
   'body'
 > & {
   /** Repository identifier (DID or handle). Defaults to authenticated user's DID. */
@@ -251,15 +256,9 @@ export type ApplyWritesOptions = Omit<
   swapCommit?: CidString
 }
 
-export type UploadBlobOptions = Omit<
-  XrpcOptions<typeof com.atproto.repo.uploadBlob.main>,
-  'body'
->
+export type UploadBlobOptions = Omit<XrpcOptions<typeof uploadBlob>, 'body'>
 
-export type GetBlobOptions = Omit<
-  XrpcOptions<typeof com.atproto.sync.getBlob.main>,
-  'params'
->
+export type GetBlobOptions = Omit<XrpcOptions<typeof getBlob>, 'params'>
 
 /**
  * Type-safe options for {@link Client.create}, combining record options with key requirements.
@@ -274,7 +273,7 @@ export type CreateOptions<T extends RecordSchema> = CreateRecordOptions &
  * Contains the URI and CID of the newly created record.
  */
 export type CreateOutput = InferMethodOutputBody<
-  typeof com.atproto.repo.createRecord.main,
+  typeof createRecord,
   Uint8Array
 >
 
@@ -289,7 +288,7 @@ export type DeleteOptions<T extends RecordSchema> = DeleteRecordOptions &
  * Output type for record deletion operations.
  */
 export type DeleteOutput = InferMethodOutputBody<
-  typeof com.atproto.repo.deleteRecord.main,
+  typeof deleteRecord,
   Uint8Array
 >
 
@@ -306,7 +305,7 @@ export type GetOptions<T extends RecordSchema> = GetRecordOptions &
  * @typeParam T - The record schema type
  */
 export type GetOutput<T extends RecordSchema> = Omit<
-  InferMethodOutputBody<typeof com.atproto.repo.getRecord.main, Uint8Array>,
+  InferMethodOutputBody<typeof getRecord, Uint8Array>,
   'value'
 > & { value: Infer<T> }
 
@@ -321,10 +320,7 @@ export type PutOptions<T extends RecordSchema> = PutRecordOptions &
  * Output type for record put (create/update) operations.
  * Contains the URI and CID of the record.
  */
-export type PutOutput = InferMethodOutputBody<
-  typeof com.atproto.repo.putRecord.main,
-  Uint8Array
->
+export type PutOutput = InferMethodOutputBody<typeof putRecord, Uint8Array>
 
 /**
  * Options for {@link Client.list} operations.
@@ -337,7 +333,7 @@ export type ListOptions = ListRecordsOptions
  * @typeParam T - The record schema type
  */
 export type ListOutput<T extends RecordSchema> = InferMethodOutputBody<
-  typeof com.atproto.repo.listRecords.main,
+  typeof listRecords,
   Uint8Array
 > & {
   /** Records that successfully validated against the schema. */
@@ -353,10 +349,11 @@ export type ListOutput<T extends RecordSchema> = InferMethodOutputBody<
  * A record from a list operation with its value typed to the schema.
  * @typeParam Value - The validated record value type
  */
-export type ListRecord<Value extends LexMap> =
-  com.atproto.repo.listRecords.Record & {
-    value: Value
-  }
+export type ListRecord<Value extends LexMap> = {
+  uri: AtUriString
+  cid: CidString
+  value: Value
+}
 
 /**
  * The Client class is the primary interface for interacting with AT Protocol
@@ -614,7 +611,7 @@ export class Client implements Agent {
     rkey?: string,
     options?: CreateRecordOptions,
   ) {
-    return this.xrpc(com.atproto.repo.createRecord.main, {
+    return this.xrpc(createRecord, {
       ...options,
       body: {
         repo: options?.repo ?? this.assertDid,
@@ -641,7 +638,7 @@ export class Client implements Agent {
     rkey: string,
     options?: DeleteRecordOptions,
   ) {
-    return this.xrpc(com.atproto.repo.deleteRecord.main, {
+    return this.xrpc(deleteRecord, {
       ...options,
       body: {
         repo: options?.repo ?? this.assertDid,
@@ -667,7 +664,7 @@ export class Client implements Agent {
     rkey: string,
     options?: GetRecordOptions,
   ) {
-    return this.xrpc(com.atproto.repo.getRecord.main, {
+    return this.xrpc(getRecord, {
       ...options,
       params: {
         repo: options?.repo ?? this.assertDid,
@@ -691,7 +688,7 @@ export class Client implements Agent {
     rkey: string,
     options?: PutRecordOptions,
   ) {
-    return this.xrpc(com.atproto.repo.putRecord.main, {
+    return this.xrpc(putRecord, {
       ...options,
       body: {
         repo: options?.repo ?? this.assertDid,
@@ -714,7 +711,7 @@ export class Client implements Agent {
    * @see {@link list} for a higher-level typed alternative
    */
   async listRecords(nsid: NsidString, options?: ListRecordsOptions) {
-    return this.xrpc(com.atproto.repo.listRecords.main, {
+    return this.xrpc(listRecords, {
       ...options,
       params: {
         repo: options?.repo ?? this.assertDid,
@@ -753,7 +750,7 @@ export class Client implements Agent {
     factory: WriteOperationsFactory,
     options?: ApplyWritesOptions,
   ) {
-    return this.xrpc(com.atproto.repo.applyWrites, {
+    return this.xrpc(applyWrites, {
       ...options,
       body: {
         repo: options?.repo ?? this.assertDid,
@@ -781,7 +778,7 @@ export class Client implements Agent {
    * ```
    */
   async uploadBlob(body: BinaryBodyInit, options?: UploadBlobOptions) {
-    return this.xrpc(com.atproto.repo.uploadBlob.main, { ...options, body })
+    return this.xrpc(uploadBlob, { ...options, body })
   }
 
   /**
@@ -792,7 +789,7 @@ export class Client implements Agent {
    * @param options - Call options
    */
   async getBlob(did: DidString, cid: CidString, options?: GetBlobOptions) {
-    return this.xrpc(com.atproto.sync.getBlob.main, {
+    return this.xrpc(getBlob, {
       ...options,
       params: { did, cid },
     })

--- a/packages/oauth/oauth-client-browser-example/src/components/ProfileInfo.tsx
+++ b/packages/oauth/oauth-client-browser-example/src/components/ProfileInfo.tsx
@@ -16,7 +16,7 @@ export function ProfileInfo({
   // @NOTE for more detailed profile info, we should be using the
   // app.bsky.actor.getProfile query. This example uses the record for
   // demonstration purposes.
-  const profileQuery = useLexRecord(app.bsky.actor.profile)
+  const profileQuery = useLexRecord(app.bsky.actor.profile.main)
 
   const avatarUrl = useBlobRefUrl(profileQuery.data?.value?.avatar)
   const bannerUrl = useBlobRefUrl(profileQuery.data?.value?.banner)

--- a/packages/oauth/oauth-client-browser-example/src/components/SessionInfo.tsx
+++ b/packages/oauth/oauth-client-browser-example/src/components/SessionInfo.tsx
@@ -4,7 +4,7 @@ import { Button } from './Button.tsx'
 import { JsonQueryResult } from './JsonQueryResult.tsx'
 
 export function SessionInfo() {
-  const result = useLexQuery(com.atproto.server.getSession)
+  const result = useLexQuery(com.atproto.server.getSession.main)
 
   return (
     <div>

--- a/packages/oauth/oauth-client-browser-example/src/components/UserMenu.tsx
+++ b/packages/oauth/oauth-client-browser-example/src/components/UserMenu.tsx
@@ -12,8 +12,8 @@ export function UserMenu() {
   const { signOut } = useOAuthContext()
   const session = useOAuthSession()
 
-  const profileQuery = useLexRecord(app.bsky.actor.profile)
-  const sessionQuery = useLexQuery(com.atproto.server.getSession)
+  const profileQuery = useLexRecord(app.bsky.actor.profile.main)
+  const sessionQuery = useLexQuery(com.atproto.server.getSession.main)
 
   const displayName = profileQuery.data?.value?.displayName
   const handle = sessionQuery.data?.body.handle


### PR DESCRIPTION
While lex SDK encourages to use namespaces to access lexicon schemas, as in:

```ts
import { com } from "#/lexicons"

await client.call(com.atproto.repo.getSession)
```

There are two aspects that need to be considered:

1) This puts more work onto the tree-shaking process as the bundler has to determine which part of the imported namespace are actually used
2) Even with proper tree-shaking, not using the `main` schema specifically (as in `com.atproto.repo.getSession.main`) results in significant overhead as the whole "Module" gets created in the Bundle (see screenshot below)

<img width="244" height="777" alt="Capture d’écran 2026-05-21 à 09 39 22" src="https://github.com/user-attachments/assets/870ad5e5-38a6-4bb7-8bce-22b04241a7f1" />

This PR makes `lex-client`'s footprint smaller (in terms of compilation time & bundle footprint) by importing the method schemas directly.