### PR TITLE
Add more details to the xrpc-server log errors

### DIFF
--- a/.changeset/gold-times-play.md
+++ b/.changeset/gold-times-play.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Add more details to the xrpc-server log errors

--- a/.changeset/two-pans-push.md
+++ b/.changeset/two-pans-push.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Add explicit error message when using invalid HTTP verb with xrpc methods defined using `.add()`

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -737,7 +737,7 @@ function createErrorMiddleware({
 
     const msgError = xrpcError.error || 'Unknown'
     const msgLoc = nsid ? `xrpc method ${nsid}` : `${req.method} ${req.url}`
-    const msgDetail = xrpcError.message ? `: ${xrpcError.message}` : ''
+    const msgDetail = xrpcError.message ? ` (${xrpcError.message})` : ''
     const msg = `${msgError} error in ${msgLoc}${msgDetail}`
 
     logger.error(

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -737,9 +737,10 @@ function createErrorMiddleware({
 
     const isInternalError = xrpcError instanceof InternalServerError
 
+    const msgError = xrpcError.error ?? 'Unknown'
     const msgDetail = xrpcError.message ? ` (${xrpcError.message})` : ''
     const msgLoc = nsid ? `xrpc method ${nsid}` : `${req.method} ${req.url}`
-    const msg = `${xrpcError.error} error${msgDetail} in ${msgLoc}`
+    const msg = `${msgError} error${msgDetail} in ${msgLoc}`
 
     logger.error(
       {

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -737,9 +737,9 @@ function createErrorMiddleware({
 
     const isInternalError = xrpcError instanceof InternalServerError
 
-    const msgPrefix = isInternalError ? 'unhandled exception' : 'error'
-    const msgSuffix = nsid ? `xrpc method ${nsid}` : `${req.method} ${req.url}`
-    const msg = `${msgPrefix} in ${msgSuffix}`
+    const msgDetail = xrpcError.message ? ` (${xrpcError.message})` : ''
+    const msgLoc = nsid ? `xrpc method ${nsid}` : `${req.method} ${req.url}`
+    const msg = `${xrpcError.error} error${msgDetail} in ${msgLoc}`
 
     logger.error(
       {

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -202,6 +202,13 @@ export class Server {
     schema: M,
     config: LexMethodConfig<M, A>,
   ): void {
+    this.routes.get(`/xrpc/${schema.nsid}`, (req, res, next) => {
+      next(
+        new InvalidRequestError(
+          `Incorrect HTTP method (${req.method}) expected POST`,
+        ),
+      )
+    })
     this.routes.post(
       `/xrpc/${schema.nsid}`,
       this.createHandlerInternal<
@@ -224,6 +231,13 @@ export class Server {
     schema: M,
     config: LexMethodConfig<M, A>,
   ): void {
+    this.routes.post(`/xrpc/${schema.nsid}`, (req, res, next) => {
+      next(
+        new InvalidRequestError(
+          `Incorrect HTTP method (${req.method}) expected GET`,
+        ),
+      )
+    })
     this.routes.get(
       `/xrpc/${schema.nsid}`,
       this.createHandlerInternal<

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -735,19 +735,18 @@ function createErrorMiddleware({
     // (id, timing) and logging configuration (serialization, etc.).
     const logger = isPinoHttpRequest(req) ? req.log : log
 
-    const isInternalError = xrpcError instanceof InternalServerError
-
-    const msgError = xrpcError.error ?? 'Unknown'
-    const msgDetail = xrpcError.message ? ` (${xrpcError.message})` : ''
+    const msgError = xrpcError.error || 'Unknown'
     const msgLoc = nsid ? `xrpc method ${nsid}` : `${req.method} ${req.url}`
-    const msg = `${msgError} error${msgDetail} in ${msgLoc}`
+    const msgDetail = xrpcError.message ? `: ${xrpcError.message}` : ''
+    const msg = `${msgError} error in ${msgLoc}${msgDetail}`
 
     logger.error(
       {
         // @NOTE Computation of error stack is an expensive operation, so
-        // we strip it for expected errors.
+        // we strip it for expected (non-server) errors.
         err:
-          isInternalError || process.env.NODE_ENV === 'development'
+          xrpcError instanceof InternalServerError ||
+          process.env.NODE_ENV === 'development'
             ? err
             : toSimplifiedErrorLike(err),
 

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -262,23 +262,20 @@ for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
 
     test('validation errors on procedures include details in logs', async () => {
       // 500 responses don't include details, so we nab details from the logger.
-      const spy = jest.spyOn(logger, 'error')
-      try {
-        await expect(
-          client.call('io.example.validationTestTwo'),
-        ).rejects.toThrow('Internal Server Error')
+      using spy = jest.spyOn(logger, 'error')
 
-        expect(spy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            err: expect.objectContaining({
-              message: expect.stringContaining('foo'),
-            }),
+      await expect(client.call('io.example.validationTestTwo')).rejects.toThrow(
+        'Internal Server Error',
+      )
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({
+            message: expect.stringContaining('foo'),
           }),
-          'unhandled exception in xrpc method io.example.validationTestTwo',
-        )
-      } finally {
-        spy.mockRestore()
-      }
+        }),
+        expect.stringContaining('InternalServerError error'),
+      )
     })
 
     it('supports ArrayBuffers', async () => {


### PR DESCRIPTION
Currently XRPC server error messages appear as follows in logs:

```
error in xrpc method app.bsky.feed.searchPosts
```

This is not very helpful
1) because it requires to dig into the log item details to see the actual error
2) because it prevents automated tools from extracting patterns from error logs

This PR makes those error messages more explicit:

```
InvalidToken error in xrpc method app.bsky.feed.searchPosts (Token could not be verified)
```