### PR TITLE
Find nested lex-cli input files

### DIFF
--- a/.changeset/hip-cooks-learn.md
+++ b/.changeset/hip-cooks-learn.md
@@ -1,0 +1,5 @@
+---
+"@atproto/lex-cli": patch
+---
+
+Allow lex-cli input paths to include directories containing nested lexicon JSON files.

--- a/packages/lex-cli/src/util.ts
+++ b/packages/lex-cli/src/util.ts
@@ -1,17 +1,16 @@
 import fs from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import chalk from 'chalk'
 import { ZodError, type ZodFormattedError } from 'zod'
 import { type LexiconDoc, parseLexiconDoc } from '@atproto/lexicon'
 import type { FileDiff, GeneratedAPI } from './types.js'
 
 export function readAllLexicons(paths: string[]): LexiconDoc[] {
-  paths = [...paths].sort() // incoming path order may have come from locale-dependent shell globs
+  paths = Array.from(
+    new Set(paths.flatMap(lexiconFilePaths).map((path) => resolve(path))),
+  ).sort() // incoming path order may have come from locale-dependent shell globs
   const docs: LexiconDoc[] = []
   for (const path of paths) {
-    if (!path.endsWith('.json') || !fs.statSync(path).isFile()) {
-      continue
-    }
     try {
       docs.push(readLexicon(path))
     } catch {
@@ -19,6 +18,23 @@ export function readAllLexicons(paths: string[]): LexiconDoc[] {
     }
   }
   return docs
+}
+
+function lexiconFilePaths(path: string): string[] {
+  if (!fs.existsSync(path)) return []
+
+  const stat = fs.statSync(path)
+  if (stat.isDirectory()) {
+    return fs
+      .readdirSync(path)
+      .flatMap((name) => lexiconFilePaths(join(path, name)))
+  }
+
+  if (path.endsWith('.json') && stat.isFile()) {
+    return [path]
+  }
+
+  return []
 }
 
 export function readLexicon(path: string): LexiconDoc {


### PR DESCRIPTION
## Summary
Allows `lex-cli` input paths to include directories, including nested directory paths produced by shell glob expansion such as `./lexicons/**/*`.

## Root Cause
`readAllLexicons()` only accepted direct `.json` file paths and skipped everything else. When a shell glob expanded to directories, nested lexicon JSON files inside those directories were never discovered.

This expands directory inputs recursively, keeps deterministic sorting, and de-dupes overlapping inputs from glob expansion.

Fixes #3642.

## Validation
- `pnpm --filter @atproto/lex-cli build`
- `pnpm exec prettier --check .changeset/hip-cooks-learn.md packages/lex-cli/src/util.ts`
- `pnpm changeset status --since=origin/main`
- `git diff --check`
- Created a temporary nested `lexicons/com/example/foo.json`, passed overlapping directory/file inputs to `readAllLexicons()`, and verified it finds the lexicon once