### PR TITLE
Fix missing list bullets on the OAuth account About page at mobile widths

### DIFF
--- a/.changeset/lucky-moons-repeat.md
+++ b/.changeset/lucky-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Fix missing list bullets on the account "About" page at mobile widths, where the base `prose` class was only applied from the `md` breakpoint up.

--- a/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/about/page.fr.tsx
+++ b/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/about/page.fr.tsx
@@ -8,7 +8,7 @@ export function Page(): ReactNode {
   const { account } = useAuthenticatedSession()
 
   return (
-    <div className="prose-sm md:prose prose-slate dark:prose-invert max-w-none">
+    <div className="prose prose-sm md:prose-base prose-slate dark:prose-invert max-w-none">
       <section>
         <h2>Qu'est-ce qu'un compte Atmosphère ?</h2>
         <p>

--- a/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/about/page.tsx
+++ b/packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/about/page.tsx
@@ -8,7 +8,7 @@ export function Page() {
   const { account } = useAuthenticatedSession()
 
   return (
-    <div className="prose-sm md:prose prose-slate dark:prose-invert max-w-none">
+    <div className="prose prose-sm md:prose-base prose-slate dark:prose-invert max-w-none">
       <section>
         <Trans>
           <h2>What is an Atmosphere account?</h2>


### PR DESCRIPTION
List items on the account-manager **About** page render indented but with no bullets on narrow viewports. They display correctly at `md` and above.

## Cause

The page wrapper in `packages/oauth/oauth-provider-ui/src/pages/account/(authenticated)/about/page.tsx` is:

```
prose-sm md:prose prose-slate dark:prose-invert max-w-none
```

The base `prose` class is applied **only from `md` up**. `prose-sm` is a Tailwind Typography *size modifier* — on its own it adjusts scale but pulls in none of the base typography styles. Below `md` there is therefore no `prose` at all, so the `ul` falls back to Preflight's `list-style: none`.

## Fix

Apply the base `prose` at every width and move the breakpoint onto the size modifier:

```
prose prose-sm md:prose-base prose-slate dark:prose-invert max-w-none
```

Applied to both `page.tsx` and `page.fr.tsx`, which carried the identical wrapper.

## After (390px viewport)

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-prose-bullets/after-mobile-bullets.png" width="390" alt="About page at 390px with bullets rendering on both lists" />

## Verification

Computed styles read off the running dev-env UI, before → after:

| Width | `list-style-type` before | after |
| --- | --- | --- |
| 375px | `none` | `disc` |
| 1000px | `disc` | `disc` |

`padding-inline-start` is unchanged at both widths (22px / 26px), so the size ramp behaves exactly as before — this only restores the base typography styles below `md`.

`tsgo --build` clean, prettier clean. Changeset included.

Note: because `prose` was absent entirely below `md`, bullets were the visible symptom but not the only effect — heading sizes, paragraph spacing, and link styling on this page were also unstyled at mobile widths and now follow the prose scale.