### PR TITLE
Make the generation of the `$defs` namespace optional by default

### DIFF
--- a/.changeset/strong-dolls-ask.md
+++ b/.changeset/strong-dolls-ask.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+remove un-necessary use of `$defs` accessor

--- a/.changeset/tired-clubs-burn.md
+++ b/.changeset/tired-clubs-burn.md
@@ -1,0 +1,6 @@
+---
+'@atproto/lex-builder': patch
+'@atproto/lex': patch
+---
+
+Make the generation of the `$defs` namespace optional by default

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -144,7 +144,7 @@ type Params = app.bsky.unspecced.getTrendingTopics.$Params & {
 type SkeletonState = app.bsky.unspecced.getTrendsSkeleton.$OutputBody
 
 function getUniqueDidsFromTrends(
-  trends?: app.bsky.unspecced.defs.$defs.SkeletonTrend[],
+  trends?: app.bsky.unspecced.defs.SkeletonTrend[],
 ): DidString[] {
   if (!trends) return []
 

--- a/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
+++ b/packages/bsky/src/api/com/atproto/admin/getAccountInfos.ts
@@ -18,7 +18,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const infos = mapDefined(
         dids,
-        (did): com.atproto.admin.defs.$defs.AccountView | undefined => {
+        (did): com.atproto.admin.defs.AccountView | undefined => {
           const info = actors.get(did)
           if (!info) return
           if (info.takedownRef && !includeTakedowns) return

--- a/packages/lex/lex-builder/src/lex-builder.ts
+++ b/packages/lex/lex-builder/src/lex-builder.ts
@@ -42,6 +42,23 @@ export type LexBuilderOptions = LexDefBuilderOptions & {
    * @default '.ts'
    */
   fileExt?: string
+  /**
+   * Whether to export the whole defs file as a namespace export (`export * as
+   * $defs from './xyz.defs.js'`). This is useful to have an escape hatch to
+   * access the definitions in case of name conflicts with child namespaces.
+   *
+   * For example if two documents with if `com.example.foo` and
+   * `com.example.foo.bar` coexist, the `com.example.foo.bar` namespace would
+   * shadow any `bar` definition from the `com.example.foo` namespace. In that
+   * case, having the `$defs` namespace export allows to still access those
+   * definitions via `com.example.foo.$defs.bar`.
+   *
+   * @note enabling this will negatively impact bundle size because and
+   * additional namespace object will be generated for each lexicon document.
+   *
+   * @default false
+   */
+  defsExport?: boolean
 }
 
 /**
@@ -221,15 +238,17 @@ export class LexBuilder {
       moduleSpecifier: `./${namespaces.at(-1)}.defs${this.importExt}`,
     })
 
-    // @NOTE Individual exports exports from the defs file might conflict with
-    // child namespaces. For this reason, we also add a namespace export for the
-    // defs (export * as $defs from './xyz.defs.js'). This is an escape hatch
-    // allowing to still access the definitions if a hash get shadowed by a
-    // child namespace.
-    file.addExportDeclaration({
-      moduleSpecifier: `./${namespaces.at(-1)}.defs${this.importExt}`,
-      namespaceExport: '$defs',
-    })
+    if (this.options.defsExport) {
+      // @NOTE Individual exports exports from the defs file might conflict with
+      // child namespaces. For this reason, we also add a namespace export for the
+      // defs (export * as $defs from './xyz.defs.js'). This is an escape hatch
+      // allowing to still access the definitions if a hash get shadowed by a
+      // child namespace.
+      file.addExportDeclaration({
+        moduleSpecifier: `./${namespaces.at(-1)}.defs${this.importExt}`,
+        namespaceExport: '$defs',
+      })
+    }
   }
 
   private async createDefsFile(

--- a/packages/lex/lex/bin/lex
+++ b/packages/lex/lex/bin/lex
@@ -87,6 +87,12 @@ yargs(hideBin(process.argv))
           describe:
             'generate an "index.<fileExt>" file that exports all root-level namespaces',
         },
+        defsExport: {
+          type: 'boolean',
+          default: false,
+          describe:
+            'when some definitions conflict with child namespaces, this option allows to export lexicon definitions under a separate $defs namespace (e.g. com.example.foo.$defs)',
+        },
         ignoreInvalidLexicons: {
           type: 'boolean',
           default: false,


### PR DESCRIPTION
The `$defs` namespace can cause a significant overhead in generated code: 

<img width="244" height="777" alt="Capture d’écran 2026-05-21 à 09 39 22" src="https://github.com/user-attachments/assets/5bc25e73-5d88-42f8-8a84-4888a363b055" />

Since its purpose is to provide an escape hatch in case of conflicting namespaces, which should not happen with properly designed lexicons, this PR makes the generation of that namespace optional (and disabled by default).