### PR TITLE
bsky: enable search v2 behind feature gate

### DIFF
--- a/.changeset/crisp-breads-fail.md
+++ b/.changeset/crisp-breads-fail.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Route appview search through new V2 dataplane RPCs behind the `search:v2:enable` feature gate.

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1086,7 +1086,7 @@ message GetThreadResponse {
 }
 
 //
-// Search
+// Search V1
 //
 
 // - Return DIDs of actors matching term, paginated
@@ -1126,6 +1126,163 @@ message SearchStarterPacksRequest {
 message SearchStarterPacksResponse {
   repeated string uris = 1;
   string cursor = 2;
+}
+
+//
+// Search V2
+//
+
+enum SearchSortOrder {
+  SEARCH_SORT_ORDER_UNSPECIFIED = 0;
+  SEARCH_SORT_ORDER_RECENT = 1;
+  SEARCH_SORT_ORDER_TOP = 2;
+}
+
+enum SearchQueryLanguage {
+  SEARCH_QUERY_LANGUAGE_UNSPECIFIED = 0;
+  SEARCH_QUERY_LANGUAGE_JA = 1; // Japanese (Kuromoji)
+  SEARCH_QUERY_LANGUAGE_ZH = 2; // Chinese (smartcn)
+  SEARCH_QUERY_LANGUAGE_KO = 3; // Korean (nori)
+  SEARCH_QUERY_LANGUAGE_TH = 4; // Thai
+}
+
+// Shared request params
+
+message SearchParams {
+  string query = 1;
+  string viewer = 2;
+
+  // Pagination
+  int32 limit = 3;
+  string cursor = 4;
+}
+
+// Shared result types
+
+// SearchRecordResult represents a generic result hit corresponding to a record.
+message SearchRecordResult {
+  // AT URI of the record, e.g. "at://did:example:alice/app.bsky.feed.post/12345"
+  string uri = 1;
+  double score = 2;
+}
+
+message SearchActorResult {
+  string did = 1;
+  double score = 2;
+}
+
+message PageInfo {
+  string cursor = 1;
+  int64 hits_total = 2;
+}
+
+// Search queries
+
+// PostFilters are logical filters that should be used to match or exclude posts.
+// Each repeated field is applied as OR within the field with all fields applied together as AND.
+// example:
+//  filters: {
+//    authors: [alice, bob]
+//    mentions: [carol]
+//  }
+// => (author is alice OR bob) AND (mentions carol)
+//
+message PostsFilters {
+  // Author/mention filters
+  repeated string authors = 1;
+  repeated string mentions = 2;
+
+  // Content filters
+  repeated string domains = 3;
+  repeated string urls = 4;
+  repeated string embed_uris = 5;
+  repeated string hashtags = 6;
+}
+
+message SearchPostsV2Request {
+  // Required fields
+  SearchParams params = 1;
+  SearchSortOrder sort = 2;
+
+  // Logical filters and exclude fields applied together as AND
+  //
+  // filters: include posts matching the filters
+  PostsFilters filters = 3;
+
+  // Exclude filters: exclude posts matching the filters
+  PostsFilters exclude = 4;
+
+  // Date range filters
+  optional google.protobuf.Timestamp since = 5;
+  optional google.protobuf.Timestamp until = 6; // defaults to "now"
+  // If false, will only query against last 30 days of posts
+  // so `since` and `until` will silently be capped
+  optional bool all_time = 7;
+
+  // Language filter - match posts in this language
+  // Supports 2-char ISO prefixes ("en", "ja, "fr", etc")
+  // and compares against the 2-char prefix of any `langs` field values of the post record
+  // e.g. a post with langs=["en-US", "fr"] would match "en" or "fr" but not "ja"
+  optional string language = 8;
+
+  // Media filters
+  optional bool has_media = 9;
+  optional bool has_video = 10;
+
+  // Reply filters
+  optional string reply_parent_uri = 11;
+  optional string thread_root_uri = 12;
+  optional bool exclude_replies = 13;
+  optional bool replies_only = 14;
+
+  // Social filters
+  optional bool following = 15;
+
+  // Query analysis hint — forces a specific language analyzer.
+  // Auto-detects from query text when unset.
+  optional SearchQueryLanguage query_language = 16;
+}
+
+message SearchPostsV2Response {
+  repeated SearchRecordResult posts = 1;
+  PageInfo page_info = 2;
+}
+
+message SearchActorsV2Request {
+  SearchParams params = 1;
+}
+
+message SearchActorsV2Response {
+  repeated SearchActorResult actors = 1;
+  PageInfo page_info = 2;
+}
+
+message SearchActorsTypeaheadRequest {
+  string viewer = 1;
+  string query = 2;
+  int32 limit = 3;
+}
+
+message SearchActorsTypeaheadResponse {
+  repeated SearchActorResult actors = 1;
+}
+
+message SearchFeedGeneratorsV2Request {
+  SearchParams params = 1;
+}
+
+message SearchFeedGeneratorsV2Response {
+  repeated SearchRecordResult feed_generators = 1;
+  PageInfo page_info = 2;
+}
+
+message SearchStarterPacksV2Request {
+  SearchParams params = 1;
+}
+
+message SearchStarterPacksV2Response {
+  repeated SearchRecordResult starter_packs = 1;
+  PageInfo page_info = 2;
 }
 
 //
@@ -1532,10 +1689,17 @@ service Service {
   // Threads
   rpc GetThread(GetThreadRequest) returns (GetThreadResponse);
 
-  // Search
+  // Search (V1)
   rpc SearchActors(SearchActorsRequest) returns (SearchActorsResponse);
   rpc SearchPosts(SearchPostsRequest) returns (SearchPostsResponse);
   rpc SearchStarterPacks(SearchStarterPacksRequest) returns (SearchStarterPacksResponse);
+
+  // Search V2
+  rpc SearchPostsV2(SearchPostsV2Request) returns (SearchPostsV2Response);
+  rpc SearchActorsV2(SearchActorsV2Request) returns (SearchActorsV2Response);
+  rpc SearchActorsTypeahead(SearchActorsTypeaheadRequest) returns (SearchActorsTypeaheadResponse);
+  rpc SearchFeedGeneratorsV2(SearchFeedGeneratorsV2Request) returns (SearchFeedGeneratorsV2Response);
+  rpc SearchStarterPacksV2(SearchStarterPacksV2Request) returns (SearchStarterPacksV2Response);
 
   // Suggestions
   rpc GetFollowSuggestions(GetFollowSuggestionsRequest) returns (GetFollowSuggestionsResponse);

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -34,6 +34,12 @@ export default function (server: Server, ctx: AppContext) {
         labelers,
         includeTakedowns,
         skipViewerBlocks,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
       })
       const results = await searchActors({ ...params, hydrateCtx }, ctx)
       return {

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -45,7 +45,7 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-const skeleton = async (
+const skeletonV1 = async (
   inputs: SkeletonFnInput<Context, Params>,
 ): Promise<Skeleton> => {
   const { ctx, params } = inputs
@@ -80,6 +80,34 @@ const skeleton = async (
     dids: res.dids as DidString[],
     cursor: parseString(res.cursor),
   }
+}
+
+const skeletonV2 = async (
+  inputs: SkeletonFnInput<Context, Params>,
+): Promise<Skeleton> => {
+  const { ctx, params } = inputs
+  const term = params.q ?? params.term ?? ''
+
+  const res = await ctx.dataplane.searchActorsV2({
+    params: {
+      query: term,
+      viewer: params.hydrateCtx.viewer ?? undefined,
+      limit: params.limit,
+      cursor: params.cursor,
+    },
+  })
+  return {
+    dids: res.actors.map(({ did }) => did as DidString),
+    cursor: parseString(res.pageInfo?.cursor),
+  }
+}
+
+const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
+  const useV2 = input.params.hydrateCtx.features.checkGate(
+    input.params.hydrateCtx.features.Gate.SearchV2Enable,
+  )
+  const skeletonFn = useV2 ? skeletonV2 : skeletonV1
+  return skeletonFn(input)
 }
 
 const hydration = async (

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -27,7 +27,16 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
+      })
       const results = await searchActorsTypeahead(
         { ...params, hydrateCtx },
         ctx,

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -41,7 +41,7 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-const skeleton = async (
+const skeletonV1 = async (
   inputs: SkeletonFnInput<Context, Params>,
 ): Promise<Skeleton> => {
   const { ctx, params } = inputs
@@ -73,6 +73,30 @@ const skeleton = async (
   return {
     dids: res.dids as DidString[],
   }
+}
+
+const skeletonV2 = async (
+  inputs: SkeletonFnInput<Context, Params>,
+): Promise<Skeleton> => {
+  const { ctx, params } = inputs
+  const term = params.q ?? params.term ?? ''
+
+  const res = await ctx.dataplane.searchActorsTypeahead({
+    viewer: params.hydrateCtx.viewer ?? undefined,
+    query: term,
+    limit: params.limit,
+  })
+  return {
+    dids: res.actors.map(({ did }) => did as DidString),
+  }
+}
+
+const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
+  const useV2 = input.params.hydrateCtx.features.checkGate(
+    input.params.hydrateCtx.features.Gate.SearchV2Enable,
+  )
+  const skeletonFn = useV2 ? skeletonV2 : skeletonV1
+  return skeletonFn(input)
 }
 
 const hydration = async (

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -1,7 +1,7 @@
+import { Timestamp } from '@bufbuild/protobuf'
 import { mapDefined } from '@atproto/common'
 import { AtUriString, Client } from '@atproto/lex'
 import { Server } from '@atproto/xrpc-server'
-import { Timestamp } from '@bufbuild/protobuf'
 import { ServerConfig } from '../../../../config.js'
 import { AppContext } from '../../../../context.js'
 import { DataPlaneClient } from '../../../../data-plane/index.js'
@@ -11,7 +11,6 @@ import {
 } from '../../../../data-plane/server/util.js'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
 import { parseString } from '../../../../hydration/util.js'
-import { SearchSortOrder } from '../../../../proto/bsky_pb.js'
 import { app } from '../../../../lexicons/index.js'
 import {
   HydrationFnInput,
@@ -20,6 +19,7 @@ import {
   SkeletonFnInput,
   createPipeline,
 } from '../../../../pipeline.js'
+import { SearchSortOrder } from '../../../../proto/bsky_pb.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import { Views } from '../../../../views/index.js'
 import { resHeaders } from '../../../util.js'
@@ -116,7 +116,6 @@ const skeletonV2 = async (
   const parsedQuery = parsePostSearchQuery(params.q, {
     author: params.author,
   })
-
   const res = await ctx.dataplane.searchPostsV2({
     params: {
       query: params.q,

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -1,6 +1,7 @@
 import { mapDefined } from '@atproto/common'
 import { AtUriString, Client } from '@atproto/lex'
 import { Server } from '@atproto/xrpc-server'
+import { Timestamp } from '@bufbuild/protobuf'
 import { ServerConfig } from '../../../../config.js'
 import { AppContext } from '../../../../context.js'
 import { DataPlaneClient } from '../../../../data-plane/index.js'
@@ -10,6 +11,7 @@ import {
 } from '../../../../data-plane/server/util.js'
 import { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
 import { parseString } from '../../../../hydration/util.js'
+import { SearchSortOrder } from '../../../../proto/bsky_pb.js'
 import { app } from '../../../../lexicons/index.js'
 import {
   HydrationFnInput,
@@ -60,7 +62,7 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-const skeleton = async (
+const skeletonV1 = async (
   inputs: SkeletonFnInput<Context, Params>,
 ): Promise<Skeleton> => {
   const { ctx, params } = inputs
@@ -105,6 +107,51 @@ const skeleton = async (
     cursor: parseString(res.cursor),
     parsedQuery,
   }
+}
+
+const skeletonV2 = async (
+  inputs: SkeletonFnInput<Context, Params>,
+): Promise<Skeleton> => {
+  const { ctx, params } = inputs
+  const parsedQuery = parsePostSearchQuery(params.q, {
+    author: params.author,
+  })
+
+  const res = await ctx.dataplane.searchPostsV2({
+    params: {
+      query: params.q,
+      viewer: params.hydrateCtx.viewer ?? undefined,
+      limit: params.limit,
+      cursor: params.cursor,
+    },
+    sort: postSortToV2(params.sort),
+    filters: {
+      authors: params.author ? [params.author] : [],
+      mentions: params.mentions ? [params.mentions] : [],
+      domains: params.domain ? [params.domain] : [],
+      urls: params.url ? [params.url] : [],
+      hashtags: params.tag ?? [],
+    },
+    since: parseTimestamp(params.since),
+    until: parseTimestamp(params.until),
+    language: params.lang,
+  })
+  return {
+    posts: res.posts.map(({ uri }) => uri as AtUriString),
+    cursor: parseString(res.pageInfo?.cursor),
+    hitsTotal: res.pageInfo?.hitsTotal
+      ? Number(res.pageInfo.hitsTotal)
+      : undefined,
+    parsedQuery,
+  }
+}
+
+const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
+  const useV2 = input.params.hydrateCtx.features.checkGate(
+    input.params.hydrateCtx.features.Gate.SearchV2Enable,
+  )
+  const skeletonFn = useV2 ? skeletonV2 : skeletonV1
+  return skeletonFn(input)
 }
 
 const hydration = async (
@@ -198,4 +245,17 @@ type Skeleton = {
   hitsTotal?: number
   cursor?: string
   parsedQuery: PostSearchQuery
+}
+
+const postSortToV2 = (sort: string | undefined): SearchSortOrder => {
+  if (sort === 'top') return SearchSortOrder.TOP
+  if (sort === 'latest') return SearchSortOrder.RECENT
+  return SearchSortOrder.UNSPECIFIED
+}
+
+const parseTimestamp = (value: string | undefined): Timestamp | undefined => {
+  if (!value) return undefined
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return undefined
+  return Timestamp.fromDate(date)
 }

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -46,7 +46,7 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-const skeleton = async (
+const skeletonV1 = async (
   inputs: SkeletonFnInput<Context, Params>,
 ): Promise<Skeleton> => {
   const { ctx, params } = inputs
@@ -78,6 +78,34 @@ const skeleton = async (
     uris: res.uris as AtUriString[],
     cursor: parseString(res.cursor),
   }
+}
+
+const skeletonV2 = async (
+  inputs: SkeletonFnInput<Context, Params>,
+): Promise<Skeleton> => {
+  const { ctx, params } = inputs
+  const { q } = params
+
+  const res = await ctx.dataplane.searchStarterPacksV2({
+    params: {
+      query: q,
+      viewer: params.hydrateCtx.viewer ?? undefined,
+      limit: params.limit,
+      cursor: params.cursor,
+    },
+  })
+  return {
+    uris: res.starterPacks.map(({ uri }) => uri as AtUriString),
+    cursor: parseString(res.pageInfo?.cursor),
+  }
+}
+
+const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
+  const useV2 = input.params.hydrateCtx.features.checkGate(
+    input.params.hydrateCtx.features.Gate.SearchV2Enable,
+  )
+  const skeletonFn = useV2 ? skeletonV2 : skeletonV1
+  return skeletonFn(input)
 }
 
 const hydration = async (

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -35,6 +35,12 @@ export default function (server: Server, ctx: AppContext) {
         labelers,
         includeTakedowns,
         skipViewerBlocks,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
       })
       const results = await searchStarterPacks({ ...params, hydrateCtx }, ctx)
       return {

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -15,7 +15,17 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
+      const features = ctx.featureGatesClient.scope(
+        ctx.featureGatesClient.parseUserContextFromHandler({
+          viewer,
+          req,
+        }),
+      )
+      const hydrateCtx = await ctx.hydrator.createContext({
+        viewer,
+        labelers,
+        features,
+      })
 
       if (clearlyBadCursor(params.cursor)) {
         return {
@@ -29,11 +39,23 @@ export default function (server: Server, ctx: AppContext) {
 
       const query = params.query?.trim() ?? ''
       if (query) {
-        const res = await ctx.dataplane.searchFeedGenerators({
-          query,
-          limit: params.limit,
-        })
-        uris = res.uris as AtUriString[]
+        const useV2 = features.checkGate(features.Gate.SearchV2Enable)
+        if (useV2) {
+          const res = await ctx.dataplane.searchFeedGeneratorsV2({
+            params: {
+              query,
+              viewer: viewer ?? undefined,
+              limit: params.limit,
+            },
+          })
+          uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
+        } else {
+          const res = await ctx.dataplane.searchFeedGenerators({
+            query,
+            limit: params.limit,
+          })
+          uris = res.uris as AtUriString[]
+        }
       } else {
         const res = await ctx.dataplane.getSuggestedFeeds({
           actorDid: viewer ?? undefined,

--- a/packages/bsky/src/data-plane/server/routes/feed-gens.ts
+++ b/packages/bsky/src/data-plane/server/routes/feed-gens.ts
@@ -45,22 +45,18 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   },
 
   async searchFeedGenerators(req) {
-    const { ref } = db.db.dynamic
-    const limit = req.limit
-    const query = req.query.trim()
-    let builder = db.db
-      .selectFrom('feed_generator')
-      .if(!!query, (q) => q.where('displayName', 'ilike', `%${query}%`))
-      .selectAll()
-    const keyset = new TimeCidKeyset(
-      ref('feed_generator.createdAt'),
-      ref('feed_generator.cid'),
+    return searchFeedGeneratorsImpl(db, req.query, req.limit)
+  },
+
+  async searchFeedGeneratorsV2(req) {
+    const { uris, cursor } = await searchFeedGeneratorsImpl(
+      db,
+      req.params?.query ?? '',
+      req.params?.limit ?? 25,
     )
-    builder = paginate(builder, { limit, keyset })
-    const feeds = await builder.execute()
     return {
-      uris: feeds.map((f) => f.uri),
-      cursor: keyset.packFromResult(feeds),
+      feedGenerators: uris.map((uri) => ({ uri, score: 0 })),
+      pageInfo: { cursor: cursor ?? '', hitsTotal: 0n },
     }
   },
 
@@ -68,3 +64,26 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     throw new Error('unimplemented')
   },
 })
+
+const searchFeedGeneratorsImpl = async (
+  db: Database,
+  query: string,
+  limit: number,
+) => {
+  const { ref } = db.db.dynamic
+  const trimmed = query.trim()
+  let builder = db.db
+    .selectFrom('feed_generator')
+    .if(!!trimmed, (q) => q.where('displayName', 'ilike', `%${trimmed}%`))
+    .selectAll()
+  const keyset = new TimeCidKeyset(
+    ref('feed_generator.createdAt'),
+    ref('feed_generator.cid'),
+  )
+  builder = paginate(builder, { limit, keyset })
+  const feeds = await builder.execute()
+  return {
+    uris: feeds.map((f) => f.uri),
+    cursor: keyset.packFromResult(feeds),
+  }
+}

--- a/packages/bsky/src/data-plane/server/routes/search.ts
+++ b/packages/bsky/src/data-plane/server/routes/search.ts
@@ -8,9 +8,12 @@ import {
 } from '../db/pagination.js'
 import { parsePostSearchQuery } from '../util.js'
 
-export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
-  // @TODO actor search endpoints still fall back to search service
-  async searchActors(req) {
+export default (db: Database): Partial<ServiceImpl<typeof Service>> => {
+  const searchActorsImpl = async (req: {
+    term: string
+    limit: number
+    cursor?: string
+  }) => {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic
     let builder = db.db
@@ -35,10 +38,13 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       dids: res.map((row) => row.did),
       cursor: keyset.packFromResult(res),
     }
-  },
+  }
 
-  // @TODO post search endpoint still falls back to search service
-  async searchPosts(req) {
+  const searchPostsImpl = async (req: {
+    term: string
+    limit: number
+    cursor?: string
+  }) => {
     const { term, limit, cursor } = req
     const { q, author } = parsePostSearchQuery(term)
 
@@ -75,9 +81,13 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       uris: res.map((row) => row.uri),
       cursor: keyset.packFromResult(res),
     }
-  },
+  }
 
-  async searchStarterPacks(req) {
+  const searchStarterPacksImpl = async (req: {
+    term: string
+    limit: number
+    cursor?: string
+  }) => {
     const { term, limit, cursor } = req
     const { ref } = db.db.dynamic
     let builder = db.db
@@ -99,14 +109,72 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
     const res = await builder.execute()
 
-    const cur = keyset.packFromResult(res)
-
     return {
       uris: res.map((row) => row.uri),
-      cursor: cur,
+      cursor: keyset.packFromResult(res),
     }
-  },
-})
+  }
+
+  return {
+    // @TODO actor search endpoints still fall back to search service
+    searchActors: searchActorsImpl,
+
+    // @TODO post search endpoint still falls back to search service
+    searchPosts: searchPostsImpl,
+
+    searchStarterPacks: searchStarterPacksImpl,
+
+    // V2 endpoints reuse the V1 SQL for dev env and reshape the response.
+    async searchActorsV2(req) {
+      const { dids, cursor } = await searchActorsImpl({
+        term: req.params?.query ?? '',
+        limit: req.params?.limit ?? 25,
+        cursor: req.params?.cursor,
+      })
+      return {
+        actors: dids.map((did) => ({ did, score: 0 })),
+        pageInfo: { cursor: cursor ?? '', hitsTotal: 0n },
+      }
+    },
+
+    async searchActorsTypeahead(req) {
+      const { dids } = await searchActorsImpl({
+        term: req.query,
+        limit: req.limit || 10,
+      })
+      return {
+        actors: dids.map((did) => ({ did, score: 0 })),
+      }
+    },
+
+    async searchPostsV2(req) {
+      const author = req.filters?.authors?.[0]
+      const baseQuery = req.params?.query ?? ''
+      const term = author ? `${baseQuery} from:${author}` : baseQuery
+      const { uris, cursor } = await searchPostsImpl({
+        term,
+        limit: req.params?.limit ?? 25,
+        cursor: req.params?.cursor,
+      })
+      return {
+        posts: uris.map((uri) => ({ uri, score: 0 })),
+        pageInfo: { cursor: cursor ?? '', hitsTotal: 0n },
+      }
+    },
+
+    async searchStarterPacksV2(req) {
+      const { uris, cursor } = await searchStarterPacksImpl({
+        term: req.params?.query ?? '',
+        limit: req.params?.limit ?? 25,
+        cursor: req.params?.cursor,
+      })
+      return {
+        starterPacks: uris.map((uri) => ({ uri, score: 0 })),
+        pageInfo: { cursor: cursor ?? '', hitsTotal: 0n },
+      }
+    },
+  }
+}
 
 // Remove leading @ in case a handle is input that way
 const cleanQuery = (query: string) => query.trim().replace(/^@/g, '')

--- a/packages/bsky/src/feature-gates/gates.ts
+++ b/packages/bsky/src/feature-gates/gates.ts
@@ -11,6 +11,7 @@ export enum Gate {
   SuggestedUsersForExploreEnable = 'suggested_users:for_explore:enable',
   SuggestedUsersForDiscoverEnable = 'suggested_users:for_discover:enable',
   SuggestedUsersForSeeMoreEnable = 'suggested_users:for_see_more:enable',
+  SearchV2Enable = 'search:v2:enable',
 
   // temp
   AATest = 'aa-test-appview',


### PR DESCRIPTION
 This PR routes appview search requests to the new dataplane V2 API.

 The handlers keep their existing V1 skeleton and use a new V2 skeleton based on the `search:v2:enable` feature gate. Search lexicons are unchanged and provide the same response shape to clients.

Note that the current lexicon queries don't expose every filter V2 supports such as`exclude` filters, reply/thread filters, has_media / has_video, following, etc.