### PR TITLE
fix(lex-installer): write lexicons.json with a trailing newline

### DIFF
--- a/.changeset/fast-cobras-shout.md
+++ b/.changeset/fast-cobras-shout.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-installer': patch
+---
+
+`writeJsonFile` (used by `lex install` to save `lexicons.json` and the installed lexicon documents) now ends the file with a trailing newline, so it no longer thrashes against formatters and linters that enforce a final newline.

--- a/packages/lex/lex-installer/src/fs.test.ts
+++ b/packages/lex/lex-installer/src/fs.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readJsonFile, writeJsonFile } from './fs.js'
+
+describe('writeJsonFile', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'lex-installer-fs-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('writes pretty-printed JSON with a trailing newline (issue #5232)', async () => {
+    const path = join(dir, 'lexicons.json')
+    await writeJsonFile(path, { version: 1, lexicons: ['com.example.foo'] })
+
+    const contents = await readFile(path, 'utf8')
+    expect(contents.endsWith('\n')).toBe(true)
+    // exactly one trailing newline, and the body is 2-space indented
+    expect(contents).toBe(
+      JSON.stringify({ version: 1, lexicons: ['com.example.foo'] }, null, 2) +
+        '\n',
+    )
+  })
+
+  it('creates missing parent directories', async () => {
+    const path = join(dir, 'nested', 'deep', 'lexicons.json')
+    await writeJsonFile(path, { ok: true })
+    expect(await readJsonFile(path)).toEqual({ ok: true })
+  })
+
+  it('round-trips through readJsonFile despite the trailing newline', async () => {
+    const path = join(dir, 'manifest.json')
+    const data = {
+      version: 1,
+      resolutions: { 'com.example.foo': { cid: 'bafyabc' } },
+    }
+    await writeJsonFile(path, data)
+    expect(await readJsonFile(path)).toEqual(data)
+  })
+})

--- a/packages/lex/lex-installer/src/fs.ts
+++ b/packages/lex/lex-installer/src/fs.ts
@@ -73,7 +73,9 @@ export async function writeJsonFile(
   data: unknown,
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true })
-  const contents = JSON.stringify(data, null, 2)
+  // Trailing newline so the written file is POSIX-friendly and does not thrash against
+  // formatters/linters that enforce final newlines (e.g. the tooling in issue #5232).
+  const contents = JSON.stringify(data, null, 2) + '\n'
   await writeFile(path, contents, {
     encoding: 'utf8',
     mode: 0o644,


### PR DESCRIPTION
## What

`lex install` saves `lexicons.json` (and each installed lexicon document) without a trailing newline. Repos whose tooling enforces final newlines — the issue reporter's, and many others — then have to special-case this file, because a format run adds the newline and `lex install` strips it back off on the next run, thrashing endlessly.

## Fix

`writeJsonFile` in `@atproto/lex-installer` serialized with `JSON.stringify(data, null, 2)` and wrote the result verbatim. It now appends a single `\n`.

This is safe against the manifest freshness check: the `--frozen`/CID comparison reads and **parses** the manifest and compares `cid` fields that are computed from lexicon *document content*, not from the manifest file's raw bytes. Trailing whitespace is inert to a JSON parse, so the check is unaffected.

## Test

Adds `packages/lex/lex-installer/src/fs.test.ts`:

- asserts the written file ends with exactly one newline (**fails on the pre-fix code**);
- confirms parent directories are still created;
- confirms `readJsonFile` round-trips the data despite the trailing newline.

Full `@atproto/lex-installer` suite: 5/5 passing. `eslint` + `prettier` clean. Patch changeset included.

Fixes #5232
