### PR TITLE
Add description field to trending topics

### DIFF
--- a/.changeset/cuddly-snails-matter.md
+++ b/.changeset/cuddly-snails-matter.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add description to trending topics

--- a/.changeset/yummy-flies-taste.md
+++ b/.changeset/yummy-flies-taste.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Add description to trending topics

--- a/lexicons/app/bsky/unspecced/defs.json
+++ b/lexicons/app/bsky/unspecced/defs.json
@@ -46,6 +46,7 @@
       "properties": {
         "topic": { "type": "string" },
         "displayName": { "type": "string" },
+        "description": { "type": "string" },
         "link": { "type": "string" },
         "startedAt": { "type": "string", "format": "datetime" },
         "postCount": { "type": "integer" },
@@ -73,6 +74,7 @@
       "properties": {
         "topic": { "type": "string" },
         "displayName": { "type": "string" },
+        "description": { "type": "string" },
         "link": { "type": "string" },
         "startedAt": { "type": "string", "format": "datetime" },
         "postCount": { "type": "integer" },

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -136,6 +136,7 @@ const presentation: PresentationFn<
     trends: skeleton.trends.map((t) => ({
       topic: t.topic,
       displayName: t.displayName,
+      description: t.description,
       link: t.link,
       startedAt: t.startedAt,
       postCount: t.postCount,


### PR DESCRIPTION
Optional string field ([source](https://github.com/bluesky-social/tango/blob/main/iris/iris/routes/topics.py#L54)).