### PR TITLE
claude: use Opus 4.8 for GitHub workflows

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -71,5 +71,5 @@ jobs:
             actions: read
           track_progress: true
           claude_args: |
-            --model claude-opus-5:api
+            --model claude-opus-4-8:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -56,7 +56,7 @@ jobs:
             actions: read
           track_progress: true
           claude_args: |
-            --model claude-opus-5:api
+            --model claude-opus-4-8:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- set every configured Claude review and mention workflow to `claude-opus-4-8:api`
- leave the Agent Gateway endpoint, org secret, and action versions unchanged

## Validation

- actionlint
- git diff --check
- Roast: NO_FINDINGS (20260810T214758Z-6a46e498)