### PR TITLE
Allow subpath URL matches for known SS hosts

### DIFF
--- a/.changeset/heavy-groups-wish.md
+++ b/.changeset/heavy-groups-wish.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Loosen validation for known Standard Site publishers in order to support quote URLs

--- a/packages/bsky/src/util/standard-site.test.ts
+++ b/packages/bsky/src/util/standard-site.test.ts
@@ -275,4 +275,149 @@ describe(validateStandardSiteForUrl, () => {
       })
     }
   })
+
+  describe('subpath-friendly hosts', () => {
+    // Allowlist of hosts where each record's author owns the full subpath
+    // space under their canonical record URL. These platforms typically
+    // serve dynamic per-record subpaths (page numbers, revision ids,
+    // comment threads, etc.) under the same slug, so an `assumedUrl` with
+    // extra path segments past the record URL is still authentic content.
+    for (const { note, baseUrl, path, assumedUrl, expected } of [
+      // Allowlisted apex domain (subdomain) — extra path segments accepted.
+      {
+        note: 'pckt.blog subdomain accepts extra path segments past the record URL',
+        baseUrl: 'https://waow-tech.pckt.blog',
+        path: '/typeahead-more-like-typebehind-amirite-tzgmqge',
+        assumedUrl:
+          'https://waow-tech.pckt.blog/typeahead-more-like-typebehind-amirite-tzgmqge/589/621',
+        expected: true,
+      },
+      {
+        note: 'leaflet.pub subdomain with one extra segment',
+        baseUrl: 'https://author.leaflet.pub',
+        path: '/post-slug',
+        assumedUrl: 'https://author.leaflet.pub/post-slug/v2',
+        expected: true,
+      },
+      {
+        note: 'offprint.app at apex with multi-segment extension',
+        baseUrl: 'https://offprint.app',
+        path: '/story/abc',
+        assumedUrl: 'https://offprint.app/story/abc/chapter/3',
+        expected: true,
+      },
+      // Allowlisted host but the assumed URL diverges from the path —
+      // still rejected; subpath is "extends with extra segments after a
+      // path-segment boundary," not "any URL on the same host."
+      {
+        note: 'pckt.blog rejects assumed URLs that diverge before the boundary',
+        baseUrl: 'https://blog.pckt.blog',
+        path: '/post-slug',
+        assumedUrl: 'https://blog.pckt.blog/different-post',
+        expected: false,
+      },
+      {
+        note: 'pckt.blog rejects partial-segment matches (no slash boundary)',
+        baseUrl: 'https://blog.pckt.blog',
+        path: '/foo',
+        assumedUrl: 'https://blog.pckt.blog/foobar',
+        expected: false,
+      },
+      // Non-allowlisted hosts — exact match still required.
+      {
+        note: 'arbitrary host rejects extra path segments',
+        baseUrl: 'https://example.com',
+        path: '/article',
+        assumedUrl: 'https://example.com/article/extra',
+        expected: false,
+      },
+      {
+        note: 'lookalike host (pckt.blog.evil.com) is NOT allowlisted',
+        baseUrl: 'https://pckt.blog.evil.com',
+        path: '/post',
+        assumedUrl: 'https://pckt.blog.evil.com/post/extra',
+        expected: false,
+      },
+      {
+        note: 'evilpckt.blog is NOT allowlisted (no subdomain dot before pckt.blog)',
+        baseUrl: 'https://evilpckt.blog',
+        path: '/post',
+        assumedUrl: 'https://evilpckt.blog/post/extra',
+        expected: false,
+      },
+      // Allowlist host with exact match still works (no regression).
+      {
+        note: 'pckt.blog still accepts exact match without subpath',
+        baseUrl: 'https://author.pckt.blog',
+        path: '/post-slug',
+        assumedUrl: 'https://author.pckt.blog/post-slug',
+        expected: true,
+      },
+      // Allowlist host with cross-host mismatch — still rejected.
+      {
+        note: 'allowlisted record host vs different host on assumed URL is rejected',
+        baseUrl: 'https://author.pckt.blog',
+        path: '/post',
+        assumedUrl: 'https://example.com/author.pckt.blog/post/extra',
+        expected: false,
+      },
+    ]) {
+      it(`doc + pub: ${note}`, () => {
+        const doc = makeDoc(
+          path === undefined ? { site: pubUri } : { site: pubUri, path },
+        )
+        const pub = makePub({ url: baseUrl })
+        expect(validateStandardSiteForUrl(doc, pub, assumedUrl)).toBe(expected)
+      })
+      it(`loose doc: ${note}`, () => {
+        const doc = makeDoc(
+          path === undefined ? { site: baseUrl } : { site: baseUrl, path },
+        )
+        expect(validateStandardSiteForUrl(doc, undefined, assumedUrl)).toBe(
+          expected,
+        )
+      })
+    }
+
+    // Publication-only validation never accepts subpaths — `assumedUrl`
+    // for a publication is the home-page URL, not an article underneath
+    // it. Subpath relaxation belongs to documents.
+    it('publication-only: allowlisted host still requires exact match', () => {
+      const pub = makePub({ url: 'https://author.pckt.blog' })
+      expect(
+        validateStandardSiteForUrl(
+          undefined,
+          pub,
+          'https://author.pckt.blog/some/sub/path',
+        ),
+      ).toBe(false)
+    })
+
+    it('publication-only: non-allowlisted host rejects subpath', () => {
+      const pub = makePub({ url: 'https://example.com' })
+      expect(
+        validateStandardSiteForUrl(
+          undefined,
+          pub,
+          'https://example.com/some/sub/path',
+        ),
+      ).toBe(false)
+    })
+
+    // Case-insensitivity on the host.
+    it('host comparison is case-insensitive', () => {
+      const doc = makeDoc({
+        site: pubUri,
+        path: '/post',
+      })
+      const pub = makePub({ url: 'https://Author.PCKT.blog' })
+      expect(
+        validateStandardSiteForUrl(
+          doc,
+          pub,
+          'https://author.pckt.BLOG/post/extra',
+        ),
+      ).toBe(true)
+    })
+  })
 })

