### PR TITLE
Resolve DID login_hint to the account handle on the authorization page

### DIFF
--- a/.changeset/olive-pans-yell.md
+++ b/.changeset/olive-pans-yell.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider': patch
+---
+
+Display the account's current handle on the authorization page when a client provides a DID as `login_hint`

--- a/packages/oauth/oauth-provider/package.json
+++ b/packages/oauth/oauth-provider/package.json
@@ -93,9 +93,11 @@
     "@types/cookie": "^0.6.0",
     "@types/forwarded": "0.1.3",
     "@types/http-errors": "^2.0.4",
-    "@types/send": "^0.17.4"
+    "@types/send": "^0.17.4",
+    "vitest": "^4.0.16"
   },
   "scripts": {
-    "build": "tsgo --build tsconfig.build.json"
+    "build": "tsgo --build tsconfig.build.json",
+    "test": "vitest run"
   }
 }

--- a/packages/oauth/oauth-provider/src/account/login-hint.test.ts
+++ b/packages/oauth/oauth-provider/src/account/login-hint.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Account } from '@atproto/oauth-provider-api'
+import type { AccountManager } from './account-manager.js'
+import { resolveLoginHint } from './login-hint.js'
+
+const aliceDid = 'did:plc:2ihkmqhirw5tturitpdyf2fa'
+
+const alice = {
+  did: aliceDid,
+  pds: 'did:web:pds.example.com',
+  deactivated: false,
+  handle: 'alice.test',
+} as Account
+
+const managerFor = (result: Account | Error) =>
+  ({
+    getAccount: vi.fn(async () => {
+      if (result instanceof Error) throw result
+      return { account: result, authorizedClients: new Map() }
+    }),
+  }) satisfies Pick<AccountManager, 'getAccount'>
+
+describe(resolveLoginHint, () => {
+  it('resolves a DID hint to the account handle', async () => {
+    const manager = managerFor(alice)
+    await expect(resolveLoginHint(aliceDid, manager)).resolves.toBe(
+      'alice.test',
+    )
+    expect(manager.getAccount).toHaveBeenCalledWith(aliceDid)
+  })
+
+  it('returns the DID unchanged when the account has no handle', async () => {
+    const manager = managerFor({ ...alice, handle: undefined } as Account)
+    await expect(resolveLoginHint(aliceDid, manager)).resolves.toBe(aliceDid)
+  })
+
+  it('returns the DID unchanged when the account is unknown', async () => {
+    const manager = managerFor(new Error('Account not found'))
+    await expect(resolveLoginHint(aliceDid, manager)).resolves.toBe(aliceDid)
+  })
+
+  it('leaves handle hints unchanged without a lookup', async () => {
+    const manager = managerFor(alice)
+    await expect(resolveLoginHint('alice.test', manager)).resolves.toBe(
+      'alice.test',
+    )
+    expect(manager.getAccount).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when no hint is provided', async () => {
+    const manager = managerFor(alice)
+    await expect(resolveLoginHint(undefined, manager)).resolves.toBeUndefined()
+    expect(manager.getAccount).not.toHaveBeenCalled()
+  })
+})

--- a/packages/oauth/oauth-provider/src/account/login-hint.ts
+++ b/packages/oauth/oauth-provider/src/account/login-hint.ts
@@ -1,0 +1,25 @@
+import { isAtprotoDid } from '@atproto/did'
+import type { AccountManager } from './account-manager.js'
+
+/**
+ * Computes the user-facing value for a `login_hint` request parameter. Clients
+ * may provide a DID (typically when re-authenticating an account they already
+ * know), which users are unlikely to recognize as their own. When the DID
+ * belongs to an account on this server, return that account's current handle
+ * for display instead.
+ */
+export async function resolveLoginHint(
+  hint: string | undefined,
+  accountManager: Pick<AccountManager, 'getAccount'>,
+): Promise<string | undefined> {
+  if (hint && isAtprotoDid(hint)) {
+    const account = await accountManager.getAccount(hint).then(
+      (result) => result.account,
+      // Unknown account: fall back to displaying the hint as-is
+      () => null,
+    )
+    if (account?.handle) return account.handle
+  }
+
+  return hint
+}

--- a/packages/oauth/oauth-provider/src/oauth-provider.ts
+++ b/packages/oauth/oauth-provider/src/oauth-provider.ts
@@ -34,6 +34,7 @@ import {
   type DeviceAccount,
   asAccountStore,
 } from './account/account-store.js'
