### PR TITLE
Remove character limits from video alt text

### DIFF
--- a/.changeset/tall-moons-shave.md
+++ b/.changeset/tall-moons-shave.md
@@ -1,0 +1,8 @@
+---
+'@atproto/api': patch
+'@atproto/bsky': patch
+'@atproto/ozone': patch
+'@atproto/pds': patch
+---
+
+Remove the `maxGraphemes` and `maxLength` constraints from the `alt` field of `app.bsky.embed.video`, matching `app.bsky.embed.images`

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -20,9 +20,7 @@
         },
         "alt": {
           "type": "string",
-          "description": "Alt text description of the video, for accessibility.",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "description": "Alt text description of the video, for accessibility."
         },
         "aspectRatio": {
           "type": "ref",
@@ -58,9 +56,7 @@
         "playlist": { "type": "string", "format": "uri" },
         "thumbnail": { "type": "string", "format": "uri" },
         "alt": {
-          "type": "string",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "type": "string"
         },
         "aspectRatio": {
           "type": "ref",


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Image embeds do not have a character limit set for alt text, the app sets a 2,000 char limit for both images and videos, so it seems weird to me that video embeds has a limit set to 1,000 characters.

## Checklist

- [ ] `pnpm build --force && pnpm verify` passes
- [ ] Tests pass, and new behavior is covered by tests
- [ ] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
