### PR TITLE
:bug: Fix docker build to allow for ozone package import

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -48,6 +48,7 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc-server ./packages/xrpc-server
 COPY ./packages/xrpc ./packages/xrpc
 
+COPY ./packages/bsky ./packages/bsky
 COPY ./services/bsky ./services/bsky
 
 # install all deps

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -49,6 +49,7 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc-server ./packages/xrpc-server
 COPY ./packages/xrpc ./packages/xrpc
 
+COPY ./packages/ozone ./packages/ozone
 COPY ./services/ozone ./services/ozone
 
 # install all deps

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -49,6 +49,7 @@ COPY ./packages/ws-client ./packages/ws-client
 COPY ./packages/xrpc-server ./packages/xrpc-server
 COPY ./packages/xrpc ./packages/xrpc
 
+COPY ./packages/pds ./packages/pds
 COPY ./services/pds ./services/pds
 
 # install all deps


### PR DESCRIPTION
PR #5045 reorganized the service Dockerfiles and accidentally dropped the `COPY ./packages/<svc> ./packages/<svc>` line for each service's own package. The transitive-dep list comment was updated to filter the service's own package out (`grep -v 'packages/ozone"'`, etc.) on the assumption it would be copied separately, but no separate COPY was added.

Result
------
`pnpm install` runs without the service's source on disk, so the workspace symlink for @atproto/<svc> resolves to nothing, and at runtime services/<svc>/api.ts blows up with:


`Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@atproto/ozone' imported from /app/services/ozone/api.ts
This adds the missing COPY line back to all three Dockerfiles (ozone, bsky, pds).`

Test plan
---------
- [ ] docker build -f services/ozone/Dockerfile . succeeds and the resulting container starts without the ERR_MODULE_NOT_FOUND for @atproto/ozone
- [ ] Same for services/bsky/Dockerfile and services/pds/Dockerfile