### PR TITLE
Use sign-in terminology consistently in OAuth UI

### DIFF
--- a/.changeset/tidy-doors-greet.md
+++ b/.changeset/tidy-doors-greet.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Use "sign in" terminology consistently in the OAuth authorization flow: the post-authorization redirect screen now says "Sign-in complete" / "Sign-in canceled" (previously "Login complete" / "Login canceled"), and the account picker's "Another account" option is labeled "Sign in to an account that is not listed"

--- a/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/authorization-page.tsx
@@ -159,7 +159,7 @@ function App() {
   if (redirectUrl) {
     return (
       <RedirectingView
-        title={rejected ? msg`Login canceled` : msg`Login complete`}
+        title={rejected ? msg`Sign-in canceled` : msg`Sign-in complete`}
         redirectUrl={redirectUrl}
         // We don't want the user to be able to click the back button and go
         // back to the consent screen after consenting/rejecting, so we replace

--- a/packages/oauth/oauth-provider-ui/src/components/sign-in-picker.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/sign-in-picker.tsx
@@ -64,7 +64,7 @@ export function SignInPicker({
         <InputContainer
           key="other"
           onAction={onOther}
-          aria-label={t`Login to account that is not listed`}
+          aria-label={t`Sign in to an account that is not listed`}
           append={<CaretRightIcon aria-hidden className="h-4" />}
           icon={<AtIcon aria-hidden weight="bold" className="h-4 w-6" />}
         >

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -744,18 +744,6 @@ msgstr "Later"
 msgid "Let's get your password reset!"
 msgstr "Let's get your password reset!"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr "Login canceled"
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "Login complete"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "Login to account that is not listed"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "Logo"
@@ -1055,6 +1043,10 @@ msgstr "Sign in as {0}"
 msgid "Sign in as..."
 msgstr "Sign in as..."
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr "Sign in to an account that is not listed"
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1069,6 +1061,14 @@ msgstr "Sign out"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "Sign up"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr "Sign-in canceled"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr "Sign-in complete"
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -734,18 +734,6 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr "¡Vamos a restablecer tu contraseña!"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr ""
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "Inicio de sesión completo"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "Iniciar sesión en una cuenta que no está en la lista"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "Logo"
@@ -1045,6 +1033,10 @@ msgstr "Iniciar sesión como {0}"
 msgid "Sign in as..."
 msgstr "Iniciar sesión como..."
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr ""
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1059,6 +1051,14 @@ msgstr "Cerrar sesión"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "Registrarse"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr ""
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr ""
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -744,18 +744,6 @@ msgstr "Plus tard"
 msgid "Let's get your password reset!"
 msgstr "Réinitialisons votre mot de passe !"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr "Connexion annulée"
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "Connexion terminée"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "Se connecter à un compte qui n'est pas listé"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "Logo"
@@ -1055,6 +1043,10 @@ msgstr "Se connecter en tant que {0}"
 msgid "Sign in as..."
 msgstr "Se connecter en tant que..."
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr "Se connecter à un compte qui n'est pas listé"
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1069,6 +1061,14 @@ msgstr "Se déconnecter"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "Inscription"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr "Connexion annulée"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr "Connexion terminée"
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -744,18 +744,6 @@ msgstr "後で"
 msgid "Let's get your password reset!"
 msgstr "パスワードをリセットしましょう！"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr "ログインキャンセル"
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "ログイン完了"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "リストにないアカウントにログイン"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "ロゴ"
@@ -1055,6 +1043,10 @@ msgstr "{0} でサインイン"
 msgid "Sign in as..."
 msgstr "アカウントの選択"
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr ""
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1069,6 +1061,14 @@ msgstr "サインアウト"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "サインアップ"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr ""
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr ""
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -734,18 +734,6 @@ msgstr ""
 msgid "Let's get your password reset!"
 msgstr "비밀번호를 재설정해 봅시다!"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr ""
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "로그인 완료"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "목록에 없는 계정으로 로그인"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "로고"
@@ -1045,6 +1033,10 @@ msgstr "{0}(으)로 로그인"
 msgid "Sign in as..."
 msgstr "로그인"
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr ""
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1059,6 +1051,14 @@ msgstr "로그아웃"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "가입"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr ""
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr ""
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -744,18 +744,6 @@ msgstr "Senare"
 msgid "Let's get your password reset!"
 msgstr "Låt oss få ditt lösenord återställt!"
 
-#: src/authorization-page.tsx:162
-msgid "Login canceled"
-msgstr "Inloggning avbruten"
-
-#: src/authorization-page.tsx:162
-msgid "Login complete"
-msgstr "Inloggning klar"
-
-#: src/components/sign-in-picker.tsx:67
-msgid "Login to account that is not listed"
-msgstr "Logga in på ett olistat konto"
-
 #: src/components/layouts/layout-app.tsx:28
 msgid "Logo"
 msgstr "Logga"
@@ -1055,6 +1043,10 @@ msgstr "Logga in som {0}"
 msgid "Sign in as..."
 msgstr "Logga in som…"
 
+#: src/components/sign-in-picker.tsx:67
+msgid "Sign in to an account that is not listed"
+msgstr ""
+
 #: src/pages/account/(authenticated)/devices/page.tsx:111
 msgctxt "device list"
 msgid "Sign out"
@@ -1069,6 +1061,14 @@ msgstr "Logga ut"
 #: src/components/sign-in-picker.tsx:85
 msgid "Sign up"
 msgstr "Registrera dig"
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in canceled"
+msgstr ""
+
+#: src/authorization-page.tsx:162
+msgid "Sign-in complete"
+msgstr ""
 
 #: src/components/utils/error-details.tsx:63
 msgctxt "Error"


### PR DESCRIPTION
Fixes #3863

The OAuth authorization flow says "Sign in" throughout, but the final redirect screen said "Login complete" / "Login canceled". This replaces the last two user-visible "login" strings in `oauth-provider-ui` (remaining `login` hits in the package are the `loginHint` OAuth parameter name):

- `authorization-page.tsx`: redirect screen title is now **"Sign-in complete"** / **"Sign-in canceled"** (hyphenated noun form).
- `sign-in-picker.tsx`: the "Another account" option's aria-label is now **"Sign in to an account that is not listed"** (verb form, plus a missing "an").

Message catalogs were re-extracted with `pnpm i18n` (the stale "Login…" entries are dropped). The French translations reuse the existing wording ("Connexion terminée" / "Connexion annulée" / "Se connecter à un compte qui n'est pas listé"); other locales are left for translators. Includes a patch changeset for `@atproto/oauth-provider-ui`.

## Screenshots

Captured against the local dev-env with the demo OAuth client.

### Redirect screen after authorizing

![Sign-in complete](https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-signin-ui/1-signin-complete.png)

### Redirect screen after denying access

![Sign-in canceled](https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-signin-ui/3-signin-canceled.png)

### Account picker (the "Another account" row carries the changed aria-label)

![Sign-in picker](https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-signin-ui/2-sign-in-picker.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)