### PR TITLE
Update undici to 8.5.0

### DIFF
--- a/.changeset/cyan-loops-swim.md
+++ b/.changeset/cyan-loops-swim.md
@@ -1,0 +1,9 @@
+---
+'@atproto-labs/fetch-node': patch
+'@atproto/dev-env': patch
+'@atproto/ozone': patch
+'@atproto/bsky': patch
+'@atproto/pds': patch
+---
+
+Update undici dependency to v8.5.0

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -70,7 +70,7 @@
     "structured-headers": "^1.0.1",
     "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
-    "undici": "^6.19.8",
+    "undici": "^8.5.0",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/packages/bsky/src/api/blob-dispatcher.ts
+++ b/packages/bsky/src/api/blob-dispatcher.ts
@@ -1,4 +1,4 @@
-import { Agent, Dispatcher, Pool, RetryAgent } from 'undici'
+import { Agent, Dispatcher, Pool, interceptors } from 'undici'
 import { isUnicastIp, unicastLookup } from '@atproto-labs/fetch-node'
 import { ServerConfig } from '../config.js'
 import { RETRYABLE_HTTP_STATUS_CODES } from '../util/retry.js'
@@ -27,11 +27,15 @@ export function createBlobDispatcher(cfg: ServerConfig): Dispatcher {
     },
   })
 
-  return cfg.proxyMaxRetries > 0
-    ? new RetryAgent(baseDispatcher, {
-        statusCodes: [...RETRYABLE_HTTP_STATUS_CODES],
-        methods: ['GET', 'HEAD'],
-        maxRetries: cfg.proxyMaxRetries,
-      })
-    : baseDispatcher
+  return baseDispatcher.compose(
+    interceptors.redirect({
+      maxRedirections: 10,
+      throwOnMaxRedirect: true,
+    }),
+    interceptors.retry({
+      statusCodes: [...RETRYABLE_HTTP_STATUS_CODES],
+      methods: ['GET', 'HEAD'],
+      maxRetries: cfg.proxyMaxRetries,
+    }),
+  )
 }

