### PR TITLE
Clean up PLC operation checks, allow self-custody of rotation keys

### DIFF
--- a/.changeset/common-peaches-shop.md
+++ b/.changeset/common-peaches-shop.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Unify how the server checks it holds the current PLC rotation key before relying on it, using one shared check and error message across `signPlcOperation`, `updateHandle`, `activateAccount`/`checkAccountStatus`, and `submitPlcOperation`, instead of several slightly different ad-hoc checks.

--- a/.changeset/deep-melons-bake.md
+++ b/.changeset/deep-melons-bake.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+`updateHandle` now checks whether the DID document's `alsoKnownAs` already reflects the requested handle before attempting to sign a PLC update. This unblocks self-custodied accounts whose owner already published the change directly, and also avoids submitting a redundant PLC operation when a PDS-custodied update is retried after a partial failure (the PLC write succeeded but the local database write did not).

--- a/.changeset/easy-rocks-stare.md
+++ b/.changeset/easy-rocks-stare.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Don't require the server to hold the PLC rotation key in order to activate an account, or to report its DID document as valid via `checkAccountStatus` - a self-custodied account (where the user keeps their own rotation key) is a legitimate setup. Activation still requires the DID document's PDS endpoint and signing key to match this server, and still rejects a tombstoned DID.

--- a/.changeset/loud-pandas-rest.md
+++ b/.changeset/loud-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+`submitPlcOperation` no longer requires the proposed operation to keep the server's rotation key - consistent with `activateAccount`/`checkAccountStatus`, a self-custodied account can submit an operation that fully transfers rotation control away from the server.

--- a/packages/pds/src/account-manager/account-manager.ts
+++ b/packages/pds/src/account-manager/account-manager.ts
@@ -20,7 +20,11 @@ import {
 } from '@atproto/syntax'
 import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import type { ActorStore } from '../actor-store/actor-store.js'
-import { assertValidDidDocumentForService } from '../api/com/atproto/server/util.js'
+import {
+  assertCanSignUpdatesForDid,
+  assertValidDidDocumentForService,
+  serverRotationKeyDid,
+} from '../api/com/atproto/server/util.js'
 import { AuthScope } from '../auth-scope.js'
 import type { ServerConfig } from '../config/config.js'
 import { softDeleted } from '../db/index.js'
