### PR TITLE
Fix PDS uploadBlob request stream stalls

### DIFF
--- a/.changeset/drain-pds-mime-stream.md
+++ b/.changeset/drain-pds-mime-stream.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Prevent blob uploads from stalling when MIME detection finishes before the other request-stream consumers.

--- a/packages/pds/src/actor-store/blob/transactor.ts
+++ b/packages/pds/src/actor-store/blob/transactor.ts
@@ -349,8 +349,8 @@ async function mimeTypeFromStream(
     const fileType = await fileTypeFromStream(blobStream)
     return fileType?.mime
   } finally {
-    // @NOTE Should not be needed
-    blobStream.destroy()
+    // @NOTE Draining avoids a Node pipe cleanup bug that can pause other clones.
+    blobStream.resume()
   }
 }
 

--- a/packages/pds/tests/blob-transactor.test.ts
+++ b/packages/pds/tests/blob-transactor.test.ts
@@ -1,0 +1,56 @@
+import crypto from 'node:crypto'
+import { Readable } from 'node:stream'
+import { cidForRawHash } from '@atproto/lex-data'
+import type { BlobStore } from '@atproto/repo'
+import { BlobTransactor } from '../src/actor-store/blob/transactor.js'
+import type { ActorDb } from '../src/actor-store/db/index.js'
+import type { BackgroundQueue } from '../src/background.js'
+
+describe('BlobTransactor', () => {
+  it('drains the MIME stream without stalling other consumers', async () => {
+    const size = 25 * 1024 * 1024
+    const chunkSize = 16 * 1024
+    const file = Buffer.alloc(size)
+    file.set([0xff, 0xd8, 0xff])
+
+    let uploadedSize = 0
+    const blobstore = {
+      async putTemp(bytes) {
+        if (bytes instanceof Uint8Array) {
+          uploadedSize = bytes.byteLength
+        } else {
+          for await (const chunk of bytes) {
+            uploadedSize += Buffer.byteLength(chunk)
+          }
+        }
+        return 'temp-key'
+      },
+    } as BlobStore
+    const transactor = new BlobTransactor(
+      {} as ActorDb,
+      blobstore,
+      {} as BackgroundQueue,
+    )
+    const stream = Readable.from(
+      (function* () {
+        for (let offset = 0; offset < file.length; offset += chunkSize) {
+          yield file.subarray(offset, offset + chunkSize)
+        }
+      })(),
+      { objectMode: false },
+    )
+
+    const metadata = await transactor.uploadBlobAndGetMetadata(
+      'application/octet-stream',
+      stream,
+    )
+
+    expect(uploadedSize).toBe(size)
+    expect(metadata).toEqual({
+      tempKey: 'temp-key',
+      size,
+      cid: cidForRawHash(crypto.createHash('sha256').update(file).digest()),
+      mimeType: 'image/jpeg',
+    })
+  }, 5000)
+})


### PR DESCRIPTION
## Summary

- drain the MIME detection stream instead of destroying it, avoiding Node pipe cleanup stalls across the other upload consumers
- add a deterministic 25 MiB multi-consumer regression test covering upload completion, size, CID, and MIME detection
- add a patch changeset for `@atproto/pds`

## Testing

- `pnpm test:sqlite tests/blob-transactor.test.ts --runInBand`
- Roast review: no findings

Linear: https://linear.app/blueskyweb/issue/APP-2836/fix-pds-uploadblob-request-stream-stall

Ref: https://github.com/nodejs/node/issues/53185 https://github.com/nodejs/node/pull/64310