### PR TITLE
Disable AppView blob retries for HTTP 429

### DIFF
--- a/.changeset/tame-blob-rate-limit-retries.md
+++ b/.changeset/tame-blob-rate-limit-retries.md
@@ -2,4 +2,4 @@
 '@atproto/bsky': patch
 ---
 
-Limit blob proxy retries for HTTP 429 responses to one retry while retaining the configured retry count for other transient failures.
+Disable blob proxy retries for HTTP 429 responses while retaining the configured retry count for other transient failures.

--- a/packages/bsky/src/api/blob-dispatcher.test.ts
+++ b/packages/bsky/src/api/blob-dispatcher.test.ts
@@ -42,8 +42,8 @@ async function getRequestCount(statusCode: number, proxyMaxRetries: number) {
 }
 
 describe(createBlobDispatcher, () => {
-  it('limits 429 responses to one retry', async () => {
-    expect(await getRequestCount(429, 3)).toBe(2)
+  it('does not retry 429 responses', async () => {
+    expect(await getRequestCount(429, 3)).toBe(1)
   })
 
   it('retains the configured retry count for other statuses', async () => {

--- a/packages/bsky/src/api/blob-dispatcher.ts
+++ b/packages/bsky/src/api/blob-dispatcher.ts
@@ -43,7 +43,7 @@ export function createBlobDispatcher(cfg: ServerConfig): Dispatcher {
       statusCodes: [429],
       errorCodes: [],
       methods: ['GET', 'HEAD'],
-      maxRetries: Math.min(cfg.proxyMaxRetries, 1),
+      maxRetries: 0,
     }),
   )
 }


### PR DESCRIPTION
## What & why

Follow-up to #5351. HTTP 429 is an explicit upstream capacity signal, so even one retry adds load without creating quota. Make one upstream attempt and fail fast.

The dedicated zero-retry interceptor preserves the existing AppView error path. Existing configured retries remain unchanged for 5xx responses and network errors.

## Checklist

- [x] AppView build, ESLint, and Prettier pass
- [x] Tests pass, including one attempt for 429 and configured retries for 503
- [x] The existing changeset is updated
- [x] Written with Codex