### PR TITLE
PDS: bump request JSON size limit on record methods

### DIFF
--- a/.changeset/stale-experts-ask.md
+++ b/.changeset/stale-experts-ask.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Bump request JSON size limit on createRecord, putRecord, and applyWrites.

--- a/packages/pds/src/api/com/atproto/repo/applyWrites.ts
+++ b/packages/pds/src/api/com/atproto/repo/applyWrites.ts
@@ -65,6 +65,10 @@ export default function (server: Server, ctx: AppContext) {
       },
     ],
 
+    opts: {
+      jsonLimit: 1_000_000,
+    },
+
     handler: async ({ input, auth }) => {
       const { repo, validate, swapCommit, writes } = input.body
 

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -44,6 +44,9 @@ export default function (server: Server, ctx: AppContext) {
         calcPoints: () => 3,
       },
     ],
+    opts: {
+      jsonLimit: 1_000_000,
+    },
     handler: async ({ input, auth }) => {
       const { repo, collection, rkey, record, swapCommit, validate } =
         input.body

--- a/packages/pds/src/api/com/atproto/repo/putRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/putRecord.ts
@@ -53,6 +53,9 @@ export default function (server: Server, ctx: AppContext) {
         calcPoints: () => 2,
       },
     ],
+    opts: {
+      jsonLimit: 1_000_000,
+    },
     handler: async ({ auth, input }) => {
       const {
         repo,

--- a/packages/pds/tests/server.test.ts
+++ b/packages/pds/tests/server.test.ts
@@ -58,7 +58,7 @@ describe('server', () => {
 
   it('limits size of json input.', async () => {
     const res = await fetch(
-      `${network.pds.url}/xrpc/com.atproto.repo.createRecord`,
+      `${network.pds.url}/xrpc/com.atproto.identity.updateHandle`,
       {
         method: 'POST',
         body: '"' + 'x'.repeat(150 * 1024) + '"', // ~150kb


### PR DESCRIPTION
Records can be up to 1MB when CBOR-encoded. Currently the record methods on the PDS inherit the baseline json size limit of 150kb.