### PR TITLE
Fix flaky ozone tests

### DIFF
--- a/.changeset/witty-tigers-tag.md
+++ b/.changeset/witty-tigers-tag.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Apply subject status tags in deterministic tagger order

--- a/packages/ozone/src/tag-service/index.ts
+++ b/packages/ozone/src/tag-service/index.ts
@@ -27,22 +27,27 @@ export class TagService {
     try {
       const tags = new Set(initialTags)
 
-      await Promise.all(
+      // Collect tagger results and add them in declared tagger order, so that
+      // the resulting tag order does not depend on which tagger resolves first
+      const taggerResults = await Promise.all(
         this.taggers.map(async (tagger) => {
           try {
-            const newTags = await tagger.getTags()
-            for (const newTag of newTags) {
-              tags.add(newTag)
-            }
+            return await tagger.getTags()
           } catch (e) {
             // Don't let one tagger error stop the rest from running
             log.error(
               { subject: this.subject, err: e },
               'Error applying tagger',
             )
+            return []
           }
         }),
       )
+      for (const newTags of taggerResults) {
+        for (const newTag of newTags) {
+          tags.add(newTag)
+        }
+      }
 
       // Ensure that before inserting new tags, we discard any tag that may
       // have been evaluated to be added but is already present in the subject

--- a/packages/ozone/tests/get-profiles.test.ts
+++ b/packages/ozone/tests/get-profiles.test.ts
@@ -49,6 +49,9 @@ describe('get profiles through ozone', () => {
       subject: repoSubject(sc.dids.bob),
     })
 
+    // ensure the takedown has been pushed out to the appview
+    await network.processAll()
+
     const profilesAfterFromOzone = await getProfiles([
       sc.dids.bob,
       sc.dids.carol,


### PR DESCRIPTION
Fixes two flaky tests in `packages/ozone`:

- **get-profiles**: `performTakedown` returns before ozone's background queue pushes the takedown out to the appview, so the test could query the appview before the takedown landed and still see the profile. The test now waits for `network.processAll()` first.
- **blob-divert** (and other tag-snapshot suites): subject status tags were added to a shared set as each tagger's async work resolved, so tag order depended on which tagger finished first. Taggers still run concurrently, but their results are now merged in declared tagger order, making the persisted tag order deterministic.