### PR TITLE
Remove unused `@atproto/xrpc` PDS dependency

### DIFF
--- a/.changeset/chilly-tables-battle.md
+++ b/.changeset/chilly-tables-battle.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Remove unused `@atproto/xrpc` dependency

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -48,7 +48,6 @@
     "@atproto/oauth-scopes": "workspace:^",
     "@atproto/repo": "workspace:^",
     "@atproto/syntax": "workspace:^",
-    "@atproto/xrpc": "workspace:^",
     "@atproto/xrpc-server": "workspace:^",
     "@did-plc/lib": "^0.0.4",
     "@hapi/address": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1944,9 +1944,6 @@ importers:
       '@atproto/syntax':
         specifier: workspace:^
         version: link:../syntax
-      '@atproto/xrpc':
-        specifier: workspace:^
-        version: link:../xrpc
       '@atproto/xrpc-server':
         specifier: workspace:^
         version: link:../xrpc-server
@@ -17497,7 +17494,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'packages/aws',
       'packages/internal/*',
       'packages/lex/*',
+      'packages/lexicon-resolver',
       'packages/oauth/*',
       'packages/syntax',
       'packages/tap',


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Two minor cleanups:
- remove `@atproto/xrpc` PDS dependency
- add missing `@atproto/lexicon-resolver` from the root Vitest config

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
