### PR TITLE
Center the redirect message on the post-authorization OAuth screen

### DIFF
--- a/.changeset/center-redirecting-copy.md
+++ b/.changeset/center-redirecting-copy.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Center the "You are being redirected..." copy on the post-authorization screen.

--- a/packages/oauth/oauth-provider-ui/src/components/redirecting-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/redirecting-view.tsx
@@ -13,6 +13,7 @@ import {
 import { buttonVariants } from '#/components/ui/button.tsx'
 import { useCountdown } from '#/hooks/use-countdown.ts'
 import type { Override } from '#/lib/util.ts'
+import { cn } from '#/lib/utils.ts'
 
 export type RedirectingViewProps = Override<
   AuthShellProps,
@@ -79,23 +80,30 @@ export function RedirectingView({
 
   return (
     <AuthShell {...props}>
-      <Trans>You are being redirected...</Trans>
+      <div className="flex w-full flex-col gap-4">
+        <p className="text-center">
+          <Trans>You are being redirected...</Trans>
+        </p>
 
-      {showLink && (
-        <a
-          href={url}
-          onClick={onClick}
-          aria-disabled={!canClick}
-          className={buttonVariants({
-            variant: 'default',
-            className: canClick ? undefined : 'pointer-events-none opacity-50',
-          })}
-        >
-          <span className="truncate">
-            <Trans>Click here if nothing happens</Trans>
-          </span>
-        </a>
-      )}
+        {showLink && (
+          <a
+            href={url}
+            onClick={onClick}
+            aria-disabled={!canClick}
+            className={buttonVariants({
+              variant: 'default',
+              className: cn(
+                'w-full',
+                !canClick && 'pointer-events-none opacity-50',
+              ),
+            })}
+          >
+            <span className="truncate">
+              <Trans>Click here if nothing happens</Trans>
+            </span>
+          </a>
+        )}
+      </div>
     </AuthShell>
   )
 }


### PR DESCRIPTION
## Motivation

On the post-authorization screen ("Sign-in complete" / "Sign-in canceled"), the "You are being redirected..." copy renders left-aligned under a centered card heading, and the fallback link sits inline right after it with no spacing.

`RedirectingView` passes a bare `<Trans>` text node straight into `CardContent`, which is a plain block `<div>` — so the copy inherits the card's default left alignment, while the heading above it is centered by `AuthShell`'s `CardHeader className="text-center"`.

## Changes

- `packages/oauth/oauth-provider-ui/src/components/redirecting-view.tsx`: wrap the copy in its own centered `<p>` — which also satisfies the pds e2e convention that body copy be a `<p>` — stack it with the fallback link in a `flex w-full flex-col gap-4` container, and give that link the `w-full` treatment the other auth screens use for their buttons.
- Changeset: patch bump for `@atproto/oauth-provider-ui`.

No string changes, so no catalog churn.

## Screenshots

Before — copy left-aligned, link inline and cramped against it:

![Post-authorization card with left-aligned redirect copy](https://raw.githubusercontent.com/bigmoves/atproto/59d834e7bc72bff0add3a62b0a05c9e3324e72fa/before-left-aligned.png)

After — copy centered under the heading, link full-width with spacing:

![Post-authorization card with centered redirect copy and a full-width fallback button](https://raw.githubusercontent.com/bigmoves/atproto/59d834e7bc72bff0add3a62b0a05c9e3324e72fa/after-centered.png)

## Verification

- Rendered the state in the mock UI (`pnpm dev:ui`) — see screenshots.
- `pnpm exec tsc --build tsconfig.json` clean; `pnpm test` 94/94 green in `oauth-provider-ui`.
- `pnpm i18n` produced no msgid changes.
- eslint + prettier clean.
