### PR TITLE
Test language syntax against atproto interop test files

### DIFF
--- a/.changeset/shy-lions-appear.md
+++ b/.changeset/shy-lions-appear.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Test language syntax against atproto interop test files

--- a/interop-test-files/syntax/language_parse_invalid.txt
+++ b/interop-test-files/syntax/language_parse_invalid.txt
@@ -1,0 +1,14 @@
+# well-formed BCP 47 syntax, but not "valid" per RFC 5646 §2.2.9 / §4.1
+# because a variant or extension singleton subtag is repeated
+
+# duplicate variant subtag
+de-DE-1901-1901
+
+# duplicate variant subtag, case-insensitive match
+en-rozaj-ROZAJ
+
+# duplicate extension singleton subtag
+en-a-foo-a-bar
+
+# duplicate extension singleton subtag, case-insensitive match
+en-u-co-phonebk-U-ca-buddhist

--- a/interop-test-files/syntax/language_syntax_invalid.txt
+++ b/interop-test-files/syntax/language_syntax_invalid.txt
@@ -1,0 +1,13 @@
+.
+123
+j
+ja-
+a-DE
+
+# part of the "invalid" interop test, but current tests allow them:
+
+# jaja
+# JA
+
+# technically not valid, but allowing in naive parser
+de-419-DE

--- a/interop-test-files/syntax/language_syntax_valid.txt
+++ b/interop-test-files/syntax/language_syntax_valid.txt
@@ -1,0 +1,26 @@
+ja
+ban
+pt-BR
+hy-Latn-IT-arevela
+en-GB
+zh-Hant
+sgn-BE-NL
+es-419
+en-GB-boont-r-extended-sequence-x-private
+
+# grandfathered
+zh-hakka
+i-default
+i-navajo
+
+# https://github.com/sebinsua/ietf-language-tag-regex/blob/master/test.js
+de-CH-1901
+qaa-Qaaa-QM-x-southern
+
+# private-use subtags are case-insensitive (RFC 5646 §2.1.1)
+X-fr-CH
+de-X-foo
+
+# multiple distinct (non-duplicate) variant/extension singleton subtags remain valid
+sl-rozaj-biske
+en-u-co-phonebk-t-en-US

--- a/packages/syntax/tests/_utils.ts
+++ b/packages/syntax/tests/_utils.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function readLines(filePath: string): string[] {
+  return readFileSync(filePath, 'utf-8')
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('#') && line.length > 0)
+}
+
+export function readInteropFile(name: string): string[] {
+  return readLines(
+    join(
+      import.meta.dirname,
+      '..',
+      '..',
+      '..',
+      'interop-test-files',
+      'syntax',
+      name,
+    ),
+  )
+}

--- a/packages/syntax/tests/aturi-string.test.ts
+++ b/packages/syntax/tests/aturi-string.test.ts
@@ -1,17 +1,13 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, test } from 'vitest'
 import {
   InvalidAtUriError,
   assertAtUriString,
   isAtUriString,
 } from '../src/index.js'
