### PR TITLE
Update KWS auth handling, schemas, and age assurance config defs

### DIFF
--- a/.changeset/fluffy-pans-wonder.md
+++ b/.changeset/fluffy-pans-wonder.md
@@ -1,0 +1,6 @@
+---
+'@atproto/bsky': patch
+'@atproto/api': patch
+---
+
+Support the new timestamp field, along with transactionId and errorCode, on KWS age verification status payloads. Add additionalVerificationMethods to Age Assurance config.

--- a/lexicons/app/bsky/ageassurance/defs.json
+++ b/lexicons/app/bsky/ageassurance/defs.json
@@ -76,6 +76,14 @@
           "type": "integer",
           "description": "The minimum age (as a whole integer) required to use Bluesky in this region."
         },
+        "additionalVerificationMethods": {
+          "type": "array",
+          "description": "Verification methods permitted in this region in addition to the third-party (KWS) flow, which is always supported. `device` permits using the native on-device age APIs (e.g. Apple Declared Age Range, Google Play Age Signals).",
+          "items": {
+            "type": "string",
+            "knownValues": ["device"]
+          }
+        },
         "rules": {
           "type": "array",
           "description": "The ordered list of Age Assurance rules that apply to this region. Rules should be applied in order, and the first matching rule determines the access level granted. The rules array should always include a default rule as the last item.",

--- a/packages/bsky/src/api/age-assurance/const.ts
+++ b/packages/bsky/src/api/age-assurance/const.ts
@@ -159,6 +159,25 @@ export const AGE_ASSURANCE_CONFIG = app.bsky.ageassurance.defs.config.$build({
       ],
     },
     {
+      countryCode: 'US',
+      regionCode: 'TX',
+      minAccessAge: 18,
+      // On-device age verification is permitted here in addition to the
+      // third-party (KWS) flow, which is always supported and remains as a
+      // fallback for platforms without the native age API (e.g. web) or
+      // insufficient device results.
+      additionalVerificationMethods: ['device'],
+      rules: [
+        app.bsky.ageassurance.defs.configRegionRuleIfAssuredOverAge.$build({
+          age: 18,
+          access: 'full',
+        }),
+        app.bsky.ageassurance.defs.configRegionRuleDefault.$build({
+          access: 'none',
+        }),
+      ],
+    },
+    {
       countryCode: 'BR',
       regionCode: undefined,
       minAccessAge: 13,

--- a/packages/bsky/src/api/age-assurance/const.ts
+++ b/packages/bsky/src/api/age-assurance/const.ts
@@ -158,25 +158,25 @@ export const AGE_ASSURANCE_CONFIG = app.bsky.ageassurance.defs.config.$build({
         }),
       ],
     },
