### PR TITLE
Fix OAuth service-proxying audience for combined `did#serviceId` scopes

### DIFF
--- a/.changeset/crisp-bridges-dream.md
+++ b/.changeset/crisp-bridges-dream.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Fix OAuth service-proxying audience check to use combined `did#serviceId` form, matching the shape of granted `rpc:` scopes.

--- a/.changeset/plain-rivers-glow.md
+++ b/.changeset/plain-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-scopes': minor
+---
+
+The `AtprotoAudience` and `isAtprotoAudience` re-exports are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` and `isAtprotoDidRefAbsolute`, also re-exported from this package.

--- a/.changeset/plain-rivers-glow.md
+++ b/.changeset/plain-rivers-glow.md
@@ -2,4 +2,4 @@
 '@atproto/oauth-scopes': minor
 ---
 
-The `AtprotoAudience` and `isAtprotoAudience` re-exports are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` and `isAtprotoDidRefAbsolute`, also re-exported from this package.
+**BREAKING:** Remove the `AtprotoAudience` and `isAtprotoAudience` re-exports. They are superseded by `AtprotoDidRefAbsolute` and `isAtprotoDidRefAbsolute`, also re-exported from this package.

--- a/.changeset/quiet-bridges-hum.md
+++ b/.changeset/quiet-bridges-hum.md
@@ -1,5 +1,5 @@
 ---
-'@atproto/did': patch
+'@atproto/did': minor
 ---
 
-Add `AtprotoDidRefAbsolute`, `DidRefRelative`, `AtprotoScopeAud`, and `AtprotoTokenAud` types and predicates. `AtprotoAudience` is renamed to `AtprotoDidRefAbsolute`; the old name is retained as a deprecated alias.
+Add `AtprotoDidRefAbsolute`, `DidRefRelative` types and predicates. The legacy `AtprotoAudience` and `isAtprotoAudience` are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` / `isAtprotoDidRefAbsolute`.

--- a/.changeset/quiet-bridges-hum.md
+++ b/.changeset/quiet-bridges-hum.md
@@ -1,0 +1,5 @@
+---
+'@atproto/did': patch
+---
+
+Add `AtprotoDidRefAbsolute`, `DidRefRelative`, `AtprotoScopeAud`, and `AtprotoTokenAud` types and predicates. `AtprotoAudience` is renamed to `AtprotoDidRefAbsolute`; the old name is retained as a deprecated alias.

--- a/.changeset/quiet-bridges-hum.md
+++ b/.changeset/quiet-bridges-hum.md
@@ -2,4 +2,4 @@
 '@atproto/did': minor
 ---
 
-Add `AtprotoDidRefAbsolute`, `DidRefRelative` types and predicates. The legacy `AtprotoAudience` and `isAtprotoAudience` are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` / `isAtprotoDidRefAbsolute`.
+Add `DidRefAbsolute`, `DidRefRelative`, and `AtprotoDidRefAbsolute` types and predicates. The legacy `AtprotoAudience` and `isAtprotoAudience` are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` / `isAtprotoDidRefAbsolute`.

--- a/.changeset/quiet-bridges-hum.md
+++ b/.changeset/quiet-bridges-hum.md
@@ -2,4 +2,4 @@
 '@atproto/did': minor
 ---
 
-Add `DidRefAbsolute`, `DidRefRelative`, and `AtprotoDidRefAbsolute` types and predicates. The legacy `AtprotoAudience` and `isAtprotoAudience` are removed (breaking) — they are superseded by `AtprotoDidRefAbsolute` / `isAtprotoDidRefAbsolute`.
+**BREAKING:** Remove `AtprotoAudience` and `isAtprotoAudience`. They are superseded by `AtprotoDidRefAbsolute` and `isAtprotoDidRefAbsolute`. Adds the related `DidRefAbsolute` and `DidRefRelative` types and predicates.

--- a/.changeset/quiet-rivers-dance.md
+++ b/.changeset/quiet-rivers-dance.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+`getServiceAuth` now accepts the combined `did#serviceId` form for its `aud` parameter, in addition to the bare DID form.

