### PR TITLE
Increase PDS com.atproto.sync.getRepo Rate Limits

### DIFF
--- a/.changeset/strict-animals-make.md
+++ b/.changeset/strict-animals-make.md
@@ -1,5 +1,4 @@
 ---
-'@atproto/common': patch
 '@atproto/pds': patch
 ---
 

--- a/.changeset/strict-animals-make.md
+++ b/.changeset/strict-animals-make.md
@@ -1,0 +1,6 @@
+---
+'@atproto/common': patch
+'@atproto/pds': patch
+---
+
+Increase rate limit rules on com.atproto.sync.getRepo

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -1,5 +1,9 @@
 import stream from 'node:stream'
-import { byteIterableToStream, coalesceByteStream } from '@atproto/common'
+import {
+  MINUTE,
+  byteIterableToStream,
+  coalesceByteStream,
+} from '@atproto/common'
 import { InvalidRequestError, Server } from '@atproto/xrpc-server'
 import {
   RepoRootNotFoundError,
@@ -9,7 +13,6 @@ import { AuthScope } from '../../../../auth-scope.js'
 import { isUserOrAdmin } from '../../../../auth-verifier.js'
 import { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
-import { SYNC_GET_REPO_IP_RATE_LIMIT } from '../../../../rate-limits.js'
 import { assertRepoAvailability } from './util.js'
 
 const CAR_STREAM_CHUNK_SIZE = 64 * 1024
@@ -23,7 +26,8 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
-      name: SYNC_GET_REPO_IP_RATE_LIMIT,
+      durationMs: 5 * MINUTE,
+      points: 6000,
     },
     handler: async ({ req, params, auth }) => {
       const { did, since } = params

--- a/packages/pds/src/api/com/atproto/sync/getRepo.ts
+++ b/packages/pds/src/api/com/atproto/sync/getRepo.ts
@@ -9,6 +9,7 @@ import { AuthScope } from '../../../../auth-scope.js'
 import { isUserOrAdmin } from '../../../../auth-verifier.js'
 import { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
+import { SYNC_GET_REPO_IP_RATE_LIMIT } from '../../../../rate-limits.js'
 import { assertRepoAvailability } from './util.js'
 
 const CAR_STREAM_CHUNK_SIZE = 64 * 1024
@@ -21,6 +22,9 @@ export default function (server: Server, ctx: AppContext) {
         // always allow
       },
     }),
+    rateLimit: {
+      name: SYNC_GET_REPO_IP_RATE_LIMIT,
+    },
     handler: async ({ req, params, auth }) => {
       const { did, since } = params
       await assertRepoAvailability(ctx, did, isUserOrAdmin(auth, did))

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -16,9 +16,7 @@ const { createHttpTerminator } = httpTerminator
 type HttpTerminator = ReturnType<typeof createHttpTerminator>
 import { DAY, SECOND } from '@atproto/common'
 import {
-  MemoryRateLimiter,
   MethodHandler,
-  RedisRateLimiter,
   ResponseType,
   XRPCError,
   createServer,
@@ -114,14 +112,7 @@ export class PDS {
 
         return XRPCError.fromError(err)
       },
-      rateLimits: rateLimits.enabled
-        ? {
-            ...buildRateLimitsConfig(rateLimits),
-            creator: ctx.redisScratch
-              ? (opts) => new RedisRateLimiter(ctx.redisScratch, opts)
-              : (opts) => new MemoryRateLimiter(opts),
-          }
-        : undefined,
+      rateLimits: buildRateLimitsConfig(rateLimits, ctx.redisScratch),
     })
 
     apiRoutes(server, ctx)

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -14,7 +14,7 @@ import httpTerminator from 'http-terminator'
 // eslint-disable-next-line import/no-named-as-default-member
 const { createHttpTerminator } = httpTerminator
 type HttpTerminator = ReturnType<typeof createHttpTerminator>
-import { DAY, HOUR, MINUTE, SECOND } from '@atproto/common'
+import { DAY, SECOND } from '@atproto/common'
 import {
   MemoryRateLimiter,
   MethodHandler,
@@ -32,6 +32,7 @@ import * as error from './error.js'
 import { app } from './lexicons.js'
 import { loggerMiddleware } from './logger.js'
 import { proxyHandler } from './pipethrough.js'
+import { buildRateLimitsConfig } from './rate-limits.js'
 import compression from './util/compression.js'
 import * as wellKnown from './well-known.js'
 
@@ -115,41 +116,10 @@ export class PDS {
       },
       rateLimits: rateLimits.enabled
         ? {
+            ...buildRateLimitsConfig(rateLimits),
             creator: ctx.redisScratch
               ? (opts) => new RedisRateLimiter(ctx.redisScratch, opts)
               : (opts) => new MemoryRateLimiter(opts),
-            bypass: ({ req }) => {
-              const { bypassKey, bypassIps } = rateLimits
-              if (
-                bypassKey &&
-                bypassKey === req.headers['x-ratelimit-bypass']
-              ) {
-                return true
-              }
-              if (bypassIps && bypassIps.includes(req.ip)) {
-                return true
-              }
-              return false
-            },
-            global: [
-              {
-                name: 'global-ip',
-                durationMs: 5 * MINUTE,
-                points: 3000,
-              },
-            ],
-            shared: [
-              {
-                name: 'repo-write-hour',
-                durationMs: HOUR,
-                points: 5000, // creates=3, puts=2, deletes=1
-              },
-              {
-                name: 'repo-write-day',
-                durationMs: DAY,
-                points: 35000, // creates=3, puts=2, deletes=1
-              },
-            ],
           }
         : undefined,
     })

