### PR TITLE
Restructure contributor and agent documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Security vulnerabilities
     url: https://github.com/bluesky-social/atproto/blob/main/SECURITY.md
     about: Do not file publicly. Email security@bsky.app instead.
-  - name: Contributing guidelines
-    url: https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-    about: Read this before filing an issue or opening a pull request.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & high-level discussion
+    url: https://github.com/bluesky-social/atproto/discussions
+    about: Ask questions and discuss protocol or design topics on the Discussion Forum.
+  - name: Bluesky app (web & mobile) issues
+    url: https://github.com/bluesky-social/social-app/issues
+    about: Bugs in the Bluesky client app belong in the social-app repo, not here.
+  - name: Security vulnerabilities
+    url: https://github.com/bluesky-social/atproto/blob/main/SECURITY.md
+    about: Do not file publicly. Email security@bsky.app instead.
+  - name: Contributing guidelines
+    url: https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
+    about: Read this before filing an issue or opening a pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
+https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
+-->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->
+
+## Checklist
+
+- [ ] `pnpm build --force && pnpm verify` passes
+- [ ] Tests pass, and new behavior is covered by tests
+- [ ] A changeset is included for every package this touches
+- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,7 +1,8 @@
 You are an experienced senior TypeScript engineer reviewing a pull request
 in the atproto monorepo — the reference implementation of the AT Protocol.
-Read the repo's CLAUDE.md and any package-level docs the diff touches
-before forming an opinion.
+Read the repo's CLAUDE.md, STYLE_GUIDE.md, CONTRIBUTING.md, and any
+package-level docs (nested CLAUDE.md, README.md) the diff touches before
+forming an opinion.
 
 Your audience is other senior engineers. Write peer-to-peer, not
 teacher-to-junior. Most PRs in this repo are fine; a review that says so
@@ -44,11 +45,23 @@ Where this repo differs from a typical TypeScript service:
 - XRPC endpoints in pds/bsky/ozone are internet-facing. New endpoints or
   loosened input validation deserve a look at rate limits, payload size
   bounds, and unbounded-fan-out queries (hydration joins, cursors).
+- A few STYLE_GUIDE.md rules are structural rather than cosmetic, and are
+  in scope: a new circular dependency between packages (the only
+  tolerated cycle is `pds` ↔ `bsky` in tests); adding `@atproto/api` as a
+  new dependency (it is being replaced by `@atproto/lex`); pinning an
+  internal package to a published version instead of `workspace:^`; and
+  leaving behind references to code the PR deleted — comments, docs, or
+  names that describe a state that no longer exists ("previously…",
+  "used to…", a removed symbol).
+- Agent files are part of the codebase. If the PR introduces, changes, or
+  removes a documented pattern, CLAUDE.md / STYLE_GUIDE.md / the skills
+  under `.agents/skills/` should be updated in the same PR; a doc left
+  describing the old behavior is a finding.
 
 Mechanical notes: generated `src/lexicons/` directories in service
-packages are gitignored — do not ask for them in the diff. The repo's
-contribution guidelines discourage drive-by refactors and new
-dependencies; flag those only when the PR's stated purpose doesn't
+packages are gitignored — do not ask for them in the diff. CONTRIBUTING.md
+discourages drive-by refactors, unsolicited tooling or framework changes,
+and new dependencies; flag those only when the PR's stated purpose doesn't
 justify them.
 
 For each finding, state the scenario in one or two sentences, cite

--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -45,18 +45,13 @@ Where this repo differs from a typical TypeScript service:
 - XRPC endpoints in pds/bsky/ozone are internet-facing. New endpoints or
   loosened input validation deserve a look at rate limits, payload size
   bounds, and unbounded-fan-out queries (hydration joins, cursors).
-- A few STYLE_GUIDE.md rules are structural rather than cosmetic, and are
-  in scope: a new circular dependency between packages (the only
-  tolerated cycle is `pds` ↔ `bsky` in tests); adding `@atproto/api` as a
-  new dependency (it is being replaced by `@atproto/lex`); pinning an
-  internal package to a published version instead of `workspace:^`; and
-  leaving behind references to code the PR deleted — comments, docs, or
-  names that describe a state that no longer exists ("previously…",
-  "used to…", a removed symbol).
 - Agent files are part of the codebase. If the PR introduces, changes, or
   removes a documented pattern, CLAUDE.md / STYLE_GUIDE.md / the skills
