### PR TITLE
Add permission-set description option

### DIFF
--- a/.changeset/quick-permissions-shave.md
+++ b/.changeset/quick-permissions-shave.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lex-schema": patch
+---
+
+Add `description` to permission-set options for developer-facing documentation.

--- a/packages/lex/lex-schema/src/schema/permission-set.test.ts
+++ b/packages/lex/lex-schema/src/schema/permission-set.test.ts
@@ -11,6 +11,7 @@ describe('PermissionSet', () => {
         permission('app.bsky.feed.post:write', {}),
       ] as const
       const options = {
+        description: 'Developer-facing permission set documentation',
         title: 'Post Management',
         detail: 'Allows reading and writing posts',
       }
@@ -21,6 +22,9 @@ describe('PermissionSet', () => {
       expect(perms.nsid).toBe(nsid)
       expect(perms.permissions).toBe(permissions)
       expect(perms.options).toBe(options)
+      expect(perms.options.description).toBe(
+        'Developer-facing permission set documentation',
+      )
     })
 
     it('creates a PermissionSet instance with minimal options', () => {
@@ -57,6 +61,22 @@ describe('PermissionSet', () => {
       const perms = permissionSet(nsid, permissions, options)
 
       expect(perms.options.title).toBe('Like Management')
+      expect(perms.options.detail).toBeUndefined()
+    })
+
+    it('creates a PermissionSet instance with description only', () => {
+      const nsid = 'app.bsky.oauth.permissions'
+      const permissions = [permission('app.bsky.feed.like:read', {})] as const
+      const options = {
+        description: 'Developer-facing permission set documentation',
+      }
+
+      const perms = permissionSet(nsid, permissions, options)
+
+      expect(perms.options.description).toBe(
+        'Developer-facing permission set documentation',
+      )
+      expect(perms.options.title).toBeUndefined()
       expect(perms.options.detail).toBeUndefined()
     })
 

--- a/packages/lex/lex-schema/src/schema/permission-set.ts
+++ b/packages/lex/lex-schema/src/schema/permission-set.ts
@@ -4,12 +4,14 @@ import type { Permission } from './permission.js'
 /**
  * Configuration options for a permission set.
  *
+ * @property description - Developer-facing documentation for the permission set
  * @property title - Human-readable title for the permission set
  * @property title:lang - Localized titles by language code
  * @property detail - Detailed description of the permission set
  * @property detail:lang - Localized descriptions by language code
  */
 export type PermissionSetOptions = {
+  description?: string
   title?: string
   'title:lang'?: Record<string, undefined | string>
   detail?: string


### PR DESCRIPTION
## Summary
Adds `description` to `@atproto/lex-schema` permission set options so it matches the legacy `@atproto/lexicon` permission-set schema and maintainer feedback.

- adds `description?: string` to `PermissionSetOptions`
- documents it as developer-facing permission set documentation
- adds regression coverage for all-options and description-only cases
- adds a patch changeset for `@atproto/lex-schema`

## Root cause
The legacy lexicon schema already models `description`, but the newer lex-schema permission-set options did not, so the two permission-set models disagreed.

Fixes #5168.

## Validation
- `pnpm exec prettier --check .changeset/quick-permissions-shave.md packages/lex/lex-schema/src/schema/permission-set.ts packages/lex/lex-schema/src/schema/permission-set.test.ts`
- `pnpm --dir packages/lex/lex-schema exec vitest run src/schema/permission-set.test.ts`
- `pnpm --filter @atproto/lex-schema build`
- `pnpm changeset status --since=origin/main`
- `git diff --check`