### PR TITLE
Always show consent screen at the end of oauth flows

### DIFF
--- a/.changeset/lazy-doodles-watch.md
+++ b/.changeset/lazy-doodles-watch.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Always show consent screen at the end of oauth flows

--- a/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
@@ -64,9 +64,7 @@ function App() {
 
   const { session, setSession, api } = useSessionContext()
   const [redirectUrl, setRedirectUrl] = useState<string | undefined>(undefined)
-  const [isDone, setIsDone] = useState(
-    session != null && session.consentRequired === false,
-  )
+  const [isDone, setIsDone] = useState(false)
 
   const redirectTo = useCallback((url: string) => {
     console.debug('Redirecting back to client:', url)


### PR DESCRIPTION
The logic in `authorization-page.tsx` is flawed:

If the `consentRequired` is set to false, the consent screen would not appear, and a "Redirecting..." screen would be displayed instead. The issue is that nothing triggered the consent in that case, which means there is *no* url the user is being redirected *to*.