### PR TITLE
bsky: dedupe associated profiles in externalview presentation

### DIFF
--- a/.changeset/silver-planes-repair.md
+++ b/.changeset/silver-planes-repair.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Fix app.bsky.embed.getEmbedExternalView associatedProfiles duplicate data

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -2326,8 +2326,14 @@ export class Views {
     // covers these DIDs alongside post-author profiles, so misses here
     // only happen when an actor is unavailable (suspended, deleted, etc.)
     // — drop those rather than emit `undefined` slots.
-    const uniqueDids = dedupeStrs(mapDefined([document?.ref.uri, publication?.ref.uri], (uri) => uri ? uriToDid(uri) : undefined) as DidString[])
-    const associatedProfiles = mapDefined(uniqueDids, (did) => this.profileBasic(did, state)) as ProfileViewBasic[]
+    const uniqueDids = dedupeStrs(
+      mapDefined([document?.ref.uri, publication?.ref.uri], (uri) =>
+        uri ? uriToDid(uri) : undefined,
+      ) as DidString[],
+    )
+    const associatedProfiles = mapDefined(uniqueDids, (did) =>
+      this.profileBasic(did, state),
+    ) as ProfileViewBasic[]
     if (associatedProfiles.length)
       overlay.associatedProfiles = associatedProfiles
 

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1,4 +1,4 @@
-import { HOUR, MINUTE, mapDefined } from '@atproto/common'
+import { HOUR, MINUTE, dedupeStrs, mapDefined } from '@atproto/common'
 import {
   $Typed,
   Un$Typed,
@@ -2326,10 +2326,8 @@ export class Views {
     // covers these DIDs alongside post-author profiles, so misses here
     // only happen when an actor is unavailable (suspended, deleted, etc.)
     // — drop those rather than emit `undefined` slots.
-    const associatedProfiles = mapDefined(
-      [document?.ref.uri, publication?.ref.uri],
-      (uri) => (uri ? this.profileBasic(uriToDid(uri), state) : undefined),
-    ) as ProfileViewBasic[]
+    const uniqueDids = dedupeStrs(mapDefined([document?.ref.uri, publication?.ref.uri], (uri) => uri ? uriToDid(uri) : undefined) as DidString[])
+    const associatedProfiles = mapDefined(uniqueDids, (did) => this.profileBasic(did, state)) as ProfileViewBasic[]
     if (associatedProfiles.length)
       overlay.associatedProfiles = associatedProfiles
 


### PR DESCRIPTION
When returning multiple `associatedRefs`, one for the document and one for the publication, we would also return multiple `associatedProfiles` - this results in the same profile being returned twice in the response