### PR TITLE
Remove need for inference when computing XRPC method derived types

### DIFF
--- a/.changeset/cute-ads-train.md
+++ b/.changeset/cute-ads-train.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-builder': patch
+---
+
+Remove need for inference when computing XRPC method derived types

--- a/.changeset/neat-spiders-fly.md
+++ b/.changeset/neat-spiders-fly.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-builder': patch
+---
+
+Export `lexiconMessageSchema` (and type) for subscription messages

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -167,74 +167,90 @@ export class LexDefBuilder {
     })
   }
 
-  private async addParameters(parameters?: LexiconParameters) {
+  private async addParameters(parameters?: LexiconParameters): Promise<string> {
+    const varName = '$params'
+
     this.addUtils({
-      $params: await this.compileParamsSchema(parameters),
+      [varName]: await this.compileParamsSchema(parameters),
     })
 
     // @TODO Build the types instead of using an inferred type.
     this.file.addTypeAlias({
       isExported: true,
       name: '$Params',
-      type: `l.InferOutput<typeof $params>`,
+      type: `l.InferOutput<typeof ${varName}>`,
       docs: compileDocs(parameters?.description),
     })
+
+    return varName
   }
 
-  private async addInput(input?: LexiconPayload) {
+  private async addInput(input?: LexiconPayload): Promise<string> {
+    const varName = '$input'
+
     this.addUtils({
-      $input: await this.compilePayload(input),
+      [varName]: await this.compilePayload(input),
     })
 
     // @TODO Build the types instead of using an inferred type.
     this.file.addTypeAlias({
       isExported: true,
       name: '$Input<B = l.BinaryData>',
-      type: `l.InferPayload<typeof $input, B>`,
+      type: `l.InferPayload<typeof ${varName}, B>`,
       docs: compileDocs(input?.description),
     })
 
     this.file.addTypeAlias({
       isExported: true,
       name: '$InputBody<B = l.BinaryData>',
-      type: `l.InferPayloadBody<typeof $input, B>`,
+      type: `l.InferPayloadBody<typeof ${varName}, B>`,
       docs: compileDocs(input?.description),
     })
+
+    return varName
   }
 
-  private async addOutput(output?: LexiconPayload) {
+  private async addOutput(output?: LexiconPayload): Promise<string> {
+    const varName = '$output'
+
     this.addUtils({
-      $output: await this.compilePayload(output),
+      [varName]: await this.compilePayload(output),
     })
 
     // @TODO Build the types instead of using an inferred type.
     this.file.addTypeAlias({
       isExported: true,
       name: '$Output<B = l.BinaryData>',
-      type: `l.InferPayload<typeof $output, B>`,
+      type: `l.InferPayload<typeof ${varName}, B>`,
       docs: compileDocs(output?.description),
     })
 
     this.file.addTypeAlias({
       isExported: true,
       name: '$OutputBody<B = l.BinaryData>',
-      type: `l.InferPayloadBody<typeof $output, B>`,
+      type: `l.InferPayloadBody<typeof ${varName}, B>`,
       docs: compileDocs(output?.description),
     })
+
+    return varName
   }
 
   private async addMessage(message?: LexiconMessage) {
+    const varName = '$message'
+
     this.addUtils({
-      $message: await this.compileBodySchema(message?.schema),
+      [varName]: await this.compileBodySchema(message?.schema),
     })
 
     // @TODO Build the types instead of using an inferred type.
     this.file.addTypeAlias({
       isExported: true,
       name: '$Message',
-      type: `l.InferOutput<typeof $message>`,
+      type: `l.InferOutput<typeof ${varName}>`,
       docs: compileDocs(message?.description),
     })
+
+    return varName
   }
 
   private async addProcedure(hash: string, def: LexiconProcedure) {
@@ -243,19 +259,24 @@ export class LexDefBuilder {
     }
 
     // Declare each piece of the method as its own top-level exported const
-    // *before* `main`, so consumers that import a single helper (e.g.
-    // `$lxm`) only pull in that subtree rather than the whole procedure.
-    // `main.parameters` etc. would otherwise pin `main` in the module graph.
-    this.addUtils({ $lxm: '$nsid' })
+    // *before* `main`. This allows to export those pieces individually instead
+    // of "extracting" them from the "main" definition as below, which is bad
+    // for tree-shaking.
+    //
+    // export const $params = main.params`
 
-    await this.addParameters(def.parameters)
-    await this.addInput(def.input)
-    await this.addOutput(def.output)
+    const paramsVar = await this.addParameters(def.parameters)
+    const inputVar = await this.addInput(def.input)
+    const outputVar = await this.addOutput(def.output)
 
     await this.addSchema(hash, def, {
       schema: markPure(
-        `l.procedure($nsid, $params, $input, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
+        `l.procedure($nsid, ${paramsVar}, ${inputVar}, ${outputVar}${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
+    })
+
+    this.addUtils({
+      $lxm: '$nsid',
     })
   }
 
@@ -264,15 +285,24 @@ export class LexDefBuilder {
       throw new Error(`Definition ${hash} cannot be of type ${def.type}`)
     }
 
-    this.addUtils({ $lxm: '$nsid' })
+    // Declare each piece of the method as its own top-level exported const
+    // *before* `main`. This allows to export those pieces individually instead
+    // of "extracting" them from the "main" definition as below, which is bad
+    // for tree-shaking:
+    //
+    // export const $params = main.params
 
-    await this.addParameters(def.parameters)
-    await this.addOutput(def.output)
+    const paramsVar = await this.addParameters(def.parameters)
+    const outputVar = await this.addOutput(def.output)
 
     await this.addSchema(hash, def, {
       schema: markPure(
-        `l.query($nsid, $params, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
+        `l.query($nsid, ${paramsVar}, ${outputVar}${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
+    })
+
+    this.addUtils({
+      $lxm: '$nsid',
     })
   }
 
@@ -281,15 +311,24 @@ export class LexDefBuilder {
       throw new Error(`Definition ${hash} cannot be of type ${def.type}`)
     }
 
-    this.addUtils({ $lxm: '$nsid' })
+    // Declare each piece of the method as its own top-level exported const
+    // *before* `main`. This allows to export those pieces individually instead
+    // of "extracting" them from the "main" definition as below, which is bad
+    // for tree-shaking.
+    //
+    // export const $params = main.params`
 
-    await this.addParameters(def.parameters)
-    await this.addMessage(def.message)
+    const paramsVar = await this.addParameters(def.parameters)
+    const messageVar = await this.addMessage(def.message)
 
     await this.addSchema(hash, def, {
       schema: markPure(
-        `l.subscription($nsid, $params, $message${formatErrorsArg(await this.compileErrors(def.errors))})`,
+        `l.subscription($nsid, ${paramsVar}, ${messageVar}${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
+    })
+
+    this.addUtils({
+      $lxm: '$nsid',
     })
   }
 

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -15,6 +15,7 @@ import {
   LexiconError,
   LexiconIndexer,
   LexiconInteger,
+  LexiconMessage,
   LexiconObject,
   LexiconParameters,
   LexiconPayload,
@@ -179,31 +180,96 @@ export class LexDefBuilder {
     })
   }
 
+  private async addParameters(parameters?: LexiconParameters) {
+    this.addUtils({
+      $params: await this.compileParamsSchema(parameters),
+    })
+
+    // @TODO Build the types instead of using an inferred type.
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$Params',
+      type: `l.InferOutput<typeof $params>`,
+      docs: compileDocs(parameters?.description),
+    })
+  }
+
+  private async addInput(input?: LexiconPayload) {
+    this.addUtils({
+      $input: await this.compilePayload(input),
+    })
+
+    // @TODO Build the types instead of using an inferred type.
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$Input<B = l.BinaryData>',
+      type: `l.InferPayload<typeof $input, B>`,
+      docs: compileDocs(input?.description),
+    })
+
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$InputBody<B = l.BinaryData>',
+      type: `l.InferPayloadBody<typeof $input, B>`,
+      docs: compileDocs(input?.description),
+    })
+  }
+
+  private async addOutput(output?: LexiconPayload) {
+    this.addUtils({
+      $output: await this.compilePayload(output),
+    })
+
+    // @TODO Build the types instead of using an inferred type.
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$Output<B = l.BinaryData>',
+      type: `l.InferPayload<typeof $output, B>`,
+      docs: compileDocs(output?.description),
+    })
+
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$OutputBody<B = l.BinaryData>',
+      type: `l.InferPayloadBody<typeof $output, B>`,
+      docs: compileDocs(output?.description),
+    })
+  }
+
+  private async addMessage(message?: LexiconMessage) {
+    this.addUtils({
+      $message: await this.compileBodySchema(message?.schema),
+    })
+
+    // @TODO Build the types instead of using an inferred type.
+    this.file.addTypeAlias({
+      isExported: true,
+      name: '$Message',
+      type: `l.InferOutput<typeof $message>`,
+      docs: compileDocs(message?.description),
+    })
+  }
+
   private async addProcedure(hash: string, def: LexiconProcedure) {
     if (hash !== 'main') {
       throw new Error(`Definition ${hash} cannot be of type ${def.type}`)
     }
 
-    // @TODO Build the types instead of using an inferred type.
-
     // Declare each piece of the method as its own top-level exported const
     // *before* `main`, so consumers that import a single helper (e.g.
     // `$lxm`) only pull in that subtree rather than the whole procedure.
     // `main.parameters` etc. would otherwise pin `main` in the module graph.
-    this.addUtils({
-      $lxm: '$nsid',
-      $params: await this.compileParamsSchema(def.parameters),
-      $input: await this.compilePayload(def.input),
-      $output: await this.compilePayload(def.output),
-    })
+    this.addUtils({ $lxm: '$nsid' })
 
-    const ref = await this.addSchema(hash, def, {
+    await this.addParameters(def.parameters)
+    await this.addInput(def.input)
+    await this.addOutput(def.output)
+
+    await this.addSchema(hash, def, {
       schema: this.pure(
         `l.procedure($nsid, $params, $input, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
-
-    this.addMethodTypeUtils(ref, def)
   }
 
   private async addQuery(hash: string, def: LexiconQuery) {
@@ -211,21 +277,16 @@ export class LexDefBuilder {
       throw new Error(`Definition ${hash} cannot be of type ${def.type}`)
     }
 
-    // @TODO Build the types instead of using an inferred type.
+    this.addUtils({ $lxm: '$nsid' })
 
-    this.addUtils({
-      $lxm: '$nsid',
-      $params: await this.compileParamsSchema(def.parameters),
-      $output: await this.compilePayload(def.output),
-    })
+    await this.addParameters(def.parameters)
+    await this.addOutput(def.output)
 
-    const ref = await this.addSchema(hash, def, {
+    await this.addSchema(hash, def, {
       schema: this.pure(
         `l.query($nsid, $params, $output${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
-
-    this.addMethodTypeUtils(ref, def)
   }
 
   private async addSubscription(hash: string, def: LexiconSubscription) {
@@ -233,74 +294,16 @@ export class LexDefBuilder {
       throw new Error(`Definition ${hash} cannot be of type ${def.type}`)
     }
 
-    // @TODO Build the types instead of using an inferred type.
+    this.addUtils({ $lxm: '$nsid' })
 
-    this.addUtils({
-      $lxm: '$nsid',
-      $params: await this.compileParamsSchema(def.parameters),
-      $message: await this.compileBodySchema(def.message?.schema),
-    })
+    await this.addParameters(def.parameters)
+    await this.addMessage(def.message)
 
-    const ref = await this.addSchema(hash, def, {
+    await this.addSchema(hash, def, {
       schema: this.pure(
         `l.subscription($nsid, $params, $message${formatErrorsArg(await this.compileErrors(def.errors))})`,
       ),
     })
-
-    this.addMethodTypeUtils(ref, def)
-  }
-
-  addMethodTypeUtils(
-    ref: ResolvedRef,
-    def: LexiconProcedure | LexiconQuery | LexiconSubscription,
-  ) {
-    this.file.addTypeAlias({
-      isExported: true,
-      name: '$Params',
-      type: `l.InferMethodParams<typeof ${ref.varName}>`,
-      docs: compileDocs(def.parameters?.description),
-    })
-
-    if (def.type === 'procedure') {
-      this.file.addTypeAlias({
-        isExported: true,
-        name: '$Input<B = l.BinaryData>',
-        type: `l.InferMethodInput<typeof ${ref.varName}, B>`,
-        docs: compileDocs(def.input?.description),
-      })
-
-      this.file.addTypeAlias({
-        isExported: true,
-        name: '$InputBody<B = l.BinaryData>',
-        type: `l.InferMethodInputBody<typeof ${ref.varName}, B>`,
-        docs: compileDocs(def.input?.description),
-      })
-    }
-
-    if (def.type === 'procedure' || def.type === 'query') {
-      this.file.addTypeAlias({
-        isExported: true,
-        name: '$Output<B = l.BinaryData>',
-        type: `l.InferMethodOutput<typeof ${ref.varName}, B>`,
-        docs: compileDocs(def.output?.description),
-      })
-
-      this.file.addTypeAlias({
-        isExported: true,
-        name: '$OutputBody<B = l.BinaryData>',
-        type: `l.InferMethodOutputBody<typeof ${ref.varName}, B>`,
-        docs: compileDocs(def.output?.description),
-      })
-    }
-
-    if (def.type === 'subscription') {
-      this.file.addTypeAlias({
-        isExported: true,
-        name: '$Message',
-        type: `l.InferSubscriptionMessage<typeof ${ref.varName}>`,
-        docs: compileDocs(def.message?.description),
-      })
-    }
   }
 
   private async addRecord(hash: string, def: LexiconRecord) {

--- a/packages/lex/lex-document/src/lexicon-document.ts
+++ b/packages/lex/lex-document/src/lexicon-document.ts
@@ -536,6 +536,13 @@ export const lexiconProcedureSchema = l.object({
  */
 export type LexiconProcedure = l.Infer<typeof lexiconProcedureSchema>
 
+export const lexiconMessageSchema = l.object({
+  description: l.optional(l.string()),
+  schema: lexiconRefUnionSchema,
+})
+
+export type LexiconMessage = l.Infer<typeof lexiconMessageSchema>
+
 /**
  * Schema for validating Lexicon subscription (WebSocket) method definitions.
  *
@@ -547,10 +554,7 @@ export const lexiconSubscriptionSchema = l.object({
   type: l.literal('subscription'),
   description: l.optional(l.string()),
   parameters: l.optional(lexiconParameters),
-  message: l.object({
-    description: l.optional(l.string()),
-    schema: lexiconRefUnionSchema,
-  }),
+  message: lexiconMessageSchema,
   errors: l.optional(l.array(lexiconError)),
 })
 


### PR DESCRIPTION
Currently, XRPC method derived types (`$Params`, `$Input`, `$Output`, `$Message`, etc.) are derived from the method schema itself:

```ts
type $Params = l.InferMethodParams<typeof main>
```

This means that TypeScript has to "extract" the `parameters` property from the schema, before being able to infer the schema of the parameters themselves:


<img width="584" height="404" alt="Capture d’écran 2026-05-21 à 10 09 02" src="https://github.com/user-attachments/assets/ff9496d7-0b79-4af8-8bb5-1ab668ac1a14" />

However, since https://github.com/bluesky-social/atproto/pull/4972 created the various xrpc method "parts" (`params`, `input`, `output`) as standalone variables, we can use them directly to infer the derived types:

```ts
type $Params = l.Infer<typeof $params>
```

<img width="577" height="418" alt="Capture d’écran 2026-05-21 à 10 08 30" src="https://github.com/user-attachments/assets/899c3eff-53ab-4817-a9b8-ed620496c3f7" />
