### PR TITLE
lex-data dependencies improvements

### DIFF
--- a/.changeset/grumpy-pears-clap.md
+++ b/.changeset/grumpy-pears-clap.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-data': patch
+---
+
+Base64 decoder now returns `Uint8Array<ArrayBuffer>`

--- a/.changeset/icy-candles-take.md
+++ b/.changeset/icy-candles-take.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-data': patch
+---
+
+Significantly reduce dependency graph by replacing "uint8arrays" with direct imports from "multiformats"

--- a/.changeset/lazy-apes-sink.md
+++ b/.changeset/lazy-apes-sink.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-json': patch
+---
+
+Update return value of `parseLexBytes` to be `Uint8Array<ArrayBuffer>`

--- a/.changeset/spicy-geese-draw.md
+++ b/.changeset/spicy-geese-draw.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-data': patch
+---
+
+Update tests code style to match recommended patterns

--- a/.changeset/tidy-falcons-show.md
+++ b/.changeset/tidy-falcons-show.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-resolver': minor
+---
+
+Remove internal `Awaitable` type from public API

--- a/packages/aws/src/s3.test.ts
+++ b/packages/aws/src/s3.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http'
-import { AddressInfo } from 'node:net'
+import type { AddressInfo, Socket } from 'node:net'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { CID } from 'multiformats/cid'
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,7 +21,7 @@ type RequestHandler = (
  */
 class FakeS3Server {
   server: http.Server
-  private sockets = new Set<import('node:net').Socket>()
+  private sockets = new Set<Socket>()
 
   constructor() {
     this.server = http.createServer((req, res) => {

--- a/packages/lex/lex-data/package.json
+++ b/packages/lex/lex-data/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "multiformats": "^13.0.0",
     "tslib": "^2.8.1",
-    "uint8arrays": "^5.0.0",
     "unicode-segmenter": "^0.14.0"
   },
   "devDependencies": {

--- a/packages/lex/lex-data/src/uint8array-concat.test.ts
+++ b/packages/lex/lex-data/src/uint8array-concat.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, expect, it } from 'vitest'
 import { ui8ConcatNode, ui8ConcatPonyfill } from './uint8array-concat.js'
 import { ui8Equals } from './uint8array.js'
 
-for (const ui8Concat of [ui8ConcatNode, ui8ConcatPonyfill] as const) {
+describe.each([ui8ConcatNode, ui8ConcatPonyfill])('%o', (ui8Concat) => {
   // Tests should run in NodeJS where implementations are available.
   assert(ui8Concat, 'ui8Concat implementation should not be undefined')
 
@@ -194,4 +194,4 @@ for (const ui8Concat of [ui8ConcatNode, ui8ConcatPonyfill] as const) {
       })
     })
   })
-}
+})

--- a/packages/lex/lex-data/src/uint8array-from-base64.test.ts
+++ b/packages/lex/lex-data/src/uint8array-from-base64.test.ts
@@ -16,115 +16,114 @@ import { ui8Equals } from './uint8array.js'
 // their behavior when encountering invalid base64 strings. This is not the case
 // for toBase64, which is straightforward and has no edge cases.
 
