### PR TITLE
bsky: consume expanded notification preferences

### DIFF
--- a/.changeset/quiet-toes-cheer.md
+++ b/.changeset/quiet-toes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Consume expanded notification preferences: add chat request preference and rename the chat include value `accepted` to `follows`.

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -818,10 +818,15 @@ message NotificationPreference {
 enum ChatNotificationInclude {
   CHAT_NOTIFICATION_INCLUDE_UNSPECIFIED = 0;
   CHAT_NOTIFICATION_INCLUDE_ALL = 1;
-  CHAT_NOTIFICATION_INCLUDE_ACCEPTED = 2;
+  CHAT_NOTIFICATION_INCLUDE_FOLLOWS = 2;
 }
 
 message ChatNotificationPreference {
+  ChatNotificationInclude include = 1;
+  NotificationChannelPush push = 2;
+}
+
+message ChatRequestNotificationPreference {
   ChatNotificationInclude include = 1;
   NotificationChannelPush push = 2;
 }
@@ -841,6 +846,7 @@ message NotificationPreferences {
   NotificationPreference subscribed_post = 12;
   NotificationPreference unverified = 13;
   NotificationPreference verified = 14;
+  ChatRequestNotificationPreference chat_request = 15;
 }
 
 message GetNotificationPreferencesResponse {

--- a/packages/bsky/src/api/app/bsky/notification/util.ts
+++ b/packages/bsky/src/api/app/bsky/notification/util.ts
@@ -2,6 +2,7 @@ import { app } from '../../../../lexicons/index.js'
 import {
   ChatNotificationInclude,
   ChatNotificationPreference,
+  ChatRequestNotificationPreference,
   FilterableNotificationPreference,
   NotificationInclude,
   NotificationPreference,
@@ -18,7 +19,20 @@ type DeepPartial<T> = T extends object
 const ensureChatPreference = (
   p?: DeepPartial<app.bsky.notification.defs.ChatPreference>,
 ): app.bsky.notification.defs.ChatPreference => {
-  const includeValues = ['all', 'accepted']
+  const includeValues = ['all', 'follows']
+  return {
+    include:
+      typeof p?.include === 'string' && includeValues.includes(p.include)
+        ? p.include
+        : 'all',
+    push: p?.push ?? true,
+  }
+}
+
+const ensureChatRequestPreference = (
+  p?: DeepPartial<app.bsky.notification.defs.ChatRequestPreference>,
+): app.bsky.notification.defs.ChatRequestPreference => {
+  const includeValues = ['all', 'follows']
   return {
     include:
       typeof p?.include === 'string' && includeValues.includes(p.include)
@@ -56,6 +70,7 @@ const ensurePreferences = (
 ): app.bsky.notification.defs.Preferences => {
   return {
     chat: ensureChatPreference(p.chat),
+    chatRequest: ensureChatRequestPreference(p.chatRequest),
     follow: ensureFilterablePreference(p.follow),
     like: ensureFilterablePreference(p.like),
     likeViaRepost: ensureFilterablePreference(p.likeViaRepost),
@@ -75,8 +90,16 @@ const protobufChatPreferenceToLex = (
   p?: DeepPartial<ChatNotificationPreference>,
 ): Partial<app.bsky.notification.defs.ChatPreference> => {
   return {
-    include:
-      p?.include === ChatNotificationInclude.ACCEPTED ? 'accepted' : 'all',
+    include: p?.include === ChatNotificationInclude.FOLLOWS ? 'follows' : 'all',
+    push: p?.push?.enabled,
+  }
+}
+
+const protobufChatRequestPreferenceToLex = (
+  p?: DeepPartial<ChatRequestNotificationPreference>,
+): Partial<app.bsky.notification.defs.ChatRequestPreference> => {
+  return {
+    include: p?.include === ChatNotificationInclude.FOLLOWS ? 'follows' : 'all',
     push: p?.push?.enabled,
   }
 }
@@ -105,6 +128,7 @@ export const protobufToLex = (
 ): app.bsky.notification.defs.Preferences => {
   return ensurePreferences({
     chat: protobufChatPreferenceToLex(res.chat),
+    chatRequest: protobufChatRequestPreferenceToLex(res.chatRequest),
     follow: protobufFilterablePreferenceToLex(res.follow),
     like: protobufFilterablePreferenceToLex(res.like),
     likeViaRepost: protobufFilterablePreferenceToLex(res.likeViaRepost),

--- a/packages/bsky/src/data-plane/server/routes/notifs.ts
+++ b/packages/bsky/src/data-plane/server/routes/notifs.ts
@@ -8,6 +8,7 @@ import { Service } from '../../../proto/bsky_connect.js'
 import {
   ChatNotificationInclude,
   ChatNotificationPreference,
+  ChatRequestNotificationPreference,
   FilterableNotificationPreference,
   NotificationInclude,
   NotificationPreference,
@@ -205,8 +206,19 @@ export const notificationPreferencesLexToProtobuf = (
   ): ChatNotificationPreference =>
     new ChatNotificationPreference({
       include:
-        p.include === 'accepted'
-          ? ChatNotificationInclude.ACCEPTED
+        p.include === 'follows'
+          ? ChatNotificationInclude.FOLLOWS
+          : ChatNotificationInclude.ALL,
+      push: { enabled: p.push ?? true },
+    })
+
+  const lexChatRequestPreferenceToProtobuf = (
+    p: app.bsky.notification.defs.ChatRequestPreference,
+  ): ChatRequestNotificationPreference =>
+    new ChatRequestNotificationPreference({
+      include:
+        p.include === 'follows'
+          ? ChatNotificationInclude.FOLLOWS
           : ChatNotificationInclude.ALL,
       push: { enabled: p.push ?? true },
     })
@@ -234,6 +246,9 @@ export const notificationPreferencesLexToProtobuf = (
   return new NotificationPreferences({
     entry: Buffer.from(json),
     chat: lexChatPreferenceToProtobuf(p.chat),
+    chatRequest: p.chatRequest
+      ? lexChatRequestPreferenceToProtobuf(p.chatRequest)
+      : undefined,
     follow: lexFilterablePreferenceToProtobuf(p.follow),
     like: lexFilterablePreferenceToProtobuf(p.like),
     likeViaRepost: lexFilterablePreferenceToProtobuf(p.likeViaRepost),

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -1052,6 +1052,10 @@ describe('notification views', () => {
       include: 'all',
       push: true,
     }
+    const crp: AppBskyNotificationDefs.ChatRequestPreference = {
+      include: 'all',
+      push: true,
+    }
 
     it('gets preferences filling up with the defaults', async () => {
       const actorDid = sc.dids.carol
@@ -1102,6 +1106,7 @@ describe('notification views', () => {
 
       const expectedApi0: AppBskyNotificationDefs.Preferences = {
         chat: cp,
+        chatRequest: crp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,
@@ -1133,6 +1138,7 @@ describe('notification views', () => {
 
       const expectedApi1: AppBskyNotificationDefs.Preferences = {
         chat: cp,
+        chatRequest: crp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,
@@ -1199,11 +1205,12 @@ describe('notification views', () => {
       const input0 = {
         chat: {
           push: false,
-          include: 'accepted',
+          include: 'follows',
         },
       }
       const expected0: AppBskyNotificationDefs.Preferences = {
         chat: input0.chat,
+        chatRequest: crp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,
@@ -1229,6 +1236,7 @@ describe('notification views', () => {
       const expected1: AppBskyNotificationDefs.Preferences = {
         // Kept from the previous call.
         chat: input0.chat,
+        chatRequest: crp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,


### PR DESCRIPTION
Track tango proto changes (bluesky-social/tango#1034):
- rename ChatNotificationInclude.ACCEPTED -> FOLLOWS (value 2 kept)
- add ChatRequestNotificationPreference message + chat_request field

Wire chatRequest through the getPreferences/putPreferencesV2 lex<->proto converters and the dataplane mock, and update the chat include value from "accepted" to "follows" to match the app.bsky.notification lexicon.