### PR TITLE
Tweaks to mod tag filtering in search

### DIFF
--- a/.changeset/hide-search-posts-by-author-tags.md
+++ b/.changeset/hide-search-posts-by-author-tags.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Hide posts in search based on moderation tags on their author, in addition to tags on the post itself

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -196,11 +196,18 @@ const noBlocksOrTagged = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
     // Cases to never show.
     if (ctx.views.viewerBlockExists(creator, hydration)) return false
 
+    // Roll the post's own tags together with moderation tags on its author,
+    // so author-level tags are filtered the same way as post-level tags.
+    const author = hydration.actors?.get(creator)
+    const tags = new Set([
+      ...post.tags,
+      ...(author?.accountModerationTags ?? []),
+      ...(author?.profileModerationTags ?? []),
+    ])
+
     // Tags that are hidden from all search surfaces (Top and Latest),
     // regardless of curation or author filtering.
-    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) =>
-      post.tags.has(t),
-    )
+    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) => tags.has(t))
     if (alwaysHidden) return false
 
     let tagged = false
@@ -209,9 +216,9 @@ const noBlocksOrTagged = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
         params.hydrateCtx.features.Gate.SearchFilteringExplorationEnable,
       )
     ) {
-      tagged = post.tags.has(ctx.cfg.visibilityTagHide)
+      tagged = tags.has(ctx.cfg.visibilityTagHide)
     } else {
-      tagged = [...ctx.cfg.searchTagsHide].some((t) => post.tags.has(t))
+      tagged = [...ctx.cfg.searchTagsHide].some((t) => tags.has(t))
     }
 
     // Cases to conditionally show based on tagging.

--- a/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
@@ -164,14 +164,21 @@ const noBlocksOrTagged = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
 
     if (ctx.views.viewerBlockExists(creator, hydration)) return false
 
+    // Roll the post's own tags together with moderation tags on its author,
+    // so author-level tags are filtered the same way as post-level tags.
+    const author = hydration.actors?.get(creator)
+    const tags = new Set([
+      ...post.tags,
+      ...(author?.accountModerationTags ?? []),
+      ...(author?.profileModerationTags ?? []),
+    ])
+
     // Tags that are hidden from all search surfaces (Top and Latest),
     // regardless of curation or author filtering.
-    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) =>
-      post.tags.has(t),
-    )
+    const alwaysHidden = [...ctx.cfg.searchTagsHideAll].some((t) => tags.has(t))
     if (alwaysHidden) return false
 
-    const tagged = [...ctx.cfg.searchTagsHide].some((t) => post.tags.has(t))
+    const tagged = [...ctx.cfg.searchTagsHide].some((t) => tags.has(t))
 
     if (isCuratedSearch && tagged) return false
     if (!(parsedQuery.author || params.authors?.length) && tagged) return false

--- a/packages/bsky/src/data-plane/server/routes/profile.ts
+++ b/packages/bsky/src/data-plane/server/routes/profile.ts
@@ -185,7 +185,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
         statusRecord: status,
         germRecord: germDeclaration,
         tags: [],
-        profileTags: [],
+        profileTags: profiles.records[i].tags,
         allowActivitySubscriptionsFrom: activitySubscription(),
         ageAssuranceStatus: ageAssuranceStatus(),
       }

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -57,6 +57,8 @@ export type Actor = {
   status?: RecordInfo<StatusRecord>
   germ?: RecordInfo<GermDeclarationRecord>
   allowActivitySubscriptionsFrom: AllowActivitySubscriptions
+  accountModerationTags: Set<string>
+  profileModerationTags: Set<string>
   /**
    * Debug information for internal development
    */
@@ -313,6 +315,8 @@ export class ActorHydrator {
         allowActivitySubscriptionsFrom: allowActivitySubscriptionsFrom(
           actor.allowActivitySubscriptionsFrom,
         ),
+        accountModerationTags: new Set(actor.tags),
+        profileModerationTags: new Set(actor.profileTags),
         debug,
       })
     }

