### PR TITLE
Fix repeated XRPC array query parsing

### DIFF
--- a/.changeset/twenty-dids-query.md
+++ b/.changeset/twenty-dids-query.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Parse repeated query parameters from the request URL so Express query parser array limits do not collapse XRPC array params above 20 values.

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -163,12 +163,13 @@ export function getQueryParams(
   req: IncomingMessage | ExpressRequest,
   opts?: { parseLoose?: boolean },
 ): UndecodedParams {
-  if ('query' in req) return req.query
-
   const result: UndecodedParams = Object.create(null)
+  const expressQuery = 'query' in req ? req.query : undefined
 
   const searchParams = getSearchParams(req.url, opts)
-  if (!searchParams) return result
+  if (!searchParams) {
+    return expressQuery ?? result
+  }
 
   if (searchParams.has('__proto__')) {
     // Prevent prototype pollution
@@ -181,6 +182,17 @@ export function getQueryParams(
   for (const key of searchParams.keys()) {
     const values = searchParams.getAll(key)
     result[key] = values.length === 1 ? values[0] : values
+  }
+
+  // Preserve Express's support for bracket-style query parameters in the
+  // legacy Lexicons path, but let repeated standard params from the URL win so
+  // Express/qs array limits cannot collapse them into numeric-keyed objects.
+  if (expressQuery) {
+    for (const [key, value] of Object.entries(expressQuery)) {
+      if (!(key in result)) {
+        result[key] = value
+      }
+    }
   }
 
   return result

--- a/packages/xrpc-server/tests/parameters.test.ts
+++ b/packages/xrpc-server/tests/parameters.test.ts
@@ -1,5 +1,6 @@
 import type * as http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import express from 'express'
 import type { LexiconDoc } from '@atproto/lexicon'
 import { XrpcClient } from '@atproto/xrpc'
 import * as xrpcServer from '../src/index.js'
@@ -158,6 +159,87 @@ describe('Parameters', () => {
         arr: [1, 2, 3],
       }),
     ).rejects.toThrow('Error: arr must not have more than 2 elements')
+  })
+})
+
+describe('Express query parsing compatibility', () => {
+  let s: http.Server
+  let url: string
+
+  const lexicons: LexiconDoc[] = [
+    {
+      lexicon: 1,
+      id: 'io.example.repeatedArrayQueryTest',
+      defs: {
+        main: {
+          type: 'query',
+          parameters: {
+            type: 'params',
+            required: ['dids'],
+            properties: {
+              dids: {
+                type: 'array',
+                items: { type: 'string', format: 'did' },
+                maxLength: 100,
+              },
+            },
+          },
+          output: {
+            encoding: 'application/json',
+          },
+        },
+      },
+    },
+  ]
+
+  beforeAll(async () => {
+    const server = xrpcServer.createServer(lexicons)
+    server.method('io.example.repeatedArrayQueryTest', (ctx) => ({
+      encoding: 'application/json',
+      body: ctx.params,
+    }))
+
+    const app = express()
+    app.set('query parser', (queryString: string) => {
+      const parsed: Record<string, unknown> = {}
+      const searchParams = new URLSearchParams(queryString)
+      for (const key of new Set(searchParams.keys())) {
+        const values = searchParams.getAll(key)
+        parsed[key] =
+          values.length > 20
+            ? Object.fromEntries(values.map((value, index) => [index, value]))
+            : values.length === 1
+              ? values[0]
+              : values
+      }
+      return parsed
+    })
+    app.use(server.router)
+
+    s = app.listen(0)
+    await new Promise((resolve) => s.once('listening', resolve))
+    const { port } = s.address() as AddressInfo
+    url = `http://localhost:${port}`
+  })
+
+  afterAll(async () => {
+    await closeServer(s)
+  })
+
+  it('handles repeated array params above Express query parser array limits', async () => {
+    const did = 'did:plc:t76alsfrlr2zewmi2nsy6rls'
+    const params = new URLSearchParams()
+    for (let index = 0; index < 21; index++) {
+      params.append('dids', did)
+    }
+
+    const res = await fetch(
+      `${url}/xrpc/io.example.repeatedArrayQueryTest?${params}`,
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.dids).toEqual(Array.from({ length: 21 }, () => did))
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #5260.

- parse XRPC query parameters from the raw request URL before falling back to Express's parsed `req.query`
- preserve existing legacy `method()` bracket-parameter behavior by merging Express-parsed keys that are not present in the raw repeated-param parse
- add regression coverage for repeated DID array parameters above the Express/qs 20-value boundary

## Validation

- `corepack pnpm --filter @atproto/xrpc-server... build`
- `corepack pnpm --dir packages/xrpc-server test -- parameters.test.ts --runInBand`
- `NODE_OPTIONS=--experimental-vm-modules corepack pnpm --dir packages/xrpc-server exec jest --runInBand`
- `corepack pnpm exec prettier --check .changeset/twenty-dids-query.md packages/xrpc-server/src/util.ts packages/xrpc-server/tests/parameters.test.ts`
- `corepack pnpm changeset status --since=origin/main`
- `git diff --check`

Generated with Hermes Agent.