### PR TITLE
bsky: add optimized profiles endpoint for service-to-service

### DIFF
--- a/.changeset/tidy-falcons-attend.md
+++ b/.changeset/tidy-falcons-attend.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+add internal.bsky.actor.getProfiles endpoint

--- a/lexicons/internal/bsky/actor/getProfiles.json
+++ b/lexicons/internal/bsky/actor/getProfiles.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "internal.bsky.actor.getProfiles",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get detailed profile views of multiple actors, hydrating social proof (known followers) only for a subset of them. Intended for internal service-to-service use.",
+      "parameters": {
+        "type": "params",
+        "required": ["dids"],
+        "properties": {
+          "dids": {
+            "type": "array",
+            "items": { "type": "string", "format": "did" },
+            "maxLength": 200
+          },
+          "viewer": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the account on whose behalf the request is made (not included for public/unauthenticated requests). Used for viewer-relative state, including social proof."
+          },
+          "socialProof": {
+            "type": "array",
+            "description": "DIDs to hydrate social proof (known followers) for. DIDs not also present in `dids` are ignored.",
+            "items": { "type": "string", "format": "did" },
+            "maxLength": 200
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["profiles"],
+          "properties": {
+            "profiles": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "app.bsky.actor.defs#profileViewDetailed"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -97,6 +97,7 @@ import resolveHandle from './com/atproto/identity/resolveHandle.js'
 import queryLabels from './com/atproto/label/queryLabels.js'
 import getRecord from './com/atproto/repo/getRecord.js'
 import fetchLabels from './com/atproto/temp/fetchLabels.js'
+import internalGetProfiles from './internal/bsky/actor/getProfiles.js'
 
 export * as health from './health.js'
 
@@ -208,4 +209,6 @@ export default function (server: Server, ctx: AppContext) {
   getRecord(server, ctx)
   fetchLabels(server, ctx)
   queryLabels(server, ctx)
+  // internal.bsky
+  internalGetProfiles(server, ctx)
 }

--- a/packages/bsky/src/api/internal/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/api/internal/bsky/actor/getProfiles.ts
@@ -1,0 +1,87 @@
+import { mapDefined } from '@atproto/common'
+import { DidString } from '@atproto/syntax'
+import { Server } from '@atproto/xrpc-server'
+import { AppContext } from '../../../../context.js'
+import {
+  HydrateCtx,
+  HydrationState,
+  Hydrator,
+} from '../../../../hydration/hydrator.js'
+import { internal } from '../../../../lexicons/index.js'
+import { createPipeline, noRules } from '../../../../pipeline.js'
+import { Views } from '../../../../views/index.js'
+
+export default function (server: Server, ctx: AppContext) {
+  const getProfiles = createPipeline(skeleton, hydration, noRules, presentation)
+  server.add(internal.bsky.actor.getProfiles, {
+    auth: ctx.authVerifier.role,
+    handler: async ({ params, req }) => {
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        viewer: params.viewer ?? null,
+        labelers,
+      })
+
+      const result = await getProfiles({ ...params, hydrateCtx }, ctx)
+
+      return {
+        encoding: 'application/json',
+        body: result,
+      }
+    },
+  })
+}
+
+const skeleton = async (input: {
+  ctx: Context
+  params: Params
+}): Promise<SkeletonState> => {
+  const { params } = input
+  const dids = params.dids
+  const didSet = new Set(dids)
+  // social proof is only hydrated for dids present in both inputs
+  const socialProofDids = (params.socialProof ?? []).filter((did) =>
+    didSet.has(did),
+  )
+  return { dids, socialProofDids }
+}
+
+const hydration = async (input: {
+  ctx: Context
+  params: Params
+  skeleton: SkeletonState
+}) => {
+  const { ctx, params, skeleton } = input
+  return ctx.hydrator.hydrateProfilesDetailed(
+    skeleton.dids,
+    params.hydrateCtx,
+    { knownFollowersDids: skeleton.socialProofDids },
+  )
+}
+
+const presentation = (input: {
+  ctx: Context
+  params: Params
+  skeleton: SkeletonState
+  hydration: HydrationState
+}) => {
+  const { ctx, skeleton, hydration } = input
+  const profiles = mapDefined(skeleton.dids, (did) =>
+    ctx.views.profileDetailed(did, hydration),
+  )
+  return { profiles }
+}
+
+type Context = {
+  hydrator: Hydrator
+  views: Views
+}
+
+type Params = internal.bsky.actor.getProfiles.$Params & {
+  hydrateCtx: HydrateCtx
+}
+
+type SkeletonState = {
+  dids: DidString[]
+  socialProofDids: DidString[]
+}

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -335,28 +335,26 @@ export class Hydrator {
     dids: DidString[],
     ctx: HydrateCtx,
   ): Promise<HydrationState> {
-    let knownFollowers: KnownFollowersStates = new HydrationMap()
-    try {
-      knownFollowers = await this.actor.getKnownFollowers(dids, ctx.viewer)
-    } catch (err) {
-      hydrationLogger.error(
-        { err },
-        'Failed to get known followers for profiles',
-      )
-    }
-
-    let activitySubscriptions: ActivitySubscriptionStates = new HydrationMap()
-    try {
-      activitySubscriptions = await this.actor.getActivitySubscriptions(
-        dids,
-        ctx.viewer,
-      )
-    } catch (err) {
-      hydrationLogger.error(
-        { err },
-        'Failed to get activity subscriptions state for profiles',
-      )
-    }
+    const [knownFollowers, activitySubscriptions] = await Promise.all([
+      this.actor
+        .getKnownFollowers(dids, ctx.viewer)
+        .catch((err): KnownFollowersStates => {
+          hydrationLogger.error(
+            { err },
+            'Failed to get known followers for profiles',
+          )
+          return new HydrationMap()
+        }),
+      this.actor
+        .getActivitySubscriptions(dids, ctx.viewer)
+        .catch((err): ActivitySubscriptionStates => {
+          hydrationLogger.error(
+            { err },
+            'Failed to get activity subscriptions state for profiles',
+          )
+          return new HydrationMap()
+        }),
+    ])
 
     const subjectsToKnownFollowersMap = new Map<DidString, DidString[]>()
 
@@ -1051,12 +1049,11 @@ export class Hydrator {
         )
       },
     )
