### PR TITLE
bsky: add displayName, handle to VerificationView

### DIFF
--- a/.changeset/full-coats-cross.md
+++ b/.changeset/full-coats-cross.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+add displayName, handle to verification view

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -269,6 +269,15 @@
           "description": "The user who issued this verification.",
           "format": "did"
         },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the issuer."
+        },
+        "handle": {
+          "type": "string",
+          "description": "The handle of the issuer.",
+          "format": "handle"
+        },
         "uri": {
           "type": "string",
           "description": "The AT-URI of the verification record.",

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -543,6 +543,8 @@ export class Views {
 
         return {
           issuer,
+          displayName,
+          handle,
           uri,
           isValid,
           createdAt,

--- a/packages/bsky/tests/views/verification.test.ts
+++ b/packages/bsky/tests/views/verification.test.ts
@@ -78,6 +78,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'display-verifier1',
+              handle: 'verifier1.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -115,12 +117,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'display-bob',
+              handle: 'bob.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
+              displayName: 'display-bob',
+              handle: 'bob.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -141,12 +147,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'display-carol',
+              handle: 'carol.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
+              displayName: 'display-carol',
+              handle: 'carol.old.handle',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -167,6 +177,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'display-dan',
+              handle: 'dan.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
@@ -193,6 +205,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'frank-old-name',
+              handle: 'frank.test',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -219,6 +233,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
+              displayName: 'display-impersonator',
+              handle: 'impersonator.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),

--- a/packages/ozone/tests/__snapshots__/verification.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/verification.test.ts.snap
@@ -120,6 +120,8 @@ exports[`verification list returns paginated list of verifications 1`] = `
       "verifications": [
         {
           "createdAt": "1970-01-01T00:00:00.000Z",
+          "displayName": "bobby",
+          "handle": "bob.test",
           "isValid": true,
           "issuer": "user(0)",
           "uri": "record(0)",


### PR DESCRIPTION
Exposes the display name and handle of verification issuers when fetching `app.bsky.actor.getProfile`. This will be used to populate SEO meta data