### PR TITLE
oauth: show connected app permission details

### DIFF
--- a/.changeset/calm-apps-review.md
+++ b/.changeset/calm-apps-review.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Show each connected app's granted OAuth permissions before access is revoked.

--- a/packages/oauth/oauth-provider-ui/src/components/oauth-session-details-dialog.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/oauth-session-details-dialog.tsx
@@ -1,0 +1,76 @@
+import { Trans } from '@lingui/react/macro'
+import { type ReactNode, useState } from 'react'
+import { Button } from '#/components/forms/button.tsx'
+import { SmartForm } from '#/components/forms/smart-form.tsx'
+import { DialogSimple } from '#/components/utils/dialog-simple.tsx'
+import { ScopeDescription } from '#/components/utils/scope-description.tsx'
+
+export type OAuthSessionDetailsDialogProps = {
+  clientName: string
+  clientIdentifier: string
+  scope?: string
+  onRevoke: () => void | PromiseLike<void>
+  children: Exclude<ReactNode, false | null | undefined>
+}
+
+export function OAuthSessionDetailsDialog({
+  clientName,
+  clientIdentifier,
+  scope,
+  onRevoke,
+  children,
+}: OAuthSessionDetailsDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const hasIdentityOnlyAccess = !scope || scope === 'atproto'
+
+  return (
+    <DialogSimple
+      trigger={children}
+      title={clientName}
+      description={clientIdentifier}
+      open={open}
+      onOpenChange={setOpen}
+      dismissable={!submitting}
+    >
+      <SmartForm
+        submitColor="error"
+        submitLabel={<Trans context="OAuthApp">Revoke access</Trans>}
+        actions={
+          <Button
+            autoFocus
+            disabled={submitting}
+            onClick={() => setOpen(false)}
+          >
+            <Trans>Close</Trans>
+          </Button>
+        }
+        onLoadingChange={setSubmitting}
+        validate={() => ({})}
+        handler={async () => {
+          await onRevoke()
+          setOpen(false)
+        }}
+        fields={() =>
+          hasIdentityOnlyAccess ? (
+            <p>
+              <Trans>
+                This app can uniquely identify you through your account.
+              </Trans>
+            </p>
+          ) : (
+            <>
+              <p>
+                <Trans>
+                  This app has access to your account with the following
+                  permissions:
+                </Trans>
+              </p>
+              <ScopeDescription scope={scope} />
+            </>
+          )
+        }
+      />
+    </DialogSimple>
+  )
+}

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -187,7 +187,7 @@ msgstr "Any service"
 msgid "Apps"
 msgstr "Apps"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 
@@ -327,6 +327,7 @@ msgstr "Choose a username"
 msgid "Click here if nothing happens"
 msgstr "Click here if nothing happens"
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr "Close"
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr "Deny access"
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr "Details"
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr "Failed to delete account"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "Failed to load connected apps"
 
@@ -712,7 +714,7 @@ msgstr "Invalid Handle"
 msgid "Invite code"
 msgstr "Invite code"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "It appears that you haven’t used this account to sign in to any apps yet."
 
@@ -993,7 +995,7 @@ msgid "Reset your password"
 msgstr "Reset your password"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr "Retry"
@@ -1002,7 +1004,7 @@ msgstr "Retry"
 msgid "Retry in {remainingSeconds}s"
 msgstr "Retry in {remainingSeconds}s"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr "Revoke access"
@@ -1165,9 +1167,17 @@ msgstr "The username is invalid"
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr "There is no time limit for account deactivation, come back any time."
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
 msgstr "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr "This app can uniquely identify you through your account."
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
+msgstr "This app has access to your account with the following permissions:"
 
 #: src/components/consent-form.tsx:142
 msgid "This application is requesting the following permissions (scopes) to access your account:"

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -187,7 +187,7 @@ msgstr "Cualquier servicio"
 msgid "Apps"
 msgstr ""
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr ""
 
@@ -327,6 +327,7 @@ msgstr "Elige un nombre de usuario"
 msgid "Click here if nothing happens"
 msgstr ""
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr ""
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr ""
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr ""
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr ""
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "Error al cargar las aplicaciones conectadas"
 
@@ -702,7 +704,7 @@ msgstr ""
 msgid "Invite code"
 msgstr "Código de invitación"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "Parece que aún no has usado esta cuenta para iniciar sesión en ninguna aplicación."
 
@@ -983,7 +985,7 @@ msgid "Reset your password"
 msgstr "Restablecer tu contraseña"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr ""
