### PR TITLE
Allow same-site authorization requests

### DIFF
--- a/.changeset/same-site-authorization.md
+++ b/.changeset/same-site-authorization.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider': patch
+---
+
+Allow same-site OAuth authorization page requests.

--- a/packages/oauth/oauth-provider/src/router/create-authorization-page-middleware.ts
+++ b/packages/oauth/oauth-provider/src/router/create-authorization-page-middleware.ts
@@ -71,10 +71,9 @@ export function createAuthorizationPageMiddleware<
 
       // "same-origin" is required to support the redirect test logic below (as
       // well as refreshing the authorization page).
-
-      // @TODO Consider removing this altogether to allow hosting PDS and app on
-      // the same site but different origins (different subdomains).
-      validateFetchSite(req, ['same-origin', 'cross-site', 'none'])
+      // "same-site" supports hosting PDS and app on the same site but different
+      // origins (different subdomains).
+      validateFetchSite(req, ['same-origin', 'same-site', 'cross-site', 'none'])
       validateFetchMode(req, ['navigate'])
       validateFetchDest(req, ['document'])
       validateOrigin(req, issuerOrigin)


### PR DESCRIPTION
Allows the authorization page to accept `Sec-Fetch-Site: same-site`, covering PDS/app deployments split across subdomains on the same site.

Tested:
- `corepack pnpm --filter @atproto/oauth-provider... build`