+import { resolveLoginHint } from './account/login-hint.js'
 import type { ClientAuth, ClientAuthLegacy } from './client/client-auth.js'
 import type { ClientId } from './client/client-id.js'
 import {
@@ -730,6 +731,10 @@ export class OAuthProvider extends OAuthVerifier {
           parameters.prompt === 'consent'
             ? sessions.find(matchesHint, parameters)?.account.did
             : undefined,
+        loginHint: await resolveLoginHint(
+          parameters.login_hint,
+          this.accountManager,
+        ),
         permissionSets: await this.lexiconManager
           .getPermissionSetsFromScope(parameters.scope)
           .catch((cause) => {

--- a/packages/oauth/oauth-provider/src/result/authorization-result-authorize-page.ts
+++ b/packages/oauth/oauth-provider/src/result/authorization-result-authorize-page.ts
@@ -13,4 +13,11 @@ export type AuthorizationResultAuthorizePage = {
   requestUri: RequestUri
   sessions: readonly Session[]
   selectedDid?: Account['did']
+
+  /**
+   * User-facing value of the `login_hint` parameter. Same as
+   * `parameters.login_hint`, except that a DID hint is resolved to the
+   * account's handle when the account is known to this server.
+   */
+  loginHint?: string
 }

--- a/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
+++ b/packages/oauth/oauth-provider/src/router/assets/send-authorization-page.ts
@@ -30,7 +30,7 @@ export function sendAuthorizePageFactory(
 
           scope: data.parameters.scope,
           uiLocales: data.parameters.ui_locales,
-          loginHint: data.parameters.login_hint,
+          loginHint: data.loginHint,
           promptMode: data.parameters.prompt,
           permissionSets: Object.fromEntries(data.permissionSets),
           selectedDid: data.selectedDid,

--- a/packages/oauth/oauth-provider/tsconfig.build.json
+++ b/packages/oauth/oauth-provider/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["../../../tsconfig/node.tsconfig.json"],
   "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     { "path": "../../common/tsconfig.build.json" },
     { "path": "../../did/tsconfig.build.json" },

--- a/packages/oauth/oauth-provider/tsconfig.json
+++ b/packages/oauth/oauth-provider/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
 }

--- a/packages/oauth/oauth-provider/tsconfig.test.json
+++ b/packages/oauth/oauth-provider/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../../tsconfig/vitest.tsconfig.json"],
+  "include": ["**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": ".",
+  },
+  "references": [{ "path": "./tsconfig.build.json" }],
+}

--- a/packages/oauth/oauth-provider/vitest.config.ts
+++ b/packages/oauth/oauth-provider/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1617,6 +1617,9 @@ importers:
       '@types/send':
         specifier: ^0.17.4
         version: 0.17.4
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1)
 
   packages/oauth/oauth-provider-api:
     dependencies:
@@ -12160,7 +12163,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       'packages/internal/handle-resolver',
       'packages/lex/*',
       'packages/oauth/oauth-client',
+      'packages/oauth/oauth-provider',
       'packages/syntax',
       'packages/tap',
 


### PR DESCRIPTION
## Motivation

Fixes #4900 — when an OAuth client passes a DID as `login_hint` (e.g. re-authenticating an account it already knows by its durable identifier), the sign-in form pre-fills the raw `did:plc:…` string, which users are unlikely to recognize as their own account.

## Changes

- New `resolveLoginHint()` helper in `packages/oauth/oauth-provider/src/account/login-hint.ts`: when the hint is a DID belonging to an account on this server, it returns the account's current handle; otherwise (unknown account, or account without a handle) it returns the hint unchanged.
- The authorize flow computes this value and passes it to the authorization page via a new optional `loginHint` field on `AuthorizationResultAuthorizePage`. The client's stored request parameters are untouched — only the display value sent to the UI changes, so SSO session matching and error redirects behave exactly as before. This also means the `@TODO` about verifying account existence in `request-manager.ts` is left as-is: an unknown DID still renders (as itself) rather than being rejected, to avoid changing behavior for existing clients.
- No UI changes needed: the page renders whatever identifier it receives, and its session-matching logic already accepts either DID or handle.
- First tests in `@atproto/oauth-provider`: adopted vitest (package config + `tsconfig.test.json`, registered in the root vitest projects list) with 5 unit tests covering resolution, both fallbacks, the no-lookup path for handle hints, and the undefined case. Also added the `**/*.test.ts` exclusion to `tsconfig.build.json` that this package never needed before.
- Changeset: patch bump for `@atproto/oauth-provider`.

## Screenshots

Client sends `login_hint=did:plc:272ug475putgca2kk7qqf4ux` (a known account) — the Identifier field now shows the handle. This is where the raw DID appeared before this change:

![Sign-in form showing the resolved handle alice.test in the read-only Identifier field](https://raw.githubusercontent.com/bigmoves/atproto/590c9e43dd8e96fdc7e924c7e285819e73d5e9a3/with-fix-did-hint-shows-handle.png)

Client sends a DID unknown to this server — graceful fallback, the DID renders unchanged (this is also exactly how every DID hint rendered before this change):

![Sign-in form showing an unresolved DID in the Identifier field](https://raw.githubusercontent.com/bigmoves/atproto/590c9e43dd8e96fdc7e924c7e285819e73d5e9a3/fallback-unknown-did.png)

> Note: screenshots are from a fork with a redesigned authorization UI; the affected Identifier field behaves identically in the stock UI.

## Verification

- `pnpm test` in `packages/oauth/oauth-provider` — 5/5 green (watched the DID-resolution case fail first, TDD).
- `tsgo --build` clean for `oauth-provider` and `pds`; eslint + prettier clean.
- Live end-to-end against dev-env: PAR with a known account's DID as `login_hint` → authorize page embeds the handle; PAR with an unknown DID → page shows the DID unchanged (see screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