-    const blocks = await this.hydrateBidirectionalBlocks(
-      pairsToMap(listCreatorMemberPairs),
-      ctx,
-    )
-    // sample top list items per starter pack based on their follows
-    const listMemberAggs = await this.actor.getProfileAggregates(listMemberDids)
+    const [blocks, listMemberAggs] = await Promise.all([
+      this.hydrateBidirectionalBlocks(pairsToMap(listCreatorMemberPairs), ctx),
+      // sample top list items per starter pack based on their follows
+      this.actor.getProfileAggregates(listMemberDids),
+    ])
     const listItemUris: AtUriString[] = []
     uris.forEach((uri) => {
       const sp = starterPackState.starterPacks?.get(uri)

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -334,10 +334,14 @@ export class Hydrator {
   async hydrateProfilesDetailed(
     dids: DidString[],
     ctx: HydrateCtx,
+    opts?: {
+      // when set, restricts known followers hydration to this subset of dids
+      knownFollowersDids?: DidString[]
+    },
   ): Promise<HydrationState> {
     const [knownFollowers, activitySubscriptions] = await Promise.all([
       this.actor
-        .getKnownFollowers(dids, ctx.viewer)
+        .getKnownFollowers(opts?.knownFollowersDids ?? dids, ctx.viewer)
         .catch((err): KnownFollowersStates => {
           hydrationLogger.error(
             { err },

--- a/packages/bsky/tests/views/internal-actor.test.ts
+++ b/packages/bsky/tests/views/internal-actor.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { AppBskyActorDefs, AtpAgent } from '@atproto/api'
+import { SeedClient, TestNetwork } from '@atproto/dev-env'
+import { knownFollowersSeed } from '../seed/known-followers.js'
+
+describe('internal actor views', () => {
+  let network: TestNetwork
+  let pdsAgent: AtpAgent
+  let seedClient: SeedClient
+
+  let dids: Record<string, string>
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_internal_actor',
+    })
+    pdsAgent = network.pds.getAgent()
+    seedClient = network.getSeedClient()
+
+    await knownFollowersSeed(seedClient)
+
+    dids = seedClient.dids
+
+    /*
+     * Mix of blocks and non, mirroring the known-followers test setup so the
+     * social proof results exercise block filtering too.
+     */
+    await pdsAgent.api.app.bsky.graph.block.create(
+      { repo: dids.mix_view },
+      { createdAt: new Date().toISOString(), subject: dids.mix_fp_block_res },
+      seedClient.getHeaders(dids.mix_view),
+    )
+    await pdsAgent.api.app.bsky.graph.block.create(
+      { repo: dids.mix_sub_1 },
+      { createdAt: new Date().toISOString(), subject: dids.mix_sp_block_res },
+      seedClient.getHeaders(dids.mix_sub_1),
+    )
+
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network.close()
+  })
+
+  describe('getProfiles', () => {
+    const getProfiles = async (
+      params: { dids: string[]; socialProof?: string[]; viewer?: string },
+      headers: Record<string, string> = network.bsky.adminAuthHeaders(),
+    ) => {
+      const search = new URLSearchParams()
+      params.dids.forEach((did) => search.append('dids', did))
+      params.socialProof?.forEach((did) => search.append('socialProof', did))
+      if (params.viewer) search.append('viewer', params.viewer)
+      const res = await fetch(
+        `${network.bsky.url}/xrpc/internal.bsky.actor.getProfiles?${search.toString()}`,
+        { headers },
+      )
+      return {
+        status: res.status,
+        body: (await res.json()) as {
+          profiles: AppBskyActorDefs.ProfileViewDetailed[]
+        },
+      }
+    }
+
+    it('requires role auth, rejecting standard user auth', async () => {
+      const userHeaders = await network.serviceHeaders(
+        dids.mix_view,
+        'internal.bsky.actor.getProfiles',
+      )
+      const { status } = await getProfiles(
+        { dids: [dids.mix_sub_1] },
+        userHeaders,
+      )
+      expect(status).toBe(401)
+    })
+
+    it('returns all profiles, with social proof only for the requested subset', async () => {
+      const { status, body } = await getProfiles({
+        dids: [dids.mix_sub_1, dids.mix_sub_2, dids.mix_sub_3],
+        socialProof: [dids.mix_sub_1],
+        viewer: dids.mix_view,
+      })
+      expect(status).toBe(200)
+      expect(body.profiles).toHaveLength(3)
+
+      const [sub_1, sub_2, sub_3] = body.profiles
+      expect(sub_1.viewer?.knownFollowers?.count).toBe(3)
+      expect(sub_1.viewer?.knownFollowers?.followers).toHaveLength(1)
+      expect(sub_2.viewer?.knownFollowers).toBeUndefined()
+      expect(sub_3.viewer?.knownFollowers).toBeUndefined()
+    })
+
+    it('ignores socialProof dids that are not in dids', async () => {
+      const { status, body } = await getProfiles({
+        dids: [dids.mix_sub_1],
+        socialProof: [dids.mix_sub_1, dids.mix_sub_2],
+        viewer: dids.mix_view,
+      })
+      expect(status).toBe(200)
+      expect(body.profiles).toHaveLength(1)
+      expect(body.profiles[0].did).toBe(dids.mix_sub_1)
+      expect(body.profiles[0].viewer?.knownFollowers?.count).toBe(3)
+    })
+
+    it('returns no social proof when socialProof is omitted', async () => {
+      const { status, body } = await getProfiles({
+        dids: [dids.mix_sub_1, dids.mix_sub_2],
+        viewer: dids.mix_view,
+      })
+      expect(status).toBe(200)
+      expect(body.profiles).toHaveLength(2)
+      for (const profile of body.profiles) {
+        expect(profile.viewer?.knownFollowers).toBeUndefined()
+      }
+    })
+
+    it('returns no viewer state when viewer is omitted', async () => {
+      const { status, body } = await getProfiles({
+        dids: [dids.mix_sub_1],
+        socialProof: [dids.mix_sub_1],
+      })
+      expect(status).toBe(200)
+      expect(body.profiles).toHaveLength(1)
+      expect(body.profiles[0].viewer).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Add new `internal.bsky.actor.getProfiles` endpoint for internal service-to-service usage.

Pair up sequential awaits with no data dependency:
- hydrateProfilesDetailed: known followers + activity subscriptions
- hydrateStarterPacks: bidirectional blocks + profile aggregates