### PR TITLE
Re-add packageManager field so Dependabot can parse the pnpm 11 lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@11.11.0",
   "devEngines": {
     "runtime": {
       "name": "node",


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Dependabot has been unable to update our npm dependencies since June 11, 2026. Every open Dependabot PR (#4953, #5013, #5029) is stuck with:

> Dependabot can't parse your pnpm-lock.yaml. Because of this, Dependabot cannot update this pull request.

The errors started the same day #5067 (`Upgrade pnpm v8 to v11 and drop corepack`,
e613eba82) landed. Two independent things broke:

1. **pnpm 11 writes a multi-document `pnpm-lock.yaml`** — an "env lockfile" document
   (pinning pnpm itself via `packageManagerDependencies`) followed by the actual project
   lockfile. Dependabot's parser couldn't handle multi-document YAML at all
   ([dependabot-core#14919](https://github.com/dependabot/dependabot-core/issues/14919),
   tracked in [dependabot-core#14794](https://github.com/dependabot/dependabot-core/issues/14794)).
   This was fixed on Dependabot's side on **2026-07-29**
   ([dependabot-core#15710](https://github.com/dependabot/dependabot-core/pull/15710),
   beta pnpm 11 support). Nothing repo-side could fix this half.

2. **#5067 also removed the `packageManager` field**, replacing it with
   `devEngines.packageManager`. Dependabot does not read `devEngines`. Its pnpm version
   detection order is:

   `packageManager` field → `engines.pnpm` → guess from `lockfileVersion`

   With the first two absent (our `engines` only declares node), it falls through to
   guessing from `lockfileVersion: '9.0'` → **pnpm 9**, which cannot process a pnpm 11
   multi-document lockfile. So even with Dependabot's parser fix shipped, updates would
   keep failing without this change.

### This PR

Re-adds `"packageManager": "pnpm@11.11.0"` to the root `package.json`, matching the
version pinned in `devEngines.packageManager`.

### Note on the corepack decision in #5067

#5067 deliberately dropped `packageManager` to move off corepack. This PR partially walks
that back, but safely:

- pnpm itself ignores `packageManager` since v11 — version enforcement still comes from
  `devEngines.packageManager` (`onFail: error`), which pnpm downloads/enforces natively.
- CI (`pnpm/action-setup@v6`) and the service Dockerfiles (`npm install -g pnpm@11.11.0`)
  don't rely on the field.
- The only consumer of the restored field is Dependabot (and corepack, for anyone still
  using it — it resolves to the same 11.11.0).

⚠️  The version now lives in **two places**: `packageManager` and
`devEngines.packageManager.version`. Future pnpm bumps must update both (plus the
Dockerfiles, as before).

### After merging

The stuck PRs won't fix themselves — their branches were generated against the old state,
and #4953 has auto-rebase disabled (open >30 days). Comment on each of #4953, #5013, #5029:

```
@dependabot recreate
```

Caveats to watch after the first successful run:

- Dependabot's pnpm 11 support is still **beta** (docs don't list v11 as supported yet).
- There's an open report in dependabot-core#14794 (2026-07-31) of repos on pnpm 11 having
  their open security alerts incorrectly auto-closed. Keep an eye on our alert list.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
