### PR TITLE
Improve Standard Site validation 

### DIFF
--- a/.changeset/smart-grapes-march.md
+++ b/.changeset/smart-grapes-march.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Update Standard Site validation to fix path resolution

--- a/packages/bsky/src/logger.ts
+++ b/packages/bsky/src/logger.ts
@@ -19,6 +19,8 @@ export const dataplaneLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky:dp')
 export const ageAssuranceLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky:aa')
+export const viewsLogger: ReturnType<typeof subsystemLogger> =
+  subsystemLogger('bsky:views')
 export const httpLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky')
 

--- a/packages/bsky/src/util/standard-site.test.ts
+++ b/packages/bsky/src/util/standard-site.test.ts
@@ -262,9 +262,9 @@ describe(validateStandardSiteForUrl, () => {
         const doc = makeDoc(
           path === undefined ? { site: baseUrl } : { site: baseUrl, path },
         )
-        expect(
-          validateStandardSiteForUrl(doc, undefined, assumedUrl),
-        ).toBe(expected)
+        expect(validateStandardSiteForUrl(doc, undefined, assumedUrl)).toBe(
+          expected,
+        )
       })
     }
   })

--- a/packages/bsky/src/util/standard-site.test.ts
+++ b/packages/bsky/src/util/standard-site.test.ts
@@ -158,29 +158,114 @@ describe(validateStandardSiteForUrl, () => {
     }
   })
 
-  describe('publication.url variants', () => {
-    it('accepts when publication.url has trailing slash', () => {
-      const doc = makeDoc({ site: pubUri, path: '/posts/hello' })
-      const pub = makePub({ url: 'https://example.com/' })
-      expect(
-        validateStandardSiteForUrl(doc, pub, 'https://example.com/posts/hello'),
-      ).toBe(true)
-    })
-
-    it('accepts when document.path lacks a leading slash', () => {
-      const doc = makeDoc({ site: pubUri, path: 'posts/hello' })
-      const pub = makePub({ url: 'https://example.com/' })
-      expect(
-        validateStandardSiteForUrl(doc, pub, 'https://example.com/posts/hello'),
-      ).toBe(true)
-    })
-
-    it('handles publication.url with sub-path and document.path joining onto it', () => {
-      const doc = makeDoc({ site: pubUri, path: 'hello' })
-      const pub = makePub({ url: 'https://example.com/blog/' })
-      expect(
-        validateStandardSiteForUrl(doc, pub, 'https://example.com/blog/hello'),
-      ).toBe(true)
-    })
+  describe('path joining (root domain × subpath × slash placement)', () => {
+    // Real-world example that originally broke:
+    //   pub.url:  'https://atproto.com/blog'
+    //   doc.path: '/indexing-standard-site'
+    //   expected: 'https://atproto.com/blog/indexing-standard-site'
+    // `new URL('/indexing-standard-site', 'https://atproto.com/blog')` would
+    // resolve to 'https://atproto.com/indexing-standard-site' (the leading
+    // slash on path swallows the base's pathname under WHATWG semantics) —
+    // we want path-append, not relative resolution.
+    for (const { note, baseUrl, path, assumedUrl, expected } of [
+      // Root-domain base, all four slash combinations.
+      {
+        note: 'root base, base/, path/',
+        baseUrl: 'https://example.com/',
+        path: '/posts/hello',
+        assumedUrl: 'https://example.com/posts/hello',
+        expected: true,
+      },
+      {
+        note: 'root base, base/, path-no-slash',
+        baseUrl: 'https://example.com/',
+        path: 'posts/hello',
+        assumedUrl: 'https://example.com/posts/hello',
+        expected: true,
+      },
+      {
+        note: 'root base, base-no-slash, path/',
+        baseUrl: 'https://example.com',
+        path: '/posts/hello',
+        assumedUrl: 'https://example.com/posts/hello',
+        expected: true,
+      },
+      {
+        note: 'root base, base-no-slash, path-no-slash',
+        baseUrl: 'https://example.com',
+        path: 'posts/hello',
+        assumedUrl: 'https://example.com/posts/hello',
+        expected: true,
+      },
+      // Subpath base, all four slash combinations (the regression case).
+      {
+        note: 'subpath base, base/, path/',
+        baseUrl: 'https://atproto.com/blog/',
+        path: '/indexing-standard-site',
+        assumedUrl: 'https://atproto.com/blog/indexing-standard-site',
+        expected: true,
+      },
+      {
+        note: 'subpath base, base/, path-no-slash',
+        baseUrl: 'https://atproto.com/blog/',
+        path: 'indexing-standard-site',
+        assumedUrl: 'https://atproto.com/blog/indexing-standard-site',
+        expected: true,
+      },
+      {
+        note: 'subpath base, base-no-slash, path/ (regression)',
+        baseUrl: 'https://atproto.com/blog',
+        path: '/indexing-standard-site',
+        assumedUrl: 'https://atproto.com/blog/indexing-standard-site',
+        expected: true,
+      },
+      {
+        note: 'subpath base, base-no-slash, path-no-slash',
+        baseUrl: 'https://atproto.com/blog',
+        path: 'indexing-standard-site',
+        assumedUrl: 'https://atproto.com/blog/indexing-standard-site',
+        expected: true,
+      },
+      // Empty path: assumedUrl should equal the base.
+      {
+        note: 'empty path, root base, no trailing slash',
+        baseUrl: 'https://example.com',
+        path: undefined,
+        assumedUrl: 'https://example.com',
+        expected: true,
+      },
+      {
+        note: 'empty path, subpath base, with trailing slash',
+        baseUrl: 'https://atproto.com/blog/',
+        path: undefined,
+        assumedUrl: 'https://atproto.com/blog',
+        expected: true,
+      },
+      // Negative: subpath base with assumedUrl that lost the subpath
+      // (what `new URL`'s relative resolution would have produced).
+      {
+        note: 'rejects when assumed URL drops the subpath',
+        baseUrl: 'https://atproto.com/blog',
+        path: '/indexing-standard-site',
+        assumedUrl: 'https://atproto.com/indexing-standard-site',
+        expected: false,
+      },
+    ]) {
+      it(`doc + pub: ${note}`, () => {
+        const doc = makeDoc(
+          path === undefined ? { site: pubUri } : { site: pubUri, path },
+        )
+        const pub = makePub({ url: baseUrl })
+        expect(validateStandardSiteForUrl(doc, pub, assumedUrl)).toBe(expected)
+      })
+      it(`loose doc: ${note}`, () => {
+        const doc = makeDoc(
+          path === undefined ? { site: baseUrl } : { site: baseUrl, path },
+        )
+        expect(
+          validateStandardSiteForUrl(doc, undefined, assumedUrl),
+        ).toBe(expected)
+      })
+    }
   })
 })

