### PR TITLE
Filter searchTagsHideAll posts from all search surfaces

### DIFF
--- a/.changeset/tame-pillows-hide.md
+++ b/.changeset/tame-pillows-hide.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add `searchTagsHideAll` config to filter tagged posts from all search surfaces

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -196,6 +196,13 @@ const noBlocksOrTagged = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
     // Cases to never show.
     if (ctx.views.viewerBlockExists(creator, hydration)) return false
 
+    // Tags that are hidden from all search surfaces (Top and Latest),
+    // regardless of curation or author filtering.
+    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) =>
+      post.tags.has(t),
+    )
+    if (alwaysHidden) return false
+
     let tagged = false
     if (
       params.hydrateCtx.features?.checkGate(

--- a/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
@@ -164,6 +164,13 @@ const noBlocksOrTagged = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
 
     if (ctx.views.viewerBlockExists(creator, hydration)) return false
 
+    // Tags that are hidden from all search surfaces (Top and Latest),
+    // regardless of curation or author filtering.
+    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) =>
+      post.tags.has(t),
+    )
+    if (alwaysHidden) return false
+
     const tagged = [...ctx.cfg.searchTagsHide].some((t) => post.tags.has(t))
 
     if (isCuratedSearch && tagged) return false

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -63,6 +63,7 @@ export interface ServerConfigValues {
   rolodexIgnoreBadTls?: boolean
   searchUrl?: string
   searchTagsHide: Set<string>
+  searchTagsHideAll: Set<string>
   suggestionsUrl?: string
   suggestionsApiKey?: string
   topicsUrl?: string
@@ -163,6 +164,9 @@ export class ServerConfig {
       process.env.BSKY_SEARCH_ENDPOINT ||
       undefined
     const searchTagsHide = new Set(envList(process.env.BSKY_SEARCH_TAGS_HIDE))
+    const searchTagsHideAll = new Set(
+      envList(process.env.BSKY_SEARCH_TAGS_HIDE_ALL),
+    )
     const suggestionsUrl = process.env.BSKY_SUGGESTIONS_URL || undefined
     const suggestionsApiKey = process.env.BSKY_SUGGESTIONS_API_KEY || undefined
     const topicsUrl = process.env.BSKY_TOPICS_URL || undefined
@@ -354,6 +358,7 @@ export class ServerConfig {
       dataplaneIgnoreBadTls,
       searchUrl,
       searchTagsHide,
+      searchTagsHideAll,
       suggestionsUrl,
       suggestionsApiKey,
       topicsUrl,
@@ -522,6 +527,10 @@ export class ServerConfig {
 
   get searchTagsHide() {
     return this.cfg.searchTagsHide
+  }
+
+  get searchTagsHideAll() {
+    return this.cfg.searchTagsHideAll
   }
 
   get suggestionsUrl() {

--- a/packages/bsky/tests/views/post-search.test.ts
+++ b/packages/bsky/tests/views/post-search.test.ts
@@ -5,6 +5,7 @@ import type { DidString } from '@atproto/syntax'
 import { DatabaseSchema } from '../../src/index.js'
 
 const TAG_HIDE = 'hide'
+const TAG_ALWAYS_HIDE = 'always-hide'
 
 describe('appview search', () => {
   let network: TestNetwork
@@ -14,6 +15,10 @@ describe('appview search', () => {
   let post0: Awaited<ReturnType<SeedClient['post']>>
   let post1: Awaited<ReturnType<SeedClient['post']>>
   let post2: Awaited<ReturnType<SeedClient['post']>>
+  // 'unicorn' term, kept separate from the 'doggo' posts above so the
+  // always-hide cases don't perturb the existing expectations.
+  let unicornPost: Awaited<ReturnType<SeedClient['post']>>
+  let unicornPostAlwaysHidden: Awaited<ReturnType<SeedClient['post']>>
   let allResults: string[]
   let nonTaggedResults: string[]
 
@@ -27,6 +32,7 @@ describe('appview search', () => {
       dbPostgresSchema: 'bsky_views_search',
       bsky: {
         searchTagsHide: new Set([TAG_HIDE]),
+        searchTagsHideAll: new Set([TAG_ALWAYS_HIDE]),
       },
     })
     agent = network.bsky.getAgent()
@@ -43,9 +49,17 @@ describe('appview search', () => {
     post2 = await sc.post(alice, 'cute doggo')
     await network.processAll()
 
+    unicornPost = await sc.post(alice, 'a unicorn')
+    unicornPostAlwaysHidden = await sc.post(alice, 'another unicorn')
+    await network.processAll()
+
     await createTag(network.bsky.db.db, {
       uri: post1.ref.uriStr,
       val: TAG_HIDE,
+    })
+    await createTag(network.bsky.db.db, {
+      uri: unicornPostAlwaysHidden.ref.uriStr,
+      val: TAG_ALWAYS_HIDE,
     })
 
     allResults = [post2.ref.uriStr, post1.ref.uriStr, post0.ref.uriStr]
@@ -178,6 +192,73 @@ describe('appview search', () => {
 
       expect(resTop.data.posts.map((p) => p.uri)).toStrictEqual(allResults)
       expect(resLatest.data.posts.map((p) => p.uri)).toStrictEqual(allResults)
+    })
+  })
+
+  describe('searchTagsHideAll', () => {
+    // Unlike searchTagsHide, an always-hide tag is filtered from every
+    // surface: both 'top' and 'latest', and even when an author is specified.
+    it.each(['top', 'latest'] as const)(
+      `with '%s' sort, hides always-hidden posts`,
+      async (sort) => {
+        const res = await agent.app.bsky.feed.searchPosts(
+          { q: 'unicorn', sort },
+          {
+            headers: await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPosts,
+            ),
+          },
+        )
+        expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+          unicornPost.ref.uriStr,
+        ])
+      },
+    )
+
+    it.each(['top', 'latest'] as const)(
+      `with '%s' sort, hides always-hidden posts even when specifying author`,
+      async (sort) => {
+        const res = await agent.app.bsky.feed.searchPosts(
+          { q: 'unicorn', author: alice, sort },
+          {
+            headers: await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPosts,
+            ),
+          },
+        )
+        expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+          unicornPost.ref.uriStr,
+        ])
+      },
+    )
+
+    it('includes always-hidden posts from the viewer', async () => {
+      const res = await agent.app.bsky.feed.searchPosts(
+        { q: 'unicorn', sort: 'latest' },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyFeedSearchPosts,
+          ),
+        },
+      )
+      expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+        unicornPostAlwaysHidden.ref.uriStr,
+        unicornPost.ref.uriStr,
+      ])
+    })
+
+    it('mod service finds even always-hidden posts', async () => {
+      const res = await ozoneAgent.app.bsky.feed.searchPosts(
+        { q: 'unicorn', sort: 'latest' },
+        { headers: await network.ozone.modHeaders(ids.AppBskyFeedSearchPosts) },
+      )
+      expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+        unicornPostAlwaysHidden.ref.uriStr,
+        unicornPost.ref.uriStr,
+      ])
     })
   })
 })

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -83,6 +83,7 @@ export class TestBsky {
       maxThreadParents: cfg.maxThreadParents ?? 50,
       disableSsrfProtection: true,
       searchTagsHide: new Set(),
+      searchTagsHideAll: new Set(),
       threadTagsBumpDown: new Set(),
       threadTagsHide: new Set(),
       visibilityTagHide: '',


### PR DESCRIPTION
Adds a new `searchTagsHideAll` config (env `BSKY_SEARCH_TAGS_HIDE_ALL`) that hides tagged posts from every search surface — both Top and Latest, and regardless of whether an author is specified — unlike `searchTagsHide`, which only filters conditionally. Applied in `noBlocksOrTagged` for searchPosts v1 and v2, after the block check but preserving the viewer/mod-service exemptions.