@@ -992,7 +994,7 @@ msgstr ""
 msgid "Retry in {remainingSeconds}s"
 msgstr ""
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr ""
@@ -1155,8 +1157,16 @@ msgstr ""
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr ""
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
+msgstr ""
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr ""
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
 msgstr ""
 
 #: src/components/consent-form.tsx:142

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -187,7 +187,7 @@ msgstr "N'importe quel service"
 msgid "Apps"
 msgstr "Applications"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr "Les applications peuvent accéder à votre compte en arrière-plan (pour vérifier les notifications, synchroniser les données, etc.) même lorsque vous ne les utilisez pas activement. C'est un comportement normal qui sera reflété dans l'heure de \"dernier accès\" affichée ci-dessus."
 
@@ -327,6 +327,7 @@ msgstr "Choisissez un nom d'utilisateur"
 msgid "Click here if nothing happens"
 msgstr "Cliquez ici si rien ne se passe"
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr "Fermer"
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr "Refuser l'accès"
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr "Détails"
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr "Échec de la suppression du compte"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "Échec du chargement des applications connectées"
 
@@ -712,7 +714,7 @@ msgstr "Pseudo invalide"
 msgid "Invite code"
 msgstr "Code d'invitation"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "Il semble que vous n'ayez pas encore utilisé ce compte pour vous connecter à des applications."
 
@@ -993,7 +995,7 @@ msgid "Reset your password"
 msgstr "Réinitialisez votre mot de passe"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr "Réessayer"
@@ -1002,7 +1004,7 @@ msgstr "Réessayer"
 msgid "Retry in {remainingSeconds}s"
 msgstr "Réessayer dans {remainingSeconds}s"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr "Révoquer l'accès"
@@ -1165,9 +1167,17 @@ msgstr "Le nom d'utilisateur est invalide"
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr "Il n'y a pas de limite de temps pour la désactivation du compte, revenez quand vous le souhaitez."
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
 msgstr "Ces applications ont accès à votre compte. Une application peut apparaître plusieurs fois si vous l'utilisez sur différents appareils. Vous pouvez révoquer l'accès pour déconnecter l'application jusqu'à ce que vous vous reconnectiez."
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr "Cette application peut vous identifier de manière unique grâce à votre compte."
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
+msgstr "Cette application a accès à votre compte avec les autorisations suivantes :"
 
 #: src/components/consent-form.tsx:142
 msgid "This application is requesting the following permissions (scopes) to access your account:"

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -187,7 +187,7 @@ msgstr "すべてのサービス"
 msgid "Apps"
 msgstr "アプリ"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr "アプリは、あなたが積極的に使用していないときでも、バックグラウンドであなたのアカウントにアクセスすることがあります（通知の確認、データの同期など）。これは正常な動作であり、上記に表示されている「最終アクセス」時間が更新されます。"
 
@@ -327,6 +327,7 @@ msgstr "ユーザー名を選んでください"
 msgid "Click here if nothing happens"
 msgstr "何も起こらない場合はここをクリックしてください"
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr "閉じる"
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr "アクセスを拒否"
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr "詳細"
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr "アカウントの削除に失敗しました"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "接続されたアプリの読み込みに失敗しました"
 
@@ -712,7 +714,7 @@ msgstr "無効なハンドル"
 msgid "Invite code"
 msgstr "招待コード"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "このアカウントをアプリにサインインするためにまだ使用していないようです。"
 
@@ -993,7 +995,7 @@ msgid "Reset your password"
 msgstr "パスワードをリセット"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr "再試行"
@@ -1002,7 +1004,7 @@ msgstr "再試行"
 msgid "Retry in {remainingSeconds}s"
 msgstr "{remainingSeconds}秒後に再試行"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr "アクセスを取り消す"
@@ -1165,9 +1167,17 @@ msgstr "ユーザー名が無効です"
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr "アカウントの無効化に期限はありません。いつでも戻ってこられます。"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
 msgstr "これらのアプリはあなたのアカウントにアクセスできます。異なるデバイスで使用している場合、アプリが複数回表示されることがあります。アクセスを取り消すと、再度サインインするまでアプリがログアウトされます。"
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr ""
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
+msgstr ""
 
 #: src/components/consent-form.tsx:142
 msgid "This application is requesting the following permissions (scopes) to access your account:"

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -187,7 +187,7 @@ msgstr "모든 서비스"
 msgid "Apps"
 msgstr "앱"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr "앱은 사용자가 앱을 적극적으로 사용하지 않을 때에도 백그라운드에서 계정에 접근할 수 있습니다. (알림 확인, 데이터 동기화 등) 이는 정상적인 동작이며, 위에 표시된 ‘마지막 접근’ 시간이 업데이트됩니다."
 
@@ -327,6 +327,7 @@ msgstr "사용자 이름 선택"
 msgid "Click here if nothing happens"
 msgstr ""
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr ""
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr "접근 거부"
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr "세부 정보"
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr ""
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "연결된 앱을 불러오지 못했습니다"
 