--- a/packages/bsky/src/util/standard-site.ts
+++ b/packages/bsky/src/util/standard-site.ts
@@ -27,10 +27,10 @@ export const parseSiteStandardRecordKey = (
  * strips a trailing slash from the path, and drops query/fragment. Returns
  * `null` when the input isn't a valid HTTP(S) URL.
  */
-const canonicalizeHttpUrl = (url: string, base?: string): string | null => {
+const canonicalizeHttpUrl = (url: string): string | null => {
   let parsed: URL
   try {
-    parsed = new URL(url, base)
+    parsed = new URL(url)
   } catch {
     return null
   }
@@ -40,11 +40,32 @@ const canonicalizeHttpUrl = (url: string, base?: string): string | null => {
 }
 
 /**
- * Confirm that the supplied SS records actually back `assumedUrl`. URL
- * comparison parses both sides via the WHATWG URL constructor (resolving
- * the document's `path` against the publication or site as a base) and
- * compares the canonical `protocol://host/path` forms — host case is
- * ignored, query/fragment are dropped, trailing slashes stripped.
+ * Append `path` to `base` with exactly one slash between, or return `base`
+ * unchanged when `path` is empty. Unlike `new URL(path, base)`, a leading
+ * slash on `path` does NOT swallow `base`'s pathname — so
+ * `joinPath('https://x.com/blog', '/foo')` is `https://x.com/blog/foo`,
+ * not `https://x.com/foo`.
+ */
+const joinPath = (base: string, path: string): string => {
+  if (!path) return base
+  const baseTrimmed = base.endsWith('/') ? base.slice(0, -1) : base
+  const pathTrimmed = path.startsWith('/') ? path.slice(1) : path
+  return `${baseTrimmed}/${pathTrimmed}`
+}
+
+/**
+ * Confirm that the supplied SS records actually back `assumedUrl`. The
+ * record-side URL is built by concatenating the publication URL (or the
+ * loose-doc site) with the document's `path` field, then both sides are
+ * canonicalized for equality: lowercase host, query/fragment dropped,
+ * trailing slash stripped.
+ *
+ * Path concatenation is `base + '/' + path` semantics — a leading `/` on
+ * `path` does NOT swallow the base's pathname (the way
+ * `new URL(path, base)` would). So
+ * `'https://atproto.com/blog' + '/indexing-standard-site'` resolves to
+ * `https://atproto.com/blog/indexing-standard-site` regardless of which
+ * side carries the slash.
  *
  * Structural validation of the doc/pub pair (matching `site` ↔ pub URI,
  * no orphan docs that claim a missing publication) happens upstream in
@@ -81,15 +102,13 @@ export const validateStandardSiteForUrl = (
 
   if (document && publication) {
     const joined = canonicalizeHttpUrl(
-      document.info.record.path ?? '',
-      publication.info.record.url,
+      joinPath(publication.info.record.url, document.info.record.path ?? ''),
     )
     return joined === canonicalAssumed
   }
   if (document) {
     const joined = canonicalizeHttpUrl(
-      document.info.record.path ?? '',
-      document.info.record.site,
+      joinPath(document.info.record.site, document.info.record.path ?? ''),
     )
     return joined === canonicalAssumed
   }

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -28,6 +28,7 @@ import { Label } from '../hydration/label.js'
 import { RecordInfo, parseString } from '../hydration/util.js'
 import { ImageUriBuilder } from '../image/uri.js'
 import { app, site } from '../lexicons/index.js'
+import { viewsLogger } from '../logger.js'
 import { Notification } from '../proto/bsky_pb.js'
 import {
   estimateReadingTimeMinutes,
@@ -2246,6 +2247,13 @@ export class Views {
     // bare embed rather than render partial / disagreeing enrichment.
     if (!document && !publication) return undefined
     if (!validateStandardSiteForUrl(document, publication, assumedUrl)) {
+      viewsLogger.warn(
+        {
+          documentUri: document?.ref.uri,
+          publicationUri: publication?.ref.uri,
+        },
+        'SS record(s) failed URL validation for external embed',
+      )
       return undefined
     }
 


### PR DESCRIPTION
Adds a log to help us debug as we roll this out, and fixes a case where subpaths on `publication.url` were getting dropped.