### PR TITLE
ozone: add materialized view refresher timeout

### DIFF
--- a/.changeset/real-papayas-cough.md
+++ b/.changeset/real-papayas-cough.md
@@ -1,0 +1,6 @@
+---
+'@atproto/ozone': patch
+---
+
+* Add postgres timeouts to materialized view refresher
+* Prevent jetstream handshake errors from crashing ozone daemon

--- a/.changeset/real-papayas-cough.md
+++ b/.changeset/real-papayas-cough.md
@@ -3,4 +3,3 @@
 ---
 
 * Add postgres timeouts to materialized view refresher
-* Prevent jetstream handshake errors from crashing ozone daemon

--- a/packages/ozone/src/config/config.ts
+++ b/packages/ozone/src/config/config.ts
@@ -26,6 +26,7 @@ export const envToCfg = (env: OzoneEnvironment): OzoneConfig => {
     poolMaxUses: env.dbPoolMaxUses,
     poolIdleTimeoutMs: env.dbPoolIdleTimeoutMs,
     materializedViewRefreshIntervalMs: env.dbMaterializedViewRefreshIntervalMs,
+    materializedViewRefreshTimeoutMs: env.dbMaterializedViewRefreshTimeoutMs,
     teamProfileRefreshIntervalMs: env.dbTeamProfileRefreshIntervalMs,
   }
 
@@ -162,6 +163,7 @@ export type DatabaseConfig = {
   poolMaxUses?: number
   poolIdleTimeoutMs?: number
   materializedViewRefreshIntervalMs?: number
+  materializedViewRefreshTimeoutMs?: number
   teamProfileRefreshIntervalMs?: number
 }
 