--- a/packages/pds/src/rate-limits.ts
+++ b/packages/pds/src/rate-limits.ts
@@ -1,19 +1,23 @@
+import type { Redis } from 'ioredis'
 import { DAY, HOUR, MINUTE } from '@atproto/common'
+import { MemoryRateLimiter, RedisRateLimiter } from '@atproto/xrpc-server'
 import type { Options } from '@atproto/xrpc-server'
 import type { RateLimitsConfig } from './config/index.js'
 
-type RateLimitDescriptions = Omit<NonNullable<Options['rateLimits']>, 'creator'>
+type RateLimitDescriptions = NonNullable<Options['rateLimits']>
 
 const SYNC_GET_REPO_PATH = '/xrpc/com.atproto.sync.getRepo'
 
-export const SYNC_GET_REPO_IP_RATE_LIMIT = 'sync-get-repo-ip'
-
 export const buildRateLimitsConfig = (
   rateLimits: RateLimitsConfig,
+  redisScratch?: Redis,
 ): RateLimitDescriptions | undefined => {
   if (!rateLimits.enabled) return undefined
 
   return {
+    creator: redisScratch
+      ? (opts) => new RedisRateLimiter(redisScratch, opts)
+      : (opts) => new MemoryRateLimiter(opts),
     bypass: ({ req }) => {
       const { bypassKey, bypassIps } = rateLimits
       if (bypassKey && bypassKey === req.headers['x-ratelimit-bypass']) {
@@ -29,6 +33,8 @@ export const buildRateLimitsConfig = (
         name: 'global-ip',
         durationMs: 5 * MINUTE,
         points: 3000,
+        // getRepo can be a high-volume sync path, so it has its own endpoint
+        // limit and should not consume the shared global read bucket.
         calcKey: ({ req }) => {
           if (req.path === SYNC_GET_REPO_PATH) {
             return null
@@ -38,11 +44,6 @@ export const buildRateLimitsConfig = (
       },
     ],
     shared: [
-      {
-        name: SYNC_GET_REPO_IP_RATE_LIMIT,
-        durationMs: 5 * MINUTE,
-        points: 6000,
-      },
       {
         name: 'repo-write-hour',
         durationMs: HOUR,

--- a/packages/pds/src/rate-limits.ts
+++ b/packages/pds/src/rate-limits.ts
@@ -1,0 +1,61 @@
+import { DAY, HOUR, MINUTE } from '@atproto/common'
+import type { Options } from '@atproto/xrpc-server'
+import type { RateLimitsConfig } from './config/index.js'
+
+type RateLimitDescriptions = Omit<
+  NonNullable<Options['rateLimits']>,
+  'creator'
+>
+
+const SYNC_GET_REPO_PATH = '/xrpc/com.atproto.sync.getRepo'
+
+export const SYNC_GET_REPO_IP_RATE_LIMIT = 'sync-get-repo-ip'
+
+export const buildRateLimitsConfig = (
+  rateLimits: RateLimitsConfig,
+): RateLimitDescriptions | undefined => {
+  if (!rateLimits.enabled) return undefined
+
+  return {
+    bypass: ({ req }) => {
+      const { bypassKey, bypassIps } = rateLimits
+      if (bypassKey && bypassKey === req.headers['x-ratelimit-bypass']) {
+        return true
+      }
+      if (bypassIps && bypassIps.includes(req.ip)) {
+        return true
+      }
+      return false
+    },
+    global: [
+      {
+        name: 'global-ip',
+        durationMs: 5 * MINUTE,
+        points: 3000,
+        calcKey: ({ req }) => {
+          if (req.path === SYNC_GET_REPO_PATH) {
+            return null
+          }
+          return req.ip
+        },
+      },
+    ],
+    shared: [
+      {
+        name: SYNC_GET_REPO_IP_RATE_LIMIT,
+        durationMs: 5 * MINUTE,
+        points: 6000,
+      },
+      {
+        name: 'repo-write-hour',
+        durationMs: HOUR,
+        points: 5000, // creates=3, puts=2, deletes=1
+      },
+      {
+        name: 'repo-write-day',
+        durationMs: DAY,
+        points: 35000, // creates=3, puts=2, deletes=1
+      },
+    ],
+  }
+}

--- a/packages/pds/src/rate-limits.ts
+++ b/packages/pds/src/rate-limits.ts
@@ -2,10 +2,7 @@ import { DAY, HOUR, MINUTE } from '@atproto/common'
 import type { Options } from '@atproto/xrpc-server'
 import type { RateLimitsConfig } from './config/index.js'
 
-type RateLimitDescriptions = Omit<
-  NonNullable<Options['rateLimits']>,
-  'creator'
->
+type RateLimitDescriptions = Omit<NonNullable<Options['rateLimits']>, 'creator'>
 
 const SYNC_GET_REPO_PATH = '/xrpc/com.atproto.sync.getRepo'
 

--- a/packages/pds/tests/rate-limits.test.ts
+++ b/packages/pds/tests/rate-limits.test.ts
@@ -1,7 +1,6 @@
 import { AtpAgent } from '@atproto/api'
 import { randomStr } from '@atproto/crypto'
 import { SeedClient, TestNetworkNoAppView } from '@atproto/dev-env'
-import { buildRateLimitsConfig } from '../src/rate-limits.js'
 import userSeed from './seeds/basic.js'
 
 describe('rate limits', () => {
@@ -67,46 +66,5 @@ describe('rate limits', () => {
       identifier: sc.accounts[bob].handle,
       password: sc.accounts[bob].password,
     })
-  })
-
-  it('uses a higher ip rate limit for sync.getRepo only', () => {
-    const rateLimits = buildRateLimitsConfig({
-      enabled: true,
-      bypassKey: undefined,
-      bypassIps: undefined,
-    })
-    if (!rateLimits?.global || !rateLimits.shared) {
-      throw new Error('expected rate limits to be configured')
-    }
-
-    expect(rateLimits.global).toHaveLength(1)
-    expect(rateLimits.global[0]?.name).toBe('global-ip')
-    expect(rateLimits.global[0]?.points).toBe(3000)
-    expect(
-      rateLimits.global[0]?.calcKey?.({
-        req: {
-          path: '/xrpc/com.atproto.sync.getRepo',
-          ip: '192.0.2.1',
-        },
-      } as never),
-    ).toBeNull()
-    expect(
-      rateLimits.global[0]?.calcKey?.({
-        req: {
-          path: '/xrpc/com.atproto.sync.getRecord',
-          ip: '192.0.2.1',
-        },
-      } as never),
-    ).toBe('192.0.2.1')
-
-    expect(rateLimits.shared).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'sync-get-repo-ip',
-          durationMs: 5 * 60 * 1000,
-          points: 6000,
-        }),
-      ]),
-    )
   })
 })

--- a/packages/pds/tests/rate-limits.test.ts
+++ b/packages/pds/tests/rate-limits.test.ts
@@ -1,6 +1,7 @@
 import { AtpAgent } from '@atproto/api'
 import { randomStr } from '@atproto/crypto'
 import { SeedClient, TestNetworkNoAppView } from '@atproto/dev-env'
+import { buildRateLimitsConfig } from '../src/rate-limits.js'
 import userSeed from './seeds/basic.js'
 
 describe('rate limits', () => {
@@ -66,5 +67,42 @@ describe('rate limits', () => {
       identifier: sc.accounts[bob].handle,
       password: sc.accounts[bob].password,
     })
+  })
+
+  it('uses a higher ip rate limit for sync.getRepo only', () => {
+    const rateLimits = buildRateLimitsConfig({
+      enabled: true,
+      bypassKey: undefined,
+      bypassIps: undefined,
+    })
+    if (!rateLimits?.global || !rateLimits.shared) {
+      throw new Error('expected rate limits to be configured')
+    }
+
+    expect(rateLimits.global).toHaveLength(1)
+    expect(rateLimits.global[0]?.name).toBe('global-ip')
+    expect(rateLimits.global[0]?.points).toBe(3000)
+    expect(rateLimits.global[0]?.calcKey?.({
+      req: {
+        path: '/xrpc/com.atproto.sync.getRepo',
+        ip: '192.0.2.1',
+      },
+    } as never)).toBeNull()
+    expect(rateLimits.global[0]?.calcKey?.({
+      req: {
+        path: '/xrpc/com.atproto.sync.getRecord',
+        ip: '192.0.2.1',
+      },
+    } as never)).toBe('192.0.2.1')
+
+    expect(rateLimits.shared).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'sync-get-repo-ip',
+          durationMs: 5 * 60 * 1000,
+          points: 6000,
+        }),
+      ]),
+    )
   })
 })

