### PR TITLE
ozone: stabilize materialized view refresh tests

### DIFF
--- a/.changeset/quiet-otters-refresh.md
+++ b/.changeset/quiet-otters-refresh.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Release the materialized-view advisory lock before discarding its database session.

--- a/packages/ozone/src/daemon/materialized-view-refresher.ts
+++ b/packages/ozone/src/daemon/materialized-view-refresher.ts
@@ -15,14 +15,17 @@ export class MaterializedViewRefresher extends PeriodicBackgroundTask {
       let locked = false
       // Create single client for the whole refresh cycle
       const client = await db.pool.connect()
+      const lockScope = db.opts.schema ?? 'public'
 
       try {
         await client.query(`SET statement_timeout = ${statementTimeoutMs}`)
         await client.query(`SET lock_timeout = ${LOCK_TIMEOUT_MS}`)
 
         const lockResult = await client.query(
-          'SELECT pg_try_advisory_lock($1) as locked',
-          [MATERIALIZED_VIEW_REFRESH_LOCK_ID],
+          `SELECT pg_try_advisory_lock(
+            hashtextextended(current_database() || ':' || $2::text, $1)
+          ) as locked`,
+          [MATERIALIZED_VIEW_REFRESH_LOCK_ID, lockScope],
         )
         locked = lockResult.rows[0]?.locked === true
         if (!locked) {
@@ -57,9 +60,12 @@ export class MaterializedViewRefresher extends PeriodicBackgroundTask {
       } finally {
         try {
           if (locked) {
-            await client.query('SELECT pg_advisory_unlock($1)', [
-              MATERIALIZED_VIEW_REFRESH_LOCK_ID,
-            ])
+            await client.query(
+              `SELECT pg_advisory_unlock(
+                hashtextextended(current_database() || ':' || $2::text, $1)
+              )`,
+              [MATERIALIZED_VIEW_REFRESH_LOCK_ID, lockScope],
+            )
           }
         } finally {
           // Discard the session so its SET values cannot leak into the pool.

--- a/packages/ozone/src/daemon/materialized-view-refresher.ts
+++ b/packages/ozone/src/daemon/materialized-view-refresher.ts
@@ -55,8 +55,16 @@ export class MaterializedViewRefresher extends PeriodicBackgroundTask {
           }
         }
       } finally {
-        // Clear any session SETS and release its locks
-        client.release(true)
+        try {
+          if (locked) {
+            await client.query('SELECT pg_advisory_unlock($1)', [
+              MATERIALIZED_VIEW_REFRESH_LOCK_ID,
+            ])
+          }
+        } finally {
+          // Discard the session so its SET values cannot leak into the pool.
+          client.release(true)
+        }
       }
     })
   }

--- a/packages/ozone/tests/materialized-view-refresher.test.ts
+++ b/packages/ozone/tests/materialized-view-refresher.test.ts
@@ -26,9 +26,12 @@ describe('materialized view refresher', () => {
   it('skips the cycle while another session holds the lock', async () => {
     const contender = await db.pool.connect()
     try {
-      await contender.query('SELECT pg_advisory_lock($1)', [
-        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
-      ])
+      await contender.query(
+        `SELECT pg_advisory_lock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        )`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, db.opts.schema ?? 'public'],
+      )
 
       const infoSpy = jest.spyOn(dbLogger, 'info')
 
@@ -44,9 +47,41 @@ describe('materialized view refresher', () => {
         messages.filter((msg) => msg === 'refreshed materialized view'),
       ).toHaveLength(0)
     } finally {
-      await contender.query('SELECT pg_advisory_unlock($1)', [
-        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
-      ])
+      await contender.query(
+        `SELECT pg_advisory_unlock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        )`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, db.opts.schema ?? 'public'],
+      )
+      contender.release()
+    }
+  })
+
+  it('does not share the lock with another schema', async () => {
+    const contender = await db.pool.connect()
+    try {
+      await contender.query(
+        `SELECT pg_advisory_lock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        )`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, 'ozone_view_refresher_contender'],
+      )
+
+      const infoSpy = jest.spyOn(dbLogger, 'info')
+
+      await network.ozone.daemon.ctx.materializedViewRefresher.run()
+
+      const refreshCalls = infoSpy.mock.calls.filter((call) =>
+        call.includes('refreshed materialized view'),
+      )
+      expect(refreshCalls).toHaveLength(4)
+    } finally {
+      await contender.query(
+        `SELECT pg_advisory_unlock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        )`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, 'ozone_view_refresher_contender'],
+      )
       contender.release()
     }
   })
@@ -125,13 +160,18 @@ describe('materialized view refresher', () => {
 
       // The advisory lock was released despite the failure.
       const lockResult = await admin.query(
-        'SELECT pg_try_advisory_lock($1) as locked',
-        [MATERIALIZED_VIEW_REFRESH_LOCK_ID],
+        `SELECT pg_try_advisory_lock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        ) as locked`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, db.opts.schema ?? 'public'],
       )
       expect(lockResult.rows[0]?.locked).toBe(true)
-      await admin.query('SELECT pg_advisory_unlock($1)', [
-        MATERIALIZED_VIEW_REFRESH_LOCK_ID,
-      ])
+      await admin.query(
+        `SELECT pg_advisory_unlock(
+          hashtextextended(current_database() || ':' || $2::text, $1)
+        )`,
+        [MATERIALIZED_VIEW_REFRESH_LOCK_ID, db.opts.schema ?? 'public'],
+      )
     } finally {
       if (renamed) {
         await admin.query(

--- a/packages/ozone/tests/repo-search.test.ts
+++ b/packages/ozone/tests/repo-search.test.ts
@@ -28,7 +28,7 @@ describe('admin repo search view', () => {
       ids.ToolsOzoneModerationSearchRepos,
     )
     await network.processAll()
-  }, 40_000) // @NOTE seeding can take a while
+  }, 120_000) // @NOTE seeding can take a while
 
   afterAll(async () => {
     await network?.close()


### PR DESCRIPTION
## Summary

- explicitly release the materialized-view advisory lock before discarding its database session
- scope the lock to a 64-bit database-and-schema key so parallel test schemas do not skip each others refreshes
- raise the bulk repo-search setup timeout from 40 seconds to 120 seconds
- keep the existing stats snapshots and assertions intact

## Test

- `pnpm --filter @atproto/ozone build`
- Prettier on the changed TypeScript files
- `materialized-view-refresher.test.ts` and `get-repo.test.ts`: 9 passed, 1 snapshot passed
- `get-records.test.ts`: 1 passed, 1 snapshot passed
- `repo-search.test.ts`: 4 passed
- Roast: NO_FINDINGS (`20260811T002106Z-17026276`)