### PR TITLE
Allow moderators to call `app.bsky.actor.getPreferences` PDS endpoint

### DIFF
--- a/.changeset/big-feet-move.md
+++ b/.changeset/big-feet-move.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Allow moderators to call `app.bsky.actor.getPreferences` endpoint

--- a/.changeset/light-sheep-jump.md
+++ b/.changeset/light-sheep-jump.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Allow `isValidDid`, `isValidHandle`, `isValidNsid`, `isValidRecordKey`, `isValidTid` and `isValidUri` to be called with any (unknown) value

--- a/.changeset/olive-dryers-end.md
+++ b/.changeset/olive-dryers-end.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Allow `isX` string format checkers to be called with any (unknown) value instead of just strings

--- a/.changeset/thirty-regions-cry.md
+++ b/.changeset/thirty-regions-cry.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-schema': patch
+---
+
+Expose `asDidString` utility

--- a/.changeset/thirty-regions-cry.md
+++ b/.changeset/thirty-regions-cry.md
@@ -1,5 +1,0 @@
----
-'@atproto/lex-schema': patch
----
-
-Expose `asDidString` utility

--- a/packages/lex/lex-schema/src/core/string-format.ts
+++ b/packages/lex/lex-schema/src/core/string-format.ts
@@ -22,7 +22,7 @@ import {
   isValidUri,
   parseLanguageString,
 } from '@atproto/syntax'
-import type { CheckFn } from '../util/assertion-util.js'
+import { type CheckFn, buildCaster } from '../util/assertion-util.js'
 
 // -----------------------------------------------------------------------------
 // Individual string format types and type guards
