### PR TITLE
Gate the new trending topics experiment

### DIFF
--- a/.changeset/tricky-trends-gate.md
+++ b/.changeset/tricky-trends-gate.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Gate the new trending topics experiment

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
@@ -25,7 +25,16 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
+      })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
       })
@@ -48,12 +57,19 @@ export default function (server: Server, ctx: AppContext) {
 const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
   const { params, ctx } = input
 
-  if (!ctx.topicsClient) {
+  // Route treatment users to iris (trending-topics v2), everyone else stays on
+  // the existing hot-topic service.
+  const useIris = params.hydrateCtx.features.checkGate(
+    params.hydrateCtx.features.Gate.TrendingTopicsV2,
+  )
+  const topicsClient = (useIris && ctx.irisClient) || ctx.topicsClient
+
+  if (!topicsClient) {
     // Use 501 instead of 500 as these are not considered retry-able by clients
     throw new MethodNotImplementedError('Topics agent not available')
   }
 
-  return ctx.topicsClient.call(
+  return topicsClient.call(
     app.bsky.unspecced.getTrendingTopics,
     {
       limit: params.limit,
@@ -86,6 +102,7 @@ type Context = {
   hydrator: Hydrator
   views: Views
   topicsClient: Client | undefined
+  irisClient: Client | undefined
 }
 
 type Params = Omit<app.bsky.unspecced.getTrendingTopics.$Params, 'viewer'> & {

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -24,7 +24,16 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
+      })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
         'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
@@ -50,12 +59,19 @@ export default function (server: Server, ctx: AppContext) {
 const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
   const { params, ctx } = input
 
-  if (!ctx.topicsClient) {
+  // Route treatment users to iris (trending-topics v2), everyone else stays on
+  // the existing hot-topic service.
+  const useIris = params.hydrateCtx.features.checkGate(
+    params.hydrateCtx.features.Gate.TrendingTopicsV2,
+  )
+  const topicsClient = (useIris && ctx.irisClient) || ctx.topicsClient
+
+  if (!topicsClient) {
     // Use 501 instead of 500 as these are not considered retry-able by clients
     throw new MethodNotImplementedError('Topics agent not available')
   }
 
-  const skeleton = await ctx.topicsClient.call(
+  const skeleton = await topicsClient.call(
     app.bsky.unspecced.getTrendsSkeleton,
     {
       limit: params.limit,
@@ -134,6 +150,7 @@ type Context = {
   hydrator: Hydrator
   views: Views
   topicsClient: Client | undefined
+  irisClient: Client | undefined
 }
 
 type Params = app.bsky.unspecced.getTrendingTopics.$Params & {

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -68,6 +68,7 @@ export interface ServerConfigValues {
   suggestionsApiKey?: string
   topicsUrl?: string
   topicsApiKey?: string
+  irisUrl?: string
   cdnUrl?: string
   videoPlaylistUrlPattern?: string
   videoThumbnailUrlPattern?: string
@@ -171,6 +172,7 @@ export class ServerConfig {
     const suggestionsApiKey = process.env.BSKY_SUGGESTIONS_API_KEY || undefined
     const topicsUrl = process.env.BSKY_TOPICS_URL || undefined
     const topicsApiKey = process.env.BSKY_TOPICS_API_KEY
+    const irisUrl = process.env.BSKY_IRIS_URL || undefined
     const dataplaneUrls =
       overrides?.dataplaneUrls ?? envList(process.env.BSKY_DATAPLANE_URLS)
     const dataplaneUrlsEtcdKeyPrefix =
@@ -363,6 +365,7 @@ export class ServerConfig {
       suggestionsApiKey,
       topicsUrl,
       topicsApiKey,
+      irisUrl,
       didPlcUrl,
       labelsFromIssuerDids,
       handleResolveNameservers,
@@ -547,6 +550,10 @@ export class ServerConfig {
 
   get topicsApiKey() {
     return this.cfg.topicsApiKey
+  }
+
+  get irisUrl() {
+    return this.cfg.irisUrl
   }
 
   get cdnUrl() {

--- a/packages/bsky/src/context.ts
+++ b/packages/bsky/src/context.ts
@@ -33,6 +33,7 @@ export class AppContext {
       searchClient: Client | undefined
       suggestionsClient: Client | undefined
       topicsClient: Client | undefined
+      irisClient: Client | undefined
       hydrator: Hydrator
       views: Views
       signingKey: Keypair
@@ -74,6 +75,10 @@ export class AppContext {
 
   get topicsClient(): Client | undefined {
     return this.opts.topicsClient
+  }
+
+  get irisClient(): Client | undefined {
+    return this.opts.irisClient
   }
 
   get hydrator(): Hydrator {

--- a/packages/bsky/src/feature-gates/gates.ts
+++ b/packages/bsky/src/feature-gates/gates.ts
@@ -12,6 +12,7 @@ export enum Gate {
   SuggestedUsersForDiscoverEnable = 'suggested_users:for_discover:enable',
   SuggestedUsersForSeeMoreEnable = 'suggested_users:for_see_more:enable',
   SearchV2Enable = 'search:v2:enable',
+  TrendingTopicsV2 = 'trending_topics_v2',
 
   // temp
   AATest = 'aa-test-appview',

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -145,6 +145,19 @@ export class BskyAppView {
         )
       : undefined
 
+    const irisClient = config.irisUrl
+      ? new Client(
+          {
+            service: config.irisUrl,
+          },
+          {
+            // Trust internal services to send us well-formed responses
+            strictResponseProcessing: false,
+            validateResponse: config.debugMode,
+          },
+        )
+      : undefined
+
     const etcd = config.etcdHosts.length
       ? new Etcd3({ hosts: config.etcdHosts })
       : undefined
@@ -236,6 +249,7 @@ export class BskyAppView {
       searchClient,
       suggestionsClient,
       topicsClient,
+      irisClient,
       hydrator,
       views,
       signingKey,


### PR DESCRIPTION
This PR adds a gate to the new trending topics experiments (`trending_topics_v2` on GrowthBook). Implemented as descibed in ALG-133:

1. `BSKY_IRIS_URL` pointing to Iris
2. Create an Iris client in `atproto/bsky` repo using that URL
3. Use Growthbook to gate the listing of trending topics to Iris or legacy

The view of the trending topics feed is not changed (the new `app.bsky.feed.generator` records will point directly to Iris).
