### PR TITLE
build: bump Node to 24.18 for June 2026 security releases

### DIFF
--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS build
+FROM node:24.18-alpine3.23 AS build
 
 RUN npm install -g pnpm@11.5.2
 
@@ -62,7 +62,7 @@ RUN pnpm run --recursive --stream --filter '@atproto/bsky...' build
 RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --config.confirmModulesPurge=false
 
 # Uses assets from build stage to reduce build size
-FROM node:24.15-alpine3.23
+FROM node:24.18-alpine3.23
 
 # dumb-init is used to handle signals properly.
 # runit is installed so it can be (optionally) used for logging via svlogd.

--- a/services/bsync/Dockerfile
+++ b/services/bsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS build
+FROM node:24.18-alpine3.23 AS build
 
 RUN npm install -g pnpm@11.5.2
 
@@ -32,7 +32,7 @@ RUN pnpm run --recursive --stream --filter '@atproto/bsync...' build
 RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --config.confirmModulesPurge=false
 
 # Uses assets from build stage to reduce build size
-FROM node:24.15-alpine3.23
+FROM node:24.18-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS build
+FROM node:24.18-alpine3.23 AS build
 
 RUN npm install -g pnpm@11.5.2
 
@@ -62,7 +62,7 @@ RUN pnpm run --recursive --stream --filter '@atproto/aws...' --filter '@atproto/
 RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --config.confirmModulesPurge=false
 
 # Uses assets from build stage to reduce build size
-FROM node:24.15-alpine3.23
+FROM node:24.18-alpine3.23
 
 RUN apk add --update dumb-init
 

--- a/services/pds/Dockerfile
+++ b/services/pds/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE there is an additional build stage below that should match
-FROM node:24.15-alpine3.23 AS build
+FROM node:24.18-alpine3.23 AS build
 
 RUN npm install -g pnpm@11.5.2
 
@@ -62,7 +62,7 @@ RUN pnpm run --recursive --stream --filter '@atproto/pds...' build
 RUN pnpm install --prod --shamefully-hoist --frozen-lockfile --prefer-offline --config.confirmModulesPurge=false
 
 # Uses assets from build stage to reduce build size
-FROM node:24.15-alpine3.23
+FROM node:24.18-alpine3.23
 
 RUN apk add --update dumb-init
 


### PR DESCRIPTION
## What

Bump the Node base image from `24.15` to `24.18-alpine3.23` (latest 24.x).

## Why

The [June 18 2026 Node.js security releases](https://nodejs.org/en/blog/vulnerability/june-2026-security-releases) patch several CVEs on the 24.x line, first fixed in **24.17.0**. These images were pinned to `24.15`, below the fix line. Notable ones affecting server-side Node:

- **CVE-2026-48618** (HIGH) — Unicode dot-separator handling enables TLS wildcard-depth authentication bypass
- **CVE-2026-48933** (HIGH) — WebCrypto AES integer overflow crashes the process
- **CVE-2026-48928 / 48930 / 48934** (MEDIUM) — TLS/SNI host-identity verification bypasses
- **CVE-2026-48619** (MEDIUM) — unbounded memory growth in HTTP/2 clients via attacker-controlled ORIGIN frames

Same-major patch bump, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)