-for (const fromBase64 of [
-  fromBase64Native,
-  fromBase64Node,
-  fromBase64Ponyfill,
-] as const) {
-  // Tests should run in NodeJS where implementations are either available or
-  // polyfilled (see core-js imports above).
-  assert(fromBase64 !== null, 'fromBase64 implementation should not be null')
+describe.each([fromBase64Native, fromBase64Node, fromBase64Ponyfill])(
+  '%o',
+  (fromBase64) => {
+    // Tests should run in NodeJS where implementations are either available or
+    // polyfilled (see core-js imports above).
+    assert(fromBase64 !== null, 'fromBase64 implementation should not be null')
 
-  describe(fromBase64.name, () => {
-    describe('valid base64 strings', () => {
-      it('decodes empty string', () => {
-        const decoded = fromBase64('')
-        expect(decoded).toBeInstanceOf(Uint8Array)
-        expect(decoded.length).toBe(0)
-      })
-
-      it('decodes 10MB', () => {
-        const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
-        const encoded = bytes.toString('base64')
-        const decoded = fromBase64(encoded)
-        expect(decoded).toBeInstanceOf(Uint8Array)
-        expect(ui8Equals(decoded, bytes)).toBe(true)
-      })
-
-      for (const buffer of [
-        Buffer.from(''),
-        Buffer.from('\0\0'),
-        Buffer.from('\0\0\0'),
-        Buffer.from('\0\0\0\0'),
-        Buffer.from('__'),
-        Buffer.from('é'),
-        Buffer.from('àç'),
-        Buffer.from('\0éàç'),
-        Buffer.from('```'),
-        Buffer.from('aaa'),
-        Buffer.from('Hello, World!'),
-        Buffer.from('😀😃😄😁😆😅😂🤣😊😇'),
-        Buffer.from('👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀'),
-        Buffer.from('🌍🌎🌏🌐🪐🌟✨⚡🔥💧'),
-        Buffer.from(new Uint8Array([0xfb, 0xff, 0xbf])),
-        Buffer.from(new Uint8Array([0xfb, 0xff, 0xbf])),
-        Buffer.from(new Uint8Array([0x4d])),
-        Buffer.from(new Uint8Array([0x4d, 0x61])),
-        Buffer.from(new Uint8Array([0x4d, 0x61, 0x6e])),
-        Buffer.from(new Uint8Array([0x4d])),
-        Buffer.from(new Uint8Array([0x4d, 0x61])),
-        Buffer.from(new Uint8Array([0x00, 0x4d, 0x61, 0x6e, 0x00])),
-      ]) {
-        const base64 = buffer.toString('base64')
-        const base64Unpadded = base64.replace(/=+$/, '')
-        const base64url = buffer.toString('base64url') // No padding in base64url
-
-        it(`decodes ${JSON.stringify(base64)}`, () => {
-          const decoded = fromBase64(base64)
+    describe(fromBase64.name, () => {
+      describe('valid base64 strings', () => {
+        it('decodes empty string', () => {
+          const decoded = fromBase64('')
           expect(decoded).toBeInstanceOf(Uint8Array)
-          expect(ui8Equals(decoded, buffer)).toBe(true)
+          expect(decoded.length).toBe(0)
         })
 
-        it(`decodes ${JSON.stringify(base64url)} (base64url)`, () => {
-          const decoded = fromBase64(base64url, 'base64url')
+        it('decodes 10MB', () => {
+          const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
+          const encoded = bytes.toString('base64')
+          const decoded = fromBase64(encoded)
           expect(decoded).toBeInstanceOf(Uint8Array)
-          expect(ui8Equals(decoded, buffer)).toBe(true)
+          expect(ui8Equals(decoded, bytes)).toBe(true)
         })
 
-        if (base64 !== base64Unpadded) {
-          it(`decodes ${JSON.stringify(base64Unpadded)} (unpadded)`, () => {
-            const decoded = fromBase64(base64Unpadded)
+        for (const buffer of [
+          Buffer.from(''),
+          Buffer.from('\0\0'),
+          Buffer.from('\0\0\0'),
+          Buffer.from('\0\0\0\0'),
+          Buffer.from('__'),
+          Buffer.from('é'),
+          Buffer.from('àç'),
+          Buffer.from('\0éàç'),
+          Buffer.from('```'),
+          Buffer.from('aaa'),
+          Buffer.from('Hello, World!'),
+          Buffer.from('😀😃😄😁😆😅😂🤣😊😇'),
+          Buffer.from('👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀'),
+          Buffer.from('🌍🌎🌏🌐🪐🌟✨⚡🔥💧'),
+          Buffer.from(new Uint8Array([0xfb, 0xff, 0xbf])),
+          Buffer.from(new Uint8Array([0xfb, 0xff, 0xbf])),
+          Buffer.from(new Uint8Array([0x4d])),
+          Buffer.from(new Uint8Array([0x4d, 0x61])),
+          Buffer.from(new Uint8Array([0x4d, 0x61, 0x6e])),
+          Buffer.from(new Uint8Array([0x4d])),
+          Buffer.from(new Uint8Array([0x4d, 0x61])),
+          Buffer.from(new Uint8Array([0x00, 0x4d, 0x61, 0x6e, 0x00])),
+        ]) {
+          const base64 = buffer.toString('base64')
+          const base64Unpadded = base64.replace(/=+$/, '')
+          const base64url = buffer.toString('base64url') // No padding in base64url
+
+          it(`decodes ${JSON.stringify(base64)}`, () => {
+            const decoded = fromBase64(base64)
             expect(decoded).toBeInstanceOf(Uint8Array)
             expect(ui8Equals(decoded, buffer)).toBe(true)
           })
-        }
-      }
-    })
 
-    describe('invalid base64 strings', () => {
-      for (const invalidB64 of [
-        'çç',
-        'é',
-        'YWJjZGU$$$',
-        '@@@@',
-        'abcd!',
-        'ab=cd',
-        // "YWFh" is "aaa" in base64
-        'YWFh' + 'é',
-        'YWFh' + 'éé',
-        'YWFh' + 'ééé',
-        'YWFh' + 'éééé',
-        // Invalid padding
-        'YWFh' + '=',
-        'YWFh' + '==',
-        'YWFh' + '===',
-        'YWFh' + '====',
-        'YWFh' + '=====',
-        'YWFh' + '======',
-        'TWEé',
-        'TWE👍',
-        // More invalid padding
-        // 'TWE=', // 'Ma'
-        'TWE=' + '=',
-        'TWE=' + '==',
-        // 'TQ==', // 'M'
-        'TQ==' + '=',
-        'TQ==' + '==',
-      ] as const) {
-        it(`throws on invalid base64 string "${invalidB64}"`, () => {
-          expect(() => fromBase64(invalidB64)).toThrow()
-        })
-      }
+          it(`decodes ${JSON.stringify(base64url)} (base64url)`, () => {
+            const decoded = fromBase64(base64url, 'base64url')
+            expect(decoded).toBeInstanceOf(Uint8Array)
+            expect(ui8Equals(decoded, buffer)).toBe(true)
+          })
+
+          if (base64 !== base64Unpadded) {
+            it(`decodes ${JSON.stringify(base64Unpadded)} (unpadded)`, () => {
+              const decoded = fromBase64(base64Unpadded)
+              expect(decoded).toBeInstanceOf(Uint8Array)
+              expect(ui8Equals(decoded, buffer)).toBe(true)
+            })
+          }
+        }
+      })
+
+      describe('invalid base64 strings', () => {
+        for (const invalidB64 of [
+          'çç',
+          'é',
+          'YWJjZGU$$$',
+          '@@@@',
+          'abcd!',
+          'ab=cd',
+          // "YWFh" is "aaa" in base64
+          'YWFh' + 'é',
+          'YWFh' + 'éé',
+          'YWFh' + 'ééé',
+          'YWFh' + 'éééé',
+          // Invalid padding
+          'YWFh' + '=',
+          'YWFh' + '==',
+          'YWFh' + '===',
+          'YWFh' + '====',
+          'YWFh' + '=====',
+          'YWFh' + '======',
+          'TWEé',
+          'TWE👍',
+          // More invalid padding
+          // 'TWE=', // 'Ma'
+          'TWE=' + '=',
+          'TWE=' + '==',
+          // 'TQ==', // 'M'
+          'TQ==' + '=',
+          'TQ==' + '==',
+        ] as const) {
+          it(`throws on invalid base64 string "${invalidB64}"`, () => {
+            expect(() => fromBase64(invalidB64)).toThrow()
+          })
+        }
+      })
     })
-  })
-}
+  },
+)

--- a/packages/lex/lex-data/src/uint8array-from-base64.ts
+++ b/packages/lex/lex-data/src/uint8array-from-base64.ts
@@ -1,4 +1,9 @@
-import { fromString } from 'uint8arrays/from-string'
+import {
+  base64,
+  base64pad,
+  base64url,
+  base64urlpad,
+} from 'multiformats/bases/base64'
 import { NodeJSBuffer } from './lib/nodejs-buffer.js'
 import type { Base64Alphabet } from './uint8array-base64.js'
 
@@ -16,7 +21,7 @@ declare global {
         alphabet?: 'base64' | 'base64url'
         lastChunkHandling?: 'loose' | 'strict' | 'stop-before-partial'
       },
-    ) => Uint8Array
+    ) => Uint8Array<ArrayBuffer>
   }
 }
 
@@ -25,7 +30,7 @@ export const fromBase64Native =
     ? function fromBase64Native(
         b64: string,
         alphabet: Base64Alphabet = 'base64',
-      ): Uint8Array {
+      ): Uint8Array<ArrayBuffer> {
         return Uint8Array.fromBase64!(b64, {
           alphabet,
           lastChunkHandling: 'loose',
@@ -37,7 +42,7 @@ export const fromBase64Node = Buffer
   ? function fromBase64Node(
       b64: string,
       alphabet: Base64Alphabet = 'base64',
-    ): Uint8Array {
+    ): Uint8Array<ArrayBuffer> {
       const bytes = Buffer.from(b64, alphabet)
       verifyBase64ForBytes(b64, bytes)
       // Convert to Uint8Array because even though Buffer is a sub class of
@@ -50,17 +55,32 @@ export const fromBase64Node = Buffer
 export function fromBase64Ponyfill(
   b64: string,
   alphabet: Base64Alphabet = 'base64',
-): Uint8Array {
-  const bytes = fromString(b64, b64.endsWith('=') ? `${alphabet}pad` : alphabet)
+): Uint8Array<ArrayBuffer> {
+  const isPadded = b64.endsWith('=')
+  const base =
+    alphabet === 'base64url'
+      ? isPadded
+        ? base64urlpad
+        : base64url
+      : isPadded
+        ? base64pad
+        : base64
+
+  // @NOTE multiformats requires the prefix to be present, which is definitely
+  // not optimal. It might be worth considering a different library here.
+  const bytes = base.decoder.decode(
+    `${base.prefix}${b64}`,
+  ) as Uint8Array<ArrayBuffer>
+
   verifyBase64ForBytes(b64, bytes)
   return bytes
 }
 
 // @NOTE NodeJS will silently stop decoding at the first invalid character,
-// while "uint8arrays/from-string" will not validate that the padding is
-// correct. The following function performs basic validation to ensure that the
-// input was a valid base64 string. The availability of the "bytes" allows
-// to perform checks with O[1] complexity.
+// while "multiformats" will not validate that the padding is correct. The
+// following function performs basic validation to ensure that the input was a
+// valid base64 string. The availability of the "bytes" allows to perform checks
+// with O[1] complexity.
 function verifyBase64ForBytes(b64: string, bytes: Uint8Array): void {
   const paddingCount = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0
   const trimmedLength = b64.length - paddingCount

--- a/packages/lex/lex-data/src/uint8array-to-base64.test.ts
+++ b/packages/lex/lex-data/src/uint8array-to-base64.test.ts
@@ -7,164 +7,172 @@ import {
   toBase64Ponyfill,
 } from './uint8array-to-base64.js'
 
-for (const toBase64 of [
-  toBase64Native,
-  toBase64Node,
-  toBase64Ponyfill,
-] as const) {
-  // Tests should run in NodeJS where implementations are either available or
-  // polyfilled (see core-js imports above).
-  assert(toBase64, 'toBase64 implementation should not be null')
+describe.each([toBase64Native, toBase64Node, toBase64Ponyfill])(
+  '%o',
+  (toBase64) => {
+    // Tests should run in NodeJS where implementations are either available or
+    // polyfilled (see core-js imports above).
+    assert(toBase64, 'toBase64 implementation should not be null')
 
-  describe(toBase64, () => {
-    describe('basic encoding', () => {
-      it('encodes empty Uint8Array', () => {
-        const encoded = toBase64(new Uint8Array(0))
-        expect(typeof encoded).toBe('string')
-        expect(encoded).toBe('')
-      })
-
-      it('encodes 10MB', () => {
-        const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
-        const encoded = toBase64(bytes)
-        expect(typeof encoded).toBe('string')
-        // Verify by decoding back
-        const decoded = Buffer.from(encoded, 'base64')
-        expect(decoded.equals(bytes)).toBe(true)
-      })
-    })
-
-    describe('base64 alphabet (default)', () => {
-      for (const string of [
-        '',
-        '\0\0',
-        '\0\0\0',
-        '\0\0\0\0',
-        '__',
-        'é',
-        'àç',
-        '\0éàç',
-        '```\x1b',
-        'aaa',
-        'Hello, World!',
-        '😀😃😄😁😆😅😂🤣😊😇',
-        '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
-        '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
-      ] as const) {
-        const buffer = Buffer.from(string, 'utf8')
-        const expected = buffer.toString('base64').replace(/=+$/, '')
-
-        it(`encodes ${JSON.stringify(string)} as ${JSON.stringify(expected)}`, () => {
-          const encoded = toBase64(buffer)
-          expect(encoded).toBe(expected)
+    describe(toBase64, () => {
+      describe('basic encoding', () => {
+        it('encodes empty Uint8Array', () => {
+          const encoded = toBase64(new Uint8Array(0))
+          expect(typeof encoded).toBe('string')
+          expect(encoded).toBe('')
         })
-      }
-    })
 
-    describe('base64url alphabet', () => {
-      for (const string of [
-        '',
-        '\0\0',
-        '\0\0\0',
-        '\0\0\0\0',
-        '__',
-        'é',
-        'àç',
-        '\0éàç',
-        '```\x1b',
-        'aaa',
-        'Hello, World!',
-        '😀😃😄😁😆😅😂🤣😊😇',
-        '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
-        '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
-      ] as const) {
-        const buffer = Buffer.from(string, 'utf8')
-        const expected = buffer.toString('base64url')
-
-        it(`encodes ${JSON.stringify(string)} as ${JSON.stringify(expected)}`, () => {
-          const encoded = toBase64(buffer, 'base64url')
-          expect(encoded).toBe(expected)
+        it('encodes 10MB', () => {
+          const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
+          const encoded = toBase64(bytes)
+          expect(typeof encoded).toBe('string')
+          // Verify by decoding back
+          const decoded = Buffer.from(encoded, 'base64')
+          expect(decoded.equals(bytes)).toBe(true)
         })
-      }
+      })
+
+      describe('base64 alphabet (default)', () => {
+        for (const string of [
+          '',
+          '\0\0',
+          '\0\0\0',
+          '\0\0\0\0',
+          '__',
+          'é',
+          'àç',
+          '\0éàç',
+          '```\x1b',
+          'aaa',
+          'Hello, World!',
+          '😀😃😄😁😆😅😂🤣😊😇',
+          '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
+          '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
+        ] as const) {
+          const buffer = Buffer.from(string, 'utf8')
+          const expected = buffer.toString('base64').replace(/=+$/, '')
+
+          it(`encodes ${JSON.stringify(string)} as ${JSON.stringify(expected)}`, () => {
+            const encoded = toBase64(buffer)
+            expect(encoded).toBe(expected)
+          })
+        }
+      })
+
+      describe('base64url alphabet', () => {
+        for (const string of [
+          '',
+          '\0\0',
+          '\0\0\0',
+          '\0\0\0\0',
+          '__',
+          'é',
+          'àç',
+          '\0éàç',
+          '```\x1b',
+          'aaa',
+          'Hello, World!',
+          '😀😃😄😁😆😅😂🤣😊😇',
+          '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
+          '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
+        ] as const) {
+          const buffer = Buffer.from(string, 'utf8')
+          const expected = buffer.toString('base64url')
+
+          it(`encodes ${JSON.stringify(string)} as ${JSON.stringify(expected)}`, () => {
+            const encoded = toBase64(buffer, 'base64url')
+            expect(encoded).toBe(expected)
+          })
+        }
+      })
+
+      describe('base64 vs base64url character differences', () => {
+        // Test data that produces + and / in standard base64
+        // These should become - and _ in base64url
+        it('uses + and / for base64 alphabet', () => {
+          // 0xfb, 0xff, 0xbf produces "+/+/" in base64
+          const bytes = new Uint8Array([0xfb, 0xff, 0xbf])
+          const encoded = toBase64(bytes)
+          expect(encoded).toContain('+')
+          expect(encoded).toContain('/')
+          expect(encoded).not.toContain('-')
+          expect(encoded).not.toContain('_')
+        })
+
+        it('uses - and _ for base64url alphabet', () => {
+          // Same bytes should use - and _ in base64url
+          const bytes = new Uint8Array([0xfb, 0xff, 0xbf])
+          const encoded = toBase64(bytes, 'base64url')
+          expect(encoded).toContain('-')
+          expect(encoded).toContain('_')
+          expect(encoded).not.toContain('+')
+          expect(encoded).not.toContain('/')
+        })
+      })
+
+      describe('padding behavior', () => {
+        it('omits padding by default for 1-byte input', () => {
+          // 1 byte -> 2 base64 chars + 2 padding
+          const bytes = new Uint8Array([0x4d]) // 'M' -> 'TQ=='
+          const encoded = toBase64(bytes)
+          expect(encoded).toBe('TQ')
+          expect(encoded).not.toContain('=')
+        })
+
+        it('omits padding by default for 2-byte input', () => {
+          // 2 bytes -> 3 base64 chars + 1 padding
+          const bytes = new Uint8Array([0x4d, 0x61]) // 'Ma' -> 'TWE='
+          const encoded = toBase64(bytes)
+          expect(encoded).toBe('TWE')
+          expect(encoded).not.toContain('=')
+        })
+
+        it('no padding needed for 3-byte input', () => {
+          // 3 bytes -> 4 base64 chars, no padding needed
+          const bytes = new Uint8Array([0x4d, 0x61, 0x6e]) // 'Man' -> 'TWFu'
+          const encoded = toBase64(bytes)
+          expect(encoded).toBe('TWFu')
+        })
+
+        it('includes double padding when omitPadding: false for 1-byte input', () => {
+          const bytes = new Uint8Array([0x4d]) // 'M' -> 'TQ=='
+          const encoded = toBase64(bytes)
+          expect(encoded).toBe('TQ')
+        })
+
+        it('includes single padding when omitPadding: false for 2-byte input', () => {
+          const bytes = new Uint8Array([0x4d, 0x61]) // 'Ma' -> 'TWE='
+          const encoded = toBase64(bytes)
+          expect(encoded).toBe('TWE')
+        })
+      })
+
+      describe('Uint8Array subarray handling', () => {
+        it('correctly encodes a subarray', () => {
+          const fullArray = new Uint8Array([0x00, 0x4d, 0x61, 0x6e, 0x00])
+          const subarray = fullArray.subarray(1, 4) // 'Man'
+          const encoded = toBase64(subarray)
+          expect(encoded).toBe('TWFu')
+        })
+
+        it('correctly encodes a subarray with offset', () => {
+          const buffer = new ArrayBuffer(10)
+          const fullView = new Uint8Array(buffer)
+          fullView.set([0x00, 0x00, 0x4d, 0x61, 0x6e, 0x00, 0x00])
+          const subarray = new Uint8Array(buffer, 2, 3) // 'Man' at offset 2
+          const encoded = toBase64(subarray)
+          expect(encoded).toBe('TWFu')
+        })
+      })
+
+      describe('default alphabet parameter', () => {
+        it('defaults to base64 when alphabet is not provided', () => {
+          const bytes = new Uint8Array([0xfb, 0xff, 0xbf])
+          const encodedDefault = toBase64(bytes)
+          const encodedExplicit = toBase64(bytes, 'base64')
+          expect(encodedDefault).toBe(encodedExplicit)
+        })
+      })
     })
-
-    describe('base64 vs base64url character differences', () => {
-      // Test data that produces + and / in standard base64
-      // These should become - and _ in base64url
-      it('uses + and / for base64 alphabet', () => {
-        // 0xfb, 0xff, 0xbf produces "+/+/" in base64
-        const bytes = new Uint8Array([0xfb, 0xff, 0xbf])
-        const encoded = toBase64(bytes)
-        expect(encoded).toContain('+')
-        expect(encoded).toContain('/')
-        expect(encoded).not.toContain('-')
-        expect(encoded).not.toContain('_')
-      })
-
-      it('uses - and _ for base64url alphabet', () => {
-        // Same bytes should use - and _ in base64url
-        const bytes = new Uint8Array([0xfb, 0xff, 0xbf])
-        const encoded = toBase64(bytes, 'base64url')
-        expect(encoded).toContain('-')
-        expect(encoded).toContain('_')
-        expect(encoded).not.toContain('+')
-        expect(encoded).not.toContain('/')
-      })
-    })
-
-    describe('padding behavior', () => {
-      it('omits padding by default for 1-byte input', () => {
-        // 1 byte -> 2 base64 chars + 2 padding
-        const bytes = new Uint8Array([0x4d]) // 'M' -> 'TQ=='
-        const encoded = toBase64(bytes)
-        expect(encoded).toBe('TQ')
-        expect(encoded).not.toContain('=')
-      })
-
-      it('omits padding by default for 2-byte input', () => {
-        // 2 bytes -> 3 base64 chars + 1 padding
-        const bytes = new Uint8Array([0x4d, 0x61]) // 'Ma' -> 'TWE='
-        const encoded = toBase64(bytes)
-        expect(encoded).toBe('TWE')
-        expect(encoded).not.toContain('=')
-      })
-
-      it('no padding needed for 3-byte input', () => {
-        // 3 bytes -> 4 base64 chars, no padding needed
-        const bytes = new Uint8Array([0x4d, 0x61, 0x6e]) // 'Man' -> 'TWFu'
-        const encoded = toBase64(bytes)
-        expect(encoded).toBe('TWFu')
-      })
-
-      it('includes double padding when omitPadding: false for 1-byte input', () => {
-        const bytes = new Uint8Array([0x4d]) // 'M' -> 'TQ=='
-        const encoded = toBase64(bytes)
-        expect(encoded).toBe('TQ')
-      })
-
-      it('includes single padding when omitPadding: false for 2-byte input', () => {
-        const bytes = new Uint8Array([0x4d, 0x61]) // 'Ma' -> 'TWE='
-        const encoded = toBase64(bytes)
-        expect(encoded).toBe('TWE')
-      })
-    })
-
-    describe('Uint8Array subarray handling', () => {
-      it('correctly encodes a subarray', () => {
-        const fullArray = new Uint8Array([0x00, 0x4d, 0x61, 0x6e, 0x00])
-        const subarray = fullArray.subarray(1, 4) // 'Man'
-        const encoded = toBase64(subarray)
-        expect(encoded).toBe('TWFu')
-      })
-
-      it('correctly encodes a subarray with offset', () => {
-        const buffer = new ArrayBuffer(10)
-        const fullView = new Uint8Array(buffer)
-        fullView.set([0x00, 0x00, 0x4d, 0x61, 0x6e, 0x00, 0x00])
-        const subarray = new Uint8Array(buffer, 2, 3) // 'Man' at offset 2
-        const encoded = toBase64(subarray)
-        expect(encoded).toBe('TWFu')
-      })
-    })
-  })
-}
+  },
+)

--- a/packages/lex/lex-data/src/uint8array-to-base64.ts
+++ b/packages/lex/lex-data/src/uint8array-to-base64.ts
@@ -1,4 +1,4 @@
-import { toString } from 'uint8arrays/to-string'
+import { base64, base64url } from 'multiformats/bases/base64'
 import { NodeJSBuffer } from './lib/nodejs-buffer.js'
 import type { Base64Alphabet } from './uint8array-base64.js'
 
@@ -35,10 +35,10 @@ export const toBase64Node = Buffer
       const buffer = bytes instanceof Buffer ? bytes : Buffer.from(bytes)
       const b64 = buffer.toString(alphabet)
 
-      // @NOTE We strip padding for strict compatibility with
-      // uint8arrays.toString behavior. Tests failing because of the presence of
-      // padding are not really synonymous with an actual error and we might
-      // (should?) actually want to keep the padding at some point.
+      // @NOTE We strip padding for strict compatibility with multiformats
+      // behavior. Tests failing because of the presence of padding are not
+      // really synonymous with an actual error and we might (should?) actually
+      // want to keep the padding at some point.
       return b64.charCodeAt(b64.length - 1) === /* '=' */ 0x3d
         ? b64.charCodeAt(b64.length - 2) === /* '=' */ 0x3d
           ? b64.slice(0, -2) // '=='
@@ -51,5 +51,9 @@ export function toBase64Ponyfill(
   bytes: Uint8Array,
   alphabet: Base64Alphabet = 'base64',
 ): string {
-  return toString(bytes, alphabet)
+  const codec = alphabet === 'base64url' ? base64url : base64
+
+  // @NOTE multiformats requires to strip the prefix, which is definitely not
+  // optimal. It might be worth considering a different library here.
+  return codec.encoder.encode(bytes).slice(codec.prefix.length)
 }

--- a/packages/lex/lex-data/src/uint8array.ts
+++ b/packages/lex/lex-data/src/uint8array.ts
@@ -68,7 +68,7 @@ export const toBase64: (
 export const fromBase64: (
   b64: string,
   alphabet?: Base64Alphabet,
-) => Uint8Array =
+) => Uint8Array<ArrayBuffer> =
   /* v8 ignore next -- @preserve */ fromBase64Native ??
   fromBase64Node ??
   fromBase64Ponyfill

--- a/packages/lex/lex-data/src/utf8-from-base64.test.ts
+++ b/packages/lex/lex-data/src/utf8-from-base64.test.ts
@@ -4,36 +4,30 @@ import {
   utf8FromBase64Ponyfill,
 } from './utf8-from-base64.js'
 
-const strings = [
-  'Hello, World!',
-  '¡Hola, Mundo!',
-  'こんにちは世界',
-  '😀👩‍💻🌍',
-  '',
-  '𓀀𓁐𓂀𓃰𓄿𓅱𓆑𓇋𓈖𓉔𓊃𓋴𓌳𓍿𓎛𓏏',
-]
+describe.each([utf8FromBase64Node, utf8FromBase64Ponyfill])(
+  '%o',
+  (utf8FromBase64) => {
+    assert(utf8FromBase64, 'implementation should not be null')
 
-for (const utf8FromBase64 of [
-  utf8FromBase64Node,
-  utf8FromBase64Ponyfill,
-] as const) {
-  assert(utf8FromBase64, 'implementation should not be null')
-
-  describe(utf8FromBase64, () => {
-    it('decodes base64 to utf8 string', () => {
-      for (const text of strings) {
+    describe.each([
+      'Hello, World!',
+      '¡Hola, Mundo!',
+      'こんにちは世界',
+      '😀👩‍💻🌍',
+      '',
+      '𓀀𓁐𓂀𓃰𓄿𓅱𓆑𓇋𓈖𓉔𓊃𓋴𓌳𓍿𓎛𓏏',
+    ])('%s', (text) => {
+      it('decodes base64 to utf8 string', () => {
         const b64 = Buffer.from(text, 'utf8').toString('base64')
         const decoded = utf8FromBase64(b64, 'base64')
         expect(decoded).toBe(text)
-      }
-    })
+      })
 
-    it('decodes base64url to utf8 string', () => {
-      for (const text of strings) {
+      it('decodes base64url to utf8 string', () => {
         const b64u = Buffer.from(text, 'utf8').toString('base64url')
         const decoded = utf8FromBase64(b64u, 'base64url')
         expect(decoded).toBe(text)
-      }
+      })
     })
-  })
-}
+  },
+)

--- a/packages/lex/lex-data/src/utf8-from-base64.ts
+++ b/packages/lex/lex-data/src/utf8-from-base64.ts
@@ -1,4 +1,4 @@
-import { fromString } from 'uint8arrays/from-string'
+import { base64, base64url } from 'multiformats/bases/base64'
 import { NodeJSBuffer } from './lib/nodejs-buffer.js'
 import type { Base64Alphabet } from './uint8array-base64.js'
 
@@ -18,6 +18,7 @@ export function utf8FromBase64Ponyfill(
   b64: string,
   alphabet?: Base64Alphabet,
 ): string {
-  const bytes = fromString(b64, alphabet)
+  const codec = alphabet === 'base64url' ? base64url : base64
+  const bytes = codec.decoder.decode(`${codec.prefix}${b64}`)
   return textDecoder.decode(bytes)
 }

--- a/packages/lex/lex-data/src/utf8-from-bytes.test.ts
+++ b/packages/lex/lex-data/src/utf8-from-bytes.test.ts
@@ -1,43 +1,46 @@
-import { assert, describe, expect, it } from 'vitest'
+import { assert, describe, expect, it, test } from 'vitest'
 import { utf8FromBytesNative, utf8FromBytesNode } from './utf8-from-bytes.js'
 
-for (const utf8FromBytes of [utf8FromBytesNode, utf8FromBytesNative] as const) {
-  assert(utf8FromBytes, 'utf8FromBytes implementation should not be null')
-  describe(utf8FromBytes, () => {
-    it('decodes empty Uint8Array', () => {
-      const decoded = utf8FromBytes(new Uint8Array(0))
-      expect(typeof decoded).toBe('string')
-      expect(decoded).toBe('')
-    })
+describe.each([utf8FromBytesNative, utf8FromBytesNode] as const)(
+  '%o',
+  (utf8FromBytes) => {
+    // Tests should run in NodeJS where implementations are either available or
+    // polyfilled
+    assert(utf8FromBytes, 'utf8FromBytes implementation should not be null')
 
-    it('decodes 10MB', () => {
-      const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
-      const decoded = utf8FromBytes(bytes)
-      expect(decoded).toBe('🐩'.repeat(10_000_000 / 4))
-    })
+    describe(utf8FromBytes, () => {
+      it('decodes empty Uint8Array', () => {
+        const decoded = utf8FromBytes(new Uint8Array(0))
+        expect(typeof decoded).toBe('string')
+        expect(decoded).toBe('')
+      })
 
-    for (const string of [
-      '',
-      '\0\0',
-      '\0\0\0',
-      '\0\0\0\0',
-      '__',
-      'é',
-      'àç',
-      '\0éàç',
-      '```\x1b',
-      'aaa',
-      'Hello, World!',
-      '😀😃😄😁😆😅😂🤣😊😇',
-      '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
-      '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
-    ] as const) {
-      const buffer = Buffer.from(string, 'utf8')
+      it('decodes 10MB', () => {
+        const bytes = Buffer.allocUnsafe(10_000_000).fill('🐩')
+        const decoded = utf8FromBytes(bytes)
+        expect(decoded).toBe('🐩'.repeat(10_000_000 / 4))
+      })
 
-      it(`decodes ${JSON.stringify(string)}`, () => {
+      test.each([
+        '',
+        '\0\0',
+        '\0\0\0',
+        '\0\0\0\0',
+        '__',
+        'é',
+        'àç',
+        '\0éàç',
+        '```\x1b',
+        'aaa',
+        'Hello, World!',
+        '😀😃😄😁😆😅😂🤣😊😇',
+        '👩‍💻👨‍💻👩‍🔬👨‍🔬👩‍🚀👨‍🚀',
+        '🌍🌎🌏🌐🪐🌟✨⚡🔥💧',
+      ])('decodes "%s"', (string) => {
+        const buffer = Buffer.from(string, 'utf8')
         const decoded = utf8FromBytes(buffer)
         expect(decoded).toBe(string)
       })
-    }
-  })
-}
+    })
+  },
+)

--- a/packages/lex/lex-data/src/utf8-len.test.ts
+++ b/packages/lex/lex-data/src/utf8-len.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { assert, describe, expect, it } from 'vitest'
 import { utf8LenCompute, utf8LenNode } from './utf8-len.js'
 
-describe.each([utf8LenNode!, utf8LenCompute!] as const)('%o', (utf8Len) => {
+describe.each([utf8LenNode, utf8LenCompute])('%o', (utf8Len) => {
+  assert(utf8Len, 'utf8Len implementation should not be null')
   it('computes utf8 string length', () => {
     expect(utf8Len('a')).toBe(1)
     expect(utf8Len('~')).toBe(1)

--- a/packages/lex/lex-data/src/utf8-to-base64.test.ts
+++ b/packages/lex/lex-data/src/utf8-to-base64.test.ts
@@ -1,35 +1,32 @@
 import { assert, describe, expect, it } from 'vitest'
 import { utf8ToBase64Node, utf8ToBase64Ponyfill } from './utf8-to-base64.js'
 
-const strings = [
-  'Hello, World!',
-  '¡Hola, Mundo!',
-  'こんにちは世界',
-  '😀👩‍💻🌍',
-  '',
-  '𓀀𓁐𓂀𓃰𓄿𓅱𓆑𓇋𓈖𓉔𓊃𓋴𓌳𓍿𓎛𓏏',
-]
+describe.each([utf8ToBase64Node, utf8ToBase64Ponyfill])(
+  '%o',
+  (utf8ToBase64) => {
+    assert(utf8ToBase64, 'implementation should not be null')
 
-for (const utf8ToBase64 of [utf8ToBase64Node, utf8ToBase64Ponyfill] as const) {
-  assert(utf8ToBase64, 'implementation should not be null')
-
-  describe(utf8ToBase64, () => {
-    it('encodes utf8 string to base64', () => {
-      for (const text of strings) {
+    describe.each([
+      'Hello, World!',
+      '¡Hola, Mundo!',
+      'こんにちは世界',
+      '😀👩‍💻🌍',
+      '',
+      '𓀀𓁐𓂀𓃰𓄿𓅱𓆑𓇋𓈖𓉔𓊃𓋴𓌳𓍿𓎛𓏏',
+    ])('%s', (text) => {
+      it('encodes utf8 string to base64', () => {
         const b64 = Buffer.from(text, 'utf8')
           .toString('base64')
           .replaceAll('=', '') // utf8ToBase64 omits padding
         const encoded = utf8ToBase64(text, 'base64')
         expect(encoded).toBe(b64)
-      }
-    })
+      })
 
-    it('encodes utf8 string to base64url', () => {
-      for (const text of strings) {
+      it('encodes utf8 string to base64url', () => {
         const b64u = Buffer.from(text, 'utf8').toString('base64url')
         const encoded = utf8ToBase64(text, 'base64url')
         expect(encoded).toBe(b64u)
-      }
+      })
     })
-  })
-}
+  },
+)

--- a/packages/lex/lex-data/src/utf8-to-base64.ts
+++ b/packages/lex/lex-data/src/utf8-to-base64.ts
@@ -1,4 +1,4 @@
-import { toString } from 'uint8arrays/to-string'
+import { base64, base64url } from 'multiformats/bases/base64'
 import { NodeJSBuffer } from './lib/nodejs-buffer.js'
 import type { Base64Alphabet } from './uint8array-base64.js'
 import { toBase64Node } from './uint8array-to-base64.js'
@@ -18,5 +18,6 @@ export function utf8ToBase64Ponyfill(
   alphabet?: Base64Alphabet,
 ): string {
   const bytes = textEncoder.encode(text)
-  return toString(bytes, alphabet)
+  const codec = alphabet === 'base64url' ? base64url : base64
+  return codec.encoder.encode(bytes).slice(codec.prefix.length)
 }

--- a/packages/lex/lex-json/src/bytes.ts
+++ b/packages/lex/lex-json/src/bytes.ts
@@ -29,7 +29,7 @@ import type { JsonValue } from './json.js'
  */
 export function parseLexBytes(
   input?: Record<string, unknown>,
-): Uint8Array | undefined {
+): Uint8Array<ArrayBuffer> | undefined {
   if (!input || !('$bytes' in input)) {
     return undefined
   }

--- a/packages/lex/lex-resolver/src/lex-resolver.ts
+++ b/packages/lex/lex-resolver/src/lex-resolver.ts
@@ -57,7 +57,7 @@ export type LexResolverFetchResult = {
   lexicon: LexiconDocument
 }
 
-export type Awaitable<T> = T | Promise<T>
+type Awaitable<T> = T | PromiseLike<T>
 
 /**
  * Callback hooks for customizing the lexicon resolution process.
@@ -174,8 +174,8 @@ export type LexResolverOptions = CreateDidResolverOptions & {
   hooks?: LexResolverHooks
 }
 
-export { AtUri, type Cid, NSID }
-export type { LexiconDocument, ResolveDidOptions }
+export { AtUri, NSID }
+export type { Cid, LexiconDocument, ResolveDidOptions }
 
 /**
  * Resolves Lexicon documents from the AT Protocol network.

--- a/packages/ozone/src/report/views.ts
+++ b/packages/ozone/src/report/views.ts
@@ -4,10 +4,10 @@ import type { ReportStat } from '../db/schema/report_stat.js'
 import type * as AppBskyActorDefs from '../lexicon/types/app/bsky/actor/defs.js'
 import type { AccountView } from '../lexicon/types/com/atproto/admin/defs.js'
 import type {
+  ModEventView,
   RecordViewDetail,
   RepoView,
 } from '../lexicon/types/tools/ozone/moderation/defs.js'
-import type * as ToolsOzoneModerationDefs from '../lexicon/types/tools/ozone/moderation/defs.js'
 import type * as ToolsOzoneQueueDefs from '../lexicon/types/tools/ozone/queue/defs.js'
 import type * as ToolsOzoneReportDefs from '../lexicon/types/tools/ozone/report/defs.js'
 import type { Member as TeamMember } from '../lexicon/types/tools/ozone/team/defs.js'
@@ -91,7 +91,7 @@ export function buildReportView(
   report: ReportWithEvent,
   hydrated: HydratedReport,
   isModerator: boolean,
-  actions?: ToolsOzoneModerationDefs.ModEventView[],
+  actions?: ModEventView[],
 ) {
   const {
     partialRepos,

--- a/packages/repo/tests/_util.ts
+++ b/packages/repo/tests/_util.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import { TID } from '@atproto/common-web'
-import type * as crypto from '@atproto/crypto'
 import { type Keypair, randomBytes } from '@atproto/crypto'
 import * as cbor from '@atproto/lex-cbor'
 import { type Cid, cidForCbor, parseCid } from '@atproto/lex-data'
@@ -88,7 +87,7 @@ export const testCollections: NsidString[] = [
 
 export const fillRepo = async (
   repo: Repo,
-  keypair: crypto.Keypair,
+  keypair: Keypair,
   itemsPerCollection: number,
 ): Promise<{ repo: Repo; data: RepoContents }> => {
   const repoData: RepoContents = {}
@@ -118,7 +117,7 @@ export const fillRepo = async (
 export const formatEdit = async (
   repo: Repo,
   prevData: RepoContents,
-  keypair: crypto.Keypair,
+  keypair: Keypair,
   params: {
     adds?: number
     updates?: number

--- a/packages/xrpc-server/tests/subscriptions.test.ts
+++ b/packages/xrpc-server/tests/subscriptions.test.ts
@@ -7,10 +7,11 @@ import {
   ErrorFrame,
   type Frame,
   MessageFrame,
+  type Server,
+  type StreamContext,
   Subscription,
   byFrame,
 } from '../src/index.js'
-import type * as xrpcServer from '../src/index.js'
 import {
   basicAuthHeaders,
   buildAddLexicons,
@@ -113,18 +114,14 @@ const LEXICONS = [
 ] as const satisfies LexiconDoc[]
 
 const handlers = {
-  'io.example.streamOne': async function* ({
-    params,
-  }: xrpcServer.StreamContext) {
+  'io.example.streamOne': async function* ({ params }: StreamContext) {
     const countdown = Number(params.countdown ?? 0)
     for (let i = countdown; i >= 0; i--) {
       await wait(0)
       yield { $type: 'io.example.streamOne#countdownStatus', count: i }
     }
   },
-  'io.example.streamTwo': async function* ({
-    params,
-  }: xrpcServer.StreamContext) {
+  'io.example.streamTwo': async function* ({ params }: StreamContext) {
     const countdown = Number(params.countdown ?? 0)
     for (let i = countdown; i >= 0; i--) {
       await wait(200)
@@ -151,7 +148,7 @@ for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
     // definitions
     const lex = new Lexicons(structuredClone(LEXICONS))
 
-    let server: xrpcServer.Server
+    let server: Server
     let s: http.Server
     let port: number
     beforeAll(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1053,9 +1053,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      uint8arrays:
-        specifier: ^5.0.0
-        version: 5.1.1
       unicode-segmenter:
         specifier: ^0.14.0
         version: 0.14.0


### PR DESCRIPTION
This PR:

- Removes the `uint8arrays` dependency from `lex-data`, replacing it with `multiformats`, which is what was used under the hood, signficantly reducing the runtime import graph (we no longer import unused base32, base58, etc. codecs)
- Updates return type of `lex-data`/`lex-json` base64 decoder to return `Uint8Array<ArrayBuffer>` instead of `Uint8Array`
- Updates the `lex-data` tests to match recommended code style