@@ -326,7 +330,10 @@ export class AccountManager {
     )
 
     if (did.startsWith('did:plc:')) {
-      // @TODO We should verify the status before issuing a PLC update.
+      assertCanSignUpdatesForDid(
+        await this.plcClient.getLastOp(did),
+        serverRotationKeyDid(this),
+      )
       await this.plcClient.updateHandle(did, this.plcRotationKey, handle)
     } else {
       const resolved = await this.idResolver.did.resolveAtprotoData(did, true)

--- a/packages/pds/src/account-manager/account-manager.ts
+++ b/packages/pds/src/account-manager/account-manager.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import type { KeyObject } from 'node:crypto'
-import type { Client as PlcClient } from '@did-plc/lib'
+import * as plc from '@did-plc/lib'
 import { isEmailValid } from '@hapi/address'
 import { isDisposableEmail } from 'disposable-email-domains-js'
 import { HOUR, wait } from '@atproto/common'
@@ -22,6 +22,7 @@ import { AuthRequiredError, InvalidRequestError } from '@atproto/xrpc-server'
 import type { ActorStore } from '../actor-store/actor-store.js'
 import {
   assertCanSignUpdatesForDid,
+  assertNotTombstoned,
   assertValidDidDocumentForService,
   serverRotationKeyDid,
 } from '../api/com/atproto/server/util.js'
@@ -93,7 +94,7 @@ export class AccountManager {
     readonly jwtKey: KeyObject,
     readonly mailer: ServerMailer,
     readonly sequencer: Sequencer,
-    readonly plcClient: PlcClient,
+    readonly plcClient: plc.Client,
     readonly plcRotationKey: Keypair,
   ) {
     this.db = getDb(cfg.db.accountDbLoc, cfg.db.disableWalAutoCheckpoint)
@@ -314,7 +315,9 @@ export class AccountManager {
    * the new handle locally, and emits an identity event.
    *
    * @throws {InvalidRequestError} when the handle is invalid, taken by another
-   * account, or cannot be resolved for non-service domains.
+   * account, cannot be resolved for non-service domains, the did:plc record
+   * is tombstoned, or (when a PLC update is actually needed) the server no
+   * longer controls a current rotation key for the did.
    *
    * @see {@link AccountManager.updateAccountHandle} for behavior when the PLC update fails.
    */
@@ -330,11 +333,18 @@ export class AccountManager {
     )
 
     if (did.startsWith('did:plc:')) {
-      assertCanSignUpdatesForDid(
-        await this.plcClient.getLastOp(did),
-        serverRotationKeyDid(this),
-      )
-      await this.plcClient.updateHandle(did, this.plcRotationKey, handle)
+      const lastOp = await this.plcClient.getLastOp(did)
+      assertNotTombstoned(lastOp)
+      // @NOTE The did:plc record may not need updating if the user already
+      // signed with their own key, or an earlier attempt got this far but
+      // then failed before completing.
+      const currentHandle = plc
+        .normalizeOp(lastOp)
+        .alsoKnownAs.find((aka) => aka.startsWith('at://'))
+      if (currentHandle?.toLowerCase() !== plc.ensureAtprotoPrefix(handle)) {
+        assertCanSignUpdatesForDid(lastOp, serverRotationKeyDid(this))
+        await this.plcClient.updateHandle(did, this.plcRotationKey, handle)
+      }
     } else {
       const resolved = await this.idResolver.did.resolveAtprotoData(did, true)
       if (resolved.handle !== handle) {

--- a/packages/pds/src/api/com/atproto/identity/getRecommendedDidCredentials.ts
+++ b/packages/pds/src/api/com/atproto/identity/getRecommendedDidCredentials.ts
@@ -1,6 +1,7 @@
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
+import { serverRotationKeyDid } from '../server/util.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.identity.getRecommendedDidCredentials, {
@@ -22,9 +23,7 @@ export default function (server: Server, ctx: AppContext) {
         ? [`at://${account.handle}`]
         : undefined
 
-      const plcRotationKey =
-        ctx.cfg.entryway?.plcRotationKey ?? ctx.plcRotationKey.did()
-      const rotationKeys = [plcRotationKey]
+      const rotationKeys = [serverRotationKeyDid(ctx)]
       if (ctx.cfg.identity.recoveryDidKey) {
         rotationKeys.unshift(ctx.cfg.identity.recoveryDidKey)
       }

--- a/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
+++ b/packages/pds/src/api/com/atproto/identity/signPlcOperation.ts
@@ -1,9 +1,12 @@
 import * as plc from '@did-plc/lib'
-import { check } from '@atproto/common'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import { ACCESS_FULL, AuthScope } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
+import {
+  assertCanSignUpdatesForDid,
+  serverRotationKeyDid,
+} from '../server/util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const { entrywayClient } = ctx
@@ -50,10 +53,14 @@ export default function (server: Server, ctx: AppContext) {
           token,
         )
 
-        const lastOp = await ctx.plcClient.getLastOp(did)
-        if (check.is(lastOp, plc.def.tombstone)) {
-          throw new InvalidRequestError('Did is tombstoned')
+        if (!did.startsWith('did:plc:')) {
+          throw new InvalidRequestError(
+            'Cannot sign a PLC operation for a non-plc DID',
+          )
         }
+        const lastOp = await ctx.plcClient.getLastOp(did)
+        assertCanSignUpdatesForDid(lastOp, serverRotationKeyDid(ctx))
+
         const operation = await plc.createUpdateOp(
           lastOp,
           ctx.plcRotationKey,

--- a/packages/pds/src/api/com/atproto/identity/submitPlcOperation.ts
+++ b/packages/pds/src/api/com/atproto/identity/submitPlcOperation.ts
@@ -4,6 +4,10 @@ import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
 import { httpLogger as log } from '../../../../logger.js'
+import {
+  assertCanSignUpdatesForDid,
+  serverRotationKeyDid,
+} from '../server/util.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.identity.submitPlcOperation, {
@@ -20,13 +24,7 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError('Invalid operation')
       }
 
-      const rotationKey =
-        ctx.cfg.entryway?.plcRotationKey ?? ctx.plcRotationKey.did()
-      if (!op.rotationKeys.includes(rotationKey)) {
-        throw new InvalidRequestError(
-          "Rotation keys do not include server's rotation key",
-        )
-      }
+      assertCanSignUpdatesForDid(op, serverRotationKeyDid(ctx))
       if (op.services['atproto_pds']?.type !== 'AtprotoPersonalDataServer') {
         throw new InvalidRequestError('Incorrect type on atproto_pds service')
       }

--- a/packages/pds/src/api/com/atproto/identity/submitPlcOperation.ts
+++ b/packages/pds/src/api/com/atproto/identity/submitPlcOperation.ts
@@ -4,10 +4,6 @@ import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { com } from '../../../../lexicons/index.js'
 import { httpLogger as log } from '../../../../logger.js'
-import {
-  assertCanSignUpdatesForDid,
-  serverRotationKeyDid,
-} from '../server/util.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(com.atproto.identity.submitPlcOperation, {
@@ -24,7 +20,6 @@ export default function (server: Server, ctx: AppContext) {
         throw new InvalidRequestError('Invalid operation')
       }
 
-      assertCanSignUpdatesForDid(op, serverRotationKeyDid(ctx))
       if (op.services['atproto_pds']?.type !== 'AtprotoPersonalDataServer') {
         throw new InvalidRequestError('Incorrect type on atproto_pds service')
       }

--- a/packages/pds/src/api/com/atproto/server/util.ts
+++ b/packages/pds/src/api/com/atproto/server/util.ts
@@ -56,7 +56,6 @@ export const isValidDidDocForService = async (
     plcClient: plc.Client
     idResolver: IdResolver
     cfg: ServerConfig
-    plcRotationKey: crypto.Keypair
     actorStore: ActorStore
   },
   did: string,
@@ -101,14 +100,13 @@ export const assertValidDidDocumentForService = async (
     plcClient: plc.Client
     idResolver: IdResolver
     cfg: ServerConfig
-    plcRotationKey: crypto.Keypair
     actorStore: ActorStore
   },
   did: string,
 ) => {
   if (did.startsWith('did:plc')) {
     const lastOp = await ctx.plcClient.getLastOp(did)
-    assertCanSignUpdatesForDid(lastOp, serverRotationKeyDid(ctx))
+    assertNotTombstoned(lastOp)
     const resolved = plc.normalizeOp(lastOp)
     await assertValidDocContents(ctx, did, {
       pdsEndpoint: resolved.services['atproto_pds']?.endpoint,

--- a/packages/pds/src/api/com/atproto/server/util.ts
+++ b/packages/pds/src/api/com/atproto/server/util.ts
@@ -1,5 +1,5 @@
-import type * as plc from '@did-plc/lib'
-import { getPdsEndpoint, getSigningDidKey } from '@atproto/common'
+import * as plc from '@did-plc/lib'
+import { check, getPdsEndpoint, getSigningDidKey } from '@atproto/common'
 import * as crypto from '@atproto/crypto'
 import type { DidDocument, IdResolver } from '@atproto/identity'
 import { InvalidRequestError } from '@atproto/xrpc-server'
@@ -69,6 +69,33 @@ export const isValidDidDocForService = async (
   }
 }
 
+export const serverRotationKeyDid = (ctx: {
+  cfg: ServerConfig
+  plcRotationKey: crypto.Keypair
+}): string => ctx.cfg.entryway?.plcRotationKey ?? ctx.plcRotationKey.did()
+
+export function assertNotTombstoned(
+  op: plc.CompatibleOpOrTombstone,
+): asserts op is plc.CompatibleOp {
+  if (check.is(op, plc.def.tombstone)) {
+    throw new InvalidRequestError('Did is tombstoned')
+  }
+}
+
+// @NOTE op may be current (eg. from getLastOp) or proposed (eg.
+// client-submitted)
+export function assertCanSignUpdatesForDid(
+  op: plc.CompatibleOpOrTombstone,
+  rotationKeyDid: string,
+): asserts op is plc.CompatibleOp {
+  assertNotTombstoned(op)
+  if (!plc.normalizeOp(op).rotationKeys.includes(rotationKeyDid)) {
+    throw new InvalidRequestError(
+      "Rotation keys do not include server's rotation key",
+    )
+  }
+}
+
 export const assertValidDidDocumentForService = async (
   ctx: {
     plcClient: plc.Client
@@ -80,11 +107,12 @@ export const assertValidDidDocumentForService = async (
   did: string,
 ) => {
   if (did.startsWith('did:plc')) {
-    const resolved = await ctx.plcClient.getDocumentData(did)
+    const lastOp = await ctx.plcClient.getLastOp(did)
+    assertCanSignUpdatesForDid(lastOp, serverRotationKeyDid(ctx))
+    const resolved = plc.normalizeOp(lastOp)
     await assertValidDocContents(ctx, did, {
       pdsEndpoint: resolved.services['atproto_pds']?.endpoint,
       signingKey: resolved.verificationMethods['atproto'],
-      rotationKeys: resolved.rotationKeys,
     })
   } else {
     const resolved = await ctx.idResolver.did.resolve(did, true)
@@ -101,25 +129,15 @@ export const assertValidDidDocumentForService = async (
 const assertValidDocContents = async (
   ctx: {
     cfg: ServerConfig
-    plcRotationKey: crypto.Keypair
     actorStore: ActorStore
   },
   did: string,
   contents: {
     signingKey?: string
     pdsEndpoint?: string
-    rotationKeys?: string[]
   },
 ) => {
-  const { signingKey, pdsEndpoint, rotationKeys } = contents
-
-  const plcRotationKey =
-    ctx.cfg.entryway?.plcRotationKey ?? ctx.plcRotationKey.did()
-  if (rotationKeys !== undefined && !rotationKeys.includes(plcRotationKey)) {
-    throw new InvalidRequestError(
-      'Server rotation key not included in PLC DID data',
-    )
-  }
+  const { signingKey, pdsEndpoint } = contents
 
   if (!pdsEndpoint || pdsEndpoint !== ctx.cfg.service.publicUrl) {
     throw new InvalidRequestError(

--- a/packages/pds/tests/_util.ts
+++ b/packages/pds/tests/_util.ts
@@ -1,10 +1,35 @@
 import { type RequestListener, createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import type * as plc from '@did-plc/lib'
 import { createHttpTerminator } from 'http-terminator'
 import { type ToolsOzoneModerationDefs, lexToJson } from '@atproto/api'
+import { type Keypair, Secp256k1Keypair } from '@atproto/crypto'
+import type { Account, SeedClient } from '@atproto/dev-env'
 import { isCidString } from '@atproto/lex'
 import { isCid, isPlainObject } from '@atproto/lex-data'
 import { AtUri } from '@atproto/syntax'
+
+// Creates an account, then transfers its did:plc rotation key away from the
+// server to a freshly-generated one the caller holds - simulating a
+// self-custodied account for tests.
+export const createSelfCustodiedAccount = async (
+  sc: SeedClient,
+  ctx: { plcClient: plc.Client; plcRotationKey: Keypair },
+  name: string,
+): Promise<{ account: Account; key: Secp256k1Keypair }> => {
+  const account = await sc.createAccount(name, {
+    handle: `${name}.test`,
+    email: `${name}@test.com`,
+    password: `${name}-pass`,
+  })
+  const key = await Secp256k1Keypair.create()
+  await ctx.plcClient.updateRotationKeys(account.did, ctx.plcRotationKey, [
+    key.did(),
+    ctx.plcRotationKey.did(),
+  ])
+  await ctx.plcClient.updateRotationKeys(account.did, key, [key.did()])
+  return { account, key }
+}
 
 // Swap out identifiers and dates with stable
 // values for the purpose of snapshot testing

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -304,4 +304,159 @@ describe('handles', () => {
     const dbHandle = await getHandleFromDb(jill.did)
     expect(dbHandle).toBe('jill.test')
   })
+
+  it('updates locally when a self-custodied account already published the change', async () => {
+    const { account: mona, key: monaKey } = await createSelfCustodiedAccount(
+      sc,
+      ctx,
+      'mona',
+    )
+
+    // Simulates the owner's own client publishing the change before telling
+    // the PDS about it - the PDS is no longer a rotation key for this DID,
+    // so it could not have signed this itself.
+    await ctx.plcClient.updateHandle(mona.did, monaKey, 'mona2.test')
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'mona2.test' },
+      { headers: sc.getHeaders(mona.did), encoding: 'application/json' },
+    )
+
+    const dbHandle = await getHandleFromDb(mona.did)
+    expect(dbHandle).toBe('mona2.test')
+  })
+
+  it('updates locally when a self-custodied account published a differently-cased handle', async () => {
+    const { account: olga, key: olgaKey } = await createSelfCustodiedAccount(
+      sc,
+      ctx,
+      'olga',
+    )
+
+    // Handles are case-insensitive, but plc.directory doesn't normalize
+    // alsoKnownAs entries - a self-custodied user's own tooling might not
+    // lowercase it the way our own signing path always does.
+    await ctx.plcClient.updateHandle(olga.did, olgaKey, 'Olga2.test')
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'olga2.test' },
+      { headers: sc.getHeaders(olga.did), encoding: 'application/json' },
+    )
+
+    const dbHandle = await getHandleFromDb(olga.did)
+    expect(dbHandle).toBe('olga2.test')
+  })
+
+  it('does not submit a redundant plc operation when retrying an already-applied handle update', async () => {
+    const nora = await sc.createAccount('nora', {
+      handle: 'nora.test',
+      email: 'nora@test.com',
+      password: 'nora-pass',
+    })
+
+    // Simulates a previous call whose plc update succeeded but which failed
+    // before the local db write, per updateHandle's @NOTE on not rolling
+    // back - the caller just calls updateHandle again with the same handle.
+    await ctx.plcClient.updateHandle(nora.did, ctx.plcRotationKey, 'nora2.test')
+    const logBefore = await ctx.plcClient.getOperationLog(nora.did)
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'nora2.test' },
+      { headers: sc.getHeaders(nora.did), encoding: 'application/json' },
+    )
+
+    const logAfter = await ctx.plcClient.getOperationLog(nora.did)
+    expect(logAfter.length).toBe(logBefore.length)
+
+    const dbHandle = await getHandleFromDb(nora.did)
+    expect(dbHandle).toBe('nora2.test')
+  })
+
+  it('skips the update when the first at:// entry already matches, leaving a later one untouched', async () => {
+    const pia = await sc.createAccount('pia', {
+      handle: 'pia.test',
+      email: 'pia@test.com',
+      password: 'pia-pass',
+    })
+    // Directly construct a doc with two at:// entries, since our own
+    // updateHandleOp-based code never produces this - it always replaces
+    // the first one it finds rather than adding a second.
+    await ctx.plcClient.updateData(pia.did, ctx.plcRotationKey, (op) => ({
+      ...op,
+      alsoKnownAs: ['at://pia2.test', 'at://pia-stale.test'],
+    }))
+    const logBefore = await ctx.plcClient.getOperationLog(pia.did)
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'pia2.test' },
+      { headers: sc.getHeaders(pia.did), encoding: 'application/json' },
+    )
+
+    const logAfter = await ctx.plcClient.getOperationLog(pia.did)
+    expect(logAfter.length).toBe(logBefore.length)
+
+    const didData = await ctx.plcClient.getDocumentData(pia.did)
+    expect(didData.alsoKnownAs).toEqual([
+      'at://pia2.test',
+      'at://pia-stale.test',
+    ])
+
+    const dbHandle = await getHandleFromDb(pia.did)
+    expect(dbHandle).toBe('pia2.test')
+  })
+
+  it('signs an update, creating a duplicate, when the matching handle is not the first at:// entry', async () => {
+    const quinn = await sc.createAccount('quinn', {
+      handle: 'quinn.test',
+      email: 'quinn@test.com',
+      password: 'quinn-pass',
+    })
+    await ctx.plcClient.updateData(quinn.did, ctx.plcRotationKey, (op) => ({
+      ...op,
+      alsoKnownAs: ['at://quinn-stale.test', 'at://quinn2.test'],
+    }))
+    const logBefore = await ctx.plcClient.getOperationLog(quinn.did)
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'quinn2.test' },
+      { headers: sc.getHeaders(quinn.did), encoding: 'application/json' },
+    )
+
+    const logAfter = await ctx.plcClient.getOperationLog(quinn.did)
+    expect(logAfter.length).toBe(logBefore.length + 1)
+
+    const didData = await ctx.plcClient.getDocumentData(quinn.did)
+    // updateHandleOp only ever replaces the first at:// entry it finds, so
+    // this is now a duplicate of the second, unrelated to the update itself
+    expect(didData.alsoKnownAs).toEqual([
+      'at://quinn2.test',
+      'at://quinn2.test',
+    ])
+
+    const dbHandle = await getHandleFromDb(quinn.did)
+    expect(dbHandle).toBe('quinn2.test')
+  })
+
+  it('adds a handle when the did document has none yet', async () => {
+    const rex = await sc.createAccount('rex', {
+      handle: 'rex.test',
+      email: 'rex@test.com',
+      password: 'rex-pass',
+    })
+    await ctx.plcClient.updateData(rex.did, ctx.plcRotationKey, (op) => ({
+      ...op,
+      alsoKnownAs: [],
+    }))
+
+    await agent.api.com.atproto.identity.updateHandle(
+      { handle: 'rex2.test' },
+      { headers: sc.getHeaders(rex.did), encoding: 'application/json' },
+    )
+
+    const didData = await ctx.plcClient.getDocumentData(rex.did)
+    expect(didData.alsoKnownAs).toEqual(['at://rex2.test'])
+
+    const dbHandle = await getHandleFromDb(rex.did)
+    expect(dbHandle).toBe('rex2.test')
+  })
 })

--- a/packages/pds/tests/handles.test.ts
+++ b/packages/pds/tests/handles.test.ts
@@ -3,6 +3,7 @@ import type { AtpAgent } from '@atproto/api'
 import type { SeedClient } from '@atproto/dev-env'
 import type { AtIdentifierString, DidString } from '@atproto/syntax'
 import type { AppContext } from '../src/index.js'
+import { createSelfCustodiedAccount } from './_util.js'
 
 // outside of suite so they can be used in mock
 let alice: DidString
@@ -269,5 +270,38 @@ describe('handles', () => {
       handle: 'bob-alt.test',
     })
     await expect(attempt2).rejects.toThrow('Authentication Required')
+  })
+
+  it('fails cleanly when the server no longer holds the rotation key', async () => {
+    const { account: erin } = await createSelfCustodiedAccount(sc, ctx, 'erin')
+
+    const attempt = agent.api.com.atproto.identity.updateHandle(
+      { handle: 'erin2.test' },
+      { headers: sc.getHeaders(erin.did), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow(
+      "Rotation keys do not include server's rotation key",
+    )
+
+    const dbHandle = await getHandleFromDb(erin.did)
+    expect(dbHandle).toBe('erin.test')
+  })
+
+  it('fails cleanly when the did is tombstoned', async () => {
+    const jill = await sc.createAccount('jill', {
+      handle: 'jill.test',
+      email: 'jill@test.com',
+      password: 'jill-pass',
+    })
+    await ctx.plcClient.tombstone(jill.did, ctx.plcRotationKey)
+
+    const attempt = agent.api.com.atproto.identity.updateHandle(
+      { handle: 'jill2.test' },
+      { headers: sc.getHeaders(jill.did), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow('Did is tombstoned')
+
+    const dbHandle = await getHandleFromDb(jill.did)
+    expect(dbHandle).toBe('jill.test')
   })
 })

--- a/packages/pds/tests/plc-operations.test.ts
+++ b/packages/pds/tests/plc-operations.test.ts
@@ -259,18 +259,63 @@ describe('plc operations', () => {
     )
   })
 
-  it('fails cleanly activating an account the server no longer controls', async () => {
+  it('activates an account the server does not control the rotation key for', async () => {
     const { account: fiona } = await createSelfCustodiedAccount(
       sc,
       ctx,
       'fiona',
     )
 
-    const attempt = agent.api.com.atproto.server.activateAccount(undefined, {
+    await agent.api.com.atproto.server.activateAccount(undefined, {
       headers: sc.getHeaders(fiona.did),
     })
+
+    const status = await agent.api.com.atproto.server.checkAccountStatus(
+      undefined,
+      { headers: sc.getHeaders(fiona.did) },
+    )
+    expect(status.data.activated).toBe(true)
+    expect(status.data.validDid).toBe(true)
+  })
+
+  it('fails cleanly activating when the pds endpoint does not match', async () => {
+    const kim = await sc.createAccount('kim', {
+      handle: 'kim.test',
+      email: 'kim@test.com',
+      password: 'kim-pass',
+    })
+    await ctx.plcClient.updatePds(
+      kim.did,
+      ctx.plcRotationKey,
+      'https://example.com',
+    )
+
+    const attempt = agent.api.com.atproto.server.activateAccount(undefined, {
+      headers: sc.getHeaders(kim.did),
+    })
     await expect(attempt).rejects.toThrow(
-      "Rotation keys do not include server's rotation key",
+      'DID document atproto_pds service endpoint does not match PDS public url',
+    )
+  })
+
+  it('fails cleanly activating when the signing key does not match', async () => {
+    const leo = await sc.createAccount('leo', {
+      handle: 'leo.test',
+      email: 'leo@test.com',
+      password: 'leo-pass',
+    })
+    const otherKey = await Secp256k1Keypair.create()
+    await ctx.plcClient.updateAtprotoKey(
+      leo.did,
+      ctx.plcRotationKey,
+      otherKey.did(),
+    )
+
+    const attempt = agent.api.com.atproto.server.activateAccount(undefined, {
+      headers: sc.getHeaders(leo.did),
+    })
+    await expect(attempt).rejects.toThrow(
+      'DID document verification method does not match expected signing key',
     )
   })
 

--- a/packages/pds/tests/plc-operations.test.ts
+++ b/packages/pds/tests/plc-operations.test.ts
@@ -84,12 +84,22 @@ describe('plc operations', () => {
     await expect(attempt).rejects.toThrow(expectedErr)
   }
 
-  it("prevents submitting an operation that removes the server's rotation key", async () => {
-    await expectFailedOp(
-      alice.did,
-      { rotationKeys: [sampleKey] },
-      "Rotation keys do not include server's rotation key",
+  it("allows submitting an operation that removes the server's rotation key", async () => {
+    const gwen = await sc.createAccount('gwen', {
+      handle: 'gwen.test',
+      email: 'gwen@test.com',
+      password: 'gwen-pass',
+    })
+    const operation = await signOp(gwen.did, { rotationKeys: [sampleKey] })
+    await agent.com.atproto.identity.submitPlcOperation(
+      { operation },
+      {
+        encoding: 'application/json',
+        headers: sc.getHeaders(gwen.did),
+      },
     )
+    const didData = await ctx.plcClient.getDocumentData(gwen.did)
+    expect(didData.rotationKeys).toEqual([sampleKey])
   })
 
   it('prevents submitting an operation that incorrectly sets the signing key', async () => {

--- a/packages/pds/tests/plc-operations.test.ts
+++ b/packages/pds/tests/plc-operations.test.ts
@@ -11,6 +11,7 @@ import {
   basicSeed,
 } from '@atproto/dev-env'
 import type { AppContext } from '../src/index.js'
+import { createSelfCustodiedAccount } from './_util.js'
 
 describe('plc operations', () => {
   let network: TestNetworkNoAppView
@@ -237,5 +238,76 @@ describe('plc operations', () => {
     assert(lastEvt)
     expect(lastEvt.did).toBe(alice.did)
     expect(lastEvt.eventType).toBe('identity')
+  })
+
+  it('fails cleanly signing for a self-custodied account the server no longer controls', async () => {
+    const { account: erin } = await createSelfCustodiedAccount(sc, ctx, 'erin')
+
+    using sendPlcOperationMock = jest.spyOn(ctx.mailer, 'sendPlcOperation')
+    await agent.api.com.atproto.identity.requestPlcOperationSignature(
+      undefined,
+      { headers: sc.getHeaders(erin.did) },
+    )
+    const [{ token: erinToken }] = sendPlcOperationMock.mock.lastCall!
+
+    const attempt = agent.api.com.atproto.identity.signPlcOperation(
+      { token: erinToken, rotationKeys: [sampleKey] },
+      { headers: sc.getHeaders(erin.did), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow(
+      "Rotation keys do not include server's rotation key",
+    )
+  })
+
+  it('fails cleanly activating an account the server no longer controls', async () => {
+    const { account: fiona } = await createSelfCustodiedAccount(
+      sc,
+      ctx,
+      'fiona',
+    )
+
+    const attempt = agent.api.com.atproto.server.activateAccount(undefined, {
+      headers: sc.getHeaders(fiona.did),
+    })
+    await expect(attempt).rejects.toThrow(
+      "Rotation keys do not include server's rotation key",
+    )
+  })
+
+  it('fails cleanly activating a tombstoned did', async () => {
+    const hank = await sc.createAccount('hank', {
+      handle: 'hank.test',
+      email: 'hank@test.com',
+      password: 'hank-pass',
+    })
+    await ctx.plcClient.tombstone(hank.did, ctx.plcRotationKey)
+
+    const attempt = agent.api.com.atproto.server.activateAccount(undefined, {
+      headers: sc.getHeaders(hank.did),
+    })
+    await expect(attempt).rejects.toThrow('Did is tombstoned')
+  })
+
+  it('fails cleanly signing for a tombstoned did', async () => {
+    const ivy = await sc.createAccount('ivy', {
+      handle: 'ivy.test',
+      email: 'ivy@test.com',
+      password: 'ivy-pass',
+    })
+
+    using sendPlcOperationMock = jest.spyOn(ctx.mailer, 'sendPlcOperation')
+    await agent.api.com.atproto.identity.requestPlcOperationSignature(
+      undefined,
+      { headers: sc.getHeaders(ivy.did) },
+    )
+    const [{ token: ivyToken }] = sendPlcOperationMock.mock.lastCall!
+
+    await ctx.plcClient.tombstone(ivy.did, ctx.plcRotationKey)
+
+    const attempt = agent.api.com.atproto.identity.signPlcOperation(
+      { token: ivyToken, rotationKeys: [sampleKey] },
+      { headers: sc.getHeaders(ivy.did), encoding: 'application/json' },
+    )
+    await expect(attempt).rejects.toThrow('Did is tombstoned')
   })
 })


### PR DESCRIPTION
## What & why

This PR rationalizes the checks surrounding PLC operations done on behalf of the user and then loosens them to make account activation and handle updates work cleanly if the user is keeping custody of their own rotation keys rather than entrusting the PDS with them, fixing [#4819](https://github.com/bluesky-social/atproto/issues/4819).

When dealing with PLC operations, the existing code had a mixture of checks to make sure that the PDS was able to sign on behalf of the account. These were aimed at either catching the condition where the PDS couldn't sign for the user before it did (`signPlcOperation`, checks absent from `updateHandle`) or trying to avoid letting an account get into that state in the first place (`activateAccount`, `submitPlcOperation`). Some of the checks made the assumption that the PDS should hold a rotation key on the user's behalf.

First we rationalize the checks to make sure they consistently check that they are dealing with an account that is not tombstoned, and the PDS has a rotation key for the did.

Then we remove that latter condition in `activateAccount` and`submitPlcOperation`, and allow it to be bypassed in `updateHandle`. In `updateHandle` we do this by checking the preexisting state of the did so it only takes the "check we can sign an op then sign it" path if it actually needs to do an update. This allows self-custodied users to avoid that path by submitting their self-signed op to the directory in advance, and also fixes a bug where an operation would be needlessly resubmitted if a previous update failed partway through.

Written by having lengthy arguments with Claude Code Sonnet 5.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling.