### PR TITLE
Match V1 search date handling with V2 date handling

### DIFF
--- a/.changeset/late-zebras-add.md
+++ b/.changeset/late-zebras-add.md
@@ -1,0 +1,6 @@
+---
+'@atproto/bsky': patch
+'@atproto/api': patch
+---
+
+Match V1 search date handling with V2 date handling

--- a/lexicons/app/bsky/feed/searchPostsV2.json
+++ b/lexicons/app/bsky/feed/searchPostsV2.json
@@ -123,13 +123,11 @@
           },
           "since": {
             "type": "string",
-            "format": "datetime",
-            "description": "Include posts indexed at or after this timestamp."
+            "description": "Include posts indexed at or after this timestamp. Can be a datetime, or just an ISO date (YYYY-MM-DD)."
           },
           "until": {
             "type": "string",
-            "format": "datetime",
-            "description": "Include posts indexed before this timestamp. Defaults to the current time."
+            "description": "Include posts indexed before this timestamp. Defaults to the current time. Can be a datetime, or just an ISO date (YYYY-MM-DD)."
           },
           "allTime": {
             "type": "boolean",


### PR DESCRIPTION
The `parseTimestamp` util used in V1 is already here in V2, so this should just work.