### PR TITLE
Ensure fields are always present on viewExternalSource

### DIFF
--- a/.changeset/slick-suns-rescue.md
+++ b/.changeset/slick-suns-rescue.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Update fields that are always present on `viewExternalSource`

--- a/lexicons/app/bsky/embed/external.json
+++ b/lexicons/app/bsky/embed/external.json
@@ -85,6 +85,7 @@
     "viewExternalSource": {
       "type": "object",
       "description": "The source of an external embed, such as a standard.site publication.",
+      "required": ["uri", "title"],
       "properties": {
         "uri": {
           "type": "string",


### PR DESCRIPTION
This is a type-only update. These fields are always present on the response.