### PR TITLE
feat(like): add hideLike field to suppress likes from firehose

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -314,7 +314,8 @@
           "#labelersPref",
           "#postInteractionSettingsPref",
           "#verificationPrefs",
-          "#liveEventPreferences"
+          "#liveEventPreferences",
+          "#hideLikesPref"
         ]
       }
     },
@@ -538,6 +539,18 @@
           "type": "array",
           "items": { "type": "string", "format": "at-uri" },
           "description": "A list of URIs of posts the account owner has hidden."
+        }
+      }
+    },
+    "hideLikesPref": {
+      "type": "object",
+      "description": "User preference controlling whether new likes are hidden from the firehose and public like counts/lists by default.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "When true, newly created likes will have hideLike set to true by default.",
+          "default": false
         }
       }
     },

--- a/lexicons/app/bsky/feed/like.json
+++ b/lexicons/app/bsky/feed/like.json
@@ -12,7 +12,11 @@
         "properties": {
           "subject": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
           "createdAt": { "type": "string", "format": "datetime" },
-          "via": { "type": "ref", "ref": "com.atproto.repo.strongRef" }
+          "via": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "hideLike": {
+            "type": "boolean",
+            "description": "When true, this like will not be broadcast on the firehose or surfaced in public like counts/lists. The like still exists in the user's repo."
+          }
         }
       }
     }

--- a/packages/bsky/src/data-plane/server/indexing/plugins/like.ts
+++ b/packages/bsky/src/data-plane/server/indexing/plugins/like.ts
@@ -19,6 +19,10 @@ const insertFn = async (
   obj: app.bsky.feed.like.Main,
   timestamp: string,
 ): Promise<IndexedLike | null> => {
+  // Respect the author's privacy preference — hidden likes are not indexed.
+  if (obj.hideLike === true) {
+    return null
+  }
   const inserted = await db
     .insertInto('like')
     .values({

--- a/packages/pds/src/sequencer/events.ts
+++ b/packages/pds/src/sequencer/events.ts
@@ -8,11 +8,13 @@ import {
   isDidString,
   isHandleString,
 } from '@atproto/lex'
-import { encode as cborEncode } from '@atproto/lex-cbor'
+import { encode as cborEncode, decode as cborDecode } from '@atproto/lex-cbor'
 import { BlockMap, blocksToCarFile } from '@atproto/repo'
 import { AccountStatus } from '../account-manager/account-manager.js'
 import { CommitDataWithOps, SyncEvtData } from '../repo/index.js'
 import { RepoSeqInsert } from './db/index.js'
+
+const LIKE_NSID = 'app.bsky.feed.like'
 
 export const formatSeqCommit = async (
   did: string,
@@ -22,13 +24,37 @@ export const formatSeqCommit = async (
   blocksToSend.addMap(commitData.newBlocks)
   blocksToSend.addMap(commitData.relevantBlocks)
 
+  // Strip hidden likes from the outbound firehose event. The like record
+  // still exists in the user's repo but won't appear in the event stream.
+  const filteredOps = commitData.ops.filter((op) => {
+    if (
+      (op.action === 'create' || op.action === 'update') &&
+      op.cid !== null &&
+      op.path.startsWith(`${LIKE_NSID}/`)
+    ) {
+      const bytes = commitData.newBlocks.get(op.cid)
+      if (bytes) {
+        try {
+          const record = cborDecode(bytes) as Record<string, unknown>
+          if (record['hideLike'] === true) {
+            blocksToSend.delete(op.cid)
+            return false
+          }
+        } catch {
+          // malformed block — leave it in the stream as-is
+        }
+      }
+    }
+    return true
+  })
+
   const evt = {
     repo: did,
     commit: commitData.cid,
     rev: commitData.rev,
     since: commitData.since,
     blocks: await blocksToCarFile(commitData.cid, blocksToSend),
-    ops: commitData.ops,
+    ops: filteredOps,
     prevData: commitData.prevData ?? undefined,
     // deprecated (but still required) fields
     rebase: false,


### PR DESCRIPTION
## Summary

- Adds an optional `hideLike: boolean` field to the `app.bsky.feed.like` record lexicon. When `true`, the like is silently dropped from the firehose before it reaches relays and downstream consumers (feed generators, AppViews, etc.).
- The **PDS sequencer** (`packages/pds/src/sequencer/events.ts`) now inspects outbound commit ops: for any `app.bsky.feed.like` create/update where the decoded record has `hideLike: true`, the op and its block are stripped from the firehose `CommitEvt` before it is persisted to the sequencer DB.
- The **AppView indexer** (`packages/bsky/src/data-plane/server/indexing/plugins/like.ts`) also skips inserting a hidden like into the database, so it never appears in `getLikes` results or post like counts.
- Adds a `hideLikesPref` entry to `app.bsky.actor.defs#preferences` so client apps can honor a user's opt-in and automatically set `hideLike: true` on newly created likes.

**What this does NOT do:**
- The like record still exists in the user's own PDS repo; it is not deleted and can be retrieved via `getRecord` or toggled/deleted by the user.
- Because the like is omitted from the firehose event's `ops` array and CAR blocks, feed generators that consume the firehose **cannot** reconstruct who liked what from a hidden like, even by subscribing to a custom feed.
- Does not affect existing (un-hidden) likes retroactively.

## Test plan

- [ ] Create a like record with `hideLike: true` via `com.atproto.repo.createRecord` and verify the next firehose commit event for that DID does not include the like op or its block.
- [ ] Verify `app.bsky.feed.getLikes` for the liked post does not include the hidden liker.
- [ ] Verify the like record is still retrievable via `com.atproto.repo.getRecord`.
- [ ] Create a like with `hideLike: false` (or omitted) and confirm normal firehose/index behavior is unchanged.
- [ ] Set `hideLikesPref.enabled: true` in user preferences; verify client SDK surfaces the new pref type correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)