### PR TITLE
bsky: return 400 for dataplane InvalidArgument in search

### DIFF
--- a/.changeset/few-states-start.md
+++ b/.changeset/few-states-start.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+return 400 for dataplane InvalidArgument in search

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -114,7 +114,7 @@ const skeletonV2 = async (
         cursor: params.cursor,
       },
     })
-    .catch(asInvalidRequest)
+    .catch(asInvalidRequest())
   return {
     dids: res.actors.map(({ did }) => did as DidString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -2,7 +2,10 @@ import { mapDefined } from '@atproto/common'
 import type { Client, DidString } from '@atproto/lex'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import type { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
@@ -101,14 +104,17 @@ const skeletonV2 = async (
   const { ctx, params } = inputs
   const term = params.q ?? params.term ?? ''
 
-  const res = await ctx.dataplane.searchActorsV2({
-    params: {
-      query: term,
-      viewer: params.hydrateCtx.viewer ?? undefined,
-      limit: params.limit,
-      cursor: params.cursor,
-    },
-  })
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchActorsV2({
+      params: {
+        query: term,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+        cursor: params.cursor,
+      },
+    })
+    .catch(asInvalidRequest)
   return {
     dids: res.actors.map(({ did }) => did as DidString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -106,7 +106,7 @@ const skeletonV2 = async (
         limit: params.limit,
       },
     })
-    .catch(asInvalidRequest)
+    .catch(asInvalidRequest())
   return {
     dids: res.actors.map(({ did }) => did as DidString),
   }

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -2,7 +2,10 @@ import { mapDefined } from '@atproto/common'
 import type { Client, DidString } from '@atproto/lex'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import type { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
 import { app } from '../../../../lexicons/index.js'
 import {
@@ -94,13 +97,16 @@ const skeletonV2 = async (
   const { ctx, params } = inputs
   const term = params.q ?? params.term ?? ''
 
-  const res = await ctx.dataplane.searchActorsTypeahead({
-    params: {
-      query: term,
-      viewer: params.hydrateCtx.viewer ?? undefined,
-      limit: params.limit,
-    },
-  })
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchActorsTypeahead({
+      params: {
+        query: term,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+      },
+    })
+    .catch(asInvalidRequest)
   return {
     dids: res.actors.map(({ did }) => did as DidString),
   }

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -146,7 +146,7 @@ const skeletonV2 = async (
       since: parseTimestamp(params.since),
       until: parseTimestamp(params.until),
     })
-    .catch(asInvalidRequest)
+    .catch(asInvalidRequest())
   return {
     posts: res.posts.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -4,7 +4,10 @@ import type { AtUriString, Client } from '@atproto/lex'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import type { ServerConfig } from '../../../../config.js'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import {
   type PostSearchQuery,
   parsePostSearchQuery,
@@ -121,26 +124,29 @@ const skeletonV2 = async (
   const parsedQuery = parsePostSearchQuery(params.q, {
     author: params.author,
   })
-  const res = await ctx.dataplane.searchPostsV2({
-    allTime: true, // match v1 behavior, v2 defaults to false
-    params: {
-      query: params.q,
-      viewer: params.hydrateCtx.viewer ?? undefined,
-      limit: params.limit,
-      cursor: sanitizeCursor(params.cursor),
-    },
-    sort: postSortToV2(params.sort),
-    filters: {
-      authors: params.author ? [params.author] : [],
-      mentions: params.mentions ? [params.mentions] : [],
-      domains: params.domain ? [params.domain] : [],
-      urls: params.url ? [params.url] : [],
-      hashtags: params.tag ?? [],
-      languages: params.lang ? [params.lang] : [],
-    },
-    since: parseTimestamp(params.since),
-    until: parseTimestamp(params.until),
-  })
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchPostsV2({
+      allTime: true, // match v1 behavior, v2 defaults to false
+      params: {
+        query: params.q,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+        cursor: sanitizeCursor(params.cursor),
+      },
+      sort: postSortToV2(params.sort),
+      filters: {
+        authors: params.author ? [params.author] : [],
+        mentions: params.mentions ? [params.mentions] : [],
+        domains: params.domain ? [params.domain] : [],
+        urls: params.url ? [params.url] : [],
+        hashtags: params.tag ?? [],
+        languages: params.lang ? [params.lang] : [],
+      },
+      since: parseTimestamp(params.since),
+      until: parseTimestamp(params.until),
+    })
+    .catch(asInvalidRequest)
   return {
     posts: res.posts.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
@@ -7,7 +7,10 @@ import {
   type Server,
 } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import {
   type PostSearchQuery,
   parsePostSearchQuery,
@@ -101,44 +104,47 @@ const skeleton = async (
     author: params.authors?.[0],
   })
 
-  const res = await ctx.dataplane.searchPostsV2({
-    params: {
-      query,
-      viewer: params.hydrateCtx.viewer ?? undefined,
-      limit: params.limit,
-      cursor: params.cursor,
-    },
-    sort: postSortToV2(params.sort),
-    filters: {
-      authors: params.authors ?? [],
-      mentions: params.mentions ?? [],
-      domains: params.domains ?? [],
-      urls: params.urls ?? [],
-      embeddedAtUris: params.embeddedAtUris ?? [],
-      hashtags: params.hashtags ?? [],
-      languages: params.languages ?? [],
-    },
-    exclude: {
-      authors: params.excludeAuthors ?? [],
-      mentions: params.excludeMentions ?? [],
-      domains: params.excludeDomains ?? [],
-      urls: params.excludeUrls ?? [],
-      embeddedAtUris: params.excludeEmbeddedAtUris ?? [],
-      hashtags: params.excludeHashtags ?? [],
-      languages: params.excludeLanguages ?? [],
-    },
-    since: parseTimestamp(params.since),
-    until: parseTimestamp(params.until),
-    allTime: params.allTime,
-    hasMedia: params.hasMedia,
-    hasVideo: params.hasVideo,
-    replyParentUri: params.replyParentUri,
-    threadRootUri: params.threadRootUri,
-    excludeReplies: params.excludeReplies,
-    repliesOnly: params.repliesOnly,
-    following: params.following,
-    queryLanguage: queryLanguageToV2(params.queryLanguage),
-  })
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchPostsV2({
+      params: {
+        query,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+        cursor: params.cursor,
+      },
+      sort: postSortToV2(params.sort),
+      filters: {
+        authors: params.authors ?? [],
+        mentions: params.mentions ?? [],
+        domains: params.domains ?? [],
+        urls: params.urls ?? [],
+        embeddedAtUris: params.embeddedAtUris ?? [],
+        hashtags: params.hashtags ?? [],
+        languages: params.languages ?? [],
+      },
+      exclude: {
+        authors: params.excludeAuthors ?? [],
+        mentions: params.excludeMentions ?? [],
+        domains: params.excludeDomains ?? [],
+        urls: params.excludeUrls ?? [],
+        embeddedAtUris: params.excludeEmbeddedAtUris ?? [],
+        hashtags: params.excludeHashtags ?? [],
+        languages: params.excludeLanguages ?? [],
+      },
+      since: parseTimestamp(params.since),
+      until: parseTimestamp(params.until),
+      allTime: params.allTime,
+      hasMedia: params.hasMedia,
+      hasVideo: params.hasVideo,
+      replyParentUri: params.replyParentUri,
+      threadRootUri: params.threadRootUri,
+      excludeReplies: params.excludeReplies,
+      repliesOnly: params.repliesOnly,
+      following: params.following,
+      queryLanguage: queryLanguageToV2(params.queryLanguage),
+    })
+    .catch(asInvalidRequest)
   return {
     posts: res.posts.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
@@ -144,7 +144,7 @@ const skeleton = async (
       following: params.following,
       queryLanguage: queryLanguageToV2(params.queryLanguage),
     })
-    .catch(asInvalidRequest)
+    .catch(asInvalidRequest())
   return {
     posts: res.posts.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -112,7 +112,7 @@ const skeletonV2 = async (
         cursor: params.cursor,
       },
     })
-    .catch(asInvalidRequest)
+    .catch(asInvalidRequest())
   return {
     uris: res.starterPacks.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -2,7 +2,10 @@ import { mapDefined } from '@atproto/common'
 import type { AtUriString, Client } from '@atproto/lex'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import type { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
@@ -99,14 +102,17 @@ const skeletonV2 = async (
   const { ctx, params } = inputs
   const { q } = params
 
-  const res = await ctx.dataplane.searchStarterPacksV2({
-    params: {
-      query: q,
-      viewer: params.hydrateCtx.viewer ?? undefined,
-      limit: params.limit,
-      cursor: params.cursor,
-    },
-  })
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchStarterPacksV2({
+      params: {
+        query: q,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+        cursor: params.cursor,
+      },
+    })
+    .catch(asInvalidRequest)
   return {
     uris: res.starterPacks.map(({ uri }) => uri as AtUriString),
     cursor: parseString(res.pageInfo?.cursor),

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -2,6 +2,7 @@ import { mapDefined } from '@atproto/common'
 import type { AtUriString } from '@atproto/syntax'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
+import { asInvalidRequest } from '../../../../data-plane/index.js'
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import {
@@ -47,20 +48,25 @@ export default function (server: Server, ctx: AppContext) {
       if (query) {
         const useV2 =
           features.checkGate(features.Gate.SearchV2Enable) || isV2Override
+        // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
         if (useV2) {
-          const res = await ctx.dataplane.searchFeedGeneratorsV2({
-            params: {
-              query,
-              viewer: viewer ?? undefined,
-              limit: params.limit,
-            },
-          })
+          const res = await ctx.dataplane
+            .searchFeedGeneratorsV2({
+              params: {
+                query,
+                viewer: viewer ?? undefined,
+                limit: params.limit,
+              },
+            })
+            .catch(asInvalidRequest)
           uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
         } else {
-          const res = await ctx.dataplane.searchFeedGenerators({
-            query,
-            limit: params.limit,
-          })
+          const res = await ctx.dataplane
+            .searchFeedGenerators({
+              query,
+              limit: params.limit,
+            })
+            .catch(asInvalidRequest)
           uris = res.uris as AtUriString[]
         }
       } else {

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -58,7 +58,7 @@ export default function (server: Server, ctx: AppContext) {
                 limit: params.limit,
               },
             })
-            .catch(asInvalidRequest)
+            .catch(asInvalidRequest())
           uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
         } else {
           const res = await ctx.dataplane
@@ -66,7 +66,7 @@ export default function (server: Server, ctx: AppContext) {
               query,
               limit: params.limit,
             })
-            .catch(asInvalidRequest)
+            .catch(asInvalidRequest())
           uris = res.uris as AtUriString[]
         }
       } else {

--- a/packages/bsky/src/data-plane/client/util.ts
+++ b/packages/bsky/src/data-plane/client/util.ts
@@ -1,6 +1,7 @@
-import { type Code, ConnectError, type Interceptor } from '@connectrpc/connect'
+import { Code, ConnectError, type Interceptor } from '@connectrpc/connect'
 import * as ui8 from 'uint8arrays'
 import { getDidKeyFromMultibase } from '@atproto/identity'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 
 export const callerInterceptor =
   (caller: string): Interceptor =>
@@ -18,6 +19,17 @@ export const isDataplaneError = (
     return !code || err.code === code
   }
   return false
+}
+
+// Rethrows a dataplane InvalidArgument error as a client-facing 400. Use as a
+// `.catch()` handler on a dataplane call whose args come from user input.
+// Returns `never`, so the awaited result keeps its type. Any other error passes
+// through unchanged.
+export const asInvalidRequest = (err: unknown): never => {
+  if (isDataplaneError(err, Code.InvalidArgument)) {
+    throw new InvalidRequestError(err.rawMessage)
+  }
+  throw err
 }
 
 export const unpackIdentityServices = (servicesBytes: Uint8Array) => {

--- a/packages/bsky/src/data-plane/client/util.ts
+++ b/packages/bsky/src/data-plane/client/util.ts
@@ -21,16 +21,18 @@ export const isDataplaneError = (
   return false
 }
 
-// Rethrows a dataplane InvalidArgument error as a client-facing 400. Use as a
-// `.catch()` handler on a dataplane call whose args come from user input.
-// Returns `never`, so the awaited result keeps its type. Any other error passes
-// through unchanged.
-export const asInvalidRequest = (err: unknown): never => {
-  if (isDataplaneError(err, Code.InvalidArgument)) {
-    throw new InvalidRequestError(err.rawMessage)
+// Rethrows a dataplane InvalidArgument error as a client-facing 400, with an
+// optional message. Use as a `.catch()` handler on a dataplane call whose args
+// come from user input. Returns `never`, so the awaited result keeps its type.
+// Any other error passes through unchanged.
+export const asInvalidRequest =
+  (message = 'Invalid request') =>
+  (err: unknown): never => {
+    if (isDataplaneError(err, Code.InvalidArgument)) {
+      throw new InvalidRequestError(message)
+    }
+    throw err
   }
-  throw err
-}
 
 export const unpackIdentityServices = (servicesBytes: Uint8Array) => {
   const servicesStr = ui8.toString(servicesBytes, 'utf8')


### PR DESCRIPTION
Search handlers pass user input straight to the dataplane. When the dataplane rejects that input with `InvalidArgument`, the appview treated it as a generic error and mapped it to a 500 instead of 400.

Adds an `asInvalidRequest` `.catch()` helper that rethrows a dataplane `InvalidArgument` as `InvalidRequestError`, and passes any other error through unchanged. Only `InvalidArgument` is translated — genuine backend faults (`Unavailable`, `Internal`, etc.) still surface as 500s.