### PR TITLE
Reject duplicate BCP 47 variant subtags and extension singletons

### DIFF
--- a/.changeset/dedup-bcp47-subtags.md
+++ b/.changeset/dedup-bcp47-subtags.md
@@ -1,5 +1,5 @@
 ---
-'@atproto/syntax': patch
+'@atproto/syntax': minor
 ---
 
-Reject duplicate variant subtags and duplicate extension singleton subtags in `isValidLanguage` / `parseLanguageString`, per RFC 5646 §4.1.
+`parseLanguageString` now rejects BCP 47 tags with duplicate variant subtags or duplicate extension singleton subtags, per RFC 5646 §4.1. `isValidLanguage` continues to check only well-formed syntax (§2.1) and is unchanged.

--- a/.changeset/dedup-bcp47-subtags.md
+++ b/.changeset/dedup-bcp47-subtags.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Reject duplicate variant subtags and duplicate extension singleton subtags in `isValidLanguage` / `parseLanguageString`, per RFC 5646 §4.1.

--- a/.changeset/language-strict-lenient.md
+++ b/.changeset/language-strict-lenient.md
@@ -1,0 +1,7 @@
+---
+'@atproto/common': minor
+'@atproto/lex-schema': minor
+'@atproto/lex': minor
+---
+
+Language-tag string-format validation now has strict and lenient variants, matching the pattern already used for `at-uri` and `datetime`. `isLanguageString` (and the default `language` string-format verifier) is now strict and rejects BCP 47 tags that violate RFC 5646 §4.1 (e.g. duplicate variant subtags or duplicate extension singletons). Pass `{ strict: false }` to fall back to the lenient (syntax-only) verifier, `isLanguageStringLenient`.

--- a/packages/lex/lex-schema/src/core/string-format.ts
+++ b/packages/lex/lex-schema/src/core/string-format.ts
@@ -20,6 +20,7 @@ import {
   isValidRecordKey,
   isValidTid,
   isValidUri,
+  parseLanguageString,
 } from '@atproto/syntax'
 import type { CheckFn } from '../util/assertion-util.js'
 