@@ -702,7 +704,7 @@ msgstr ""
 msgid "Invite code"
 msgstr "초대 코드"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "이 계정으로 아직 어떤 앱에도 로그인한 적이 없는 것 같습니다."
 
@@ -983,7 +985,7 @@ msgid "Reset your password"
 msgstr "비밀번호 재설정"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr "다시 시도"
@@ -992,7 +994,7 @@ msgstr "다시 시도"
 msgid "Retry in {remainingSeconds}s"
 msgstr "{remainingSeconds}초 후에 다시 시도"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr "접근 권한 취소"
@@ -1155,9 +1157,17 @@ msgstr ""
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr ""
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
 msgstr "이 앱은 내 계정에 대한 접근 권한을 가지고 있습니다. 여러 기기에서 동일한 앱을 사용하는 경우 동일한 앱이 여러 번 나타날 수 있습니다. 접근 권한을 취소하면 다시 로그인할 때까지 앱에서 로그아웃됩니다."
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr ""
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
+msgstr ""
 
 #: src/components/consent-form.tsx:142
 msgid "This application is requesting the following permissions (scopes) to access your account:"

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -187,7 +187,7 @@ msgstr "Vilken tjänst som helst"
 msgid "Apps"
 msgstr "Appar"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:58
+#: src/pages/account/(authenticated)/apps/page.tsx:59
 msgid "Apps may access your account in the background (to check notifications, sync data, etc.) even when you're not actively using them. This is normal behavior and will update the \"last accessed\" time shown above."
 msgstr "Appar kan utföra aktiviteter på ditt konto i bakgrunden (t.ex. för att titta efter notiser eller synkronisera data) även när du själv inte använder dem aktivt. Det är en normal företeelse som också påverkar tidsangivelserna för ”senaste aktivitet” ovan."
 
@@ -327,6 +327,7 @@ msgstr "Välj ett användarnamn"
 msgid "Click here if nothing happens"
 msgstr "Klicka här om ingenting händer"
 
+#: src/components/oauth-session-details-dialog.tsx:45
 #: src/components/utils/dialog-simple.tsx:70
 msgid "Close"
 msgstr "Stäng"
@@ -430,6 +431,7 @@ msgctxt "OAuthConsent"
 msgid "Deny access"
 msgstr "Neka åtkomst"
 
+#: src/pages/account/(authenticated)/apps/page.tsx:131
 #: src/components/utils/description-card.tsx:70
 msgid "Details"
 msgstr "Detaljer"
@@ -549,7 +551,7 @@ msgid "Failed to delete account"
 msgstr "Det gick inte att radera kontot"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:36
-#: src/pages/account/(authenticated)/apps/page.tsx:34
+#: src/pages/account/(authenticated)/apps/page.tsx:35
 msgid "Failed to load connected apps"
 msgstr "Det gick inte att läsa in anslutna appar"
 
@@ -712,7 +714,7 @@ msgstr "Ogiltigt användarnamn"
 msgid "Invite code"
 msgstr "Inbjudningskod"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:68
+#: src/pages/account/(authenticated)/apps/page.tsx:69
 msgid "It appears that you haven’t used this account to sign in to any apps yet."
 msgstr "Det verkar som att du inte har använt det här kontot för att logga in på någon app ännu."
 
@@ -993,7 +995,7 @@ msgid "Reset your password"
 msgstr "Återställ ditt lösenord"
 
 #: src/pages/account/(authenticated)/devices/page.tsx:32
-#: src/pages/account/(authenticated)/apps/page.tsx:30
+#: src/pages/account/(authenticated)/apps/page.tsx:31
 #: src/components/utils/error-card.tsx:85
 msgid "Retry"
 msgstr "Försök igen"
@@ -1002,7 +1004,7 @@ msgstr "Försök igen"
 msgid "Retry in {remainingSeconds}s"
 msgstr "Försök igen om {remainingSeconds} s"
 
-#: src/pages/account/(authenticated)/apps/page.tsx:132
+#: src/components/oauth-session-details-dialog.tsx:38
 msgctxt "OAuthApp"
 msgid "Revoke access"
 msgstr "Återkalla åtkomst"
@@ -1165,9 +1167,17 @@ msgstr "Användarnamnet är ogiltigt"
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr "Det finns ingen gräns för hur länge ett konto kan vara inaktiverat. Kom tillbaka när du vill."
 
-#: src/pages/account/(authenticated)/apps/page.tsx:42
+#: src/pages/account/(authenticated)/apps/page.tsx:43
 msgid "These apps have access to your account. An app may appear multiple times if you use it on different devices. You can revoke access to log out the app until you sign in again."
 msgstr "De här apparna har åtkomst till ditt konto. En app kan visas flera gånger om du använder den på olika enheter. Återkalla åtkomsten för att logga ut dig själv från appen. Därefter kan du ge ny åtkomst genom att logga in igen."