--- a/packages/bsky/tests/views/post-search.test.ts
+++ b/packages/bsky/tests/views/post-search.test.ts
@@ -19,6 +19,9 @@ describe('appview search', () => {
   // always-hide cases don't perturb the existing expectations.
   let unicornPost: Awaited<ReturnType<SeedClient['post']>>
   let unicornPostAlwaysHidden: Awaited<ReturnType<SeedClient['post']>>
+  // 'narwhal' term: post is untagged but its author's profile carries an
+  // always-hide moderation tag, so it should be filtered on author grounds.
+  let narwhalPostByTaggedAuthor: Awaited<ReturnType<SeedClient['post']>>
   let allResults: string[]
   let nonTaggedResults: string[]
 
@@ -51,6 +54,9 @@ describe('appview search', () => {
 
     unicornPost = await sc.post(alice, 'a unicorn')
     unicornPostAlwaysHidden = await sc.post(alice, 'another unicorn')
+    // Post by an author whose profile carries an always-hide tag. The post
+    // itself is untagged.
+    narwhalPostByTaggedAuthor = await sc.post(bob, 'a narwhal')
     await network.processAll()
 
     await createTag(network.bsky.db.db, {
@@ -59,6 +65,11 @@ describe('appview search', () => {
     })
     await createTag(network.bsky.db.db, {
       uri: unicornPostAlwaysHidden.ref.uriStr,
+      val: TAG_ALWAYS_HIDE,
+    })
+    // Tag bob's profile record so the always-hide tag applies via the author.
+    await createTag(network.bsky.db.db, {
+      uri: `at://${bob}/app.bsky.actor.profile/self`,
       val: TAG_ALWAYS_HIDE,
     })
 
@@ -258,6 +269,67 @@ describe('appview search', () => {
       expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
         unicornPostAlwaysHidden.ref.uriStr,
         unicornPost.ref.uriStr,
+      ])
+    })
+  })
+
+  describe('hiding by author moderation tags', () => {
+    // The post is untagged, but its author's profile carries an always-hide
+    // tag, so it is filtered as if the post itself were tagged.
+    it.each(['top', 'latest'] as const)(
+      `with '%s' sort, hides posts by an always-hidden author`,
+      async (sort) => {
+        const res = await agent.app.bsky.feed.searchPosts(
+          { q: 'narwhal', sort },
+          {
+            headers: await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPosts,
+            ),
+          },
+        )
+        expect(res.data.posts.map((p) => p.uri)).toStrictEqual([])
+      },
+    )
+
+    it.each(['top', 'latest'] as const)(
+      `with '%s' sort, hides posts by an always-hidden author even when specifying that author`,
+      async (sort) => {
+        const res = await agent.app.bsky.feed.searchPosts(
+          { q: 'narwhal', author: bob, sort },
+          {
+            headers: await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPosts,
+            ),
+          },
+        )
+        expect(res.data.posts.map((p) => p.uri)).toStrictEqual([])
+      },
+    )
+
+    it('includes posts by an always-hidden author when they are the viewer', async () => {
+      const res = await agent.app.bsky.feed.searchPosts(
+        { q: 'narwhal', sort: 'latest' },
+        {
+          headers: await network.serviceHeaders(
+            bob,
+            ids.AppBskyFeedSearchPosts,
+          ),
+        },
+      )
+      expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+        narwhalPostByTaggedAuthor.ref.uriStr,
+      ])
+    })
+
+    it('mod service finds posts by an always-hidden author', async () => {
+      const res = await ozoneAgent.app.bsky.feed.searchPosts(
+        { q: 'narwhal', sort: 'latest' },
+        { headers: await network.ozone.modHeaders(ids.AppBskyFeedSearchPosts) },
+      )
+      expect(res.data.posts.map((p) => p.uri)).toStrictEqual([
+        narwhalPostByTaggedAuthor.ref.uriStr,
       ])
     })
   })


### PR DESCRIPTION
Extend search filtering so a post is hidden not only when it carries a configured tag, but also when moderation tags on its author match. In `noBlocksOrTagged` (searchPosts v1 and v2) the post's own tags are now rolled together with the author's account- and profile-level moderation tags into a single set, which the existing searchTagsHide / searchTagsHideAll / visibilityTagHide checks run against. Viewer and mod-service exemptions are preserved.

Surfaces the author tags as first-class `accountModerationTags` / `profileModerationTags` on the hydration `Actor` (populated from the dataplane ActorInfo tags), and wires the in-repo dataplane to return `profileTags` from the profile record so the behavior is testable via dev-env.