--- a/packages/pds/tests/rate-limits.test.ts
+++ b/packages/pds/tests/rate-limits.test.ts
@@ -82,18 +82,22 @@ describe('rate limits', () => {
     expect(rateLimits.global).toHaveLength(1)
     expect(rateLimits.global[0]?.name).toBe('global-ip')
     expect(rateLimits.global[0]?.points).toBe(3000)
-    expect(rateLimits.global[0]?.calcKey?.({
-      req: {
-        path: '/xrpc/com.atproto.sync.getRepo',
-        ip: '192.0.2.1',
-      },
-    } as never)).toBeNull()
-    expect(rateLimits.global[0]?.calcKey?.({
-      req: {
-        path: '/xrpc/com.atproto.sync.getRecord',
-        ip: '192.0.2.1',
-      },
-    } as never)).toBe('192.0.2.1')
+    expect(
+      rateLimits.global[0]?.calcKey?.({
+        req: {
+          path: '/xrpc/com.atproto.sync.getRepo',
+          ip: '192.0.2.1',
+        },
+      } as never),
+    ).toBeNull()
+    expect(
+      rateLimits.global[0]?.calcKey?.({
+        req: {
+          path: '/xrpc/com.atproto.sync.getRecord',
+          ip: '192.0.2.1',
+        },
+      } as never),
+    ).toBe('192.0.2.1')
 
     expect(rateLimits.shared).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
Previous work #5073 

This doubles the rate limit on `com.atproto.sync.getRepo` from 3k/5m to 6k/5m. Other routes are untouched.

I didn't add this as a tuning parameter for operators to set. Thoughts on allowing people to control this one endpoint via an env var? I was thinking that other operators may not want this change? This is a heavy-duty endpoint. If you think that's worthwhile, I can add that as a knob.