### PR TITLE
pds: proxy unregisterPush to notification service (mirrors registerPush)

### DIFF
--- a/.changeset/calm-bulls-cure.md
+++ b/.changeset/calm-bulls-cure.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Proxy `app.bsky.notification.unregisterPush` to the notification service identified by `serviceDid`, matching the behavior of `registerPush`.

--- a/packages/pds/src/api/app/bsky/notification/index.ts
+++ b/packages/pds/src/api/app/bsky/notification/index.ts
@@ -1,7 +1,9 @@
 import { Server } from '@atproto/xrpc-server'
 import { AppContext } from '../../../../context.js'
 import registerPush from './registerPush.js'
+import unregisterPush from './unregisterPush.js'
 
 export default function (server: Server, ctx: AppContext) {
   registerPush(server, ctx)
+  unregisterPush(server, ctx)
 }

--- a/packages/pds/src/api/app/bsky/notification/unregisterPush.ts
+++ b/packages/pds/src/api/app/bsky/notification/unregisterPush.ts
@@ -1,0 +1,65 @@
+import { getNotif } from '@atproto/identity'
+import { xrpc } from '@atproto/lex'
+import { InvalidRequestError, Server } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context.js'
+import { app } from '../../../../lexicons/index.js'
+import { getDidDoc } from '../util/resolver.js'
+
+export default function (server: Server, ctx: AppContext) {
+  const { bskyAppView } = ctx
+  if (!bskyAppView) return
+
+  server.add(app.bsky.notification.unregisterPush, {
+    auth: ctx.authVerifier.authorization({
+      additional: [],
+      authorize: () => {},
+    }),
+    handler: async ({ auth, input: { body } }) => {
+      const { serviceDid } = body
+      const { did } = auth.credentials
+
+      if (auth.credentials.type === 'oauth') {
+        auth.credentials.permissions.assertRpc({
+          aud: `${serviceDid}#bsky_notif`,
+          lxm: app.bsky.notification.unregisterPush.$lxm,
+        })
+      }
+
+      const { headers } = await ctx.serviceAuthHeaders(
+        did,
+        serviceDid,
+        app.bsky.notification.unregisterPush.$lxm,
+      )
+
+      if (bskyAppView.did === serviceDid) {
+        await bskyAppView.client.call(
+          app.bsky.notification.unregisterPush,
+          body,
+          { headers },
+        )
+        return
+      }
+
+      const notifEndpoint = await getEndpoint(ctx, serviceDid)
+
+      await xrpc(notifEndpoint, app.bsky.notification.unregisterPush, {
+        validateRequest: ctx.cfg.service.devMode,
+        validateResponse: ctx.cfg.service.devMode,
+        strictResponseProcessing: ctx.cfg.service.devMode,
+        body,
+        headers,
+      })
+    },
+  })
+}
+
+const getEndpoint = async (ctx: AppContext, serviceDid: string) => {
+  const doc = await getDidDoc(ctx, serviceDid)
+  const notifEndpoint = getNotif(doc)
+  if (!notifEndpoint) {
+    throw new InvalidRequestError(
+      `invalid notification service details in did document: ${serviceDid}`,
+    )
+  }
+  return notifEndpoint
+}

--- a/packages/pds/tests/proxied/notif.test.ts
+++ b/packages/pds/tests/proxied/notif.test.ts
@@ -40,7 +40,7 @@ describe('notif service proxy', () => {
     await network?.close()
   })
 
-  it('proxies to notif service.', async () => {
+  it('proxies registerPush to notif service.', async () => {
     await agent.api.app.bsky.notification.registerPush(
       {
         serviceDid: notifDid,
@@ -71,11 +71,49 @@ describe('notif service proxy', () => {
     )
     expect(auth.iss).toEqual(sc.dids.bob)
   })
+
+  it('proxies unregisterPush to notif service.', async () => {
+    await agent.api.app.bsky.notification.unregisterPush(
+      {
+        serviceDid: notifDid,
+        token: 'tok1',
+        platform: 'web',
+        appId: 'app1',
+      },
+      {
+        headers: sc.getHeaders(sc.dids.bob),
+        encoding: 'application/json',
+      },
+    )
+    expect(spy.current?.['input']).toEqual({
+      serviceDid: notifDid,
+      token: 'tok1',
+      platform: 'web',
+      appId: 'app1',
+    })
+
+    const auth = await verifyJwt(
+      spy.current?.['jwt'] as string,
+      notifDid,
+      'app.bsky.notification.unregisterPush',
+      async (did) => {
+        const keypair = await network.pds.ctx.actorStore.keypair(did)
+        return keypair.did()
+      },
+    )
+    expect(auth.iss).toEqual(sc.dids.bob)
+  })
 })
 
 async function createMockNotifService(ref: { current: unknown }) {
   const svc = createServer()
   svc.add(app.bsky.notification.registerPush, ({ input, req }) => {
+    ref.current = {
+      input: input.body,
+      jwt: req.headers.authorization?.replace('Bearer ', ''),
+    }
+  })
+  svc.add(app.bsky.notification.unregisterPush, ({ input, req }) => {
     ref.current = {
       input: input.body,
       jwt: req.headers.authorization?.replace('Bearer ', ''),


### PR DESCRIPTION
`app.bsky.notification.registerPush` has a dedicated PDS handler that reads
`serviceDid` from the request body, resolves the `bsky_notif` endpoint from
the DID document, and proxies the request there with a service auth JWT.
`app.bsky.notification.unregisterPush` had no such handler, so requests fell
through to the catchall pipethrough and were routed to the bskyAppView instead
of the correct notification service — resulting in `InvalidRequestError: Invalid
serviceDid` for clients that did not manually set the `atproto-proxy` header.

This PR adds a dedicated `unregisterPush` handler that mirrors `registerPush`
exactly, so clients can call either endpoint the same way: send `serviceDid` in
the request body, and the PDS handles routing transparently.

**Before:** calling `unregisterPush` without `atproto-proxy` header fails with
`InvalidRequestError: Invalid serviceDid.`

**After:** `unregisterPush` is proxied to the notification service identified by
`serviceDid`, identical to how `registerPush` behaves.

Fixes #5043