### PR TITLE
Create searchStarterPacksV2 endpoint

### DIFF
--- a/.changeset/sparkly-oranges-hug.md
+++ b/.changeset/sparkly-oranges-hug.md
@@ -1,0 +1,6 @@
+---
+'@atproto/api': patch
+'@atproto/bsky': patch
+---
+
+Create new searchStarterPacksV2 endpoint

--- a/lexicons/app/bsky/authFullApp.json
+++ b/lexicons/app/bsky/authFullApp.json
@@ -70,6 +70,7 @@
             "app.bsky.graph.muteActorList",
             "app.bsky.graph.muteThread",
             "app.bsky.graph.searchStarterPacks",
+            "app.bsky.graph.searchStarterPacksV2",
             "app.bsky.graph.unmuteActor",
             "app.bsky.graph.unmuteActorList",
             "app.bsky.graph.unmuteThread",

--- a/lexicons/app/bsky/authViewAll.json
+++ b/lexicons/app/bsky/authViewAll.json
@@ -55,6 +55,7 @@
             "app.bsky.graph.getStarterPacksWithMembership",
             "app.bsky.graph.getSuggestedFollowsByActor",
             "app.bsky.graph.searchStarterPacks",
+            "app.bsky.graph.searchStarterPacksV2",
             "app.bsky.labeler.getServices",
             "app.bsky.notification.getPreferences",
             "app.bsky.notification.getUnreadCount",

