### PR TITLE
searchv2: typeahead params envelope, arabic hint, detected langs

### DIFF
--- a/.changeset/clever-books-join.md
+++ b/.changeset/clever-books-join.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+searchv2: typeahead params envelope, arabic hint, detected langs

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1144,10 +1144,10 @@ enum SearchQueryLanguage {
   SEARCH_QUERY_LANGUAGE_ZH = 2; // Chinese (smartcn)
   SEARCH_QUERY_LANGUAGE_KO = 3; // Korean (nori)
   SEARCH_QUERY_LANGUAGE_TH = 4; // Thai
+  SEARCH_QUERY_LANGUAGE_AR = 5; // Arabic
 }
 
-// Shared request params
-
+// Shared request params for paginated methods
 message SearchParams {
   string query = 1;
   string viewer = 2;
@@ -1155,6 +1155,13 @@ message SearchParams {
   // Pagination
   int32 limit = 3;
   string cursor = 4;
+}
+
+// Shared params for typeahead-style searches, which aren't paginated.
+message SearchTypeaheadParams {
+  string query = 1;
+  string viewer = 2;
+  int32 limit = 3;
 }
 
 // Shared result types
@@ -1246,6 +1253,11 @@ message SearchPostsV2Request {
 message SearchPostsV2Response {
   repeated SearchRecordResult posts = 1;
   PageInfo page_info = 2;
+  // Detected CJK/Thai/Arabic languages of the query, usually one. Han-only text
+  // returns ["zh", "ja"] since it's ambiguous between Chinese and Japanese.
+  // set query_language on the request to disambiguate.
+  // Currently left empty for other scripts (e.g. Latin-based languages like English).
+  repeated string detected_query_languages = 3;
 }
 
 message SearchActorsV2Request {
@@ -1258,9 +1270,7 @@ message SearchActorsV2Response {
 }
 
 message SearchActorsTypeaheadRequest {
-  string viewer = 1;
-  string query = 2;
-  int32 limit = 3;
+  SearchTypeaheadParams params = 1;
 }
 
 message SearchActorsTypeaheadResponse {

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -95,9 +95,11 @@ const skeletonV2 = async (
   const term = params.q ?? params.term ?? ''
 
   const res = await ctx.dataplane.searchActorsTypeahead({
-    viewer: params.hydrateCtx.viewer ?? undefined,
-    query: term,
-    limit: params.limit,
+    params: {
+      query: term,
+      viewer: params.hydrateCtx.viewer ?? undefined,
+      limit: params.limit,
+    },
   })
   return {
     dids: res.actors.map(({ did }) => did as DidString),

--- a/packages/bsky/src/data-plane/server/routes/search.ts
+++ b/packages/bsky/src/data-plane/server/routes/search.ts
@@ -139,8 +139,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => {
 
     async searchActorsTypeahead(req) {
       const { dids } = await searchActorsImpl({
-        term: req.query,
-        limit: req.limit || 10,
+        term: req.params?.query ?? '',
+        limit: req.params?.limit || 10,
       })
       return {
         actors: dids.map((did) => ({ did, score: 0 })),


### PR DESCRIPTION
The `SearchActorsTypeahead` request now takes its query, viewer, and limit inside a `params` envelope, bringing it in line with the other v2 search request format.

It also adds an Arabic option to the query-language hint enum and a `detected_query_languages` field on the posts response. The detected languages aren't surfaced to clients yet will come with v2 lexicons.