+import { readInteropFile } from './_utils.js'
 
 describe('valid interop', () => {
-  test.each(
-    readLines(
-      `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_valid.txt`,
-    ),
-  )('%s', (value) => {
+  test.each(readInteropFile(`aturi_syntax_valid.txt`))('%s', (value) => {
     expect(isAtUriString(value)).toBe(true)
     expect(isAtUriString(value, { strict: false })).toBe(true)
     expect(() => assertAtUriString(value)).not.toThrow()
@@ -20,11 +16,7 @@ describe('valid interop', () => {
 })
 
 describe('invalid interop', () => {
-  test.each(
-    readLines(
-      `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_invalid.txt`,
-    ),
-  )('%s', (value) => {
+  test.each(readInteropFile(`aturi_syntax_invalid.txt`))('%s', (value) => {
     expect(isAtUriString(value)).toBe(false)
     expect(() => assertAtUriString(value)).toThrow(InvalidAtUriError)
   })
@@ -214,10 +206,4 @@ function testLoose(value: string) {
     expect(() => assertAtUriString(value)).toThrow()
     expect(() => assertAtUriString(value, { strict: false })).not.toThrow()
   })
-}
-
-function readLines(filePath: string): string[] {
-  return readFileSync(filePath, 'utf-8')
-    .split(/\r?\n/)
-    .filter((line) => !line.startsWith('#') && line.length > 0)
 }

--- a/packages/syntax/tests/aturi.test.ts
+++ b/packages/syntax/tests/aturi.test.ts
@@ -1,14 +1,10 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
 import { AtUri } from '../src/index.js'
+import { readInteropFile } from './_utils.js'
 
 describe(AtUri, () => {
-  describe('parses valid interop', () => {
-    test.each(
-      readLines(
-        `${__dirname}/../../../interop-test-files/syntax/aturi_syntax_valid.txt`,
-      ),
-    )('%s', (value) => {
+  describe('valid interop', () => {
+    test.each(readInteropFile(`aturi_syntax_valid.txt`))('%s', (value) => {
       expect(() => new AtUri(value)).not.toThrow()
     })
   })
@@ -420,9 +416,3 @@ describe(AtUri, () => {
     expect(() => urip.rkeySafe).toThrow()
   })
 })
-
-function readLines(filePath: string): string[] {
-  return readFileSync(filePath, 'utf-8')
-    .split(/\r?\n/)
-    .filter((line) => !line.startsWith('#') && line.length > 0)
-}

--- a/packages/syntax/tests/datetime.test.ts
+++ b/packages/syntax/tests/datetime.test.ts
@@ -1,4 +1,3 @@
-import * as fs from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
 import {
   InvalidDatetimeError,
@@ -8,16 +7,11 @@ import {
   normalizeDatetime,
   normalizeDatetimeAlways,
 } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
-const interopValid = readLines(
-  `${__dirname}/interop-files/datetime_syntax_valid.txt`,
-)
-const interopInvalidSyntax = readLines(
-  `${__dirname}/interop-files/datetime_syntax_invalid.txt`,
-)
-const interopInvalidParse = readLines(
-  `${__dirname}/interop-files/datetime_parse_invalid.txt`,
-)
+const interopValid = readInteropFile(`datetime_syntax_valid.txt`)
+const interopInvalidSyntax = readInteropFile(`datetime_syntax_invalid.txt`)
+const interopInvalidParse = readInteropFile(`datetime_parse_invalid.txt`)
 
 // These strings come from the test suite in "@atproto/lexicon", kept around
 // to ensure compatibility with legacy implementation.
@@ -271,10 +265,3 @@ describe(normalizeDatetimeAlways, () => {
     })
   })
 })
-
-function readLines(filePath: string): string[] {
-  return fs
-    .readFileSync(filePath, 'utf-8')
-    .split(/\r?\n/)
-    .filter((line) => !line.startsWith('#') && line.length > 0)
-}

--- a/packages/syntax/tests/did.test.ts
+++ b/packages/syntax/tests/did.test.ts
@@ -1,11 +1,10 @@
-import * as fs from 'node:fs'
-import * as readline from 'node:readline'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import {
   InvalidDidError,
   ensureValidDid,
   ensureValidDidRegex,
 } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
 describe('DID permissive validation', () => {
   const expectValid = (h: string) => {
@@ -72,33 +71,11 @@ describe('DID permissive validation', () => {
     expectValid('did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a')
   })
 
-  it('conforms to interop valid DIDs', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/did_syntax_valid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectValid(line)
-    })
+  describe('valid interop', () => {
+    test.each(readInteropFile(`did_syntax_valid.txt`))('%s', expectValid)
   })
 
-  it('conforms to interop invalid DIDs', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/did_syntax_invalid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectInvalid(line)
-    })
+  describe('invalid interop', () => {
+    test.each(readInteropFile(`did_syntax_invalid.txt`))('%s', expectInvalid)
   })
 })

--- a/packages/syntax/tests/handle.test.ts
+++ b/packages/syntax/tests/handle.test.ts
@@ -1,12 +1,11 @@
-import * as fs from 'node:fs'
-import * as readline from 'node:readline'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import {
   InvalidHandleError,
   ensureValidHandle,
   ensureValidHandleRegex,
   normalizeAndEnsureValidHandle,
 } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
 describe('handle validation', () => {
   const expectValid = (h: string) => {
@@ -194,34 +193,12 @@ describe('handle validation', () => {
     badStackoverflow.forEach(expectInvalid)
   })
 
-  it('conforms to interop valid handles', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/handle_syntax_valid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectValid(line)
-    })
+  describe('valid interop', () => {
+    test.each(readInteropFile(`handle_syntax_valid.txt`))('%s', expectValid)
   })
 
-  it('conforms to interop invalid handles', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/handle_syntax_invalid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectInvalid(line)
-    })
+  describe('invalid interop', () => {
+    test.each(readInteropFile(`handle_syntax_invalid.txt`))('%s', expectInvalid)
   })
 })
 

--- a/packages/syntax/tests/interop-files/datetime_invalid.txt
+++ b/packages/syntax/tests/interop-files/datetime_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/datetime_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/datetime_parse_invalid.txt
+++ b/packages/syntax/tests/interop-files/datetime_parse_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/datetime_parse_invalid.txt

--- a/packages/syntax/tests/interop-files/datetime_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/datetime_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/datetime_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/datetime_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/datetime_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/datetime_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/datetime_valid.txt
+++ b/packages/syntax/tests/interop-files/datetime_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/datetime_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/did_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/did_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/did_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/did_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/did_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/did_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/handle_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/handle_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/handle_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/handle_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/handle_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/handle_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/nsid_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/nsid_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/nsid_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/nsid_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/nsid_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/nsid_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/recordkey_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/recordkey_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/recordkey_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/recordkey_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/recordkey_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/recordkey_syntax_valid.txt

--- a/packages/syntax/tests/interop-files/tid_syntax_invalid.txt
+++ b/packages/syntax/tests/interop-files/tid_syntax_invalid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/tid_syntax_invalid.txt

--- a/packages/syntax/tests/interop-files/tid_syntax_valid.txt
+++ b/packages/syntax/tests/interop-files/tid_syntax_valid.txt
@@ -1,1 +1,0 @@
-../../../../interop-test-files/syntax/tid_syntax_valid.txt

--- a/packages/syntax/tests/language.test.ts
+++ b/packages/syntax/tests/language.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import { isValidLanguage, parseLanguageString } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
+
+describe('valid interop', () => {
+  test.each(readInteropFile('language_syntax_valid.txt'))('%s', (value) => {
+    expect(isValidLanguage(value)).toBe(true)
+    expect(parseLanguageString(value)).not.toBeNull()
+  })
+})
+
+describe('invalid interop', () => {
+  test.each(readInteropFile('language_syntax_invalid.txt'))('%s', (value) => {
+    expect(isValidLanguage(value)).toBe(false)
+    expect(parseLanguageString(value)).toBeNull()
+  })
+})
+
+describe('invalid parse interop', () => {
+  test.each(readInteropFile('language_parse_invalid.txt'))('%s', (value) => {
+    expect(isValidLanguage(value)).toBe(true)
+    expect(parseLanguageString(value)).toBeNull()
+  })
+})
 
 describe(isValidLanguage, () => {
   it('validates BCP 47', () => {

--- a/packages/syntax/tests/nsid.test.ts
+++ b/packages/syntax/tests/nsid.test.ts
@@ -1,4 +1,3 @@
-import * as fs from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
 import {
   InvalidNsidError,
@@ -9,6 +8,7 @@ import {
   validateNsid,
   validateNsidRegex,
 } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
 describe('NSID parsing & creation', () => {
   it('parses valid NSIDs', () => {
@@ -157,18 +157,10 @@ describe('NSID validation', () => {
   })
 
   describe('conforms to interop valid NSIDs', () => {
-    test.each(readInteropLines('nsid_syntax_valid.txt'))('%s', expectValid)
+    test.each(readInteropFile(`nsid_syntax_valid.txt`))('%s', expectValid)
   })
 
   describe('conforms to interop invalid NSIDs', () => {
-    test.each(readInteropLines('nsid_syntax_invalid.txt'))('%s', expectInvalid)
+    test.each(readInteropFile(`nsid_syntax_invalid.txt`))('%s', expectInvalid)
   })
 })
-
-function readInteropLines(filename: string): string[] {
-  return fs
-    .readFileSync(`${__dirname}/interop-files/${filename}`)
-    .toString()
-    .split('\n')
-    .filter((line) => line.length > 0 && !line.startsWith('#'))
-}

--- a/packages/syntax/tests/recordkey.test.ts
+++ b/packages/syntax/tests/recordkey.test.ts
@@ -1,43 +1,15 @@
-import * as fs from 'node:fs'
-import * as readline from 'node:readline'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { InvalidRecordKeyError, ensureValidRecordKey } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
-describe('recordkey validation', () => {
-  const expectValid = (r: string) => {
-    ensureValidRecordKey(r)
-  }
-  const expectInvalid = (r: string) => {
-    expect(() => ensureValidRecordKey(r)).toThrow(InvalidRecordKeyError)
-  }
-
-  it('conforms to interop valid recordkey', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/recordkey_syntax_valid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectValid(line)
-    })
+describe('valid interop', () => {
+  test.each(readInteropFile(`recordkey_syntax_valid.txt`))('%s', (value) => {
+    ensureValidRecordKey(value)
   })
+})
 
-  it('conforms to interop invalid recordkeys', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/recordkey_syntax_invalid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectInvalid(line)
-    })
+describe('invalid interop', () => {
+  test.each(readInteropFile(`recordkey_syntax_invalid.txt`))('%s', (value) => {
+    expect(() => ensureValidRecordKey(value)).toThrow(InvalidRecordKeyError)
   })
 })

--- a/packages/syntax/tests/tid.test.ts
+++ b/packages/syntax/tests/tid.test.ts
@@ -1,43 +1,15 @@
-import * as fs from 'node:fs'
-import * as readline from 'node:readline'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { InvalidTidError, ensureValidTid } from '../src/index.js'
+import { readInteropFile } from './_utils.ts'
 
-describe('tid validation', () => {
-  const expectValid = (t: string) => {
-    ensureValidTid(t)
-  }
-  const expectInvalid = (t: string) => {
-    expect(() => ensureValidTid(t)).toThrow(InvalidTidError)
-  }
-
-  it('conforms to interop valid tid', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/tid_syntax_valid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectValid(line)
-    })
+describe('valid interop', () => {
+  test.each(readInteropFile(`tid_syntax_valid.txt`))('%s', (value) => {
+    ensureValidTid(value)
   })
+})
 
-  it('conforms to interop invalid tids', () => {
-    const lineReader = readline.createInterface({
-      input: fs.createReadStream(
-        `${__dirname}/interop-files/tid_syntax_invalid.txt`,
-      ),
-      terminal: false,
-    })
-    lineReader.on('line', (line) => {
-      if (line.startsWith('#') || line.length === 0) {
-        return
-      }
-      expectInvalid(line)
-    })
+describe('invalid interop', () => {
+  test.each(readInteropFile(`tid_syntax_invalid.txt`))('%s', (value) => {
+    expect(() => ensureValidTid(value)).toThrow(InvalidTidError)
   })
 })


### PR DESCRIPTION
This PR tests the "language" string format against `language_parse_invalid.txt`, `language_syntax_invalid.txt‎` and `language_syntax_valid.txt‎`.

Doing this allowed to detect that `jaja` and `JA`, while technically invalid, are actually allowed by the TS implementation