### PR TITLE
Require createGroup members

### DIFF
--- a/lexicons/chat/bsky/group/createGroup.json
+++ b/lexicons/chat/bsky/group/createGroup.json
@@ -22,6 +22,7 @@
           "properties": {
             "members": {
               "type": "array",
+              "minLength": 1,
               "maxLength": 49,
               "items": {
                 "type": "string",


### PR DESCRIPTION
## Summary
Adds `minLength: 1` to `chat.bsky.group.createGroup`'s `members` array so group creation requires at least one member.

## Root Cause
The lexicon required the `members` field and capped it at 49 entries, but did not reject an empty array.

Fixes #5085.

## Validation
- `pnpm exec prettier --check lexicons/chat/bsky/group/createGroup.json`
- `git diff --check`
- Parsed `lexicons/chat/bsky/group/createGroup.json` with `parseLexiconDoc`
- Validated `chat.bsky.group.createGroup` input accepts one member and rejects an empty `members` array