### PR TITLE
examples: add post-with-facets script

### DIFF
--- a/examples/post-with-facets/README.md
+++ b/examples/post-with-facets/README.md
@@ -1,0 +1,54 @@
+# Posting with facets (clickable #tags, links, and @mentions)
+
+Bluesky does **not** parse your post text. A post record stores `text` literally —
+the clickable `#hashtags`, URLs, and `@mentions` come from a separate **`facets`**
+array of byte-range annotations on the record.
+
+That `facets` array is generated **client-side**. The facet detector
+([`detectFacets`](../../packages/api/src/rich-text/detection.ts), wrapped by
+[`RichText`](../../packages/api/src/rich-text/rich-text.ts)) lives in
+`@atproto/api`; the PDS and AppView never generate facets for you and serve
+whatever record they're given verbatim.
+
+So a raw `createRecord` call that sends only `{ text, createdAt }` produces a post
+whose tags and links render as **plain, unclickable text**. The official app looks
+different only because it runs facet detection before writing the record — exactly
+the step this example makes explicit.
+
+## Run
+
+```bash
+npm install @atproto/api
+
+# Use an App Password (Settings -> App Passwords), not your account password.
+BSKY_HANDLE=you.bsky.social BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+  node index.mjs
+```
+
+Optional env overrides:
+
+- `BSKY_SERVICE` — PDS/service URL (default `https://bsky.social`)
+- `BSKY_TEXT` — custom post text (default includes a tag, a link, and a mention)
+
+The script logs in, runs `RichText.detectFacets(agent)` (which also resolves
+`@handle` → DID for mentions), prints the detected `facets`, then creates the post
+**with** them and prints a `bsky.app` link to the result.
+
+## The one line that matters
+
+```js
+const rt = new RichText({ text })
+await rt.detectFacets(agent)          // build facets client-side (+ resolve mentions)
+await agent.post({ text: rt.text, facets: rt.facets, createdAt: new Date().toISOString() })
+//                                   ^^^^^^^^^^^^^^^ omit this and tags/links go plain
+```
+
+### Notes
+
+- Facet indices are **UTF-8 byte offsets**, not character offsets — non-ASCII text
+  (emoji, accents) will misalign if you hand-roll facets instead of using `RichText`.
+- Mentions initially carry the handle in `did`; passing `agent` to `detectFacets`
+  resolves it to a real DID. `detectFacetsWithoutResolution()` skips this and
+  produces invalid mention facets.
+- A tag feature stores `catlife`, not `#catlife` (the `#` stays in `text`, inside
+  the byte range).

