### PR TITLE
Sanitize bidi control characters in display names

### DIFF
--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -14,6 +14,7 @@ import {
   type DidString,
   INVALID_HANDLE,
   normalizeDatetimeAlways,
+  stripBidiControls,
 } from '@atproto/syntax'
 import type { Actor, ProfileViewerState } from '../hydration/actor.js'
 import {
@@ -389,7 +390,9 @@ export class Views {
     return {
       did,
       handle: actor.handle ?? INVALID_HANDLE,
-      displayName: actor.profile?.displayName,
+      displayName:
+        actor.profile?.displayName &&
+        stripBidiControls(actor.profile.displayName),
       pronouns: actor.profile?.pronouns,
       avatar: actor.profile?.avatar
         ? this.imgUriBuilder.getPresetUri(
@@ -581,7 +584,9 @@ export class Views {
 
         return {
           issuer,
-          issuerDisplayName: issuerActor?.profile?.displayName,
+          issuerDisplayName:
+            issuerActor?.profile?.displayName &&
+            stripBidiControls(issuerActor.profile.displayName),
           issuerHandle: issuerActor?.handle,
           uri,
           isValid,

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -387,12 +387,11 @@ export class Views {
         record: actor.profile,
       }),
     ]
+    const rawDisplayName = actor.profile?.displayName
     return {
       did,
       handle: actor.handle ?? INVALID_HANDLE,
-      displayName:
-        actor.profile?.displayName &&
-        stripBidiControls(actor.profile.displayName),
+      displayName: rawDisplayName && stripBidiControls(rawDisplayName),
       pronouns: actor.profile?.pronouns,
       avatar: actor.profile?.avatar
         ? this.imgUriBuilder.getPresetUri(
@@ -581,12 +580,12 @@ export class Views {
         // Expose the *issuer's* current handle/displayName, sourced from the
         // issuer's hydrated actor record (see `Hydrator.hydrateProfiles`).
         const issuerActor = state.actors?.get(issuer)
+        const rawIssuerDisplayName = issuerActor?.profile?.displayName
 
         return {
           issuer,
           issuerDisplayName:
-            issuerActor?.profile?.displayName &&
-            stripBidiControls(issuerActor.profile.displayName),
+            rawIssuerDisplayName && stripBidiControls(rawIssuerDisplayName),
           issuerHandle: issuerActor?.handle,
           uri,
           isValid,

--- a/packages/bsky/tests/views/profile.test.ts
+++ b/packages/bsky/tests/views/profile.test.ts
@@ -144,6 +144,32 @@ describe('pds profile views', () => {
     expect(forSnapshot(res.data)).toMatchSnapshot()
   })
 
+  it('strips bidi control characters from displayName (#1480)', async () => {
+    const rlo = String.fromCodePoint(0x202e)
+    const maliciousDisplayName = `Carol${rlo}redaeR ykseulB`
+
+    await sc.createAccount('carol-bidi', {
+      handle: 'carol-bidi.test',
+      email: 'carol-bidi@test.com',
+      password: 'carol-bidi-pass',
+    })
+    await sc.createProfile(sc.dids['carol-bidi'], maliciousDisplayName)
+    await network.processAll()
+
+    const res = await agent.api.app.bsky.actor.getProfile(
+      { actor: sc.dids['carol-bidi'] },
+      {
+        headers: await network.serviceHeaders(
+          alice,
+          ids.AppBskyActorGetProfile,
+        ),
+      },
+    )
+
+    expect(res.data.displayName).toBe('CarolredaeR ykseulB')
+    expect(res.data.displayName).not.toContain(rlo)
+  })
+
   it('reflects self-labels', async () => {
     const aliceForBob = await agent.api.app.bsky.actor.getProfile(
       { actor: alice },

--- a/packages/bsky/tests/views/profile.test.ts
+++ b/packages/bsky/tests/views/profile.test.ts
@@ -153,7 +153,7 @@ describe('pds profile views', () => {
       email: 'carol-bidi@test.com',
       password: 'carol-bidi-pass',
     })
-    await sc.createProfile(sc.dids['carol-bidi'], maliciousDisplayName)
+    await sc.createProfile(sc.dids['carol-bidi'], maliciousDisplayName, '')
     await network.processAll()
 
     const res = await agent.api.app.bsky.actor.getProfile(

--- a/packages/pds/src/read-after-write/viewer.ts
+++ b/packages/pds/src/read-after-write/viewer.ts
@@ -4,6 +4,7 @@ import {
   type DidString,
   type HandleString,
   INVALID_HANDLE,
+  stripBidiControls,
 } from '@atproto/syntax'
 import { createServiceAuthHeaders } from '@atproto/xrpc-server'
 import type { AccountManager } from '../account-manager/account-manager.js'
@@ -73,7 +74,8 @@ export class LocalViewer {
     return {
       did: this.did,
       handle: (accountRes.handle ?? INVALID_HANDLE) as HandleString,
-      displayName: profileRes?.displayName,
+      displayName:
+        profileRes?.displayName && stripBidiControls(profileRes.displayName),
       avatar: profileRes?.avatar
         ? this.getImageUrl('avatar', getBlobCidString(profileRes.avatar))
         : undefined,
@@ -257,7 +259,7 @@ export class LocalViewer {
   >(view: T, record: app.bsky.actor.profile.Main): T {
     return {
       ...view,
-      displayName: record.displayName,
+      displayName: record.displayName && stripBidiControls(record.displayName),
       avatar: record.avatar
         ? this.getImageUrl('avatar', getBlobCidString(record.avatar))
         : undefined,

--- a/packages/syntax/src/bidi.ts
+++ b/packages/syntax/src/bidi.ts
@@ -1,0 +1,20 @@
+// Directional embedding/override/isolate characters. These can make text
+// render in an order different from its logical character order, the
+// mechanism behind the "Trojan Source" disclosure (CVE-2021-42574) and the
+// class of bug reported in bluesky-social/atproto#1480, where a display
+// name containing one of these characters made notification text render in
+// a confusing or reversed direction for other users.
+//
+// Single-character directional *marks* (U+200E LRM, U+200F RLM, U+061C ALM)
+// are intentionally excluded: they have no reordering power on their own,
+// and real Arabic/Hebrew text can legitimately contain them.
+const BIDI_CONTROL_CHARS = /[\u202A-\u202E\u2066-\u2069]/
+const BIDI_CONTROL_CHARS_G = /[\u202A-\u202E\u2066-\u2069]/g
+
+export function hasBidiControls(input: string): boolean {
+  return BIDI_CONTROL_CHARS.test(input)
+}
+
+export function stripBidiControls(input: string): string {
+  return input.replace(BIDI_CONTROL_CHARS_G, '')
+}

--- a/packages/syntax/src/index.ts
+++ b/packages/syntax/src/index.ts
@@ -1,5 +1,6 @@
 export * from './at-identifier.js'
 export * from './aturi.js'
+export * from './bidi.js'
 export * from './datetime.js'
 export * from './did.js'
 export * from './handle.js'

--- a/packages/syntax/tests/bidi.test.ts
+++ b/packages/syntax/tests/bidi.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasBidiControls, stripBidiControls } from '../src/index.js'
+
+// Fixtures are built from code points, never typed as literal invisible
+// characters in this file, matching the reasoning in src/bidi.ts.
+const RLO = String.fromCodePoint(0x202e)
+const LRE = String.fromCodePoint(0x202a)
+const RLE = String.fromCodePoint(0x202b)
+const PDF = String.fromCodePoint(0x202c)
+const LRO = String.fromCodePoint(0x202d)
+const LRI = String.fromCodePoint(0x2066)
+const RLI = String.fromCodePoint(0x2067)
+const FSI = String.fromCodePoint(0x2068)
+const PDI = String.fromCodePoint(0x2069)
+const LRM = String.fromCodePoint(0x200e)
+const RLM = String.fromCodePoint(0x200f)
+const ALM = String.fromCodePoint(0x061c)
+
+describe('hasBidiControls', () => {
+  it('is false for plain ASCII text', () => {
+    expect(hasBidiControls('Alice')).toBe(false)
+  })
+
+  it('is false for real Arabic text with legitimate direction marks', () => {
+    expect(hasBidiControls(`price: 100${LRM}${RLM} ريال${ALM}`)).toBe(false)
+  })
+
+  it('is true for the exact character from atproto#1480', () => {
+    expect(hasBidiControls(`Alice${RLO}redaeR yekulB`)).toBe(true)
+  })
+
+  it('is true for every embedding, override, and isolate control character', () => {
+    for (const char of [LRE, RLE, PDF, LRO, RLO, LRI, RLI, FSI, PDI]) {
+      expect(hasBidiControls(`a${char}b`)).toBe(true)
+    }
+  })
+})
+
+describe('stripBidiControls', () => {
+  it('leaves plain text unchanged', () => {
+    expect(stripBidiControls('Alice')).toBe('Alice')
+  })
+
+  it('removes the override character so notification text cannot be spoofed', () => {
+    const malicious = `Alice${RLO}redaeR yekulB`
+    const cleaned = stripBidiControls(malicious)
+    expect(cleaned).toBe('AliceredaeR yekulB')
+    expect(hasBidiControls(cleaned)).toBe(false)
+  })
+
+  it('removes every embedding, override, and isolate control character', () => {
+    for (const char of [LRE, RLE, PDF, LRO, RLO, LRI, RLI, FSI, PDI]) {
+      expect(stripBidiControls(`a${char}b`)).toBe('ab')
+    }
+  })
+
+  it('never strips legitimate direction marks, real RTL text must survive intact', () => {
+    const input = `price: 100${LRM}${RLM} ريال${ALM}`
+    expect(stripBidiControls(input)).toBe(input)
+  })
+
+  it('is idempotent', () => {
+    const once = stripBidiControls(`a${RLO}b`)
+    expect(stripBidiControls(once)).toBe(once)
+  })
+})


### PR DESCRIPTION
Fixes #1480

## Problem

`displayName` records are validated only for length (`maxGraphemes`,
`maxLength`), there is no character-level validation. A display name
containing a bidi embedding/override character (for example U+202E
RIGHT-TO-LEFT OVERRIDE) is accepted as-is and served unchanged, so
notification text and verification-badge text built from that display
name can render in a confusing or reversed direction for other users.

I confirmed this is still reproducible today: I set a display name
containing U+202E on a real account and fetched it back through the
public `getProfile` endpoint, the character round-trips unchanged.

## Fix

Adds `hasBidiControls` / `stripBidiControls` to `@atproto/syntax` and
applies `stripBidiControls` everywhere I found `displayName` independently
built into a `ProfileViewBasic`-shaped response:

- `profileBasic` in bsky views, the value that flows into notification
  author views
- `verification` in bsky views, the issuer's display name shown on
  verification badges
- `LocalViewer.getProfileBasic` and `LocalViewer.updateProfileViewBasic`
  in the PDS's read-after-write path, which independently builds/patches
  the same view shape and could otherwise reintroduce the unsanitized
  value right after a profile edit

Legitimate single-character direction marks (LRM, RLM, ALM) and script
joiners (ZWJ, ZWNJ, used by real RTL text and emoji) are intentionally
left untouched, only embedding/override/isolate control characters are
stripped.

## Scope

This PR sanitizes `displayName` at every read/view-construction site I
could find for `app.bsky.actor.profile`. Two things I deliberately left
out, happy to follow up separately if maintainers want them here instead:

- Write-time validation/rejection in the PDS record-validation path
  (`packages/pds/src/repo/prepare.ts`). I chose read-side sanitization
  because it protects every consumer regardless of which PDS wrote the
  record (this is a federated protocol), but it means a malicious
  `displayName` is still accepted and stored, just no longer served
  unsanitized through the paths this PR touches.
- `app.bsky.feed.generator#displayName` (a feed generator's own name) is
  a different lexicon field with a different threat model, not covered
  here since issue #1480 is specifically about actor identity.

## Testing

- Added unit tests in `packages/syntax/tests/bidi.test.ts` covering the
  attack character class, every embedding/override/isolate character, and
  that legitimate direction marks and emoji ZWJ sequences are left intact.
- Verified against the compiled `Views` class directly (`profileBasic`
  and `verification`), not just the standalone utility, with a malicious
  display name, a clean display name, a real Arabic display name with a
  legitimate direction mark, a missing profile, and a stacked multi-character
  attack.