--- a/packages/bsky/src/api/blob-resolver.ts
+++ b/packages/bsky/src/api/blob-resolver.ts
@@ -1,7 +1,7 @@
 import { Duplex, Transform, Writable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import createError, { isHttpError } from 'http-errors'
-import { Dispatcher } from 'undici'
+import { Dispatcher, RedirectHandler } from 'undici'
 import {
   VerifyCidError,
   VerifyCidTransform,
@@ -197,7 +197,6 @@ export async function streamBlob(
         path: url.pathname + url.search,
         headers,
         signal: options.signal,
-        maxRedirections: 10,
       },
       (upstream) => {
         headersReceived = true

--- a/packages/bsky/src/api/blob-resolver.ts
+++ b/packages/bsky/src/api/blob-resolver.ts
@@ -1,7 +1,7 @@
 import { Duplex, Transform, Writable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import createError, { isHttpError } from 'http-errors'
-import { Dispatcher, RedirectHandler } from 'undici'
+import { Dispatcher } from 'undici'
 import {
   VerifyCidError,
   VerifyCidTransform,

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -42,7 +42,7 @@
     "get-port": "^5.1.1",
     "multiformats": "^13.0.0",
     "uint8arrays": "^5.0.0",
-    "undici": "^6.14.1"
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13"

--- a/packages/internal/fetch-node/package.json
+++ b/packages/internal/fetch-node/package.json
@@ -28,7 +28,7 @@
     "@atproto-labs/fetch": "workspace:^",
     "@atproto-labs/pipe": "workspace:^",
     "ipaddr.js": "^2.1.0",
-    "undici": "^6.14.1"
+    "undici": "^8.5.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/packages/ozone/package.json
+++ b/packages/ozone/package.json
@@ -50,7 +50,7 @@
     "structured-headers": "^1.0.1",
     "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
-    "undici": "^6.14.1",
+    "undici": "^8.5.0",
     "ws": "^8.12.0"
   },
   "devDependencies": {

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -74,7 +74,7 @@
     "pino-http": "^8.2.1",
     "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
-    "undici": "^6.19.8",
+    "undici": "^8.5.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -21,12 +21,7 @@ import {
   createServiceAuthHeaders,
   createServiceJwt,
 } from '@atproto/xrpc-server'
-import {
-  Fetch,
-  isUnicastIp,
-  safeFetchWrap,
-  unicastLookup,
-} from '@atproto-labs/fetch-node'
+import { Fetch, safeFetchWrap } from '@atproto-labs/fetch-node'
 import { AccountManager } from './account-manager/account-manager.js'
 import { OAuthStore } from './account-manager/oauth-store.js'
 import { ScopeReferenceGetter } from './account-manager/scope-reference-getter.js'
@@ -47,6 +42,7 @@ import { ImageUrlBuilder } from './image/image-url-builder.js'
 import { fetchLogger, lexiconResolverLogger, oauthLogger } from './logger.js'
 import { ServerMailer } from './mailer/index.js'
 import { ModerationMailer } from './mailer/moderation.js'
+import { buildProxyAgent } from './pipethrough.js'
 import { LocalViewer, LocalViewerCreator } from './read-after-write/viewer.js'
 import { getRedisClient } from './redis.js'
 import { Sequencer } from './sequencer/index.js'
@@ -295,36 +291,7 @@ export class AppContext {
     )
 
     // An agent for performing HTTP requests based on user provided URLs.
-    const proxyAgentBase = new undici.Agent({
-      allowH2: cfg.proxy.allowHTTP2, // This is experimental
-      headersTimeout: cfg.proxy.headersTimeout,
-      maxResponseSize: cfg.proxy.maxResponseSize,
-      bodyTimeout: cfg.proxy.bodyTimeout,
-      factory: cfg.proxy.disableSsrfProtection
-        ? undefined
-        : (origin, opts) => {
-            const { protocol, hostname } =
-              origin instanceof URL ? origin : new URL(origin)
-            if (protocol !== 'https:') {
-              throw new Error(`Forbidden protocol "${protocol}"`)
-            }
-            if (isUnicastIp(hostname) === false) {
-              throw new Error('Hostname resolved to non-unicast address')
-            }
-            return new undici.Pool(origin, opts)
-          },
-      connect: {
-        lookup: cfg.proxy.disableSsrfProtection ? undefined : unicastLookup,
-      },
-    })
-    const proxyAgent =
-      cfg.proxy.maxRetries > 0
-        ? new undici.RetryAgent(proxyAgentBase, {
-            statusCodes: [], // Only retry on socket errors
-            methods: ['GET', 'HEAD'],
-            maxRetries: cfg.proxy.maxRetries,
-          })
-        : proxyAgentBase
+    const proxyAgent = buildProxyAgent(cfg.proxy)
 
     /**
      * A fetch() function that protects against SSRF attacks, large responses &

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -59,8 +59,7 @@ export function buildProxyAgent(cfg: ProxyConfig): Dispatcher {
           methods: ['GET', 'HEAD'],
           maxRetries: cfg.maxRetries,
         })
-      : // @TODO replace with "null" https://github.com/nodejs/undici/pull/5443
-        (dispatcher) => dispatcher,
+      : (dispatch) => dispatch,
   )
 }
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -1,7 +1,7 @@
 import { IncomingHttpHeaders, ServerResponse } from 'node:http'
 import { PassThrough, Readable, finished } from 'node:stream'
 import { Request } from 'express'
-import { Dispatcher } from 'undici'
+import { Agent, Dispatcher, Pool, interceptors } from 'undici'
 import {
   decodeStream,
   getServiceEndpoint,
@@ -20,11 +20,49 @@ import {
   excludeErrorResult,
   parseReqNsid,
 } from '@atproto/xrpc-server'
+import { isUnicastIp, unicastLookup } from '@atproto-labs/fetch-node'
 import { buildProxiedContentEncoding } from '@atproto-labs/xrpc-utils'
 import { isAccessPrivileged } from './auth-scope.js'
+import { ProxyConfig } from './config/config.js'
 import { AppContext } from './context.js'
 import { chat, com, tools } from './lexicons/index.js'
 import { httpLogger } from './logger.js'
+
+export function buildProxyAgent(cfg: ProxyConfig): Dispatcher {
+  const agent = new Agent({
+    allowH2: cfg.allowHTTP2,
+    headersTimeout: cfg.headersTimeout,
+    maxResponseSize: cfg.maxResponseSize,
+    bodyTimeout: cfg.bodyTimeout,
+    factory: cfg.disableSsrfProtection
+      ? undefined
+      : (origin, opts) => {
+          const { protocol, hostname } =
+            origin instanceof URL ? origin : new URL(origin)
+          if (protocol !== 'https:') {
+            throw new Error(`Forbidden protocol "${protocol}"`)
+          }
+          if (isUnicastIp(hostname) === false) {
+            throw new Error('Hostname resolved to non-unicast address')
+          }
+          return new Pool(origin, opts)
+        },
+    connect: {
+      lookup: cfg.disableSsrfProtection ? undefined : unicastLookup,
+    },
+  })
+
+  return agent.compose(
+    cfg.maxRetries > 0
+      ? interceptors.retry({
+          statusCodes: [], // Only retry on socket errors
+          methods: ['GET', 'HEAD'],
+          maxRetries: cfg.maxRetries,
+        })
+      : // @TODO replace with "null" https://github.com/nodejs/undici/pull/5443
+        (dispatcher) => dispatcher,
+  )
+}
 
 export const proxyHandler = (ctx: AppContext): CatchallHandler => {
   const performAuth = ctx.authVerifier.authorization<RpcPermissionMatch>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,8 +495,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.1
       undici:
-        specifier: ^6.19.8
-        version: 6.19.8
+        specifier: ^8.5.0
+        version: 8.5.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -719,8 +719,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.1
       undici:
-        specifier: ^6.14.1
-        version: 6.19.8
+        specifier: ^8.5.0
+        version: 8.5.0
     devDependencies:
       '@types/express':
         specifier: ^4.17.13
@@ -809,8 +809,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       undici:
-        specifier: ^6.14.1
-        version: 6.19.8
+        specifier: ^8.5.0
+        version: 8.5.0
 
   packages/internal/handle-resolver:
     dependencies:
@@ -1801,8 +1801,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.1
       undici:
-        specifier: ^6.14.1
-        version: 6.19.8
+        specifier: ^8.5.0
+        version: 8.5.0
       ws:
         specifier: ^8.12.0
         version: 8.18.0
@@ -1973,8 +1973,8 @@ importers:
         specifier: ^5.0.0
         version: 5.1.1
       undici:
-        specifier: ^6.19.8
-        version: 6.19.8
+        specifier: ^8.5.0
+        version: 8.5.0
       zod:
         specifier: ^3.23.8
         version: 3.24.2
@@ -11016,6 +11016,10 @@ packages:
     resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
     engines: {node: '>=18.17'}
 
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -18977,7 +18981,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4
@@ -22298,6 +22302,8 @@ snapshots:
       '@fastify/busboy': 2.1.0
 
   undici@6.19.8: {}
+
+  undici@8.5.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
Note that we still depend on `undici@6.19.8` through `@expo/cli@54.0.10`. That package should be updated separately.