### PR TITLE
Dependabot flow fine tuning

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write # push the changeset commit
-  actions: write # dispatch repo.yaml on the new head
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref }}'
@@ -23,10 +22,13 @@ jobs:
     name: Generate changeset
     runs-on: ubuntu-latest
     # Only same-repo PRs authored by dependabot. PR author (not actor) so a
-    # human reopening/rebasing the PR still gets a changeset regenerated.
+    # human reopening/rebasing the PR still gets a changeset regenerated, but
+    # never react to our own changeset commit (sender is the pusher on
+    # `synchronize`, and the commit below is made as github-actions[bot]).
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.sender.login != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,14 +86,3 @@ jobs:
           git commit -m 'Sync changeset with Dependabot update'
           git push origin "HEAD:$HEAD_REF"
           echo 'pushed=true' >>"$GITHUB_OUTPUT"
-
-      # A push made with GITHUB_TOKEN does not re-trigger pull_request
-      # workflows, so the new head commit would show no checks. Explicit
-      # workflow_dispatch is exempt from that rule and attaches its check
-      # runs to the new head commit.
-      - name: Re-run CI on the new head
-        if: steps.generate.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: gh workflow run repo.yaml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"

--- a/.github/workflows/repo.yaml
+++ b/.github/workflows/repo.yaml
@@ -2,27 +2,12 @@ name: Repository CI
 
 on:
   pull_request:
-  # Dispatched by dependabot-changeset.yml after it pushes a changeset commit:
-  # pushes made with GITHUB_TOKEN don't trigger pull_request runs, so checks
-  # for the new head commit have to be created explicitly. Required status
-  # checks match on check-run (job) names, so those dispatched runs only
-  # satisfy the merge gate as long as job names don't depend on the event
-  # type.
-  workflow_dispatch:
 
-# Read-only: every job here only checks out and builds. Declared explicitly
-# because workflow_dispatch runs would otherwise inherit the repository-default
-# token scopes, which can include write.
 permissions:
   contents: read
 
 concurrency:
-  # head_ref is only set on pull_request runs; ref_name covers the
-  # workflow_dispatch re-runs. Both resolve to the bare branch name (unlike
-  # ref, which is the fully qualified refs/heads/... on dispatch), so a
-  # dispatched re-run cancels the same branch's in-flight PR run and
-  # vice-versa instead of running alongside it.
-  group: '${{ github.workflow }}-${{ github.head_ref || github.ref_name }}'
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

1) there is no point dispatching the "repo" workflow from the action here because: 1. it's result won't show up in the dependabot PR 2. the dependabot PR will run the workflow itself.
2) the changeset workflow should not run after it just ran

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