--- a/examples/post-with-facets/README.md
+++ b/examples/post-with-facets/README.md
@@ -43,6 +43,21 @@ await agent.post({ text: rt.text, facets: rt.facets, createdAt: new Date().toISO
 //                                   ^^^^^^^^^^^^^^^ omit this and tags/links go plain
 ```
 
+## Alternative: opt-in server-side detection (PDS change)
+
+This fork also adds an **opt-in** PDS flag, `PDS_ENRICH_POST_FACETS`, that makes
+the server auto-populate facets when an `app.bsky.feed.post` is created via
+`com.atproto.repo.createRecord` **without** a `facets` field. This lets a client
+that only sends `{ text, createdAt }` still get clickable tags/links/mentions.
+
+- Implementation: [`packages/pds/src/api/com/atproto/repo/detect-facets.ts`](../../packages/pds/src/api/com/atproto/repo/detect-facets.ts),
+  wired into [`createRecord.ts`](../../packages/pds/src/api/com/atproto/repo/createRecord.ts).
+- Off by default. It **mutates user records on write** and diverges from
+  atproto's design (facets are normally a client responsibility), so client-side
+  detection remains the recommended approach.
+- Scope: `createRecord` only (not `applyWrites` / `putRecord`). Mentions that
+  don't resolve to a DID are dropped rather than written invalid.
+
 ### Notes
 
 - Facet indices are **UTF-8 byte offsets**, not character offsets — non-ASCII text

--- a/examples/post-with-facets/facets.mjs
+++ b/examples/post-with-facets/facets.mjs
@@ -1,0 +1,54 @@
+/**
+ * Reusable client-side helper: turn plain post text into a post record whose
+ * #hashtags, links, and @mentions are clickable.
+ *
+ * Bluesky stores post `text` verbatim and never parses it — the clickable parts
+ * come from a `facets` array the client must attach. These helpers wrap
+ * `RichText.detectFacets`, which computes the byte-range facets and resolves
+ * @handles to DIDs. Import them into your own app.
+ *
+ *   import { buildPostRecord, postWithFacets } from './facets.mjs'
+ *
+ *   // build a record you can inspect / augment before writing:
+ *   const record = await buildPostRecord(agent, 'Hello #world https://example.com')
+ *   await agent.post(record)
+ *
+ *   // or one-shot create:
+ *   const res = await postWithFacets(agent, 'Hello #world https://example.com')
+ */
+
+import { RichText } from '@atproto/api'
+
+/**
+ * Build an `app.bsky.feed.post` record with facets detected from the text.
+ *
+ * @param {import('@atproto/api').AtpAgent} agent  logged-in agent (used to resolve mentions)
+ * @param {string} text
+ * @param {object} [extra]  extra record fields to merge (e.g. { langs, embed, reply })
+ * @returns {Promise<object>} a post record: { text, facets, createdAt, ...extra }
+ */
+export async function buildPostRecord(agent, text, extra = {}) {
+  const rt = new RichText({ text })
+  await rt.detectFacets(agent) // detect tags/links/mentions + resolve @handle -> DID
+  return {
+    $type: 'app.bsky.feed.post',
+    text: rt.text,
+    // omit the key entirely when nothing was detected, rather than sending []
+    ...(rt.facets?.length ? { facets: rt.facets } : {}),
+    createdAt: new Date().toISOString(),
+    ...extra,
+  }
+}
+
+/**
+ * Detect facets and create the post in one call.
+ *
+ * @param {import('@atproto/api').AtpAgent} agent
+ * @param {string} text
+ * @param {object} [extra]
+ * @returns {Promise<{uri: string, cid: string}>}
+ */
+export async function postWithFacets(agent, text, extra = {}) {
+  const record = await buildPostRecord(agent, text, extra)
+  return agent.post(record)
+}

--- a/examples/post-with-facets/index.mjs
+++ b/examples/post-with-facets/index.mjs
@@ -20,7 +20,8 @@
  *   BSKY_TEXT="Your custom post with #tags, https://example.com and @someone.bsky.social"
  */
 
-import { AtpAgent, RichText } from '@atproto/api'
+import { AtpAgent } from '@atproto/api'
+import { buildPostRecord } from './facets.mjs'
 
 const {
   BSKY_SERVICE = 'https://bsky.social',
@@ -46,27 +47,21 @@ async function main() {
   await agent.login({ identifier: BSKY_HANDLE, password: BSKY_APP_PASSWORD })
   console.log(`Logged in as ${agent.session?.handle} (${agent.session?.did})`)
 
-  // 2. Build rich text and detect facets.
-  //    - detectFacets scans the text for tags / links / mentions
-  //    - passing `agent` lets it resolve @handles into DIDs (required for mentions)
-  const rt = new RichText({ text })
-  await rt.detectFacets(agent)
+  // 2. Build the post record with facets, using the reusable helper in ./facets.mjs
+  //    (which wraps RichText.detectFacets + mention resolution).
+  const record = await buildPostRecord(agent, text)
 
   // 3. Show what the CLIENT computed — this is the piece a raw createRecord call omits.
-  console.log('\nText:', rt.text)
-  console.log('Detected facets:', JSON.stringify(rt.facets ?? [], null, 2))
-  if (!rt.facets?.length) {
+  console.log('\nText:', record.text)
+  console.log('Detected facets:', JSON.stringify(record.facets ?? [], null, 2))
+  if (!record.facets?.length) {
     console.log(
       '(No facets detected — the post would render as plain, unclickable text.)',
     )
   }
 
   // 4. Create the post WITH facets. Without `facets`, tags/links/mentions are plain text.
-  const res = await agent.post({
-    text: rt.text,
-    facets: rt.facets, // <-- the missing ingredient
-    createdAt: new Date().toISOString(),
-  })
+  const res = await agent.post(record)
 
   // 5. Print a link to the created post.
   const rkey = res.uri.split('/').pop()

--- a/examples/post-with-facets/index.mjs
+++ b/examples/post-with-facets/index.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Full working example: post to Bluesky with clickable hashtags, links, and mentions.
+ *
+ * The key idea: Bluesky does NOT parse your post text. Clickable #tags, URLs, and
+ * @mentions come from a separate `facets` array on the record, which the CLIENT must
+ * generate. RichText.detectFacets() does exactly that (and resolves @handles -> DIDs).
+ *
+ * Setup:
+ *   npm init -y
+ *   npm install @atproto/api
+ *   # package.json needs:  "type": "module"   (or name this file .mjs, as it is)
+ *
+ * Run (use an App Password, NOT your main password — Settings -> App Passwords):
+ *   BSKY_HANDLE=you.bsky.social BSKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx \
+ *     node bsky-post-with-facets.mjs
+ *
+ *   # Optional overrides:
+ *   BSKY_SERVICE=https://bsky.social   (default)
+ *   BSKY_TEXT="Your custom post with #tags, https://example.com and @someone.bsky.social"
+ */
+
+import { AtpAgent, RichText } from '@atproto/api'
+
+const {
+  BSKY_SERVICE = 'https://bsky.social',
+  BSKY_HANDLE,
+  BSKY_APP_PASSWORD,
+  BSKY_TEXT,
+} = process.env
+
+if (!BSKY_HANDLE || !BSKY_APP_PASSWORD) {
+  console.error(
+    'Missing credentials. Set BSKY_HANDLE and BSKY_APP_PASSWORD (an App Password).',
+  )
+  process.exit(1)
+}
+
+const text =
+  BSKY_TEXT ??
+  'Testing the API with a #hashtag, a link to https://atproto.com, and a mention of @bsky.app 🚀'
+
+async function main() {
+  // 1. Log in
+  const agent = new AtpAgent({ service: BSKY_SERVICE })
+  await agent.login({ identifier: BSKY_HANDLE, password: BSKY_APP_PASSWORD })
+  console.log(`Logged in as ${agent.session?.handle} (${agent.session?.did})`)
+
+  // 2. Build rich text and detect facets.
+  //    - detectFacets scans the text for tags / links / mentions
+  //    - passing `agent` lets it resolve @handles into DIDs (required for mentions)
+  const rt = new RichText({ text })
+  await rt.detectFacets(agent)
+
+  // 3. Show what the CLIENT computed — this is the piece a raw createRecord call omits.
+  console.log('\nText:', rt.text)
+  console.log('Detected facets:', JSON.stringify(rt.facets ?? [], null, 2))
+  if (!rt.facets?.length) {
+    console.log(
+      '(No facets detected — the post would render as plain, unclickable text.)',
+    )
+  }
+
+  // 4. Create the post WITH facets. Without `facets`, tags/links/mentions are plain text.
+  const res = await agent.post({
+    text: rt.text,
+    facets: rt.facets, // <-- the missing ingredient
+    createdAt: new Date().toISOString(),
+  })
+
+  // 5. Print a link to the created post.
+  const rkey = res.uri.split('/').pop()
+  console.log('\nPosted!')
+  console.log('  AT URI:', res.uri)
+  console.log('  CID   :', res.cid)
+  console.log(
+    `  Web   : https://bsky.app/profile/${agent.session?.handle}/post/${rkey}`,
+  )
+}
+
+main().catch((err) => {
+  console.error('\nFailed:', err?.message ?? err)
+  process.exit(1)
+})