@@ -80,7 +80,8 @@ export function isAtUriStringLenient<I>(input: I): input is I & AtUriString {
  * @param value - The value to check
  * @returns `true` if the value is a valid CID string
  */
-export const isCidString = ((v) => validateCidString(v)) as CheckFn<CidString>
+export const isCidString = ((input) =>
+  typeof input === 'string' && validateCidString(input)) as CheckFn<CidString>
 /**
  * A Content Identifier (CID) string.
  *
@@ -97,6 +98,7 @@ export type CidString = string
  * @returns `true` if the value is a valid DID string
  */
 export const isDidString: CheckFn<DidString> = isValidDid
+export const asDidString = buildCaster(isDidString, 'Invalid DID string')
 export type {
   /**
    * A Decentralized Identifier (DID) string.
@@ -134,8 +136,9 @@ export type {
  * @param value - The value to check
  * @returns `true` if the value is a valid language string
  */
-export const isLanguageString = ((v) =>
-  parseLanguageString(v) !== null) as CheckFn<LanguageString>
+export const isLanguageString = ((input) =>
+  typeof input === 'string' &&
+  parseLanguageString(input) !== null) as CheckFn<LanguageString>
 
 /**
  * Lenient version of {@link isLanguageString} that only checks well-formed

--- a/packages/lex/lex-schema/src/core/string-format.ts
+++ b/packages/lex/lex-schema/src/core/string-format.ts
@@ -22,7 +22,7 @@ import {
   isValidUri,
   parseLanguageString,
 } from '@atproto/syntax'
-import { type CheckFn, buildCaster } from '../util/assertion-util.js'
+import type { CheckFn } from '../util/assertion-util.js'
 
 // -----------------------------------------------------------------------------
 // Individual string format types and type guards
@@ -98,7 +98,6 @@ export type CidString = string
  * @returns `true` if the value is a valid DID string
  */
 export const isDidString: CheckFn<DidString> = isValidDid
-export const asDidString = buildCaster(isDidString, 'Invalid DID string')
 export type {
   /**
    * A Decentralized Identifier (DID) string.

--- a/packages/lex/lex-schema/src/util/assertion-util.ts
+++ b/packages/lex/lex-schema/src/util/assertion-util.ts
@@ -1,1 +1,11 @@
-export type CheckFn<T> = <I extends string>(input: I) => input is I & T
+export type CheckFn<T> = <I>(input: I) => input is I & T
+
+export function buildCaster<T>(
+  checker: CheckFn<T>,
+  message: string,
+): (input: unknown) => T {
+  return function caster(input) {
+    if (!checker(input)) throw new Error(message)
+    return input
+  }
+}

--- a/packages/lex/lex-schema/src/util/assertion-util.ts
+++ b/packages/lex/lex-schema/src/util/assertion-util.ts
@@ -1,11 +1,1 @@
 export type CheckFn<T> = <I>(input: I) => input is I & T
-
-export function buildCaster<T>(
-  checker: CheckFn<T>,
-  message: string,
-): (input: unknown) => T {
-  return function caster(input) {
-    if (!checker(input)) throw new Error(message)
-    return input
-  }
-}

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -1,3 +1,5 @@
+import type { DidString } from '@atproto/lex'
+import { asDidString } from '@atproto/lex'
 import type { Server } from '@atproto/xrpc-server'
 import { AuthScope, isAccessFull } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
@@ -13,7 +15,7 @@ export default function (server: Server, ctx: AppContext) {
   if (!bskyAppView) return
 
   server.add(app.bsky.actor.getPreferences, {
-    auth: ctx.authVerifier.authorization({
+    auth: ctx.authVerifier.authorizationOrModerator({
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.getPreferences.$lxm
@@ -21,8 +23,16 @@ export default function (server: Server, ctx: AppContext) {
         permissions.assertRpc({ aud, lxm })
       },
     }),
-    handler: async ({ auth, req }) => {
-      const { did } = auth.credentials
+    handler: async ({ auth, req, params }) => {
+      const did: DidString =
+        auth.credentials.type === 'mod_service' ||
+        auth.credentials.type === 'admin_token'
+          ? asDidString((params as Record<string, unknown>).did)
+          : auth.credentials.did
+
+      const isModerator =
+        auth.credentials.type === 'mod_service' ||
+        auth.credentials.type === 'admin_token'
 
       // If the request has a proxy header different from the bsky app view,
       // we need to proxy the request to the requested app view.
@@ -39,13 +49,12 @@ export default function (server: Server, ctx: AppContext) {
       }
 
       const hasAccessFull =
-        auth.credentials.type === 'access' &&
-        isAccessFull(auth.credentials.scope)
+        isModerator ||
+        (auth.credentials.type === 'access' &&
+          isAccessFull(auth.credentials.scope))
 
       const preferences = await ctx.actorStore.read(did, (store) => {
-        return store.pref.getPreferences('app.bsky', {
-          hasAccessFull,
-        })
+        return store.pref.getPreferences('app.bsky', { hasAccessFull })
       })
 
       return {

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -1,6 +1,5 @@
-import type { DidString } from '@atproto/lex'
 import { asDidString } from '@atproto/lex'
-import type { Server } from '@atproto/xrpc-server'
+import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import { AuthScope, isAccessFull } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
@@ -24,15 +23,18 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     handler: async ({ auth, req, params }) => {
-      const did: DidString =
+      const { did, isModerator } =
         auth.credentials.type === 'mod_service' ||
         auth.credentials.type === 'admin_token'
-          ? asDidString((params as Record<string, unknown>).did)
-          : auth.credentials.did
-
-      const isModerator =
-        auth.credentials.type === 'mod_service' ||
-        auth.credentials.type === 'admin_token'
+          ? {
+              // @NOTE undocumented parameter
+              did: asDidString((params as Record<string, unknown>).did),
+              isModerator: true,
+            }
+          : {
+              did: auth.credentials.did,
+              isModerator: false,
+            }
 
       // If the request has a proxy header different from the bsky app view,
       // we need to proxy the request to the requested app view.
@@ -40,6 +42,12 @@ export default function (server: Server, ctx: AppContext) {
       const lxm = app.bsky.actor.getPreferences.$lxm
       const aud = computeProxyTo(ctx, req, lxm)
       if (aud !== `${bskyAppView.did}#bsky_appview`) {
+        if (isModerator) {
+          throw new InvalidRequestError(
+            'Moderator requests cannot be proxied to other app views',
+          )
+        }
+
         // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
         return pipethrough(ctx, req, {
           iss: did,

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -1,4 +1,4 @@
-import { asDidString } from '@atproto/lex'
+import { type DidString, isDidString } from '@atproto/lex'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import { AuthScope, isAccessFull } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
@@ -14,7 +14,7 @@ export default function (server: Server, ctx: AppContext) {
   if (!bskyAppView) return
 
   server.add(app.bsky.actor.getPreferences, {
-    auth: ctx.authVerifier.authorizationOrModerator({
+    auth: ctx.authVerifier.authorizationOrModService({
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.getPreferences.$lxm
@@ -23,18 +23,10 @@ export default function (server: Server, ctx: AppContext) {
       },
     }),
     handler: async ({ auth, req, params }) => {
-      const { did, isModerator } =
-        auth.credentials.type === 'mod_service' ||
-        auth.credentials.type === 'admin_token'
-          ? {
-              // @NOTE undocumented parameter
-              did: asDidString((params as Record<string, unknown>).did),
-              isModerator: true,
-            }
-          : {
-              did: auth.credentials.did,
-              isModerator: false,
-            }
+      const isModerator = auth.credentials.type === 'mod_service'
+      const did: DidString = isModerator
+        ? getAccountDidFromParams(params)
+        : auth.credentials.did
 
       // If the request has a proxy header different from the bsky app view,
       // we need to proxy the request to the requested app view.
@@ -71,4 +63,10 @@ export default function (server: Server, ctx: AppContext) {
       }
     },
   })
+}
+
+function getAccountDidFromParams(params: Record<string, unknown>): DidString {
+  // @NOTE undocumented parameters used only internally by mod service
+  if (isDidString(params.did)) return params.did
+  throw new InvalidRequestError('Invalid or missing did parameter')
 }

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -1,6 +1,5 @@
 import { type KeyObject, createPublicKey, createSecretKey } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { deprecate } from 'node:util'
 import * as jose from 'jose'
 import KeyEncoderModule from 'key-encoder'
 import { getVerificationMaterial } from '@atproto/common'

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -281,6 +281,22 @@ export class AuthVerifier {
     }
   }
 
+  public authorizationOrModerator<P extends Params>(
+    opts: VerifiedOptions & ExtraScopedOptions & AuthorizedOptions<P>,
+  ): MethodAuthVerifier<
+    AccessOutput | OAuthOutput | AdminTokenOutput | ModServiceOutput,
+    P
+  > {
+    const authorization = this.authorization(opts)
+    return async (ctx) => {
+      try {
+        return await this.moderator(ctx)
+      } catch {
+        return authorization(ctx)
+      }
+    }
+  }
+
   public authorizationOrAdminTokenOptional<P extends Params>(
     opts: VerifiedOptions & ExtraScopedOptions & AuthorizedOptions<P>,
   ): MethodAuthVerifier<

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -134,7 +134,7 @@ export class AuthVerifier {
     }
   }
 
-  /** @deprecated We are steering await from this auth method */
+  /** @deprecated We are steering away from this auth method */
   public adminToken: MethodAuthVerifier<AdminTokenOutput> = async (ctx) => {
     setAuthHeaders(ctx.res)
     const parsed = parseBasicAuth(ctx.req)
@@ -165,7 +165,7 @@ export class AuthVerifier {
     }
   }
 
-  /** @deprecated We are steering await from {@link adminToken} auth. Use {@link modService} instead. */
+  /** @deprecated We are steering away from {@link adminToken} auth. Use {@link modService} instead. */
   public moderator: MethodAuthVerifier<AdminTokenOutput | ModServiceOutput> =
     async (ctx) => {
       const type = extractAuthType(ctx.req)
@@ -290,8 +290,11 @@ export class AuthVerifier {
     return async (ctx) => {
       try {
         return await this.modService(ctx)
-      } catch {
-        return authorization(ctx)
+      } catch (err) {
+        if (err instanceof AuthRequiredError) {
+          return authorization(ctx)
+        }
+        throw err
       }
     }
   }

--- a/packages/pds/src/auth-verifier.ts
+++ b/packages/pds/src/auth-verifier.ts
@@ -1,5 +1,6 @@
 import { type KeyObject, createPublicKey, createSecretKey } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { deprecate } from 'node:util'
 import * as jose from 'jose'
 import KeyEncoderModule from 'key-encoder'
 import { getVerificationMaterial } from '@atproto/common'
@@ -134,6 +135,7 @@ export class AuthVerifier {
     }
   }
 
+  /** @deprecated We are steering await from this auth method */
   public adminToken: MethodAuthVerifier<AdminTokenOutput> = async (ctx) => {
     setAuthHeaders(ctx.res)
     const parsed = parseBasicAuth(ctx.req)
@@ -164,6 +166,7 @@ export class AuthVerifier {
     }
   }
 
+  /** @deprecated We are steering await from {@link adminToken} auth. Use {@link modService} instead. */
   public moderator: MethodAuthVerifier<AdminTokenOutput | ModServiceOutput> =
     async (ctx) => {
       const type = extractAuthType(ctx.req)
@@ -281,16 +284,13 @@ export class AuthVerifier {
     }
   }
 
-  public authorizationOrModerator<P extends Params>(
+  public authorizationOrModService<P extends Params>(
     opts: VerifiedOptions & ExtraScopedOptions & AuthorizedOptions<P>,
-  ): MethodAuthVerifier<
-    AccessOutput | OAuthOutput | AdminTokenOutput | ModServiceOutput,
-    P
-  > {
+  ): MethodAuthVerifier<AccessOutput | OAuthOutput | ModServiceOutput, P> {
     const authorization = this.authorization(opts)
     return async (ctx) => {
       try {
-        return await this.moderator(ctx)
+        return await this.modService(ctx)
       } catch {
         return authorization(ctx)
       }

--- a/packages/syntax/src/did.ts
+++ b/packages/syntax/src/did.ts
@@ -64,8 +64,10 @@ export function ensureValidDidRegex<I extends string>(
   }
 }
 
-export function isValidDid<I extends string>(input: I): input is I & DidString {
-  return input.length <= 2048 && DID_REGEX.test(input)
+export function isValidDid<I>(input: I): input is I & DidString {
+  return (
+    typeof input === 'string' && input.length <= 2048 && DID_REGEX.test(input)
+  )
 }
 
 export class InvalidDidError extends Error {}

--- a/packages/syntax/src/handle.ts
+++ b/packages/syntax/src/handle.ts
@@ -104,10 +104,10 @@ export function normalizeAndEnsureValidHandle(handle: string): HandleString {
   return normalized
 }
 
-export function isValidHandle<I extends string>(
-  input: I,
-): input is I & HandleString {
-  return input.length <= 253 && HANDLE_REGEX.test(input)
+export function isValidHandle<I>(input: I): input is I & HandleString {
+  return (
+    typeof input === 'string' && input.length <= 253 && HANDLE_REGEX.test(input)
+  )
 }
 
 export function isValidTld(handle: string): boolean {

--- a/packages/syntax/src/nsid.ts
+++ b/packages/syntax/src/nsid.ts
@@ -75,12 +75,10 @@ export function parseNsid(nsid: string): string[] {
   return result.value
 }
 
-export function isValidNsid<I extends string>(
-  input: I,
-): input is I & NsidString {
+export function isValidNsid<I>(input: I): input is I & NsidString {
   // Since the regex version is more performant for valid NSIDs, we use it when
   // we don't care about error details.
-  return validateNsidRegex(input).success
+  return typeof input === 'string' && validateNsidRegex(input).success
 }
 
 // Human readable constraints on NSID:

--- a/packages/syntax/src/recordkey.ts
+++ b/packages/syntax/src/recordkey.ts
@@ -37,10 +37,9 @@ export function ensureValidRecordKey<I extends string>(
   }
 }
 
-export function isValidRecordKey<I extends string>(
-  input: I,
-): input is I & RecordKeyString {
+export function isValidRecordKey<I>(input: I): input is I & RecordKeyString {
   return (
+    typeof input === 'string' &&
     input.length >= RECORD_KEY_MIN_LENGTH &&
     input.length <= RECORD_KEY_MAX_LENGTH &&
     RECORD_KEY_REGEX.test(input) &&

--- a/packages/syntax/src/tid.ts
+++ b/packages/syntax/src/tid.ts
@@ -15,8 +15,12 @@ export function ensureValidTid<I extends string>(
   }
 }
 
-export function isValidTid<I extends string>(input: I): input is I & TidString {
-  return input.length === TID_LENGTH && TID_REGEX.test(input)
+export function isValidTid<I>(input: I): input is I & TidString {
+  return (
+    typeof input === 'string' &&
+    input.length === TID_LENGTH &&
+    TID_REGEX.test(input)
+  )
 }
 
 export class InvalidTidError extends Error {}

--- a/packages/syntax/src/uri.ts
+++ b/packages/syntax/src/uri.ts
@@ -1,5 +1,5 @@
 export type UriString = `${string}:${string}`
 
-export function isValidUri<I extends string>(input: I): input is I & UriString {
-  return /^\w+:(?:\/\/)?[^\s/][^\s]*$/.test(input)
+export function isValidUri<I>(input: I): input is I & UriString {
+  return typeof input === 'string' && /^\w+:(?:\/\/)?[^\s/][^\s]*$/.test(input)
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

This allows administrators to call the `getPreferences` endpoint instead of having to read into the database directly.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
