### PR TITLE
Support entryway-matching `PDS_SERVICE_HANDLE_DOMAINS` on PDS

### DIFF
--- a/.changeset/violet-poems-attack.md
+++ b/.changeset/violet-poems-attack.md
@@ -1,0 +1,6 @@
+---
+'@atproto/pds': patch
+'@atproto/dev-env': patch
+---
+
+defer service handle resolution to entryway when configured, allowing PDS_SERVICE_HANDLE_DOMAINS to match the entryway's domains

--- a/packages/dev-env/src/util.ts
+++ b/packages/dev-env/src/util.ts
@@ -14,7 +14,12 @@ export const mockNetworkUtilities = (pds: TestPds, bsky?: TestBsky) => {
   }
 }
 
-export const mockResolvers = (idResolver: IdResolver, pds: TestPds) => {
+export const mockResolvers = (
+  idResolver: IdResolver,
+  pds: TestPds,
+  // handles resolve against the pds by default, but may point elsewhere e.g. an entryway
+  handleResolveUrl: string = pds.url,
+) => {
   // Map pds public url to its local url when resolving from plc
   const origResolveDid = idResolver.did.resolveNoCache
   idResolver.did.resolveNoCache = async (did: string) => {
@@ -41,7 +46,7 @@ export const mockResolvers = (idResolver: IdResolver, pds: TestPds) => {
       return origResolveHandleDns.call(idResolver.handle, handle)
     }
 
-    const url = new URL(`/.well-known/atproto-did`, pds.url)
+    const url = new URL(`/.well-known/atproto-did`, handleResolveUrl)
     try {
       const res = await request(url, { headers: { host: handle } })
       if (res.statusCode !== 200) {

--- a/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
@@ -9,22 +9,24 @@ export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.identity.resolveHandle, async ({ params }) => {
     const handle = baseNormalizeAndValidate(params.handle)
 
-    const user = await ctx.accountManager.getAccount(handle)
-    if (user) {
-      return {
-        encoding: 'application/json' as const,
-        body: { did: user.did as DidString },
+    // when behind an entryway, the entryway is authoritative for handles
+    // rather than this pds' local accounts
+    if (!ctx.cfg.entryway) {
+      const user = await ctx.accountManager.getAccount(handle)
+      if (user) {
+        return {
+          encoding: 'application/json' as const,
+          body: { did: user.did as DidString },
+        }
       }
-    }
 
-    const supportedHandle =
-      !ctx.cfg.entryway &&
-      ctx.cfg.identity.serviceHandleDomains.some(
+      const supportedHandle = ctx.cfg.identity.serviceHandleDomains.some(
         (host) => handle.endsWith(host) || handle === host.slice(1),
       )
-    // this should be in our DB & we couldn't find it, so fail
-    if (supportedHandle) {
-      throw new InvalidRequestError('Unable to resolve handle')
+      // this should be in our DB & we couldn't find it, so fail
+      if (supportedHandle) {
+        throw new InvalidRequestError('Unable to resolve handle')
+      }
     }
 
     const did: DidString = ctx.bskyAppView

--- a/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
+++ b/packages/pds/src/api/com/atproto/identity/resolveHandle.ts
@@ -17,9 +17,11 @@ export default function (server: Server, ctx: AppContext) {
       }
     }
 
-    const supportedHandle = ctx.cfg.identity.serviceHandleDomains.some(
-      (host) => handle.endsWith(host) || handle === host.slice(1),
-    )
+    const supportedHandle =
+      !ctx.cfg.entryway &&
+      ctx.cfg.identity.serviceHandleDomains.some(
+        (host) => handle.endsWith(host) || handle === host.slice(1),
+      )
     // this should be in our DB & we couldn't find it, so fail
     if (supportedHandle) {
       throw new InvalidRequestError('Unable to resolve handle')

--- a/packages/pds/src/config/config.ts
+++ b/packages/pds/src/config/config.ts
@@ -95,6 +95,7 @@ export const envToCfg = (env: ServerEnvironment): ServerConfig => {
     throw new Error('Must configure either S3 or disk blobstore')
   }
 
+  // @NOTE when behind an entryway, this should be configured to match the entryway's domains
   let serviceHandleDomains: string[]
   if (env.serviceHandleDomains && env.serviceHandleDomains.length > 0) {
     serviceHandleDomains = env.serviceHandleDomains

--- a/packages/pds/src/well-known.ts
+++ b/packages/pds/src/well-known.ts
@@ -7,9 +7,11 @@ export const createRouter = (ctx: AppContext): Router => {
 
   router.get('/.well-known/atproto-did', async function (req, res) {
     const handle = req.hostname as HandleString
-    const supportedHandle = ctx.cfg.identity.serviceHandleDomains.some(
-      (host) => handle.endsWith(host) || handle === host.slice(1),
-    )
+    const supportedHandle =
+      !ctx.cfg.entryway &&
+      ctx.cfg.identity.serviceHandleDomains.some(
+        (host) => handle.endsWith(host) || handle === host.slice(1),
+      )
     if (!supportedHandle) {
       return res.status(404).send('User not found')
     }

--- a/packages/pds/tests/entryway-mock.ts
+++ b/packages/pds/tests/entryway-mock.ts
@@ -304,6 +304,18 @@ export class MockEntryway {
       },
     })
 
+    server.routes.get('/.well-known/atproto-did', (req, res) => {
+      const handle = req.hostname
+      const account = [...accounts.values()].find(
+        (acc) => acc.handle === handle,
+      )
+      if (!account) {
+        res.status(404).send('User not found')
+        return
+      }
+      res.type('text/plain').send(account.did)
+    })
+
     const httpServer = server.listen(opts.port)
     const terminator = createHttpTerminator({ server: httpServer })
 
@@ -315,6 +327,11 @@ export class MockEntryway {
 
   getAccount(did: string): Account | undefined {
     return this.accounts.get(did)
+  }
+
+  // e.g. for representing accounts on other pdses behind the entryway
+  addAccount(account: Account): void {
+    this.accounts.set(account.did, account)
   }
 
   async destroy(): Promise<void> {

--- a/packages/pds/tests/entryway.test.ts
+++ b/packages/pds/tests/entryway.test.ts
@@ -127,11 +127,30 @@ describe('entryway', () => {
     expect(accountFromEntryway?.handle).toEqual('alice3.test')
   })
 
-  it('resolves handle of local account.', async () => {
+  it('resolves handle of local account via entryway.', async () => {
     const res = await pdsAgent.api.com.atproto.identity.resolveHandle({
       handle: 'alice3.test',
     })
     expect(res.data.did).toEqual(alice)
+  })
+
+  it('does not resolve handle from local account store.', async () => {
+    // known locally but not by the entryway, e.g. local state that diverged
+    await pds.ctx.accountManager.updateAccountHandle(
+      alice,
+      'alice-diverged.test' as HandleString,
+    )
+    try {
+      const attempt = pdsAgent.api.com.atproto.identity.resolveHandle({
+        handle: 'alice-diverged.test',
+      })
+      await expect(attempt).rejects.toThrow('Unable to resolve handle')
+    } finally {
+      await pds.ctx.accountManager.updateAccountHandle(
+        alice,
+        'alice3.test' as HandleString,
+      )
+    }
   })
 
   it('resolves handle of account behind entryway on another pds.', async () => {

--- a/packages/pds/tests/entryway.test.ts
+++ b/packages/pds/tests/entryway.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert'
 import * as plcLib from '@did-plc/lib'
 import getPort from 'get-port'
+import { request } from 'undici'
 import { AtpAgent } from '@atproto/api'
 import { Secp256k1Keypair } from '@atproto/crypto'
 import { SeedClient, TestPds, TestPlc, mockResolvers } from '@atproto/dev-env'
 import { isDidString } from '@atproto/lex'
-import type { DidString } from '@atproto/syntax'
+import type { DidString, HandleString } from '@atproto/syntax'
 import { MockEntryway } from './entryway-mock.js'
 
 describe('entryway', () => {
@@ -28,7 +29,10 @@ describe('entryway', () => {
       entrywayJwtVerifyKeyK256PublicKeyHex: jwtSigningKey.publicKeyStr('hex'),
       entrywayPlcRotationKey: plcRotationKey.did(),
       adminPassword: 'admin-pass',
-      serviceHandleDomains: [],
+      // matches the entryway's handle domains, which it makes resolvable
+      serviceHandleDomains: ['.test'],
+      bskyAppViewUrl: undefined,
+      bskyAppViewDid: undefined,
       didPlcUrl: plc.url,
       serviceDid: 'did:example:pds',
       inviteRequired: false,
@@ -43,8 +47,8 @@ describe('entryway', () => {
       jwtSigningKey,
       plcRotationKey,
     })
-    mockResolvers(pds.ctx.idResolver, pds)
-    mockResolvers(entryway.idResolver, pds)
+    mockResolvers(pds.ctx.idResolver, pds, entryway.url)
+    mockResolvers(entryway.idResolver, pds, entryway.url)
     pdsAgent = pds.getAgent()
     entrywayAgent = new AtpAgent({
       service: entryway.url,
@@ -121,6 +125,46 @@ describe('entryway', () => {
     expect(handleToDid).toEqual(alice)
     expect(accountFromPds?.handle).toEqual('alice3.test')
     expect(accountFromEntryway?.handle).toEqual('alice3.test')
+  })
+
+  it('resolves handle of local account.', async () => {
+    const res = await pdsAgent.api.com.atproto.identity.resolveHandle({
+      handle: 'alice3.test',
+    })
+    expect(res.data.did).toEqual(alice)
+  })
+
+  it('resolves handle of account behind entryway on another pds.', async () => {
+    entryway.addAccount({
+      did: 'did:plc:aaaaaaaaaaaaaaaaaaaaaaaa' as DidString,
+      handle: 'sibling.test' as HandleString,
+    })
+    const res = await pdsAgent.api.com.atproto.identity.resolveHandle({
+      handle: 'sibling.test',
+    })
+    expect(res.data.did).toEqual('did:plc:aaaaaaaaaaaaaaaaaaaaaaaa')
+  })
+
+  it('fails to resolve unknown handle on service domain.', async () => {
+    const attempt = pdsAgent.api.com.atproto.identity.resolveHandle({
+      handle: 'nonexistent.test',
+    })
+    await expect(attempt).rejects.toThrow('Unable to resolve handle')
+  })
+
+  it('defers handle resolution over well-known to entryway.', async () => {
+    const resPds = await request(new URL('/.well-known/atproto-did', pds.url), {
+      headers: { host: 'alice3.test' },
+    })
+    expect(resPds.statusCode).toEqual(404)
+    await resPds.body.dump()
+
+    const resEntryway = await request(
+      new URL('/.well-known/atproto-did', entryway.url),
+      { headers: { host: 'alice3.test' } },
+    )
+    expect(resEntryway.statusCode).toEqual(200)
+    await expect(resEntryway.body.text()).resolves.toEqual(alice)
   })
 
   it('does not allow bringing own op to account creation.', async () => {


### PR DESCRIPTION
When a PDS runs behind an entryway, `PDS_SERVICE_HANDLE_DOMAINS` could not be configured to match the entryway's handle domains: any handle under those domains that wasn't hosted locally would fail resolution, even though it may belong to an account on a sibling PDS behind the same entryway.

- `com.atproto.identity.resolveHandle` no longer consults the PDS's local account store when an entryway is configured — the entryway is authoritative for handles, so resolution always goes through the appview or network. This also prevents serving local handle state that has diverged from the entryway.
- `/.well-known/atproto-did` no longer answers authoritatively for service domains when an entryway is configured, deferring handle resolution to the entryway.
- dev-env's `mockResolvers()` accepts an optional URL controlling where handle resolution is served from, and the mock entryway now implements `/.well-known/atproto-did` — used by new entryway test cases covering resolution of hosted accounts, accounts on sibling PDSes, diverged local handle state, and well-known deferral.