-    {
-      countryCode: 'US',
-      regionCode: 'TX',
-      minAccessAge: 18,
-      // On-device age verification is permitted here in addition to the
-      // third-party (KWS) flow, which is always supported and remains as a
-      // fallback for platforms without the native age API (e.g. web) or
-      // insufficient device results.
-      additionalVerificationMethods: ['device'],
-      rules: [
-        app.bsky.ageassurance.defs.configRegionRuleIfAssuredOverAge.$build({
-          age: 18,
-          access: 'full',
-        }),
-        app.bsky.ageassurance.defs.configRegionRuleDefault.$build({
-          access: 'none',
-        }),
-      ],
-    },
+    // {
+    //   countryCode: 'US',
+    //   regionCode: 'TX',
+    //   minAccessAge: 18,
+    //   // On-device age verification is permitted here in addition to the
+    //   // third-party (KWS) flow, which is always supported and remains as a
+    //   // fallback for platforms without the native age API (e.g. web) or
+    //   // insufficient device results.
+    //   additionalVerificationMethods: ['device'],
+    //   rules: [
+    //     app.bsky.ageassurance.defs.configRegionRuleIfAssuredOverAge.$build({
+    //       age: 18,
+    //       access: 'full',
+    //     }),
+    //     app.bsky.ageassurance.defs.configRegionRuleDefault.$build({
+    //       access: 'none',
+    //     }),
+    //   ],
+    // },
     {
       countryCode: 'BR',
       regionCode: undefined,

--- a/packages/bsky/src/api/age-assurance/kws/age-verified.test.ts
+++ b/packages/bsky/src/api/age-assurance/kws/age-verified.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseKWSAgeVerifiedStatus,
+  serializeKWSAgeVerifiedStatus,
+} from './age-verified.js'
+
+describe('parseKWSAgeVerifiedStatus', () => {
+  it('parses a minimal status object', () => {
+    const raw = JSON.stringify({ verified: true, verifiedMinimumAge: 18 })
+    expect(parseKWSAgeVerifiedStatus(raw)).toEqual({
+      verified: true,
+      verifiedMinimumAge: 18,
+    })
+  })
+
+  it('parses the optional transactionId and timestamp fields', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      verifiedMinimumAge: 18,
+      transactionId: 'txn-123',
+      timestamp: 1750680000,
+    })
+    expect(parseKWSAgeVerifiedStatus(raw)).toEqual({
+      verified: true,
+      verifiedMinimumAge: 18,
+      transactionId: 'txn-123',
+      timestamp: 1750680000,
+    })
+  })
+
+  it('tolerates the new timestamp field without transactionId', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      verifiedMinimumAge: 18,
+      timestamp: 1750680000,
+    })
+    expect(parseKWSAgeVerifiedStatus(raw)).toEqual({
+      verified: true,
+      verifiedMinimumAge: 18,
+      timestamp: 1750680000,
+    })
+  })
+
+  it('silently strips unknown fields KWS may add', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      verifiedMinimumAge: 18,
+      timestamp: 1750680000,
+      errorCode: null,
+      somethingNew: 'ignored',
+    })
+    expect(parseKWSAgeVerifiedStatus(raw)).toEqual({
+      verified: true,
+      verifiedMinimumAge: 18,
+      timestamp: 1750680000,
+      errorCode: null,
+    })
+  })
+
+  it('strips a truly unknown field', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      verifiedMinimumAge: 18,
+      somethingNew: 'ignored',
+    })
+    expect(parseKWSAgeVerifiedStatus(raw)).toEqual({
+      verified: true,
+      verifiedMinimumAge: 18,
+    })
+  })
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseKWSAgeVerifiedStatus('not json')).toThrow(
+      /Invalid KWS age-verified status/,
+    )
+  })
+
+  it('throws when a required field is missing', () => {
+    const raw = JSON.stringify({ verified: true })
+    expect(() => parseKWSAgeVerifiedStatus(raw)).toThrow(
+      /Invalid KWS age-verified status/,
+    )
+  })
+})
+
+describe('serializeKWSAgeVerifiedStatus', () => {
+  it('round-trips a status object including timestamp', () => {
+    const status = {
+      verified: true,
+      verifiedMinimumAge: 18,
+      transactionId: 'txn-123',
+      timestamp: 1750680000,
+    }
+    expect(
+      parseKWSAgeVerifiedStatus(serializeKWSAgeVerifiedStatus(status)),
+    ).toEqual(status)
+  })
+})

