### PR TITLE
Fix node-fetch on Node24 and older

### DIFF
--- a/.changeset/breezy-badgers-own.md
+++ b/.changeset/breezy-badgers-own.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch': patch
+---
+
+Fix support of NodeJS 24+

--- a/.changeset/breezy-badgers-own.md
+++ b/.changeset/breezy-badgers-own.md
@@ -2,4 +2,4 @@
 '@atproto-labs/fetch': patch
 ---
 
-Fix support of NodeJS 24+
+Fix support of NodeJS 24 and before

--- a/.changeset/chubby-heads-reply.md
+++ b/.changeset/chubby-heads-reply.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': patch
+---
+
+Wrap all errors thrown through `unicastFetchWrap` in Whatwg fetch like `TypeError`.

--- a/.changeset/curly-months-sin.md
+++ b/.changeset/curly-months-sin.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': patch
+---
+
+Allow `unicastFetchWrap` to be called without options object

--- a/.changeset/early-jeans-obey.md
+++ b/.changeset/early-jeans-obey.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch': patch
+---
+
+Minor url parsing optimization

--- a/.changeset/eight-streets-study.md
+++ b/.changeset/eight-streets-study.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': patch
+---
+
+Rename `isUnicastIp` to `isUnicastIpHostname` (`isUnicastIp` is still exported as deprecated for backwards compatibility).

--- a/.changeset/giant-regions-sit.md
+++ b/.changeset/giant-regions-sit.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': patch
+---
+
+Add tests for unicast ip lookup and utilities

--- a/.changeset/slick-roses-sell.md
+++ b/.changeset/slick-roses-sell.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/fetch-node': patch
+---
+
+unicastFetchWrap now cancels request bodies when throwing an error (to avoid resource leak)

--- a/.changeset/slick-roses-sell.md
+++ b/.changeset/slick-roses-sell.md
@@ -2,4 +2,4 @@
 '@atproto-labs/fetch-node': patch
 ---
 
-unicastFetchWrap now cancels request bodies when throwing an error (to avoid resource leak)
+`unicastFetchWrap` now cancels request bodies when throwing an error (to avoid resource leak)

--- a/packages/internal/fetch-node/package.json
+++ b/packages/internal/fetch-node/package.json
@@ -28,10 +28,15 @@
     "@atproto-labs/fetch": "workspace:^",
     "@atproto-labs/pipe": "workspace:^",
     "ipaddr.js": "^2.1.0",
-    "undici": "^8.5.0"
+    "undici_v6": "npm:undici@^6.X",
+    "undici_v7": "npm:undici@^7.x",
+    "undici_v8": "npm:undici@^8.x"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "vitest": "^4.0.16"
+  },
   "scripts": {
-    "build": "tsgo --build tsconfig.json"
+    "build": "tsgo --build tsconfig.json",
+    "test": "vitest run"
   }
 }

--- a/packages/internal/fetch-node/package.json
+++ b/packages/internal/fetch-node/package.json
@@ -28,7 +28,7 @@
     "@atproto-labs/fetch": "workspace:^",
     "@atproto-labs/pipe": "workspace:^",
     "ipaddr.js": "^2.1.0",
-    "undici_v6": "npm:undici@^6.X",
+    "undici_v6": "npm:undici@^6.x",
     "undici_v7": "npm:undici@^7.x",
     "undici_v8": "npm:undici@^8.x"
   },

--- a/packages/internal/fetch-node/src/index.ts
+++ b/packages/internal/fetch-node/src/index.ts
@@ -2,9 +2,9 @@ export * from '@atproto-labs/fetch'
 
 export * from './safe.js'
 export * from './unicast.js'
-export * from './util.js'
 
 export {
+  isUnicastIpHostname,
   /** @deprecated use {@link isUnicastIpHostname} instead */
   isUnicastIpHostname as isUnicastIp,
 } from './util.js'

--- a/packages/internal/fetch-node/src/index.ts
+++ b/packages/internal/fetch-node/src/index.ts
@@ -3,3 +3,8 @@ export * from '@atproto-labs/fetch'
 export * from './safe.js'
 export * from './unicast.js'
 export * from './util.js'
