### PR TITLE
update chat lexicons and deprecate chat notif pref

### DIFF
--- a/.changeset/silly-pugs-cheer.md
+++ b/.changeset/silly-pugs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+update chat lexicons

--- a/lexicons/app/bsky/notification/defs.json
+++ b/lexicons/app/bsky/notification/defs.json
@@ -8,6 +8,7 @@
     },
     "chatPreference": {
       "type": "object",
+      "description": "Deprecated: use chat.bsky.notification preferences instead. This will only return a default value.",
       "required": ["include", "push"],
       "properties": {
         "include": { "type": "string", "knownValues": ["all", "accepted"] },
@@ -49,7 +50,11 @@
         "verified"
       ],
       "properties": {
-        "chat": { "type": "ref", "ref": "#chatPreference" },
+        "chat": {
+          "type": "ref",
+          "ref": "#chatPreference",
+          "description": "Deprecated: use chat.bsky.notification preferences instead. This will only return a default value."
+        },
         "follow": { "type": "ref", "ref": "#filterablePreference" },
         "like": { "type": "ref", "ref": "#filterablePreference" },
         "likeViaRepost": { "type": "ref", "ref": "#filterablePreference" },

--- a/lexicons/app/bsky/notification/putPreferencesV2.json
+++ b/lexicons/app/bsky/notification/putPreferencesV2.json
@@ -12,7 +12,8 @@
           "properties": {
             "chat": {
               "type": "ref",
-              "ref": "app.bsky.notification.defs#chatPreference"
+              "ref": "app.bsky.notification.defs#chatPreference",
+              "description": "Deprecated: use chat.bsky.notification preferences instead. Setting this won't stick and the default values will be returned."
             },
             "follow": {
               "type": "ref",

--- a/lexicons/chat/bsky/notification/defs.json
+++ b/lexicons/chat/bsky/notification/defs.json
@@ -1,0 +1,25 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.notification.defs",
+  "defs": {
+    "preferences": {
+      "type": "object",
+      "required": ["chat", "chatRequest"],
+      "properties": {
+        "chat": { "type": "ref", "ref": "#chatPreference" },
+        "chatRequest": { "type": "ref", "ref": "#chatPreference" }
+      }
+    },
+    "chatPreference": {
+      "type": "object",
+      "required": ["include", "push"],
+      "properties": {
+        "include": {
+          "type": "string",
+          "knownValues": ["all", "follows"]
+        },
+        "push": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/lexicons/chat/bsky/notification/getPreferences.json
+++ b/lexicons/chat/bsky/notification/getPreferences.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.notification.getPreferences",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get the requesting account's chat notification preferences. Defaults are returned for accounts that have not set any preferences. Requires auth.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "ref",
+              "ref": "chat.bsky.notification.defs#preferences"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/chat/bsky/notification/putPreferences.json
+++ b/lexicons/chat/bsky/notification/putPreferences.json
@@ -1,0 +1,39 @@
+{
+  "lexicon": 1,
+  "id": "chat.bsky.notification.putPreferences",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Set the requesting account's chat notification preferences. Only the provided preferences are updated; omitted preferences are left unchanged.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "chat": {
+              "type": "ref",
+              "ref": "chat.bsky.notification.defs#chatPreference"
+            },
+            "chatRequest": {
+              "type": "ref",
+              "ref": "chat.bsky.notification.defs#chatPreference"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["preferences"],
+          "properties": {
+            "preferences": {
+              "type": "ref",
+              "ref": "chat.bsky.notification.defs#preferences"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -815,20 +815,12 @@ message NotificationPreference {
   NotificationChannelPush push = 2;
 }
 
-enum ChatNotificationInclude {
-  CHAT_NOTIFICATION_INCLUDE_UNSPECIFIED = 0;
-  CHAT_NOTIFICATION_INCLUDE_ALL = 1;
-  CHAT_NOTIFICATION_INCLUDE_ACCEPTED = 2;
-}
-
-message ChatNotificationPreference {
-  ChatNotificationInclude include = 1;
-  NotificationChannelPush push = 2;
-}
-
 message NotificationPreferences {
   bytes entry = 1;
-  ChatNotificationPreference chat = 2;
+
+  reserved 2; // formerly "chat". This is now stored on the chat service.
+  reserved "chat";
+
   FilterableNotificationPreference follow = 3;
   FilterableNotificationPreference like = 4;
   FilterableNotificationPreference like_via_repost = 5;

--- a/packages/bsky/src/api/app/bsky/notification/putPreferencesV2.ts
+++ b/packages/bsky/src/api/app/bsky/notification/putPreferencesV2.ts
@@ -5,7 +5,7 @@ import { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
 import { GetNotificationPreferencesResponse } from '../../../../proto/bsky_pb.js'
 import { Namespaces } from '../../../../stash.js'
-import { protobufToLex } from './util.js'
+import { DEFAULT_CHAT_PREFERENCE, protobufToLex } from './util.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(app.bsky.notification.putPreferencesV2, {
@@ -57,5 +57,8 @@ const computePreferences = async (
 
   const currentPreferences = protobufToLex(res.preferences[0])
   const preferences = { ...currentPreferences, ...input.body }
+  // NOTE: See the deprecation notice on the lexicon. This field returns a static default value and shouldn't be used.
+  // Use the chat.bsky.notification.defs#preferences type instead.
+  preferences.chat = DEFAULT_CHAT_PREFERENCE
   return preferences
 }

--- a/packages/bsky/src/api/app/bsky/notification/util.ts
+++ b/packages/bsky/src/api/app/bsky/notification/util.ts
@@ -1,7 +1,5 @@
 import { app } from '../../../../lexicons/index.js'
 import {
-  ChatNotificationInclude,
-  ChatNotificationPreference,
   FilterableNotificationPreference,
   NotificationInclude,
   NotificationPreference,
@@ -71,15 +69,11 @@ const ensurePreferences = (
   }
 }
 
-const protobufChatPreferenceToLex = (
-  p?: DeepPartial<ChatNotificationPreference>,
-): Partial<app.bsky.notification.defs.ChatPreference> => {
-  return {
-    include:
-      p?.include === ChatNotificationInclude.ACCEPTED ? 'accepted' : 'all',
-    push: p?.push?.enabled,
+export const DEFAULT_CHAT_PREFERENCE: app.bsky.notification.defs.ChatPreference =
+  {
+    include: 'all',
+    push: true,
   }
-}
 
 const protobufFilterablePreferenceToLex = (
   p?: DeepPartial<FilterableNotificationPreference>,
@@ -104,7 +98,9 @@ export const protobufToLex = (
   res: DeepPartial<NotificationPreferences>,
 ): app.bsky.notification.defs.Preferences => {
   return ensurePreferences({
-    chat: protobufChatPreferenceToLex(res.chat),
+    // NOTE: See the deprecation notice on the lexicon. This field returns a static default value and shouldn't be used.
+    // Use the chat.bsky.notification.defs#preferences type instead.
+    chat: DEFAULT_CHAT_PREFERENCE,
     follow: protobufFilterablePreferenceToLex(res.follow),
     like: protobufFilterablePreferenceToLex(res.like),
     likeViaRepost: protobufFilterablePreferenceToLex(res.likeViaRepost),

--- a/packages/bsky/src/data-plane/server/routes/notifs.ts
+++ b/packages/bsky/src/data-plane/server/routes/notifs.ts
@@ -6,8 +6,6 @@ import { lexParse } from '@atproto/lex'
 import { app } from '../../../lexicons/index.js'
 import { Service } from '../../../proto/bsky_connect.js'
 import {
-  ChatNotificationInclude,
-  ChatNotificationPreference,
   FilterableNotificationPreference,
   NotificationInclude,
   NotificationPreference,
@@ -203,17 +201,6 @@ export const notificationPreferencesLexToProtobuf = (
   p: app.bsky.notification.defs.Preferences,
   json: string,
 ): NotificationPreferences => {
-  const lexChatPreferenceToProtobuf = (
-    p: app.bsky.notification.defs.ChatPreference,
-  ): ChatNotificationPreference =>
-    new ChatNotificationPreference({
-      include:
-        p.include === 'accepted'
-          ? ChatNotificationInclude.ACCEPTED
-          : ChatNotificationInclude.ALL,
-      push: { enabled: p.push ?? true },
-    })
-
   const lexFilterablePreferenceToProtobuf = (
     p: app.bsky.notification.defs.FilterablePreference,
   ): FilterableNotificationPreference =>
@@ -236,7 +223,6 @@ export const notificationPreferencesLexToProtobuf = (
 
   return new NotificationPreferences({
     entry: Buffer.from(json),
-    chat: lexChatPreferenceToProtobuf(p.chat),
     follow: lexFilterablePreferenceToProtobuf(p.follow),
     like: lexFilterablePreferenceToProtobuf(p.like),
     likeViaRepost: lexFilterablePreferenceToProtobuf(p.likeViaRepost),

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -728,12 +728,12 @@ describe('notification views', () => {
     await network.processAll()
   })
 
-  // @NOTE there is some flakyness between these tests. We sometimes get
-  // "priority": true when the snapshot expects false.
-
   it('filters notifications by reason', async () => {
     const res = await agent.app.bsky.notification.listNotifications(
       {
+        // Pin priority so the snapshot doesn't race with the viewer's stored
+        // priority preference, which neighbouring tests mutate.
+        priority: false,
         reasons: ['mention'],
       },
       {
@@ -750,6 +750,9 @@ describe('notification views', () => {
   it('filters notifications by multiple reasons', async () => {
     const res = await agent.app.bsky.notification.listNotifications(
       {
+        // Pin priority so the snapshot doesn't race with the viewer's stored
+        // priority preference, which neighbouring tests mutate.
+        priority: false,
         reasons: ['mention', 'reply'],
       },
       {

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -1203,7 +1203,8 @@ describe('notification views', () => {
         },
       }
       const expected0: AppBskyNotificationDefs.Preferences = {
-        chat: input0.chat,
+        // chat is deprecated: input is ignored and the default is always returned.
+        chat: cp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,
@@ -1227,8 +1228,8 @@ describe('notification views', () => {
         },
       }
       const expected1: AppBskyNotificationDefs.Preferences = {
-        // Kept from the previous call.
-        chat: input0.chat,
+        // chat is deprecated: input is ignored and the default is always returned.
+        chat: cp,
         follow: fp,
         like: fp,
         likeViaRepost: fp,


### PR DESCRIPTION
Sync chat notification preferences from chat repo (APP-2027): add chat.bsky.notification.{defs,getPreferences,putPreferences} and remove chatPreference from app.bsky.notification.