### PR TITLE
pds: make account deletion more robust to partial failures of file operations

### DIFF
--- a/.changeset/purple-bags-accept.md
+++ b/.changeset/purple-bags-accept.md
@@ -1,0 +1,5 @@
+---
+'@atproto/common': patch
+---
+
+Make rmIfExists() more robust to partial failures.

--- a/.changeset/salty-corners-rule.md
+++ b/.changeset/salty-corners-rule.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Make account deletion more robust to partial failures of file operations.

--- a/packages/common/src/fs.ts
+++ b/packages/common/src/fs.ts
@@ -31,14 +31,12 @@ export const rmIfExists = async (
   filepath: string,
   recursive = false,
 ): Promise<void> => {
-  try {
-    await fs.rm(filepath, { recursive })
-  } catch (err) {
-    if (isErrnoException(err) && err.code === 'ENOENT') {
-      return
-    }
-    throw err
-  }
+  await fs.rm(filepath, {
+    force: true, // ignore errors if the file/directory does not exist
+    recursive,
+    maxRetries: 5,
+    retryDelay: 50,
+  })
 }
 
 export const renameIfExists = async (


### PR DESCRIPTION
The common `rmIfExists()` helper is prone to partial failures when recursively deleting a directory, which happens during account deletion in the pds.  Here we lean on node's builtin retry mechanism of `fs.rm()` to add some robustness to these file operations.

Replaces #4014 