### PR TITLE
feature: Adds rate limit headers to Access-Control-Expose-Headers on xrpc servers (PDS)

### DIFF
--- a/.changeset/pink-trams-reply.md
+++ b/.changeset/pink-trams-reply.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Add the rate limit response headers `RateLimit-Limit`, `RateLimit-Reset`, `RateLimit-Remaining`, `RateLimit-Policy`, and `Retry-After` on 429s to `Access-Control-Expose-Headers` so browser clients can read them on cross-origin requests.

--- a/packages/xrpc-server/src/rate-limiter-http.ts
+++ b/packages/xrpc-server/src/rate-limiter-http.ts
@@ -50,6 +50,7 @@ export class HttpRateLimiter<
           'Retry-After',
           Math.ceil(err.status.msBeforeNext / 1e3),
         )
+        ctx.res?.appendHeader('Access-Control-Expose-Headers', 'Retry-After')
       }
 
       throw err
@@ -84,4 +85,10 @@ function setStatusHeaders<
   ctx.res?.setHeader('RateLimit-Reset', resetAt)
   ctx.res?.setHeader('RateLimit-Remaining', status.remainingPoints)
   ctx.res?.setHeader('RateLimit-Policy', `${status.limit};w=${status.duration}`)
+
+  // Expose the rate limit headers to browser clients (CORS)
+  ctx.res?.appendHeader(
+    'Access-Control-Expose-Headers',
+    'RateLimit-Limit, RateLimit-Reset, RateLimit-Remaining, RateLimit-Policy',
+  )
 }

--- a/packages/xrpc-server/tests/rate-limiter.test.ts
+++ b/packages/xrpc-server/tests/rate-limiter.test.ts
@@ -239,6 +239,35 @@ describe('Parameters', () => {
     await expect(makeCall).rejects.toThrow('Rate Limit Exceeded')
   })
 
+  it('exposes rate limit headers to browsers (CORS)', async () => {
+    const { port } = s.address() as AddressInfo
+    const url = `http://localhost:${port}/xrpc/io.example.routeLimit?str=cors-headers`
+
+    const okRes = await fetch(url)
+    await okRes.arrayBuffer()
+    expect(okRes.status).toBe(200)
+    expect(okRes.headers.get('ratelimit-limit')).toBe('5')
+    expect(okRes.headers.get('ratelimit-remaining')).toBe('4')
+    expect(okRes.headers.get('ratelimit-reset')).toBeTruthy()
+    expect(okRes.headers.get('ratelimit-policy')).toBe('5;w=300')
+    expect(okRes.headers.get('access-control-expose-headers')).toBe(
+      'RateLimit-Limit, RateLimit-Reset, RateLimit-Remaining, RateLimit-Policy',
+    )
+
+    for (let i = 0; i < 4; i++) {
+      await fetch(url).then((res) => res.arrayBuffer())
+    }
+
+    const limitedRes = await fetch(url)
+    await limitedRes.arrayBuffer()
+    expect(limitedRes.status).toBe(429)
+    expect(limitedRes.headers.get('ratelimit-remaining')).toBe('0')
+    expect(limitedRes.headers.get('retry-after')).toBeTruthy()
+    expect(limitedRes.headers.get('access-control-expose-headers')).toBe(
+      'RateLimit-Limit, RateLimit-Reset, RateLimit-Remaining, RateLimit-Policy, Retry-After',
+    )
+  })
+
   it('can reset route rate limits', async () => {
     // Limit is 2.
     // Call 0 is OK (1/2).


### PR DESCRIPTION
Not sure if this is the best path, but while adding rate limiting in [pdsmoover.com](https://pdsmoover.com) I found that I could not access the rate limit headers since it is all client side. After some research I found that `Access-Control-Expose-Headers` needed to have them set. This fix resolved my issues for me and allowed me to access the rate limit headers on the browser so I can do things like "Limit blob uploads to leave 5 so that they can still upload pics if limit is hit during migrations" which is not possible since it goes till rate limit and the user is out of luck for 24 hours. 

Happy too if there is another path to be able to add this. But would really appreciate some kind of resolution to give users this. 