### PR TITLE
fix(syntax): accept uppercase X- private-use subtags in BCP 47 tags

### DIFF
--- a/.changeset/bcp47-uppercase-privateuse.md
+++ b/.changeset/bcp47-uppercase-privateuse.md
@@ -1,0 +1,10 @@
+---
+'@atproto/syntax': patch
+---
+
+`isValidLanguage` and `parseLanguageString` now accept BCP 47 tags whose
+private-use subtag uses an uppercase `X` (for example `X-fr-CH` or `de-X-foo`).
+Per RFC 5646 §2.1.1 (and RFC 5234 §2.3, which makes ABNF quoted-string literals
+case-insensitive), private-use subtags are case-insensitive, so these tags are
+well-formed. Previously only the lowercase `x` form was matched. Lowercase tags
+behave exactly as before.

--- a/packages/syntax/src/language.ts
+++ b/packages/syntax/src/language.ts
@@ -1,5 +1,5 @@
 const BCP47_REGEXP =
-  /^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?<extension>[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?<privateUseA>x(-[A-Za-z0-9]{1,8})+))?)|(?<privateUseB>x(-[A-Za-z0-9]{1,8})+))$/
+  /^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?<extension>[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?<privateUseA>[xX](-[A-Za-z0-9]{1,8})+))?)|(?<privateUseB>[xX](-[A-Za-z0-9]{1,8})+))$/
 
 export type LanguageTag = {
   grandfathered?: string

--- a/packages/syntax/tests/language.test.ts
+++ b/packages/syntax/tests/language.test.ts
@@ -11,6 +11,9 @@ describe(isValidLanguage, () => {
     expect(isValidLanguage('sl-IT-nedis')).toEqual(true)
     expect(isValidLanguage('mn-Cyrl-MN')).toEqual(true)
     expect(isValidLanguage('x-fr-CH')).toEqual(true)
+    // private-use subtags are case-insensitive (RFC 5646 §2.1.1)
+    expect(isValidLanguage('X-fr-CH')).toEqual(true)
+    expect(isValidLanguage('de-X-foo')).toEqual(true)
     expect(
       isValidLanguage('en-GB-boont-r-extended-sequence-x-private'),
     ).toEqual(true)
@@ -56,6 +59,14 @@ describe(parseLanguageString, () => {
     })
     expect(parseLanguageString('x-fr-CH')).toEqual({
       privateUse: 'x-fr-CH',
+    })
+    // private-use subtags are case-insensitive (RFC 5646 §2.1.1)
+    expect(parseLanguageString('X-fr-CH')).toEqual({
+      privateUse: 'X-fr-CH',
+    })
+    expect(parseLanguageString('de-X-foo')).toEqual({
+      language: 'de',
+      privateUse: 'X-foo',
     })
     expect(
       parseLanguageString('en-GB-boont-r-extended-sequence-x-private'),


### PR DESCRIPTION
## Problem

`@atproto/syntax`'s `isValidLanguage` and `parseLanguageString` reject well-formed BCP 47 language tags whose private-use subtag is written with an uppercase `X`:

| Input        | Before      | Expected |
|--------------|-------------|----------|
| `X-fr-CH`    | `false` ❌  | `true`   |
| `de-X-foo`   | `false` ❌  | `true`   |
| `x-fr-CH`    | `true`      | `true`   |
| `de-x-foo`   | `true`      | `true`   |

## Root cause

`BCP47_REGEXP` in `packages/syntax/src/language.ts` hard-codes a lowercase `x` literal in both the `privateUseA` and `privateUseB` groups, and the regex carries no `i` flag.

Per RFC 5646 §2.1.1, language tags and their subtags, including private use, are case-insensitive. RFC 5234 §2.3 also makes the ABNF quoted-string literal `"x"` in the `privateuse = "x" 1*("-" (1*8alphanum))` production case-insensitive. So an uppercase `X-` private-use subtag is well-formed and should be accepted.

The lowercase `x` looks like a faithful but incomplete transliteration of the ABNF: where the spec does intend case sensitivity it uses explicit hex ranges, e.g. the extension singleton `[0-9A-WY-Za-wy-z]`, which deliberately excludes `x`/`X`. Private use uses a quoted literal, so it is not case sensitive.

## Fix

Replace the two `x` literals with the character class `[xX]`:

```diff
- (-(?<privateUseA>x(-[A-Za-z0-9]{1,8})+))?)|(?<privateUseB>x(-[A-Za-z0-9]{1,8})+))$/
+ (-(?<privateUseA>[xX](-[A-Za-z0-9]{1,8})+))?)|(?<privateUseB>[xX](-[A-Za-z0-9]{1,8})+))$/
```

This is the minimal, one-concern change for the reported bug and it is purely additive:

- Every tag that was valid before stays valid (verified: all 868 existing `packages/syntax` tests pass).
- The extension-singleton class `[0-9A-WY-Za-wy-z]` is untouched, so `x`/`X` are still correctly excluded there.
- All other subtags already use `[A-Za-z]` / `[A-Za-z0-9]` classes, so case behavior elsewhere is unchanged.

The issue also proposed a broader Option 2 (adding the `i` flag), which would additionally accept mixed-case grandfathered tags such as `I-Klingon`. That is a wider behavior change than the reported bug, so I kept this PR to the scoped private-use fix. Happy to switch to the `i`-flag approach instead if the maintainers prefer the broader RFC §2.1.1 alignment.

## Testing

Added case-insensitive private-use assertions to `packages/syntax/tests/language.test.ts` for both `isValidLanguage` and `parseLanguageString`. These fail on the unpatched source and pass with the fix.

```
### BEFORE FIX (unpatched source)
 ❯ tests/language.test.ts (2 tests | 2 failed)
   × validates BCP 47
   × parses BCP 47
 AssertionError: expected false to deeply equal true
 AssertionError: expected null to deeply equal { privateUse: 'X-fr-CH' }

### AFTER FIX
 Test Files  9 passed (9)
      Tests  868 passed | 92 skipped (960)
```

`pnpm exec prettier --check` and `pnpm exec eslint` on both changed files report clean. A changeset is included (`@atproto/syntax`, patch).

## Severity

Low. Real-world clients do not emit uppercase `X-` private-use tags today, so wire-format impact is minimal. This is a spec-compliance and reference-implementation-correctness fix.

Fixes #5160