@@ -126,10 +127,25 @@ export type {
 /**
  * Type guard that checks if a value is a valid BCP-47 language tag.
  *
+ * Strict: rejects tags whose syntax is well-formed but violate semantic
+ * constraints from RFC 5646 §4.1 (e.g. repeated variant subtags or repeated
+ * extension singletons). Use {@link isLanguageStringLenient} to accept those.
+ *
  * @param value - The value to check
  * @returns `true` if the value is a valid language string
  */
-export const isLanguageString = isValidLanguage as CheckFn<LanguageString>
+export const isLanguageString = ((v) =>
+  parseLanguageString(v) !== null) as CheckFn<LanguageString>
+
+/**
+ * Lenient version of {@link isLanguageString} that only checks well-formed
+ * BCP 47 syntax (RFC 5646 §2.1) and does not enforce semantic constraints
+ * from §4.1.
+ *
+ * @see {@link isLanguageString}
+ */
+export const isLanguageStringLenient =
+  isValidLanguage as CheckFn<LanguageString>
 /**
  * A BCP-47 language tag string.
  *
@@ -242,7 +258,7 @@ const stringFormatVerifiers: {
   datetime: [isDatetimeString, isDatetimeStringLenient],
   did: [isDidString],
   handle: [isHandleString],
-  language: [isLanguageString],
+  language: [isLanguageString, isLanguageStringLenient],
   nsid: [isNsidString],
   'record-key': [isRecordKeyString],
   tid: [isTidString],

--- a/packages/lex/lex-schema/src/schema/string.test.ts
+++ b/packages/lex/lex-schema/src/schema/string.test.ts
@@ -514,6 +514,34 @@ describe('StringSchema', () => {
       const result = schema.safeParse('not valid')
       expect(result.success).toBe(false)
     })
+
+    it('rejects tags with duplicate variant subtags (RFC 5646 §4.1)', () => {
+      const result = schema.safeParse('de-DE-1901-1901')
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects tags with duplicate extension singletons (RFC 5646 §4.1)', () => {
+      const result = schema.safeParse('en-a-foo-a-bar')
+      expect(result.success).toBe(false)
+    })
+
+    describe('loose validation', () => {
+      it('accepts tags with duplicate variant subtags', () => {
+        const result = schema.safeParse('de-DE-1901-1901', { strict: false })
+        expect(result.success).toBe(true)
+      })
+
+      it('accepts tags with duplicate extension singletons', () => {
+        const result = schema.safeParse('en-a-foo-a-bar', { strict: false })
+        expect(result.success).toBe(true)
+      })
+
+      it('still rejects syntactically invalid strings', () => {
+        expect(schema.safeParse('not valid', { strict: false }).success).toBe(
+          false,
+        )
+      })
+    })
   })
 
   describe('format: tid', () => {

--- a/packages/syntax/src/language.ts
+++ b/packages/syntax/src/language.ts
@@ -12,8 +12,80 @@ export type LanguageTag = {
   privateUse?: string
 }
 
-export function parseLanguageString(input: string): LanguageTag | null {
+function matchValidLanguage(input: string): RegExpMatchArray | null {
   const parsed = input.match(BCP47_REGEXP)
+  if (!parsed?.groups) return null
+  if (hasDuplicateVariantOrSingleton(input, parsed.groups)) return null
+  return parsed
+}
+
+/**
+ * Detect repeated variant subtags or repeated extension singleton
+ * subtags within a well-formed BCP 47 langtag. The comparison is
+ * case-insensitive.
+ *
+ * The regex alone cannot enforce this — JavaScript named captures keep
+ * only the last occurrence of a repeated group — so this is run as a
+ * post-match check on the original input string.
+ *
+ * Grandfathered and privateuse-only tags carry neither variants nor
+ * extension singletons and short-circuit.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc5646.html#section-4.1 RFC 5646 §4.1 Choice of Language Tag}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1.1 RFC 5646 §2.1.1 Case Considerations}
+ */
+function hasDuplicateVariantOrSingleton(
+  input: string,
+  groups: { grandfathered?: string; privateUseB?: string },
+): boolean {
+  if (groups.grandfathered || groups.privateUseB) return false
+
+  const subtags = input.split('-')
+  let i = 1 // language
+
+  if (subtags[0].length === 2 || subtags[0].length === 3) {
+    // extlang: 0–3 subtags of 3 letters
+    let count = 0
+    while (
+      count < 3 &&
+      i < subtags.length &&
+      /^[A-Za-z]{3}$/.test(subtags[i])
+    ) {
+      i++
+      count++
+    }
+  }
+
+  // script
+  if (i < subtags.length && /^[A-Za-z]{4}$/.test(subtags[i])) i++
+  // region
+  if (i < subtags.length && /^([A-Za-z]{2}|[0-9]{3})$/.test(subtags[i])) i++
+
+  const seenVariants = new Set<string>()
+  while (
+    i < subtags.length &&
+    /^([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3})$/.test(subtags[i])
+  ) {
+    const key = subtags[i].toLowerCase()
+    if (seenVariants.has(key)) return true
+    seenVariants.add(key)
+    i++
+  }
+
+  const seenSingletons = new Set<string>()
+  while (i < subtags.length && /^[0-9A-WYZa-wyz]$/.test(subtags[i])) {
+    const singleton = subtags[i].toLowerCase()
+    if (seenSingletons.has(singleton)) return true
+    seenSingletons.add(singleton)
+    i++
+    while (i < subtags.length && /^[A-Za-z0-9]{2,8}$/.test(subtags[i])) i++
+  }
+
+  return false
+}
+
+export function parseLanguageString(input: string): LanguageTag | null {
+  const parsed = matchValidLanguage(input)
   if (!parsed?.groups) return null
 
   const { groups } = parsed
@@ -35,5 +107,5 @@ export function parseLanguageString(input: string): LanguageTag | null {
  * @see {@link https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1}
  */
 export function isValidLanguage(input: string): boolean {
-  return BCP47_REGEXP.test(input)
+  return matchValidLanguage(input) !== null
 }

--- a/packages/syntax/src/language.ts
+++ b/packages/syntax/src/language.ts
@@ -102,10 +102,14 @@ export function parseLanguageString(input: string): LanguageTag | null {
 }
 
 /**
- * Validates well-formed BCP 47 syntax
+ * Validates well-formed BCP 47 syntax.
+ *
+ * Only checks the ABNF grammar of RFC 5646 §2.1. Semantic constraints from
+ * §4.1 (e.g. no repeated variant subtags) are NOT enforced — use
+ * {@link parseLanguageString} for strict validation.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1}
  */
 export function isValidLanguage(input: string): boolean {
-  return matchValidLanguage(input) !== null
+  return BCP47_REGEXP.test(input)
 }

--- a/packages/syntax/tests/language.test.ts
+++ b/packages/syntax/tests/language.test.ts
@@ -20,11 +20,18 @@ describe(isValidLanguage, () => {
     expect(isValidLanguage('sr-Cyrl')).toEqual(true)
     expect(isValidLanguage('hy-Latn-IT-arevela')).toEqual(true)
     expect(isValidLanguage('i-klingon')).toEqual(true)
+    expect(isValidLanguage('sl-rozaj-biske')).toEqual(true)
+    expect(isValidLanguage('en-u-co-phonebk-t-en-US')).toEqual(true)
     // invalid
     expect(isValidLanguage('')).toEqual(false)
     expect(isValidLanguage('x')).toEqual(false)
     expect(isValidLanguage('de-CH-')).toEqual(false)
     expect(isValidLanguage('i-bad-grandfathered')).toEqual(false)
+    // duplicate variant / extension singleton subtags (RFC 5646 §4.1)
+    expect(isValidLanguage('de-DE-1901-1901')).toEqual(false)
+    expect(isValidLanguage('en-rozaj-ROZAJ')).toEqual(false)
+    expect(isValidLanguage('en-a-foo-a-bar')).toEqual(false)
+    expect(isValidLanguage('en-u-co-phonebk-U-ca-buddhist')).toEqual(false)
   })
 })
 
@@ -90,10 +97,23 @@ describe(parseLanguageString, () => {
     expect(parseLanguageString('i-klingon')).toEqual({
       grandfathered: 'i-klingon',
     })
+    expect(parseLanguageString('sl-rozaj-biske')).toEqual({
+      language: 'sl',
+      variant: 'biske',
+    })
+    expect(parseLanguageString('en-u-co-phonebk-t-en-US')).toEqual({
+      language: 'en',
+      extension: 't-en-US',
+    })
     // invalid
     expect(parseLanguageString('')).toEqual(null)
     expect(parseLanguageString('x')).toEqual(null)
     expect(parseLanguageString('de-CH-')).toEqual(null)
     expect(parseLanguageString('i-bad-grandfathered')).toEqual(null)
+    // duplicate variant / extension singleton subtags (RFC 5646 §4.1)
+    expect(parseLanguageString('de-DE-1901-1901')).toEqual(null)
+    expect(parseLanguageString('en-rozaj-ROZAJ')).toEqual(null)
+    expect(parseLanguageString('en-a-foo-a-bar')).toEqual(null)
+    expect(parseLanguageString('en-u-co-phonebk-U-ca-buddhist')).toEqual(null)
   })
 })

