### PR TITLE
Add configurable blob rate limit separate from global limits

### DIFF
--- a/.changeset/metal-taxes-follow.md
+++ b/.changeset/metal-taxes-follow.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Make the `com.atproto.repo.uploadBlob` rate limit configurable via `PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_TIME_DURATION` and `PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_POINTS` (defaults preserve the existing 1000 points / day behavior).

--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -17,8 +17,8 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
-      durationMs: DAY,
-      points: 1000,
+      durationMs: ctx.cfg.rateLimits.repoUploadBlobRateLimitDuration,
+      points: ctx.cfg.rateLimits.repoUploadBlobRateLimitPoints,
     },
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did

--- a/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
+++ b/packages/pds/src/api/com/atproto/repo/uploadBlob.ts
@@ -8,6 +8,7 @@ import { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
 
 export default function (server: Server, ctx: AppContext) {
+  const rateLimits = ctx.cfg.rateLimits
   server.add(com.atproto.repo.uploadBlob, {
     auth: ctx.authVerifier.authorizationOrUserServiceAuth({
       checkTakedown: true,
@@ -17,8 +18,8 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     rateLimit: {
-      durationMs: ctx.cfg.rateLimits.repoUploadBlobRateLimitDuration,
-      points: ctx.cfg.rateLimits.repoUploadBlobRateLimitPoints,
+      durationMs: rateLimits.enabled ? rateLimits.repoUploadBlobRateLimitDuration : DAY,
+      points: rateLimits.enabled ? rateLimits.repoUploadBlobRateLimitPoints : 1000,
     },
     handler: async ({ auth, input }) => {
       const requester = auth.credentials.did

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -243,6 +243,8 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
         bypassIps: env.rateLimitBypassIps?.map((ipOrCidr) =>
           ipOrCidr.split('/')[0]?.trim(),
         ),
+        repoUploadBlobRateLimitDuration: env.rateLimitRepoUploadBlobTimeDuration ? env.rateLimitRepoUploadBlobTimeDuration : DAY,
+        repoUploadBlobRateLimitPoints: env.rateLimitRepoUploadBlobPoints ? env.rateLimitRepoUploadBlobPoints : 1000,
       }
     : { enabled: false }
 
@@ -533,6 +535,8 @@ export type RateLimitsConfig =
       enabled: true
       bypassKey?: string
       bypassIps?: string[]
+      repoUploadBlobRateLimitDuration: number
+      repoUploadBlobRateLimitPoints: number
     }
   | { enabled: false }
 

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -124,6 +124,8 @@ export function readEnv() {
     rateLimitsEnabled: envBool('PDS_RATE_LIMITS_ENABLED'),
     rateLimitBypassKey: envStr('PDS_RATE_LIMIT_BYPASS_KEY'),
     rateLimitBypassIps: envList('PDS_RATE_LIMIT_BYPASS_IPS'),
+    rateLimitRepoUploadBlobTimeDuration: envInt('PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_TIME_DURATION'),
+    rateLimitRepoUploadBlobPoints: envInt('PDS_RATE_LIMIT_REPO_UPLOAD_BLOB_POINTS'),
 
     // redis
     redisScratchAddress: envStr('PDS_REDIS_SCRATCH_ADDRESS'),


### PR DESCRIPTION
In order to support large account migrations, we had this change in the Eurosky fork of the atproto repo. I think this actually should be sent upstream, since it's a genuinely useful configuration change.