--- a/packages/pds/src/api/com/atproto/repo/createRecord.ts
+++ b/packages/pds/src/api/com/atproto/repo/createRecord.ts
@@ -15,6 +15,7 @@ import {
   prepareCreate,
   prepareDelete,
 } from '../../../../repo/index.js'
+import { maybeEnrichPostFacets } from './detect-facets.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.repo.createRecord, {
@@ -69,6 +70,18 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const swapCommitCid = swapCommit ? parseCid(swapCommit) : undefined
+
+      // Opt-in (PDS_ENRICH_POST_FACETS): auto-populate facets for posts that
+      // arrive without them, so bare { text, createdAt } writes still render
+      // clickable #tags / links / @mentions. Off by default; facet detection is
+      // normally a client responsibility (see @atproto/api RichText).
+      if (ctx.cfg.service.enrichPostFacets) {
+        await maybeEnrichPostFacets(
+          collection,
+          record as Record<string, unknown>,
+          ctx.idResolver,
+        )
+      }
 
       let write: PreparedCreate
       try {

--- a/packages/pds/src/api/com/atproto/repo/detect-facets.ts
+++ b/packages/pds/src/api/com/atproto/repo/detect-facets.ts
@@ -1,0 +1,160 @@
+import type { IdResolver } from '@atproto/identity'
+
+/**
+ * Server-side facet detection for `app.bsky.feed.post` records.
+ *
+ * @NOTE This is OPT-IN (PDS_ENRICH_POST_FACETS) and diverges from atproto's
+ * design, in which facet detection is a client responsibility and the PDS stores
+ * records verbatim. It exists so a client that only sends `{ text, createdAt }`
+ * still gets clickable #hashtags, links, and @mentions. Prefer detecting facets
+ * on the client (see @atproto/api's RichText) whenever possible.
+ *
+ * The regexes and logic are copied from the client
+ * (packages/api/src/rich-text/{util,detection}.ts) so the server produces
+ * byte-identical facets. Facet indices are UTF-8 byte offsets, per the
+ * app.bsky.richtext.facet lexicon.
+ */
+
+const encoder = new TextEncoder()
+
+// utf16 (JS string) index -> utf8 byte index
+const utf8Len = (s: string): number => encoder.encode(s).byteLength
+const toByte = (text: string, utf16Index: number): number =>
+  utf8Len(text.slice(0, utf16Index))
+
+const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
+const URL_REGEX =
+  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
+const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
+// The `[#＃]` sigil is NON-capturing, so match[2] is the tag text.
+// `️` emoji modifier; `­⁠ ​‌‍⃢` zero-widths.
+// eslint-disable-next-line no-misleading-character-class
+const TAG_REGEX =
+  /(^|\s)[#＃]((?!️)[^\s­⁠ ​‌‍⃢]*[^\d\s\p{P}­⁠ ​‌‍⃢]+[^\s­⁠ ​‌‍⃢]*)?/gu
+
+type Facet = {
+  $type?: string
+  index: { byteStart: number; byteEnd: number }
+  features: Array<Record<string, unknown>>
+}
+
+const isValidTld = (str: string): boolean => {
+  // Lightweight validity check: a dotted host whose final label is 2+ letters.
+  // (The client validates against the full `tlds` list; we keep the PDS
+  // dependency-free and accept the small precision tradeoff.)
+  return /\.[a-z]{2,}$/i.test(str)
+}
+
+/**
+ * Detect link and hashtag facets from post text. Mentions are detected and
+ * returned with the *handle* in `did`; the caller must resolve them to DIDs.
+ */
+export function detectFacetsFromText(text: string): Facet[] {
+  const facets: Facet[] = []
+  let match: RegExpExecArray | null
+
+  // mentions (unresolved: `did` holds the handle for the caller to resolve)
+  const mentionRe = new RegExp(MENTION_REGEX)
+  while ((match = mentionRe.exec(text))) {
+    const handle = match[3]
+    if (!isValidTld(handle) && !handle.endsWith('.test')) continue
+    const start = text.indexOf(handle, match.index) - 1 // include the '@'
+    facets.push({
+      $type: 'app.bsky.richtext.facet',
+      index: {
+        byteStart: toByte(text, start),
+        byteEnd: toByte(text, start + handle.length + 1),
+      },
+      features: [{ $type: 'app.bsky.richtext.facet#mention', did: handle }],
+    })
+  }
+
+  // links
+  const urlRe = new RegExp(URL_REGEX)
+  while ((match = urlRe.exec(text))) {
+    let uri = match[2]
+    if (!uri.startsWith('http')) {
+      const domain = match.groups?.domain
+      if (!domain || !isValidTld(domain)) continue
+      uri = `https://${uri}`
+    }
+    const start = text.indexOf(match[2], match.index)
+    const index = { start, end: start + match[2].length }
+    if (/[.,;:!?]$/.test(uri)) {
+      uri = uri.slice(0, -1)
+      index.end--
+    }
+    if (/[)]$/.test(uri) && !uri.includes('(')) {
+      uri = uri.slice(0, -1)
+      index.end--
+    }
+    facets.push({
+      $type: 'app.bsky.richtext.facet',
+      index: {
+        byteStart: toByte(text, index.start),
+        byteEnd: toByte(text, index.end),
+      },
+      features: [{ $type: 'app.bsky.richtext.facet#link', uri }],
+    })
+  }
+
+  // hashtags (match[2] is the tag text; sigil is non-capturing)
+  const tagRe = new RegExp(TAG_REGEX)
+  while ((match = tagRe.exec(text))) {
+    const leading = match[1]
+    let tag = match[2]
+    if (!tag) continue
+    tag = tag.trim().replace(TRAILING_PUNCTUATION_REGEX, '')
+    // lexicon caps tags at maxGraphemes 64 / maxLength 640; a UTF-16 length
+    // guard is a conservative superset (grapheme count <= utf16 length).
+    if (tag.length === 0 || tag.length > 640) continue
+    const index = match.index + leading.length
+    facets.push({
+      $type: 'app.bsky.richtext.facet',
+      index: {
+        byteStart: toByte(text, index),
+        byteEnd: toByte(text, index + 1 + tag.length), // +1 for the sigil
+      },
+      features: [{ $type: 'app.bsky.richtext.facet#tag', tag }],
+    })
+  }
+
+  return facets
+}
+
+/**
+ * If `record` is an app.bsky.feed.post with text and no facets, populate its
+ * facets in place (resolving mention handles to DIDs). Returns the (possibly
+ * mutated) record. No-op for any other collection, or when facets already exist.
+ */
+export async function maybeEnrichPostFacets(
+  collection: string,
+  record: Record<string, unknown>,
+  idResolver: IdResolver,
+): Promise<Record<string, unknown>> {
+  if (collection !== 'app.bsky.feed.post') return record
+  if (typeof record.text !== 'string' || record.text.length === 0) return record
+  if (Array.isArray(record.facets) && record.facets.length > 0) return record
+
+  const facets = detectFacetsFromText(record.text)
+  if (facets.length === 0) return record
+
+  // Resolve mention handles -> DIDs; drop mentions that don't resolve.
+  const resolved: Facet[] = []
+  for (const facet of facets) {
+    const feature = facet.features[0]
+    if (feature?.$type === 'app.bsky.richtext.facet#mention') {
+      const did = await idResolver.handle
+        .resolve(feature.did as string)
+        .catch(() => undefined)
+      if (!did) continue // skip unresolvable mentions rather than write junk
+      feature.did = did
+    }
+    resolved.push(facet)
+  }
+  if (resolved.length === 0) return record
+
+  resolved.sort((a, b) => a.index.byteStart - b.index.byteStart)
+  record.facets = resolved
+  return record
+}

--- a/packages/pds/src/api/com/atproto/repo/detect-facets.ts
+++ b/packages/pds/src/api/com/atproto/repo/detect-facets.ts
@@ -26,11 +26,13 @@ const MENTION_REGEX = /(^|\s|\()(@)([a-zA-Z0-9.-]+)(\b)/g
 const URL_REGEX =
   /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/gim
 const TRAILING_PUNCTUATION_REGEX = /\p{P}+$/gu
-// The `[#＃]` sigil is NON-capturing, so match[2] is the tag text.
-// `️` emoji modifier; `­⁠ ​‌‍⃢` zero-widths.
-// eslint-disable-next-line no-misleading-character-class
+// The sigil (ascii `#` + fullwidth U+FF03) is NON-capturing, so match[2] is the
+// tag text. \ufe0f = emoji modifier; the rest are zero-width codepoints.
+// Zero-width/joiner codepoints in the class trip no-misleading-character-class;
+// they are intentional (matching the client), hence the disable below.
 const TAG_REGEX =
-  /(^|\s)[#＃]((?!️)[^\s­⁠ ​‌‍⃢]*[^\d\s\p{P}­⁠ ​‌‍⃢]+[^\s­⁠ ​‌‍⃢]*)?/gu
+  // eslint-disable-next-line no-misleading-character-class
+  /(^|\s)[#\uff03]((?!\ufe0f)[^\s\u00ad\u2060\u200a\u200b\u200c\u200d\u20e2]*[^\d\s\p{P}\u00ad\u2060\u200a\u200b\u200c\u200d\u20e2]+[^\s\u00ad\u2060\u200a\u200b\u200c\u200d\u20e2]*)?/gu
 
 type Facet = {
   $type?: string
@@ -48,14 +50,17 @@ const isValidTld = (str: string): boolean => {
 /**
  * Detect link and hashtag facets from post text. Mentions are detected and
  * returned with the *handle* in `did`; the caller must resolve them to DIDs.
+ *
+ * @NOTE synchronous by design: the module-level `g`-flag regexes have their
+ * `lastIndex` reset here, which is only safe with no interleaving await.
  */
 export function detectFacetsFromText(text: string): Facet[] {
   const facets: Facet[] = []
   let match: RegExpExecArray | null
 
   // mentions (unresolved: `did` holds the handle for the caller to resolve)
-  const mentionRe = new RegExp(MENTION_REGEX)
-  while ((match = mentionRe.exec(text))) {
+  MENTION_REGEX.lastIndex = 0
+  while ((match = MENTION_REGEX.exec(text))) {
     const handle = match[3]
     if (!isValidTld(handle) && !handle.endsWith('.test')) continue
     const start = text.indexOf(handle, match.index) - 1 // include the '@'
@@ -70,8 +75,8 @@ export function detectFacetsFromText(text: string): Facet[] {
   }
 
   // links
-  const urlRe = new RegExp(URL_REGEX)
-  while ((match = urlRe.exec(text))) {
+  URL_REGEX.lastIndex = 0
+  while ((match = URL_REGEX.exec(text))) {
     let uri = match[2]
     if (!uri.startsWith('http')) {
       const domain = match.groups?.domain
@@ -99,8 +104,8 @@ export function detectFacetsFromText(text: string): Facet[] {
   }
 
   // hashtags (match[2] is the tag text; sigil is non-capturing)
-  const tagRe = new RegExp(TAG_REGEX)
-  while ((match = tagRe.exec(text))) {
+  TAG_REGEX.lastIndex = 0
+  while ((match = TAG_REGEX.exec(text))) {
     const leading = match[1]
     let tag = match[2]
     if (!tag) continue

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -39,6 +39,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     maxImportSize: env.maxImportSize,
     blobUploadLimit: env.blobUploadLimit ?? 5 * 1024 * 1024, // 5mb
     devMode: env.devMode ?? false,
+    enrichPostFacets: env.enrichPostFacets ?? false,
   }
 
   const dbLoc = (name: string) => {
@@ -415,6 +416,7 @@ export type ServiceConfig = {
   blobUploadLimit: number
   contactEmailAddress?: string
   devMode: boolean
+  enrichPostFacets: boolean
 }
 
 export type DatabaseConfig = {

--- a/packages/pds/src/config/env.ts
+++ b/packages/pds/src/config/env.ts
@@ -18,6 +18,8 @@ export function readEnv() {
     maxImportSize: envInt('PDS_MAX_REPO_IMPORT_SIZE'),
     blobUploadLimit: envInt('PDS_BLOB_UPLOAD_LIMIT'),
     devMode: envBool('PDS_DEV_MODE'),
+    // Opt-in: server-side facet detection for posts written without facets.
+    enrichPostFacets: envBool('PDS_ENRICH_POST_FACETS'),
 
     // hCaptcha
     hcaptchaSiteKey: envStr('PDS_HCAPTCHA_SITE_KEY'),

--- a/packages/pds/tests/detect-facets.test.ts
+++ b/packages/pds/tests/detect-facets.test.ts
@@ -1,0 +1,125 @@
+import type { IdResolver } from '@atproto/identity'
+import {
+  detectFacetsFromText,
+  maybeEnrichPostFacets,
+} from '../src/api/com/atproto/repo/detect-facets.js'
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+// substring of `text` covered by a facet's utf8 byte range
+const sliceOf = (text: string, f: { index: { byteStart: number; byteEnd: number } }) =>
+  dec.decode(enc.encode(text).slice(f.index.byteStart, f.index.byteEnd))
+
+const typeOf = (f: { features: Array<Record<string, unknown>> }) =>
+  f.features[0].$type
+
+describe('detectFacetsFromText', () => {
+  it('returns [] when there is nothing to detect', () => {
+    expect(detectFacetsFromText('just some plain words here')).toEqual([])
+  })
+
+  it('detects a hashtag and stores the bare tag (byte range covers the #)', () => {
+    const text = 'hello #world'
+    const [facet] = detectFacetsFromText(text)
+    expect(typeOf(facet)).toBe('app.bsky.richtext.facet#tag')
+    expect(facet.features[0].tag).toBe('world')
+    expect(sliceOf(text, facet)).toBe('#world')
+  })
+
+  it('detects a link and normalizes bare domains to https', () => {
+    const text = 'see example.com for more'
+    const [facet] = detectFacetsFromText(text)
+    expect(typeOf(facet)).toBe('app.bsky.richtext.facet#link')
+    expect(facet.features[0].uri).toBe('https://example.com')
+    expect(sliceOf(text, facet)).toBe('example.com')
+  })
+
+  it('strips trailing punctuation from links', () => {
+    const text = 'read https://atproto.com.'
+    const [facet] = detectFacetsFromText(text)
+    expect(facet.features[0].uri).toBe('https://atproto.com')
+    expect(sliceOf(text, facet)).toBe('https://atproto.com')
+  })
+
+  it('keeps utf8 byte offsets correct when preceded by multi-byte text', () => {
+    const text = 'emoji 🎉🎉 then #café tail'
+    const [facet] = detectFacetsFromText(text)
+    expect(facet.features[0].tag).toBe('café')
+    // the byte range must still slice back to exactly "#café"
+    expect(sliceOf(text, facet)).toBe('#café')
+  })
+
+  it('detects a mention with the handle in `did` (unresolved)', () => {
+    const text = 'hi @alice.test how are you'
+    const [facet] = detectFacetsFromText(text)
+    expect(typeOf(facet)).toBe('app.bsky.richtext.facet#mention')
+    expect(facet.features[0].did).toBe('alice.test')
+    expect(sliceOf(text, facet)).toBe('@alice.test')
+  })
+
+  it('detects multiple hashtags', () => {
+    const facets = detectFacetsFromText('#one #two #three')
+    expect(facets.map((f) => f.features[0].tag)).toEqual(['one', 'two', 'three'])
+  })
+})
+
+describe('maybeEnrichPostFacets', () => {
+  const idResolver = {
+    handle: {
+      resolve: async (handle: string) =>
+        handle === 'alice.test' ? 'did:plc:alice' : undefined,
+    },
+  } as unknown as IdResolver
+
+  it('populates facets on a bare post record', async () => {
+    const record: Record<string, unknown> = {
+      $type: 'app.bsky.feed.post',
+      text: 'hello #world and https://atproto.com',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+    await maybeEnrichPostFacets('app.bsky.feed.post', record, idResolver)
+    expect(Array.isArray(record.facets)).toBe(true)
+    const facets = record.facets as Array<{ features: Array<{ $type: string }> }>
+    const types = facets.map((f) => f.features[0].$type)
+    expect(types).toContain('app.bsky.richtext.facet#tag')
+    expect(types).toContain('app.bsky.richtext.facet#link')
+  })
+
+  it('resolves mention handles to DIDs and drops unresolvable ones', async () => {
+    const record: Record<string, unknown> = {
+      text: 'hi @alice.test and @nobody.test',
+    }
+    await maybeEnrichPostFacets('app.bsky.feed.post', record, idResolver)
+    const facets = record.facets as Array<{
+      features: Array<{ $type: string; did?: string }>
+    }>
+    const mentions = facets.filter(
+      (f) => f.features[0].$type === 'app.bsky.richtext.facet#mention',
+    )
+    // alice resolves; nobody.test does not and is dropped
+    expect(mentions).toHaveLength(1)
+    expect(mentions[0].features[0].did).toBe('did:plc:alice')
+  })
+
+  it('is a no-op when facets are already present', async () => {
+    const existing = [{ marker: true }]
+    const record: Record<string, unknown> = {
+      text: 'hello #world',
+      facets: existing,
+    }
+    await maybeEnrichPostFacets('app.bsky.feed.post', record, idResolver)
+    expect(record.facets).toBe(existing)
+  })
+
+  it('is a no-op for non-post collections', async () => {
+    const record: Record<string, unknown> = { text: 'hello #world' }
+    await maybeEnrichPostFacets('app.bsky.feed.like', record, idResolver)
+    expect(record.facets).toBeUndefined()
+  })
+
+  it('is a no-op when the text has no facets', async () => {
+    const record: Record<string, unknown> = { text: 'plain words only' }
+    await maybeEnrichPostFacets('app.bsky.feed.post', record, idResolver)
+    expect(record.facets).toBeUndefined()
+  })
+})

--- a/packages/pds/tests/post-facet-enrichment.test.ts
+++ b/packages/pds/tests/post-facet-enrichment.test.ts
@@ -1,0 +1,93 @@
+import { AppBskyFeedPost, type AtpAgent } from '@atproto/api'
+import { TestNetworkNoAppView } from '@atproto/dev-env'
+
+// End-to-end coverage for the opt-in PDS_ENRICH_POST_FACETS behavior: a post
+// created via com.atproto.repo.createRecord with only { text, createdAt } should
+// come back with server-detected facets when the flag is on.
+describe('opt-in server-side post facet enrichment', () => {
+  let network: TestNetworkNoAppView
+  let agent: AtpAgent
+  let did: string
+
+  beforeAll(async () => {
+    network = await TestNetworkNoAppView.create({
+      dbPostgresSchema: 'post_facet_enrichment',
+      pds: { enrichPostFacets: true },
+    })
+    agent = network.pds.getAgent()
+    await agent.createAccount({
+      email: 'facets@test.com',
+      handle: 'facets.test',
+      password: 'facets-pass',
+    })
+    did = agent.assertDid
+  })
+
+  afterAll(async () => {
+    await network?.close()
+  })
+
+  const createPost = async (record: Record<string, unknown>) => {
+    const res = await agent.com.atproto.repo.createRecord({
+      repo: did,
+      collection: 'app.bsky.feed.post',
+      record: { $type: 'app.bsky.feed.post', ...record },
+    })
+    const got = await agent.com.atproto.repo.getRecord({
+      repo: did,
+      collection: 'app.bsky.feed.post',
+      rkey: res.data.uri.split('/').pop() as string,
+    })
+    return got.data.value as AppBskyFeedPost.Record
+  }
+
+  it('populates facets for a bare { text } post', async () => {
+    const value = await createPost({
+      text: 'hello #world see https://atproto.com',
+      createdAt: new Date().toISOString(),
+    })
+    expect(value.facets?.length).toBeGreaterThan(0)
+    const types = (value.facets ?? []).map((f) => f.features[0].$type)
+    expect(types).toContain('app.bsky.richtext.facet#tag')
+    expect(types).toContain('app.bsky.richtext.facet#link')
+  })
+
+  it('resolves a mention of a real account to its DID', async () => {
+    const value = await createPost({
+      text: 'talking to @facets.test today',
+      createdAt: new Date().toISOString(),
+    })
+    const mention = (value.facets ?? []).find(
+      (f) => f.features[0].$type === 'app.bsky.richtext.facet#mention',
+    )
+    expect(mention).toBeDefined()
+    expect((mention?.features[0] as { did: string }).did).toBe(did)
+  })
+
+  it('leaves a post that already supplies facets untouched', async () => {
+    const supplied = [
+      {
+        index: { byteStart: 0, byteEnd: 6 },
+        features: [{ $type: 'app.bsky.richtext.facet#tag', tag: 'world' }],
+      },
+    ]
+    const value = await createPost({
+      text: '#world and also example.com',
+      facets: supplied,
+      createdAt: new Date().toISOString(),
+    })
+    // untouched: still exactly the one facet the client supplied
+    expect(value.facets).toHaveLength(1)
+    expect(value.facets?.[0].features[0].$type).toBe(
+      'app.bsky.richtext.facet#tag',
+    )
+  })
+
+  it('adds no facets to plain text', async () => {
+    const value = await createPost({
+      text: 'just some plain words',
+      createdAt: new Date().toISOString(),
+    })
+    expect(value.facets).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Demonstrates that clickable #hashtags, links, and @mentions come from a client-generated `facets` array (via RichText.detectFacets), not from any server-side parsing. A raw createRecord with only { text, createdAt } renders tags/links as plain text; this example shows the missing facet-detection step.