### PR TITLE
oauth: keep refreshable sessions in connected apps

### DIFF
--- a/.changeset/fresh-apps-stay.md
+++ b/.changeset/fresh-apps-stay.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider': patch
+---
+
+Keep refreshable OAuth sessions visible until their refresh or session lifetime expires.

--- a/packages/oauth/oauth-provider/package.json
+++ b/packages/oauth/oauth-provider/package.json
@@ -93,9 +93,11 @@
     "@types/cookie": "^0.6.0",
     "@types/forwarded": "0.1.3",
     "@types/http-errors": "^2.0.4",
-    "@types/send": "^0.17.4"
+    "@types/send": "^0.17.4",
+    "vitest": "^4.0.16"
   },
   "scripts": {
-    "build": "tsgo --build tsconfig.build.json"
+    "build": "tsgo --build tsconfig.build.json",
+    "test": "vitest run"
   }
 }

--- a/packages/oauth/oauth-provider/src/oauth-provider.ts
+++ b/packages/oauth/oauth-provider/src/oauth-provider.ts
@@ -74,14 +74,7 @@ import {
   type CustomMetadata,
   buildMetadata,
 } from './metadata/build-metadata.js'
-import {
-  AUTHENTICATION_MAX_AGE,
-  CONFIDENTIAL_CLIENT_REFRESH_LIFETIME,
-  CONFIDENTIAL_CLIENT_SESSION_LIFETIME,
-  PUBLIC_CLIENT_REFRESH_LIFETIME,
-  PUBLIC_CLIENT_SESSION_LIFETIME,
-  TOKEN_MAX_AGE,
-} from './oauth-constants.js'
+import { AUTHENTICATION_MAX_AGE, TOKEN_MAX_AGE } from './oauth-constants.js'
 import type { OAuthHooks } from './oauth-hooks.js'
 import {
   type DpopProof,
@@ -102,6 +95,7 @@ import type { AccessTokenPayload } from './signer/access-token-payload.js'
 import { refreshTokenSchema } from './token/refresh-token.js'
 import type { TokenData } from './token/token-data.js'
 import { TokenManager } from './token/token-manager.js'
+import { getOAuthSessionLifetimes } from './token/token-session.js'
 import { type TokenStore, asTokenStore } from './token/token-store.js'
 import { isPARResponseError } from './types/par-response-error.js'
 
@@ -1037,13 +1031,9 @@ export class OAuthProvider extends OAuthVerifier {
     clientAuth: ClientAuth,
     data: TokenData,
   ): Promise<void> {
-    const [sessionLifetime, refreshLifetime] =
-      clientAuth.method !== 'none' || client.info.isFirstParty
-        ? [
-            CONFIDENTIAL_CLIENT_SESSION_LIFETIME,
-            CONFIDENTIAL_CLIENT_REFRESH_LIFETIME,
-          ]
-        : [PUBLIC_CLIENT_SESSION_LIFETIME, PUBLIC_CLIENT_REFRESH_LIFETIME]
+    const [sessionLifetime, refreshLifetime] = getOAuthSessionLifetimes(
+      clientAuth.method !== 'none' || client.info.isFirstParty,
+    )
 
     const sessionAge = Date.now() - data.createdAt.getTime()
     if (sessionAge > sessionLifetime) {

--- a/packages/oauth/oauth-provider/src/router/create-api-middleware.ts
+++ b/packages/oauth/oauth-provider/src/router/create-api-middleware.ts
@@ -54,6 +54,10 @@ import type { OAuthProvider } from '../oauth-provider.js'
 import { type RequestUri, requestUriSchema } from '../request/request-uri.js'
 import type { AuthorizationRedirectParameters } from '../result/authorization-redirect-parameters.js'
 import { tokenIdSchema } from '../token/token-id.js'
+import {
+  isOAuthSessionActive,
+  usesExtendedOAuthSessionLifetime,
+} from '../token/token-session.js'
 import { emailOtpSchema } from '../types/email-otp.js'
 import { emailSchema } from '../types/email.js'
 import { handleSchema } from '../types/handle.js'
@@ -495,8 +499,16 @@ export function createApiMiddleware<
         const tokenInfos = await server.tokenManager.listAccountTokens(
           account.did,
         )
+        const now = Date.now()
+        const tokenCandidates = tokenInfos.filter(
+          (tokenInfo) =>
+            tokenInfo.currentRefreshToken !== null ||
+            tokenInfo.data.expiresAt.getTime() > now,
+        )
 
-        const clientIds = tokenInfos.map((tokenInfo) => tokenInfo.data.clientId)
+        const clientIds = tokenCandidates.map(
+          (tokenInfo) => tokenInfo.data.clientId,
+        )
 
         const clients = await server.clientManager.loadClients(clientIds, {
           onError: (err, clientId) => {
@@ -505,23 +517,39 @@ export function createApiMiddleware<
           },
         })
 
-        // @TODO: We should ideally filter sessions that are expired (or even
-        // expose the expiration date). This requires a change to the way
-        // TokenInfo are stored (see TokenManager#isTokenExpired and
-        // TokenManager#isTokenInactive).
-        const json = tokenInfos.map(({ id, data }): ActiveOAuthSession => {
-          return {
-            tokenId: id,
+        const activeTokenInfos = tokenCandidates.filter((tokenInfo) => {
+          const client = clients.get(tokenInfo.data.clientId)
+          const usesExtendedSessionLifetime = usesExtendedOAuthSessionLifetime(
+            tokenInfo,
+            client && {
+              isConfidential:
+                client.metadata.token_endpoint_auth_method !== 'none',
+              isFirstParty: client.info.isFirstParty,
+            },
+          )
 
-            createdAt: data.createdAt.toISOString() as ISODateString,
-            updatedAt: data.updatedAt.toISOString() as ISODateString,
-
-            clientId: data.clientId,
-            clientMetadata: clients.get(data.clientId)?.metadata,
-
-            scope: data.parameters.scope,
-          }
+          return isOAuthSessionActive(
+            tokenInfo,
+            usesExtendedSessionLifetime,
+            now,
+          )
         })
+
+        const json = activeTokenInfos.map(
+          ({ id, data }): ActiveOAuthSession => {
+            return {
+              tokenId: id,
+
+              createdAt: data.createdAt.toISOString() as ISODateString,
+              updatedAt: data.updatedAt.toISOString() as ISODateString,
+
+              clientId: data.clientId,
+              clientMetadata: clients.get(data.clientId)?.metadata,
+
+              scope: data.parameters.scope,
+            }
+          },
+        )
 
         return { json }
       },

--- a/packages/oauth/oauth-provider/src/token/token-manager.test.ts
+++ b/packages/oauth/oauth-provider/src/token/token-manager.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, test, vi } from 'vitest'
+import {
+  CONFIDENTIAL_CLIENT_REFRESH_LIFETIME,
+  CONFIDENTIAL_CLIENT_SESSION_LIFETIME,
+  PUBLIC_CLIENT_REFRESH_LIFETIME,
+  PUBLIC_CLIENT_SESSION_LIFETIME,
+} from '../oauth-constants.js'
+import { AccessTokenMode, TokenManager } from './token-manager.js'
+import {
+  isOAuthSessionActive,
+  usesExtendedOAuthSessionLifetime,
+} from './token-session.js'
+import { type TokenInfo, type TokenStore, asTokenStore } from './token-store.js'
+
+const NOW = new Date('2026-07-11T12:00:00.000Z')
+const ACCOUNT_DID = 'did:example:alice'
+const OTHER_ACCOUNT_DID = 'did:example:bob'
+const PDS_DID = 'did:web:pds.example'
+const CLIENT_ID = 'https://client.example/oauth-client-metadata.json'
+const TOKEN_ID = `tok-${'0'.repeat(32)}` as TokenInfo['id']
+const REFRESH_TOKEN = `ref-${'0'.repeat(64)}` as NonNullable<
+  TokenInfo['currentRefreshToken']
+>
+
+function createTokenInfo({
+  accountDid = ACCOUNT_DID,
+  createdAt = new Date(NOW.getTime() - 60_000),
+  updatedAt = new Date(NOW.getTime() - 60_000),
+  expiresAt,
+  currentRefreshToken,
+  clientAuth = { method: 'none' },
+}: {
+  accountDid?: TokenInfo['account']['did']
+  createdAt?: Date
+  updatedAt?: Date
+  expiresAt: Date
+  currentRefreshToken: TokenInfo['currentRefreshToken']
+  clientAuth?: TokenInfo['data']['clientAuth']
+}): TokenInfo {
+  return {
+    id: TOKEN_ID,
+    account: {
+      did: accountDid,
+      pds: PDS_DID,
+      deactivated: false,
+    },
+    currentRefreshToken,
+    data: {
+      createdAt,
+      updatedAt,
+      expiresAt,
+      clientId: CLIENT_ID,
+      clientAuth,
+      deviceId: null,
+      did: accountDid,
+      parameters: {
+        client_id: CLIENT_ID,
+        response_type: 'code',
+      },
+      code: null,
+      scope: null,
+    },
+  }
+}
+
+function createTokenManager(tokenInfos: TokenInfo[]) {
+  const listAccountTokens = vi.fn<TokenStore['listAccountTokens']>(
+    async () => tokenInfos,
+  )
+  const store = asTokenStore({
+    createToken: async () => {},
+    readToken: async () => null,
+    deleteToken: async () => {},
+    rotateToken: async () => {},
+    findTokenByRefreshToken: async () => null,
+    findTokenByCode: async () => null,
+    listAccountTokens,
+  })
+
+  const manager = new TokenManager(
+    store,
+    null as never,
+    null as never,
+    {},
+    AccessTokenMode.stateless,
+  )
+
+  return { manager, listAccountTokens }
+}
+
+describe(isOAuthSessionActive, () => {
+  test.each([
+    {
+      note: 'unexpired access token without refresh token',
+      expiresAt: new Date(NOW.getTime() + 1),
+      currentRefreshToken: null,
+      usesExtendedSessionLifetime: false,
+      expected: true,
+    },
+    {
+      note: 'expired access token without refresh token',
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: null,
+      usesExtendedSessionLifetime: false,
+      expected: false,
+    },
+    {
+      note: 'access token exactly at its expiry',
+      expiresAt: new Date(NOW),
+      currentRefreshToken: null,
+      usesExtendedSessionLifetime: false,
+      expected: false,
+    },
+    {
+      note: 'refreshable public session with expired access token',
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: false,
+      expected: true,
+    },
+    {
+      note: 'public session exactly at its lifetime boundaries',
+      createdAt: new Date(NOW.getTime() - PUBLIC_CLIENT_SESSION_LIFETIME),
+      updatedAt: new Date(NOW.getTime() - PUBLIC_CLIENT_REFRESH_LIFETIME),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: false,
+      expected: true,
+    },
+    {
+      note: 'public session past its total lifetime',
+      createdAt: new Date(NOW.getTime() - PUBLIC_CLIENT_SESSION_LIFETIME - 1),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: false,
+      expected: false,
+    },
+    {
+      note: 'public session past its refresh inactivity lifetime',
+      updatedAt: new Date(NOW.getTime() - PUBLIC_CLIENT_REFRESH_LIFETIME - 1),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: false,
+      expected: false,
+    },
+    {
+      note: 'extended session past public client lifetime',
+      createdAt: new Date(NOW.getTime() - PUBLIC_CLIENT_SESSION_LIFETIME - 1),
+      updatedAt: new Date(NOW.getTime() - PUBLIC_CLIENT_REFRESH_LIFETIME - 1),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: true,
+      expected: true,
+    },
+    {
+      note: 'extended session past its total lifetime',
+      createdAt: new Date(
+        NOW.getTime() - CONFIDENTIAL_CLIENT_SESSION_LIFETIME - 1,
+      ),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: true,
+      expected: false,
+    },
+    {
+      note: 'extended session past its refresh inactivity lifetime',
+      updatedAt: new Date(
+        NOW.getTime() - CONFIDENTIAL_CLIENT_REFRESH_LIFETIME - 1,
+      ),
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      usesExtendedSessionLifetime: true,
+      expected: false,
+    },
+  ])(
+    '$note',
+    ({
+      createdAt,
+      updatedAt,
+      expiresAt,
+      currentRefreshToken,
+      usesExtendedSessionLifetime,
+      expected,
+    }) => {
+      const tokenInfo = createTokenInfo({
+        createdAt,
+        updatedAt,
+        expiresAt,
+        currentRefreshToken,
+      })
+
+      expect(
+        isOAuthSessionActive(
+          tokenInfo,
+          usesExtendedSessionLifetime,
+          NOW.getTime(),
+        ),
+      ).toBe(expected)
+    },
+  )
+})
+
+describe(usesExtendedOAuthSessionLifetime, () => {
+  test.each([
+    {
+      note: 'loaded public client',
+      clientAuth: { method: 'none' } as const,
+      client: { isConfidential: false, isFirstParty: false },
+      expected: false,
+    },
+    {
+      note: 'loaded confidential client',
+      clientAuth: { method: 'none' } as const,
+      client: { isConfidential: true, isFirstParty: false },
+      expected: true,
+    },
+    {
+      note: 'loaded first-party public client',
+      clientAuth: { method: 'none' } as const,
+      client: { isConfidential: false, isFirstParty: true },
+      expected: true,
+    },
+    {
+      note: 'missing public client metadata',
+      clientAuth: { method: 'none' } as const,
+      client: undefined,
+      expected: false,
+    },
+    {
+      note: 'missing confidential client metadata',
+      clientAuth: {
+        method: 'private_key_jwt',
+        alg: 'ES256',
+        kid: 'key-1',
+        jkt: 'thumbprint',
+        jti: 'assertion-1',
+      } as const,
+      client: undefined,
+      expected: true,
+    },
+  ])('$note', ({ clientAuth, client, expected }) => {
+    const tokenInfo = createTokenInfo({
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: REFRESH_TOKEN,
+      clientAuth,
+    })
+
+    expect(usesExtendedOAuthSessionLifetime(tokenInfo, client)).toBe(expected)
+  })
+})
+
+describe(TokenManager, () => {
+  it('returns only tokens belonging to the requested account', async () => {
+    const accountToken = createTokenInfo({
+      expiresAt: new Date(NOW.getTime() - 1),
+      currentRefreshToken: null,
+    })
+    const otherAccountToken = createTokenInfo({
+      accountDid: OTHER_ACCOUNT_DID,
+      expiresAt: new Date(NOW.getTime() + 1),
+      currentRefreshToken: null,
+    })
+    const { manager, listAccountTokens } = createTokenManager([
+      accountToken,
+      otherAccountToken,
+    ])
+
+    await expect(manager.listAccountTokens(ACCOUNT_DID)).resolves.toEqual([
+      accountToken,
+    ])
+    expect(listAccountTokens).toHaveBeenCalledOnce()
+    expect(listAccountTokens).toHaveBeenCalledWith(ACCOUNT_DID)
+  })
+})

--- a/packages/oauth/oauth-provider/src/token/token-manager.ts
+++ b/packages/oauth/oauth-provider/src/token/token-manager.ts
@@ -388,7 +388,7 @@ export class TokenManager {
       throw new InvalidTokenError(tokenType, `Invalid token`)
     }
 
-    if (isCurrentTokenExpired(tokenInfo)) {
+    if (isCurrentAccessTokenExpired(tokenInfo)) {
       await this.deleteToken(tokenId)
       throw new InvalidTokenError(tokenType, `Token expired`)
     }
@@ -405,16 +405,18 @@ export class TokenManager {
     }
   }
 
+  /**
+   * Lists stored tokens for an account. Callers must apply access, refresh,
+   * and session lifetime rules before presenting them as active sessions.
+   */
   async listAccountTokens(did: Did): Promise<TokenInfo[]> {
     const results = await this.store.listAccountTokens(did)
-    return results
-      .filter((tokenInfo) => tokenInfo.account.did === did) // Fool proof
-      .filter((tokenInfo) => !isCurrentTokenExpired(tokenInfo))
+    return results.filter((tokenInfo) => tokenInfo.account.did === did) // Fool proof
   }
 }
 
-function isCurrentTokenExpired(tokenInfo: TokenInfo): boolean {
-  return tokenInfo.data.expiresAt.getTime() < Date.now()
+function isCurrentAccessTokenExpired(tokenInfo: TokenInfo): boolean {
+  return tokenInfo.data.expiresAt.getTime() <= Date.now()
 }
 
 function inferTokenType(

--- a/packages/oauth/oauth-provider/src/token/token-session.ts
+++ b/packages/oauth/oauth-provider/src/token/token-session.ts
@@ -1,0 +1,61 @@
+import {
+  CONFIDENTIAL_CLIENT_REFRESH_LIFETIME,
+  CONFIDENTIAL_CLIENT_SESSION_LIFETIME,
+  PUBLIC_CLIENT_REFRESH_LIFETIME,
+  PUBLIC_CLIENT_SESSION_LIFETIME,
+} from '../oauth-constants.js'
+import type { TokenInfo } from './token-store.js'
+
+export type OAuthSessionClientClassification = {
+  isConfidential: boolean
+  isFirstParty: boolean
+}
+
+/**
+ * Uses current client information when available. The stored authentication
+ * method is a best-effort fallback because first-party status is not persisted.
+ */
+export function usesExtendedOAuthSessionLifetime(
+  tokenInfo: TokenInfo,
+  client?: OAuthSessionClientClassification,
+): boolean {
+  return client
+    ? client.isConfidential || client.isFirstParty
+    : tokenInfo.data.clientAuth.method !== 'none'
+}
+
+export function getOAuthSessionLifetimes(usesExtendedSessionLifetime: boolean) {
+  return usesExtendedSessionLifetime
+    ? ([
+        CONFIDENTIAL_CLIENT_SESSION_LIFETIME,
+        CONFIDENTIAL_CLIENT_REFRESH_LIFETIME,
+      ] as const)
+    : ([
+        PUBLIC_CLIENT_SESSION_LIFETIME,
+        PUBLIC_CLIENT_REFRESH_LIFETIME,
+      ] as const)
+}
+
+/**
+ * Evaluates time-based activity. Refresh authentication can still fail because
+ * of client credentials, DPoP binding, or metadata changes.
+ */
+export function isOAuthSessionActive(
+  tokenInfo: TokenInfo,
+  usesExtendedSessionLifetime: boolean,
+  now = Date.now(),
+): boolean {
+  const { currentRefreshToken, data } = tokenInfo
+
+  if (data.expiresAt.getTime() > now) return true
+  if (currentRefreshToken === null) return false
+
+  const [sessionLifetime, refreshLifetime] = getOAuthSessionLifetimes(
+    usesExtendedSessionLifetime,
+  )
+
+  return (
+    now - data.createdAt.getTime() <= sessionLifetime &&
+    now - data.updatedAt.getTime() <= refreshLifetime
+  )
+}

--- a/packages/oauth/oauth-provider/tsconfig.build.json
+++ b/packages/oauth/oauth-provider/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["../../../tsconfig/node.tsconfig.json"],
   "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     { "path": "../../common/tsconfig.build.json" },
     { "path": "../../did/tsconfig.build.json" },

--- a/packages/oauth/oauth-provider/tsconfig.json
+++ b/packages/oauth/oauth-provider/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
 }

--- a/packages/oauth/oauth-provider/tsconfig.test.json
+++ b/packages/oauth/oauth-provider/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../../tsconfig/vitest.tsconfig.json"],
+  "include": ["./src/**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": ".",
+  },
+  "references": [{ "path": "./tsconfig.build.json" }],
+}

--- a/packages/oauth/oauth-provider/vitest.config.ts
+++ b/packages/oauth/oauth-provider/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1612,6 +1612,9 @@ importers:
       '@types/send':
         specifier: ^0.17.4
         version: 0.17.4
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)
 
   packages/oauth/oauth-provider-api:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'packages/aws',
       'packages/lex/*',
       'packages/oauth/oauth-client',
+      'packages/oauth/oauth-provider',
       'packages/syntax',
       'packages/tap',
 


### PR DESCRIPTION
## Summary

- keep refreshable OAuth sessions visible after the current access token expires
- apply the existing public vs. confidential/first-party refresh and session lifetimes before listing sessions
- add focused Vitest coverage for token lifecycle boundaries and client classification

## Root cause

`TokenManager.listAccountTokens()` treated the current access-token expiry as the OAuth-session expiry. Access tokens expire after an hour, while a client with a refresh token can retain access for the applicable refresh and session lifetime. The account UI therefore hid an app until its next token refresh updated `expiresAt`.

The route now cheaply drops expired access-only rows before metadata loading, then classifies the remaining clients and applies the same lifetime calculation used by refresh-grant validation. If current client metadata is unavailable, classification falls back to the stored authentication method so the existing partial-session UI remains useful.

## User impact

Connected Apps continues to show apps that can refresh their credentials, while excluding access-only, refresh-expired, and session-expired entries.

Fixes #3998

## Validation

- `pnpm test` in `packages/oauth/oauth-provider` (16 tests)
- `pnpm build --force`
- `pnpm verify`
