### PR TITLE
Accept localhost redirect URIs for loopback OAuth clients

### DIFF
--- a/.changeset/quick-moons-refuse.md
+++ b/.changeset/quick-moons-refuse.md
@@ -1,0 +1,7 @@
+---
+'@atproto/oauth-types': minor
+'@atproto/oauth-provider': minor
+'@atproto/oauth-client-browser': minor
+---
+
+Accept `http://localhost` redirect URIs for loopback (development) clients, in addition to the `http://127.0.0.1` and `http://[::1]` loopback IP literals, per the updated atproto OAuth spec. `http://localhost/` is added to the default loopback redirect URIs (the loopback IP literals remain the default). The browser client no longer redirects the user away from a `localhost` origin when it matches one of the client's explicitly configured redirect URIs. Client behavior is otherwise unchanged: using a `localhost` redirect URI is opt-in, and requires an Authorization Server that accepts them.

--- a/packages/oauth/oauth-client-browser-example/src/constants.ts
+++ b/packages/oauth/oauth-client-browser-example/src/constants.ts
@@ -1,3 +1,5 @@
+import { isLoopbackHost } from '@atproto/oauth-client-browser'
+
 const { searchParams } = new URL(window.location.href)
 const getParam = <T extends string | undefined>(
   name: string,
@@ -67,13 +69,17 @@ export const OAUTH_SCOPE_DEFAULT: string =
 export const OAUTH_SCOPE: string =
   searchParams.get('scope') ?? OAUTH_SCOPE_DEFAULT
 
-// This app is dynamically configured via query parameters. The canonical URL is
-// always 127.0.0.1 with the relevant params set.
+// This app is dynamically configured via query parameters. The canonical URL
+// preserves the current loopback hostname ("localhost", "127.0.0.1" or
+// "[::1]") with the relevant params set, falling back to 127.0.0.1 for
+// non-loopback hostnames.
 export const LOOPBACK_CANONICAL_LOCATION = Object.assign(
   new URL(window.location.origin),
   {
     protocol: 'http:',
-    hostname: '127.0.0.1',
+    hostname: isLoopbackHost(window.location.hostname)
+      ? window.location.hostname
+      : '127.0.0.1',
     search: new URLSearchParams({
       ...(ENV !== ENV_DEFAULT && { env: ENV }),
       ...(PLC_DIRECTORY_URL !== PLC_DIRECTORY_URL_DEFAULT && {
@@ -94,4 +100,4 @@ export const LOOPBACK_CANONICAL_LOCATION = Object.assign(
       ...(OAUTH_SCOPE !== OAUTH_SCOPE_DEFAULT && { scope: OAUTH_SCOPE }),
     }).toString(),
   },
-).href as `http://127.0.0.1/${string}`
+).href as `http://${string}`

--- a/packages/oauth/oauth-client-browser/README.md
+++ b/packages/oauth/oauth-client-browser/README.md
@@ -303,9 +303,10 @@ This has several restrictions:
 2. The validity of the refresh tokens (if any) will be very limited (typically 1
    day)
 3. Silent-sign-in will not be allowed
-4. Only `http://127.0.0.1:<any_port>` and `http://[::1]:<any_port>` can be used
-   as origin for your app, and **not** `http://localhost:<any_port>`. This
-   library will automatically redirect the user to an IP based origin
+4. Only `http://localhost:<any_port>`, `http://127.0.0.1:<any_port>` and
+   `http://[::1]:<any_port>` can be used as origin for your app. If the
+   client's `redirect_uris` are restricted to IP based origins, this library
+   will automatically redirect the user to an IP based origin
    (`http://127.0.0.1:<port>`) when visiting an origin with `localhost`.
 
 Using a loopback client is only recommended for development purposes. A loopback
@@ -328,10 +329,11 @@ import { BrowserOAuthClient } from '@atproto/oauth-client-browser'
 
 const client = new BrowserOAuthClient({
   handleResolver: 'https://bsky.social',
-  // Note that the origin of the "client_id" URL must be "http://localhost" when
-  // using this configuration, regardless of the actual hostname ("127.0.0.1" or
-  // "[::1]"), port or pathname. Only the `redirect_uris` must contain the
-  // actual url that will be used to redirect the user back to the application.
+  // Note that the origin of the "client_id" URL must be "http://localhost"
+  // (with no port) when using this configuration, regardless of the actual
+  // hostname ("localhost", "127.0.0.1" or "[::1]"), port or pathname. Only the
+  // `redirect_uris` must contain the actual url that will be used to redirect
+  // the user back to the application.
   clientMetadata: `http://localhost?redirect_uri=${encodeURIComponent('http://127.0.0.1:8080/callback')}`,
 })
 ```

--- a/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts
+++ b/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts
@@ -224,7 +224,7 @@ export class BrowserOAuthClient extends OAuthClient implements AsyncDisposable {
 
   async initRestore(refresh?: boolean) {
     // @NOTE Fixing the location should not be needed from callback endpoints
-    // since callback endpoint are required to use IP based URLs (for localhost)
+    // since callback endpoints necessarily match one of the redirect URIs
     await fixLocation(this.clientMetadata)
 
     const sub = localStorage.getItem(`${NAMESPACE}(sub)`)
@@ -511,19 +511,32 @@ export class BrowserOAuthClient extends OAuthClient implements AsyncDisposable {
 }
 
 /**
- * Since "localhost" is often used either in IP mode or in hostname mode,
- * and because the redirect uris must use the IP mode, we need to make sure
- * that the current location url is not using "localhost".
- *
- * This is required for the IndexedDB to work properly. Indeed, the IndexedDB
- * is shared by origin, so we must ensure to be on the same origin as the
- * redirect uris.
+ * The session state of loopback clients is stored in origin-scoped browser
+ * storage (IndexedDB), so the app must be running on the same origin as the
+ * redirect URI that will be used. If the current location is "localhost" but
+ * none of the client's redirect URIs use the "localhost" hostname, redirect
+ * to a matching loopback IP based redirect URI instead.
  */
 function fixLocation(clientMetadata: ClientMetadata) {
   if (!isOAuthClientIdLoopback(clientMetadata.client_id)) return
   if (window.location.hostname !== 'localhost') return
 
   const locationUrl = new URL(window.location.href)
+
+  // If the current "localhost" location matches one of the client's redirect
+  // URIs, the OAuth flow will be able to return to this origin; nothing to
+  // fix.
+  for (const uri of clientMetadata.redirect_uris) {
+    const url = new URL(uri)
+    if (
+      url.hostname === 'localhost' &&
+      (!url.port || url.port === locationUrl.port) &&
+      url.protocol === locationUrl.protocol &&
+      url.pathname === locationUrl.pathname
+    ) {
+      return
+    }
+  }
 
   for (const uri of clientMetadata.redirect_uris) {
     const url = new URL(uri)

--- a/packages/oauth/oauth-client-browser/src/util.ts
+++ b/packages/oauth/oauth-client-browser/src/util.ts
@@ -8,6 +8,11 @@ export type TupleUnion<U extends string, R extends any[] = []> = {
 }[U]
 
 /**
+ * @param localhost - Hostname to use in the redirect URI when the location's
+ * hostname is "localhost". Defaults to "127.0.0.1" for compatibility with
+ * Authorization Servers that do not (yet) accept "localhost" redirect URIs.
+ * Pass "localhost" to preserve the hostname as-is.
+ *
  * @example
  * ```ts
  * const clientId = buildLoopbackClientId(window.location)

--- a/packages/oauth/oauth-provider/src/client/client-manager.ts
+++ b/packages/oauth/oauth-provider/src/client/client-manager.ts
@@ -487,22 +487,13 @@ export class ClientManager {
       switch (true) {
         // FIRST: Loopback redirect URI exception (only for native apps)
 
-        case url.hostname === 'localhost': {
-          // https://datatracker.ietf.org/doc/html/rfc8252#section-8.3
-          //
-          // > While redirect URIs using localhost (i.e.,
-          // > "http://localhost:{port}/{path}") function similarly to loopback IP
-          // > redirects described in Section 7.3, the use of localhost is NOT
-          // > RECOMMENDED. Specifying a redirect URI with the loopback IP literal
-          // > rather than localhost avoids inadvertently listening on network
-          // > interfaces other than the loopback interface. It is also less
-          // > susceptible to client-side firewalls and misconfigured host name
-          // > resolution on the user's device.
-          throw new InvalidRedirectUriError(
-            `Loopback redirect URI ${url} is not allowed (use explicit IPs instead)`,
-          )
-        }
-
+        // @NOTE Although RFC 8252 (section 8.3) recommends loopback IP
+        // literals over "localhost" for native apps binding a local port
+        // listener, the atproto OAuth profile allows "localhost" redirect
+        // URIs for loopback (development) clients.
+        //
+        // https://atproto.com/specs/oauth#localhost-client-development
+        case url.hostname === 'localhost':
         case url.hostname === '127.0.0.1':
         case url.hostname === '[::1]': {
           // Only allowed for native apps

--- a/packages/oauth/oauth-types/src/atproto-loopback-client-redirect-uris.ts
+++ b/packages/oauth/oauth-types/src/atproto-loopback-client-redirect-uris.ts
@@ -1,4 +1,7 @@
+// @NOTE Order matters: clients that do not specify an explicit redirect URI
+// default to the first entry.
 export const DEFAULT_LOOPBACK_CLIENT_REDIRECT_URIS = Object.freeze([
   `http://127.0.0.1/`,
   `http://[::1]/`,
+  `http://localhost/`,
 ] as const)

--- a/packages/oauth/oauth-types/src/oauth-redirect-uri.ts
+++ b/packages/oauth/oauth-types/src/oauth-redirect-uri.ts
@@ -1,7 +1,6 @@
 import { type TypeOf, ZodIssueCode, z } from 'zod'
 import {
   type HttpsUri,
-  type LoopbackUri,
   type PrivateUseUri,
   httpsUriSchema,
   loopbackUriSchema,
@@ -9,33 +8,20 @@ import {
 } from './uri.js'
 
 /**
- * This is a {@link loopbackUriSchema} with the additional restriction that
- * the hostname `localhost` is not allowed.
+ * Any loopback URI ("localhost", "127.0.0.1" or "[::1]" hostname) is allowed
+ * as a redirect URI.
  *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc8252#section-8.3 Loopback Redirect Considerations} RFC8252
+ * @NOTE {@link https://datatracker.ietf.org/doc/html/rfc8252#section-8.3 RFC8252}
+ * recommends loopback IP literals over "localhost" for native apps binding a
+ * local port listener, out of concern that "localhost" could resolve to a
+ * non-loopback address. The atproto OAuth profile allows "localhost" redirect
+ * URIs for loopback (development) clients: browser-mediated flows resolve
+ * "localhost" to the loopback interface, and the mandatory PKCE and DPoP
+ * requirements prevent use of an intercepted authorization code.
  *
- * > While redirect URIs using localhost (i.e.,
- * > "http://localhost:{port}/{path}") function similarly to loopback IP
- * > redirects described in Section 7.3, the use of localhost is NOT
- * > RECOMMENDED. Specifying a redirect URI with the loopback IP literal rather
- * > than localhost avoids inadvertently listening on network interfaces other
- * > than the loopback interface.  It is also less susceptible to client-side
- * > firewalls and misconfigured host name resolution on the user's device.
+ * @see {@link https://atproto.com/specs/oauth#localhost-client-development}
  */
-export const loopbackRedirectURISchema = loopbackUriSchema.superRefine(
-  (value, ctx): value is Exclude<LoopbackUri, `http://localhost${string}`> => {
-    if (value.startsWith('http://localhost')) {
-      ctx.addIssue({
-        code: ZodIssueCode.custom,
-        message:
-          'Use of "localhost" hostname is not allowed (RFC 8252), use a loopback IP such as "127.0.0.1" instead',
-      })
-      return false
-    }
-
-    return true
-  },
-)
+export const loopbackRedirectURISchema = loopbackUriSchema
 export type LoopbackRedirectURI = TypeOf<typeof loopbackRedirectURISchema>
 
 export const oauthLoopbackClientRedirectUriSchema = loopbackRedirectURISchema

--- a/packages/pds/tests/_puppeteer.ts
+++ b/packages/pds/tests/_puppeteer.ts
@@ -18,6 +18,10 @@ export class PageHelper implements AsyncDisposable {
     return this.page.isClosed()
   }
 
+  url() {
+    return this.page.url()
+  }
+
   async title() {
     await this.waitForNetworkIdle()
     return this.page.title()

--- a/packages/pds/tests/oauth.test.ts
+++ b/packages/pds/tests/oauth.test.ts
@@ -13,6 +13,7 @@ describe('oauth', () => {
   let server: Server
 
   let appUrl: string
+  let localhostAppUrl: string
 
   // @NOTE We are using another language than "en" as default language to
   // test the language negotiation.
@@ -55,11 +56,14 @@ describe('oauth', () => {
       scope: `account:email identity:* repo:*`,
     }
 
-    appUrl = `http://127.0.0.1:${port}?${new URLSearchParams(
+    const appQueryString = new URLSearchParams(
       Object.entries(appConfig).filter(
         (e): e is [string, string] => e[1] != null,
       ),
-    )}`
+    ).toString()
+
+    appUrl = `http://127.0.0.1:${port}?${appQueryString}`
+    localhostAppUrl = `http://localhost:${port}?${appQueryString}`
   })
 
   afterAll(async () => {
@@ -241,6 +245,40 @@ describe('oauth', () => {
     await page.navigationClick('Autoriser')
 
     await page.assertTitle('OAuth Client Example')
+
+    await page.ensureTextVisibility('Token info', 'h2')
+
+    await page.clickOnAriaLabel('User menu')
+
+    await page.clickOnText('Sign out')
+
+    await page.waitForNetworkIdle()
+  })
+
+  it('Allows to sign-in through OAuth from a "localhost" origin', async () => {
+    await using page = await PageHelper.from(browser, { languages })
+
+    await page.goto(localhostAppUrl)
+
+    await page.assertTitle('OAuth Client Example')
+
+    // The app must not have redirected away from the "localhost" origin
+    expect(new URL(page.url()).hostname).toBe('localhost')
+
+    const input = await page.typeInInput('identifier', 'alice.test')
+
+    await page.navigationAction(async () => input.press('Enter'))
+
+    // The device session on the Authorization Server is remembered from the
+    // previous sign-in, so the flow jumps straight to the consent screen.
+    await page.assertTitle('Autoriser')
+
+    await page.navigationClick('Autoriser')
+
+    await page.assertTitle('OAuth Client Example')
+
+    // The OAuth flow must have returned to the "localhost" origin
+    expect(new URL(page.url()).hostname).toBe('localhost')
 
     await page.ensureTextVisibility('Token info', 'h2')
 


### PR DESCRIPTION
Implements the spec change proposed in bluesky-social/atproto-website#709.

We now accept `localhost` as a redirect URI hostname alongside the `127.0.0.1` and `[::1]` loopback IP literals.

---

*The rest is written by Claude.*

This change is opt-in for clients: the loopback IP literals remain first in the default redirect URIs, and the browser SDK only stays on a "localhost" origin when the client explicitly declares a matching localhost redirect URI.

- oauth-types: drop the localhost rejection from loopbackRedirectURISchema, add http://localhost/ to the default loopback redirect URIs (last, so defaults are unchanged)
- oauth-provider: accept localhost redirect URIs for native clients in client metadata validation
- oauth-client-browser: don't redirect away from a localhost origin when it matches one of the client's declared redirect URIs
- example app: preserve the current loopback hostname in the canonical location instead of forcing 127.0.0.1
- pds: add an integration test signing in through OAuth from a localhost origin