--- a/lexicons/app/bsky/graph/searchStarterPacksV2.json
+++ b/lexicons/app/bsky/graph/searchStarterPacksV2.json
@@ -1,0 +1,52 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.searchStarterPacksV2",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Find starter packs matching search criteria. Does not require auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["q"],
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 25
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["starterPacks"],
+          "properties": {
+            "cursor": {
+              "type": "string"
+            },
+            "hitsTotal": {
+              "type": "integer",
+              "description": "Estimated total number of matching hits. May be rounded or truncated."
+            },
+            "starterPacks": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "app.bsky.graph.defs#starterPackView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacksV2.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacksV2.ts
@@ -1,0 +1,129 @@
+import { mapDefined } from '@atproto/common'
+import type { AtUriString } from '@atproto/lex'
+import type { Server } from '@atproto/xrpc-server'
+import type { AppContext } from '../../../../context.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
+import type { HydrateCtx, Hydrator } from '../../../../hydration/hydrator.js'
+import { parseString } from '../../../../hydration/util.js'
+import { app } from '../../../../lexicons/index.js'
+import {
+  type HydrationFnInput,
+  type PresentationFnInput,
+  type RulesFnInput,
+  type SkeletonFnInput,
+  createPipeline,
+} from '../../../../pipeline.js'
+import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
+import type { Views } from '../../../../views/index.js'
+import { resHeaders } from '../../../util.js'
+
+export default function (server: Server, ctx: AppContext) {
+  const searchStarterPacksV2 = createPipeline(
+    skeleton,
+    hydration,
+    noBlocks,
+    presentation,
+  )
+  server.add(app.bsky.graph.searchStarterPacksV2, {
+    auth: ctx.authVerifier.standardOptional,
+    handler: async ({ auth, params, req }) => {
+      const { viewer, includeTakedowns, skipViewerBlocks } =
+        ctx.authVerifier.parseCreds(auth)
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        viewer,
+        labelers,
+        includeTakedowns,
+        skipViewerBlocks,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({
+            viewer,
+            req,
+          }),
+        ),
+      })
+
+      const results = await searchStarterPacksV2({ ...params, hydrateCtx }, ctx)
+      return {
+        encoding: 'application/json',
+        body: results,
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}
+
+const skeleton = async (
+  inputs: SkeletonFnInput<Context, Params>,
+): Promise<Skeleton> => {
+  const { ctx, params } = inputs
+  const { q } = params
+
+  // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+  const res = await ctx.dataplane
+    .searchStarterPacksV2({
+      params: {
+        query: q,
+        viewer: params.hydrateCtx.viewer ?? undefined,
+        limit: params.limit,
+        cursor: params.cursor,
+      },
+    })
+    .catch(asInvalidRequest())
+  return {
+    uris: res.starterPacks.map(({ uri }) => uri as AtUriString),
+    cursor: parseString(res.pageInfo?.cursor),
+    hitsTotal: res.pageInfo?.hitsTotal
+      ? Number(res.pageInfo.hitsTotal)
+      : undefined,
+  }
+}
+
+const hydration = async (
+  inputs: HydrationFnInput<Context, Params, Skeleton>,
+) => {
+  const { ctx, params, skeleton } = inputs
+  return ctx.hydrator.hydrateStarterPacks(skeleton.uris, params.hydrateCtx)
+}
+
+const noBlocks = (inputs: RulesFnInput<Context, Params, Skeleton>) => {
+  const { ctx, skeleton, hydration } = inputs
+  skeleton.uris = skeleton.uris.filter((uri) => {
+    const creator = creatorFromUri(uri)
+    return !ctx.views.viewerBlockExists(creator, hydration)
+  })
+  return skeleton
+}
+
+const presentation = (
+  inputs: PresentationFnInput<Context, Params, Skeleton>,
+) => {
+  const { ctx, skeleton, hydration } = inputs
+  const starterPacks = mapDefined(skeleton.uris, (uri) =>
+    ctx.views.starterPack(uri, hydration),
+  )
+  return {
+    starterPacks,
+    cursor: skeleton.cursor,
+    hitsTotal: skeleton.hitsTotal,
+  }
+}
+
+type Context = {
+  dataplane: DataPlaneClient
+  hydrator: Hydrator
+  views: Views
+}
+
+type Params = app.bsky.graph.searchStarterPacksV2.$Params & {
+  hydrateCtx: HydrateCtx
+}
+
+type Skeleton = {
+  uris: AtUriString[]
+  cursor?: string
+  hitsTotal?: number
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -60,6 +60,7 @@ import muteActor from './app/bsky/graph/muteActor.js'
 import muteActorList from './app/bsky/graph/muteActorList.js'
 import muteThread from './app/bsky/graph/muteThread.js'
 import searchStarterPacks from './app/bsky/graph/searchStarterPacks.js'
+import searchStarterPacksV2 from './app/bsky/graph/searchStarterPacksV2.js'
 import unmuteActor from './app/bsky/graph/unmuteActor.js'
 import unmuteActorList from './app/bsky/graph/unmuteActorList.js'
 import unmuteThread from './app/bsky/graph/unmuteThread.js'
@@ -164,6 +165,7 @@ export default function (server: Server, ctx: AppContext) {
   getStarterPacks(server, ctx)
   getStarterPacksWithMembership(server, ctx)
   searchStarterPacks(server, ctx)
+  searchStarterPacksV2(server, ctx)
   muteActor(server, ctx)
   unmuteActor(server, ctx)
   muteActorList(server, ctx)

--- a/packages/bsky/tests/views/starter-packs.test.ts
+++ b/packages/bsky/tests/views/starter-packs.test.ts
@@ -25,6 +25,7 @@ describe('starter packs', () => {
   let sp2: RecordRef
   let sp3: RecordRef
   let sp4: RecordRef
+  let feedgen: RecordRef
 
   beforeAll(async () => {
     network = await TestNetwork.create({
@@ -35,7 +36,7 @@ describe('starter packs', () => {
     await basicSeed(sc)
     await network.processAll()
 
-    const feedgen = await sc.createFeedGen(
+    feedgen = await sc.createFeedGen(
       sc.dids.alice,
       'did:web:example.com',
       "alice's feedgen",
@@ -262,6 +263,53 @@ describe('starter packs', () => {
         },
       )
 
+      expect(data.starterPacks).toMatchObject([
+        expect.objectContaining({ uri: sp4.uriStr }),
+      ])
+    })
+  })
+
+  describe('searchStarterPacksV2', () => {
+    it('returns fully hydrated starter pack views', async () => {
+      const { data } = await agent.app.bsky.graph.searchStarterPacksV2({
+        q: 'starter',
+        limit: 10,
+      })
+
+      expect(data.starterPacks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            uri: sp1.uriStr,
+            feeds: [expect.objectContaining({ uri: feedgen.uriStr })],
+            list: expect.objectContaining({ listItemCount: 3 }),
+            listItemsSample: expect.arrayContaining([
+              expect.objectContaining({
+                subject: expect.objectContaining({ did: sc.dids.bob }),
+              }),
+              expect.objectContaining({
+                subject: expect.objectContaining({ did: sc.dids.carol }),
+              }),
+              expect.objectContaining({
+                subject: expect.objectContaining({ did: sc.dids.dan }),
+              }),
+            ]),
+          }),
+        ]),
+      )
+    })
+
+    it('does not include starter packs with creator block relationships', async () => {
+      const { data } = await agent.app.bsky.graph.searchStarterPacksV2(
+        { q: 'starter', limit: 10 },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.frankie,
+            ids.AppBskyGraphSearchStarterPacksV2,
+          ),
+        },
+      )
+
+      expect(data.starterPacks).toHaveLength(1)
       expect(data.starterPacks).toMatchObject([
         expect.objectContaining({ uri: sp4.uriStr }),
       ])


### PR DESCRIPTION
Primarily to return `app.bsky.graph.defs#starterPackView` vs `app.bsky.graph.defs#starterPackViewBasic`.