### PR TITLE
chore: remove typed-emitter

### DIFF
--- a/.changeset/perky-mice-visit.md
+++ b/.changeset/perky-mice-visit.md
@@ -1,0 +1,9 @@
+---
+'@atproto/lex-cli': patch
+'@atproto/bsync': patch
+'@atproto/ozone': patch
+'@atproto/bsky': patch
+'@atproto/pds': patch
+---
+
+Remove typed-emitter and use built-in strongly typed `EventEmitter`

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -68,7 +68,6 @@
     "pino-http": "^11.0.0",
     "sharp": "^0.33.5",
     "structured-headers": "^1.0.1",
-    "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
     "undici": "^8.5.0",
     "zod": "3.23.8"

--- a/packages/bsky/src/data-plane/server/db/db.ts
+++ b/packages/bsky/src/data-plane/server/db/db.ts
@@ -14,7 +14,6 @@ import { Migrator } from 'kysely/migration'
 import pg from 'pg'
 const { Pool: PgPool, types: pgTypes } = pg
 type PgPool = InstanceType<typeof PgPool>
-import type TypedEmitter from 'typed-emitter'
 import { dbLogger } from '../../../logger.js'
 import type { DatabaseSchema, DatabaseSchemaType } from './database-schema.js'
 import * as migrations from './migrations/index.js'
