### PR TITLE
bsky: add internal.bsky.notification.getPreferences endpoint

### DIFF
--- a/.changeset/sour-lizards-repair.md
+++ b/.changeset/sour-lizards-repair.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+add internal.bsky.notification.getPreferences endpoint

--- a/lexicons/internal/bsky/notification/getPreferences.json
+++ b/lexicons/internal/bsky/notification/getPreferences.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "internal.bsky.notification.getPreferences",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get notification-related preferences for a list of accounts. Intended for internal service-to-service use. Only accounts that have stored preferences are returned, so the response may be shorter than the requested list and is not positional.",
+      "parameters": {
+        "type": "params",
+        "required": ["dids"],
+        "properties": {
+          "dids": {
+            "type": "array",
+            "items": { "type": "string", "format": "did" },
+            "description": "The DIDs of the accounts to get notification preferences for."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#preferencesByDid"
+              }
+            }
+          }
+        }
+      }
+    },
+    "preferencesByDid": {
+      "type": "object",
+      "required": ["did", "preferences"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "preferences": {
+          "type": "ref",
+          "ref": "app.bsky.notification.defs#preferences"
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -97,6 +97,7 @@ import resolveHandle from './com/atproto/identity/resolveHandle.js'
 import queryLabels from './com/atproto/label/queryLabels.js'
 import getRecord from './com/atproto/repo/getRecord.js'
 import fetchLabels from './com/atproto/temp/fetchLabels.js'
+import getNotificationPreferences from './internal/bsky/notification/getPreferences.js'
 
 export * as health from './health.js'
 
@@ -200,6 +201,8 @@ export default function (server: Server, ctx: AppContext) {
   aaGetConfig(server, ctx)
   aaGetState(server, ctx)
   aaBegin(server, ctx)
+  // internal.bsky
+  getNotificationPreferences(server, ctx)
   // com.atproto
   getSubjectStatus(server, ctx)
   updateSubjectStatus(server, ctx)

--- a/packages/bsky/src/api/internal/bsky/notification/getPreferences.ts
+++ b/packages/bsky/src/api/internal/bsky/notification/getPreferences.ts
@@ -1,0 +1,50 @@
+import { Un$Typed } from '@atproto/lex'
+import { Server, UpstreamFailureError } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context.js'
+import { internal } from '../../../../lexicons/index.js'
+import { GetNotificationPreferencesResponse } from '../../../../proto/bsky_pb.js'
+import { protobufToLex } from '../../../app/bsky/notification/util.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(internal.bsky.notification.getPreferences, {
+    auth: ctx.authVerifier.role,
+    handler: async ({ params }) => {
+      const { dids } = params
+
+      let res: GetNotificationPreferencesResponse
+      try {
+        res = await ctx.dataplane.getNotificationPreferences({ dids })
+      } catch (err) {
+        throw new UpstreamFailureError(
+          'cannot get notification preferences',
+          'NotificationPreferencesFailed',
+          { cause: err },
+        )
+      }
+
+      const preferences: Un$Typed<internal.bsky.notification.getPreferences.PreferencesByDid>[] =
+        []
+      dids.forEach((did, i) => {
+        const protoPreferences = res.preferences[i]
+        // The dataplane returns an entry for every requested DID, positionally.
+        // An empty `entry` means the account has no stored preferences, in which
+        // case we omit it from the (non-positional) response.
+        // This is for extra-safety, but it shouldn't happen.
+        if (!protoPreferences || protoPreferences.entry.length === 0) {
+          return
+        }
+        preferences.push({
+          did,
+          preferences: protobufToLex(protoPreferences),
+        })
+      })
+
+      return {
+        encoding: 'application/json',
+        body: {
+          preferences,
+        },
+      }
+    },
+  })
+}

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -1254,6 +1254,132 @@ describe('notification views', () => {
     })
   })
 
