### PR TITLE
Fix app.bsky.actor.getProfile verifier data

### DIFF
--- a/.changeset/fix-verification-issuer-info.md
+++ b/.changeset/fix-verification-issuer-info.md
@@ -2,4 +2,4 @@
 '@atproto/bsky': patch
 ---
 
-Fix `verificationView`'s `displayName` and `handle` to reflect the verification issuer rather than the subject. These fields were introduced in #5015 to expose the issuer's identity, but were inadvertently being populated with the subject's snapshot stored on the verification record.
+Fix `verificationView`'s `displayName` and `handle` to reflect the verification issuer rather than the subject, and rename them to `issuerDisplayName` and `issuerHandle`. These fields were introduced in #5015 to expose the issuer's identity, but were inadvertently being populated with the subject's snapshot stored on the verification record.

--- a/.changeset/fix-verification-issuer-info.md
+++ b/.changeset/fix-verification-issuer-info.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Fix `verificationView`'s `displayName` and `handle` to reflect the verification issuer rather than the subject. These fields were introduced in #5015 to expose the issuer's identity, but were inadvertently being populated with the subject's snapshot stored on the verification record.

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -269,11 +269,11 @@
           "description": "The user who issued this verification.",
           "format": "did"
         },
-        "displayName": {
+        "issuerDisplayName": {
           "type": "string",
           "description": "The display name of the issuer."
         },
-        "handle": {
+        "issuerHandle": {
           "type": "string",
           "description": "The handle of the issuer.",
           "format": "handle"

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -277,6 +277,30 @@ export class Hydrator {
       this.label.getLabelsForSubjects(labelSubjectsForDid(dids), ctx.labelers),
       this.hydrateProfileViewers(dids, ctx),
     ])
+    // Hydrate verification issuer actors so the verification view can expose
+    // the issuer's current handle and displayName. Skipped when no hydrated
+    // actor has any verifications, which is the common case.
+    const issuerDids: DidString[] = []
+    const issuerDidSet = new Set<DidString>()
+    for (const actor of actors.values()) {
+      if (!actor) continue
+      for (const verification of actor.verifications) {
+        const issuer = verification.issuer
+        if (actors.has(issuer) || issuerDidSet.has(issuer)) continue
+        issuerDidSet.add(issuer)
+        issuerDids.push(issuer)
+      }
+    }
+    if (issuerDids.length > 0) {
+      const issuerActors = await this.actor.getActors(issuerDids, {
+        includeTakedowns,
+      })
+      // Merge into actors without overwriting existing entries (the original
+      // dids may have been fetched with skipCacheForDids, etc.).
+      for (const [did, actor] of issuerActors) {
+        if (!actors.has(did)) actors.set(did, actor)
+      }
+    }
     if (!includeTakedowns) {
       actionTakedownLabels(dids, actors, labels)
     }

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -535,16 +535,22 @@ export class Views {
       ({ issuer, uri, displayName, handle, createdAt }): VerificationView => {
         // @NOTE: We don't factor-in impersonation when evaluating the validity of each verification,
         // only in the overall profile verification validity.
+        // The verification record's `displayName`/`handle` are the *subject's* snapshot at
+        // verification time; we compare them to the subject's current values to determine validity.
         const isValid =
           !!displayName &&
           displayName === actor.profile?.displayName &&
           !!handle &&
           handle === actor.handle
 
+        // Expose the *issuer's* current handle/displayName, sourced from the
+        // issuer's hydrated actor record (see `Hydrator.hydrateProfiles`).
+        const issuerActor = state.actors?.get(issuer)
+
         return {
           issuer,
-          displayName,
-          handle,
+          displayName: issuerActor?.profile?.displayName,
+          handle: issuerActor?.handle,
           uri,
           isValid,
           createdAt,

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -549,8 +549,8 @@ export class Views {
 
         return {
           issuer,
-          displayName: issuerActor?.profile?.displayName,
-          handle: issuerActor?.handle,
+          issuerDisplayName: issuerActor?.profile?.displayName,
+          issuerHandle: issuerActor?.handle,
           uri,
           isValid,
           createdAt,

--- a/packages/bsky/tests/views/verification.test.ts
+++ b/packages/bsky/tests/views/verification.test.ts
@@ -78,8 +78,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier1',
-              handle: 'verifier1.test',
+              displayName: 'display-verifier2',
+              handle: 'verifier2.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -117,16 +117,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-bob',
-              handle: 'bob.test',
+              displayName: 'display-verifier1',
+              handle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
-              displayName: 'display-bob',
-              handle: 'bob.test',
+              displayName: 'display-verifier2',
+              handle: 'verifier2.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -147,16 +147,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-carol',
-              handle: 'carol.test',
+              displayName: 'display-verifier1',
+              handle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
-              displayName: 'display-carol',
-              handle: 'carol.old.handle',
+              displayName: 'display-verifier2',
+              handle: 'verifier2.test',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -177,8 +177,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-dan',
-              handle: 'dan.test',
+              displayName: 'display-verifier1',
+              handle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
@@ -205,8 +205,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'frank-old-name',
-              handle: 'frank.test',
+              displayName: 'display-verifier2',
+              handle: 'verifier2.test',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -233,8 +233,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-impersonator',
-              handle: 'impersonator.test',
+              displayName: 'display-verifier1',
+              handle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),

--- a/packages/bsky/tests/views/verification.test.ts
+++ b/packages/bsky/tests/views/verification.test.ts
@@ -78,8 +78,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier2',
-              handle: 'verifier2.test',
+              issuerDisplayName: 'display-verifier2',
+              issuerHandle: 'verifier2.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -117,16 +117,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier1',
-              handle: 'verifier1.test',
+              issuerDisplayName: 'display-verifier1',
+              issuerHandle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier2',
-              handle: 'verifier2.test',
+              issuerDisplayName: 'display-verifier2',
+              issuerHandle: 'verifier2.test',
               isValid: true,
               issuer: verifier2,
               uri: expect.any(String),
@@ -147,16 +147,16 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier1',
-              handle: 'verifier1.test',
+              issuerDisplayName: 'display-verifier1',
+              issuerHandle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
             },
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier2',
-              handle: 'verifier2.test',
+              issuerDisplayName: 'display-verifier2',
+              issuerHandle: 'verifier2.test',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -177,8 +177,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier1',
-              handle: 'verifier1.test',
+              issuerDisplayName: 'display-verifier1',
+              issuerHandle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),
@@ -205,8 +205,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier2',
-              handle: 'verifier2.test',
+              issuerDisplayName: 'display-verifier2',
+              issuerHandle: 'verifier2.test',
               isValid: false,
               issuer: verifier2,
               uri: expect.any(String),
@@ -233,8 +233,8 @@ describe('verification views', () => {
           verifications: [
             {
               createdAt: expect.any(String),
-              displayName: 'display-verifier1',
-              handle: 'verifier1.test',
+              issuerDisplayName: 'display-verifier1',
+              issuerHandle: 'verifier1.test',
               isValid: true,
               issuer: verifier1,
               uri: expect.any(String),

--- a/packages/ozone/tests/__snapshots__/verification.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/verification.test.ts.snap
@@ -120,8 +120,8 @@ exports[`verification list returns paginated list of verifications 1`] = `
       "verifications": [
         {
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "displayName": "bobby",
-          "handle": "bob.test",
+          "displayName": "ali",
+          "handle": "alice.test",
           "isValid": true,
           "issuer": "user(0)",
           "uri": "record(0)",

--- a/packages/ozone/tests/__snapshots__/verification.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/verification.test.ts.snap
@@ -120,8 +120,8 @@ exports[`verification list returns paginated list of verifications 1`] = `
       "verifications": [
         {
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "displayName": "ali",
-          "handle": "alice.test",
+          "issuerDisplayName": "ali",
+          "issuerHandle": "alice.test",
           "isValid": true,
           "issuer": "user(0)",
           "uri": "record(0)",

--- a/packages/ozone/tests/__snapshots__/verification.test.ts.snap
+++ b/packages/ozone/tests/__snapshots__/verification.test.ts.snap
@@ -120,10 +120,10 @@ exports[`verification list returns paginated list of verifications 1`] = `
       "verifications": [
         {
           "createdAt": "1970-01-01T00:00:00.000Z",
-          "issuerDisplayName": "ali",
-          "issuerHandle": "alice.test",
           "isValid": true,
           "issuer": "user(0)",
+          "issuerDisplayName": "ali",
+          "issuerHandle": "alice.test",
           "uri": "record(0)",
         },
       ],


### PR DESCRIPTION
In my previous PR https://github.com/bluesky-social/atproto/pull/5015, I introduced `handle` and `displayName` for the verifier on `app.bsky.actor.getProfile` but I did not source that data from the correct hydrated actor. This PR fixes the bug by hydrating the issuer and fetching the issuer actor's data from the hydration state. Verified with updated tests.