### PR TITLE
OAuth UI: fix sign-up username max length on long PDS service domains

### DIFF
--- a/.changeset/quiet-handles-fit.md
+++ b/.changeset/quiet-handles-fit.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Fix sign-up handle form to allow usernames up to 18 characters regardless of the service domain length

--- a/packages/oauth/oauth-provider-ui/src/components/sign-up-handle-form.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/sign-up-handle-form.tsx
@@ -10,7 +10,6 @@ import {
 import { InputText } from '#/components/forms/input-text.tsx'
 import { Admonition } from '#/components/utils/admonition.tsx'
 import {
-  MAX_FULL_LENGTH,
   MAX_LENGTH,
   MIN_LENGTH,
   ValidDomain,
@@ -19,9 +18,9 @@ import {
 import { mergeRefs } from '#/lib/ref.ts'
 import { Override } from '#/lib/util.ts'
 
-function useSegmentValidator(domain: ValidDomain) {
+function useSegmentValidator() {
   const minLen = MIN_LENGTH
-  const maxLen = Math.min(MAX_LENGTH, MAX_FULL_LENGTH - domain.length)
+  const maxLen = MAX_LENGTH
 
   const validateSegment = useCallback(
     (segment: string) => {
@@ -95,7 +94,7 @@ export function SignUpHandleForm({
 
   const domain: ValidDomain | null = domains[domainIdx] || domains[0] || null
 
-  const { minLength, maxLength, validateSegment } = useSegmentValidator(domain)
+  const { minLength, maxLength, validateSegment } = useSegmentValidator()
 
   const validity = validateSegment(segment)
   const handle = domain && validity.valid ? `${segment}${domain}` : undefined


### PR DESCRIPTION
> [!NOTE]
Message from the human: I did use AI as I am not completely familiar with typescript and such. I do am a seasoned dev/sysadmin/chief software crafting officer™️ with deployed PDSes and active development of an at proto mobile multiplatform application (see a little bit down this pr for screenshots). 
The patche code was built locally with success via `pnpm --filter @atproto/oauth-provider-ui... build`

> [!IMPORTANT]
Our use case is that for now we use a public OAuth client and this issue is almost blocking for us to release (our domain name [tempomusic.social](https://tempomusic.social/) limits our usernames to 12 characters). That being said 12 is a good start so we can manage for a while as well.

[The fixed issue was originally raised on the project Discord](https://discord.com/channels/1097580399187738645/1362879435002347815/1497637750185398524)

Now to the proof read dreaming 🤖 output -->

## Description

Fixes #4886.

The `SignUpHandleForm` component clamps the username max length to `MAX_FULL_LENGTH - domain.length`, reflecting an obsolete 30-character total cap on the handle. The reference PDS dropped that constraint in #2410 and now only enforces an 18-character cap on the username segment (the `front` in `ensureHandleServiceConstraints`). The overall handle length is only constrained by the 253-character spec limit, enforced upstream in `@atproto/syntax`.

When the configured service domain is long enough that `MAX_FULL_LENGTH - domain.length` falls below `MIN_LENGTH`, the form degenerates: with a 27-character domain (including the leading dot), the displayed range collapses to `Between 3 and 3 characters`; with a longer domain, the max can fall below the min entirely, making the form impossible to satisfy regardless of input.

## Fix

Use `MAX_LENGTH` (18) directly. The `domain` parameter of `useSegmentValidator` is no longer needed and is removed at the call site.

## Scope

This PR is intentionally limited to the symptom reported in the issue. A separate (and currently unreported) instance of the same obsolete contract lives in `isValidDomain` in `packages/oauth/oauth-provider-ui/src/lib/handle.ts`, which would drop service domains longer than `MAX_FULL_LENGTH - MIN_LENGTH = 27` characters from the dropdown entirely. 

> [!NOTE]
Me the human again: I could open another pr, fold the second fix in the present one, or do nothing. Just let me know.

## Repro

1. Configure a PDS with a service domain whose length (including the leading dot) is ≥ 27 characters
2. Open the OAuth sign-up flow
3. Observe the validation message `Between 3 and 3 characters` on the username field

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/cd0d4751-30ef-499d-bcb8-2c30b3f8980d" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/fe0506eb-3836-4f80-81a3-3178b56f54b0" />


## Test plan

The PDS-side contract is already locked in by [`packages/pds/tests/handle-validation.test.ts`](https://github.com/bluesky-social/atproto/blob/877e6293b93b2c32342b2023ab4f0c0e1cce643a/packages/pds/tests/handle-validation.test.ts#L52), which asserts both that usernames over 18 chars are rejected and that handles whose total length exceeds 30 are accepted as long as the username segment is within bounds. The UI now matches this contract.

There is no test infrastructure in `packages/oauth/oauth-provider-ui` currently, so no UI-level test is added.

> [!NOTE]
Final human note: I would be happy to answer any question and/or make any changes