### PR TITLE
interop-test-files: add valid TID vectors with letter first characters

### DIFF
--- a/interop-test-files/syntax/tid_syntax_valid.txt
+++ b/interop-test-files/syntax/tid_syntax_valid.txt
@@ -4,3 +4,8 @@
 3jzfcijpj2z2a
 7777777777777
 3zzzzzzzzzzzz
+
+# letter first characters (decoded value < 16, high bit zero)
+a222222222222
+j222222222222
+azzzzzzzzzzzz


### PR DESCRIPTION
The TID syntax allows first characters `234567abcdefghij` (decoded value < 16, keeping the high bit of the underlying 64-bit value zero). The invalid vectors cover the rejection side of this boundary (`# high bit can't be high`: `zzzzzzzzzzzzz`, `kjzfcijpj2z2a`), but `tid_syntax_valid.txt` has no vector starting with a letter — all three valid vectors are digit-first, so implementations get no coverage of the accepted side.

The gap has real cost: it recently concealed a downstream divergence where a Python SDK rejected every spec-valid TID starting with `a`–`j` while passing the interop suite green (found while writing spec-conformance tests for an AT Protocol project I'm working on; fixed in MarshalX/atproto#695).

This PR adds three letter-first valid vectors. Verified against `@atproto/syntax`: ran the package test suite (`pnpm test` in `packages/syntax`, vitest), which loads the interop files directly — all tests pass, with `tid.test.ts` picking up the new vectors (13 tests, up from 10).