--- a/packages/syntax/tests/language.test.ts
+++ b/packages/syntax/tests/language.test.ts
@@ -22,16 +22,15 @@ describe(isValidLanguage, () => {
     expect(isValidLanguage('i-klingon')).toEqual(true)
     expect(isValidLanguage('sl-rozaj-biske')).toEqual(true)
     expect(isValidLanguage('en-u-co-phonebk-t-en-US')).toEqual(true)
+    // duplicate variant / extension singleton subtags are well-formed
+    // syntax (§2.1) — semantic rejection is left to parseLanguageString
+    expect(isValidLanguage('de-DE-1901-1901')).toEqual(true)
+    expect(isValidLanguage('en-a-foo-a-bar')).toEqual(true)
     // invalid
     expect(isValidLanguage('')).toEqual(false)
     expect(isValidLanguage('x')).toEqual(false)
     expect(isValidLanguage('de-CH-')).toEqual(false)
     expect(isValidLanguage('i-bad-grandfathered')).toEqual(false)
-    // duplicate variant / extension singleton subtags (RFC 5646 §4.1)
-    expect(isValidLanguage('de-DE-1901-1901')).toEqual(false)
-    expect(isValidLanguage('en-rozaj-ROZAJ')).toEqual(false)
-    expect(isValidLanguage('en-a-foo-a-bar')).toEqual(false)
-    expect(isValidLanguage('en-u-co-phonebk-U-ca-buddhist')).toEqual(false)
   })
 })
 


### PR DESCRIPTION
This PR rejects duplicate variant subtags and duplicate extension singleton subtags in `isValidLanguage` / `parseLanguageString` via a Set-based post-validation check, per RFC 5646 §4.1.

Closes #5161.