+
+#: src/components/oauth-session-details-dialog.tsx:57
+msgid "This app can uniquely identify you through your account."
+msgstr ""
+
+#: src/components/oauth-session-details-dialog.tsx:64
+msgid "This app has access to your account with the following permissions:"
+msgstr ""
 
 #: src/components/consent-form.tsx:142
 msgid "This application is requesting the following permissions (scopes) to access your account:"

--- a/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/apps/page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/apps/page.tsx
@@ -1,6 +1,7 @@
 import { Trans, useLingui } from '@lingui/react/macro'
 import type { ActiveOAuthSession, DidString } from '@atproto/oauth-provider-api'
 import { Button } from '#/components/forms/button'
+import { OAuthSessionDetailsDialog } from '#/components/oauth-session-details-dialog.tsx'
 import { Admonition, AdmonitionAction } from '#/components/utils/admonition.tsx'
 import { CircularProgress } from '#/components/utils/circular-progress'
 import { DateAgo } from '#/components/utils/date-ago'
@@ -80,7 +81,7 @@ function ApplicationSessionCard({
     tokenId,
     createdAt,
     updatedAt,
-    scope: _scope = clientMetadata?.scope, // @TODO Display scopes using <ScopeDescription />
+    scope = clientMetadata?.scope,
   },
   did,
 }: {
@@ -88,8 +89,7 @@ function ApplicationSessionCard({
   did: DidString
 }) {
   const { i18n } = useLingui()
-  const { mutateAsync: revokeSessions, isPending } =
-    useRevokeOAuthSessionMutation()
+  const { mutateAsync: revokeSession } = useRevokeOAuthSessionMutation()
 
   const friendlyClientId = useOAuthClientIdentifier({
     clientId,
@@ -119,18 +119,18 @@ function ApplicationSessionCard({
           </Trans>
         </p>
       </div>
-      <Button
-        size="sm"
-        className="min-w-max shrink-0 grow-0"
-        loading={isPending}
-        onClick={(_event) => {
-          void revokeSessions({ did, tokenId }).catch((err) => {
-            console.warn('Failed to revoke OAuth session', err)
-          })
+      <OAuthSessionDetailsDialog
+        clientName={clientName}
+        clientIdentifier={friendlyClientId}
+        scope={scope}
+        onRevoke={async () => {
+          await revokeSession({ did, tokenId })
         }}
       >
-        <Trans context="OAuthApp">Revoke access</Trans>
-      </Button>
+        <Button size="sm" className="min-w-max shrink-0 grow-0">
+          <Trans>Details</Trans>
+        </Button>
+      </OAuthSessionDetailsDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- replace the connected-app list's immediate revoke action with a `Details` dialog
- reuse `ScopeDescription` so users can review the OAuth permissions they previously granted
- keep revocation in the details dialog as a two-action flow, with safe initial focus, pending-state locking, and existing form error handling
- add the generated locale updates, required French translations, and a patch changeset

The existing session API already exposes the granted scope string, so this stays UI-only: no API, schema, primitive, or dependency changes.

Closes #4838.

## Behavior

For granular scopes, the dialog reuses the same permission-card component used by the authorization screen. Identity-only `atproto` sessions receive a short explanation because `ScopeDescription` intentionally omits a card for that base scope.

`Close` receives initial focus. Selecting `Revoke access` disables every dialog action while the mutation is pending; success closes the dialog and removes the session, while failures remain visible through `SmartForm`.

## Validation

```sh
pnpm --dir packages/oauth/oauth-provider-ui i18n
pnpm --dir packages/oauth/oauth-provider-ui exec tsgo --build tsconfig.json
pnpm exec eslint \
  packages/oauth/oauth-provider-ui/src/components/oauth-session-details-dialog.tsx \
  'packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/apps/page.tsx'
pnpm --dir packages/oauth/oauth-provider-ui exec prettier --check \
  src/components/oauth-session-details-dialog.tsx \
  'src/pages/account/(authenticated)/apps/page.tsx'
pnpm --dir packages/oauth/oauth-provider-ui build
pnpm changeset status
```

Production build result: 5,041 modules transformed successfully.

The mock account UI was also exercised end to end at a narrow viewport:

- Details rendered Bluesky, Chat, Repository, and Authenticate permission groups
- Close had initial focus and exited without revoking
- Revoke locked all controls while pending, closed on success, removed the app card, and showed the empty state

## AI assistance

OpenAI Codex assisted with implementation, duplicate checks, validation, and the initial PR description. The commit includes explicit co-author attribution.
