### PR TITLE
fix(lexicon): remove non-spec description field from lexPermissionSet

### DIFF
--- a/.changeset/permission-set-drop-description.md
+++ b/.changeset/permission-set-drop-description.md
@@ -1,0 +1,11 @@
+---
+'@atproto/lexicon': patch
+---
+
+Remove the non-spec `description` field from the `lexPermissionSet` Zod schema.
+The Lexicon `permission-set` definition only allows `title`, `title:lang`,
+`detail`, `detail:lang`, and `permissions`, and the newer `@atproto/lex-schema`
+`PermissionSetOptions` model does not include `description` either. No lexicon
+JSON in this repository sets a top-level `description` on a permission set, so
+this aligns the legacy schema with the specification and the modern SDK without
+affecting any valid document.

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -224,7 +224,6 @@ export type LexPermission = z.infer<typeof lexPermission>
 
 export const lexPermissionSet = z.object({
   type: z.literal('permission-set'),
-  description: z.string().optional(),
   title: z.string().optional(),
   'title:lang': lexLang.optional(),
   detail: z.string().optional(),


### PR DESCRIPTION
## Problem

The `lexPermissionSet` Zod schema in `packages/lexicon/src/types.ts` declared an optional top-level `description` field:

```ts
export const lexPermissionSet = z.object({
  type: z.literal('permission-set'),
  description: z.string().optional(), // <- not in the spec
  title: z.string().optional(),
  ...
})
```

## Root cause

`description` is not part of the Lexicon `permission-set` definition. The three sources of truth disagreed:

- **Spec** ([atproto.com/specs/lexicon#permission-set](https://atproto.com/specs/lexicon#permission-set)) lists only `title`, `title:lang`, `detail`, `detail:lang`, and `permissions`.
- **New SDK** — `PermissionSetOptions` in `@atproto/lex-schema` (`packages/lex/lex-schema/src/schema/permission-set.ts`) models only `title`, `title:lang`, `detail`, `detail:lang`.
- **Lexicon JSON** — none of the 10 `"type": "permission-set"` definitions in `lexicons/` set a top-level `description`.

The field has been present since `permission-set` was introduced (#4108) and appears vestigial: the modern stack already omits it. An implementer reading `@atproto/lexicon` as a reference could wrongly conclude `description` is a valid permission-set field.

## Fix

Remove the single `description` line from `lexPermissionSet`, aligning the legacy schema with the spec and the modern `@atproto/lex-schema` model. The schema is non-strict (`z.object`, not `.strict()`), so unknown keys were never rejected and no valid document changes behaviour — this only corrects the reference model. No code in the repo reads `.description` off a permission set, so there is no consumer regression.

## Test evidence

- `@atproto/lexicon` jest suite: **47 passed, 47 total** (unchanged before/after).
- `tsgo --build tsconfig.build.json`: exit 0 (clean typecheck).
- `eslint` + `prettier --check` on the changed file: clean.

Changeset added (`@atproto/lexicon: patch`).

Fixes #5168

---

*Opened as a draft for maintainer review. This is a one-line schema correction; the device/CI build is deferred to the repo's CI.*
