### PR TITLE
Improve PDS getRepo Compression

### DIFF
--- a/.changeset/stale-toes-sip.md
+++ b/.changeset/stale-toes-sip.md
@@ -2,4 +2,4 @@
 '@atproto/pds': patch
 ---
 
-Improve gzip streaming performance for com.atproto.sync.getRepo by coalescing in chunks chunks before compression.
+Improve gzip streaming performance for com.atproto.sync.getRepo by coalescing in larger chunks before compression.

--- a/.changeset/stale-toes-sip.md
+++ b/.changeset/stale-toes-sip.md
@@ -1,0 +1,6 @@
+---
+'@atproto/common': patch
+'@atproto/pds': patch
+---
+
+Improve gzip streaming performance for com.atproto.sync.getRepo by coalescing small CAR chunks before compression.

--- a/.changeset/stale-toes-sip.md
+++ b/.changeset/stale-toes-sip.md
@@ -1,6 +1,5 @@
 ---
-'@atproto/common': patch
 '@atproto/pds': patch
 ---
 
-Improve gzip streaming performance for com.atproto.sync.getRepo by coalescing small CAR chunks before compression.
+Improve gzip streaming performance for com.atproto.sync.getRepo by coalescing in chunks chunks before compression.

--- a/.changeset/tired-goats-kick.md
+++ b/.changeset/tired-goats-kick.md
@@ -1,0 +1,5 @@
+---
+'@atproto/common': patch
+---
+
+Add `coalesceByteStream` utility to coalesce a byte stream into chunks with a minimal size.

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ clean: ## Deletes all 'dist' and 'node_package' directories (including nested)
 
 .PHONY: nvm-setup
 nvm-setup: ## Use NVM to install and activate node+pnpm
-	nvm install 18
-	nvm use 18
+	nvm install
+	nvm use
 	corepack enable
+	corepack install

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -61,6 +61,69 @@ export const byteIterableToStream = (
   return Readable.from(iter, { objectMode: false })
 }
 