-  under `.agents/skills/` should be updated in the same PR; a doc left
-  describing the old behavior is a finding.
+  under `.agents/skills/` should be updated in the same PR.
+- Documentation and comments must describe the current state of the code.
+  A doc or comment the PR leaves behind describing the old behavior — a
+  stale JSDoc, a comment referring to a deleted symbol, a "previously…" /
+  "used to…" note — is a finding.
 
 Mechanical notes: generated `src/lexicons/` directories in service
 packages are gitignored — do not ask for them in the diff. CONTRIBUTING.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Repository overview
 
 This is the TypeScript reference implementation of [AT Protocol](https://atproto.com), the decentralized social media protocol behind Bluesky. It is a pnpm monorepo (runtime floor Node.js ≥22; local dev and CI build/verify default to Node 24 via `.nvmrc` — only the test matrix runs on 22) containing client libraries, schema/codegen tooling, and the two main service implementations: the Personal Data Server (PDS) and the `app.bsky` AppView.
@@ -14,35 +12,46 @@ Workspace layout (see [pnpm-workspace.yaml](./pnpm-workspace.yaml) and [tsconfig
 - [packages/internal/\*](packages/internal/) — `@atproto-labs/*` internal shared utilities (fetch, handle/identity/DID resolvers, simple-store, pipe, xrpc-utils, rollup plugin).
 - [services/{pds,bsky,bsync,ozone}](services/) — thin runtime wrappers; the actual implementation code lives in `packages/{pds,bsky,bsync,ozone}`.
 - [lexicons/](lexicons/) — canonical JSON Lexicon schemas for `com.atproto.*`, `app.bsky.*`, `chat.bsky.*`, `tools.ozone.*`. These are the source-of-truth that codegen consumes.
-- [interop-test-files/](interop-test-files/) — language-neutral protocol conformance fixtures. Don't edit unless changing protocol-level behavior; these are shared across SDKs.
+- [interop-test-files/](interop-test-files/) — language-neutral protocol conformance fixtures, copied from [bluesky-social/atproto-interop-tests](https://github.com/bluesky-social/atproto-interop-tests/) (their canonical source, shared across SDKs). Don't edit unless changing protocol-level behavior; any edit must also be contributed upstream.
 
 ## Common commands
 
 Whole-repo verification commands (from root):
 
 ```bash
-pnpm verify         # parallel: style + lint
-pnpm build --force  # single root `tsgo --build` over the project-references graph, then UI bundlers
-pnpm codegen        # parallel codegen across all packages; runs from .ts sources via Node type-stripping
+# build:tooling → prebuild (codegen) → build:ts → build:ui
+pnpm run build [--force]
+
+# TypeScript-only build & typecheck
+pnpm run build:ts [--force]
+
+# force code generation (lexicons, protobuf, i18n, utils, etc.)
+pnpm run codegen
+
+# style + lint
+pnpm run verify
+pnpm run style:fix # Avoid, prefer per-file formatting & linting
+
+# lint specific files only
+pnpm exec eslint --fix <path>
+
+# format specific files only
+pnpm exec prettier --write <path>
 ```
-
-The pipeline is: `build:tooling` → `codegen` → `prebuild` → `build` (one `tsgo --build tsconfig.json` at the root) → `postbuild` (Vite/UI bundlers).
-
-The [Makefile](Makefile) wraps the most common entry points: `make build`, `make test`, `make lint`, `make fmt`, `make codegen`, `make run-dev-env` (boots the in-process PDS+AppView+bsync+plc+ozone constellation), `make run-dev-env-logged` (same with `pino-pretty` log output), `make fmt-lexicons` (eslint-fix on `lexicons/*.json`).
 
 Per-package work — **always run from inside the package directory**, not from the root:
 
 ```bash
 cd packages/<pkg>
-pnpm exec tsgo --build tsconfig.build.json   # build that package + its referenced deps
-pnpm test                                    # run that package's test suite
-pnpm exec prettier --write <path>            # format specific files only
-pnpm exec eslint --fix <path>                # lint specific files only
+pnpm run build
+pnpm run test
 ```
 
-Every package now ships a `tsconfig.build.json` (composite, with explicit `references` to its workspace deps) and a `tsconfig.test.json` for the test sources. The root `tsconfig.json` is a project-graph aggregator only.
+Every package ships a `tsconfig.build.json` (composite, with explicit `references` to its workspace deps) and a `tsconfig.test.json` for the test sources. The root `tsconfig.json` is a project-graph aggregator only.
 
 Avoid `pnpm run style:fix` (whole-repo prettier) unless the user explicitly asks for a repo-wide formatting pass.
+
+Run the formatter/linter once the work is complete: when about to commit, or when the user says the change is done, not after every small edit.
 
 ## Tests
 
@@ -50,31 +59,39 @@ Before writing or extending any test, invoke the `testing` skill ([.claude/skill
 
 ## Codegen
 
-After editing anything under [lexicons/](lexicons/), run `pnpm codegen` from the repo root before building or testing. The `bsky` package additionally runs `buf generate` for protobuf bindings against `bsync` as part of its codegen step.
+After editing anything under [lexicons/](lexicons/), or any `.proto` file, run `pnpm codegen` from the repo root.
 
-For everything else lexicon-related — `lex install` / `lex build`, the per-package `prebuild` setup, and migrating from the legacy `@atproto/api` / `@atproto/lexicon` / `@atproto/xrpc` / `@atproto/lex-cli` stack to the new `@atproto/lex` family — invoke the `lex-sdk` skill ([.claude/skills/lex-sdk/SKILL.md](.claude/skills/lex-sdk/SKILL.md)).
+The lexicon JSON schemas are derived into TypeScript runtime schemas by `@atproto/lex` (`lex install` / `lex build`, wired through each package's `prebuild`). For anything involving those, invoke the `lex-sdk` skill ([.claude/skills/lex-sdk/SKILL.md](.claude/skills/lex-sdk/SKILL.md)).
 
 ## Architecture notes
 
 - **Lexicons are the contract.** The JSON files in [lexicons/](lexicons/) drive both client types and server route validation. Service packages don't hand-write XRPC method signatures — they import the generated definitions from their `src/lexicons/` directory (gitignored / regenerated).
-- **PDS** ([packages/pds](packages/pds)) — a single-tenant atproto server: account management, repo storage (kysely-over-sqlite), actor storage (kysely-over-postgres), email, OAuth provider, blob storage. Runtime entry point is [services/pds](services/pds); production code is in `packages/pds/src`.
-- **Bsky AppView** ([packages/bsky](packages/bsky)) — read-side service for `app.bsky.*` queries (timelines, profiles, feed generators, hydration pipeline, GraphQL-like view composition). Talks to PDSes via XRPC and to `bsync` via Connect-RPC (protobuf in `packages/bsky/proto`). Runtime entry point in [services/bsky](services/bsky).
-- **Bsync** ([packages/bsync](packages/bsync)) — internal service for cross-AppView synchronization (mutes, notifications). Connect-RPC interface.
-- **Ozone** ([packages/ozone](packages/ozone)) — moderation service for `tools.ozone.*`.
-- **dev-env** ([packages/dev-env](packages/dev-env)) — boots a full PDS + AppView + bsync + plc + ozone constellation in-process for tests and the `make run-dev-env` REPL. Most integration tests in `pds`/`bsky`/`ozone` use it as a fixture builder.
-- **OAuth** ([packages/oauth](packages/oauth)) — split into `oauth-types` (shared schemas), `oauth-client` (browser/node/expo variants), `oauth-provider` (used inside the PDS), and `oauth-scopes`.
+- ([packages/pds](packages/pds)) — a single-tenant atproto server: account management, repo storage (kysely-over-sqlite), actor storage (kysely-over-postgres), email, OAuth provider, blob storage. Runtime entry point is [services/pds](services/pds); production code is in `packages/pds/src`.
+- ([packages/bsky](packages/bsky)) — read-side service for `app.bsky.*` queries (timelines, profiles, feed generators, hydration pipeline, GraphQL-like view composition). Talks to PDSes via XRPC and to `bsync` via Connect-RPC (protobuf in `packages/bsky/proto`). Runtime entry point in [services/bsky](services/bsky).
+- ([packages/bsync](packages/bsync)) — internal service for cross-AppView synchronization (mutes, notifications). Connect-RPC interface.
+- ([packages/ozone](packages/ozone)) — moderation service for `tools.ozone.*`.
+- ([packages/dev-env](packages/dev-env)) — boots a full PDS + AppView + bsync + plc + ozone constellation in-process for tests and the `make run-dev-env` REPL. Most integration tests in `pds`/`bsky`/`ozone` use it as a fixture builder.
 
 ## Conventions
 
-- Node ≥22 runtime floor; build/dev default to Node 24 (`.nvmrc`). ESM only (`"type": "module"` in every package). Use `node --enable-source-maps` for production-style runs.
+**Code style rules live in [STYLE_GUIDE.md](./STYLE_GUIDE.md)** — imports, typing, dependencies, change scope, and formatting. Read it before writing code. The rest of this section covers repository mechanics only.
+
+- Node ≥22 runtime floor; build/dev default to Node 24 (`.nvmrc`). Use `node --enable-source-maps` for production-style runs.
 - TypeScript compilation uses `tsgo` (TS7, `@typescript/native-preview`), not `tsc`. There is no per-package `typescript` devDependency — `tsgo` is hoisted at the root.
-- Import paths use workspace protocol (`workspace:^`). Don't pin internal packages to a published version.
-- Don't refactor unrelated code; this project's contribution guidelines explicitly discourage large refactors and unsolicited tooling changes (see [README.md](README.md) "Contributions").
-- Don't add new dependencies without strong justification.
-- When picking lexicon SDK APIs in new code, prefer the `@atproto/lex` family over the old `@atproto/api` stack.
+- **Every package touched by a change needs a changeset entry.** Add a file under [.changeset/](.changeset/) listing each modified package with an appropriate bump level (`minor` for breaking or new public API, `patch` otherwise). Dependency-only bumps are generated automatically — don't list them by hand.
+
+## Agent files
+
+Agent files — this `CLAUDE.md`, the skills under [.agents/skills/](.agents/skills/), and any package-level equivalents — are part of the codebase and must stay in sync with it.
+
+- **New pattern introduced** → document it in the relevant agent file (package-specific if scoped, global otherwise) so it can be re-applied.
+- **Existing important pattern found undocumented** → add it.
+- **Concept removed** → remove it from the agent files in the same change. Reviewers should check for this (see [.github/claude-review-prompt.md](.github/claude-review-prompt.md)).
+- Keep them **as concise as possible**: only the minimal directives an expert needs. No tutorials, no restating what the code already says.
 
 ## Troubleshooting
 
 - **Stale codegen.** If the build fails due to a generated file in [packages/api](packages/api) or [packages/ozone](packages/ozone) being out of date, run `pnpm run codegen && pnpm run build` from those packages, then re-run the build. This is only needed on these two packages because their `prebuild` step skips codegen as a performance optimization.
 - **Codegen ran but produced stale output.** Codegen relies on `pnpm build:tooling` to build the `@atproto/lex-cli` and `@atproto/lex-builder` packages first. If you see a codegen failure, run `pnpm build:tooling` from the root, then re-run codegen.
 - **End-to-end test fails with stale infra.** If docker containers persist across test runs, reset them with `cd packages/dev-infra && docker compose down --volumes`.
+- **Nothing else worked.** `make clean` wipes every installed dependency (`node_modules`), build artifact (`dist`, `*.tsbuildinfo`), and prebuild/codegen output across all packages; follow it with `pnpm install && pnpm run build` to restore a clean state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+> While we do accept contributions, we prioritize high quality issues and pull requests. Adhering to the below guidelines will ensure a more timely review.
+
+> [!IMPORTANT]
+>
+> **Found a security vulnerability?** Don't open an issue or a PR. Email `security@bsky.app` instead — see [SECURITY.md](./SECURITY.md). We acknowledge reports within 3 business days, and with your consent we'll add you to [CONTRIBUTORS.md](./CONTRIBUTORS.md).
+
+**Rules:**
+
+- We may not respond to your issue or PR.
+- We may close an issue or PR without much feedback.
+- We may lock discussions or contributions if our attention is getting DDOSed.
+- We do not provide support for build issues.
+
+**Guidelines:**
+
+- Check for existing issues before filing a new one, please.
+- Open an issue and give some time for discussion before submitting a PR.
+- If submitting a PR that includes a lexicon change, please get sign off on the lexicon change _before_ doing the implementation.
+- Issues are for bugs & feature requests related to the TypeScript implementation of atproto and related services.
+  - For high-level discussions, please use the [Discussion Forum](https://github.com/bluesky-social/atproto/discussions).
+  - For client issues, please use the relevant [social-app](https://github.com/bluesky-social/social-app) repo.
+- Stay away from PRs that:
+  - Refactor large parts of the codebase
+  - Add entirely new features without prior discussion
+  - Change the tooling or frameworks used without prior discussion
+  - Introduce new unnecessary dependencies
+
+Remember, we serve a wide community of users. Our day-to-day involves us constantly asking "which top priority is our top priority." If you submit well-written PRs that solve problems concisely, that's an awesome contribution. Otherwise, as much as we'd love to accept your ideas and contributions, we really don't have the bandwidth.
+
+## Developer Quickstart
+
+We recommend [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js installs. This project requires Node.js version 22 or later. `pnpm` is used to manage the workspace of multiple packages. You can install it with `npm install --global pnpm`.
+
+There is a Makefile which can help with basic development tasks:
+
+```shell
+# use existing nvm to install node 22 and pnpm
+make nvm-setup
+
+# pull dependencies and build all local packages
+make deps
+make build
+
+# run the tests, using Docker services as needed
+make test
+
+# run a local PDS and AppView with fake test accounts and data
+# (this requires a global installation of `jq` and `docker`)
+make run-dev-env
+
+# show all other commands
+make help
+```
+
+## Working in this codebase
+
+**Code style is documented in [STYLE_GUIDE.md](./STYLE_GUIDE.md)** — read it before writing code. It covers imports, typing, dependencies, and the scope of a change. PRs that ignore it will be sent back.
+
+Beyond style, two things are worth calling out up front: don't change tooling or frameworks without prior discussion, and don't add dependencies without strong justification.
+
+**Before opening the PR**
+
+- **The project must build and pass verification.** Run this from the repo root and make sure it comes back clean:
+
+  ```bash
+  pnpm build --force && pnpm verify
+  ```
+
+- **The test suite must pass**, and new behavior must be covered by tests. Bug fixes need a test that fails before the fix and passes after it; new features need tests for the paths they add. Run the tests with `pnpm test` from the repo root, or from inside the package you changed for a faster loop. Some suites (`bsky`, `pds`, `ozone`) need Docker for postgres and redis — go through `pnpm test` rather than invoking vitest or jest directly, so the infra gets started for you.
+
+- Every package your change touches needs a changeset entry under [.changeset/](./.changeset/) — `minor` for breaking changes or new public API, `patch` otherwise. Dependency-only bumps are generated for you; don't list them by hand.
+
+- If your change introduces, alters, or removes a documented pattern, update [CLAUDE.md](./CLAUDE.md) and the skills under `.agents/skills/` in the same PR. Agent files are part of the codebase and must stay in sync with it.
+
+## LLM-assisted contributions
+
+Contributions written with the help of an LLM or coding agent are welcome, under three conditions.
+
+**Disclose it.** Say so in the pull request description, and name the tooling you used. We are not going to reject a PR for being agent-assisted, but reviewers calibrate differently depending on how code was produced, and discovering it after the fact costs trust.
+
+**Follow [CLAUDE.md](./CLAUDE.md), whatever agent you use.** That file is named for one tool but it is simply this repository's set of directives. If your agent reads a different configuration file, mirror the relevant rules into it, or feed `CLAUDE.md` in as context. A PR that violates these conventions gets the same treatment whether a person or a model wrote it.
+
+**Own every line.** You are the author of the patch, not a courier for your agent's output. Before you open the PR, read the whole diff and make sure you can explain why each change is there, that it does what the description claims, and that it doesn't drag in unrelated edits, invented APIs, or unnecessary dependencies. Expect review questions and be able to answer them yourself. "The model generated it" is not an answer, and unreviewed agent output — plausible-looking code that nobody has actually vetted — costs us more time than it saves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,28 +31,42 @@ Remember, we serve a wide community of users. Our day-to-day involves us constan
 
 ## Developer Quickstart
 
-We recommend [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js installs. This project requires Node.js version 22 or later. `pnpm` is used to manage the workspace of multiple packages. You can install it with `npm install --global pnpm`.
+Node.js 22 is the minimum supported version; the version in [.nvmrc](./.nvmrc) is what we develop and test against. Install [`nvm`](https://github.com/nvm-sh/nvm) to manage Node.js installs, then pick that version up from the repo root:
 
-There is a Makefile which can help with basic development tasks:
-
-```shell
-# use existing nvm to install node 22 and pnpm
-make nvm-setup
-
-# pull dependencies and build all local packages
-make deps
-make build
-
-# run the tests, using Docker services as needed
-make test
-
-# run a local PDS and AppView with fake test accounts and data
-# (this requires a global installation of `jq` and `docker`)
-make run-dev-env
-
-# show all other commands
-make help
+```bash
+nvm install
+nvm use
 ```
+
+`pnpm` manages the workspace, and is itself managed by [Corepack](https://nodejs.org/api/corepack.html) so that everyone runs the version pinned in [package.json](./package.json). Corepack ships with Node.js — enable it, then let it install `pnpm`:
+
+```bash
+corepack enable
+corepack install
+```
+
+From there, install dependencies and build every package:
+
+```bash
+pnpm install
+pnpm build
+```
+
+Once built, `pnpm dev` runs a full local stack — a PDS, an AppView, a PLC directory, an Ozone instance and a bsync service, seeded with fake test accounts and data. It runs against the compiled output, so pair it with `pnpm dev:ts` in a second terminal to rebuild as you edit. This requires [Docker](https://docs.docker.com/get-started/get-docker/) and `jq` for the postgres and redis containers.
+
+```bash
+pnpm dev
+```
+
+The stack prints the URL of every service it starts. The seeded accounts all live on the PDS, and you can sign in as any of them:
+
+| Handle       | Password  |
+| ------------ | --------- |
+| `alice.test` | `hunter2` |
+| `bob.test`   | `hunter2` |
+| `carla.test` | `hunter2` |
+
+The seed data is regenerated from scratch on every run, so feel free to break things.
 
 ## Working in this codebase
 

--- a/README.md
+++ b/README.md
@@ -4,103 +4,43 @@ Welcome friends!
 
 This repository contains Bluesky's reference implementation of AT Protocol, and of the `app.bsky` microblogging application service backend.
 
+## About AT Protocol
+
+The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky Social PBC](https://bsky.social). Third-party software can be as seamless as first-party: custom feeds, federated services, and alternative clients are all built against the same APIs, so developers are never locked out of the ecosystems they help build. Learn more at:
+
+- [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
+- [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
+- [Protocol Specifications](https://atproto.com/specs/atp)
+
+The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
+
 ## What is in here?
-
-**TypeScript Packages:**
-
-| Package                                                                       | Docs                                       | NPMX                                                                                                       |
-| ----------------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `@atproto/api`: client library                                                | [README](./packages/api/README.md)         | [![NPM](https://img.shields.io/npm/v/@atproto/api)](https://npmx.dev/package/@atproto/api)                 |
-| `@atproto/common-web`: shared code and helpers which can run in web browsers  | [README](./packages/common-web/README.md)  | [![NPM](https://img.shields.io/npm/v/@atproto/common-web)](https://npmx.dev/package/@atproto/common-web)   |
-| `@atproto/common`: shared code and helpers which doesn't work in web browsers | [README](./packages/common/README.md)      | [![NPM](https://img.shields.io/npm/v/@atproto/common)](https://npmx.dev/package/@atproto/common)           |
-| `@atproto/crypto`: cryptographic signing and key serialization                | [README](./packages/crypto/README.md)      | [![NPM](https://img.shields.io/npm/v/@atproto/crypto)](https://npmx.dev/package/@atproto/crypto)           |
-| `@atproto/identity`: DID and handle resolution                                | [README](./packages/identity/README.md)    | [![NPM](https://img.shields.io/npm/v/@atproto/identity)](https://npmx.dev/package/@atproto/identity)       |
-| `@atproto/lex`: modern type-safe client library with codegen                  | [README](./packages/lex/lex/README.md)     | [![NPM](https://img.shields.io/npm/v/@atproto/lex)](https://npmx.dev/package/@atproto/lex)                 |
-| `@atproto/lexicon`: schema definition language                                | [README](./packages/lexicon/README.md)     | [![NPM](https://img.shields.io/npm/v/@atproto/lexicon)](https://npmx.dev/package/@atproto/lexicon)         |
-| `@atproto/repo`: data storage structure, including MST                        | [README](./packages/repo/README.md)        | [![NPM](https://img.shields.io/npm/v/@atproto/repo)](https://npmx.dev/package/@atproto/repo)               |
-| `@atproto/syntax`: string parsers for identifiers                             | [README](./packages/syntax/README.md)      | [![NPM](https://img.shields.io/npm/v/@atproto/syntax)](https://npmx.dev/package/@atproto/syntax)           |
-| `@atproto/xrpc`: client-side HTTP API helpers                                 | [README](./packages/xrpc/README.md)        | [![NPM](https://img.shields.io/npm/v/@atproto/xrpc)](https://npmx.dev/package/@atproto/xrpc)               |
-| `@atproto/xrpc-server`: server-side HTTP API helpers                          | [README](./packages/xrpc-server/README.md) | [![NPM](https://img.shields.io/npm/v/@atproto/xrpc-server)](https://npmx.dev/package/@atproto/xrpc-server) |
-
-**TypeScript Services:**
-
-- `pds`: "Personal Data Server", hosting repo content for atproto accounts. Most implementation code in `packages/pds`, with runtime wrapper in `services/pds`. See [bluesky-social/pds](https://github.com/bluesky-social/pds) for directions on self-hosting.
-- `bsky`: AppView implementation of the `app.bsky.*` API endpoints. Running on main network at `api.bsky.app`. Most implementation code in `packages/bsky`, with runtime wrapper in `services/bsky`.
 
 **Lexicons:** for both the `com.atproto.*` and `app.bsky.*` are canonically versioned in this repo, for now, under `./lexicons/`. These are JSON files in the [Lexicon schema definition language](https://atproto.com/specs/lexicon), similar to JSON Schema or OpenAPI.
 
-**Interoperability Test Data:** the language-neutral test files in `./interop-test-files/` may be useful for other protocol implementations to ensure that they follow the specification correctly
+**TypeScript Packages:** everything under [`./packages/`](./packages/) is published to npm under the `@atproto/*` scope (except for the shared utilities in [`./packages/internal/`](./packages/internal/), which use the `@atproto-labs/*` scope). Each package has its own README; [`packages/README.md`](./packages/README.md) lists them all. The short version, if you're new here:
+
+- **Building an app or bot?** Start with [`@atproto/lex`](./packages/lex/lex/README.md) — the type-safe SDK that generates TypeScript from Lexicon schemas and gives you an HTTP (XRPC) client. The rest of [`./packages/lex/`](./packages/lex/) contains its building blocks (data model, JSON/CBOR encoding, schema validation, server routing), which you rarely need to install directly. The older [`@atproto/api`](./packages/api/README.md) client still exists and is still used in parts of this repo, but new code should prefer `@atproto/lex`.
+- **Adding "Sign in with Bluesky"?** The OAuth client and server implementations live in [`./packages/oauth/`](./packages/oauth/) — pick the client variant matching your runtime ([browser](./packages/oauth/oauth-client-browser/README.md), [node](./packages/oauth/oauth-client-node/README.md), [expo](./packages/oauth/oauth-client-expo/README.md)).
+- **Implementing atproto itself?** The protocol primitives are split into focused packages: identifier parsing ([`syntax`](./packages/syntax/README.md)), DID/handle resolution ([`identity`](./packages/identity/README.md), [`did`](./packages/did/)), signing ([`crypto`](./packages/crypto/README.md)), repository & Merkle Search Tree ([`repo`](./packages/repo/README.md)), and firehose consumption ([`sync`](./packages/sync/)).
+- **Everything else** is either a service implementation (see below), shared internal glue ([`common`](./packages/common/README.md), [`common-web`](./packages/common-web/README.md), [`./packages/internal/`](./packages/internal/)), or dev tooling ([`dev-env`](./packages/dev-env/), [`dev-infra`](./packages/dev-infra/)).
+
+**TypeScript Services:** each has its implementation in `packages/<name>` and a thin runtime wrapper in `services/<name>`.
+
+- `pds`: "Personal Data Server", hosting repo content for atproto accounts. See [bluesky-social/pds](https://github.com/bluesky-social/pds) for directions on self-hosting.
+- `bsky`: AppView implementation of the `app.bsky.*` API endpoints. Running on main network at `api.bsky.app`.
+- `bsync`: Internal synchronization service used by the AppView for cross-service state such as mutes and notifications.
+- `ozone`: Moderation service implementing the `tools.ozone.*` API.
+
+## What is not in here?
 
 The source code for the Bluesky Social client app (for web and mobile) can be found at [bluesky-social/social-app](https://github.com/bluesky-social/social-app).
 
 Go programming language source code is in [bluesky-social/indigo](https://github.com/bluesky-social/indigo), including the BGS implementation.
 
-## Developer Quickstart
-
-We recommend [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js installs. This project requires Node.js version 22 or later. `pnpm` is used to manage the workspace of multiple packages. You can install it with `npm install --global pnpm`.
-
-There is a Makefile which can help with basic development tasks:
-
-```shell
-# use existing nvm to install node 22 and pnpm
-make nvm-setup
-
-# pull dependencies and build all local packages
-make deps
-make build
-
-# run the tests, using Docker services as needed
-make test
-
-# run a local PDS and AppView with fake test accounts and data
-# (this requires a global installation of `jq` and `docker`)
-make run-dev-env
-
-# show all other commands
-make help
-```
-
-## About AT Protocol
-
-The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky Social PBC](https://bsky.social). Learn more at:
-
-- [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
-- [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
-- [Protocol Specifications](https://atproto.com/specs/atp)
-- [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
-
-The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
-
 ## Contributions
 
-> While we do accept contributions, we prioritize high quality issues and pull requests. Adhering to the below guidelines will ensure a more timely review.
-
-**Rules:**
-
-- We may not respond to your issue or PR.
-- We may close an issue or PR without much feedback.
-- We may lock discussions or contributions if our attention is getting DDOSed.
-- We do not provide support for build issues.
-
-**Guidelines:**
-
-- Check for existing issues before filing a new one, please.
-- Open an issue and give some time for discussion before submitting a PR.
-- If submitting a PR that includes a lexicon change, please get sign off on the lexicon change _before_ doing the implementation.
-- Issues are for bugs & feature requests related to the TypeScript implementation of atproto and related services.
-  - For high-level discussions, please use the [Discussion Forum](https://github.com/bluesky-social/atproto/discussions).
-  - For client issues, please use the relevant [social-app](https://github.com/bluesky-social/social-app) repo.
-- Stay away from PRs that:
-  - Refactor large parts of the codebase
-  - Add entirely new features without prior discussion
-  - Change the tooling or frameworks used without prior discussion
-  - Introduce new unnecessary dependencies
-
-Remember, we serve a wide community of users. Our day-to-day involves us constantly asking "which top priority is our top priority." If you submit well-written PRs that solve problems concisely, that's an awesome contribution. Otherwise, as much as we'd love to accept your ideas and contributions, we really don't have the bandwidth.
-
-## Are you a developer interested in building on atproto?
-
-Bluesky is an open social network built on the AT Protocol, a flexible technology that will never lock developers out of the ecosystems that they help build. With atproto, third-party can be as seamless as first-party through custom feeds, federated services, clients, and more.
+While we do accept contributions, we prioritize high quality issues and pull requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the developer quickstart, the rules and guidelines to follow before filing an issue or submitting a PR, and our policy on LLM-assisted contributions. Code conventions are documented in [STYLE_GUIDE.md](./STYLE_GUIDE.md).
 
 ## Security disclosures
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ Please do NOT report possible security vulnerabilities in public channels such a
 
 We will acknowledge the vulnerability as soon as possible - within 3 business days - and follow up when a fix lands. Please avoid discussing the vulnerability until we do so.
 
-With your consent, we will add you to the repository [CONTRIBUTORS](https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTORS.md) file.
+With your consent, we will add you to the repository [CONTRIBUTORS](./CONTRIBUTORS.md) file.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -2,7 +2,7 @@
 
 Code conventions for this repository. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the process around issues and pull requests.
 
-Prettier and ESLint enforce what can be enforced mechanically. The rules below are the ones they can't check.
+Prettier (`pnpm run style`) and ESLint (`pnpm run lint`) enforce what can be enforced mechanically. The rules below are the conventions followed by this repo and are not enforced by tooling.
 
 ## Modules and imports
 
@@ -14,6 +14,12 @@ Prettier and ESLint enforce what can be enforced mechanically. The rules below a
 
 - **Type explicitly where types originate, rely on inference everywhere else.** Annotate public API surfaces: exported functions, class members, and module-level constants whose type isn't obvious.
 - Never re-annotate what the call site already provides. `expressApp.use((...args) => …)` and `onChange={(event) => …}` need no parameter or return type annotations — TypeScript infers them from the expected callback type.
+
+## Comments
+
+- **Write for an experienced developer.** A comment earns its place by explaining something the code can't: a non-obvious invariant, a subtle edge case, a workaround for an upstream bug, or _why_ a counter-intuitive approach was chosen.
+- **Keep them short.** One or two lines is usually enough. Don't write a tutorial where a sentence suffices.
+- **Delete comments that restate the code.** `// increment the counter` above `counter++` is noise. Remove such comments when you touch the surrounding code.
 
 ## Dependencies
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -9,17 +9,34 @@ Prettier (`pnpm run style`) and ESLint (`pnpm run lint`) enforce what can be enf
 - ESM only — every package ships `"type": "module"`.
 - **Always import explicitly**; never rely on globals (e.g. no global `React`). The only exception is jest's ambient test globals.
 - Prefer named imports over namespace or barrel imports: `import { useEffect } from 'react'`, not `import * as React from 'react'`.
+- **Relative imports carry an explicit `.js` extension**, even from a `.ts` source: `import { httpLogger } from './logger.js'`. ESLint's `import/extensions` rule is deliberately off, so nothing catches a missing extension for you.
+- **Prefer named exports over `export default`.** Only use a default export when something outside your control requires it (a `vite.config.ts`, a framework's route convention, …).
+
+## Naming
+
+- **Files are kebab-case**: `lex-error.ts`, `write-operation-builder.ts`, `input-new-password.tsx`.
+- **Exception — XRPC route handlers.** Under `src/api/**` in the service packages, the file name mirrors the lexicon method name and is therefore camelCase: [packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts](./packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts).
+- **Exception — React components.** A file exporting a single component may be named after it, in PascalCase (`ProfileCard.tsx`).
 
 ## TypeScript
 
 - **Type explicitly where types originate, rely on inference everywhere else.** Annotate public API surfaces: exported functions, class members, and module-level constants whose type isn't obvious.
 - Never re-annotate what the call site already provides. `expressApp.use((...args) => …)` and `onChange={(event) => …}` need no parameter or return type annotations — TypeScript infers them from the expected callback type.
+- **Prefer `export function` over an arrow function assigned to a const.** Function declarations support overload signatures, which arrow consts cannot express.
 
 ## Comments
 
 - **Write for an experienced developer.** A comment earns its place by explaining something the code can't: a non-obvious invariant, a subtle edge case, a workaround for an upstream bug, or _why_ a counter-intuitive approach was chosen.
 - **Keep them short.** One or two lines is usually enough. Don't write a tutorial where a sentence suffices.
 - **Delete comments that restate the code.** `// increment the counter` above `counter++` is noise. Remove such comments when you touch the surrounding code.
+- **Mark explanatory comments with `@NOTE` and deferred work with `@TODO`.** These two annotations are the only ones used in this repo — no `FIXME`, no `HACK`, and no bare `TODO:`.
+
+  ```ts
+  // @NOTE keep in sync with same interface in bsky/src/image/invalidator.ts
+  // @TODO drop dependency on uint8arrays package once Uint8Array.fromBase64 lands
+  ```
+
+- **Document public APIs with JSDoc**: a short description and, where it helps, an `@example` block. Don't restate parameter and return types — TypeScript already carries those. Reserve `@param` / `@returns` for saying something the signature doesn't.
 
 ## Dependencies
 
@@ -27,6 +44,38 @@ Prettier (`pnpm run style`) and ESLint (`pnpm run lint`) enforce what can be enf
 - Reference internal packages with the workspace protocol (`workspace:^`); never pin them to a published version.
 - `@atproto/api` is being replaced by `@atproto/lex`. Never add `@atproto/api` as a new dependency; use the `@atproto/lex` family instead. It remains in use in [packages/ozone](./packages/ozone/) and in some test suites (`pds`, `bsky`, `dev-env`) — keep using it there until those are migrated.
 - **No new circular dependencies**, explicit or implicit. The only tolerated cycle is `pds` ↔ `bsky` in tests. This applies to comments too: a dependency package must never reference an implementation detail of a package that depends on it.
+
+## Errors
+
+- Custom error classes are suffixed `Error` and declare `name` as a class field matching the class name, so the name is set once at the declaration rather than in every constructor:
+
+  ```ts
+  export class XrpcResponseError extends XrpcError {
+    name = 'XrpcResponseError'
+  }
+  ```
+
+  Older packages predate this and omit the field — follow the convention in new code rather than propagating the old shape.
+
+## Lexicons
+
+- **Never write NSID string literals** in a package that uses `@atproto/lex`. Import the generated schema and use the constant it exposes:
+
+  | Lexicon definition               | Use                                     |
+  | -------------------------------- | --------------------------------------- |
+  | record / typed object            | `app.bsky.feed.post.$type`              |
+  | query / procedure / subscription | `app.bsky.feed.getPosts.$lxm`           |
+  | token                            | `app.bsky.feed.defs.requestLess.$token` |
+
+  Each constant is emitted once per schema, so every reference shares one string instance instead of duplicating the literal at each call site — and the schema stays the single source of truth.
+
+## Logging
+
+- Never instantiate a logger inline. Each package declares its loggers as exported constants in its own `src/logger.ts`, built with `subsystemLogger('<package>:<subsystem>')`, and imports them where needed.
+
+## Resource disposal
+
+- A class owning a resource (server, subscription, DB handle) implements `async [Symbol.asyncDispose]()`, typically delegating to its existing `destroy()` / `close()`. Consumers then use `await using` instead of `try` / `finally`.
 
 ## Scope of a change
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,28 @@
+# Style guide
+
+Code conventions for this repository. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the process around issues and pull requests.
+
+Prettier and ESLint enforce what can be enforced mechanically. The rules below are the ones they can't check.
+
+## Modules and imports
+
+- ESM only — every package ships `"type": "module"`.
+- **Always import explicitly**; never rely on globals (e.g. no global `React`). The only exception is jest's ambient test globals.
+- Prefer named imports over namespace or barrel imports: `import { useEffect } from 'react'`, not `import * as React from 'react'`.
+
+## TypeScript
+
+- **Type explicitly where types originate, rely on inference everywhere else.** Annotate public API surfaces: exported functions, class members, and module-level constants whose type isn't obvious.
+- Never re-annotate what the call site already provides. `expressApp.use((...args) => …)` and `onChange={(event) => …}` need no parameter or return type annotations — TypeScript infers them from the expected callback type.
+
+## Dependencies
+
+- Don't add new dependencies without strong justification.
+- Reference internal packages with the workspace protocol (`workspace:^`); never pin them to a published version.
+- `@atproto/api` is being replaced by `@atproto/lex`. Never add `@atproto/api` as a new dependency; use the `@atproto/lex` family instead. It remains in use in [packages/ozone](./packages/ozone/) and in some test suites (`pds`, `bsky`, `dev-env`) — keep using it there until those are migrated.
+- **No new circular dependencies**, explicit or implicit. The only tolerated cycle is `pds` ↔ `bsky` in tests. This applies to comments too: a dependency package must never reference an implementation detail of a package that depends on it.
+
+## Scope of a change
+
+- Don't refactor unrelated code. Keep the diff to what the change actually requires.
+- **When removing code, don't leave references to it.** Comments, docs, and names must describe the current state only — no "previously…", "used to…", or mentions of a deleted symbol.

--- a/interop-test-files/README.md
+++ b/interop-test-files/README.md
@@ -4,6 +4,8 @@ atproto Interop Test Files
 
 This directory contains reusable files for testing interoperability and specification compliance for atproto (AT Protocol).
 
+These files are a copy of <https://github.com/bluesky-social/atproto-interop-tests/>, which is their canonical source and is shared across atproto implementations. Any change made here must also be contributed upstream to that repository.
+
 The protocol itself is documented at <https://atproto.com/specs/atp>. If there are conflicts or ambiguity between these test files and the specs, the specs are the authority, and these test files should usually be corrected.
 
 These files are intended to be simple (JSON, text files, etc) and mostly self-documenting.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,41 +1,93 @@
 # Packages
 
-## Applications
+Every package in this directory is published to npm. Packages under [`./internal/`](./internal/) are published under the `@atproto-labs/*` scope; all others use `@atproto/*`. Thin runtime wrappers for the services live in [`../services/`](../services/).
 
-- [PDS](./pds): The Personal Data Server (PDS). This is atproto's main server-side implementation.
-- [Dev Env](./dev-env): A command-line application for developers to construct and manage development environments.
-- [Lexicon CLI](./lex-cli/): A command-line application for generating code and documentation from Lexicon schemas.
+## Services
 
-## Libraries
+- [`pds`](./pds): The Personal Data Server (PDS) — account management, repo storage, blob storage, and OAuth provider. atproto's main server-side implementation.
+- [`bsky`](./bsky): The `app.bsky.*` AppView — read-side service for timelines, profiles, feed generators, and view hydration.
+- [`bsync`](./bsync): Cross-AppView synchronization service (mutes, notifications) over Connect-RPC.
+- [`ozone`](./ozone): Moderation service implementing the `tools.ozone.*` API.
 
-- [API](./api): A library for communicating with atproto servers.
-- [Common](./common): A library containing code which is shared between atproto packages.
-- [Crypto](./crypto): Atproto's common cryptographic operations.
-- [Syntax](./syntax): A library for identifier syntax: NSID, AT URI, handles, etc.
-- [Lexicon](./lexicon): A library for validating data using atproto's schema system.
-- [OAuth Provider](./oauth/oauth-provider): A library for supporting ATPROTO's OAuth.
-- [Repo](./repo): The "atproto repository" core implementation (a Merkle Search Tree).
-- [WebSocket Client](./ws-client): A library for working with long-lived WebSocket client connections.
-- [XRPC](./xrpc): An XRPC client implementation.
-- [XRPC Server](./xrpc-server): An XRPC server implementation.
+## Lexicon SDK
 
-## Benchmarking and profiling
+The modern, type-safe Lexicon toolchain. Most consumers only need [`@atproto/lex`](./lex/lex), which re-exports the core pieces.
 
-Only applicable to packages which contain benchmarks(`jest.bench.config.js`).
+- [`lex`](./lex/lex): The umbrella SDK — `lex install` / `lex build` CLI, typed XRPC client, and re-exports of the packages below.
+- [`lex-schema`](./lex/lex-schema): The runtime schema system that generated code is built on.
+- [`lex-builder`](./lex/lex-builder): Generates TypeScript schemas from Lexicon documents.
+- [`lex-document`](./lex/lex-document): Validation of Lexicon documents themselves.
+- [`lex-installer`](./lex/lex-installer): Resolves and installs Lexicon documents into a project.
+- [`lex-resolver`](./lex/lex-resolver): Resolves Lexicon documents from the network.
+- [`lex-data`](./lex/lex-data): Core data-model types and utilities.
+- [`lex-json`](./lex/lex-json): JSON encoding/decoding of Lexicon data.
+- [`lex-cbor`](./lex/lex-cbor): CBOR (DRISL) encoding/decoding of Lexicon data.
+- [`lex-client`](./lex/lex-client): HTTP (XRPC) client for Lexicon-defined APIs.
+- [`lex-server`](./lex/lex-server): Request router for Lexicon-defined APIs.
+- [`lex-password-session`](./lex/lex-password-session): Password-based client authentication, for scripts and bots.
+- [`xrpc-server`](./xrpc-server): Express-based XRPC server. `server.add()` registers routes from generated lexicon schemas; used by all four services in this repo.
 
-You can run benchmarks with `pnpm bench`.
+## OAuth
 
-### Attaching a profiler
+- [`oauth-provider`](./oauth/oauth-provider): OAuth 2.0 / OpenID Connect provider, as used by the PDS.
+- [`oauth-provider-api`](./oauth/oauth-provider-api): Shared types between the OAuth provider and its UI.
+- [`oauth-provider-ui`](./oauth/oauth-provider-ui): Sign-in and sign-up interface for the OAuth provider.
+- [`oauth-client`](./oauth/oauth-client): Runtime-agnostic OAuth client base.
+- [`oauth-client-browser`](./oauth/oauth-client-browser): OAuth client for browsers (WebCrypto + IndexedDB).
+- [`oauth-client-node`](./oauth/oauth-client-node): OAuth client for Node.js.
+- [`oauth-client-expo`](./oauth/oauth-client-expo): OAuth client for Expo applications.
+- [`oauth-client-browser-example`](./oauth/oauth-client-browser-example): Example single-page app using atproto OAuth.
+- [`oauth-types`](./oauth/oauth-types): OAuth typing and validation.
+- [`oauth-scopes`](./oauth/oauth-scopes): Manipulation and validation of atproto OAuth scopes.
+- [`jwk`](./oauth/jwk): JSON Web Key abstractions, extended by the implementations below.
+- [`jwk-jose`](./oauth/jwk-jose): `jose`-backed implementation of `@atproto/jwk`.
+- [`jwk-webcrypto`](./oauth/jwk-webcrypto): WebCrypto-backed implementation of `@atproto/jwk`.
 
-Running `pnpm bench:profile` will launch `bench` with `--inspect-brk` flag.
-Execution will be paused until a debugger is attached, you can read more
-about node debuggers [here](https://nodejs.org/en/docs/guides/debugging-getting-started#inspector-clients)
+## Protocol libraries
 
-An easy way to profile is:
+- [`syntax`](./syntax): Identifier and string-format validation: DID, handle, NSID, AT URI, TID, record key, datetime.
+- [`did`](./did): DID parsing, resolution, and verification.
+- [`identity`](./identity): Decentralized identity resolution combining DIDs and handles.
+- [`crypto`](./crypto): Cryptographic keys and signing.
+- [`repo`](./repo): The atproto repository implementation (a Merkle Search Tree) and CAR handling.
+- [`sync`](./sync): Firehose consumption and repo synchronization.
+- [`tap`](./tap): Client for the atproto tap (event stream) interface.
+- [`ws-client`](./ws-client): Long-lived WebSocket client connections.
+- [`lexicon-resolver`](./lexicon-resolver): Network resolution of Lexicon documents.
 
-1. open `about://inspect` in chrome
-2. select which process to connect to(there will probably only be one)
-3. go to performance tab
-4. press record, this will unpause execution
-5. wait for the benches to run
-6. finish recording
+## Earlier client and schema stack
+
+Being replaced by the Lexicon SDK above. Still used in parts of this repo; prefer `@atproto/lex` for new code.
+
+- [`api`](./api): Client library for atproto and Bluesky.
+- [`lexicon`](./lexicon): The original Lexicon schema language and validation library.
+- [`xrpc`](./xrpc): XRPC client implementation.
+- [`lex-cli`](./lex-cli): Codegen tool for the `@atproto/api` / `@atproto/lexicon` stack.
+
+## Shared internals
+
+Utility packages published under the `@atproto-labs/*` scope, all located in [`./internal/`](./internal/).
+
+- [`fetch`](./internal/fetch): Isomorphic wrappers around the `fetch` API.
+- [`fetch-node`](./internal/fetch-node): SSRF protection for `fetch()` in Node.js.
+- [`pipe`](./internal/pipe): Composition of multiple functions into one.
+- [`did-resolver`](./internal/did-resolver): DID resolution and verification.
+- [`handle-resolver`](./internal/handle-resolver): Isomorphic handle-to-DID resolution.
+- [`handle-resolver-node`](./internal/handle-resolver-node): Node-specific handle-to-DID resolution.
+- [`identity-resolver`](./internal/identity-resolver): Full atproto identity resolution.
+- [`simple-store`](./internal/simple-store): Minimal key-value store interfaces and utilities.
+- [`simple-store-memory`](./internal/simple-store-memory): In-memory `SimpleStore`.
+- [`simple-store-redis`](./internal/simple-store-redis): Redis-backed `SimpleStore`.
+- [`xrpc-utils`](./internal/xrpc-utils): XRPC server utilities for Node.js.
+- [`rollup-plugin-bundle-manifest`](./internal/rollup-plugin-bundle-manifest): Generates a manifest of bundled files from a Rollup build.
+
+A few further shared libraries live at the top level under the `@atproto/*` scope:
+
+- [`common`](./common): Code shared between atproto packages (Node-friendly).
+- [`common-web`](./common-web): The web-platform-friendly subset of `common`.
+- [`aws`](./aws): AWS helpers (S3 blob storage, etc.) for atproto services.
+
+## Development tooling
+
+- [`dev-env`](./dev-env): Boots a full PDS + AppView + bsync + PLC + Ozone constellation in-process, for tests and the `make run-dev-env` REPL.
+- [`dev-infra`](./dev-infra): Docker Compose definitions for the backing services (Postgres, Redis, etc.) used by tests.

--- a/packages/README.md
+++ b/packages/README.md
@@ -29,7 +29,7 @@ The modern, type-safe Lexicon toolchain. Most consumers only need [`@atproto/lex
 
 ## OAuth
 
-- [`oauth-provider`](./oauth/oauth-provider): OAuth 2.0 / OpenID Connect provider, as used by the PDS.
+- [`oauth-provider`](./oauth/oauth-provider): OAuth 2.1 provider, as used by the PDS.
 - [`oauth-provider-api`](./oauth/oauth-provider-api): Shared types between the OAuth provider and its UI.
 - [`oauth-provider-ui`](./oauth/oauth-provider-ui): Sign-in and sign-up interface for the OAuth provider.
 - [`oauth-client`](./oauth/oauth-client): Runtime-agnostic OAuth client base.


### PR DESCRIPTION
Split the repo's guidance into four documents with distinct audiences, and make the package index accurate.

- STYLE_GUIDE.md (new): code conventions extracted from CLAUDE.md — imports, typing, dependencies, scope of a change, and when to run the formatter. Applies to humans and agents alike.
- CONTRIBUTING.md (new): the README's contribution guidelines and developer quickstart, plus build/verify and test requirements, a security-disclosure pointer, and a policy on LLM-assisted contributions (disclose the tooling, follow the repo's directives whatever agent you use, and own every line you submit).
- CLAUDE.md: drops the style rules now in STYLE_GUIDE.md and keeps repository mechanics — layout, commands, codegen, architecture, troubleshooting.
- README.md: trimmed to a landing page. The package table was verbose and already incomplete, so it is replaced by task-oriented prose pointing at packages/README.md.
- packages/README.md: rewritten as an exhaustive index of all 61 published packages, grouped by role.

Also:

- Add a lightweight pull request template and an issue-template config.yml routing questions to Discussions, client bugs to social-app, and vulnerabilities to security@bsky.app.
- Update .github/claude-review-prompt.md for the new documents, and give it the agent-file sync check that CLAUDE.md already claimed it performed.
- Note in interop-test-files/README.md that the fixtures are copied from bluesky-social/atproto-interop-tests and edits must go upstream.
- Make self-referential links in the root docs relative. Package READMEs keep absolute URLs, since those are published to npm.

Documentation only; no package sources touched, so no changeset.