### PR TITLE
Limit AppView blob retries for HTTP 429

### DIFF
--- a/.changeset/tame-blob-rate-limit-retries.md
+++ b/.changeset/tame-blob-rate-limit-retries.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Limit blob proxy retries for HTTP 429 responses to one retry while retaining the configured retry count for other transient failures.

--- a/packages/bsky/src/api/blob-dispatcher.test.ts
+++ b/packages/bsky/src/api/blob-dispatcher.test.ts
@@ -1,0 +1,52 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { request } from 'undici'
+import { describe, expect, it } from 'vitest'
+import type { ServerConfig } from '../config.js'
+import { createBlobDispatcher } from './blob-dispatcher.js'
+
+const createConfig = (proxyMaxRetries: number) =>
+  ({
+    disableSsrfProtection: true,
+    proxyAllowHTTP2: false,
+    proxyBodyTimeout: 30e3,
+    proxyHeadersTimeout: 30e3,
+    proxyMaxResponseSize: 10 * 1024 * 1024,
+    proxyMaxRetries,
+  }) as ServerConfig
+
+async function getRequestCount(statusCode: number, proxyMaxRetries: number) {
+  let requestCount = 0
+  await using server = createServer((_req, res) => {
+    requestCount += 1
+    res.writeHead(statusCode).end()
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const address = server.address()
+  if (address == null || typeof address === 'string') {
+    throw new Error('Expected server to listen on a TCP port')
+  }
+
+  const dispatcher = createBlobDispatcher(createConfig(proxyMaxRetries))
+  try {
+    await expect(
+      request(`http://127.0.0.1:${address.port}`, { dispatcher }),
+    ).rejects.toMatchObject({ statusCode })
+  } finally {
+    await dispatcher.close()
+  }
+
+  return requestCount
+}
+
+describe(createBlobDispatcher, () => {
+  it('limits 429 responses to one retry', async () => {
+    expect(await getRequestCount(429, 3)).toBe(2)
+  })
+
+  it('retains the configured retry count for other statuses', async () => {
+    expect(await getRequestCount(503, 2)).toBe(3)
+  })
+})

--- a/packages/bsky/src/api/blob-dispatcher.ts
+++ b/packages/bsky/src/api/blob-dispatcher.ts
@@ -33,9 +33,17 @@ export function createBlobDispatcher(cfg: ServerConfig): Dispatcher {
       throwOnMaxRedirect: true,
     }),
     interceptors.retry({
-      statusCodes: [...RETRYABLE_HTTP_STATUS_CODES],
+      statusCodes: [...RETRYABLE_HTTP_STATUS_CODES].filter(
+        (statusCode) => statusCode !== 429,
+      ),
       methods: ['GET', 'HEAD'],
       maxRetries: cfg.proxyMaxRetries,
+    }),
+    interceptors.retry({
+      statusCodes: [429],
+      errorCodes: [],
+      methods: ['GET', 'HEAD'],
+      maxRetries: Math.min(cfg.proxyMaxRetries, 1),
     }),
   )
 }


### PR DESCRIPTION
## What & why

AppView currently retries upstream HTTP 429 responses three times, resulting in four total attempts and amplifying an external rate limit during the pop1 incident.

Split 429 responses onto a dedicated retry interceptor capped at one retry. Existing configured retries remain unchanged for 5xx responses and network errors.

## Checklist

- [x] Full build, ESLint, and Prettier pass
- [x] Tests pass, including coverage for 429 and 503 retry counts
- [x] A changeset is included
- [x] Written with Codex