--- a/packages/bsky/src/util/standard-site.ts
+++ b/packages/bsky/src/util/standard-site.ts
@@ -54,6 +54,52 @@ const joinPath = (base: string, path: string): string => {
 }
 
 /**
+ * Apex domains whose authors own the full subpath space under their
+ * record-claimed URL. Each entry matches itself and any subdomain; e.g.
+ * `pckt.blog` matches `pckt.blog` and `waow-tech.pckt.blog`.
+ *
+ * On these domains, an `assumedUrl` whose pathname extends the canonical
+ * record URL with extra segments is treated as valid. Adding to this list
+ * is a trust call — only platforms where each record's URL space is
+ * authoritatively owned by its author belong here.
+ */
+const SUBPATH_FRIENDLY_DOMAINS = ['pckt.blog', 'leaflet.pub', 'offprint.app']
+
+const isSubpathFriendlyHost = (host: string): boolean => {
+  const lower = host.toLowerCase()
+  return SUBPATH_FRIENDLY_DOMAINS.some(
+    (domain) => lower === domain || lower.endsWith(`.${domain}`),
+  )
+}
+
+/**
+ * Return whether `recordUrl` and `assumedUrl` should validate as the same
+ * canonical content. Strictly equal canonical forms always match. On
+ * subpath-friendly hosts (see `SUBPATH_FRIENDLY_DOMAINS`), an `assumedUrl`
+ * whose path extends `recordUrl`'s with extra segments is also accepted.
+ *
+ * Both inputs are pre-canonicalized strings (`canonicalizeHttpUrl` output)
+ * with no trailing slash and no query/fragment.
+ */
+const canonicalUrlMatchesAssumed = (
+  canonicalRecordUrl: string,
+  canonicalAssumedUrl: string,
+): boolean => {
+  if (canonicalRecordUrl === canonicalAssumedUrl) return true
+  // Subpath fallback. Both strings are canonicalized, so a real
+  // path-segment boundary at `recordUrl + '/'` (e.g. `/foo` vs `/foo-bar`
+  // never matches; `/foo` vs `/foo/bar` does).
+  if (!canonicalAssumedUrl.startsWith(`${canonicalRecordUrl}/`)) return false
+  let host: string
+  try {
+    host = new URL(canonicalAssumedUrl).host
+  } catch {
+    return false
+  }
+  return isSubpathFriendlyHost(host)
+}
+
+/**
  * Confirm that the supplied SS records actually back `assumedUrl`. The
  * record-side URL is built by concatenating the publication URL (or the
  * loose-doc site) with the document's `path` field, then both sides are
@@ -74,13 +120,21 @@ const joinPath = (base: string, path: string): string => {
  * function runs the pair is already known to be structurally consistent,
  * so we only check whether the records back the URL.
  *
+ * For document validation, `SUBPATH_FRIENDLY_DOMAINS` (and their
+ * subdomains) accept an assumed URL whose path extends the canonical
+ * record URL with additional segments — these are platforms where each
+ * record's author owns the full subpath space under their claimed URL.
+ * Publication-only validation always requires exact match: there's no
+ * coherent "subpath" of a publication's home page.
+ *
  * Cases:
  * - Document + publication: `publication.url + document.path` must
- *   canonicalize to `assumedUrl`.
+ *   canonicalize to `assumedUrl` (or be a subpath-friendly prefix of it).
  * - Loose document (web-URL `site`): `document.site + document.path`
- *   must canonicalize to `assumedUrl`. (Doc with at-uri `site` but no
- *   publication can't reach this function — the lookups reject it.)
- * - Publication only: `publication.url` must canonicalize to
+ *   must canonicalize to `assumedUrl` (or be a subpath-friendly prefix).
+ *   (Doc with at-uri `site` but no publication can't reach this function
+ *   — the lookups reject it.)
+ * - Publication only: `publication.url` must canonicalize exactly to
  *   `assumedUrl`.
  * - Neither: vacuously valid; the caller short-circuits before we get
  *   here.
@@ -104,15 +158,18 @@ export const validateStandardSiteForUrl = (
     const joined = canonicalizeHttpUrl(
       joinPath(publication.info.record.url, document.info.record.path ?? ''),
     )
-    return joined === canonicalAssumed
+    return joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
   }
   if (document) {
     const joined = canonicalizeHttpUrl(
       joinPath(document.info.record.site, document.info.record.path ?? ''),
     )
-    return joined === canonicalAssumed
+    return joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
   }
   if (publication) {
+    // Publication-only matches are exact: `assumedUrl` represents the
+    // publication's home page, not an article underneath it. Subpath
+    // extensions belong to document validation.
     return canonicalizeHttpUrl(publication.info.record.url) === canonicalAssumed
   }
   return true

--- a/packages/bsky/src/util/standard-site.ts
+++ b/packages/bsky/src/util/standard-site.ts
@@ -158,13 +158,17 @@ export const validateStandardSiteForUrl = (
     const joined = canonicalizeHttpUrl(
       joinPath(publication.info.record.url, document.info.record.path ?? ''),
     )
-    return joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
+    return (
+      joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
+    )
   }
   if (document) {
     const joined = canonicalizeHttpUrl(
       joinPath(document.info.record.site, document.info.record.path ?? ''),
     )
-    return joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
+    return (
+      joined !== null && canonicalUrlMatchesAssumed(joined, canonicalAssumed)
+    )
   }
   if (publication) {
     // Publication-only matches are exact: `assumedUrl` represents the


### PR DESCRIPTION
Some SS-record platforms (pckt.blog, leaflet.pub, offprint.app) serve dynamic per-record subpaths (page numbers, revisions, etc.) under each record's slug. Records on those domains validate against any URL whose path extends the canonical record URL with additional segments after a path-segment boundary.

Subpath relaxation is gated on a hardcoded SUBPATH_FRIENDLY_DOMAINS allowlist (apex domains plus subdomains). Match is segment-boundary-aware, so `/foo` doesn't match `/foobar`, and lookalike hosts like `pckt.blog.evil.com` or `evilpckt.blog` aren't covered. Document validation (with or without a publication) goes through this path; publication-only validation always requires exact match because there's no coherent "subpath" of a publication's home page.

Adds 23 tests covering allowlisted hits, segment-boundary safety, lookalike rejections, exact-match regression, and case insensitivity.