--- a/packages/ozone/src/config/env.ts
+++ b/packages/ozone/src/config/env.ts
@@ -24,6 +24,9 @@ export const readEnv = (): OzoneEnvironment => {
     dbMaterializedViewRefreshIntervalMs: envInt(
       'OZONE_DB_MATERIALIZED_VIEW_REFRESH_INTERVAL_MS',
     ),
+    dbMaterializedViewRefreshTimeoutMs: envInt(
+      'OZONE_DB_MATERIALIZED_VIEW_REFRESH_TIMEOUT_MS',
+    ),
     dbTeamProfileRefreshIntervalMs: envInt(
       'OZONE_DB_TEAM_PROFILE_REFRESH_INTERVAL_MS',
     ),
@@ -72,6 +75,7 @@ export type OzoneEnvironment = {
   dbPoolMaxUses?: number
   dbPoolIdleTimeoutMs?: number
   dbMaterializedViewRefreshIntervalMs?: number
+  dbMaterializedViewRefreshTimeoutMs?: number
   dbTeamProfileRefreshIntervalMs?: number
   didPlcUrl?: string
   didCacheStaleTTL?: number

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -105,6 +105,7 @@ export class DaemonContext {
     const materializedViewRefresher = new MaterializedViewRefresher(
       backgroundQueue,
       cfg.db.materializedViewRefreshIntervalMs,
+      cfg.db.materializedViewRefreshTimeoutMs,
     )
 
     const scheduledActionProcessor = new ScheduledActionProcessor(

--- a/packages/ozone/src/daemon/materialized-view-refresher.ts
+++ b/packages/ozone/src/daemon/materialized-view-refresher.ts
@@ -1,32 +1,62 @@
-import { sql } from 'kysely'
 import { MINUTE } from '@atproto/common'
 import { type BackgroundQueue, PeriodicBackgroundTask } from '../background.js'
 import { dbLogger } from '../logger.js'
+import { MATERIALIZED_VIEW_REFRESH_LOCK_ID } from '../db/index.js'
+
+const LOCK_TIMEOUT_MS = 1 * MINUTE
 
 export class MaterializedViewRefresher extends PeriodicBackgroundTask {
-  constructor(backgroundQueue: BackgroundQueue, interval = 30 * MINUTE) {
-    super(backgroundQueue, interval, async ({ db }, signal) => {
-      for (const view of [
-        'account_events_stats',
-        'record_events_stats',
-        'account_record_events_stats',
-        'account_record_status_stats',
-      ]) {
-        if (signal.aborted) break
+  constructor(
+    backgroundQueue: BackgroundQueue,
+    interval = 30 * MINUTE,
+    statementTimeoutMs = 10 * MINUTE,
+  ) {
+    super(backgroundQueue, interval, async (db, signal) => {
+      let locked = false
+      // Create single client for the whole refresh cycle
+      const client = await db.pool.connect()
 
-        // Kysely does not provide a way to cancel a running query. Because of
-        // this, killing the process during a refresh will cause the process to
-        // wait for the current refresh to finish before exiting. This is not
-        // ideal, but it is the best we can do until Kysely provides a way to
-        // cancel a query.
-        try {
-          await sql`REFRESH MATERIALIZED VIEW CONCURRENTLY ${sql.id(view)}`.execute(
-            db,
-          )
-          dbLogger.info(`refreshed materialized view ${view}`)
-        } catch (err) {
-          dbLogger.error({ err, view }, 'failed to refresh materialized view')
+      try {
+        await client.query(`SET statement_timeout = ${statementTimeoutMs}`)
+        await client.query(`SET lock_timeout = ${LOCK_TIMEOUT_MS}`)
+
+        const lockResult = await client.query(
+          'SELECT pg_try_advisory_lock($1) as locked',
+          [MATERIALIZED_VIEW_REFRESH_LOCK_ID],
+        )
+        locked = lockResult.rows[0]?.locked === true
+        if (!locked) {
+          dbLogger.info('lock is held - skipping materialized view refresh')
+          return
         }
+
+        for (const view of [
+          'account_events_stats',
+          'record_events_stats',
+          'account_record_events_stats',
+          'account_record_status_stats',
+        ]) {
+          if (signal.aborted) break
+
+          const startedAt = Date.now()
+          try {
+            await client.query(
+              `REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`,
+            )
+            dbLogger.info(
+              { view, durationMs: Date.now() - startedAt },
+              'refreshed materialized view',
+            )
+          } catch (err) {
+            dbLogger.error(
+              { err, view, durationMs: Date.now() - startedAt },
+              'failed to refresh materialized view',
+            )
+          }
+        }
+      } finally {
+        // Clear any session SETS and release its locks
+        client.release(true)
       }
     })
   }

--- a/packages/ozone/src/daemon/materialized-view-refresher.ts
+++ b/packages/ozone/src/daemon/materialized-view-refresher.ts
@@ -1,7 +1,7 @@
 import { MINUTE } from '@atproto/common'
 import { type BackgroundQueue, PeriodicBackgroundTask } from '../background.js'
-import { dbLogger } from '../logger.js'
 import { MATERIALIZED_VIEW_REFRESH_LOCK_ID } from '../db/index.js'
+import { dbLogger } from '../logger.js'
 
 const LOCK_TIMEOUT_MS = 1 * MINUTE
 

--- a/packages/ozone/src/daemon/stats-computer.ts
+++ b/packages/ozone/src/daemon/stats-computer.ts
@@ -1,11 +1,8 @@
 import { sql } from 'kysely'
 import { MINUTE } from '@atproto/common'
-import type { Database } from '../db/index.js'
+import { STATS_COMPUTER_LOCK_ID, type Database } from '../db/index.js'
 import { dbLogger } from '../logger.js'
 import type { ReportStatsServiceCreator } from '../report/stats.js'
-
-// Stable lock ID for pg_try_advisory_lock across all instances
-const ADVISORY_LOCK_ID = 7_239_401
 
 /**
  * Background daemon that materializes report statistics on an interval (default is 15 minutes).
@@ -69,7 +66,7 @@ export class StatsComputer {
   private async materializeStats() {
     const lockResult = await sql<{
       locked: boolean
-    }>`SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) as locked`.execute(
+    }>`SELECT pg_try_advisory_lock(${STATS_COMPUTER_LOCK_ID}) as locked`.execute(
       this.db.db,
     )
     const acquired = lockResult.rows[0]?.locked === true
@@ -84,7 +81,7 @@ export class StatsComputer {
       const statsService = this.reportStatsServiceCreator(this.db)
       await statsService.materializeAll()
     } finally {
-      await sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.execute(
+      await sql`SELECT pg_advisory_unlock(${STATS_COMPUTER_LOCK_ID})`.execute(
         this.db.db,
       )
     }

--- a/packages/ozone/src/daemon/stats-computer.ts
+++ b/packages/ozone/src/daemon/stats-computer.ts
@@ -1,6 +1,6 @@
 import { sql } from 'kysely'
 import { MINUTE } from '@atproto/common'
-import { STATS_COMPUTER_LOCK_ID, type Database } from '../db/index.js'
+import { type Database, STATS_COMPUTER_LOCK_ID } from '../db/index.js'
 import { dbLogger } from '../logger.js'
 import type { ReportStatsServiceCreator } from '../report/stats.js'
 

--- a/packages/ozone/src/daemon/verification-listener.ts
+++ b/packages/ozone/src/daemon/verification-listener.ts
@@ -5,6 +5,15 @@ import { type CommitCreateEvent, Jetstream } from '../jetstream/service.js'
 import { verificationLogger } from '../logger.js'
 import { VerificationService } from '../verification/service.js'
 
+/**
+ * Hack to parse HTTP status code from `ws` library.
+ */
+const getHttpStatus = (err: unknown): number | null => {
+  if (!(err instanceof Error)) return null
+  const match = err.message.match(/^Unexpected server response: (\d{3})$/)
+  return match ? parseInt(match[1], 10) : null
+}
+
 type VerificationRecord = {
   subject: string
   handle: string
@@ -117,43 +126,61 @@ export class VerificationListener {
         : undefined,
     })
 
-    await this.jetstream.start({
-      onCreate: {
-        [this.collection]: async (e: CommitCreateEvent<VerificationRecord>) => {
-          const recordValidity = lexicons.validate(
-            this.collection,
-            e.commit.record,
-          )
-
-          if (!recordValidity.success) {
-            verificationLogger.error(
-              recordValidity.error,
-              'Invalid verification record in the firehose',
+    try {
+      await this.jetstream.start({
+        onCreate: {
+          [this.collection]: async (
+            e: CommitCreateEvent<VerificationRecord>,
+          ) => {
+            const recordValidity = lexicons.validate(
+              this.collection,
+              e.commit.record,
             )
-            return
-          }
 
-          const hasCapacity = await this.ensureCoolDown()
-          if (hasCapacity) {
-            const issuer = e.did
-            const { record, rkey, collection, cid } = e.commit
-            const uri = `at://${issuer}/${collection}/${rkey}`
-            this.handleNewVerification(issuer, uri, cid, record, e.time_us)
-          }
+            if (!recordValidity.success) {
+              verificationLogger.error(
+                recordValidity.error,
+                'Invalid verification record in the firehose',
+              )
+              return
+            }
+
+            const hasCapacity = await this.ensureCoolDown()
+            if (hasCapacity) {
+              const issuer = e.did
+              const { record, rkey, collection, cid } = e.commit
+              const uri = `at://${issuer}/${collection}/${rkey}`
+              this.handleNewVerification(issuer, uri, cid, record, e.time_us)
+            }
+          },
         },
-      },
-      onDelete: {
-        [this.collection]: async (e) => {
-          const hasCapacity = await this.ensureCoolDown()
-          if (hasCapacity) {
-            this.handleDeletedVerification(
-              `at://${e.did}/${e.commit.collection}/${e.commit.rkey}`,
-              e.time_us,
-            )
-          }
+        onDelete: {
+          [this.collection]: async (e) => {
+            const hasCapacity = await this.ensureCoolDown()
+            if (hasCapacity) {
+              this.handleDeletedVerification(
+                `at://${e.did}/${e.commit.collection}/${e.commit.rkey}`,
+                e.time_us,
+              )
+            }
+          },
         },
-      },
-    })
+      })
+    } catch (err) {
+      const status = getHttpStatus(err)
+
+      // Handle recoverable handshake errors and prevent rethrows
+      if (status === 429 || status === 503) {
+        verificationLogger.error(
+          { err, status },
+          'Jetstream websocket handshake rejected',
+        )
+        return
+      }
+
+      verificationLogger.error(err, 'Irrecoverable error in jetstream')
+      throw err
+    }
   }
 
   async stop() {

--- a/packages/ozone/src/daemon/verification-listener.ts
+++ b/packages/ozone/src/daemon/verification-listener.ts
@@ -10,6 +10,8 @@ import { VerificationService } from '../verification/service.js'
  */
 const getHttpStatus = (err: unknown): number | null => {
   if (!(err instanceof Error)) return null
+  // Attempt to parse this error
+  // https://github.com/websockets/ws/blob/a3214d31b63acee8e31065be9f5ce3dd89203055/lib/websocket.js#L891
   const match = err.message.match(/^Unexpected server response: (\d{3})$/)
   return match ? parseInt(match[1], 10) : null
 }

--- a/packages/ozone/src/daemon/verification-listener.ts
+++ b/packages/ozone/src/daemon/verification-listener.ts
@@ -5,17 +5,6 @@ import { type CommitCreateEvent, Jetstream } from '../jetstream/service.js'
 import { verificationLogger } from '../logger.js'
 import { VerificationService } from '../verification/service.js'
 
-/**
- * Hack to parse HTTP status code from `ws` library.
- */
-const getHttpStatus = (err: unknown): number | null => {
-  if (!(err instanceof Error)) return null
-  // Attempt to parse this error
-  // https://github.com/websockets/ws/blob/a3214d31b63acee8e31065be9f5ce3dd89203055/lib/websocket.js#L891
-  const match = err.message.match(/^Unexpected server response: (\d{3})$/)
-  return match ? parseInt(match[1], 10) : null
-}
-
 type VerificationRecord = {
   subject: string
   handle: string
@@ -128,61 +117,43 @@ export class VerificationListener {
         : undefined,
     })
 
-    try {
-      await this.jetstream.start({
-        onCreate: {
-          [this.collection]: async (
-            e: CommitCreateEvent<VerificationRecord>,
-          ) => {
-            const recordValidity = lexicons.validate(
-              this.collection,
-              e.commit.record,
+    await this.jetstream.start({
+      onCreate: {
+        [this.collection]: async (e: CommitCreateEvent<VerificationRecord>) => {
+          const recordValidity = lexicons.validate(
+            this.collection,
+            e.commit.record,
+          )
+
+          if (!recordValidity.success) {
+            verificationLogger.error(
+              recordValidity.error,
+              'Invalid verification record in the firehose',
             )
+            return
+          }
 
-            if (!recordValidity.success) {
-              verificationLogger.error(
-                recordValidity.error,
-                'Invalid verification record in the firehose',
-              )
-              return
-            }
-
-            const hasCapacity = await this.ensureCoolDown()
-            if (hasCapacity) {
-              const issuer = e.did
-              const { record, rkey, collection, cid } = e.commit
-              const uri = `at://${issuer}/${collection}/${rkey}`
-              this.handleNewVerification(issuer, uri, cid, record, e.time_us)
-            }
-          },
+          const hasCapacity = await this.ensureCoolDown()
+          if (hasCapacity) {
+            const issuer = e.did
+            const { record, rkey, collection, cid } = e.commit
+            const uri = `at://${issuer}/${collection}/${rkey}`
+            this.handleNewVerification(issuer, uri, cid, record, e.time_us)
+          }
         },
-        onDelete: {
-          [this.collection]: async (e) => {
-            const hasCapacity = await this.ensureCoolDown()
-            if (hasCapacity) {
-              this.handleDeletedVerification(
-                `at://${e.did}/${e.commit.collection}/${e.commit.rkey}`,
-                e.time_us,
-              )
-            }
-          },
+      },
+      onDelete: {
+        [this.collection]: async (e) => {
+          const hasCapacity = await this.ensureCoolDown()
+          if (hasCapacity) {
+            this.handleDeletedVerification(
+              `at://${e.did}/${e.commit.collection}/${e.commit.rkey}`,
+              e.time_us,
+            )
+          }
         },
-      })
-    } catch (err) {
-      const status = getHttpStatus(err)
-
-      // Handle recoverable handshake errors and prevent rethrows
-      if (status === 429 || status === 503) {
-        verificationLogger.error(
-          { err, status },
-          'Jetstream websocket handshake rejected',
-        )
-        return
-      }
-
-      verificationLogger.error(err, 'Irrecoverable error in jetstream')
-      throw err
-    }
+      },
+    })
   }
 
   async stop() {

--- a/packages/ozone/src/db/index.ts
+++ b/packages/ozone/src/db/index.ts
@@ -23,6 +23,11 @@ import { CtxMigrationProvider } from './migrations/provider.js'
 import type { DatabaseSchema, DatabaseSchemaType } from './schema/index.js'
 import type { PgOptions } from './types.js'
 
+// Stable pg advisory lock IDs used to coordinate daemon work across
+// instances. Centralized here so IDs can never silently collide.
+export const STATS_COMPUTER_LOCK_ID = 7_239_401
+export const MATERIALIZED_VIEW_REFRESH_LOCK_ID = 7_239_402
+
 export class Database {
   pool: PgPool
   db: DatabaseSchema

--- a/packages/ozone/tests/materialized-view-refresher.test.ts
+++ b/packages/ozone/tests/materialized-view-refresher.test.ts
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals'
 import { TestNetwork } from '@atproto/dev-env'
+import { MATERIALIZED_VIEW_REFRESH_LOCK_ID } from '../src/db/index.js'
 import type { Database } from '../src/index.js'
 import { dbLogger } from '../src/logger.js'
-import { MATERIALIZED_VIEW_REFRESH_LOCK_ID } from '../src/db/index.js'
 
 describe('materialized view refresher', () => {
   let network: TestNetwork

--- a/packages/ozone/tests/materialized-view-refresher.test.ts
+++ b/packages/ozone/tests/materialized-view-refresher.test.ts
@@ -1,0 +1,144 @@
+import { jest } from '@jest/globals'
+import { TestNetwork } from '@atproto/dev-env'
+import type { Database } from '../src/index.js'
+import { dbLogger } from '../src/logger.js'
+import { MATERIALIZED_VIEW_REFRESH_LOCK_ID } from '../src/db/index.js'
+
+describe('materialized view refresher', () => {
+  let network: TestNetwork
+  let db: Database
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_view_refresher',
+    })
+    db = network.ozone.ctx.db
+  })
+
+  afterAll(async () => {
+    await network?.close()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('skips the cycle while another session holds the lock', async () => {
+    const contender = await db.pool.connect()
+    try {
+      await contender.query('SELECT pg_advisory_lock($1)', [
+        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
+      ])
+
+      const infoSpy = jest.spyOn(dbLogger, 'info')
+
+      await network.ozone.daemon.ctx.materializedViewRefresher.run()
+
+      const messages = infoSpy.mock.calls.map(
+        (call) => call.find((arg) => typeof arg === 'string') ?? '',
+      )
+      expect(messages).toContain(
+        'lock is held - skipping materialized view refresh',
+      )
+      expect(
+        messages.filter((msg) => msg === 'refreshed materialized view'),
+      ).toHaveLength(0)
+    } finally {
+      await contender.query('SELECT pg_advisory_unlock($1)', [
+        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
+      ])
+      contender.release()
+    }
+  })
+
+  it('completes a cycle with per-view durations and releases the lock', async () => {
+    const infoSpy = jest.spyOn(dbLogger, 'info')
+
+    await network.ozone.daemon.ctx.materializedViewRefresher.run()
+
+    const refreshCalls = infoSpy.mock.calls.filter((call) =>
+      call.includes('refreshed materialized view'),
+    )
+    expect(refreshCalls).toHaveLength(4)
+    const views = refreshCalls.map((call) => {
+      const obj = call[0] as { view: string; durationMs: number }
+      expect(typeof obj.durationMs).toBe('number')
+      return obj.view
+    })
+    expect(views.sort()).toEqual([
+      'account_events_stats',
+      'account_record_events_stats',
+      'account_record_status_stats',
+      'record_events_stats',
+    ])
+
+    // The lock was released between cycles: a second run also succeeds.
+    infoSpy.mockClear()
+    await network.ozone.daemon.ctx.materializedViewRefresher.run()
+    const secondRefreshCalls = infoSpy.mock.calls.filter((call) =>
+      call.includes('refreshed materialized view'),
+    )
+    expect(secondRefreshCalls).toHaveLength(4)
+  })
+
+  it('logs a stable failure message, continues with remaining views, and releases the lock when one refresh fails', async () => {
+    // Rename one view away so its refresh fails, the way a dropped or
+    // re-owned view would in prod (the test connection may be a superuser,
+    // so revoking ownership would not reliably fail).
+    const admin = await db.pool.connect()
+    let renamed = false
+    try {
+      await admin.query(
+        'ALTER MATERIALIZED VIEW "record_events_stats" RENAME TO "record_events_stats_broken"',
+      )
+      renamed = true
+
+      const infoSpy = jest.spyOn(dbLogger, 'info')
+      const errorSpy = jest.spyOn(dbLogger, 'error')
+
+      await network.ozone.daemon.ctx.materializedViewRefresher.run()
+
+      // The failure log carries the stable alert-target message and shape.
+      const failureCalls = errorSpy.mock.calls.filter((call) =>
+        call.includes('failed to refresh materialized view'),
+      )
+      expect(failureCalls).toHaveLength(1)
+      const failure = failureCalls[0][0] as {
+        err: unknown
+        view: string
+        durationMs: number
+      }
+      expect(failure.err).toBeDefined()
+      expect(failure.view).toBe('record_events_stats')
+      expect(typeof failure.durationMs).toBe('number')
+
+      // The remaining views still refreshed, including those ordered after
+      // the failing one.
+      const refreshedViews = infoSpy.mock.calls
+        .filter((call) => call.includes('refreshed materialized view'))
+        .map((call) => (call[0] as { view: string }).view)
+      expect(refreshedViews.sort()).toEqual([
+        'account_events_stats',
+        'account_record_events_stats',
+        'account_record_status_stats',
+      ])
+
+      // The advisory lock was released despite the failure.
+      const lockResult = await admin.query(
+        'SELECT pg_try_advisory_lock($1) as locked',
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID],
+      )
+      expect(lockResult.rows[0]?.locked).toBe(true)
+      await admin.query('SELECT pg_advisory_unlock($1)', [
+        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
+      ])
+    } finally {
+      if (renamed) {
+        await admin.query(
+          'ALTER MATERIALIZED VIEW "record_events_stats_broken" RENAME TO "record_events_stats"',
+        )
+      }
+      admin.release()
+    }
+  })
+})


### PR DESCRIPTION
Add timeouts in ozone daemon processes for better durability

The daemon's materialized view refresher previously ran with no timeouts and no locking. The refresh cycle now runs on a single dedicated connection with:

- a pg_try_advisory_lock guard so only one cycle is guaranteed to run at once
- statement_timeout so that crashed refreshes release the lock


## Tests

- skipping the cycle while another cycle holds the advisory lock
- a full cycle logging per-view durations and releasing the lock between runs
- a failing view not preventing the remaining views from refreshing