### PR TITLE
fix: runtime ERR_MODULE_NOT_FOUND for services/* containers

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -9,6 +9,7 @@ COPY ./.nvmrc ./
 COPY ./package.json ./
 
 # Move files into the image and install
+COPY ./[a-zA-Z]*.* ./
 COPY ./pnpm-lock.yaml ./
 COPY ./pnpm-workspace.yaml ./
 COPY ./patches ./patches

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -9,6 +9,7 @@ COPY ./.nvmrc ./
 COPY ./package.json ./
 
 # Move files into the image and install
+COPY ./[a-zA-Z]*.* ./
 COPY ./pnpm-lock.yaml ./
 COPY ./pnpm-workspace.yaml ./
 COPY ./patches ./patches

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -9,6 +9,7 @@ COPY ./.nvmrc ./
 COPY ./package.json ./
 
 # Move files into the image and install
+COPY ./[a-zA-Z]*.* ./
 COPY ./pnpm-lock.yaml ./
 COPY ./pnpm-workspace.yaml ./
 COPY ./patches ./patches

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -10,6 +10,7 @@ COPY ./.nvmrc ./
 COPY ./package.json ./
 
 # Move files into the image and install
+COPY ./[a-zA-Z]*.* ./
 COPY ./pnpm-lock.yaml ./
 COPY ./pnpm-workspace.yaml ./
 COPY ./patches ./patches


### PR DESCRIPTION
close #5091

When I  simply tried recovering the line ```COPY ./*.* ./``` in services/*/Dockerfile, the build error raised as below.

So,  use ```COPY ./[a-zA-Z]*.* ./``` in this PR.  then it succeeded to build and all containers are recovered (worked as expected).

```
=> ERROR [build  7/48] COPY ./*.* ./ 
------
 > [build  7/48] COPY ./*.* ./:
 
  11 |         # Move files into the image and install
  12 | >>> COPY ./*.* ./
  13 |         COPY ./pnpm-lock.yaml ./

failed to solve: cannot replace to directory /var/lib/docker/overlay2/t649pl33u4vcgf39e69ekn41z/merged/app/skills with file
  
```
