### PR TITLE
chore: replace glob with `node:fs` globSync in pds

### DIFF
--- a/.changeset/mighty-insects-lick.md
+++ b/.changeset/mighty-insects-lick.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Remove the `glob` dependency. It was only used by the mailer template build script, which now uses the `globSync` built into `node:fs`.

--- a/packages/pds/build.templates.cjs
+++ b/packages/pds/build.templates.cjs
@@ -1,5 +1,5 @@
+const { globSync } = require('node:fs')
 const hbsPlugin = require('esbuild-plugin-handlebars')
-const { globSync } = require('glob')
 
 require('esbuild').build({
   logLevel: 'info',

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -77,7 +77,6 @@
     "express": "^4.17.2",
     "express-async-errors": "^3.1.1",
     "file-type": "^16.5.4",
-    "glob": "^10.3.10",
     "handlebars": "^4.7.7",
     "http-terminator": "^3.2.0",
     "ioredis": "^5.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,9 +2019,6 @@ importers:
       file-type:
         specifier: ^16.5.4
         version: 16.5.4
-      glob:
-        specifier: ^10.3.10
-        version: 10.3.10
       handlebars:
         specifier: ^4.7.7
         version: 4.7.7


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

removes the `glob` dependency from `@atproto/pds`, part of the efforts of e18e.

related: #5341

<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