--- a/lexicons/com/atproto/server/getServiceAuth.json
+++ b/lexicons/com/atproto/server/getServiceAuth.json
@@ -11,8 +11,8 @@
         "properties": {
           "aud": {
             "type": "string",
-            "maxLength": 1024,
-            "description": "The DID, or `did#serviceId` reference, of the service that the token will be used to authenticate with. Phase 1 accepts either form."
+            "maxLength": 2048,
+            "description": "The DID or `did#serviceId` reference of the service that the token will be used to authenticate with."
           },
           "exp": {
             "type": "integer",

--- a/lexicons/com/atproto/server/getServiceAuth.json
+++ b/lexicons/com/atproto/server/getServiceAuth.json
@@ -11,8 +11,8 @@
         "properties": {
           "aud": {
             "type": "string",
-            "format": "did",
-            "description": "The DID of the service that the token will be used to authenticate with"
+            "maxLength": 1024,
+            "description": "The DID, or `did#serviceId` reference, of the service that the token will be used to authenticate with. Phase 1 accepts either form."
           },
           "exp": {
             "type": "integer",

--- a/packages/did/src/atproto.ts
+++ b/packages/did/src/atproto.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { DidDocument, DidService } from './did-document.js'
 import { DidError, InvalidDidError } from './did-error.js'
 import { Did } from './did.js'
-import { canParse, isFragment } from './lib/uri.js'
+import { canParse } from './lib/uri.js'
 import {
   DID_PLC_PREFIX,
   DID_WEB_PREFIX,
@@ -115,16 +115,6 @@ function isDidWebWithHttpsPort(did: Did<'web'>): boolean {
   return hasPort
 }
 
-export type AtprotoAudience = `${AtprotoDid}#${string}`
-export const isAtprotoAudience = (value: unknown): value is AtprotoAudience => {
-  if (typeof value !== 'string') return false
-  const hashIndex = value.indexOf('#')
-  if (hashIndex === -1) return false
-  if (value.indexOf('#', hashIndex + 1) !== -1) return false
-  return (
-    isFragment(value, hashIndex + 1) && isAtprotoDid(value.slice(0, hashIndex))
-  )
-}
 
 export type AtprotoData<
   M extends AtprotoIdentityDidMethods = AtprotoIdentityDidMethods,

--- a/packages/did/src/atproto.ts
+++ b/packages/did/src/atproto.ts
@@ -115,7 +115,6 @@ function isDidWebWithHttpsPort(did: Did<'web'>): boolean {
   return hasPort
 }
 
-
 export type AtprotoData<
   M extends AtprotoIdentityDidMethods = AtprotoIdentityDidMethods,
 > = {

--- a/packages/did/src/atproto.ts
+++ b/packages/did/src/atproto.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { DidDocument, DidService } from './did-document.js'
 import { DidError, InvalidDidError } from './did-error.js'
+import { DidRefAbsolute, isDidRefAbsolute } from './did-ref.js'
 import { Did } from './did.js'
 import { canParse } from './lib/uri.js'
 import {
@@ -219,4 +220,16 @@ export function isAtprotoVerificationMethod<
     ) &&
     matchesIdentifier(this.id, 'atproto', method.id)
   )
+}
+
+/**
+ * An atproto-constrained absolute DID reference: `${AtprotoDid}#${fragment}`.
+ */
+export type AtprotoDidRefAbsolute = DidRefAbsolute<AtprotoIdentityDidMethods>
+
+export function isAtprotoDidRefAbsolute(
+  value: unknown,
+): value is AtprotoDidRefAbsolute {
+  if (!isDidRefAbsolute(value)) return false
+  return isAtprotoDid(value.slice(0, value.indexOf('#')))
 }

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -15,6 +15,7 @@ export const isAtprotoDidRefAbsolute = (
   if (typeof value !== 'string') return false
   const hashIndex = value.indexOf('#')
   if (hashIndex === -1) return false
+  if (hashIndex === value.length - 1) return false
   if (value.indexOf('#', hashIndex + 1) !== -1) return false
   return (
     isFragment(value, hashIndex + 1) &&

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -18,8 +18,7 @@ export const isAtprotoDidRefAbsolute = (
   if (hashIndex === value.length - 1) return false // empty fragment
   if (value.indexOf('#', hashIndex + 1) !== -1) return false // more than one '#'
   return (
-    isFragment(value, hashIndex + 1) &&
-    isAtprotoDid(value.slice(0, hashIndex))
+    isFragment(value, hashIndex + 1) && isAtprotoDid(value.slice(0, hashIndex))
   )
 }
 
@@ -57,6 +56,5 @@ export type AtprotoTokenAud = AtprotoDid | AtprotoDidRefAbsolute
 export type AtprotoAudience = AtprotoDidRefAbsolute
 
 /** @deprecated use {@link isAtprotoDidRefAbsolute}. */
-export const isAtprotoAudience: (
-  value: unknown,
-) => value is AtprotoAudience = isAtprotoDidRefAbsolute
+export const isAtprotoAudience: (value: unknown) => value is AtprotoAudience =
+  isAtprotoDidRefAbsolute

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -14,9 +14,9 @@ export const isAtprotoDidRefAbsolute = (
 ): value is AtprotoDidRefAbsolute => {
   if (typeof value !== 'string') return false
   const hashIndex = value.indexOf('#')
-  if (hashIndex === -1) return false
-  if (hashIndex === value.length - 1) return false
-  if (value.indexOf('#', hashIndex + 1) !== -1) return false
+  if (hashIndex === -1) return false // no '#'
+  if (hashIndex === value.length - 1) return false // empty fragment
+  if (value.indexOf('#', hashIndex + 1) !== -1) return false // more than one '#'
   return (
     isFragment(value, hashIndex + 1) &&
     isAtprotoDid(value.slice(0, hashIndex))
@@ -34,11 +34,11 @@ export function isDidRefRelative<I extends string = string>(
   id?: I,
 ): value is DidRefRelative<I> {
   if (typeof value !== 'string') return false
-  if (value.charCodeAt(0) !== 35 /* '#' */) return false
-  if (value.length < 2) return false
-  if (value.indexOf('#', 1) !== -1) return false
+  if (value.charCodeAt(0) !== 35 /* '#' */) return false // doesn't start with '#'
+  if (value.length < 2) return false // empty fragment
+  if (value.indexOf('#', 1) !== -1) return false // more than one '#'
   if (!isFragment(value, 1)) return false
-  if (id !== undefined && value !== `#${id}`) return false
+  if (id !== undefined && value !== `#${id}`) return false // id mismatch
   return true
 }
 

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -3,9 +3,6 @@ import { isFragment } from './lib/uri.js'
 
 /**
  * An atproto-constrained absolute DID reference: `${AtprotoDid}#${fragment}`.
- *
- * This is the same shape as the legacy `AtprotoAudience` type, kept under a
- * more accurate name now that the union is reused for non-audience contexts.
  */
 export type AtprotoDidRefAbsolute = `${AtprotoDid}#${string}`
 
@@ -40,21 +37,3 @@ export function isDidRefRelative<I extends string = string>(
   if (id !== undefined && value !== `#${id}`) return false // id mismatch
   return true
 }
-
-/**
- * The shape of `aud=...` values appearing in OAuth scopes — always combined.
- */
-export type AtprotoScopeAud = AtprotoDidRefAbsolute
-
-/**
- * The shape of `aud` claims in atproto service-auth JWTs — bare DID or
- * combined absolute reference. Phase 1 accepts both.
- */
-export type AtprotoTokenAud = AtprotoDid | AtprotoDidRefAbsolute
-
-/** @deprecated use {@link AtprotoScopeAud} or {@link AtprotoDidRefAbsolute}. */
-export type AtprotoAudience = AtprotoDidRefAbsolute
-
-/** @deprecated use {@link isAtprotoDidRefAbsolute}. */
-export const isAtprotoAudience: (value: unknown) => value is AtprotoAudience =
-  isAtprotoDidRefAbsolute

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -1,27 +1,25 @@
-import { AtprotoDid, isAtprotoDid } from './atproto.js'
+import { Did, isDid } from './did.js'
 import { isFragment } from './lib/uri.js'
 
 /**
- * An atproto-constrained absolute DID reference: `${AtprotoDid}#${fragment}`.
+ * An absolute DID reference: `${Did}#${fragment}`.
+ *
+ * @see {@link https://www.w3.org/TR/did-core/#did-url-syntax}
  */
-export type AtprotoDidRefAbsolute = `${AtprotoDid}#${string}`
+export type DidRefAbsolute<M extends string = string> = `${Did<M>}#${string}`
 
-export const isAtprotoDidRefAbsolute = (
-  value: unknown,
-): value is AtprotoDidRefAbsolute => {
+export const isDidRefAbsolute = (value: unknown): value is DidRefAbsolute => {
   if (typeof value !== 'string') return false
   const hashIndex = value.indexOf('#')
   if (hashIndex === -1) return false // no '#'
   if (hashIndex === value.length - 1) return false // empty fragment
   if (value.indexOf('#', hashIndex + 1) !== -1) return false // more than one '#'
-  return (
-    isFragment(value, hashIndex + 1) && isAtprotoDid(value.slice(0, hashIndex))
-  )
+  return isFragment(value, hashIndex + 1) && isDid(value.slice(0, hashIndex))
 }
 
 /**
- * A relative DID reference, e.g. `#atproto`. The optional `id` parameter
- * narrows the fragment.
+ * A relative DID reference (a `#fragment` resolved against the surrounding
+ * DID document's `id`). The optional `id` parameter narrows the fragment.
  */
 export type DidRefRelative<I extends string = string> = `#${I}`
 

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -1,0 +1,61 @@
+import { AtprotoDid, isAtprotoDid } from './atproto.js'
+import { isFragment } from './lib/uri.js'
+
+/**
+ * An atproto-constrained absolute DID reference: `${AtprotoDid}#${fragment}`.
+ *
+ * This is the same shape as the legacy `AtprotoAudience` type, kept under a
+ * more accurate name now that the union is reused for non-audience contexts.
+ */
+export type AtprotoDidRefAbsolute = `${AtprotoDid}#${string}`
+
+export const isAtprotoDidRefAbsolute = (
+  value: unknown,
+): value is AtprotoDidRefAbsolute => {
+  if (typeof value !== 'string') return false
+  const hashIndex = value.indexOf('#')
+  if (hashIndex === -1) return false
+  if (value.indexOf('#', hashIndex + 1) !== -1) return false
+  return (
+    isFragment(value, hashIndex + 1) &&
+    isAtprotoDid(value.slice(0, hashIndex))
+  )
+}
+
+/**
+ * A relative DID reference, e.g. `#atproto`. The optional `id` parameter
+ * narrows the fragment.
+ */
+export type DidRefRelative<I extends string = string> = `#${I}`
+
+export function isDidRefRelative<I extends string = string>(
+  value: unknown,
+  id?: I,
+): value is DidRefRelative<I> {
+  if (typeof value !== 'string') return false
+  if (value.charCodeAt(0) !== 35 /* '#' */) return false
+  if (value.length < 2) return false
+  if (value.indexOf('#', 1) !== -1) return false
+  if (!isFragment(value, 1)) return false
+  if (id !== undefined && value !== `#${id}`) return false
+  return true
+}
+
+/**
+ * The shape of `aud=...` values appearing in OAuth scopes — always combined.
+ */
+export type AtprotoScopeAud = AtprotoDidRefAbsolute
+
+/**
+ * The shape of `aud` claims in atproto service-auth JWTs — bare DID or
+ * combined absolute reference. Phase 1 accepts both.
+ */
+export type AtprotoTokenAud = AtprotoDid | AtprotoDidRefAbsolute
+
+/** @deprecated use {@link AtprotoScopeAud} or {@link AtprotoDidRefAbsolute}. */
+export type AtprotoAudience = AtprotoDidRefAbsolute
+
+/** @deprecated use {@link isAtprotoDidRefAbsolute}. */
+export const isAtprotoAudience: (
+  value: unknown,
+) => value is AtprotoAudience = isAtprotoDidRefAbsolute

--- a/packages/did/src/did-ref.ts
+++ b/packages/did/src/did-ref.ts
@@ -13,7 +13,7 @@ export const isDidRefAbsolute = (value: unknown): value is DidRefAbsolute => {
   const hashIndex = value.indexOf('#')
   if (hashIndex === -1) return false // no '#'
   if (hashIndex === value.length - 1) return false // empty fragment
-  if (value.indexOf('#', hashIndex + 1) !== -1) return false // more than one '#'
+  if (value.includes('#', hashIndex + 1)) return false // more than one '#'
   return isFragment(value, hashIndex + 1) && isDid(value.slice(0, hashIndex))
 }
 
@@ -30,7 +30,7 @@ export function isDidRefRelative<I extends string = string>(
   if (typeof value !== 'string') return false
   if (value.charCodeAt(0) !== 35 /* '#' */) return false // doesn't start with '#'
   if (value.length < 2) return false // empty fragment
-  if (value.indexOf('#', 1) !== -1) return false // more than one '#'
+  if (value.includes('#', 1)) return false // more than one '#'
   if (!isFragment(value, 1)) return false
   if (id !== undefined && value !== `#${id}`) return false // id mismatch
   return true

--- a/packages/did/src/index.ts
+++ b/packages/did/src/index.ts
@@ -1,6 +1,7 @@
 export * from './atproto.js'
 export * from './did-document.js'
 export * from './did-error.js'
+export * from './did-ref.js'
 export * from './did.js'
 export * from './methods.js'
 export * from './utils.js'

--- a/packages/did/tests/did-ref.test.ts
+++ b/packages/did/tests/did-ref.test.ts
@@ -1,9 +1,4 @@
-import {
-  AtprotoAudience,
-  isAtprotoAudience,
-  isAtprotoDidRefAbsolute,
-  isDidRefRelative,
-} from '../src/did-ref.js'
+import { isAtprotoDidRefAbsolute, isDidRefRelative } from '../src/did-ref.js'
 
 describe('isAtprotoDidRefAbsolute', () => {
   it('accepts well-formed absolute references', () => {
@@ -69,19 +64,5 @@ describe('isDidRefRelative', () => {
     expect(isDidRefRelative('#a#b')).toBe(false)
     expect(isDidRefRelative(null)).toBe(false)
     expect(isDidRefRelative(123)).toBe(false)
-  })
-})
-
-describe('AtprotoAudience deprecated alias', () => {
-  it('still type-checks as the same shape', () => {
-    const sample: AtprotoAudience = 'did:web:example.com#svc'
-    expect(isAtprotoAudience(sample)).toBe(true)
-  })
-
-  it('isAtprotoAudience matches isAtprotoDidRefAbsolute behavior', () => {
-    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj#atproto')).toBe(
-      true,
-    )
-    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj')).toBe(false)
   })
 })

--- a/packages/did/tests/did-ref.test.ts
+++ b/packages/did/tests/did-ref.test.ts
@@ -1,0 +1,80 @@
+import {
+  AtprotoAudience,
+  isAtprotoAudience,
+  isAtprotoDidRefAbsolute,
+  isDidRefRelative,
+} from '../src/did-ref.js'
+
+describe('isAtprotoDidRefAbsolute', () => {
+  it('accepts well-formed absolute references', () => {
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
+      .toBe(true)
+    expect(isAtprotoDidRefAbsolute('did:web:example.com#service_id'))
+      .toBe(true)
+    expect(isAtprotoDidRefAbsolute('did:web:example.com#atproto_label'))
+      .toBe(true)
+  })
+
+  it('rejects bare DIDs', () => {
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj'))
+      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:web:example.com')).toBe(false)
+  })
+
+  it('rejects relative references', () => {
+    expect(isAtprotoDidRefAbsolute('#atproto')).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(isAtprotoDidRefAbsolute('')).toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#'))
+      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj##foo'))
+      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#a#b'))
+      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:foo:bar#baz')).toBe(false)
+    expect(isAtprotoDidRefAbsolute(null)).toBe(false)
+    expect(isAtprotoDidRefAbsolute(123)).toBe(false)
+  })
+})
+
+describe('isDidRefRelative', () => {
+  it('accepts well-formed relative references', () => {
+    expect(isDidRefRelative('#atproto')).toBe(true)
+    expect(isDidRefRelative('#atproto_label')).toBe(true)
+    expect(isDidRefRelative('#a')).toBe(true)
+  })
+
+  it('narrows on a specific id when supplied', () => {
+    expect(isDidRefRelative('#atproto', 'atproto')).toBe(true)
+    expect(isDidRefRelative('#atproto_label', 'atproto')).toBe(false)
+  })
+
+  it('rejects absolute references and bare strings', () => {
+    expect(isDidRefRelative('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
+      .toBe(false)
+    expect(isDidRefRelative('atproto')).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(isDidRefRelative('')).toBe(false)
+    expect(isDidRefRelative('#')).toBe(false)
+    expect(isDidRefRelative('#a#b')).toBe(false)
+    expect(isDidRefRelative(null)).toBe(false)
+    expect(isDidRefRelative(123)).toBe(false)
+  })
+})
+
+describe('AtprotoAudience deprecated alias', () => {
+  it('still type-checks as the same shape', () => {
+    const sample: AtprotoAudience = 'did:web:example.com#svc'
+    expect(isAtprotoAudience(sample)).toBe(true)
+  })
+
+  it('isAtprotoAudience matches isAtprotoDidRefAbsolute behavior', () => {
+    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
+      .toBe(true)
+    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj')).toBe(false)
+  })
+})

--- a/packages/did/tests/did-ref.test.ts
+++ b/packages/did/tests/did-ref.test.ts
@@ -7,17 +7,19 @@ import {
 
 describe('isAtprotoDidRefAbsolute', () => {
   it('accepts well-formed absolute references', () => {
-    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
-      .toBe(true)
-    expect(isAtprotoDidRefAbsolute('did:web:example.com#service_id'))
-      .toBe(true)
-    expect(isAtprotoDidRefAbsolute('did:web:example.com#atproto_label'))
-      .toBe(true)
+    expect(
+      isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'),
+    ).toBe(true)
+    expect(isAtprotoDidRefAbsolute('did:web:example.com#service_id')).toBe(true)
+    expect(isAtprotoDidRefAbsolute('did:web:example.com#atproto_label')).toBe(
+      true,
+    )
   })
 
   it('rejects bare DIDs', () => {
-    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj'))
-      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj')).toBe(
+      false,
+    )
     expect(isAtprotoDidRefAbsolute('did:web:example.com')).toBe(false)
   })
 
@@ -27,12 +29,15 @@ describe('isAtprotoDidRefAbsolute', () => {
 
   it('rejects malformed input', () => {
     expect(isAtprotoDidRefAbsolute('')).toBe(false)
-    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#'))
-      .toBe(false)
-    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj##foo'))
-      .toBe(false)
-    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#a#b'))
-      .toBe(false)
+    expect(isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#')).toBe(
+      false,
+    )
+    expect(
+      isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj##foo'),
+    ).toBe(false)
+    expect(
+      isAtprotoDidRefAbsolute('did:plc:l3rouwludahu3ui3bt66mfvj#a#b'),
+    ).toBe(false)
     expect(isAtprotoDidRefAbsolute('did:foo:bar#baz')).toBe(false)
     expect(isAtprotoDidRefAbsolute(null)).toBe(false)
     expect(isAtprotoDidRefAbsolute(123)).toBe(false)
@@ -52,8 +57,9 @@ describe('isDidRefRelative', () => {
   })
 
   it('rejects absolute references and bare strings', () => {
-    expect(isDidRefRelative('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
-      .toBe(false)
+    expect(isDidRefRelative('did:plc:l3rouwludahu3ui3bt66mfvj#atproto')).toBe(
+      false,
+    )
     expect(isDidRefRelative('atproto')).toBe(false)
   })
 
@@ -73,8 +79,9 @@ describe('AtprotoAudience deprecated alias', () => {
   })
 
   it('isAtprotoAudience matches isAtprotoDidRefAbsolute behavior', () => {
-    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj#atproto'))
-      .toBe(true)
+    expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj#atproto')).toBe(
+      true,
+    )
     expect(isAtprotoAudience('did:plc:l3rouwludahu3ui3bt66mfvj')).toBe(false)
   })
 })

--- a/packages/did/tests/did-ref.test.ts
+++ b/packages/did/tests/did-ref.test.ts
@@ -1,4 +1,5 @@
-import { isAtprotoDidRefAbsolute, isDidRefRelative } from '../src/did-ref.js'
+import { isAtprotoDidRefAbsolute } from '../src/atproto.js'
+import { isDidRefRelative } from '../src/did-ref.js'
 
 describe('isAtprotoDidRefAbsolute', () => {
   it('accepts well-formed absolute references', () => {

--- a/packages/oauth/oauth-scopes/src/scope-permissions.test.ts
+++ b/packages/oauth/oauth-scopes/src/scope-permissions.test.ts
@@ -265,7 +265,7 @@ describe('ScopePermissions', () => {
     })
   })
 
-  describe('assertRpc combined-aud (issue #4850)', () => {
+  describe('assertRpc combined-aud', () => {
     it('allows did#serviceId aud when scope grants the same combined form', () => {
       const set = new ScopePermissions(
         'rpc:app.bsky.feed.getFeed?aud=did:web:example.com%23bsky_appview',

--- a/packages/oauth/oauth-scopes/src/scope-permissions.test.ts
+++ b/packages/oauth/oauth-scopes/src/scope-permissions.test.ts
@@ -264,4 +264,40 @@ describe('ScopePermissions', () => {
       ).toBe(false)
     })
   })
+
+  describe('assertRpc combined-aud (issue #4850)', () => {
+    it('allows did#serviceId aud when scope grants the same combined form', () => {
+      const set = new ScopePermissions(
+        'rpc:app.bsky.feed.getFeed?aud=did:web:example.com%23bsky_appview',
+      )
+      expect(() =>
+        set.assertRpc({
+          aud: 'did:web:example.com#bsky_appview',
+          lxm: 'app.bsky.feed.getFeed',
+        }),
+      ).not.toThrow()
+    })
+
+    it('rejects bare-DID aud when scope grants a combined form', () => {
+      const set = new ScopePermissions(
+        'rpc:app.bsky.feed.getFeed?aud=did:web:example.com%23bsky_appview',
+      )
+      expect(() =>
+        set.assertRpc({
+          aud: 'did:web:example.com',
+          lxm: 'app.bsky.feed.getFeed',
+        }),
+      ).toThrow()
+    })
+
+    it('allows wildcard aud against a combined-form match', () => {
+      const set = new ScopePermissions('rpc:app.bsky.feed.getFeed?aud=*')
+      expect(() =>
+        set.assertRpc({
+          aud: 'did:web:example.com#bsky_appview',
+          lxm: 'app.bsky.feed.getFeed',
+        }),
+      ).not.toThrow()
+    })
+  })
 })

--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
@@ -1,4 +1,3 @@
-import { AtprotoScopeAud, isAtprotoDidRefAbsolute } from '@atproto/did'
 import { LexiconPermission, LexiconPermissionSet } from '../lib/lexicon.js'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
@@ -11,7 +10,11 @@ import {
   isScopeSyntaxFor,
 } from '../lib/syntax.js'
 import { RepoPermission } from './repo-permission.js'
-import { RpcPermission } from './rpc-permission.js'
+import {
+  AtprotoDidRefAbsolute,
+  RpcPermission,
+  isAtprotoDidRefAbsolute,
+} from './rpc-permission.js'
 
 export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
 
@@ -23,7 +26,7 @@ export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
 export class IncludeScope {
   constructor(
     public readonly nsid: Nsid,
-    public readonly aud: undefined | AtprotoScopeAud = undefined,
+    public readonly aud: undefined | AtprotoDidRefAbsolute = undefined,
   ) {}
 
   toString() {

--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
@@ -1,4 +1,7 @@
-import { AtprotoAudience, isAtprotoAudience } from '@atproto/did'
+import {
+  AtprotoScopeAud,
+  isAtprotoDidRefAbsolute,
+} from '@atproto/did'
 import { LexiconPermission, LexiconPermissionSet } from '../lib/lexicon.js'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
@@ -23,7 +26,7 @@ export { type LexiconPermission, type LexiconPermissionSet, type Nsid, isNsid }
 export class IncludeScope {
   constructor(
     public readonly nsid: Nsid,
-    public readonly aud: undefined | AtprotoAudience = undefined,
+    public readonly aud: undefined | AtprotoScopeAud = undefined,
   ) {}
 
   toString() {
@@ -166,7 +169,7 @@ export class IncludeScope {
       aud: {
         multiple: false,
         required: false,
-        validate: isAtprotoAudience,
+        validate: isAtprotoDidRefAbsolute,
       },
     },
     'nsid',

--- a/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/include-scope.ts
@@ -1,7 +1,4 @@
-import {
-  AtprotoScopeAud,
-  isAtprotoDidRefAbsolute,
-} from '@atproto/did'
+import { AtprotoScopeAud, isAtprotoDidRefAbsolute } from '@atproto/did'
 import { LexiconPermission, LexiconPermissionSet } from '../lib/lexicon.js'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'

--- a/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
@@ -83,8 +83,8 @@ export class RpcPermission
 
   static scopeNeededFor(options: RpcPermissionMatch): string {
     return RpcPermission.parser.format({
-      aud: options.aud as AudParam,
-      lxm: [options.lxm as LxmParam],
+      aud: options.aud as AtprotoDidRefAbsolute,
+      lxm: [options.lxm as Nsid],
     })
   }
 }

--- a/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
@@ -1,18 +1,21 @@
-import { AtprotoAudience, isAtprotoAudience } from '@atproto/did'
+import {
+  AtprotoScopeAud,
+  isAtprotoDidRefAbsolute,
+} from '@atproto/did'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
 import { ResourcePermission } from '../lib/resource-permission.js'
 import { ScopeStringSyntax } from '../lib/syntax-string.js'
 import { NeRoArray, ScopeSyntax, isScopeStringFor } from '../lib/syntax.js'
 
-export { type AtprotoAudience, type Nsid, isAtprotoAudience, isNsid }
+export { type AtprotoScopeAud, type Nsid, isAtprotoDidRefAbsolute, isNsid }
 
 export type LxmParam = '*' | Nsid
 export const isLxmParam = (value: unknown): value is LxmParam =>
   value === '*' || isNsid(value)
-export type AudParam = '*' | AtprotoAudience
+export type AudParam = '*' | AtprotoScopeAud
 export const isAudParam = (value: unknown): value is AudParam =>
-  value === '*' || isAtprotoAudience(value)
+  value === '*' || isAtprotoDidRefAbsolute(value)
 
 export type RpcPermissionMatch = {
   lxm: string
@@ -23,7 +26,7 @@ export class RpcPermission
   implements ResourcePermission<'rpc', RpcPermissionMatch>
 {
   constructor(
-    public readonly aud: '*' | AtprotoAudience,
+    public readonly aud: '*' | AtprotoScopeAud,
     public readonly lxm: NeRoArray<'*' | Nsid>,
   ) {}
 
@@ -78,7 +81,7 @@ export class RpcPermission
 
   static scopeNeededFor(options: RpcPermissionMatch): string {
     return RpcPermission.parser.format({
-      aud: options.aud as AtprotoAudience,
+      aud: options.aud as AtprotoScopeAud,
       lxm: [options.lxm as Nsid],
     })
   }

--- a/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
@@ -1,16 +1,21 @@
-import { AtprotoScopeAud, isAtprotoDidRefAbsolute } from '@atproto/did'
+import { AtprotoDidRefAbsolute, isAtprotoDidRefAbsolute } from '@atproto/did'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
 import { ResourcePermission } from '../lib/resource-permission.js'
 import { ScopeStringSyntax } from '../lib/syntax-string.js'
 import { NeRoArray, ScopeSyntax, isScopeStringFor } from '../lib/syntax.js'
 
-export { type AtprotoScopeAud, type Nsid, isAtprotoDidRefAbsolute, isNsid }
+export {
+  type AtprotoDidRefAbsolute,
+  type Nsid,
+  isAtprotoDidRefAbsolute,
+  isNsid,
+}
 
 export type LxmParam = '*' | Nsid
 export const isLxmParam = (value: unknown): value is LxmParam =>
   value === '*' || isNsid(value)
-export type AudParam = '*' | AtprotoScopeAud
+export type AudParam = '*' | AtprotoDidRefAbsolute
 export const isAudParam = (value: unknown): value is AudParam =>
   value === '*' || isAtprotoDidRefAbsolute(value)
 
@@ -23,8 +28,8 @@ export class RpcPermission
   implements ResourcePermission<'rpc', RpcPermissionMatch>
 {
   constructor(
-    public readonly aud: '*' | AtprotoScopeAud,
-    public readonly lxm: NeRoArray<'*' | Nsid>,
+    public readonly aud: AudParam,
+    public readonly lxm: NeRoArray<LxmParam>,
   ) {}
 
   matches(options: RpcPermissionMatch) {
@@ -78,8 +83,8 @@ export class RpcPermission
 
   static scopeNeededFor(options: RpcPermissionMatch): string {
     return RpcPermission.parser.format({
-      aud: options.aud as AtprotoScopeAud,
-      lxm: [options.lxm as Nsid],
+      aud: options.aud as AudParam,
+      lxm: [options.lxm as LxmParam],
     })
   }
 }

--- a/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
+++ b/packages/oauth/oauth-scopes/src/scopes/rpc-permission.ts
@@ -1,7 +1,4 @@
-import {
-  AtprotoScopeAud,
-  isAtprotoDidRefAbsolute,
-} from '@atproto/did'
+import { AtprotoScopeAud, isAtprotoDidRefAbsolute } from '@atproto/did'
 import { Nsid, isNsid } from '../lib/nsid.js'
 import { Parser } from '../lib/parser.js'
 import { ResourcePermission } from '../lib/resource-permission.js'

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -39,6 +39,7 @@
     "@atproto/aws": "workspace:^",
     "@atproto/common": "workspace:^",
     "@atproto/crypto": "workspace:^",
+    "@atproto/did": "workspace:^",
     "@atproto/identity": "workspace:^",
     "@atproto/lex": "workspace:^",
     "@atproto/lex-cbor": "workspace:^",

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -2,7 +2,11 @@ import { Server } from '@atproto/xrpc-server'
 import { AuthScope, isAccessFull } from '../../../../auth-scope.js'
 import { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
-import { computeProxyTo, pipethrough } from '../../../../pipethrough.js'
+import {
+  bareDidFromProxyTo,
+  computeProxyTo,
+  pipethrough,
+} from '../../../../pipethrough.js'
 
 export default function (server: Server, ctx: AppContext) {
   const { bskyAppView } = ctx
@@ -13,8 +17,8 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.getPreferences.$lxm
-        const aud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud, lxm })
+        const scopeAud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud: scopeAud, lxm })
       },
     }),
     handler: async ({ auth, req }) => {
@@ -24,9 +28,14 @@ export default function (server: Server, ctx: AppContext) {
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = app.bsky.actor.getPreferences.$lxm
-      const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
-        return pipethrough(ctx, req, { iss: did, aud, lxm })
+      const scopeAud = computeProxyTo(ctx, req, lxm)
+      if (scopeAud !== `${bskyAppView.did}#bsky_appview`) {
+        // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
+        return pipethrough(ctx, req, {
+          iss: did,
+          aud: bareDidFromProxyTo(scopeAud),
+          lxm,
+        })
       }
 
       const hasAccessFull =

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -17,8 +17,8 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.getPreferences.$lxm
-        const scopeAud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud: scopeAud, lxm })
+        const aud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud, lxm })
       },
     }),
     handler: async ({ auth, req }) => {
@@ -28,12 +28,12 @@ export default function (server: Server, ctx: AppContext) {
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = app.bsky.actor.getPreferences.$lxm
-      const scopeAud = computeProxyTo(ctx, req, lxm)
-      if (scopeAud !== `${bskyAppView.did}#bsky_appview`) {
+      const aud = computeProxyTo(ctx, req, lxm)
+      if (aud !== `${bskyAppView.did}#bsky_appview`) {
         // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
         return pipethrough(ctx, req, {
           iss: did,
-          aud: bareDidFromProxyTo(scopeAud),
+          aud: bareDidFromProxyTo(aud),
           lxm,
         })
       }

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -3,7 +3,11 @@ import { AccountPreference } from '../../../../actor-store/preference/reader.js'
 import { isAccessFull } from '../../../../auth-scope.js'
 import { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
-import { computeProxyTo, pipethrough } from '../../../../pipethrough.js'
+import {
+  bareDidFromProxyTo,
+  computeProxyTo,
+  pipethrough,
+} from '../../../../pipethrough.js'
 
 export default function (server: Server, ctx: AppContext) {
   const { bskyAppView } = ctx
@@ -14,8 +18,8 @@ export default function (server: Server, ctx: AppContext) {
       checkTakedown: true,
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.putPreferences.$lxm
-        const aud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud, lxm })
+        const scopeAud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud: scopeAud, lxm })
       },
     }),
     handler: async ({ req, auth, input }) => {
@@ -25,9 +29,14 @@ export default function (server: Server, ctx: AppContext) {
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = app.bsky.actor.putPreferences.$lxm
-      const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
-        return pipethrough(ctx, req, { iss: did, aud, lxm })
+      const scopeAud = computeProxyTo(ctx, req, lxm)
+      if (scopeAud !== `${bskyAppView.did}#bsky_appview`) {
+        // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
+        return pipethrough(ctx, req, {
+          iss: did,
+          aud: bareDidFromProxyTo(scopeAud),
+          lxm,
+        })
       }
 
       const checkedPreferences: AccountPreference[] = []

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -18,8 +18,8 @@ export default function (server: Server, ctx: AppContext) {
       checkTakedown: true,
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.putPreferences.$lxm
-        const scopeAud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud: scopeAud, lxm })
+        const aud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud, lxm })
       },
     }),
     handler: async ({ req, auth, input }) => {
@@ -29,12 +29,12 @@ export default function (server: Server, ctx: AppContext) {
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
       const lxm = app.bsky.actor.putPreferences.$lxm
-      const scopeAud = computeProxyTo(ctx, req, lxm)
-      if (scopeAud !== `${bskyAppView.did}#bsky_appview`) {
+      const aud = computeProxyTo(ctx, req, lxm)
+      if (aud !== `${bskyAppView.did}#bsky_appview`) {
         // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
         return pipethrough(ctx, req, {
           iss: did,
-          aud: bareDidFromProxyTo(scopeAud),
+          aud: bareDidFromProxyTo(aud),
           lxm,
         })
       }

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -11,15 +11,12 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = com.atproto.moderation.createReport.$lxm
-        const scopeAud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud: scopeAud, lxm })
+        const aud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud, lxm })
       },
     }),
     handler: async ({ auth, params, input: { body }, req }) => {
-      // Phase 1 of service auth updates: scope check (in authorize, above)
-      // sees the combined did#serviceId form, the outbound service-auth JWT
-      // keeps bare-DID aud.
-      const { url, did: tokenAud } = await parseProxyInfo(
+      const { url, did: aud } = await parseProxyInfo(
         ctx,
         req,
         com.atproto.moderation.createReport.$lxm,
@@ -27,7 +24,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const { headers } = await ctx.serviceAuthHeaders(
         auth.credentials.did,
-        tokenAud,
+        aud,
         com.atproto.moderation.createReport.$lxm,
       )
 

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -11,12 +11,15 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = com.atproto.moderation.createReport.$lxm
-        const aud = computeProxyTo(ctx, req, lxm)
-        permissions.assertRpc({ aud, lxm })
+        const scopeAud = computeProxyTo(ctx, req, lxm)
+        permissions.assertRpc({ aud: scopeAud, lxm })
       },
     }),
     handler: async ({ auth, params, input: { body }, req }) => {
-      const { url, did: aud } = await parseProxyInfo(
+      // Phase 1 of service auth updates: scope check (in authorize, above)
+      // sees the combined did#serviceId form, the outbound service-auth JWT
+      // keeps bare-DID aud.
+      const { url, did: tokenAud } = await parseProxyInfo(
         ctx,
         req,
         com.atproto.moderation.createReport.$lxm,
@@ -24,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const { headers } = await ctx.serviceAuthHeaders(
         auth.credentials.did,
-        aud,
+        tokenAud,
         com.atproto.moderation.createReport.$lxm,
       )
 

--- a/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
@@ -26,11 +26,6 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { params }) => {
         const { aud, lxm = '*' } = params
-        if (!isAtprotoDid(aud) && !isAtprotoDidRefAbsolute(aud)) {
-          throw new InvalidRequestError(
-            'aud must be a valid atproto DID or did#serviceId reference',
-          )
-        }
         permissions.assertRpc({ aud, lxm })
       },
     }),
@@ -39,6 +34,12 @@ export default function (server: Server, ctx: AppContext) {
 
       // @NOTE "exp" is expressed in seconds since epoch, not milliseconds
       const { aud, exp, lxm = null } = params
+
+      if (!isAtprotoDid(aud) && !isAtprotoDidRefAbsolute(aud)) {
+        throw new InvalidRequestError(
+          'aud must be a valid atproto DID or did#serviceId reference',
+        )
+      }
 
       // Takendown accounts should not be able to generate service auth tokens except for methods necessary for account migration
       if (auth.credentials.type === 'access') {

--- a/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
+++ b/packages/pds/src/api/com/atproto/server/getServiceAuth.ts
@@ -1,4 +1,5 @@
 import { HOUR, MINUTE } from '@atproto/common'
+import { isAtprotoDid, isAtprotoDidRefAbsolute } from '@atproto/did'
 import { l } from '@atproto/lex'
 import {
   InvalidRequestError,
@@ -25,6 +26,11 @@ export default function (server: Server, ctx: AppContext) {
       additional: [AuthScope.Takendown],
       authorize: (permissions, { params }) => {
         const { aud, lxm = '*' } = params
+        if (!isAtprotoDid(aud) && !isAtprotoDidRefAbsolute(aud)) {
+          throw new InvalidRequestError(
+            'aud must be a valid atproto DID or did#serviceId reference',
+          )
+        }
         permissions.assertRpc({ aud, lxm })
       },
     }),

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -57,10 +57,10 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
       }
 
       const { url: origin, did, serviceId } = await parseProxyInfo(ctx, req, lxm)
-      // Phase 1 asymmetry: the scope check sees the combined did#serviceId
-      // form (so OAuth callers' rpc:?aud=did#service scopes match), while the
-      // outbound service-auth JWT keeps bare-DID aud regardless of session
-      // type. Slice D will introduce a config flag to flip the JWT side.
+      // Phase 1 of service auth updates: the scope check sees the combined
+      // did#serviceId form (so OAuth callers' rpc:?aud=did#service scopes
+      // match), while the outbound service-auth JWT keeps bare-DID aud
+      // regardless of session type.
       const scopeAud = `${did}#${serviceId}`
       const tokenAud = did
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -222,6 +222,13 @@ export function computeProxyTo(
   throw new InvalidRequestError(`No service configured for ${lxm}`)
 }
 
+// Bare-DID portion of `proxyTo`, suitable as a service-auth JWT audience
+// (Phase 1 of service auth updates).
+export function bareDidFromProxyTo(proxyTo: string): string {
+  const hashIndex = proxyTo.indexOf('#')
+  return hashIndex === -1 ? proxyTo : proxyTo.slice(0, hashIndex)
+}
+
 export async function parseProxyInfo(
   ctx: AppContext,
   req: Request,

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -57,9 +57,14 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
       }
 
       const { url: origin, did, serviceId } = await parseProxyInfo(ctx, req, lxm)
-      const aud = `${did}#${serviceId}`
+      // Phase 1 asymmetry: the scope check sees the combined did#serviceId
+      // form (so OAuth callers' rpc:?aud=did#service scopes match), while the
+      // outbound service-auth JWT keeps bare-DID aud regardless of session
+      // type. Slice D will introduce a config flag to flip the JWT side.
+      const scopeAud = `${did}#${serviceId}`
+      const tokenAud = did
 
-      const authResult = await performAuth({ req, res, params: { lxm, aud } })
+      const authResult = await performAuth({ req, res, params: { lxm, aud: scopeAud } })
 
       const { credentials } = excludeErrorResult(authResult)
 
@@ -81,11 +86,7 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         'content-encoding': body && req.headers['content-encoding'],
         'content-length': body && req.headers['content-length'],
 
-        // Phase 1: scope check uses the combined did#serviceId form (so
-        // OAuth callers' rpc:?aud=did#service scopes match); the outbound
-        // service-auth JWT keeps bare-DID aud regardless of session type.
-        // Slice D will introduce a config flag to flip the JWT side.
-        authorization: `Bearer ${await ctx.serviceAuthJwt(credentials.did, did, lxm)}`,
+        authorization: `Bearer ${await ctx.serviceAuthJwt(credentials.did, tokenAud, lxm)}`,
       }
 
       const dispatchOptions: Dispatcher.RequestOptions = {
@@ -161,8 +162,7 @@ export async function pipethrough(
 
   const lxm = parseReqNsid(req)
 
-  const { url: origin, did } = await parseProxyInfo(ctx, req, lxm)
-  const aud = did
+  const { url: origin, did: aud } = await parseProxyInfo(ctx, req, lxm)
 
   const dispatchOptions: Dispatcher.RequestOptions = {
     origin,

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -56,7 +56,8 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         throw new InvalidRequestError('Bad token method', 'InvalidToken')
       }
 
-      const { url: origin, did: aud } = await parseProxyInfo(ctx, req, lxm)
+      const { url: origin, did, serviceId } = await parseProxyInfo(ctx, req, lxm)
+      const aud = `${did}#${serviceId}`
 
       const authResult = await performAuth({ req, res, params: { lxm, aud } })
 
@@ -80,7 +81,11 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         'content-encoding': body && req.headers['content-encoding'],
         'content-length': body && req.headers['content-length'],
 
-        authorization: `Bearer ${await ctx.serviceAuthJwt(credentials.did, aud, lxm)}`,
+        // Phase 1: scope check uses the combined did#serviceId form (so
+        // OAuth callers' rpc:?aud=did#service scopes match); the outbound
+        // service-auth JWT keeps bare-DID aud regardless of session type.
+        // Slice D will introduce a config flag to flip the JWT side.
+        authorization: `Bearer ${await ctx.serviceAuthJwt(credentials.did, did, lxm)}`,
       }
 
       const dispatchOptions: Dispatcher.RequestOptions = {
@@ -156,7 +161,8 @@ export async function pipethrough(
 
   const lxm = parseReqNsid(req)
 
-  const { url: origin, did: aud } = await parseProxyInfo(ctx, req, lxm)
+  const { url: origin, did } = await parseProxyInfo(ctx, req, lxm)
+  const aud = did
 
   const dispatchOptions: Dispatcher.RequestOptions = {
     origin,
@@ -220,14 +226,14 @@ export async function parseProxyInfo(
   ctx: AppContext,
   req: Request,
   lxm: string,
-): Promise<{ url: string; did: string }> {
+): Promise<{ url: string; did: string; serviceId: string }> {
   // /!\ Hot path
 
   const proxyToHeader = req.header('atproto-proxy')
   if (proxyToHeader) return parseProxyHeader(ctx, proxyToHeader)
 
-  const { serviceInfo } = defaultService(ctx, lxm)
-  if (serviceInfo) return serviceInfo
+  const { serviceId, serviceInfo } = defaultService(ctx, lxm)
+  if (serviceInfo) return { ...serviceInfo, serviceId }
 
   throw new InvalidRequestError(`No service configured for ${lxm}`)
 }
@@ -236,7 +242,7 @@ export const parseProxyHeader = async (
   // Using subset of AppContext for testing purposes
   ctx: Pick<AppContext, 'cfg' | 'idResolver'>,
   proxyTo: string,
-): Promise<{ did: string; url: string }> => {
+): Promise<{ did: string; url: string; serviceId: string }> => {
   // /!\ Hot path
 
   const hashIndex = proxyTo.indexOf('#')
@@ -260,13 +266,14 @@ export const parseProxyHeader = async (
   }
 
   const did = proxyTo.slice(0, hashIndex)
+  const serviceId = proxyTo.slice(hashIndex + 1)
 
   // Special case a configured appview, while still proxying correctly any other appview
   if (
     ctx.cfg.bskyAppView &&
     proxyTo === `${ctx.cfg.bskyAppView.did}#bsky_appview`
   ) {
-    return { did, url: ctx.cfg.bskyAppView.url }
+    return { did, url: ctx.cfg.bskyAppView.url, serviceId }
   }
 
   const didDoc = await ctx.idResolver.did.resolve(did)
@@ -274,13 +281,12 @@ export const parseProxyHeader = async (
     throw new InvalidRequestError('could not resolve proxy did')
   }
 
-  const serviceId = proxyTo.slice(hashIndex)
-  const url = getServiceEndpoint(didDoc, { id: serviceId })
+  const url = getServiceEndpoint(didDoc, { id: `#${serviceId}` })
   if (!url) {
     throw new InvalidRequestError('could not resolve proxy did service url')
   }
 
-  return { did, url }
+  return { did, url, serviceId }
 }
 
 /**

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -56,7 +56,11 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         throw new InvalidRequestError('Bad token method', 'InvalidToken')
       }
 
-      const { url: origin, did, serviceId } = await parseProxyInfo(ctx, req, lxm)
+      const {
+        url: origin,
+        did,
+        serviceId,
+      } = await parseProxyInfo(ctx, req, lxm)
       // Phase 1 of service auth updates: the scope check sees the combined
       // did#serviceId form (so OAuth callers' rpc:?aud=did#service scopes
       // match), while the outbound service-auth JWT keeps bare-DID aud
@@ -64,7 +68,11 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
       const scopeAud = `${did}#${serviceId}`
       const tokenAud = did
 
-      const authResult = await performAuth({ req, res, params: { lxm, aud: scopeAud } })
+      const authResult = await performAuth({
+        req,
+        res,
+        params: { lxm, aud: scopeAud },
+      })
 
       const { credentials } = excludeErrorResult(authResult)
 

--- a/packages/pds/tests/app-passwords.test.ts
+++ b/packages/pds/tests/app-passwords.test.ts
@@ -115,7 +115,7 @@ describe('app_passwords', () => {
   it('restricts service auth token methods for non-privileged access tokens', async () => {
     const attemptCaseSensitive = appAgent.api.com.atproto.server.getServiceAuth(
       {
-        aud: 'did:example:test',
+        aud: network.pds.ctx.cfg.service.did,
         lxm: 'com.atproto.server.createAccount',
       },
     )
@@ -124,7 +124,7 @@ describe('app_passwords', () => {
     )
     const attemptCaseInsensitive =
       appAgent.api.com.atproto.server.getServiceAuth({
-        aud: 'did:example:test',
+        aud: network.pds.ctx.cfg.service.did,
         lxm: 'com.atproto.server.createaccount',
       })
     await expect(attemptCaseInsensitive).rejects.toThrow(
@@ -134,7 +134,7 @@ describe('app_passwords', () => {
 
   it('allows privileged service auth token scopes for privileged access tokens', async () => {
     await priviAgent.api.com.atproto.server.getServiceAuth({
-      aud: 'did:example:test',
+      aud: network.pds.ctx.cfg.service.did,
       lxm: 'com.atproto.server.createAccount',
     })
   })
@@ -165,7 +165,7 @@ describe('app_passwords', () => {
 
     // allows privileged app passwords or higher
     const priviAttempt = appAgent.api.com.atproto.server.getServiceAuth({
-      aud: 'did:example:test',
+      aud: network.pds.ctx.cfg.service.did,
       lxm: 'com.atproto.server.createAccount',
     })
     await expect(priviAttempt).rejects.toThrow(
@@ -211,7 +211,7 @@ describe('app_passwords', () => {
 
     // allows privileged app passwords or higher
     await priviAgent.api.com.atproto.server.getServiceAuth({
-      aud: 'did:example:test',
+      aud: network.pds.ctx.cfg.service.did,
     })
 
     // allows only full access auth

--- a/packages/pds/tests/get-service-auth.test.ts
+++ b/packages/pds/tests/get-service-auth.test.ts
@@ -1,0 +1,81 @@
+import * as jose from 'jose'
+import { AtpAgent } from '@atproto/api'
+import { TestNetworkNoAppView } from '@atproto/dev-env'
+
+describe('com.atproto.server.getServiceAuth', () => {
+  let network: TestNetworkNoAppView
+  let agent: AtpAgent
+  let aliceDid: string
+  let pdsDid: string
+
+  beforeAll(async () => {
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'get_service_auth',
+    })
+    pdsDid = network.pds.ctx.cfg.service.did
+    agent = network.pds.getAgent()
+    const session = await agent.createAccount({
+      handle: 'alice.test',
+      email: 'alice@test.com',
+      password: 'alice-pass',
+    })
+    aliceDid = session.data.did
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  it('issues a token whose aud matches a bare-DID input', async () => {
+    const res = await agent.api.com.atproto.server.getServiceAuth({
+      aud: pdsDid,
+      lxm: 'com.atproto.server.describeServer',
+    })
+    const decoded = jose.decodeJwt(res.data.token)
+    expect(decoded.aud).toBe(pdsDid)
+    expect(decoded.iss).toBe(aliceDid)
+    expect(decoded.lxm).toBe('com.atproto.server.describeServer')
+  })
+
+  it('issues a token whose aud matches a combined did#serviceId input', async () => {
+    const aud = `${pdsDid}#atproto_pds`
+    const res = await agent.api.com.atproto.server.getServiceAuth({
+      aud,
+      lxm: 'com.atproto.server.describeServer',
+    })
+    const decoded = jose.decodeJwt(res.data.token)
+    expect(decoded.aud).toBe(aud)
+    expect(decoded.iss).toBe(aliceDid)
+    expect(decoded.lxm).toBe('com.atproto.server.describeServer')
+  })
+
+  it('rejects malformed aud with InvalidRequest', async () => {
+    const attempt = agent.api.com.atproto.server.getServiceAuth({
+      aud: 'not-a-did',
+      lxm: 'com.atproto.server.describeServer',
+    })
+    await expect(attempt).rejects.toThrow(
+      /aud must be a valid atproto DID or did#serviceId reference/,
+    )
+  })
+
+  it('rejects an aud with a non-atproto DID method', async () => {
+    const attempt = agent.api.com.atproto.server.getServiceAuth({
+      aud: 'did:foo:bar',
+      lxm: 'com.atproto.server.describeServer',
+    })
+    await expect(attempt).rejects.toThrow(
+      /aud must be a valid atproto DID or did#serviceId reference/,
+    )
+  })
+
+  it('rejects an aud with empty fragment', async () => {
+    const attempt = agent.api.com.atproto.server.getServiceAuth({
+      aud: `${pdsDid}#`,
+      lxm: 'com.atproto.server.describeServer',
+    })
+    await expect(attempt).rejects.toThrow(
+      /aud must be a valid atproto DID or did#serviceId reference/,
+    )
+  })
+})

--- a/packages/pds/tests/proxied/proxy-header.test.ts
+++ b/packages/pds/tests/proxied/proxy-header.test.ts
@@ -77,6 +77,7 @@ describe('proxy header', () => {
     ).resolves.toEqual({
       did: proxyServer.did,
       url: proxyServer.url,
+      serviceId: 'atproto_test',
     })
   })
 

--- a/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
+++ b/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
@@ -1,0 +1,159 @@
+import { once } from 'node:events'
+import { AddressInfo } from 'node:net'
+import express from 'express'
+import { ScopePermissions, RpcPermissionMatch } from '@atproto/oauth-scopes'
+import { AppContext } from '../../src/context.js'
+import { proxyHandler } from '../../src/pipethrough.js'
+
+// Regression test for the OAuth service-proxying audience fix.
+//
+// Before the fix, proxyHandler passed a bare DID as `aud` to the rpc scope
+// check. An OAuth caller granted `rpc:<lxm>?aud=<did>#<serviceId>` (the
+// canonical scope shape used in atproto OAuth) had no way to match, so
+// proxied calls failed at the scope check. The fix combines the proxied
+// service id into the scope-check audience as `<did>#<serviceId>`.
+//
+// The test stubs only the AppContext fields proxyHandler depends on, so the
+// catchall runs without a full PDS network. It captures the `aud` that
+// reaches the authorize callback and asserts the combined form.
+
+describe('proxy oauth audience', () => {
+  let server: import('node:http').Server
+  let serverUrl: string
+  let lastAud: string | undefined
+
+  const proxyDid = 'did:web:example.com'
+  const serviceId = 'atproto_test'
+  const lxm = 'app.bsky.feed.getFeed'
+
+  beforeAll(async () => {
+    const ctx = makeStubCtx({
+      proxyDid,
+      serviceId,
+      onAud: (aud) => (lastAud = aud),
+    })
+
+    const app = express()
+    app.all('/xrpc/*', proxyHandler(ctx))
+
+    server = app.listen(0)
+    await once(server, 'listening')
+    serverUrl = `http://localhost:${(server.address() as AddressInfo).port}`
+  })
+
+  beforeEach(() => {
+    lastAud = undefined
+  })
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+
+  it('passes combined did#serviceId aud to the rpc scope check', async () => {
+    await fetch(`${serverUrl}/xrpc/${lxm}`, {
+      headers: {
+        'atproto-proxy': `${proxyDid}#${serviceId}`,
+        'x-test-scope': `rpc:${lxm}?aud=${encodeURIComponent(`${proxyDid}#${serviceId}`)}`,
+      },
+    })
+    expect(lastAud).toBe(`${proxyDid}#${serviceId}`)
+  })
+
+  it('matches an OAuth rpc scope granted with combined did#serviceId aud', async () => {
+    // Pre-fix this would have rejected because the scope check received
+    // bare-DID aud and never matched the combined-form scope.
+    const res = await fetch(`${serverUrl}/xrpc/${lxm}`, {
+      headers: {
+        'atproto-proxy': `${proxyDid}#${serviceId}`,
+        'x-test-scope': `rpc:${lxm}?aud=${encodeURIComponent(`${proxyDid}#${serviceId}`)}`,
+      },
+    })
+    // The stub fails the upstream fetch, but the scope check runs first;
+    // a 4xx here means the scope check threw before reaching the upstream.
+    // Anything else (including the upstream failure) means the scope check
+    // passed.
+    expect(res.status).not.toBe(401)
+    expect(res.status).not.toBe(403)
+  })
+
+  it('rejects an OAuth rpc scope granted with only bare-DID aud', async () => {
+    const res = await fetch(`${serverUrl}/xrpc/${lxm}`, {
+      headers: {
+        'atproto-proxy': `${proxyDid}#${serviceId}`,
+        'x-test-scope': `rpc:${lxm}?aud=${proxyDid}`,
+      },
+    })
+    expect([401, 403]).toContain(res.status)
+  })
+})
+
+// Stubs the minimal AppContext surface proxyHandler depends on: an
+// authVerifier that runs the authorize callback against a ScopePermissions
+// instance built from the `x-test-scope` header, an idResolver that returns
+// a DID document with the requested service endpoint, and stubs for the
+// JWT signer and config the handler reads. The proxyAgent is a tiny
+// undici-shaped object whose stream() always rejects; we only care that
+// the scope check ran and reported success or failure before that point.
+function makeStubCtx(opts: {
+  proxyDid: string
+  serviceId: string
+  onAud: (aud: string) => void
+}): AppContext {
+  const stubAuthVerifier = {
+    authorization<P extends { aud: string }>({
+      authorize,
+    }: {
+      authorize: (
+        permissions: ScopePermissions,
+        ctx: { params: P },
+      ) => Promise<void> | void
+    }) {
+      return async (ctx: { req: any; res: any; params: P }) => {
+        opts.onAud(ctx.params.aud)
+        const scopeHeader = ctx.req.headers['x-test-scope'] as
+          | string
+          | undefined
+        const permissions = new ScopePermissions(scopeHeader?.split(' ') ?? [])
+        await authorize(permissions, ctx)
+        return {
+          credentials: {
+            type: 'oauth' as const,
+            did: 'did:plc:abcdefghijklmnopqrstuvwx',
+            permissions,
+          },
+        }
+      }
+    },
+  }
+
+  const stubProxyAgent = {
+    stream: () => Promise.reject(new Error('stub upstream not connected')),
+    request: () => Promise.reject(new Error('stub upstream not connected')),
+  }
+
+  return {
+    authVerifier: stubAuthVerifier,
+    serviceAuthJwt: async () => 'stub.jwt.value',
+    idResolver: {
+      did: {
+        resolve: async () => ({
+          id: opts.proxyDid,
+          service: [
+            {
+              id: `#${opts.serviceId}`,
+              type: 'TestAtprotoService',
+              serviceEndpoint: `http://localhost:1`,
+            },
+          ],
+        }),
+      },
+    },
+    cfg: {
+      bskyAppView: undefined,
+      modService: undefined,
+      reportService: undefined,
+      proxy: { preferCompressed: false },
+    },
+    proxyAgent: stubProxyAgent,
+  } as unknown as AppContext
+}

--- a/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
+++ b/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
@@ -32,7 +32,6 @@ describe('proxy oauth audience', () => {
   let upstream: ProxyServer
   let server: http.Server
   let serverUrl: string
-  let lastAud: string | undefined
 
   beforeAll(async () => {
     network = await TestNetworkNoAppView.create({
@@ -55,10 +54,6 @@ describe('proxy oauth audience', () => {
     const stubAuthorization: typeof network.pds.ctx.authVerifier.authorization =
       ({ authorize }) => {
         return async (ctx) => {
-          // proxyHandler is the only caller in these tests, and it always
-          // passes RpcPermissionMatch params; read the aud defensively.
-          const params = ctx.params as unknown as { aud?: unknown }
-          if (typeof params.aud === 'string') lastAud = params.aud
           const scopeHeader = ctx.req.headers['x-test-scope'] as
             | string
             | undefined
@@ -98,29 +93,16 @@ describe('proxy oauth audience', () => {
     serverUrl = `http://localhost:${(server.address() as AddressInfo).port}`
   })
 
-  beforeEach(() => {
-    lastAud = undefined
-  })
-
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()))
     await upstream.close()
     await network.close()
   })
 
-  it('passes combined did#serviceId aud to the rpc scope check', async () => {
-    await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
-      headers: {
-        'atproto-proxy': `${upstream.did}#atproto_test`,
-        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${encodeURIComponent(`${upstream.did}#atproto_test`)}`,
-      },
-    })
-    expect(lastAud).toBe(`${upstream.did}#atproto_test`)
-  })
-
   it('matches an OAuth rpc scope granted with combined did#serviceId aud', async () => {
     // Pre-fix this would have rejected because the scope check received
-    // bare-DID aud and never matched the combined-form scope.
+    // bare-DID aud and never matched the combined-form scope. A 200 here
+    // implies the scope check ran with combined-form aud.
     const res = await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
       headers: {
         'atproto-proxy': `${upstream.did}#atproto_test`,
@@ -130,11 +112,14 @@ describe('proxy oauth audience', () => {
     expect(res.status).toBe(200)
   })
 
-  it('rejects an OAuth rpc scope granted with only bare-DID aud', async () => {
+  it('rejects an OAuth rpc scope granted for a different service id', async () => {
+    // Same DID, different service id — both forms parse as valid scope
+    // audiences, but the runtime aud (`upstream.did#atproto_test`) doesn't
+    // match the granted aud (`upstream.did#atproto_other`).
     const res = await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
       headers: {
         'atproto-proxy': `${upstream.did}#atproto_test`,
-        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${upstream.did}`,
+        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${encodeURIComponent(`${upstream.did}#atproto_other`)}`,
       },
     })
     expect([401, 403]).toContain(res.status)

--- a/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
+++ b/packages/pds/tests/proxied/proxy-oauth-aud.test.ts
@@ -1,7 +1,12 @@
 import { once } from 'node:events'
+import http from 'node:http'
 import { AddressInfo } from 'node:net'
+import * as plc from '@did-plc/lib'
 import express from 'express'
-import { ScopePermissions, RpcPermissionMatch } from '@atproto/oauth-scopes'
+import { Keypair } from '@atproto/crypto'
+import { SeedClient, TestNetworkNoAppView, usersSeed } from '@atproto/dev-env'
+import { ScopePermissions } from '@atproto/oauth-scopes'
+import { DidString } from '@atproto/syntax'
 import { AppContext } from '../../src/context.js'
 import { proxyHandler } from '../../src/pipethrough.js'
 
@@ -13,29 +18,81 @@ import { proxyHandler } from '../../src/pipethrough.js'
 // proxied calls failed at the scope check. The fix combines the proxied
 // service id into the scope-check audience as `<did>#<serviceId>`.
 //
-// The test stubs only the AppContext fields proxyHandler depends on, so the
-// catchall runs without a full PDS network. It captures the `aud` that
-// reaches the authorize callback and asserts the combined form.
+// We use a real PDS AppContext (so every field is real-typed). Only the
+// `authVerifier.authorization` method is replaced, with a thin stub that
+// drives the OAuth path off an `x-test-scope` request header — letting us
+// exercise the rpc scope check without minting a real OAuth token. A
+// separate express app mounts a fresh proxyHandler against the real ctx
+// and forwards to a real upstream ProxyServer.
 
 describe('proxy oauth audience', () => {
-  let server: import('node:http').Server
+  let network: TestNetworkNoAppView
+  let sc: SeedClient
+  let alice: string
+  let upstream: ProxyServer
+  let server: http.Server
   let serverUrl: string
   let lastAud: string | undefined
 
-  const proxyDid = 'did:web:example.com'
-  const serviceId = 'atproto_test'
-  const lxm = 'app.bsky.feed.getFeed'
-
   beforeAll(async () => {
-    const ctx = makeStubCtx({
-      proxyDid,
-      serviceId,
-      onAud: (aud) => (lastAud = aud),
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'proxy_oauth_aud',
     })
+    sc = network.getSeedClient()
+    await usersSeed(sc)
+    alice = sc.dids.alice
+    upstream = await ProxyServer.create(
+      network.pds.ctx.plcClient,
+      network.pds.ctx.plcRotationKey,
+      'atproto_test',
+    )
+
+    // Replace only the `authorization` method on the real AuthVerifier so
+    // every other ctx field stays real and real-typed. The override's
+    // signature is constrained by AuthVerifier['authorization']: an OAuth
+    // shape change in the real verifier breaks the body of this stub at
+    // compile time.
+    const stubAuthorization: typeof network.pds.ctx.authVerifier.authorization =
+      ({ authorize }) => {
+        return async (ctx) => {
+          // proxyHandler is the only caller in these tests, and it always
+          // passes RpcPermissionMatch params; read the aud defensively.
+          const params = ctx.params as unknown as { aud?: unknown }
+          if (typeof params.aud === 'string') lastAud = params.aud
+          const scopeHeader = ctx.req.headers['x-test-scope'] as
+            | string
+            | undefined
+          const permissions = new ScopePermissions(
+            scopeHeader?.split(' ') ?? [],
+          )
+          await authorize(permissions, ctx)
+          return {
+            credentials: {
+              type: 'oauth',
+              did: alice as DidString,
+              permissions,
+            },
+          }
+        }
+      }
+    network.pds.ctx.authVerifier.authorization = stubAuthorization
 
     const app = express()
-    app.all('/xrpc/*', proxyHandler(ctx))
-
+    // dev-env exports AppContext from its built dist/, while we import
+    // proxyHandler from src/. Cast at this boundary to bridge the two
+    // identical shapes; downstream behavior is real.
+    app.all('/xrpc/*', proxyHandler(network.pds.ctx as unknown as AppContext))
+    app.use(
+      (
+        err: Error & { status?: number; statusCode?: number },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        if (res.headersSent) return
+        res.status(err.status ?? err.statusCode ?? 500).end()
+      },
+    )
     server = app.listen(0)
     await once(server, 'listening')
     serverUrl = `http://localhost:${(server.address() as AddressInfo).port}`
@@ -47,113 +104,87 @@ describe('proxy oauth audience', () => {
 
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()))
+    await upstream.close()
+    await network.close()
   })
 
   it('passes combined did#serviceId aud to the rpc scope check', async () => {
-    await fetch(`${serverUrl}/xrpc/${lxm}`, {
+    await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
       headers: {
-        'atproto-proxy': `${proxyDid}#${serviceId}`,
-        'x-test-scope': `rpc:${lxm}?aud=${encodeURIComponent(`${proxyDid}#${serviceId}`)}`,
+        'atproto-proxy': `${upstream.did}#atproto_test`,
+        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${encodeURIComponent(`${upstream.did}#atproto_test`)}`,
       },
     })
-    expect(lastAud).toBe(`${proxyDid}#${serviceId}`)
+    expect(lastAud).toBe(`${upstream.did}#atproto_test`)
   })
 
   it('matches an OAuth rpc scope granted with combined did#serviceId aud', async () => {
     // Pre-fix this would have rejected because the scope check received
     // bare-DID aud and never matched the combined-form scope.
-    const res = await fetch(`${serverUrl}/xrpc/${lxm}`, {
+    const res = await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
       headers: {
-        'atproto-proxy': `${proxyDid}#${serviceId}`,
-        'x-test-scope': `rpc:${lxm}?aud=${encodeURIComponent(`${proxyDid}#${serviceId}`)}`,
+        'atproto-proxy': `${upstream.did}#atproto_test`,
+        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${encodeURIComponent(`${upstream.did}#atproto_test`)}`,
       },
     })
-    // The stub fails the upstream fetch, but the scope check runs first;
-    // a 4xx here means the scope check threw before reaching the upstream.
-    // Anything else (including the upstream failure) means the scope check
-    // passed.
-    expect(res.status).not.toBe(401)
-    expect(res.status).not.toBe(403)
+    expect(res.status).toBe(200)
   })
 
   it('rejects an OAuth rpc scope granted with only bare-DID aud', async () => {
-    const res = await fetch(`${serverUrl}/xrpc/${lxm}`, {
+    const res = await fetch(`${serverUrl}/xrpc/app.bsky.feed.getFeed`, {
       headers: {
-        'atproto-proxy': `${proxyDid}#${serviceId}`,
-        'x-test-scope': `rpc:${lxm}?aud=${proxyDid}`,
+        'atproto-proxy': `${upstream.did}#atproto_test`,
+        'x-test-scope': `rpc:app.bsky.feed.getFeed?aud=${upstream.did}`,
       },
     })
     expect([401, 403]).toContain(res.status)
   })
 })
 
-// Stubs the minimal AppContext surface proxyHandler depends on: an
-// authVerifier that runs the authorize callback against a ScopePermissions
-// instance built from the `x-test-scope` header, an idResolver that returns
-// a DID document with the requested service endpoint, and stubs for the
-// JWT signer and config the handler reads. The proxyAgent is a tiny
-// undici-shaped object whose stream() always rejects; we only care that
-// the scope check ran and reported success or failure before that point.
-function makeStubCtx(opts: {
-  proxyDid: string
-  serviceId: string
-  onAud: (aud: string) => void
-}): AppContext {
-  const stubAuthVerifier = {
-    authorization<P extends { aud: string }>({
-      authorize,
-    }: {
-      authorize: (
-        permissions: ScopePermissions,
-        ctx: { params: P },
-      ) => Promise<void> | void
-    }) {
-      return async (ctx: { req: any; res: any; params: P }) => {
-        opts.onAud(ctx.params.aud)
-        const scopeHeader = ctx.req.headers['x-test-scope'] as
-          | string
-          | undefined
-        const permissions = new ScopePermissions(scopeHeader?.split(' ') ?? [])
-        await authorize(permissions, ctx)
-        return {
-          credentials: {
-            type: 'oauth' as const,
-            did: 'did:plc:abcdefghijklmnopqrstuvwx',
-            permissions,
+class ProxyServer {
+  constructor(
+    public server: http.Server,
+    public url: string,
+    public did: string,
+  ) {}
+
+  static async create(
+    plcClient: plc.Client,
+    keypair: Keypair,
+    serviceId: string,
+  ): Promise<ProxyServer> {
+    const app = express()
+    app.all('*', (_req, res) => res.sendStatus(200))
+
+    const server = app.listen(0)
+    await once(server, 'listening')
+
+    const { port } = server.address() as AddressInfo
+    const url = `http://localhost:${port}`
+    const plcOp = await plc.signOperation(
+      {
+        type: 'plc_operation',
+        rotationKeys: [keypair.did()],
+        alsoKnownAs: [],
+        verificationMethods: {},
+        services: {
+          [serviceId]: {
+            type: 'TestAtprotoService',
+            endpoint: url,
           },
-        }
-      }
-    },
-  }
-
-  const stubProxyAgent = {
-    stream: () => Promise.reject(new Error('stub upstream not connected')),
-    request: () => Promise.reject(new Error('stub upstream not connected')),
-  }
-
-  return {
-    authVerifier: stubAuthVerifier,
-    serviceAuthJwt: async () => 'stub.jwt.value',
-    idResolver: {
-      did: {
-        resolve: async () => ({
-          id: opts.proxyDid,
-          service: [
-            {
-              id: `#${opts.serviceId}`,
-              type: 'TestAtprotoService',
-              serviceEndpoint: `http://localhost:1`,
-            },
-          ],
-        }),
+        },
+        prev: null,
       },
-    },
-    cfg: {
-      bskyAppView: undefined,
-      modService: undefined,
-      reportService: undefined,
-      proxy: { preferCompressed: false },
-    },
-    proxyAgent: stubProxyAgent,
-  } as unknown as AppContext
+      keypair,
+    )
+    const did = await plc.didForCreateOp(plcOp)
+    await plcClient.sendOperation(did, plcOp)
+    return new ProxyServer(server, url, did)
+  }
+
+  close(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.server.close(() => resolve())
+    })
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1786,6 +1786,9 @@ importers:
       '@atproto/crypto':
         specifier: workspace:^
         version: link:../crypto
+      '@atproto/did':
+        specifier: workspace:^
+        version: link:../did
       '@atproto/identity':
         specifier: workspace:^
         version: link:../identity


### PR DESCRIPTION
Implements the first chunk of phase 1 of the [Service Auth Audience Revised proposal](https://github.com/bluesky-social/proposals/blob/main/0014-service-auth-revised/README.md) and resolves #4850.

OAuth scopes for service-proxying use `rpc:<lxm>?aud=<did>#<serviceId>`, where `aud` has the combined form including a `serviceId`. The PDS scope check was passing the _bare DID_ `<did>` as `aud`, so no granted scope ever matched and proxied calls failed for OAuth callers.

This PR aligns the scope-check audience to combined `did#serviceId` form across the relevant PDS code paths. Note that **service-auth JWT audiences are unchanged** — they continue to use bare DID, matching what receivers expect today. This asymmetry is deliberate in phase 1 and documented inline.

As part of this phase the `com.atproto.server.getServiceAuth` lexicon was also loosened to permit `aud` with the combined `did#serviceId` form.  OAuth callers can now request tokens with combined `aud` in line with their `rpc:<lxm>?aud=<did>#<serviceId>` permissions.

A future config flag (phase 2 of [the proposal](https://github.com/bluesky-social/proposals/blob/main/0014-service-auth-revised/README.md)) will allow flipping the proxy-path JWT `aud` to the combined form.

Along the way `@atproto/did` gained a couple new types: `AtprotoDidRefAbsolute` (renamed from `AtprotoAudience`, deprecated alias retained) e.g. `'did:web:api.bsky.app#bsky_appview'`; and `DidRefRelative` e.g. `'#atproto'` with an optional id-narrowing parameter (sets up `kid`-based signing-key resolution for the next part of phase 1).  `@atproto/oauth-scopes` migrated to the new canonical names.