--- a/packages/bsky/src/api/age-assurance/kws/age-verified.ts
+++ b/packages/bsky/src/api/age-assurance/kws/age-verified.ts
@@ -7,6 +7,12 @@ export const KWSAgeVerifiedStatusSchema = z.object({
   verified: z.boolean(),
   verifiedMinimumAge: z.number(),
   transactionId: z.string().optional(),
+  // A code indicating the reason for failure, or null when verification
+  // succeeded.
+  errorCode: z.string().nullable().optional(),
+  // Epoch seconds indicating when KWS generated the payload. Optional so we
+  // remain compatible with payloads sent before this field was introduced.
+  timestamp: z.number().optional(),
 })
 
 /**

--- a/packages/bsky/src/api/kws/types.ts
+++ b/packages/bsky/src/api/kws/types.ts
@@ -25,6 +25,14 @@ export const externalPayloadSchema = z
 
 export type KwsStatus = {
   verified: boolean
+  // A unique reference ID for the verification transaction.
+  transactionId?: string
+  // A code indicating the reason for failure, or null when verification
+  // succeeded.
+  errorCode?: string | null
+  // Epoch seconds indicating when KWS generated the payload. Optional so we
+  // remain compatible with payloads sent before this field was introduced.
+  timestamp?: number
 }
 
 export type KwsVerificationIntermediateQuery = {
@@ -56,6 +64,9 @@ export type KwsWebhookBody = {
 // Not `.strict()` to avoid breaking if KWS adds fields.
 export const statusSchema = z.object({
   verified: z.boolean(),
+  transactionId: z.string().optional(),
+  errorCode: z.string().nullable().optional(),
+  timestamp: z.number().optional(),
 })
 
 // Not `.strict()` to avoid breaking if KWS adds fields.

--- a/packages/bsky/src/api/kws/util.test.ts
+++ b/packages/bsky/src/api/kws/util.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { parseStatus } from './util.js'
+
+describe('parseStatus', () => {
+  it('parses a minimal status object', () => {
+    const raw = JSON.stringify({ verified: true })
+    expect(parseStatus(raw)).toEqual({ verified: true })
+  })
+
+  it('parses the optional transactionId, errorCode, and timestamp fields', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      transactionId: 'txn-123',
+      errorCode: null,
+      timestamp: 1750680000,
+    })
+    expect(parseStatus(raw)).toEqual({
+      verified: true,
+      transactionId: 'txn-123',
+      errorCode: null,
+      timestamp: 1750680000,
+    })
+  })
+
+  it('parses a non-null errorCode', () => {
+    const raw = JSON.stringify({ verified: false, errorCode: 'some-failure' })
+    expect(parseStatus(raw)).toEqual({
+      verified: false,
+      errorCode: 'some-failure',
+    })
+  })
+
+  it('silently strips unknown fields KWS may add', () => {
+    const raw = JSON.stringify({
+      verified: true,
+      timestamp: 1750680000,
+      somethingNew: 'ignored',
+    })
+    expect(parseStatus(raw)).toEqual({ verified: true, timestamp: 1750680000 })
+  })
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseStatus('not json')).toThrow(/Invalid status/)
+  })
+
+  it('throws when verified is missing', () => {
+    const raw = JSON.stringify({ timestamp: 1750680000 })
+    expect(() => parseStatus(raw)).toThrow(/Invalid status/)
+  })
+})

--- a/packages/bsky/src/kws.ts
+++ b/packages/bsky/src/kws.ts
@@ -12,7 +12,17 @@ export const createKwsClient = (cfg: KwsConfig): KwsClient => {
 // Not `.strict()` to avoid breaking if KWS adds fields.
 const authResponseSchema = z.object({
   access_token: z.string(),
+  // Seconds the token remains valid. KWS notes this varies with usage, and
+  // it's optional here: if absent we can't anticipate expiry, so we skip
+  // caching and lean on the reactive re-auth-on-401 path instead.
+  expires_in: z.number().optional(),
 })
+
+// Re-authenticate once the token has burned through this fraction of its
+// advertised lifetime, so we never send a token that's on the edge of expiry.
+const TOKEN_LIFETIME_REFRESH_RATIO = 0.9
+
+type CachedToken = { accessToken: string; expiresAt: number }
 
 const EXTERNAL_PAYLOAD_CHAR_LIMIT = 200
 /**
@@ -40,9 +50,32 @@ export type KWSSendEmailRequest =
     })
 
 export class KwsClient {
+  private cachedToken?: CachedToken
+  // In-flight auth request, so concurrent callers share a single token fetch
+  // rather than each hitting the token endpoint (which the WAF rate-limits).
+  private pendingAuth?: Promise<string>
+
   constructor(public cfg: KwsConfig) {}
 
-  private async auth() {
+  /**
+   * Returns a valid access token, reusing the cached one until it nears
+   * expiry. Pass `force` to bypass the cache and mint a fresh token, e.g.
+   * after a 401 from the API indicates the current token was rejected.
+   */
+  private async auth(force = false): Promise<string> {
+    if (!force && this.cachedToken && Date.now() < this.cachedToken.expiresAt) {
+      return this.cachedToken.accessToken
+    }
+    // Coalesce concurrent (re-)auth attempts onto one request.
+    if (!this.pendingAuth) {
+      this.pendingAuth = this.fetchToken().finally(() => {
+        this.pendingAuth = undefined
+      })
+    }
+    return this.pendingAuth
+  }
+
+  private async fetchToken(): Promise<string> {
     try {
       const res = await fetch(
         `${this.cfg.authOrigin}/auth/realms/kws/protocol/openid-connect/token`,
@@ -68,8 +101,23 @@ export class KwsClient {
 
       const auth = await res.json()
       const authResponse = authResponseSchema.parse(auth)
+      if (authResponse.expires_in == null) {
+        // Without a lifetime we can't proactively refresh, but we still cache
+        // the token and reuse it until a 401 triggers the re-auth-on-401 path.
+        log.error('KWS auth response missing expires_in; caching without a TTL')
+      }
+      this.cachedToken = {
+        accessToken: authResponse.access_token,
+        expiresAt:
+          authResponse.expires_in == null
+            ? Infinity
+            : Date.now() +
+              authResponse.expires_in * 1000 * TOKEN_LIFETIME_REFRESH_RATIO,
+      }
       return authResponse.access_token
     } catch (err) {
+      // Drop any stale cache so the next call retries the token fetch.
+      this.cachedToken = undefined
       log.error({ err }, 'Failed to authenticate with KWS')
       throw err
     }
@@ -79,15 +127,27 @@ export class KwsClient {
     url: string,
     init: RequestInit,
   ): Promise<Response> {
-    const accessToken = await this.auth()
-
-    return fetch(url, {
+    const res = await fetch(url, {
       ...init,
       headers: {
         ...(init.headers ?? {}),
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${await this.auth()}`,
       },
     })
+
+    // A 401 means the token expired (KWS token TTL is variable). Re-auth once
+    // with a fresh token and retry, per the KWS integration docs.
+    if (res.status === 401) {
+      return fetch(url, {
+        ...init,
+        headers: {
+          ...(init.headers ?? {}),
+          Authorization: `Bearer ${await this.auth(true)}`,
+        },
+      })
+    }
+
+    return res
   }
 
   /**


### PR DESCRIPTION
Re-adds in https://github.com/bluesky-social/atproto/pull/5166 and https://github.com/bluesky-social/atproto/pull/5164. Also adds better handling for auth, so that we re-use tokens and only re-auth with KWS when they expire.