### PR TITLE
Check plc.directory before trying to update it, unbreaking updates for accounts with self-custodied rotation keys

### DIFF
--- a/.changeset/tame-hounds-relax.md
+++ b/.changeset/tame-hounds-relax.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Don't require the PDS's own rotation key to update a handle that's already been changed directly on the DID document (e.g. by a self-custodied account)

--- a/packages/pds/src/account-manager/account-manager.ts
+++ b/packages/pds/src/account-manager/account-manager.ts
@@ -325,12 +325,11 @@ export class AccountManager {
       options,
     )
 
-    if (did.startsWith('did:plc:')) {
-      // @TODO We should verify the status before issuing a PLC update.
-      await this.plcClient.updateHandle(did, this.plcRotationKey, handle)
-    } else {
-      const resolved = await this.idResolver.did.resolveAtprotoData(did, true)
-      if (resolved.handle !== handle) {
+    const resolved = await this.idResolver.did.resolveAtprotoData(did, true)
+    if (resolved.handle !== handle) {
+      if (did.startsWith('did:plc:')) {
+        await this.plcClient.updateHandle(did, this.plcRotationKey, handle)
+      } else {
         throw new InvalidRequestError(
           'DID is not properly configured for handle',
         )

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals'
 import type { AtpAgent } from '@atproto/api'
+import { Secp256k1Keypair } from '@atproto/crypto'
 import type { SeedClient } from '@atproto/dev-env'
 import type { AtIdentifierString, DidString } from '@atproto/syntax'
 import type { AppContext } from '../src/index.js'
@@ -35,6 +36,8 @@ describe('handles', () => {
   let sc: SeedClient
   let ctx: AppContext
   let idResolver: InstanceType<typeof IdResolver>
+  let erinDid: DidString
+  let erinKey: Secp256k1Keypair
 
   const newHandle = 'alice2.test'
 
@@ -269,5 +272,53 @@ describe('handles', () => {
       handle: 'bob-alt.test',
     })
     await expect(attempt2).rejects.toThrow('Authentication Required')
+  })
+
+  it('lets a self-custodied account take over its own rotation key', async () => {
+    const { did } = await sc.createAccount('erin', {
+      handle: 'erin.test',
+      email: 'erin@test.com',
+      password: 'erin-pass',
+    })
+    erinDid = did
+    erinKey = await Secp256k1Keypair.create()
+
+    // Take control the same way a real self-custodied client would: add
+    // the held key (signed by the PDS's own key, still current at this
+    // point), then drop the PDS's key from rotationKeys (signed by the
+    // held key, current as of the previous op).
+    await ctx.plcClient.updateRotationKeys(erinDid, ctx.plcRotationKey, [
+      erinKey.did(),
+      ctx.plcRotationKey.did(),
+    ])
+    await ctx.plcClient.updateRotationKeys(erinDid, erinKey, [erinKey.did()])
+  })
+
+  it('succeeds updating a handle already self-signed directly to plc.directory', async () => {
+    // The PDS is no longer a rotation key for this DID, so it could not
+    // have signed this itself - simulates the owner's own client
+    // publishing the change before telling the PDS about it. Without the
+    // fix, this call unconditionally attempts to self-sign with the PDS's
+    // (no longer valid) rotation key and fails outright.
+    await ctx.plcClient.updateHandle(erinDid, erinKey, 'erin2.test')
+
+    await agent.com.atproto.identity.updateHandle(
+      { handle: 'erin2.test' },
+      { headers: sc.getHeaders(erinDid), encoding: 'application/json' },
+    )
+
+    const dbHandle = await getHandleFromDb(erinDid)
+    expect(dbHandle).toBe('erin2.test')
+  })
+
+  it('still fails for a self-custodied account when the change was not already published', async () => {
+    const attempt = agent.com.atproto.identity.updateHandle(
+      { handle: 'erin3.test' },
+      { headers: sc.getHeaders(erinDid), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow()
+
+    const dbHandle = await getHandleFromDb(erinDid)
+    expect(dbHandle).toBe('erin2.test')
   })
 })


### PR DESCRIPTION
`updateHandle` for a did:plc account currently assumes it always needs to update plc.directory and unconditionally tries to sign an update and send it. But in some circumstances this assumption does not hold: If the user is holding their own keys, they should update the directory themselves, then call `updateHandle` against the PDS to get it to update its local database and send the relevant sync event. This is also the flow a did:web user would use. This currently fails with an invalid signature error because the PDS doesn't have a rotation key they can sign the update with, so the unnecessary update attempt fails and the failure blocks the other steps in the update.

There was a TODO in the code to check the state of the plc.directory before trying to update it, probably because even if the PDS has the necessary keys, the lack of a check will still result in the PDS creating an unnecessary duplicate PLC operation if a previous handle update failed partway through.

This PR adds the missing check, and also adds some tests to cover the expected handle update flow of a user who doesn't trust the PDS with their rotation keys.