+export const coalesceByteStream = (
+  stream: Readable,
+  targetSize: number,
+): Readable => {
+  if (!Number.isInteger(targetSize) || targetSize < 1) {
+    throw new TypeError('targetSize must be a positive integer')
+  }
+  const coalescer = new ByteCoalescer(targetSize)
+  return pipeline(stream, coalescer, () => {})
+}
+
+class ByteCoalescer extends Transform {
+  private buffered: Uint8Array[] = []
+  private bufferedSize = 0
+
+  constructor(private targetSize: number) {
+    super()
+  }
+
+  _transform(
+    chunk: Uint8Array,
+    _enc: BufferEncoding,
+    cb: TransformCallback,
+  ) {
+    let offset = 0
+
+    while (offset < chunk.length) {
+      if (chunk.length - offset >= this.targetSize) {
+        this.flushBuffered()
+        this.push(chunk.subarray(offset))
+        offset = chunk.length
+        continue
+      }
+
+      const take = Math.min(
+        this.targetSize - this.bufferedSize,
+        chunk.length - offset,
+      )
+      this.buffered.push(chunk.subarray(offset, offset + take))
+      this.bufferedSize += take
+      offset += take
+
+      if (this.bufferedSize === this.targetSize) {
+        this.flushBuffered()
+      }
+    }
+
+    cb()
+  }
+
+  _flush(cb: TransformCallback) {
+    this.flushBuffered()
+    cb()
+  }
+
+  private flushBuffered() {
+    if (this.bufferedSize < 1) return
+    this.push(Buffer.concat(this.buffered, this.bufferedSize))
+    this.buffered = []
+    this.bufferedSize = 0
+  }
+}
+
 export const bytesToStream = (bytes: Uint8Array): Readable => {
   const stream = new Readable()
   stream.push(bytes)

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -61,63 +61,42 @@ export const byteIterableToStream = (
   return Readable.from(iter, { objectMode: false })
 }
 
+/**
+ * Coalesce a stream of Uint8Array chunks into larger chunks of at least the
+ * specified size. This is useful for optimizing downstream processing that
+ * benefits from larger chunk sizes, such as compression or hashing.
+ */
 export const coalesceByteStream = (
-  stream: Readable,
-  targetSize: number,
+  stream: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  minChunkSize: number,
 ): Readable => {
-  if (!Number.isInteger(targetSize) || targetSize < 1) {
-    throw new TypeError('targetSize must be a positive integer')
-  }
-  const coalescer = new ByteCoalescer(targetSize)
-  return pipeline(stream, coalescer, () => {})
-}
+  return pipeline(
+    stream,
+    async function* (
+      iter: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+    ): AsyncGenerator<Uint8Array> {
+      const buffered: Uint8Array[] = []
+      let bufferedLength = 0
 
-class ByteCoalescer extends Transform {
-  private buffered: Uint8Array[] = []
-  private bufferedSize = 0
+      for await (const chunk of iter) {
+        buffered.push(chunk)
+        bufferedLength += Buffer.byteLength(chunk)
 
-  constructor(private targetSize: number) {
-    super()
-  }
-
-  _transform(chunk: Uint8Array, _enc: BufferEncoding, cb: TransformCallback) {
-    let offset = 0
-
-    while (offset < chunk.length) {
-      if (chunk.length - offset >= this.targetSize) {
-        this.flushBuffered()
-        this.push(chunk.subarray(offset))
-        offset = chunk.length
-        continue
+        if (bufferedLength >= minChunkSize) {
+          yield Buffer.concat(buffered, bufferedLength)
+          buffered.length = 0
+          bufferedLength = 0
+        }
       }
 
-      const take = Math.min(
-        this.targetSize - this.bufferedSize,
-        chunk.length - offset,
-      )
-      this.buffered.push(chunk.subarray(offset, offset + take))
-      this.bufferedSize += take
-      offset += take
-
-      if (this.bufferedSize === this.targetSize) {
-        this.flushBuffered()
+      if (bufferedLength > 0) {
+        yield Buffer.concat(buffered, bufferedLength)
+        buffered.length = 0
+        bufferedLength = 0
       }
-    }
-
-    cb()
-  }
-
-  _flush(cb: TransformCallback) {
-    this.flushBuffered()
-    cb()
-  }
-
-  private flushBuffered() {
-    if (this.bufferedSize < 1) return
-    this.push(Buffer.concat(this.buffered, this.bufferedSize))
-    this.buffered = []
-    this.bufferedSize = 0
-  }
+    },
+    () => {},
+  ) as PassThrough
 }
 
 export const bytesToStream = (bytes: Uint8Array): Readable => {

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -72,7 +72,7 @@ export const coalesceByteStream = (
   minChunkSize: number,
 ): Readable => {
   if (!Number.isInteger(minChunkSize) || minChunkSize < 1) {
-    throw new TypeError('targetSize must be a positive number')
+    throw new TypeError('minChunkSize must be a positive integer')
   }
 
   // @NOTE On Node 22, this *does* return a PassThrough ("@types/node"
@@ -83,7 +83,7 @@ export const coalesceByteStream = (
 
   // @NOTE This implementation is not NodeJS specific and could be exported as
   // utility (from "@atproto/common-web") if needed. We don't do it now to avoid
-  // adding increasing the API surface.
+  // increasing the API surface of our packages.
   async function* coalesce(
     iter: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
   ): AsyncGenerator<Uint8Array> {

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -63,13 +63,17 @@ export const byteIterableToStream = (
 
 /**
  * Coalesce a stream of Uint8Array chunks into larger chunks of at least the
- * specified size. This is useful for optimizing downstream processing that
- * benefits from larger chunk sizes, such as compression or hashing.
+ * specified size ({@link minChunkSize}). This is useful for optimizing
+ * downstream processing that benefits from larger chunk sizes, such as
+ * compression or hashing.
  */
 export const coalesceByteStream = (
   stream: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
   minChunkSize: number,
 ): Readable => {
+  if (Number.isNaN(minChunkSize) || minChunkSize < 1) {
+    throw new TypeError('targetSize must be a positive number')
+  }
   return pipeline(
     stream,
     async function* (

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -80,11 +80,7 @@ class ByteCoalescer extends Transform {
     super()
   }
 
-  _transform(
-    chunk: Uint8Array,
-    _enc: BufferEncoding,
-    cb: TransformCallback,
-  ) {
+  _transform(chunk: Uint8Array, _enc: BufferEncoding, cb: TransformCallback) {
     let offset = 0
 
     while (offset < chunk.length) {

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -71,36 +71,71 @@ export const coalesceByteStream = (
   stream: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
   minChunkSize: number,
 ): Readable => {
-  if (Number.isNaN(minChunkSize) || minChunkSize < 1) {
+  if (!Number.isInteger(minChunkSize) || minChunkSize < 1) {
     throw new TypeError('targetSize must be a positive number')
   }
-  return pipeline(
-    stream,
-    async function* (
-      iter: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
-    ): AsyncGenerator<Uint8Array> {
-      const buffered: Uint8Array[] = []
-      let bufferedLength = 0
 
-      for await (const chunk of iter) {
-        buffered.push(chunk)
-        bufferedLength += Buffer.byteLength(chunk)
+  // @NOTE On Node 22, this *does* return a PassThrough ("@types/node"
+  // incorrectly types it as Writable).
+  return pipeline(stream, coalesce, (_err) => {
+    // Errors are expected to be handled through the stream
+  }) as PassThrough
 
-        if (bufferedLength >= minChunkSize) {
-          yield Buffer.concat(buffered, bufferedLength)
-          buffered.length = 0
-          bufferedLength = 0
+  // @NOTE This implementation is not NodeJS specific and could be exported as
+  // utility (from "@atproto/common-web") if needed. We don't do it now to avoid
+  // adding increasing the API surface.
+  async function* coalesce(
+    iter: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  ): AsyncGenerator<Uint8Array> {
+    // @NOTE This implementation avoids as many un-necessary copies as possible
+    // and only buffers incoming chunks when they are smaller than the
+    // coalescing buffer.
+
+    let buffer = new Uint8Array(minChunkSize)
+    let offset = 0
+
+    for await (const chunk of iter) {
+      const freeSpace = buffer.length - offset
+      if (freeSpace > chunk.length) {
+        // If the incoming chunk is smaller than the free space, we copy the
+        // entire chunk into the coalescing buffer and continue to the next
+        // chunk
+        buffer.set(chunk, offset)
+        offset += chunk.length
+      } else if (offset === 0 && chunk.length >= minChunkSize) {
+        // If the coalescing buffer is empty and the incoming chunk is larger
+        // than the coalescing buffer, we can skip any copying and yield the
+        // incoming chunk directly
+        yield chunk
+      } else {
+        // Otherwise, we need to copy as much of the incoming chunk as we can
+        // into the coalescing buffer and yield the full coalescing buffer.
+        buffer.set(chunk.subarray(0, freeSpace), offset)
+        yield buffer
+
+        // We create a new coalescing buffer (for future use)
+        buffer = new Uint8Array(minChunkSize)
+        offset = 0
+
+        const remainingBytes = chunk.subarray(freeSpace)
+        if (remainingBytes.length > minChunkSize) {
+          // If the remaining of chunk is still too big to fit in the
+          // coalescing buffer, we yield it directly without copying it
+          yield remainingBytes
+        } else if (remainingBytes.length > 0) {
+          // Otherwise, we copy the remaining bytes into the coalescing buffer
+          // and continue to the next chunk
+          buffer.set(remainingBytes, offset)
+          offset += remainingBytes.length
         }
       }
+    }
 
-      if (bufferedLength > 0) {
-        yield Buffer.concat(buffered, bufferedLength)
-        buffered.length = 0
-        bufferedLength = 0
-      }
-    },
-    () => {},
-  ) as PassThrough
+    // Yield any remaining bytes in the coalescing buffer
+    if (offset > 0) {
+      yield buffer.subarray(0, offset)
+    }
+  }
 }
 
 export const bytesToStream = (bytes: Uint8Array): Readable => {

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -146,6 +146,44 @@ describe('streams', () => {
       }
     })
 
+    it('yields chunks as they come when target size is 1', async () => {
+      const stream = streams.coalesceByteStream(
+        Readable.from([
+          new Uint8Array([0x1]),
+          new Uint8Array([0x2, 0x3]),
+          new Uint8Array([0x4, 0x5, 0x6]),
+        ]),
+        1,
+      )
+
+      const chunks = await stream.toArray()
+
+      expect(chunks.length).toBe(3)
+      expect(chunks).toEqual([
+        new Uint8Array([0x1]),
+        new Uint8Array([0x2, 0x3]),
+        new Uint8Array([0x4, 0x5, 0x6]),
+      ])
+    })
+
+    it('coaloasces into a single chunk when target size Infinity', async () => {
+      const stream = streams.coalesceByteStream(
+        Readable.from([
+          new Uint8Array([0x1]),
+          new Uint8Array([0x2, 0x3]),
+          new Uint8Array([0x4, 0x5, 0x6]),
+        ]),
+        Infinity,
+      )
+
+      const chunks = await stream.toArray()
+
+      expect(chunks.length).toBe(1)
+      expect(Buffer.concat(chunks)).toEqual(
+        Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6]),
+      )
+    })
+
     it('forwards source stream errors', async () => {
       const source = new PassThrough()
       const stream = streams.coalesceByteStream(source, 4)

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -133,7 +133,6 @@ describe('streams', () => {
 
       const chunks = await stream.toArray()
 
-      expect(chunks.length).toBe(2)
       expect(Buffer.concat(chunks)).toEqual(
         Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]),
       )
@@ -158,7 +157,6 @@ describe('streams', () => {
 
       const chunks = await stream.toArray()
 
-      expect(chunks.length).toBe(3)
       expect(chunks).toEqual([
         new Uint8Array([0x1]),
         new Uint8Array([0x2, 0x3]),
@@ -173,7 +171,7 @@ describe('streams', () => {
           new Uint8Array([0x2, 0x3]),
           new Uint8Array([0x4, 0x5, 0x6]),
         ]),
-        Infinity,
+        1000,
       )
 
       const chunks = await stream.toArray()

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -125,46 +125,25 @@ describe('streams', () => {
           new Uint8Array([0x2, 0x3]),
           new Uint8Array([0x4, 0x5, 0x6]),
           new Uint8Array([0x7]),
+          new Uint8Array([0x8]),
+          new Uint8Array([0x9]),
         ]),
         4,
       )
-      const chunks: Buffer[] = []
 
-      stream.on('data', (chunk) => chunks.push(chunk))
-      await events.once(stream, 'end')
+      const chunks = await stream.toArray()
 
-      expect(chunks.map((chunk) => [...chunk])).toEqual([
-        [0x1, 0x2, 0x3, 0x4],
-        [0x5, 0x6, 0x7],
-      ])
+      expect(chunks.length).toBe(2)
       expect(Buffer.concat(chunks)).toEqual(
-        Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7]),
+        Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9]),
       )
-    })
 
-    it('passes through chunks that meet the target size', async () => {
-      const largeChunk = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5])
-      const stream = streams.coalesceByteStream(
-        Readable.from([
-          new Uint8Array([0xa]),
-          largeChunk,
-          new Uint8Array([0xb]),
-        ]),
-        4,
-      )
-      const chunks: Buffer[] = []
-
-      stream.on('data', (chunk) => chunks.push(chunk))
-      await events.once(stream, 'end')
-
-      expect(chunks).toEqual([
-        Buffer.from([0xa]),
-        largeChunk,
-        Buffer.from([0xb]),
-      ])
-      expect(Buffer.concat(chunks)).toEqual(
-        Buffer.from([0xa, 0x1, 0x2, 0x3, 0x4, 0x5, 0xb]),
-      )
+      for (let i = 0; i < chunks.length; i++) {
+        expect(chunks[i]).toBeInstanceOf(Uint8Array)
+        if (i < chunks.length - 1) {
+          expect(chunks[i].length).toBeGreaterThanOrEqual(4)
+        }
+      }
     })
 
     it('forwards source stream errors', async () => {

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -164,7 +164,7 @@ describe('streams', () => {
       ])
     })
 
-    it('coaloasces into a single chunk when target size Infinity', async () => {
+    it('coaloasces into a single chunk when target size exceeds total', async () => {
       const stream = streams.coalesceByteStream(
         Readable.from([
           new Uint8Array([0x1]),

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -164,7 +164,7 @@ describe('streams', () => {
       ])
     })
 
-    it('coaloasces into a single chunk when target size exceeds total', async () => {
+    it('coalesces into a single chunk when target size exceeds total', async () => {
       const stream = streams.coalesceByteStream(
         Readable.from([
           new Uint8Array([0x1]),

--- a/packages/common/tests/streams.test.ts
+++ b/packages/common/tests/streams.test.ts
@@ -1,3 +1,4 @@
+import events from 'node:events'
 import { PassThrough, Readable } from 'node:stream'
 import * as streams from '../src/streams.js'
 
@@ -113,6 +114,90 @@ describe('streams', () => {
         expect(chunk[0]).toBe(0xa)
         expect(chunk[1]).toBe(0xb)
       }
+    })
+  })
+
+  describe('coalesceByteStream', () => {
+    it('coalesces chunks without changing bytes', async () => {
+      const stream = streams.coalesceByteStream(
+        Readable.from([
+          new Uint8Array([0x1]),
+          new Uint8Array([0x2, 0x3]),
+          new Uint8Array([0x4, 0x5, 0x6]),
+          new Uint8Array([0x7]),
+        ]),
+        4,
+      )
+      const chunks: Buffer[] = []
+
+      stream.on('data', (chunk) => chunks.push(chunk))
+      await events.once(stream, 'end')
+
+      expect(chunks.map((chunk) => [...chunk])).toEqual([
+        [0x1, 0x2, 0x3, 0x4],
+        [0x5, 0x6, 0x7],
+      ])
+      expect(Buffer.concat(chunks)).toEqual(
+        Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7]),
+      )
+    })
+
+    it('passes through chunks that meet the target size', async () => {
+      const largeChunk = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5])
+      const stream = streams.coalesceByteStream(
+        Readable.from([
+          new Uint8Array([0xa]),
+          largeChunk,
+          new Uint8Array([0xb]),
+        ]),
+        4,
+      )
+      const chunks: Buffer[] = []
+
+      stream.on('data', (chunk) => chunks.push(chunk))
+      await events.once(stream, 'end')
+
+      expect(chunks).toEqual([
+        Buffer.from([0xa]),
+        largeChunk,
+        Buffer.from([0xb]),
+      ])
+      expect(Buffer.concat(chunks)).toEqual(
+        Buffer.from([0xa, 0x1, 0x2, 0x3, 0x4, 0x5, 0xb]),
+      )
+    })
+
+    it('forwards source stream errors', async () => {
+      const source = new PassThrough()
+      const stream = streams.coalesceByteStream(source, 4)
+      const err = new Error('source failed')
+
+      const gotError = events.once(stream, 'error')
+      source.emit('error', err)
+
+      expect(await gotError).toEqual([err])
+    })
+
+    it('destroying the coalesced stream destroys the source', async () => {
+      let finalized = false
+      async function* gen() {
+        try {
+          while (true) {
+            yield new Uint8Array(1024)
+          }
+        } finally {
+          finalized = true
+        }
+      }
+      const source = Readable.from(gen(), { objectMode: false })
+      const stream = streams.coalesceByteStream(source, 4096)
+
+      await events.once(stream, 'data')
+      stream.destroy()
+      await new Promise((resolve) => source.once('close', resolve))
+
+      expect(source.destroyed).toBe(true)
+      expect(finalized).toBe(true)
     })
   })
 

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -21,7 +21,7 @@ export default function (server: Server, ctx: AppContext) {
         // always allow
       },
     }),
-    handler: async ({ params, auth }) => {
+    handler: async ({ req, params, auth }) => {
       const { did, since } = params
       await assertRepoAvailability(ctx, did, isUserOrAdmin(auth, did))
 
@@ -29,7 +29,15 @@ export default function (server: Server, ctx: AppContext) {
 
       return {
         encoding: 'application/vnd.ipld.car' as const,
-        body: carStream,
+        // @NOTE If the client asked for compression (via "accept-encoding"), we
+        // coalesce the CAR stream into larger chunks to improve compression
+        // efficiency. See https://github.com/bluesky-social/atproto/pull/5078
+        //
+        // @TODO This would be better handled by xrpc-server and/or the
+        // compression middleware instead of manually coalescing the stream.
+        body: req.headers['accept-encoding']
+          ? coalesceByteStream(carStream, CAR_STREAM_CHUNK_SIZE)
+          : carStream,
       }
     },
   })
@@ -41,14 +49,14 @@ export const getCarStream = async (
   since?: string,
 ): Promise<stream.Readable> => {
   const actorDb = await ctx.actorStore.openDb(did)
-  let carStream: stream.Readable
   try {
     const storage = new SqlRepoReader(actorDb)
     const carIter = await storage.getCarStream(since)
-    carStream = coalesceByteStream(
-      byteIterableToStream(carIter),
-      CAR_STREAM_CHUNK_SIZE,
-    )
+    const carStream = byteIterableToStream(carIter)
+    const closeDb = () => actorDb.close()
+    carStream.on('error', closeDb)
+    carStream.on('close', closeDb)
+    return carStream
   } catch (err) {
     await actorDb.close()
     if (err instanceof RepoRootNotFoundError) {
@@ -56,8 +64,4 @@ export const getCarStream = async (
     }
     throw err
   }
-  const closeDb = () => actorDb.close()
-  carStream.on('error', closeDb)
-  carStream.on('close', closeDb)
-  return carStream
 }

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -1,5 +1,5 @@
 import stream from 'node:stream'
-import { byteIterableToStream } from '@atproto/common'
+import { byteIterableToStream, coalesceByteStream } from '@atproto/common'
 import { InvalidRequestError, Server } from '@atproto/xrpc-server'
 import {
   RepoRootNotFoundError,
@@ -10,6 +10,8 @@ import { isUserOrAdmin } from '../../../../auth-verifier.js'
 import { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
 import { assertRepoAvailability } from './util.js'
+
+const CAR_STREAM_CHUNK_SIZE = 64 * 1024
 
 export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.sync.getRepo, {
@@ -43,7 +45,10 @@ export const getCarStream = async (
   try {
     const storage = new SqlRepoReader(actorDb)
     const carIter = await storage.getCarStream(since)
-    carStream = byteIterableToStream(carIter)
+    carStream = coalesceByteStream(
+      byteIterableToStream(carIter),
+      CAR_STREAM_CHUNK_SIZE,
+    )
   } catch (err) {
     await actorDb.close()
     if (err instanceof RepoRootNotFoundError) {


### PR DESCRIPTION
@uniphil noticed that calls to getRepo are _much_ slower if you ask for compression. For example:

```
$ curl 'https://morel.us-east.host.bsky.network/xrpc/com.atproto.sync.getRepo?did=did:plc:ragtjsm2j2vknwkz3zp4oxrd' -o /dev/null
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 73.80M   0 73.80M   0      0 15.77M      0           00:04         15.97M

$ curl 'https://morel.us-east.host.bsky.network/xrpc/com.atproto.sync.getRepo?did=did:plc:ragtjsm2j2vknwkz3zp4oxrd' -o /dev/null -H 'Accept-encoding: gzip'
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 31.95M   0 31.95M   0      0  1.67M      0           00:19          1.88M
```

I think there's two reasons for this:

1. express' default compression level is 6, which is pretty aggressive tbh. I didn't change it here, but @uniphil suggested dropping it to 3 and I think I agree agree. That will be a second PR if so
2. We're feeding very small chunks of data in to the compressor over and over, and it would be more efficient to chunk it up in to batches (that's what this PR does)

Locally with a reproducer on Paul's repo, I get about a 4x speedup

---

ALSO! I noticed that the Makefile was out of date since we upgraded node. I'm not familiar with what the typical dev workflow is for this package, but that was the change I needed to make to get things to run locally. Happy to revert that or just update it to what the latest and greatest should be, but looking for guidance there.