### PR TITLE
#5285 review

### DIFF
--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -1,6 +1,11 @@
-import { createTransport } from '#transport'
-import { createWebSocket } from './websocket.js'
-import type { WebSocketFn } from './websocket.js'
+import { HEADERS_SUPPORTED, createTransport } from '#transport'
+import type { DataMode } from './message-channel.js'
+import {
+  type Awaitable,
+  type WebSocketIterable,
+  type WebSocketOptions,
+  websocketFactory,
+} from './websocket.js'
 
 export type {
   CloseEventDetail,
@@ -16,9 +21,6 @@ export type {
 export type { HeadersInit, Sender } from './transport/transport.js'
 export type {
   Awaitable,
-  BrowserWebSocketOptions,
-  NodeWebSocketOptions,
-  WebSocketFn,
   WebSocketIterable,
   WebSocketOptions,
 } from './websocket.js'
@@ -40,8 +42,37 @@ export {
 } from './lib/reconnect-policy.js'
 
 /**
- * The `websocket()` generator, bound to the platform transport selected by the
- * `#transport` imports condition. The single entrypoint for consuming a
- * WebSocket as a reconnecting async stream.
+ * Whether the platform WebSocket implementation supports creating WebSockets
+ * with a {@link WebSocketOptions.headers} option. Node does, the browser
+ * doesn't. Creating a WebSocket with headers on a platform that doesn't support
+ * them throws an error.
  */
-export const websocket: WebSocketFn = createWebSocket(createTransport)
+// @NOTE Must be explicitly typed a boolean
+export const HEADERS_SUPPORTED_PLATFORM: boolean = HEADERS_SUPPORTED
+
+export type NodeWebSocketOptions<M extends DataMode = 'auto'> =
+  WebSocketOptions<M>
+export type BrowserWebSocketOptions<M extends DataMode = 'auto'> = Omit<
+  WebSocketOptions<M>,
+  'headers'
+>
+
+/**
+ * A function allows building an isomorphic {@link WebSocketIterable}.
+ */
+export function websocket(
+  url: string | URL | (() => Awaitable<string | URL>),
+  options?: WebSocketOptions<'auto'>,
+): WebSocketIterable<'auto'>
+export function websocket<M extends DataMode>(
+  url: string | URL | (() => Awaitable<string | URL>),
+  options: M extends 'auto'
+    ? WebSocketOptions<'auto'>
+    : WebSocketOptions<M> & { dataMode: M },
+): WebSocketIterable<M>
+export function websocket<M extends DataMode>(
+  url: string | URL | (() => Awaitable<string | URL>),
+  options: WebSocketOptions<M> = {},
+): WebSocketIterable<M> {
+  return websocketFactory(url, createTransport, options)
+}

--- a/packages/ws-client/src/message-channel.test.ts
+++ b/packages/ws-client/src/message-channel.test.ts
@@ -5,7 +5,7 @@ import {
   DataModeError,
   IdleTimeoutError,
 } from './lib/errors.js'
-import { createMessageChannel } from './message-channel.js'
+import { closeGuard, createMessageChannel } from './message-channel.js'
 
 describe(createMessageChannel, () => {
   describe('delivery', () => {
@@ -471,6 +471,292 @@ describe(createMessageChannel, () => {
       const boom = new Error('boom')
       await expect(iterator.throw(boom)).rejects.toBe(boom)
       expect(onAbort).toHaveBeenCalled()
+    })
+  })
+})
+
+describe(closeGuard, () => {
+  // The guard holds a terminal on a pending promise, not a timer, so letting one
+  // macrotask turn elapse is enough to tell "held" from "settled".
+  async function isPending(promise: Promise<unknown>): Promise<boolean> {
+    let settled = false
+    const mark = () => {
+      settled = true
+    }
+    promise.then(mark, mark)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    return !settled
+  }
+
+  // An inner iterator that ends however the test asks, plus a `returned` flag so
+  // cleanup can be asserted. `throw` is left off deliberately — the guard's
+  // fallback to `return()` is documented behavior.
+  function source<T>(
+    values: T[],
+    end: { type: 'done' } | { type: 'error'; error: unknown } = {
+      type: 'done',
+    },
+  ) {
+    let returned = false
+    const iterator: AsyncIterator<T, void, unknown> = {
+      async next() {
+        if (values.length) return { value: values.shift()!, done: false }
+        if (end.type === 'error') throw end.error
+        return { value: undefined, done: true }
+      },
+      async return() {
+        returned = true
+        return { value: undefined, done: true }
+      },
+    }
+    return { iterator, returned: () => returned }
+  }
+
+  it('noops when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { iterator } = source(['one'])
+    const guarded = closeGuard(iterator, controller.signal)
+    expect(guarded).toBe(iterator)
+  })
+
+  it('yields messages without waiting for the signal', async () => {
+    const controller = new AbortController()
+    const guarded = closeGuard(source(['one']).iterator, controller.signal)
+    await expect(guarded.next()).resolves.toEqual({ value: 'one', done: false })
+  })
+
+  it('holds `done` until the signal aborts', async () => {
+    const controller = new AbortController()
+    const guarded = closeGuard(source([]).iterator, controller.signal)
+    const pending = guarded.next()
+    expect(await isPending(pending)).toBe(true)
+    controller.abort()
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('holds a rejection until the signal aborts, then rethrows it', async () => {
+    const controller = new AbortController()
+    const boom = new Error('boom')
+    const guarded = closeGuard(
+      source([], { type: 'error', error: boom }).iterator,
+      controller.signal,
+    )
+    const pending = guarded.next()
+    expect(await isPending(pending)).toBe(true)
+    controller.abort()
+    await expect(pending).rejects.toBe(boom)
+  })
+
+  it('returns the inner iterator, then holds done until the signal aborts', async () => {
+    const controller = new AbortController()
+    const inner = source(['unread'])
+    const guarded = closeGuard(inner.iterator, controller.signal)
+    assert(guarded.return)
+    const pending = guarded.return()
+    expect(await isPending(pending)).toBe(true)
+    // Cleanup ran eagerly; only the reported end waits on the signal.
+    expect(inner.returned()).toBe(true)
+    controller.abort()
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  it('forwards a return() the inner iterator declines', async () => {
+    // An iterator may yield from a `finally` to refuse closing, and that
+    // refusal is the inner iterator's to make.
+    const controller = new AbortController()
+    async function* gen(i = 0): AsyncGenerator<number, void, unknown> {
+      try {
+        yield i++
+      } finally {
+        yield i++
+      }
+    }
+    const inner = gen()
+    await inner.next()
+    const guarded = closeGuard(inner, controller.signal)
+    assert(guarded.return)
+    await expect(guarded.return()).resolves.toEqual({
+      value: 1,
+      done: false,
+    })
+  })
+
+  it('treats a missing return() as a clean close', async () => {
+    const controller = new AbortController()
+    const inner: AsyncIterator<string, void, unknown> = {
+      async next() {
+        return { value: 'a', done: false }
+      },
+    }
+    const guarded = closeGuard(inner, controller.signal)
+    assert(guarded.return)
+    const pending = guarded.return()
+    expect(await isPending(pending)).toBe(true)
+    controller.abort()
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
+  })
+
+  describe('delegation with yield*', () => {
+    // `closeGuard` hands back a bare iterator, so wrap it the way both transports
+    // expose theirs — `[Symbol.asyncIterator]: () => iterator` — to hand the
+    // engine something it will delegate to.
+    const asIterable = <T>(
+      iterator: AsyncIterator<T, void, unknown>,
+    ): AsyncIterable<T> => ({ [Symbol.asyncIterator]: () => iterator })
+
+    it('forwards values, then holds the end of delegation until the signal aborts', async () => {
+      const controller = new AbortController()
+      const guarded = closeGuard(
+        source(['one', 'two']).iterator,
+        controller.signal,
+      )
+      async function* delegating() {
+        yield* asIterable(guarded)
+        yield 'after'
+      }
+      const outer = delegating()
+      await expect(outer.next()).resolves.toEqual({
+        value: 'one',
+        done: false,
+      })
+      await expect(outer.next()).resolves.toEqual({
+        value: 'two',
+        done: false,
+      })
+      // The inner iterator is exhausted, so `yield*` is ending — and the engine
+      // can't resume the outer generator until the guard releases that `done`.
+      const pending = outer.next()
+      expect(await isPending(pending)).toBe(true)
+      controller.abort()
+      await expect(pending).resolves.toEqual({ value: 'after', done: false })
+    })
+
+    it('holds a `for await` body that exits via break', async () => {
+      // The idiomatic consumer shape, and the reason the guard exists: `break`
+      // makes the engine call `return()`, so the loop cannot be left until the
+      // close has completed.
+      const controller = new AbortController()
+      const inner = source(['one', 'two'])
+      const guarded = closeGuard(inner.iterator, controller.signal)
+      const seen: string[] = []
+      const loop = (async () => {
+        for await (const value of asIterable(guarded)) {
+          seen.push(value)
+          break
+        }
+      })()
+      expect(await isPending(loop)).toBe(true)
+      expect(seen).toEqual(['one'])
+      controller.abort()
+      await loop
+      expect(inner.returned()).toBe(true)
+    })
+
+    it('propagates a refusal to terminate, then gates the eventual close', async () => {
+      // A generator that yields from its `finally` declines to close. The guard
+      // forwards that verbatim, so the engine keeps the delegation alive — and
+      // only once the generator really does end does the gate apply.
+      const controller = new AbortController()
+      async function* stubborn(): AsyncGenerator<string, void, unknown> {
+        try {
+          yield 'live'
+        } finally {
+          yield 'cleanup'
+        }
+      }
+      const guarded = closeGuard(stubborn(), controller.signal)
+      async function* delegating() {
+        yield* asIterable(guarded)
+      }
+      const outer = delegating()
+      await expect(outer.next()).resolves.toEqual({
+        value: 'live',
+        done: false,
+      })
+      // The refusal reaches the caller as a live value, ungated: waiting here
+      // would deadlock on a close that this unfinished iteration is holding up.
+      await expect(outer.return()).resolves.toEqual({
+        value: 'cleanup',
+        done: false,
+      })
+      // Asking again lets the `finally` run out, which is a real terminal.
+      const pending = outer.return()
+      expect(await isPending(pending)).toBe(true)
+      controller.abort()
+      await pending
+    })
+
+    it('gives `yield*` the throw() it demands, even when the inner iterator has none', async () => {
+      // Delegating straight to a throw-less iterator makes the engine raise a
+      // TypeError and discard the caller's error. The guard always defines
+      // `throw()`, so that hole is closed and the caller's error survives.
+      const controller = new AbortController()
+      const inner = source(['one'])
+      assert(inner.iterator.throw === undefined)
+      const guarded = closeGuard(inner.iterator, controller.signal)
+      async function* delegating() {
+        yield* asIterable(guarded)
+      }
+      const outer = delegating()
+      await outer.next()
+      const boom = new Error('boom')
+      const pending = outer.throw(boom)
+      expect(await isPending(pending)).toBe(true)
+      controller.abort()
+      await expect(pending).rejects.toBe(boom)
+    })
+
+    it('ends delegation on throw() even when the inner iterator recovers', async () => {
+      // The guard treats `throw()` as terminal by choice: an inner iterator that
+      // answers `done: false` to keep going is overruled, where bare `yield*`
+      // would have resumed the delegation.
+      const controller = new AbortController()
+      async function* recovering(
+        onError?: (err: unknown) => void,
+      ): AsyncGenerator<string, void, unknown> {
+        while (true) {
+          try {
+            yield 'live'
+          } catch (err) {
+            // Swallows an continue iterating
+            onError?.(err)
+          }
+        }
+      }
+
+      {
+        using onError = vi.fn()
+        const control = recovering(onError)
+        await expect(control.next()).resolves.toEqual({
+          value: 'live',
+          done: false,
+        })
+        const error = new Error('boom')
+        await control.throw(error)
+        expect(onError).toHaveBeenLastCalledWith(error)
+        await expect(control.next()).resolves.toEqual({
+          value: 'live',
+          done: false,
+        })
+        await expect(control.next()).resolves.toEqual({
+          value: 'live',
+          done: false,
+        })
+        await control.return()
+      }
+
+      const guarded = closeGuard(recovering(), controller.signal)
+      async function* delegating() {
+        yield* asIterable(guarded)
+      }
+      const outer = delegating()
+      await outer.next()
+      const boom = new Error('boom')
+      const pending = outer.throw(boom)
+      expect(await isPending(pending)).toBe(true)
+      controller.abort()
+      await expect(pending).rejects.toBe(boom)
     })
   })
 })

--- a/packages/ws-client/src/message-channel.test.ts
+++ b/packages/ws-client/src/message-channel.test.ts
@@ -11,7 +11,7 @@ describe(createMessageChannel, () => {
   describe('delivery', () => {
     it('yields a pushed message to a parked pull', async () => {
       const channel = createMessageChannel({ dataMode: 'auto' })
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       const pending = iterator.next()
       channel.push('hello')
       await expect(pending).resolves.toEqual({ value: 'hello', done: false })
@@ -22,7 +22,7 @@ describe(createMessageChannel, () => {
       channel.push('one')
       channel.push('two')
       channel.push('three')
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: 'one',
         done: false,
@@ -42,7 +42,7 @@ describe(createMessageChannel, () => {
       const bin = new Uint8Array([1, 2, 3])
       channel.push('text-frame')
       channel.push(bin)
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: 'text-frame',
         done: false,
@@ -56,7 +56,7 @@ describe(createMessageChannel, () => {
     it('yields string for text mode and Uint8Array for binary mode', async () => {
       const textChannel = createMessageChannel({ dataMode: 'text' })
       textChannel.push('hi')
-      const textIterator = textChannel.iterable[Symbol.asyncIterator]()
+      const textIterator = textChannel.iterator
       const textResult = await textIterator.next()
       assert(!textResult.done)
       expect(typeof textResult.value).toBe('string')
@@ -64,7 +64,7 @@ describe(createMessageChannel, () => {
       const binChannel = createMessageChannel({ dataMode: 'binary' })
       const bin = new Uint8Array([9, 8, 7])
       binChannel.push(bin)
-      const binIterator = binChannel.iterable[Symbol.asyncIterator]()
+      const binIterator = binChannel.iterator
       const binResult = await binIterator.next()
       assert(!binResult.done)
       expect(binResult.value).toBeInstanceOf(Uint8Array)
@@ -76,7 +76,7 @@ describe(createMessageChannel, () => {
     it('fails a binary frame in text mode, asking for a 1003 close', async () => {
       const onAbort = vi.fn()
       const channel = createMessageChannel({ dataMode: 'text', onAbort })
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       const pending = iterator.next()
       channel.push(new Uint8Array([1, 2, 3]))
       await expect(pending).rejects.toSatisfy((err: unknown) => {
@@ -94,7 +94,7 @@ describe(createMessageChannel, () => {
     it('fails a text frame in binary mode', async () => {
       const onAbort = vi.fn()
       const channel = createMessageChannel({ dataMode: 'binary', onAbort })
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       const pending = iterator.next()
       channel.push('surprise')
       await expect(pending).rejects.toSatisfy((err: unknown) => {
@@ -134,7 +134,7 @@ describe(createMessageChannel, () => {
       })
       channel.push('a'.repeat(6)) // 12 bytes: over highWaterMark (10)
       expect(onPause).toHaveBeenCalledTimes(1)
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       // Draining down to 12 - 12 = 0 bytes is below half (5), so resume fires.
       await iterator.next()
       expect(onResume).toHaveBeenCalledTimes(1)
@@ -152,7 +152,7 @@ describe(createMessageChannel, () => {
       channel.push('a'.repeat(6)) // 12 bytes
       channel.push('a'.repeat(2)) // +4 = 16 bytes
       expect(onPause).toHaveBeenCalledTimes(1)
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       // Drain the first message: 16 - 12 = 4 bytes remain, below half (5) —
       // resume fires here, so push a third message to keep it above half.
       channel.push('a'.repeat(6)) // +12 = 16 bytes again before draining
@@ -182,7 +182,7 @@ describe(createMessageChannel, () => {
       })
       channel.push('a'.repeat(20)) // 40 bytes: well over the mark
       channel.push('more')
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: 'a'.repeat(20),
         done: false,
@@ -203,7 +203,7 @@ describe(createMessageChannel, () => {
       // No pull is parked, so this buffers rather than delivering directly: 20
       // bytes against a 10-byte cap overflows.
       channel.push('a'.repeat(10))
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).rejects.toBeInstanceOf(BufferOverflowError)
       expect(onAbort).toHaveBeenCalledTimes(1)
       const [error, code] = onAbort.mock.calls[0]
@@ -258,7 +258,7 @@ describe(createMessageChannel, () => {
           idleTimeoutMs: 1000,
           onAbort,
         })
-        const iterator = channel.iterable[Symbol.asyncIterator]()
+        const iterator = channel.iterator
         // Attach the assertion synchronously: the rejection fires mid-tick, before
         // this test resumes, and would otherwise look unhandled.
         const pending = expect(iterator.next()).rejects.toBeInstanceOf(
@@ -334,7 +334,7 @@ describe(createMessageChannel, () => {
           onAbort,
           // No `backpressure`: the browser shape.
         })
-        const iterator = channel.iterable[Symbol.asyncIterator]()
+        const iterator = channel.iterator
         // Leave the buffer between the low mark (5) and the high mark (10), where
         // the pause flag used to latch.
         channel.push('a'.repeat(6)) // 12 bytes
@@ -370,7 +370,7 @@ describe(createMessageChannel, () => {
       channel.push('one')
       channel.push('two')
       channel.finish()
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: 'one',
         done: false,
@@ -391,13 +391,13 @@ describe(createMessageChannel, () => {
       channel.push('two')
       const boom = new Error('boom')
       channel.fail(boom)
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).rejects.toBe(boom)
     })
 
     it('rejects a parked pull on fail', async () => {
       const channel = createMessageChannel({ dataMode: 'auto' })
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       const pending = iterator.next()
       const boom = new Error('boom')
       channel.fail(boom)
@@ -411,17 +411,13 @@ describe(createMessageChannel, () => {
       const first = new Error('first')
       failed.fail(first)
       failed.fail(new Error('second'))
-      await expect(failed.iterable[Symbol.asyncIterator]().next()).rejects.toBe(
-        first,
-      )
+      await expect(failed.iterator.next()).rejects.toBe(first)
 
       // A finish after a failure likewise cannot turn it into a clean end.
       const failedThenFinished = createMessageChannel({ dataMode: 'auto' })
       failedThenFinished.fail(first)
       failedThenFinished.finish()
-      await expect(
-        failedThenFinished.iterable[Symbol.asyncIterator]().next(),
-      ).rejects.toBe(first)
+      await expect(failedThenFinished.iterator.next()).rejects.toBe(first)
 
       // And a failure after a clean finish can't turn it into a rejection: the
       // buffered message drains, then the stream ends.
@@ -429,7 +425,7 @@ describe(createMessageChannel, () => {
       finished.push('buffered')
       finished.finish()
       finished.fail(new Error('too late'))
-      const iterator = finished.iterable[Symbol.asyncIterator]()
+      const iterator = finished.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: 'buffered',
         done: false,
@@ -445,7 +441,7 @@ describe(createMessageChannel, () => {
       const channel = createMessageChannel({ dataMode: 'auto', onAbort })
       channel.push('one')
       channel.push('two')
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       assert(iterator.return)
       await iterator.return()
       expect(onAbort).toHaveBeenCalledWith(undefined, CloseCode.Normal)
@@ -460,11 +456,21 @@ describe(createMessageChannel, () => {
       const channel = createMessageChannel({ dataMode: 'auto' })
       channel.finish()
       channel.push('too-late')
-      const iterator = channel.iterable[Symbol.asyncIterator]()
+      const iterator = channel.iterator
       await expect(iterator.next()).resolves.toEqual({
         value: undefined,
         done: true,
       })
+    })
+
+    it('triggers termination when throwing the iterator', async () => {
+      const onAbort = vi.fn()
+      const channel = createMessageChannel({ dataMode: 'auto', onAbort })
+      const iterator = channel.iterator
+      assert(iterator.throw)
+      const boom = new Error('boom')
+      await expect(iterator.throw(boom)).rejects.toBe(boom)
+      expect(onAbort).toHaveBeenCalled()
     })
   })
 })

--- a/packages/ws-client/src/message-channel.ts
+++ b/packages/ws-client/src/message-channel.ts
@@ -114,14 +114,14 @@ export const ABNORMAL_CLOSE_DETAIL: CloseEventDetail = Object.freeze({
  * signal is a secondary gate: if it fires, the iterator's next/return/throw
  * waits for it to settle before reporting done or throwing.
  */
-export function guarded<T>(
+export function closeGuard<T>(
   iterator: AsyncIterator<T, void, unknown>,
-  signal: AbortSignal,
+  closeSignal: AbortSignal,
 ): AsyncIterator<T, void, unknown> {
-  if (signal.aborted) return iterator
+  closeSignal.throwIfAborted()
 
   const promise = new Promise((resolve) => {
-    signal.addEventListener('abort', resolve, { once: true })
+    closeSignal.addEventListener('abort', resolve, { once: true })
   })
 
   return {
@@ -148,7 +148,14 @@ export function guarded<T>(
     },
     async throw(error: unknown) {
       try {
-        await iterator.throw?.(error)
+        // @NOTE Because we define a throw() function, the caller is allowed to
+        // throw() even if the inner iterator doesn't implement it. We have to
+        // ensure proper cleanup in that case, so we call return() instead.
+        if (iterator.throw) {
+          await iterator.throw?.(error)
+        } else {
+          await iterator.return?.()
+        }
         throw error
       } finally {
         await promise

--- a/packages/ws-client/src/message-channel.ts
+++ b/packages/ws-client/src/message-channel.ts
@@ -396,17 +396,9 @@ export function createMessageChannel<M extends DataMode>(
     return { value: undefined as never, done: true }
   }
 
-  async function iteratorThrow(
-    error: unknown,
-  ): Promise<IteratorResult<MessageOf<M>, void>> {
-    await iteratorReturn()
-    throw error
-  }
-
   const iterator: AsyncIterator<MessageOf<M>, void, unknown> = {
     next: iteratorNext,
     return: iteratorReturn,
-    throw: iteratorThrow,
   }
 
   return {

--- a/packages/ws-client/src/message-channel.ts
+++ b/packages/ws-client/src/message-channel.ts
@@ -109,56 +109,84 @@ export const ABNORMAL_CLOSE_DETAIL: CloseEventDetail = Object.freeze({
 })
 
 /**
- * Wraps an iterator so its terminal state is gated on a signal. The iterator's
- * own terminal state is still the primary determinant of iteration, but the
- * signal is a secondary gate: if it fires, the iterator's next/return/throw
- * waits for it to settle before reporting done or throwing.
+ * Wraps an iterator so the *end* of iteration is gated on a signal: a terminal
+ * outcome — `done: true`, or a rejection — is withheld until `closeSignal`
+ * fires, letting a consumer treat "iteration finished" as "teardown finished".
+ * The inner iterator still decides *whether* iteration ends; the signal only
+ * decides when the caller is told.
+ *
+ * Only terminal outcomes wait. A `done: false` result means iteration
+ * continues, so gating it would stall a live stream — and that applies to every
+ * method, not just `next()`: per the iterator protocol both `throw()` and
+ * `return()` may answer `done: false` to decline ending iteration.
+ *
+ * @NOTE How this compares to `yield*`, the closest built-in equivalent. Two
+ * deliberate differences, both on one path — an inner iterator with no `throw()`
+ * method:
+ *
+ * - `yield*` rejects with a `TypeError` ("The iterator does not provide a
+ *   'throw' method") and *discards the caller's error*. Defining `throw()` here
+ *   means callers may always call it, so that hole would be ours to fall into:
+ *   instead we close the inner iterator with `return()` — skipping cleanup would
+ *   leak it — and rethrow the caller's error, the more useful of the two.
+ * - `yield*` prefers a failing `return()` over that `TypeError`; we prefer it
+ *   over the caller's error. A cleanup failure is new information, whereas the
+ *   caller's error is something they just handed us and still hold.
+ *
+ * Everything else matches the engine: a recovering `throw()` resumes iteration,
+ * a `return()` the inner iterator declines is forwarded as-is, and an absent
+ * `return()` counts as a clean close.
  */
 export function closeGuard<T>(
   iterator: AsyncIterator<T, void, unknown>,
   closeSignal: AbortSignal,
 ): AsyncIterator<T, void, unknown> {
-  closeSignal.throwIfAborted()
+  if (closeSignal.aborted) return iterator
 
-  const promise = new Promise((resolve) => {
-    closeSignal.addEventListener('abort', resolve, { once: true })
+  const closed = new Promise<void>((resolve) => {
+    // The event is dropped rather than resolved with: nothing here reads it, and
+    // keeping it would pin the event object for the lifetime of the guard.
+    closeSignal.addEventListener('abort', () => resolve(), { once: true })
   })
 
   return {
     async next() {
       try {
         const result = await iterator.next()
-        // Only the terminal pull waits: a yielded message means the connection is
-        // still live, and delaying data until close would deadlock the stream.
-        if (result.done) await promise
+        // Only the terminal pull waits: a yielded message means the connection
+        // is still live, and delaying data until close would deadlock the
+        // stream.
+        if (result.done) await closed
         return result
       } catch (error) {
-        // A rejection is the end of iteration too, so it waits the same way.
-        await promise
+        // A rejection ends iteration too, so it waits the same way.
+        await closed
         throw error
       }
     },
     async return() {
       try {
-        await iterator.return?.()
-        return { value: undefined, done: true }
-      } finally {
-        await promise
+        // An iterator with no `return()` has nothing to release, which the
+        // protocol treats as a successful close.
+        const result = await iterator.return?.()
+        if (!result || result.done) await closed
+        return result ?? { value: undefined, done: true }
+      } catch (error) {
+        await closed
+        throw error
       }
     },
-    async throw(error: unknown) {
+    async throw(error: unknown): Promise<IteratorResult<T, void>> {
       try {
-        // @NOTE Because we define a throw() function, the caller is allowed to
-        // throw() even if the inner iterator doesn't implement it. We have to
-        // ensure proper cleanup in that case, so we call return() instead.
-        if (iterator.throw) {
-          await iterator.throw?.(error)
-        } else {
-          await iterator.return?.()
-        }
+        const result = await iterator.throw?.(error)
+        // A `throw()` may "recover" and decline to end iteration, so it can
+        // return `done: false`.
+        if (result?.done) await closed
         throw error
-      } finally {
-        await promise
+      } catch (error) {
+        // A failing `throw()` ends iteration too, so it waits the same way.
+        await closed
+        throw error
       }
     },
   }
@@ -375,7 +403,7 @@ export function createMessageChannel<M extends DataMode>(
     throw error
   }
 
-  const iterator: Required<AsyncIterator<MessageOf<M>, void, unknown>> = {
+  const iterator: AsyncIterator<MessageOf<M>, void, unknown> = {
     next: iteratorNext,
     return: iteratorReturn,
     throw: iteratorThrow,

--- a/packages/ws-client/src/message-channel.ts
+++ b/packages/ws-client/src/message-channel.ts
@@ -12,8 +12,8 @@ export type DataMode = 'auto' | 'text' | 'binary'
 export type MessageOf<M extends DataMode> = M extends 'text'
   ? string
   : M extends 'binary'
-    ? Uint8Array
-    : string | Uint8Array
+    ? Uint8Array<ArrayBuffer>
+    : string | Uint8Array<ArrayBuffer>
 
 export interface CloseEventDetail {
   code: number
@@ -52,8 +52,8 @@ export interface MessageChannelOptions<M extends DataMode> {
 }
 
 export interface MessageChannel<M extends DataMode> {
-  /** Single-consumer async iterable of received messages. */
-  readonly iterable: AsyncIterable<MessageOf<M>, void, unknown>
+  /** Single-consumer async iterator of received messages. */
+  readonly iterator: AsyncIterator<MessageOf<M>, void, unknown>
   /** Feed a received frame. Binary vs text is carried by the data type. */
   push(data: string | Uint8Array): void
   /** End the channel with an error; discards undelivered buffered messages. */
@@ -109,42 +109,50 @@ export const ABNORMAL_CLOSE_DETAIL: CloseEventDetail = Object.freeze({
 })
 
 /**
- * Wraps a channel's iterator so it settles only once `closed` resolves — the
- * transport's signal that the socket's close event has fired.
- *
- * This is what lets a consumer treat the end of iteration as "teardown is done".
- * Two paths need it, both of which would otherwise settle while the socket is
- * still closing: a consumer `break` (whose `return()` only *asks* the transport
- * to close) and a failure the transport records before its close event lands.
- *
- * The wait is bounded by the transport — on Node by `ws`'s `closeTimeout`, which
- * forces the close event if a peer never answers the handshake.
+ * Wraps an iterator so its terminal state is gated on a signal. The iterator's
+ * own terminal state is still the primary determinant of iteration, but the
+ * signal is a secondary gate: if it fires, the iterator's next/return/throw
+ * waits for it to settle before reporting done or throwing.
  */
-export function closeGuard<M extends DataMode>(
-  iterable: AsyncIterable<MessageOf<M>, void, unknown>,
-  closed: Promise<void>,
-): AsyncIterator<MessageOf<M>, void, unknown> {
-  const iterator = iterable[Symbol.asyncIterator]()
+export function guarded<T>(
+  iterator: AsyncIterator<T, void, unknown>,
+  signal: AbortSignal,
+): AsyncIterator<T, void, unknown> {
+  if (signal.aborted) return iterator
+
+  const promise = new Promise((resolve) => {
+    signal.addEventListener('abort', resolve, { once: true })
+  })
+
   return {
-    async next(): Promise<IteratorResult<MessageOf<M>, void>> {
+    async next() {
       try {
         const result = await iterator.next()
         // Only the terminal pull waits: a yielded message means the connection is
         // still live, and delaying data until close would deadlock the stream.
-        if (result.done) await closed
+        if (result.done) await promise
         return result
       } catch (error) {
         // A rejection is the end of iteration too, so it waits the same way.
-        await closed
+        await promise
         throw error
       }
     },
-    async return(): Promise<IteratorResult<MessageOf<M>, void>> {
-      // Asks the channel to stop (which asks the transport to close the socket),
-      // then waits for the socket to actually be down.
-      await iterator.return?.()
-      await closed
-      return { value: undefined, done: true }
+    async return() {
+      try {
+        await iterator.return?.()
+        return { value: undefined, done: true }
+      } finally {
+        await promise
+      }
+    },
+    async throw(error: unknown) {
+      try {
+        await iterator.throw?.(error)
+        throw error
+      } finally {
+        await promise
+      }
     },
   }
 }
@@ -173,11 +181,15 @@ export function closeCodeForStop(reason: unknown): number {
 export function createMessageChannel<M extends DataMode>(
   options: MessageChannelOptions<M>,
 ): MessageChannel<M> {
-  const dataMode: DataMode = options.dataMode
-  const highWaterMark = options.highWaterMark ?? 1_048_576
-  const maxBufferedBytes = options.maxBufferedBytes ?? Infinity
-  const idleTimeoutMs = options.idleTimeoutMs
-  const { backpressure, onAbort } = options
+  const {
+    dataMode,
+    backpressure,
+    highWaterMark = 1_048_576,
+    maxBufferedBytes = Infinity,
+    idleTimeoutMs,
+    onAbort,
+  } = options
+
   // Whether this platform can actually stop the peer from sending: Node can (it
   // pauses the socket), the browser can't. Gates the pause state itself, not
   // just the callbacks — see `idleTick`.
@@ -226,7 +238,6 @@ export function createMessageChannel<M extends DataMode>(
 
   if (idleTimeoutMs != null) {
     idleTimer = setInterval(idleTick, idleTimeoutMs)
-    idleTimer.unref?.()
   }
 
   function rejectWaiters(error: unknown): void {
@@ -315,29 +326,27 @@ export function createMessageChannel<M extends DataMode>(
     }
   }
 
-  function pull(): Promise<IteratorResult<MessageOf<M>, void>> {
+  async function iteratorNext(): Promise<IteratorResult<MessageOf<M>, void>> {
     // Drain buffered messages first, even after a `done` terminal: a
     // server-initiated clean close never drops received data.
     const item = buffer.shift()
     if (item) {
       bufferedBytes -= item.bytes
       afterDrain()
-      return Promise.resolve({ value: item.value, done: false })
+      return { value: item.value, done: false }
     }
     if (terminal) {
       if (terminal.type === 'done') {
-        return Promise.resolve({ value: undefined as never, done: true })
+        return { value: undefined as never, done: true }
       }
-      return Promise.reject(terminal.error)
+      throw terminal.error
     }
-    return new Promise<IteratorResult<MessageOf<M>, void>>(
-      (resolve, reject) => {
-        waiters.push({ resolve, reject })
-      },
-    )
+    return new Promise((resolve, reject) => {
+      waiters.push({ resolve, reject })
+    })
   }
 
-  function iteratorReturn(): Promise<IteratorResult<MessageOf<M>, void>> {
+  async function iteratorReturn(): Promise<IteratorResult<MessageOf<M>, void>> {
     // The consumer abandoned iteration (a `break`/`return` in a `for await`).
     // Stopping is a loss of interest, not a request to drain, so discard the
     // buffer. First-wins: a channel that already ended is left as-is.
@@ -349,20 +358,26 @@ export function createMessageChannel<M extends DataMode>(
       resolveWaitersDone()
       invokeHook(onAbort, undefined, CloseCode.Normal)
     }
-    return Promise.resolve({ value: undefined as never, done: true })
+    return { value: undefined as never, done: true }
+  }
+
+  async function iteratorThrow(
+    error: unknown,
+  ): Promise<IteratorResult<MessageOf<M>, void>> {
+    await iteratorReturn()
+    throw error
+  }
+
+  const iterator: Required<AsyncIterator<MessageOf<M>, void, unknown>> = {
+    next: iteratorNext,
+    return: iteratorReturn,
+    throw: iteratorThrow,
   }
 
   return {
     push,
     fail,
     finish,
-    iterable: {
-      [Symbol.asyncIterator]() {
-        return {
-          next: () => pull(),
-          return: () => iteratorReturn(),
-        }
-      },
-    },
+    iterator,
   }
 }

--- a/packages/ws-client/src/transport/browser-transport.ts
+++ b/packages/ws-client/src/transport/browser-transport.ts
@@ -5,8 +5,8 @@ import {
   type CloseEventDetail,
   type DataMode,
   closeCodeForStop,
+  closeGuard,
   createMessageChannel,
-  guarded,
 } from '../message-channel.js'
 import type {
   HeadersInit,
@@ -283,7 +283,7 @@ function createTransportImpl<M extends DataMode>(
 
   // This lets consumers treat the end of iteration as "teardown is done"
   // (resources have been released).
-  const iterator = guarded(channel.iterator, closeController.signal)
+  const iterator = closeGuard(channel.iterator, closeController.signal)
 
   return {
     send: sender.send,

--- a/packages/ws-client/src/transport/browser-transport.ts
+++ b/packages/ws-client/src/transport/browser-transport.ts
@@ -5,8 +5,8 @@ import {
   type CloseEventDetail,
   type DataMode,
   closeCodeForStop,
-  closeGuard,
   createMessageChannel,
+  guarded,
 } from '../message-channel.js'
 import type {
   HeadersInit,
@@ -15,6 +15,8 @@ import type {
   TransportFactory,
   TransportOptions,
 } from './transport.js'
+
+export const HEADERS_SUPPORTED = false
 
 // Only the WHATWG WebSocket members this transport actually touches, rather than
 // the ambient `WebSocket` — which pulls in all of `EventTarget` plus
@@ -44,7 +46,7 @@ interface WHATWGErrorEvent {
 
 interface WHATWGWebSocket {
   binaryType: 'blob' | 'arraybuffer'
-  send(data: string | ArrayBufferLike | ArrayBufferView): void
+  send(data: string | BufferSource): void
   close(code?: number, reason?: string): void
   addEventListener(type: 'open', listener: () => void): void
   addEventListener(
@@ -110,8 +112,7 @@ function createTransportImpl<M extends DataMode>(
   // loosely-typed view of `globalThis` rather than relying on assignability from
   // the ambient DOM `WebSocket`, which drags in members `WHATWGWebSocket`
   // doesn't ask for.
-  WebSocketImpl: WebSocketCtor = (globalThis as { WebSocket?: WebSocketCtor })
-    .WebSocket as WebSocketCtor,
+  WebSocketImpl: WebSocketCtor = globalThis.WebSocket,
 ): Transport<M> {
   // The WHATWG API has no request-header mechanism, so accepting headers here
   // would silently drop what is usually auth. Fail loudly at construction rather
@@ -127,6 +128,12 @@ function createTransportImpl<M extends DataMode>(
     throw new TypeError('WebSocket is not available in this environment')
   }
 
+  // Marked as aborted once the socket's close event has fired — the transport's
+  // proof that teardown finished, handed to the channel so iteration doesn't
+  // settle until the socket is down.
+  const closeController = new AbortController()
+  const markClosed = () => closeController.abort()
+
   const channel = createMessageChannel<M>({
     dataMode: options.dataMode,
     highWaterMark: options.highWaterMark,
@@ -135,7 +142,7 @@ function createTransportImpl<M extends DataMode>(
     // No `backpressure`, per the module doc above. Its absence is also what lets
     // the idle timeout work here: a merely-full buffer must not read as a pause,
     // since this platform can never actually pause.
-    onAbort: (_error, code) => {
+    onAbort: (error, code) => {
       // A polite close is the strongest teardown the WHATWG API offers — there is
       // no `terminate()`.
       closeSocket(ws, code)
@@ -153,18 +160,6 @@ function createTransportImpl<M extends DataMode>(
     closeReported = true
     options.onClose(detail)
   }
-
-  // Resolves once the socket's close event has fired — the transport's proof that
-  // teardown finished, handed to the consumer by `closeGuard` below so iteration
-  // doesn't settle until the socket is down.
-  //
-  // Unlike Node there is no `terminate()` here, so a peer that never answers a
-  // close frame is bounded only by the runtime's own handshake timeout. The
-  // WHATWG API offers nothing stronger.
-  let markClosed!: () => void
-  const closed = new Promise<void>((resolve) => {
-    markClosed = resolve
-  })
 
   // Ends the connection with a failure, the moment teardown begins.
   //
@@ -226,8 +221,8 @@ function createTransportImpl<M extends DataMode>(
 
   // Where a connection ends, and normally the only place: per spec every teardown
   // fires `close`, with `error` confined to failures before the connection is
-  // established. `markClosed` releases whatever pull `closeGuard` has parked — see
-  // the 'error' handler below for the runtime where `close` alone isn't enough.
+  // established. See the 'error' handler below for the runtime where `close`
+  // alone isn't enough.
   ws.addEventListener('close', (ev) => {
     open = false
     if (pendingError) {
@@ -286,9 +281,13 @@ function createTransportImpl<M extends DataMode>(
     { once: true },
   )
 
+  // This lets consumers treat the end of iteration as "teardown is done"
+  // (resources have been released).
+  const iterator = guarded(channel.iterator, closeController.signal)
+
   return {
     send: sender.send,
-    [Symbol.asyncIterator]: () => closeGuard(channel.iterable, closed),
+    [Symbol.asyncIterator]: () => iterator,
   }
 }
 

--- a/packages/ws-client/src/transport/node-transport.ts
+++ b/packages/ws-client/src/transport/node-transport.ts
@@ -9,8 +9,8 @@ import {
   type CloseEventDetail,
   type DataMode,
   closeCodeForStop,
-  closeGuard,
   createMessageChannel,
+  guarded,
 } from '../message-channel.js'
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -19,6 +19,8 @@ import {
   type TransportFactory,
   type TransportOptions,
 } from './transport.js'
+
+export const HEADERS_SUPPORTED = true
 
 // How long a polite close may wait for the peer's answering close frame before
 // the socket is destroyed and 'close' fires anyway. Enforced by `ws` itself via
@@ -42,6 +44,12 @@ function createTransportImpl<M extends DataMode>(
   // have seen a pong (or anything else) arrive.
   let paused = false
 
+  // Marked as aborted once the socket's close event has fired — the transport's
+  // proof that teardown finished, handed to the channel so iteration doesn't
+  // settle until the socket is down.
+  const closeController = new AbortController()
+  const markClosed = () => closeController.abort()
+
   const channel = createMessageChannel<M>({
     dataMode: options.dataMode,
     highWaterMark: options.highWaterMark,
@@ -57,7 +65,7 @@ function createTransportImpl<M extends DataMode>(
         ws.resume()
       },
     },
-    onAbort: (_error, code) => {
+    onAbort: (error, code) => {
       // Send the close code the channel asked for. Missing code here indicates the connection should be dropped outright.
       if (code !== undefined) {
         ws.close(code)
@@ -95,14 +103,6 @@ function createTransportImpl<M extends DataMode>(
     closeReported = true
     options.onClose(detail)
   }
-
-  // Resolves once the socket's close event has fired — the transport's proof
-  // that teardown finished. `closeGuard` below hands that guarantee to the
-  // consumer: iteration doesn't settle until the socket is really down.
-  let markClosed!: () => void
-  const closed = new Promise<void>((resolve) => {
-    markClosed = resolve
-  })
 
   // Ends the connection with a failure, the moment teardown begins.
   //
@@ -278,9 +278,13 @@ function createTransportImpl<M extends DataMode>(
     { once: true },
   )
 
+  // This lets consumers treat the end of iteration as "teardown is done"
+  // (resources have been released).
+  const iterator = guarded(channel.iterator, closeController.signal)
+
   return {
     send: sender.send,
-    [Symbol.asyncIterator]: () => closeGuard(channel.iterable, closed),
+    [Symbol.asyncIterator]: () => iterator,
   }
 }
 

--- a/packages/ws-client/src/transport/node-transport.ts
+++ b/packages/ws-client/src/transport/node-transport.ts
@@ -161,7 +161,6 @@ function createTransportImpl<M extends DataMode>(
       heartbeatAlive = false
       ws.ping()
     }, intervalMs)
-    heartbeatTimer.unref?.()
   }
 
   function clearHeartbeat(): void {

--- a/packages/ws-client/src/transport/node-transport.ts
+++ b/packages/ws-client/src/transport/node-transport.ts
@@ -9,8 +9,8 @@ import {
   type CloseEventDetail,
   type DataMode,
   closeCodeForStop,
+  closeGuard,
   createMessageChannel,
-  guarded,
 } from '../message-channel.js'
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -280,7 +280,7 @@ function createTransportImpl<M extends DataMode>(
 
   // This lets consumers treat the end of iteration as "teardown is done"
   // (resources have been released).
-  const iterator = guarded(channel.iterator, closeController.signal)
+  const iterator = closeGuard(channel.iterator, closeController.signal)
 
   return {
     send: sender.send,

--- a/packages/ws-client/src/transport/transport.ts
+++ b/packages/ws-client/src/transport/transport.ts
@@ -36,7 +36,12 @@ export const DEFAULT_HEARTBEAT_INTERVAL_MS = 10_000
 export interface TransportOptions<M extends DataMode = 'auto'> {
   url: string | URL
   dataMode: M
-  /** Teardown: aborting ends the iteration and closes the socket. */
+  /**
+   * Teardown: aborting ends the iteration and closes the socket. Use a
+   * {@link CloseError} instance as the reason for controlling the close code
+   * and message sent to the server. Any other value will result in a normal
+   * close with code 1000 and no message.
+   */
   signal: AbortSignal
   /**
    * Protocol ping/pong liveness. On by default at

--- a/packages/ws-client/src/websocket.ts
+++ b/packages/ws-client/src/websocket.ts
@@ -27,14 +27,14 @@ export type Awaitable<T> = T | Promise<T>
  * single call site (see {@link TransportOptions}). Out here every field is
  * genuinely optional, and {@link connectionOptions} bridges the two.
  */
-type ConnectionOptions<M extends DataMode = 'auto'> = Partial<
+type ConnectionOptions<M extends DataMode> = Partial<
   Omit<
     TransportOptions<M>,
     'url' | 'signal' | 'dataMode' | 'onOpen' | 'onClose'
   >
 > & { dataMode?: M }
 
-export interface WebSocketOptions<M extends DataMode = 'auto'>
+export interface WebSocketOptions<M extends DataMode>
   extends ConnectionOptions<M> {
   /** Exponential-backoff ceiling in seconds. Default 64. */
   maxReconnectSeconds?: number
@@ -107,22 +107,14 @@ export interface WebSocketOptions<M extends DataMode = 'auto'>
   onClose?: (detail: CloseEventDetail) => void
 }
 
-export type NodeWebSocketOptions<M extends DataMode = 'auto'> =
-  WebSocketOptions<M>
-export type BrowserWebSocketOptions<M extends DataMode = 'auto'> = Omit<
-  WebSocketOptions<M>,
-  'headers'
->
-
 /**
  * A reconnecting stream of WebSocket messages: `for await` over it and the
- * stream spans reconnects, so a consumer never has to notice that the underlying
- * connection was torn down and replaced. Ends on `break`, `throw`, or an aborted
- * `signal`.
- *
- * An `AsyncGenerator` rather than a bare `AsyncIterable`, so a consumer can use
- * `next()` or `return()` if it wants to. The runtime object is a generator
- * either way, and a quieter type would only hide that.
+ * stream spans reconnects, so a consumer never has to notice that the
+ * underlying connection was torn down and replaced. Ends on `break`, `throw`,
+ * or an aborted `signal` (see {@link WebSocketOptions.signal}). When throwing,
+ * or aborting, use a {@link CloseError} to control the close code and message
+ * sent to the server; any other value results in a normal close with code 1000
+ * and no message.
  */
 export type WebSocketIterable<M extends DataMode = 'auto'> = AsyncGenerator<
   MessageOf<M>,
@@ -130,170 +122,163 @@ export type WebSocketIterable<M extends DataMode = 'auto'> = AsyncGenerator<
   unknown
 >
 
-export type WebSocketFn = <M extends DataMode = 'auto'>(
-  url: string | URL | (() => Awaitable<string | URL>),
-  options?: WebSocketOptions<M>,
-) => WebSocketIterable<M>
-
 /**
  * Binds a platform transport factory into the public `websocket()` generator.
  * Called once per entrypoint; the `#transport` imports condition selects the
  * platform.
  */
-export function createWebSocket(
+
+export async function* websocketFactory<M extends DataMode = 'auto'>(
+  url: string | URL | (() => Awaitable<string | URL>),
   createTransport: TransportFactory,
-): WebSocketFn {
-  return async function* websocket<M extends DataMode = 'auto'>(
-    url: string | URL | (() => Awaitable<string | URL>),
-    options: WebSocketOptions<M> = {},
-  ): WebSocketIterable<M> {
-    const { signal } = options
-    const maxMs = 1000 * (options.maxReconnectSeconds ?? 64)
-    const shouldReconnect = normalizeShouldReconnect(options.shouldReconnect)
+  options: WebSocketOptions<M> = {},
+): WebSocketIterable<M> {
+  const { signal } = options
+  const maxMs = 1000 * (options.maxReconnectSeconds ?? 64)
+  const shouldReconnect = normalizeShouldReconnect(options.shouldReconnect)
 
-    // Consecutive failed connections since the last successful open, so the
-    // backoff restarts at ~1s after any stable open and only escalates across
-    // repeated failures with nothing working in between.
-    let retries = 0
-    let firstOpen = true
-    // How the last connection ended, recorded by the transport's `onClose` below.
-    // A transport settles its iteration only after its socket has closed, so this
-    // is always already set when a `yield*` resumes or rejects — which is what
-    // lets both the thrown CloseError and the terminal hook read it directly,
-    // with no synchronization of their own.
-    let closeDetail: CloseEventDetail | undefined
+  // Consecutive failed connections since the last successful open, so the
+  // backoff restarts at ~1s after any stable open and only escalates across
+  // repeated failures with nothing working in between.
+  let retries = 0
+  let firstOpen = true
+  // How the last connection ended, recorded by the transport's `onClose` below.
+  // A transport settles its iteration only after its socket has closed, so this
+  // is always already set when a `yield*` resumes or rejects — which is what
+  // lets both the thrown CloseError and the terminal hook read it directly,
+  // with no synchronization of their own.
+  let closeDetail: CloseEventDetail | undefined
 
-    try {
-      for (;;) {
-        // One abort check for every way this loop is entered: the first pull (the
-        // generator body doesn't run until then, so an already-aborted signal
-        // rejects that `next()` rather than the call that created the generator),
-        // and each re-entry after a backoff.
+  try {
+    for (;;) {
+      // One abort check for every way this loop is entered: the first pull (the
+      // generator body doesn't run until then, so an already-aborted signal
+      // rejects that `next()` rather than the call that created the generator),
+      // and each re-entry after a backoff.
+      signal?.throwIfAborted()
+
+      const resolved = typeof url === 'function' ? await url() : url
+      // Resolving the url is an async gap of its own: an abort that lands while
+      // it's in flight must not fall through to a connection nothing tears down.
+      signal?.throwIfAborted()
+
+      // A transport is created already connecting and has no close method —
+      // aborting is the only way to end it. Forwarding the caller's signal in
+      // means an outer abort reaches the socket; aborting in the `finally`
+      // means every exit path tears the connection down exactly once.
+      const teardown = new AbortController()
+      forwardAbort(signal, teardown)
+      let opened = false
+      // Per-attempt, and cleared here rather than only written on success: a
+      // detail left over from an earlier connection would otherwise be reported
+      // as this stream's ending.
+      closeDetail = undefined
+      try {
+        const transport = createTransport<M>({
+          // The transport-facing subset of the caller's options
+          dataMode: options.dataMode ?? ('auto' as M),
+          protocols: options.protocols,
+          headers: options.headers,
+          heartbeat: options.heartbeat,
+          idleTimeoutMs: options.idleTimeoutMs,
+          highWaterMark: options.highWaterMark,
+          maxBufferedBytes: options.maxBufferedBytes,
+          // Transport options wired by this websocket implementation and not directly by the caller
+          url: resolved,
+          signal: teardown.signal,
+          // The sender handed out is the transport's own: its send() already
+          // rejects once this connection is no longer open, which the
+          // transport knows the moment its socket closes, errors, or aborts.
+          onOpen: (sender) => {
+            retries = 0 // a stable open: the backoff starts over
+            opened = true
+            // onOpen bookends the stream and fires once, before the first
+            // onConnect; onConnect fires for every connection including this
+            // one.
+            if (firstOpen) {
+              firstOpen = false
+              invokeHook(options.onOpen)
+            }
+            invokeHook(options.onConnect, sender)
+          },
+          onClose: (detail) => {
+            closeDetail = detail
+            // Only for a connection that actually connected, and only once:
+            // this is what makes onConnect/onDisconnect pair exactly.
+            if (opened) {
+              opened = false
+              invokeHook(options.onDisconnect)
+            }
+          },
+        })
+
+        // Per the ordinary iterator contract, a transport reports a failure by
+        // rejecting and an orderly close by completing. So a close arrives
+        // here as a normal completion, and this layer turns its detail into
+        // the error the policy below classifies — which saves transports from
+        // inventing an error for something that isn't one. `closeDetail` is
+        // always already recorded here, since a transport settles its iteration
+        // only after its socket has closed.
+        //
+        // A consumer `break` also lands here, resuming with a return
+        // completion: it runs the `finally` and leaves the loop without
+        // reaching the throw.
+        yield* transport
+        throw closeError(closeDetail)
+      } catch (error) {
+        // An abort is the caller's decision, not a connection failure:
+        // surface the reason rather than classifying it as retryable.
         signal?.throwIfAborted()
 
-        const resolved = typeof url === 'function' ? await url() : url
-        // Resolving the url is an async gap of its own: an abort that lands while
-        // it's in flight must not fall through to a connection nothing tears down.
-        signal?.throwIfAborted()
+        const willReconnect = shouldReconnect(error, retries)
+        // A 1000 close goes to the policy like anything else, so an override can
+        // re-dial a server that closes after each batch. But when the policy
+        // declines, a peer that ended the session normally is a *completed*
+        // stream, not a failure the consumer has to catch.
+        //
+        // Keyed on the code rather than on `wasClean`, which asks a different
+        // question: whether the closing handshake completed. A fatal 1002
+        // protocol close completes its handshake too, and must still reject.
+        const endedNormally =
+          error instanceof CloseError && error.code === CloseCode.Normal
+        if (!willReconnect && endedNormally) return
 
-        // A transport is created already connecting and has no close method —
-        // aborting is the only way to end it. Forwarding the caller's signal in
-        // means an outer abort reaches the socket; aborting in the `finally`
-        // means every exit path tears the connection down exactly once.
-        const teardown = new AbortController()
-        forwardAbort(signal, teardown)
-        let opened = false
-        // Per-attempt, and cleared here rather than only written on success: a
-        // detail left over from an earlier connection would otherwise be reported
-        // as this stream's ending.
-        closeDetail = undefined
-        try {
-          const transport = createTransport<M>({
-            // The transport-facing subset of the caller's options
-            dataMode: options.dataMode ?? ('auto' as M),
-            protocols: options.protocols,
-            headers: options.headers,
-            heartbeat: options.heartbeat,
-            idleTimeoutMs: options.idleTimeoutMs,
-            highWaterMark: options.highWaterMark,
-            maxBufferedBytes: options.maxBufferedBytes,
-            // Transport options wired by this websocket implementation and not directly by the caller
-            url: resolved,
-            signal: teardown.signal,
-            // The sender handed out is the transport's own: its send() already
-            // rejects once this connection is no longer open, which the
-            // transport knows the moment its socket closes, errors, or aborts.
-            onOpen: (sender) => {
-              retries = 0 // a stable open: the backoff starts over
-              opened = true
-              // onOpen bookends the stream and fires once, before the first
-              // onConnect; onConnect fires for every connection including this
-              // one.
-              if (firstOpen) {
-                firstOpen = false
-                invokeHook(options.onOpen)
-              }
-              invokeHook(options.onConnect, sender)
-            },
-            onClose: (detail) => {
-              closeDetail = detail
-              // Only for a connection that actually connected, and only once:
-              // this is what makes onConnect/onDisconnect pair exactly.
-              if (opened) {
-                opened = false
-                invokeHook(options.onDisconnect)
-              }
-            },
-          })
-
-          // Per the ordinary iterator contract, a transport reports a failure by
-          // rejecting and an orderly close by completing. So a close arrives
-          // here as a normal completion, and this layer turns its detail into
-          // the error the policy below classifies — which saves transports from
-          // inventing an error for something that isn't one. `closeDetail` is
-          // always already recorded here, since a transport settles its iteration
-          // only after its socket has closed.
-          //
-          // A consumer `break` also lands here, resuming with a return
-          // completion: it runs the `finally` and leaves the loop without
-          // reaching the throw.
-          yield* transport
-          throw closeError(closeDetail)
-        } catch (error) {
-          // An abort is the caller's decision, not a connection failure:
-          // surface the reason rather than classifying it as retryable.
-          signal?.throwIfAborted()
-
-          const willReconnect = shouldReconnect(error, retries)
-          // A 1000 close goes to the policy like anything else, so an override can
-          // re-dial a server that closes after each batch. But when the policy
-          // declines, a peer that ended the session normally is a *completed*
-          // stream, not a failure the consumer has to catch.
-          //
-          // Keyed on the code rather than on `wasClean`, which asks a different
-          // question: whether the closing handshake completed. A fatal 1002
-          // protocol close completes its handshake too, and must still reject.
-          const endedNormally =
-            error instanceof CloseError && error.code === CloseCode.Normal
-          if (!willReconnect && endedNormally) return
-
-          // Two hooks rather than one with an optional argument, because they
-          // report different things: `onReconnect` is the only place a swallowed
-          // failure surfaces, while an `onError` error is also what the iterator
-          // rejects with — so a caller can handle it there or in a `catch`.
-          if (!willReconnect) {
-            invokeHook(options.onError, error)
-            throw error
-          }
-          invokeHook(options.onReconnect, error, { attempt: retries })
-
-          // Backoff lives in the one branch that actually retries rather than at
-          // the top of the loop, because the other three exits (a fatal error
-          // rethrowing, a non-reconnectable clean close returning, a consumer
-          // `break` resuming at the `yield*`) must not be delayed by it.
-          // Post-increment so the first reconnect waits ~1s (2^0) and each
-          // consecutive failure escalates; a successful open resets to 0.
-          await sleep(backoffMs(retries++, maxMs), signal)
-          // Loop: the check at the top catches an abort that landed during the
-          // backoff, then the url is re-resolved and redialed.
-        } finally {
-          // Also detaches the forwarding listener, which is bound to this
-          // controller's own signal.
-          teardown.abort()
+        // Two hooks rather than one with an optional argument, because they
+        // report different things: `onReconnect` is the only place a swallowed
+        // failure surfaces, while an `onError` error is also what the iterator
+        // rejects with — so a caller can handle it there or in a `catch`.
+        if (!willReconnect) {
+          invokeHook(options.onError, error)
+          throw error
         }
+        invokeHook(options.onReconnect, error, { attempt: retries })
+
+        // Backoff lives in the one branch that actually retries rather than at
+        // the top of the loop, because the other three exits (a fatal error
+        // rethrowing, a non-reconnectable clean close returning, a consumer
+        // `break` resuming at the `yield*`) must not be delayed by it.
+        // Post-increment so the first reconnect waits ~1s (2^0) and each
+        // consecutive failure escalates; a successful open resets to 0.
+        await sleep(backoffMs(retries++, maxMs), signal)
+        // Loop: the check at the top catches an abort that landed during the
+        // backoff, then the url is re-resolved and redialed.
+      } finally {
+        // Also detaches the forwarding listener, which is bound to this
+        // controller's own signal.
+        teardown.abort()
       }
-    } finally {
-      // The single terminal transition: runs however the stream ends, exactly
-      // once. A generator that was never pulled never gets here.
-      //
-      // No waiting for the close: a transport settles its iteration only after
-      // its socket has closed and its detail was reported, so by the time this
-      // runs there is nothing left to synchronize with. `closeDetail` is unset
-      // only when no connection ever closed — a stop while parked in backoff, or
-      // a transport that threw at construction — where an abnormal close is the
-      // honest answer.
-      invokeHook(options.onClose, closeDetail ?? ABNORMAL_CLOSE_DETAIL)
     }
+  } finally {
+    // The single terminal transition: runs however the stream ends, exactly
+    // once. A generator that was never pulled never gets here.
+    //
+    // No waiting for the close: a transport settles its iteration only after
+    // its socket has closed and its detail was reported, so by the time this
+    // runs there is nothing left to synchronize with. `closeDetail` is unset
+    // only when no connection ever closed — a stop while parked in backoff, or
+    // a transport that threw at construction — where an abnormal close is the
+    // honest answer.
+    invokeHook(options.onClose, closeDetail ?? ABNORMAL_CLOSE_DETAIL)
   }
 }
 
@@ -311,7 +296,7 @@ function normalizeShouldReconnect(
 ): (error: unknown, attempt: number) => boolean {
   if (typeof option === 'function') return option
   if (option === false) return () => false
-  return (error) => defaultShouldReconnect(error)
+  return defaultShouldReconnect
 }
 
 // Forwards an abort from `source` (the caller's signal, if any) into `target`,
@@ -336,8 +321,8 @@ function forwardAbort(
 // The timer stays ref'd on purpose: a process whose only pending work is this
 // backoff should stay alive to reconnect rather than exiting mid-wait.
 function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted) return Promise.resolve()
   return new Promise((resolve) => {
-    if (signal?.aborted) return resolve()
     const timer = setTimeout(() => {
       signal?.removeEventListener('abort', onStop)
       resolve()

--- a/packages/ws-client/tests/entries.test.ts
+++ b/packages/ws-client/tests/entries.test.ts
@@ -37,14 +37,14 @@ describe('public entrypoint', () => {
   })
 
   it('binds dataMode to the yielded type, with all generator type args', () => {
-    expectTypeOf<MessageOf<'binary'>>().toEqualTypeOf<Uint8Array>()
+    expectTypeOf<MessageOf<'binary'>>().toEqualTypeOf<Uint8Array<ArrayBuffer>>()
     expectTypeOf<MessageOf<'text'>>().toEqualTypeOf<string>()
     // The named alias is what consumers annotate with, so it has to stay
     // equivalent to the spelled-out generator, all three type args included —
     // omitting them defaults TReturn and TNext to `any`, which would silently
     // un-type next()/return().
     expectTypeOf<WebSocketIterable<'binary'>>().toEqualTypeOf<
-      AsyncGenerator<Uint8Array, void, unknown>
+      AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>
     >()
     expectTypeOf(websocket<'binary'>).returns.toEqualTypeOf<
       WebSocketIterable<'binary'>

--- a/packages/ws-client/tests/websocket.test.ts
+++ b/packages/ws-client/tests/websocket.test.ts
@@ -1,9 +1,22 @@
 import { assert, describe, expect, it, vi } from 'vitest'
 import { CloseCode } from '../src/lib/close-codes.js'
 import { CloseError, SocketError } from '../src/lib/errors.js'
-import type { CloseEventDetail } from '../src/message-channel.js'
+import type { CloseEventDetail, DataMode } from '../src/message-channel.js'
 import type { Transport, TransportFactory } from '../src/transport/transport.js'
-import { createWebSocket } from '../src/websocket.js'
+import {
+  type Awaitable,
+  type WebSocketOptions,
+  websocketFactory,
+} from '../src/websocket.js'
+
+const createWebSocket = (createTransport: TransportFactory) => {
+  return <M extends DataMode>(
+    url: string | URL | (() => Awaitable<string | URL>),
+    options: WebSocketOptions<M> = {},
+  ) => {
+    return websocketFactory(url, createTransport, options)
+  }
+}
 
 // One entry per connection the loop will make. Every connection end reaches the
 // loop as a throw — a clean close included, as a CloseError carrying its code —


### PR DESCRIPTION
Serves as review suggestion for #5285 

Here are the motivations for some of the changes:

## Improvements

**`websocket` function interface**

Removed `WebSocketFn` in favor of a self defined export function

Before:
<img width="659" height="101" alt="Capture d’écran 2026-07-31 à 10 16 27" src="https://github.com/user-attachments/assets/43a51e5d-f68a-4dd6-ac49-df5d3e8f3f45" />

After:
<img width="819" height="197" alt="Capture d’écran 2026-07-31 à 10 23 17" src="https://github.com/user-attachments/assets/3b224557-c264-47b3-85d5-0c6f79b45dce" />

**protection against invalid call**

Before:
Specifying a generic would invalidly cast the return type

After:
<img width="873" height="301" alt="Capture d’écran 2026-07-31 à 10 48 00" src="https://github.com/user-attachments/assets/d9e4379f-f0d2-4e48-b5a7-766a755350f5" />

**Exposes `HEADERS_SUPPORTED_PLATFORM`**

Allows consumers to dynamically detect support for headers.

**`Uint8Array<ArrayBuffer>` instead of `Uint8Array<ArrayBufferLike>`**


## Fixes

- ~Iterators should be cleaned up when `throw()` is called~ (not accurate, `return()` should be called when `throw()` is not defined.)
- `guarded` would not always await the promise (e.g. if the inner iterator's `return()` throws)
- `WHATWGWebSocket` is now compatible with the `dom.lib.ts` definition (no more type cast needed)
- `timer.unref?.()` should not be needed since the lifetime of timers is tied to the channel, and both should be cleaned up together (there is no reason why the timers would still run, but not the channel)

## Aestetical changes

- Removed a few un-necessary function nesting (`() => iterable[Symbol.asyncIterator]()`, `(error) => defaultShouldReconnect(error)`, `() => pull()`)
- `closeGuard` now uses an `AbortSignal` instead of a `Promise`. This was mostly the result of intermediary work and can be reverted.