### PR TITLE
Use a single project as import-x/resolver-next eslint setting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,19 +50,7 @@ export default [
       node: { version: '>=22' },
       'import-x/internal-regex': '^@atproto(?:-labs)?/',
       'import-x/parsers': { '@typescript-eslint/parser': ['.ts', '.tsx'] },
-      'import-x/resolver-next': createTypeScriptImportResolver({
-        project: [
-          'packages/lex/*/tsconfig.build.json',
-          'packages/lex/*/tsconfig.test.json',
-          'packages/oauth/*/tsconfig.build.json',
-          'packages/oauth/*/tsconfig.test.json',
-          'packages/oauth/*/tsconfig.lib.json',
-          'packages/internal/*/tsconfig.build.json',
-          'packages/internal/*/tsconfig.test.json',
-          'packages/*/tsconfig.build.json',
-          'packages/*/tsconfig.test.json',
-        ],
-      }),
+      'import-x/resolver-next': createTypeScriptImportResolver(),
     },
     rules: {
       'no-var': 'error',


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

`pnpm verify:lint` displays the following warning:

> Multiple projects found, consider using a single `tsconfig` with `references` to speed up, or use `noWarnOnMultipleProjects` to suppress this warning

The explicit list of projects was due to the old configuration (which was updated in https://github.com/bluesky-social/atproto/pull/5301 by @43081j) and not moved to the "single ts project" this new option supports.

The speed bump is barely noticeable though:

<img width="689" height="152" alt="Capture d’écran 2026-08-05 à 20 29 03" src="https://github.com/user-attachments/assets/6ded4058-8e58-4ac4-9859-29779464b82c" />


## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
