### PR TITLE
Allow lex-client requests to opt out of default proxy headers

### DIFF
--- a/packages/lex/lex-client/src/client.ts
+++ b/packages/lex/lex-client/src/client.ts
@@ -280,6 +280,8 @@ export type UploadBlobOptions = Omit<XrpcOptions<typeof uploadBlob>, 'body'>
 
 export type GetBlobOptions = Omit<XrpcOptions<typeof getBlob>, 'params'>
 
+const xrpcDefaultHeaderOptOut = '__atproto_client_default_header_opt_out__'
+
 /**
  * Type-safe options for {@link Client.create}, combining record options with key requirements.
  * @typeParam T - The record schema type
@@ -422,8 +424,8 @@ export class Client implements Agent {
 
   constructor(agent: Agent | AgentOptions, options: ClientOptions = {}) {
     this.agent = buildAgent(agent)
-    this.service = options.service
-    this.labelers = new Set(options.labelers)
+    this.service = options.service ?? undefined
+    this.labelers = new Set(options.labelers ?? undefined)
     this.headers = new Headers(options.headers)
     this.xrpcDefaults = Object.freeze({
       validateRequest: options.validateRequest ?? false,
@@ -502,15 +504,26 @@ export class Client implements Agent {
     path: `/${string}`,
     init: RequestInit,
   ): Promise<Response> {
+    const requestHeaders = new Headers(init.headers)
+    const skipService =
+      requestHeaders.get('atproto-proxy') === xrpcDefaultHeaderOptOut
+    const skipLabelers =
+      requestHeaders.get('atproto-accept-labelers') === xrpcDefaultHeaderOptOut
+
+    if (skipService) requestHeaders.delete('atproto-proxy')
+    if (skipLabelers) requestHeaders.delete('atproto-accept-labelers')
+
     const headers = buildXrpcRequestHeaders({
-      headers: init.headers,
-      service: this.service,
-      labelers: [
-        ...(this.constructor as typeof Client).appLabelers.map(
-          (l) => `${l};redact` as const,
-        ),
-        ...this.labelers,
-      ],
+      headers: requestHeaders,
+      service: skipService ? undefined : this.service,
+      labelers: skipLabelers
+        ? undefined
+        : [
+            ...(this.constructor as typeof Client).appLabelers.map(
+              (l) => `${l};redact` as const,
+            ),
+            ...this.labelers,
+          ],
     })
 
     // Incoming headers take precedence
@@ -564,7 +577,7 @@ export class Client implements Agent {
     ns: Main<M>,
     options: XrpcOptions<M> = {} as XrpcOptions<M>,
   ): Promise<XrpcResponse<M>> {
-    return xrpc(this, ns, applyDefaults(options, this.xrpcDefaults))
+    return xrpc(this, ns, this.applyXrpcDefaults(options))
   }
 
   /**
@@ -603,7 +616,28 @@ export class Client implements Agent {
     ns: Main<M>,
     options: XrpcOptions<M> = {} as XrpcOptions<M>,
   ): Promise<XrpcResponse<M> | XrpcFailure<M>> {
-    return xrpcSafe(this, ns, applyDefaults(options, this.xrpcDefaults))
+    return xrpcSafe(this, ns, this.applyXrpcDefaults(options))
+  }
+
+  private applyXrpcDefaults<const M extends Query | Procedure>(
+    options: XrpcOptions<M>,
+  ): XrpcOptions<M> & typeof this.xrpcDefaults {
+    const optionsWithDefaults = applyDefaults(options, this.xrpcDefaults)
+
+    if (options.service !== null && options.labelers !== null) {
+      return optionsWithDefaults
+    }
+
+    const headers = new Headers(optionsWithDefaults.headers)
+    if (options.service === null) {
+      headers.set('atproto-proxy', xrpcDefaultHeaderOptOut)
+    }
+    if (options.labelers === null) {
+      headers.set('atproto-accept-labelers', xrpcDefaultHeaderOptOut)
+    }
+
+    optionsWithDefaults.headers = headers
+    return optionsWithDefaults
   }
 
   /**

--- a/packages/lex/lex-client/src/util.ts
+++ b/packages/lex/lex-client/src/util.ts
@@ -78,10 +78,10 @@ export type XrpcRequestHeadersOptions = {
   headers?: HeadersInit
 
   /** Labeler DIDs to request labels from for content moderation. */
-  labelers?: Iterable<DidString>
+  labelers?: Iterable<DidString> | null
 
   /** Service proxy identifier for routing requests through a specific service. */
-  service?: Service
+  service?: Service | null
 }
 
 /**

--- a/packages/lex/lex-client/tests/client.test.ts
+++ b/packages/lex/lex-client/tests/client.test.ts
@@ -59,6 +59,35 @@ describe('utils', () => {
 })
 
 describe('Client', () => {
+  describe('xrpc defaults', () => {
+    it('allows default proxy and labeler headers to be disabled per request', async () => {
+      const service = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz#bsky_appview'
+      const labeler = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz'
+      const calls: Headers[] = []
+      const fetchHandler = vi.fn<FetchHandler>(async (_url, init) => {
+        calls.push(new Headers(init?.headers))
+        return Response.json({ preferences: [] })
+      })
+      const client = new Client(
+        { fetchHandler },
+        { service, labelers: [labeler] },
+      )
+
+      await client.xrpcSafe(app.bsky.actor.getPreferences, {})
+
+      expect(calls[0].get('atproto-proxy')).toBe(service)
+      expect(calls[0].get('atproto-accept-labelers')).toBe(labeler)
+
+      await client.xrpcSafe(app.bsky.actor.getPreferences, {
+        service: null,
+        labelers: null,
+      })
+
+      expect(calls[1].has('atproto-proxy')).toBe(false)
+      expect(calls[1].has('atproto-accept-labelers')).toBe(false)
+    })
+  })
+
   describe('actions', () => {
     it('updatePreferences', async () => {
       const fetchHandler = vi.fn<FetchHandler>(async (url, init) => {


### PR DESCRIPTION
## Summary

Fixes #5110.

`Client` default `service` and `labelers` options were always re-applied by `fetchHandler`, so a single XRPC request could not suppress the default `atproto-proxy` or `atproto-accept-labelers` headers. This adds an explicit `null` opt-out for per-request `service` and `labelers` while preserving the existing `undefined` behavior of inheriting defaults.

## Changes

- Allow `service: null` and `labelers: null` in XRPC request options.
- Carry that opt-out through the client boundary without sending the internal marker on the wire.
- Add regression coverage that verifies defaults still apply normally and can be disabled per request.

## Testing

- `pnpm --dir packages/lex/lex-client test -- tests/client.test.ts`
- `pnpm --dir packages/lex/lex-client run build`
- `pnpm exec prettier --check packages/lex/lex-client/src/client.ts packages/lex/lex-client/src/util.ts packages/lex/lex-client/tests/client.test.ts`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.