+  describe('internal getPreferences', () => {
+    beforeEach(async () => {
+      await clearPrivateData(db)
+    })
+
+    // Defaults, as filled in by the endpoint.
+    const fp: AppBskyNotificationDefs.FilterablePreference = {
+      include: 'all',
+      list: true,
+      push: true,
+    }
+    const p: AppBskyNotificationDefs.Preference = {
+      list: true,
+      push: true,
+    }
+    const cp: AppBskyNotificationDefs.ChatPreference = {
+      include: 'all',
+      push: true,
+    }
+    const crp: AppBskyNotificationDefs.ChatRequestPreference = {
+      include: 'all',
+      push: true,
+    }
+    const defaults: AppBskyNotificationDefs.Preferences = {
+      chat: cp,
+      chatRequest: crp,
+      follow: fp,
+      like: fp,
+      likeViaRepost: fp,
+      mention: fp,
+      quote: fp,
+      reply: fp,
+      repost: fp,
+      repostViaRepost: fp,
+      starterpackJoined: p,
+      subscribedPost: p,
+      unverified: p,
+      verified: p,
+    }
+
+    const storePreferences = async (
+      actorDid: string,
+      input: AppBskyNotificationPutPreferencesV2.InputSchema,
+    ) => {
+      await agent.app.bsky.notification.putPreferencesV2(input, {
+        encoding: 'application/json',
+        headers: await network.serviceHeaders(
+          actorDid,
+          ids.AppBskyNotificationPutPreferencesV2,
+        ),
+      })
+      await network.processAll()
+    }
+
+    const getPreferences = async (dids: string[]) => {
+      const params = new URLSearchParams()
+      dids.forEach((did) => params.append('dids', did))
+      const res = await fetch(
+        `${network.bsky.url}/xrpc/internal.bsky.notification.getPreferences?${params.toString()}`,
+        { headers: network.bsky.adminAuthHeaders() },
+      )
+      return {
+        status: res.status,
+        body: (await res.json()) as {
+          preferences: {
+            did: string
+            preferences: AppBskyNotificationDefs.Preferences
+          }[]
+        },
+      }
+    }
+
+    it('requires role auth, rejecting standard user auth', async () => {
+      // A regular user (standard service JWT) must not be able to call this.
+      const userHeaders = await network.serviceHeaders(
+        carol,
+        'internal.bsky.notification.getPreferences',
+      )
+      const res = await fetch(
+        `${network.bsky.url}/xrpc/internal.bsky.notification.getPreferences?dids=${carol}`,
+        { headers: userHeaders },
+      )
+      expect(res.status).toBe(401)
+    })
+
+    it('returns preferences for the accounts that have them stored', async () => {
+      await storePreferences(carol, { verified: { list: false, push: false } })
+      await storePreferences(dan, { chat: { include: 'follows', push: false } })
+
+      const { status, body } = await getPreferences([carol, dan])
+      expect(status).toBe(200)
+
+      expect(body.preferences).toStrictEqual([
+        {
+          did: carol,
+          preferences: { ...defaults, verified: { list: false, push: false } },
+        },
+        {
+          did: dan,
+          preferences: {
+            ...defaults,
+            chat: { include: 'follows', push: false },
+          },
+        },
+      ])
+    })
+
+    it('omits accounts that have no stored preferences', async () => {
+      await storePreferences(carol, { verified: { list: false, push: false } })
+
+      // `eve` never stored preferences.
+      const { status, body } = await getPreferences([carol, eve])
+      expect(status).toBe(200)
+
+      // Only `carol` is returned, and the response is not positional.
+      expect(body.preferences).toHaveLength(1)
+      expect(body.preferences[0].did).toBe(carol)
+    })
+
+    it('returns an empty list when no account has stored preferences', async () => {
+      const { status, body } = await getPreferences([carol, dan, eve])
+      expect(status).toBe(200)
+      expect(body.preferences).toStrictEqual([])
+    })
+  })
+
   describe('activity subscriptions', () => {
     const sortProfiles = (profiles: AppBskyActorDefs.ProfileView[]) => {
       return profiles.sort((a, b) => (a.handle > b.handle ? 1 : -1))


### PR DESCRIPTION
New internal (service-to-service) query that takes a list of DIDs and returns notification preferences for each account that has them stored.

- new `internal` lexicon namespace with getPreferences query; output is a non-positional array of { did, preferences } items, so accounts with no stored preferences are simply omitted
- handler uses ctx.authVerifier.role and fetches from the dataplane, reusing the existing protobufToLex converter (default-filled)
- tests covering found/omitted/empty cases and role-auth enforcement