### PR TITLE
Don't require the PDS's own rotation key in the DID doc when activating

### DIFF
--- a/.changeset/silly-otters-jump.md
+++ b/.changeset/silly-otters-jump.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Don't require the PDS's own rotation key to be in the DID document when activating an account (e.g. for a self-custodied account)

--- a/packages/pds/src/api/com/atproto/server/util.ts
+++ b/packages/pds/src/api/com/atproto/server/util.ts
@@ -84,7 +84,6 @@ export const assertValidDidDocumentForService = async (
     await assertValidDocContents(ctx, did, {
       pdsEndpoint: resolved.services['atproto_pds']?.endpoint,
       signingKey: resolved.verificationMethods['atproto'],
-      rotationKeys: resolved.rotationKeys,
     })
   } else {
     const resolved = await ctx.idResolver.did.resolve(did, true)
@@ -108,18 +107,9 @@ const assertValidDocContents = async (
   contents: {
     signingKey?: string
     pdsEndpoint?: string
-    rotationKeys?: string[]
   },
 ) => {
-  const { signingKey, pdsEndpoint, rotationKeys } = contents
-
-  const plcRotationKey =
-    ctx.cfg.entryway?.plcRotationKey ?? ctx.plcRotationKey.did()
-  if (rotationKeys !== undefined && !rotationKeys.includes(plcRotationKey)) {
-    throw new InvalidRequestError(
-      'Server rotation key not included in PLC DID data',
-    )
-  }
+  const { signingKey, pdsEndpoint } = contents
 
   if (!pdsEndpoint || pdsEndpoint !== ctx.cfg.service.publicUrl) {
     throw new InvalidRequestError(


### PR DESCRIPTION
Fixes #4819. This PR allows activation even if the user is holding their own rotation keys instead of entrusting them with the PDS.

Without this fix a user could still remove the PDS's rotation key, which may break assumptions that some front-ends make about handle changes etc, but they had to first create the account with it included, and then immediately remove it, which is more error-prone and increases the user's trust assumptions on the PLC directory.