### PR TITLE
feat: add includeTakedowns param to internal getProfiles

### DIFF
--- a/.changeset/quick-otters-share.md
+++ b/.changeset/quick-otters-share.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add includeTakedowns param to internal.bsky.actor.getProfiles

--- a/lexicons/internal/bsky/actor/getProfiles.json
+++ b/lexicons/internal/bsky/actor/getProfiles.json
@@ -24,6 +24,11 @@
             "description": "DIDs to hydrate social proof (known followers) for. DIDs not also present in `dids` are ignored.",
             "items": { "type": "string", "format": "did" },
             "maxLength": 200
+          },
+          "includeTakedowns": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include taken-down accounts in the response rather than omitting them. For service-to-service moderation use only."
           }
         }
       },

--- a/packages/bsky/src/api/internal/bsky/actor/getProfiles.ts
+++ b/packages/bsky/src/api/internal/bsky/actor/getProfiles.ts
@@ -20,6 +20,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({
         viewer: params.viewer ?? null,
         labelers,
+        includeTakedowns: params.includeTakedowns,
       })
 
       const result = await getProfiles({ ...params, hydrateCtx }, ctx)

--- a/packages/bsky/tests/views/internal-actor.test.ts
+++ b/packages/bsky/tests/views/internal-actor.test.ts
@@ -140,7 +140,9 @@ describe('internal actor views', () => {
 
     describe('takedowns', () => {
       afterEach(async () => {
-        await network.bsky.ctx.dataplane.untakedownActor({ did: dids.mix_sub_2 })
+        await network.bsky.ctx.dataplane.untakedownActor({
+          did: dids.mix_sub_2,
+        })
       })
 
       it('omits taken-down accounts by default', async () => {

--- a/packages/bsky/tests/views/internal-actor.test.ts
+++ b/packages/bsky/tests/views/internal-actor.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest'
 import type { AppBskyActorDefs, AtpAgent } from '@atproto/api'
 import { type SeedClient, TestNetwork } from '@atproto/dev-env'
 import type { DidString } from '@atproto/syntax'
@@ -43,13 +51,19 @@ describe('internal actor views', () => {
 
   describe('getProfiles', () => {
     const getProfiles = async (
-      params: { dids: string[]; socialProof?: string[]; viewer?: string },
+      params: {
+        dids: string[]
+        socialProof?: string[]
+        viewer?: string
+        includeTakedowns?: boolean
+      },
       headers: Record<string, string> = network.bsky.adminAuthHeaders(),
     ) => {
       const search = new URLSearchParams()
       params.dids.forEach((did) => search.append('dids', did))
       params.socialProof?.forEach((did) => search.append('socialProof', did))
       if (params.viewer) search.append('viewer', params.viewer)
+      if (params.includeTakedowns) search.append('includeTakedowns', 'true')
       const res = await fetch(
         `${network.bsky.url}/xrpc/internal.bsky.actor.getProfiles?${search.toString()}`,
         { headers },
@@ -122,6 +136,35 @@ describe('internal actor views', () => {
       expect(status).toBe(200)
       expect(body.profiles).toHaveLength(1)
       expect(body.profiles[0].viewer).toBeUndefined()
+    })
+
+    describe('takedowns', () => {
+      afterEach(async () => {
+        await network.bsky.ctx.dataplane.untakedownActor({ did: dids.mix_sub_2 })
+      })
+
+      it('omits taken-down accounts by default', async () => {
+        await network.bsky.ctx.dataplane.takedownActor({ did: dids.mix_sub_2 })
+        const { status, body } = await getProfiles({
+          dids: [dids.mix_sub_1, dids.mix_sub_2, dids.mix_sub_3],
+          viewer: dids.mix_view,
+        })
+        expect(status).toBe(200)
+        expect(body.profiles).toHaveLength(2)
+        expect(body.profiles.map((p) => p.did)).not.toContain(dids.mix_sub_2)
+      })
+
+      it('includes taken-down accounts when includeTakedowns is set', async () => {
+        await network.bsky.ctx.dataplane.takedownActor({ did: dids.mix_sub_2 })
+        const { status, body } = await getProfiles({
+          dids: [dids.mix_sub_1, dids.mix_sub_2, dids.mix_sub_3],
+          viewer: dids.mix_view,
+          includeTakedowns: true,
+        })
+        expect(status).toBe(200)
+        expect(body.profiles).toHaveLength(3)
+        expect(body.profiles.map((p) => p.did)).toContain(dids.mix_sub_2)
+      })
     })
   })
 })


### PR DESCRIPTION
The internal.bsky.actor.getProfiles endpoint applied the same takedown filtering as the public endpoint, silently omitting taken-down accounts. Service-to-service moderation callers (e.g. bchat super-admin) need those profiles. Add an opt-in includeTakedowns param, defaulting to false so the member-facing path keeps omitting them.