### PR TITLE
Remove the ↗ marker appended to external links in the OAuth UI

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Remove the `↗` marker appended to external links.

--- a/packages/oauth/oauth-provider-ui/src/components/utils/link-external.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/utils/link-external.tsx
@@ -41,11 +41,7 @@ export function LinkExternal({
       target={target}
       rel={rel}
       role={role}
-      className={clsx(
-        'after:text-[1em] after:content-[" ↗"]',
-        !href && 'cursor-not-allowed opacity-50',
-        className,
-      )}
+      className={clsx(!href && 'cursor-not-allowed opacity-50', className)}
       aria-disabled={ariaDisabled}
       {...props}
     >


### PR DESCRIPTION
Removes the arrows from external links in the oauth provider UI. I think it's acceptable for an underlined link to either go to an internal or external page without an icon.