### PR TITLE
Fix PDS's describe server in entryway setup

### DIFF
--- a/.changeset/common-cases-travel.md
+++ b/.changeset/common-cases-travel.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Read part of the `describeServer` config from entryway

--- a/packages/pds/src/api/com/atproto/server/describeServer.ts
+++ b/packages/pds/src/api/com/atproto/server/describeServer.ts
@@ -1,29 +1,48 @@
 import type { UriString } from '@atproto/lex'
-import type { DidString } from '@atproto/syntax'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  server.add(com.atproto.server.describeServer, () => {
-    const did = ctx.cfg.service.did as DidString
-    const availableUserDomains = ctx.cfg.identity.serviceHandleDomains
-    const inviteCodeRequired = ctx.cfg.invites.required
-    const privacyPolicy = ctx.cfg.service.privacyPolicyUrl as UriString
-    const termsOfService = ctx.cfg.service.termsOfServiceUrl as UriString
-    const contactEmailAddress = ctx.cfg.service.contactEmailAddress
+  const { entrywayClient } = ctx
 
-    return {
-      encoding: 'application/json' as const,
-      body: {
-        did,
-        availableUserDomains,
-        inviteCodeRequired,
-        links: { privacyPolicy, termsOfService },
-        contact: {
-          email: contactEmailAddress,
-        },
+  const did = ctx.cfg.service.did
+  const availableUserDomains = ctx.cfg.identity.serviceHandleDomains
+  const inviteCodeRequired = ctx.cfg.invites.required
+  const privacyPolicy = ctx.cfg.service.privacyPolicyUrl as UriString
+  const termsOfService = ctx.cfg.service.termsOfServiceUrl as UriString
+  const contactEmailAddress = ctx.cfg.service.contactEmailAddress
+
+  if (entrywayClient) {
+    server.add(com.atproto.server.describeServer, {
+      handler: async ({ params }) => {
+        // @NOTE We don't report `inviteCodeRequired` here because account
+        // creation is dictated by the entryway. We *do* return
+        // `availableUserDomains` because it is needed for handle updates, which
+        // may be performed against both the entryway and the PDS.
+        const { availableUserDomains, links, contact } =
+          await entrywayClient.call(com.atproto.server.describeServer, params)
+
+        return {
+          encoding: 'application/json' as const,
+          body: { did, availableUserDomains, links, contact },
+        }
       },
-    }
-  })
+    })
+  } else {
+    server.add(com.atproto.server.describeServer, () => {
+      return {
+        encoding: 'application/json' as const,
+        body: {
+          did,
+          availableUserDomains,
+          inviteCodeRequired,
+          links: { privacyPolicy, termsOfService },
+          contact: {
+            email: contactEmailAddress,
+          },
+        },
+      }
+    })
+  }
 }


### PR DESCRIPTION
In a setup where account management is performed by an Entryway (like Bluesky's deployment), account creation logic should not be allowed on PDSs.

Similarly, some configuration should be dictated by the Entryway, and not individual PDSs.

This PR addresses that by delegating part of the `describeServer` response to entryway values.

Most notably, it removes the `inviteCodeRequired` property from the output since this value does not makes sense on a server that should not handle `createAccount`.

This PR does not remove the ability to call `createAccount` though, which might be part of a larger rework.