+
+export {
+  /** @deprecated use {@link isUnicastIpHostname} instead */
+  isUnicastIpHostname as isUnicastIp,
+} from './util.js'

--- a/packages/internal/fetch-node/src/unicast.test.ts
+++ b/packages/internal/fetch-node/src/unicast.test.ts
@@ -1,0 +1,135 @@
+import { assert, describe, expect, it, vi } from 'vitest'
+import { unicastFetchWrap, unicastLookup } from './unicast.js'
+
+vi.mock(import('node:dns'), async (importOriginal) => {
+  const dns = await importOriginal()
+  return {
+    ...dns,
+    lookup: ((hostname, options, callback) => {
+      if (hostname === 'invalid.com') {
+        setTimeout(callback, 0, null, '127.2.2.2', 4)
+        return
+      }
+
+      if (hostname === 'valid.com') {
+        setTimeout(callback, 0, null, '1.2.3.4', 4)
+        return
+      }
+
+      // @ts-ignore
+      return dns.lookup(hostname, options, callback)
+    }) as typeof dns.lookup,
+  }
+})
+
+describe(unicastLookup, () => {
+  it('should reject hostnames that resolve to private IPs', async () => {
+    await expect(
+      new Promise((resolve, reject) => {
+        unicastLookup('invalid.com', { all: true }, (err, address, family) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve({ address, family })
+          }
+        })
+      }),
+    ).rejects.toThrow('Hostname resolved to non-unicast address')
+  })
+
+  it('should allow hostnames that resolve to public IPs', async () => {
+    await expect(
+      new Promise((resolve, reject) => {
+        unicastLookup('valid.com', { all: true }, (err, address, family) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve({ address, family })
+          }
+        })
+      }),
+    ).resolves.toEqual({ address: '1.2.3.4', family: 4 })
+  })
+})
+
+describe(unicastFetchWrap, () => {
+  describe('expected failures', () => {
+    it('should reject private IPv4 hostnames', async () => {
+      const fetch = unicastFetchWrap()
+      await expect(fetch('http://127.0.0.1/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
+      )
+    })
+
+    it('should reject private IPv6 hostnames', async () => {
+      const fetch = unicastFetchWrap()
+      await expect(fetch('http://[::1]/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
+      )
+    })
+
+    it('should reject hostnames that are not public domain tlds', async () => {
+      const fetch = unicastFetchWrap()
+      await expect(fetch('http://localhost/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is not a public domain'),
+      )
+
+      await expect(fetch('https://printer.local')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is not a public domain'),
+      )
+    })
+
+    it('should reject hostnames that resolve to private IPs', async () => {
+      const fetch = unicastFetchWrap()
+      await expect(fetch('http://invalid.com/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname resolved to non-unicast address'),
+      )
+    })
+  })
+
+  describe('expected successes', () => {
+    // Let's avoid calling actual services in tests. There is no easy way to
+    // ensure this works without a real public domain hostname that resolves to
+    // a public IP. So we skip this test for now.
+    it.skip('should allow public domain hostnames that resolve to public IPs', async () => {
+      const fetch = unicastFetchWrap()
+      await fetch('http://atproto.com/@atproto/node-fetch/test')
+    })
+  })
+
+  describe('version handling', () => {
+    it('should throw an error if undici version is too old', () => {
+      using _ = vi
+        .spyOn(process.versions, 'undici', 'get')
+        .mockReturnValue('6.11.0')
+      expect(process.versions.undici).toBe('6.11.0')
+      expect(() => unicastFetchWrap()).toThrowError()
+    })
+
+    it('should support undici version 6.11.1', () => {
+      using _ = vi
+        .spyOn(process.versions, 'undici', 'get')
+        .mockReturnValue('6.11.1')
+      expect(process.versions.undici).toBe('6.11.1')
+      expect(() => unicastFetchWrap()).not.toThrowError()
+    })
+
+    it('should throw an error if undici version is too new', () => {
+      using _ = vi
+        .spyOn(process.versions, 'undici', 'get')
+        .mockReturnValue('9.0.0')
+      expect(process.versions.undici).toBe('9.0.0')
+      expect(() => unicastFetchWrap()).toThrowError()
+    })
+  })
+})
+
+function fetchFailedErrorCauseBy(message: string) {
+  return (err: unknown) => {
+    assert(err instanceof TypeError)
+    expect(err.message).toBe('fetch failed')
+    assert(err.cause instanceof Error)
+    expect(err.cause.message).toBe(message)
+    return true
+  }
+}

--- a/packages/internal/fetch-node/src/unicast.test.ts
+++ b/packages/internal/fetch-node/src/unicast.test.ts
@@ -56,15 +56,15 @@ describe(unicastFetchWrap, () => {
   describe('expected failures', () => {
     it('should reject private IPv4 hostnames', async () => {
       const fetch = unicastFetchWrap()
-      await expect(fetch('http://127.0.0.1/test')).rejects.toThrowError(
-        'Hostname is a non-unicast address',
+      await expect(fetch('http://127.0.0.1/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
       )
     })
 
     it('should reject private IPv6 hostnames', async () => {
       const fetch = unicastFetchWrap()
-      await expect(fetch('http://[::1]/test')).rejects.toThrowError(
-        'Hostname is a non-unicast address',
+      await expect(fetch('http://[::1]/test')).rejects.toSatisfy(
+        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
       )
     })
 

--- a/packages/internal/fetch-node/src/unicast.test.ts
+++ b/packages/internal/fetch-node/src/unicast.test.ts
@@ -56,15 +56,15 @@ describe(unicastFetchWrap, () => {
   describe('expected failures', () => {
     it('should reject private IPv4 hostnames', async () => {
       const fetch = unicastFetchWrap()
-      await expect(fetch('http://127.0.0.1/test')).rejects.toSatisfy(
-        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
+      await expect(fetch('http://127.0.0.1/test')).rejects.toThrowError(
+        'Hostname is a non-unicast address',
       )
     })
 
     it('should reject private IPv6 hostnames', async () => {
       const fetch = unicastFetchWrap()
-      await expect(fetch('http://[::1]/test')).rejects.toSatisfy(
-        fetchFailedErrorCauseBy('Hostname is a non-unicast address'),
+      await expect(fetch('http://[::1]/test')).rejects.toThrowError(
+        'Hostname is a non-unicast address',
       )
     })
 

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -73,11 +73,14 @@ export function unicastFetchWrap<C = FetchContext>({
     if (init != null && 'dispatcher' in init && init.dispatcher != null) {
       const request = asRequest(input, init)
       await request.body?.cancel()
-      throw new FetchRequestError(
+      const cause = new FetchRequestError(
         request,
         500,
         'SSRF protection cannot be used with a custom request dispatcher',
       )
+      // @NOTE Use Whatwg style errors so that the error is similar whether
+      // caused by this line of an error caused by the lookup function
+      throw new TypeError('fetch failed', { cause })
     }
 
     const url = extractUrl(input)
@@ -85,11 +88,14 @@ export function unicastFetchWrap<C = FetchContext>({
     if (url.hostname && isUnicastIpHostname(url.hostname) === false) {
       const request = asRequest(input, init)
       await request.body?.cancel()
-      throw new FetchRequestError(
+      const cause = new FetchRequestError(
         request,
         400,
         'Hostname is a non-unicast address',
       )
+      // @NOTE Use Whatwg style errors so that the error is similar whether
+      // caused by this line of an error caused by the lookup function
+      throw new TypeError('fetch failed', { cause })
     }
 
     return fetch.call(this, input, {

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -1,7 +1,10 @@
-import dns, { LookupAddress } from 'node:dns'
-import { LookupFunction } from 'node:net'
+import { lookup } from 'node:dns'
+import type { LookupAddress, LookupOptions } from 'node:dns'
+import type { LookupFunction } from 'node:net'
 import ipaddr from 'ipaddr.js'
-import { Agent } from 'undici'
+import { Agent as Agent6 } from 'undici_v6'
+import { Agent as Agent7 } from 'undici_v7'
+import { Agent as Agent8 } from 'undici_v8'
 import {
   Fetch,
   FetchContext,
@@ -9,7 +12,12 @@ import {
   asRequest,
   extractUrl,
 } from '@atproto-labs/fetch'
-import { isUnicastIp } from './util.js'
+import {
+  Version,
+  compareVersions,
+  isUnicastIpHostname,
+  parseVersion,
+} from './util.js'
 
 const { IPv4, IPv6 } = ipaddr
 
@@ -17,29 +25,56 @@ export type UnicastFetchWrapOptions<C = FetchContext> = {
   fetch?: Fetch<C>
 }
 
-const SUPPORTS_REQUEST_INIT_DISPATCHER =
-  Number(process.versions.node.split('.')[0]) >= 20
+// https://github.com/nodejs/undici/pull/2928
+const MIN_SUPPORTED_UNDICI_VERSION: Version = [6, 11, 1]
 
 /**
  * @see {@link https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/}
  */
 export function unicastFetchWrap<C = FetchContext>({
   fetch = globalThis.fetch,
-}: UnicastFetchWrapOptions<C>): Fetch<C> {
-  if (!SUPPORTS_REQUEST_INIT_DISPATCHER) {
+}: UnicastFetchWrapOptions<C> = {}): Fetch<C> {
+  // @NOTE we parse here instead of top-level to allow version mocking in tests.
+  const nodeUndiciVersion = parseVersion(process.versions.undici)
+
+  if (
+    nodeUndiciVersion == null ||
+    compareVersions(nodeUndiciVersion, MIN_SUPPORTED_UNDICI_VERSION) < 0
+  ) {
     throw new Error(
       'Unicast SSRF protection unavailable on your platform. Update to Node.js 22+.',
     )
   }
 
-  const dispatcher = new Agent({
-    connect: { lookup: unicastLookup },
-  })
+  // @NOTE Since major versions of undici are not guaranteed to be backwards
+  // compatible, we need to check the major version and use the appropriate
+  // Agent class for that version, to ensure that the dispatcher interface is
+  // compatible with the version of undici being used.
+  const dispatcher =
+    nodeUndiciVersion[0] === 6
+      ? new Agent6({ connect: { lookup: unicastLookup } })
+      : nodeUndiciVersion[0] === 7
+        ? new Agent7({ connect: { lookup: unicastLookup } })
+        : nodeUndiciVersion[0] === 8
+          ? new Agent8({ connect: { lookup: unicastLookup } })
+          : null
+
+  // @NOTE Because this is a security feature, we don't want to fallback to
+  // using Agent8 to "future proof" this package. Although future version of
+  // undici may have a backwards compatible dispatcher interface, we don't want
+  // to assume that and risk a security issue.
+  if (!dispatcher) {
+    throw new Error(
+      'This version of @atproto-labs/fetch-node does not support your version of undici. Please upgrade @atproto-labs/fetch-node or use an older version of NodeJS.',
+    )
+  }
 
   return async function (input, init): Promise<Response> {
-    if (init?.dispatcher) {
+    if (init != null && 'dispatcher' in init && init.dispatcher != null) {
+      const request = asRequest(input, init)
+      await request.body?.cancel()
       throw new FetchRequestError(
-        asRequest(input, init),
+        request,
         500,
         'SSRF protection cannot be used with a custom request dispatcher',
       )
@@ -47,23 +82,29 @@ export function unicastFetchWrap<C = FetchContext>({
 
     const url = extractUrl(input)
 
-    if (url.hostname && isUnicastIp(url.hostname) === false) {
+    if (url.hostname && isUnicastIpHostname(url.hostname) === false) {
+      const request = asRequest(input, init)
+      await request.body?.cancel()
       throw new FetchRequestError(
-        asRequest(input, init),
+        request,
         400,
         'Hostname is a non-unicast address',
       )
     }
 
-    // @ts-expect-error non-standard option
-    const request = new Request(input, { ...init, dispatcher })
-    return fetch.call(this, request)
+    return fetch.call(this, input, {
+      ...init,
+      // @ts-ignore There is a type mismatch because of undici version
+      // differences, but we know this is safe because we are using the correct
+      // Agent class for the undici version.
+      dispatcher,
+    })
   }
 }
 
 export function unicastLookup(
   hostname: string,
-  options: dns.LookupOptions,
+  options: LookupOptions,
   callback: Parameters<LookupFunction>[2],
 ) {
   if (isLocalHostname(hostname)) {
@@ -71,7 +112,7 @@ export function unicastLookup(
     return
   }
 
-  dns.lookup(hostname, options, (err, address, family) => {
+  lookup(hostname, options, (err, address, family) => {
     if (err) {
       callback(err, address, family)
     } else {

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -1,10 +1,10 @@
-import { lookup } from 'node:dns'
 import type { LookupAddress, LookupOptions } from 'node:dns'
+import { lookup } from 'node:dns'
 import type { LookupFunction } from 'node:net'
 import ipaddr from 'ipaddr.js'
-import { Agent as Agent6 } from 'undici_v6'
-import { Agent as Agent7 } from 'undici_v7'
-import { Agent as Agent8 } from 'undici_v8'
+import { Agent as Undici6Agent } from 'undici_v6' // NodeJS 22
+import { Agent as Undici7Agent } from 'undici_v7' // NodeJS 24
+import { Agent as Undici8Agent } from 'undici_v8' // NodeJS 26
 import {
   Fetch,
   FetchContext,
@@ -12,21 +12,13 @@ import {
   asRequest,
   extractUrl,
 } from '@atproto-labs/fetch'
-import {
-  Version,
-  compareVersions,
-  isUnicastIpHostname,
-  parseVersion,
-} from './util.js'
+import { compareVersions, isUnicastIpHostname, parseVersion } from './util.js'
 
 const { IPv4, IPv6 } = ipaddr
 
 export type UnicastFetchWrapOptions<C = FetchContext> = {
   fetch?: Fetch<C>
 }
-
-// https://github.com/nodejs/undici/pull/2928
-const MIN_SUPPORTED_UNDICI_VERSION: Version = [6, 11, 1]
 
 /**
  * @see {@link https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/}
@@ -38,13 +30,11 @@ export function unicastFetchWrap<C = FetchContext>({
   const nodeUndiciVersion = parseVersion(process.versions.undici)
 
   if (
-    nodeUndiciVersion == null ||
-    compareVersions(nodeUndiciVersion, MIN_SUPPORTED_UNDICI_VERSION) < 0
+    !nodeUndiciVersion ||
+    // https://github.com/nodejs/undici/pull/2928
+    compareVersions(nodeUndiciVersion, [6, 11, 1]) < 0
   ) {
-    // The actual min version is Node 20.6+ but all @atproto packages require Node 22+
-    throw new Error(
-      'Unicast SSRF protection unavailable on your platform. Update to Node.js 22+.',
-    )
+    throw new Error('Unicast SSRF protection requires Node.js 20.6+')
   }
 
   // @NOTE Since major versions of undici are not guaranteed to be backwards
@@ -53,11 +43,11 @@ export function unicastFetchWrap<C = FetchContext>({
   // compatible with the version of undici being used.
   const dispatcher =
     nodeUndiciVersion[0] === 6
-      ? new Agent6({ connect: { lookup: unicastLookup } })
+      ? new Undici6Agent({ connect: { lookup: unicastLookup } })
       : nodeUndiciVersion[0] === 7
-        ? new Agent7({ connect: { lookup: unicastLookup } })
+        ? new Undici7Agent({ connect: { lookup: unicastLookup } })
         : nodeUndiciVersion[0] === 8
-          ? new Agent8({ connect: { lookup: unicastLookup } })
+          ? new Undici8Agent({ connect: { lookup: unicastLookup } })
           : null
 
   // @NOTE Because this is a security feature, we don't want to fallback to
@@ -66,11 +56,11 @@ export function unicastFetchWrap<C = FetchContext>({
   // to assume that and risk a security issue.
   if (!dispatcher) {
     throw new Error(
-      'This version of @atproto-labs/fetch-node does not support your version of undici. Please upgrade @atproto-labs/fetch-node or use an older version of NodeJS.',
+      'This version of @atproto-labs/fetch-node does not support your version of undici. Please upgrade @atproto-labs/fetch-node, and use a version of NodeJS that uses undici 6, 7, or 8 internally.',
     )
   }
 
-  return async function (input, init): Promise<Response> {
+  return async function (this: C, input, init): Promise<Response> {
     if (init != null && 'dispatcher' in init && init.dispatcher != null) {
       const request = asRequest(input, init)
       await request.body?.cancel()

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -41,6 +41,7 @@ export function unicastFetchWrap<C = FetchContext>({
     nodeUndiciVersion == null ||
     compareVersions(nodeUndiciVersion, MIN_SUPPORTED_UNDICI_VERSION) < 0
   ) {
+    // The actual min version is Node 20.6+ but all @atproto packages require Node 22+
     throw new Error(
       'Unicast SSRF protection unavailable on your platform. Update to Node.js 22+.',
     )

--- a/packages/internal/fetch-node/src/util.test.ts
+++ b/packages/internal/fetch-node/src/util.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { compareVersions, isUnicastIpHostname, parseVersion } from './util.js'
+
+describe(isUnicastIpHostname, () => {
+  describe('IPv4', () => {
+    it('should return true for unicast IP addresses', () => {
+      expect(isUnicastIpHostname('1.1.1.1')).toBe(true)
+      expect(isUnicastIpHostname('8.8.8.8')).toBe(true)
+    })
+
+    it('should return false for Multicast IP addresses', () => {
+      // https://en.wikipedia.org/wiki/Multicast_address
+
+      expect(isUnicastIpHostname('224.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('224.0.0.255')).toBe(false)
+      expect(isUnicastIpHostname('224.0.1.0')).toBe(false)
+      expect(isUnicastIpHostname('224.0.1.255')).toBe(false)
+      expect(isUnicastIpHostname('224.0.2.0')).toBe(false)
+      expect(isUnicastIpHostname('224.0.255.255')).toBe(false)
+      expect(isUnicastIpHostname('224.1.0.0')).toBe(false)
+      expect(isUnicastIpHostname('224.1.255.255')).toBe(false)
+      expect(isUnicastIpHostname('224.2.0.0')).toBe(false)
+      expect(isUnicastIpHostname('224.2.255.255')).toBe(false)
+      expect(isUnicastIpHostname('224.3.0.0')).toBe(false)
+      expect(isUnicastIpHostname('224.4.255.255')).toBe(false)
+      expect(isUnicastIpHostname('224.5.0.0')).toBe(false)
+      expect(isUnicastIpHostname('224.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('225.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('231.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('232.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('232.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('233.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('233.251.255.255')).toBe(false)
+      expect(isUnicastIpHostname('233.252.0.0')).toBe(false)
+      expect(isUnicastIpHostname('233.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('234.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('234.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('235.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('238.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('239.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('239.255.255.255')).toBe(false)
+    })
+
+    it('should return false for loopback IP addresses', () => {
+      // https://en.wikipedia.org/wiki/Loopback
+
+      expect(isUnicastIpHostname('127.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('127.0.0.1')).toBe(false)
+      expect(isUnicastIpHostname('127.0.34.54')).toBe(false)
+      expect(isUnicastIpHostname('127.255.255.255')).toBe(false)
+    })
+
+    it('should return false for private IP addresses', () => {
+      // https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
+
+      expect(isUnicastIpHostname('10.0.0.0')).toBe(false)
+      expect(isUnicastIpHostname('10.255.255.255')).toBe(false)
+      expect(isUnicastIpHostname('172.16.0.0')).toBe(false)
+      expect(isUnicastIpHostname('172.16.0.1')).toBe(false)
+      expect(isUnicastIpHostname('172.31.255.255')).toBe(false)
+      expect(isUnicastIpHostname('192.168.0.0')).toBe(false)
+      expect(isUnicastIpHostname('192.168.1.1')).toBe(false)
+      expect(isUnicastIpHostname('192.168.255.255')).toBe(false)
+    })
+  })
+
+  it('should return undefined for non-IP hostnames', () => {
+    expect(isUnicastIpHostname('example.com')).toBeUndefined()
+    expect(isUnicastIpHostname('localhost')).toBeUndefined()
+  })
+})
+
+describe(parseVersion, () => {
+  it('should parse valid version strings', () => {
+    expect(parseVersion('1.2.3')).toEqual([1, 2, 3])
+    expect(parseVersion('0.0.1')).toEqual([0, 0, 1])
+    expect(parseVersion('10.20.30')).toEqual([10, 20, 30])
+  })
+
+  it('should return undefined for invalid version strings', () => {
+    expect(parseVersion('1.2')).toBeUndefined()
+    expect(parseVersion('1.2.3.4')).toBeUndefined()
+    expect(parseVersion('abc')).toBeUndefined()
+  })
+
+  it('should return undefined for empty or undefined input', () => {
+    expect(parseVersion('')).toBeUndefined()
+    expect(parseVersion(undefined)).toBeUndefined()
+  })
+})
+
+describe(compareVersions, () => {
+  it('should return 0 for equal versions', () => {
+    expect(compareVersions([1, 2, 3], [1, 2, 3])).toBe(0)
+  })
+
+  it('should return -1 for a < b', () => {
+    expect(compareVersions([1, 2, 3], [1, 2, 4])).toBe(-1)
+    expect(compareVersions([1, 2, 3], [1, 3, 0])).toBe(-1)
+    expect(compareVersions([1, 2, 3], [2, 0, 0])).toBe(-1)
+  })
+
+  it('should return 1 for a > b', () => {
+    expect(compareVersions([1, 2, 4], [1, 2, 3])).toBe(1)
+    expect(compareVersions([1, 3, 0], [1, 2, 3])).toBe(1)
+    expect(compareVersions([2, 0, 0], [1, 2, 3])).toBe(1)
+  })
+})

--- a/packages/internal/fetch-node/src/util.ts
+++ b/packages/internal/fetch-node/src/util.ts
@@ -16,7 +16,22 @@ function parseIpHostname(
   return undefined
 }
 
-export function isUnicastIp(hostname: string): boolean | undefined {
+export function isUnicastIpHostname(hostname: string): boolean | undefined {
   const ip = parseIpHostname(hostname)
   return ip ? ip.range() === 'unicast' : undefined
+}
+
+export type Version = [major: number, minor: number, patch: number]
+export function parseVersion(version?: string): Version | undefined {
+  const match = version?.match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!match) return undefined
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+export function compareVersions(a: Version, b: Version): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] < b[i]) return -1
+    if (a[i] > b[i]) return 1
+  }
+  return 0
 }

--- a/packages/internal/fetch-node/tsconfig.build.json
+++ b/packages/internal/fetch-node/tsconfig.build.json
@@ -1,8 +1,9 @@
 {
   "extends": ["../../../tsconfig/node.json"],
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
   },
-  "include": ["src"],
 }

--- a/packages/internal/fetch-node/tsconfig.json
+++ b/packages/internal/fetch-node/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
 }

--- a/packages/internal/fetch-node/tsconfig.test.json
+++ b/packages/internal/fetch-node/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../../tsconfig/vitest.json"],
+  "include": ["./tests", "./src/**/*.test.ts"],
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "rootDir": "./",
+  },
+}

--- a/packages/internal/fetch-node/vitest.config.ts
+++ b/packages/internal/fetch-node/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {},
+})

--- a/packages/internal/fetch/src/fetch-request.ts
+++ b/packages/internal/fetch/src/fetch-request.ts
@@ -1,6 +1,6 @@
 import { FetchError } from './fetch-error.js'
 import { asRequest } from './fetch.js'
-import { extractUrl, isIp } from './util.js'
+import { isIp } from './util.js'
 
 export class FetchRequestError extends FetchError {
   constructor(
@@ -99,9 +99,9 @@ export function protocolCheckRequestTransform(protocols: {
   'https:'?: boolean | { allowCustomPort: boolean }
 }) {
   return (input: Request | string | URL, init?: RequestInit) => {
-    const { protocol, port } = extractUrl(input)
-
     const request = asRequest(input, init)
+
+    const { protocol, port } = new URL(request.url)
 
     const config: undefined | boolean | { allowCustomPort?: boolean } =
       Object.hasOwn(protocols, protocol) ? protocols[protocol] : undefined
@@ -155,9 +155,9 @@ export function requireHostHeaderTransform() {
     // Note that fetch() will automatically add the Host header from the URL and
     // discard any Host header manually set in the request.
 
-    const { protocol, hostname } = extractUrl(input)
-
     const request = asRequest(input, init)
+
+    const { protocol, hostname } = new URL(request.url)
 
     // "Host" header only makes sense in the context of an HTTP request
     if (protocol !== 'http:' && protocol !== 'https:') {
@@ -199,9 +199,9 @@ export function forbiddenDomainNameRequestTransform(
   }
 
   return async (input: Request | string | URL, init?: RequestInit) => {
-    const { hostname } = extractUrl(input)
-
     const request = asRequest(input, init)
+
+    const { hostname } = new URL(request.url)
 
     // Full domain name check
     if (denySet.has(hostname)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,9 +814,19 @@ importers:
       ipaddr.js:
         specifier: ^2.1.0
         version: 2.1.0
-      undici:
-        specifier: ^8.5.0
-        version: 8.5.0
+      undici_v6:
+        specifier: npm:undici@^6.X
+        version: undici@6.19.8
+      undici_v7:
+        specifier: npm:undici@^7.x
+        version: undici@7.28.0
+      undici_v8:
+        specifier: npm:undici@^8.x
+        version: undici@8.5.0
+    devDependencies:
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)
 
   packages/internal/handle-resolver:
     dependencies:
@@ -4188,9 +4198,6 @@ packages:
 
   '@jridgewell/source-map@0.3.11':
     resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -7676,14 +7683,6 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
-  fdir@6.4.3:
-    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -10830,10 +10829,6 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.12:
-    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -11030,6 +11025,10 @@ packages:
   undici@6.19.8:
     resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
     engines: {node: '>=18.17'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
@@ -14306,13 +14305,13 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.19
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -14331,8 +14330,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.19':
@@ -14343,7 +14340,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -14353,7 +14350,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -15709,7 +15706,7 @@ snapshots:
     dependencies:
       minimatch: 9.0.5
       path-browserify: 1.0.1
-      tinyglobby: 0.2.12
+      tinyglobby: 0.2.15
 
   '@ts-morph/common@0.28.1':
     dependencies:
@@ -18166,10 +18163,6 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
-
-  fdir@6.4.3(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -22071,11 +22064,6 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyglobby@0.2.12:
-    dependencies:
-      fdir: 6.4.3(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -22317,6 +22305,8 @@ snapshots:
       '@fastify/busboy': 2.1.0
 
   undici@6.19.8: {}
+
+  undici@7.28.0: {}
 
   undici@8.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,7 +815,7 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       undici_v6:
-        specifier: npm:undici@^6.X
+        specifier: npm:undici@^6.x
         version: undici@6.19.8
       undici_v7:
         specifier: npm:undici@^7.x


### PR DESCRIPTION
Since the recent update of undici to version 8 (https://github.com/bluesky-social/atproto/pull/5116), `node-fetch` has been broken on NodeJS 22 and NodeJS 24.

This is due to the fact that the interface of `dispatcher` option that can be passed to `fetch()` has significantly changed between Undici v6 and v8.

This regression was not detected in dev or tests because we explicitly disable SSRF in those environments.

The heart of the solution consists of loading a version of `undici` that matches the version used by the node process, ensuring that 1) we benefit from security updates in undici 2) we use a dispatcher with the right interface with `fetch()`.

**Before** (notice the node version at the top of each square)

<img width="1005" height="948" alt="Capture d’écran 2026-06-25 à 12 30 27" src="https://github.com/user-attachments/assets/39e08df3-aadc-44f0-9a24-e371d70e3735" />

**After**

<img width="1000" height="945" alt="Capture d’écran 2026-06-25 à 12 22 17" src="https://github.com/user-attachments/assets/67776765-a74f-44ec-9066-15eba6d8fe14" />
