### PR TITLE
Align chat group editGroup name limit with createGroup (50 graphemes)

### DIFF
--- a/lexicons/chat/bsky/convo/defs.json
+++ b/lexicons/chat/bsky/convo/defs.json
@@ -408,8 +408,8 @@
         "name": {
           "type": "string",
           "description": "The display name of the group conversation.",
-          "maxGraphemes": 128,
-          "maxLength": 1280
+          "maxGraphemes": 50,
+          "maxLength": 500
         },
         "unreadJoinRequestCount": {
           "type": "integer",

--- a/lexicons/chat/bsky/group/editGroup.json
+++ b/lexicons/chat/bsky/group/editGroup.json
@@ -20,8 +20,8 @@
             "name": {
               "type": "string",
               "minLength": 1,
-              "maxGraphemes": 128,
-              "maxLength": 1280
+              "maxGraphemes": 50,
+              "maxLength": 500
             }
           }
         }

--- a/lexicons/chat/bsky/moderation/defs.json
+++ b/lexicons/chat/bsky/moderation/defs.json
@@ -61,8 +61,8 @@
         "name": {
           "type": "string",
           "description": "The display name of the group conversation.",
-          "maxGraphemes": 128,
-          "maxLength": 1280
+          "maxGraphemes": 50,
+          "maxLength": 500
         }
       }
     }


### PR DESCRIPTION
editGroup allowed a group name of up to 128 graphemes / 1280 bytes while
createGroup capped it at 50 graphemes / 500 bytes. Lower editGroup to match
createGroup so the limit is consistent across both endpoints.