@@ -27,7 +26,7 @@ export class Database {
   pool: PgPool
   db: DatabaseSchema
   migrator: Migrator
-  txEvt = new EventEmitter() as TxnEmitter
+  txEvt = new EventEmitter<TxnEvents>()
   destroyed = false
 
   constructor(
@@ -193,10 +192,8 @@ class LeakyTxPlugin implements KyselyPlugin {
   }
 }
 
-type TxnEmitter = TypedEmitter.default<TxnEvents>
-
 type TxnEvents = {
-  commit: () => void
+  commit: []
 }
 
 const noopAsync = async () => {}

--- a/packages/bsync/package.json
+++ b/packages/bsync/package.json
@@ -37,8 +37,7 @@
     "http-terminator": "^3.2.0",
     "kysely": "^0.29.2",
     "pg": "^8.10.0",
-    "pino-http": "^11.0.0",
-    "typed-emitter": "^2.1.0"
+    "pino-http": "^11.0.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.28.1",

--- a/packages/bsync/src/context.ts
+++ b/packages/bsync/src/context.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'node:events'
-import type TypedEmitter from 'typed-emitter'
 import type { ServerConfig } from './config.js'
 import { Database } from './db/index.js'
 import type { createMuteOpChannel } from './db/schema/mute_op.js'
@@ -16,13 +15,13 @@ export class AppContext {
   db: Database
   cfg: ServerConfig
   shutdown: AbortSignal
-  events: TypedEmitter.default<AppEvents>
+  events: EventEmitter<AppEvents>
 
   constructor(opts: AppContextOptions) {
     this.db = opts.db
     this.cfg = opts.cfg
     this.shutdown = opts.shutdown
-    this.events = new EventEmitter() as TypedEmitter.default<AppEvents>
+    this.events = new EventEmitter<AppEvents>()
   }
 
   static async fromConfig(
@@ -42,7 +41,7 @@ export class AppContext {
 }
 
 export type AppEvents = {
-  [createMuteOpChannel]: () => void
-  [createNotifOpChannel]: () => void
-  [createOperationChannel]: () => void
+  [createMuteOpChannel]: []
+  [createNotifOpChannel]: []
+  [createOperationChannel]: []
 }

--- a/packages/bsync/src/db/index.ts
+++ b/packages/bsync/src/db/index.ts
@@ -14,7 +14,6 @@ import { Migrator } from 'kysely/migration'
 import pg from 'pg'
 const { Pool: PgPool, types: pgTypes } = pg
 type PgPool = InstanceType<typeof PgPool>
-import type TypedEmitter from 'typed-emitter'
 import { dbLogger } from '../logger.js'
 import * as migrations from './migrations/index.js'
 import { DbMigrationProvider } from './migrations/provider.js'
@@ -25,7 +24,7 @@ export class Database {
   pool: PgPool
   db: DatabaseSchema
   migrator: Migrator
-  txEvt = new EventEmitter() as TxnEmitter
+  txEvt = new EventEmitter<TxnEvents>()
   destroyed = false
 
   constructor(
@@ -189,10 +188,8 @@ class LeakyTxPlugin implements KyselyPlugin {
   }
 }
 
-type TxnEmitter = TypedEmitter.default<TxnEvents>
-
 type TxnEvents = {
-  commit: () => void
+  commit: []
 }
 
 const noopAsync = async () => {}

--- a/packages/ozone/package.json
+++ b/packages/ozone/package.json
@@ -50,7 +50,6 @@
     "pg": "^8.10.0",
     "pino-http": "^11.0.0",
     "structured-headers": "^1.0.1",
-    "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
     "undici": "^8.5.0",
     "ws": "^8.12.0"

--- a/packages/ozone/src/db/index.ts
+++ b/packages/ozone/src/db/index.ts
@@ -14,7 +14,6 @@ import { Migrator } from 'kysely/migration'
 import pg from 'pg'
 const { Pool: PgPool, types: pgTypes } = pg
 type PgPool = InstanceType<typeof PgPool>
-import type TypedEmitter from 'typed-emitter'
 import { dbLogger } from '../logger.js'
 import * as migrations from './migrations/index.js'
 import { CtxMigrationProvider } from './migrations/provider.js'
@@ -30,7 +29,7 @@ export class Database {
   pool: PgPool
   db: DatabaseSchema
   migrator: Migrator
-  txEvt = new EventEmitter() as TxnEmitter
+  txEvt = new EventEmitter<TxnEvents>()
   destroyed = false
   isPrimary = false
 
@@ -197,10 +196,8 @@ class LeakyTxPlugin implements KyselyPlugin {
   }
 }
 
-type TxnEmitter = TypedEmitter.default<TxnEvents>
-
 type TxnEvents = {
-  commit: () => void
+  commit: []
 }
 
 const noopAsync = async () => {}

--- a/packages/ozone/src/sequencer/sequencer.ts
+++ b/packages/ozone/src/sequencer/sequencer.ts
@@ -2,7 +2,6 @@ import EventEmitter from 'node:events'
 import type { Selectable } from 'kysely'
 import type pg from 'pg'
 type PoolClient = pg.PoolClient
-import type TypedEmitter from 'typed-emitter'
 import type { Database } from '../db/index.js'
 import { type Label as LabelTable, LabelChannel } from '../db/schema/label.js'
 import type { Labels as LabelsEvt } from '../lexicon/types/com/atproto/label/subscribeLabels.js'
@@ -12,7 +11,7 @@ import type { ModerationService } from '../mod-service/index.js'
 export type { Labels as LabelsEvt } from '../lexicon/types/com/atproto/label/subscribeLabels.js'
 type LabelRow = Selectable<LabelTable>
 
-export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
+export class Sequencer extends EventEmitter<SequencerEvents> {
   db: Database
   destroyed = false
   pollPromise: Promise<void> | undefined
@@ -139,8 +138,8 @@ export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
 }
 
 type SequencerEvents = {
-  events: (evts: LabelsEvt[]) => void
-  close: () => void
+  events: [evts: LabelsEvt[]]
+  close: []
 }
 
-export type SequencerEmitter = TypedEmitter.default<SequencerEvents>
+export type SequencerEmitter = EventEmitter<SequencerEvents>

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -70,7 +70,6 @@
     "p-queue": "^8.0.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
-    "typed-emitter": "^2.1.0",
     "uint8arrays": "^5.0.0",
     "undici": "^8.5.0",
     "zod": "^3.23.8"

--- a/packages/pds/src/sequencer/sequencer.ts
+++ b/packages/pds/src/sequencer/sequencer.ts
@@ -1,5 +1,4 @@
 import EventEmitter from 'node:events'
-import type TypedEmitter from 'typed-emitter'
 import { SECOND, wait } from '@atproto/common'
 import { decode as cborDecode } from '@atproto/lex-cbor'
 import type { DatetimeString, DidString, HandleString } from '@atproto/syntax'
@@ -29,7 +28,7 @@ import {
 
 export * from './events.js'
 
-export class Sequencer extends (EventEmitter as new () => SequencerEmitter) {
+export class Sequencer extends EventEmitter<SequencerEvents> {
   db: SequencerDb
   destroyed = false
   pollPromise: Promise<void> | null = null
@@ -281,10 +280,10 @@ export const parseRepoSeqRows = (rows: RepoSeqEntry[]): SeqEvt[] => {
 type SeqRow = RepoSeqEntry
 
 type SequencerEvents = {
-  events: (evts: SeqEvt[]) => void
-  close: () => void
+  events: [evts: SeqEvt[]]
+  close: []
 }
 
-export type SequencerEmitter = TypedEmitter.default<SequencerEvents>
+export type SequencerEmitter = EventEmitter<SequencerEvents>
 
 export default Sequencer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,9 +507,6 @@ importers:
       structured-headers:
         specifier: ^1.0.1
         version: 1.0.1
-      typed-emitter:
-        specifier: ^2.1.0
-        version: 2.1.0
       uint8arrays:
         specifier: ^5.0.0
         version: 5.1.1
@@ -586,9 +583,6 @@ importers:
       pino-http:
         specifier: ^11.0.0
         version: 11.0.0
-      typed-emitter:
-        specifier: ^2.1.0
-        version: 2.1.0
     devDependencies:
       '@bufbuild/buf':
         specifier: ^1.28.1
@@ -1844,9 +1838,6 @@ importers:
       structured-headers:
         specifier: ^1.0.1
         version: 1.0.1
-      typed-emitter:
-        specifier: ^2.1.0
-        version: 2.1.0
       uint8arrays:
         specifier: ^5.0.0
         version: 5.1.1
@@ -2013,9 +2004,6 @@ importers:
       pino-http:
         specifier: ^11.0.0
         version: 11.0.0
-      typed-emitter:
-        specifier: ^2.1.0
-        version: 2.1.0
       uint8arrays:
         specifier: ^5.0.0
         version: 5.1.1
@@ -9839,9 +9827,6 @@ packages:
     resolution: {integrity: sha512-euNvEYki6iYYpkNbeudW+lEMMYGEmN7EBwVF8ezlbv0bZoQpVYB7W10cCeUIGV7Ed50sJynLQ0c559q5iI0ejQ==}
     engines: {node: '>=10'}
 
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -10401,9 +10386,6 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
-
-  typed-emitter@2.1.0:
-    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
@@ -20161,11 +20143,6 @@ snapshots:
   russian-bad-words@0.5.0:
     optional: true
 
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -20841,10 +20818,6 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-
-  typed-emitter@2.1.0:
-    optionalDependencies:
-      rxjs: 7.8.2
 
   typed-query-selector@2.12.0: {}
 


### PR DESCRIPTION
In modern Node types, `EventEmitter` is already generic. This means we
can drop `typed-emitter` and use `EventEmitter<T>` directly.

For example:

```ts
class MyEmitter extends EventEmitter<{ myEvent: [Arg1Type, Arg2Type] }> {
  // ...
}
```

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
