### PR TITLE
Add batched canonical OP thread metadata to post hydration

### DIFF
--- a/.changeset/calm-threads-count.md
+++ b/.changeset/calm-threads-count.md
@@ -2,4 +2,4 @@
 '@atproto/bsky': patch
 ---
 
-Add batched canonical OP thread metadata to post hydration. Thread roots carrying more OP replies than the per-root ceiling are omitted rather than numbered from a truncated reply set.
+Add batched canonical OP thread chains to post hydration so AppView can derive position metadata. Thread roots carrying more OP replies than the per-root ceiling are omitted rather than returned as a truncated chain.

--- a/.changeset/calm-threads-count.md
+++ b/.changeset/calm-threads-count.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add batched canonical OP thread metadata to post hydration. Thread roots carrying more OP replies than the per-root ceiling are omitted rather than numbered from a truncated reply set.

--- a/.changeset/calm-threads-count.md
+++ b/.changeset/calm-threads-count.md
@@ -2,4 +2,4 @@
 '@atproto/bsky': patch
 ---
 
-Add batched canonical OP thread chains to post hydration so AppView can derive position metadata. Thread roots carrying more OP replies than the per-root ceiling are omitted rather than returned as a truncated chain.
+Add batched canonical OP thread chains to post hydration so AppView can derive position metadata.

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -84,27 +84,31 @@ message PostRecordMeta {
   bool has_post_gate = 5;
   bool has_thread_gate = 6;
   bool has_video = 7;
-  // The 1-indexed position of this post in the canonical OP thread. Present
-  // together with op_thread_post_count, and only for threads with an OP reply.
-  optional int32 op_thread_post_index = 8;
-  // The total number of posts in the canonical OP thread. Present together
-  // with op_thread_post_index, and only for threads with an OP reply.
-  optional int32 op_thread_post_count = 9;
 }
 
 message GetPostRecordsRequest {
   repeated string uris = 1;
   optional string process_dynamic_tags_for_view = 2;
   optional string viewer_did = 3;
-  // Include canonical OP thread position metadata in PostRecordMeta. This is
-  // opt-in because resolving complete OP threads is more expensive than the
-  // normal post record lookup.
+  // Include complete canonical OP threads used by AppView to derive position
+  // metadata. This is opt-in because resolving them is more expensive than
+  // the normal post record lookup.
   bool include_op_thread_metadata = 4;
 }
 
 message GetPostRecordsResponse {
   repeated Record records = 1;
   repeated PostRecordMeta meta = 2;
+  // Complete canonical OP threads for roots represented by the requested
+  // posts. AppView derives each post's index and count from these chains.
+  repeated OpThread op_threads = 3;
+}
+
+message OpThread {
+  string root_uri = 1;
+  // The root post followed by its canonical chain of OP replies. Only chains
+  // containing at least one OP reply are returned.
+  repeated string uris = 2;
 }
 
 message GetProfileRecordsRequest {

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -84,12 +84,22 @@ message PostRecordMeta {
   bool has_post_gate = 5;
   bool has_thread_gate = 6;
   bool has_video = 7;
+  // The 1-indexed position of this post in the canonical OP thread. Present
+  // together with op_thread_post_count, and only for threads with an OP reply.
+  optional int32 op_thread_post_index = 8;
+  // The total number of posts in the canonical OP thread. Present together
+  // with op_thread_post_index, and only for threads with an OP reply.
+  optional int32 op_thread_post_count = 9;
 }
 
 message GetPostRecordsRequest {
   repeated string uris = 1;
   optional string process_dynamic_tags_for_view = 2;
   optional string viewer_did = 3;
+  // Include canonical OP thread position metadata in PostRecordMeta. This is
+  // opt-in because resolving complete OP threads is more expensive than the
+  // normal post record lookup.
+  bool include_op_thread_metadata = 4;
 }
 
 message GetPostRecordsResponse {

--- a/packages/bsky/src/data-plane/server/op-thread.test.ts
+++ b/packages/bsky/src/data-plane/server/op-thread.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { TID } from '@atproto/common'
+import { type OpThreadReply, resolveCanonicalOpThread } from './op-thread.js'
+
+const BASE_TIMESTAMP_MS = 1_700_000_000_000
+
+const postUri = (offsetMs: number) =>
+  `at://did:plc:op/app.bsky.feed.post/${TID.fromTime(
+    (BASE_TIMESTAMP_MS + offsetMs) * 1000,
+    0,
+  ).toString()}`
+
+const deletedAt = (offsetMs: number) =>
+  new Date(BASE_TIMESTAMP_MS + offsetMs).toISOString()
+
+const reply = (
+  uri: string,
+  parentUri: string,
+  deletedAt: string | null = null,
+): OpThreadReply => ({ uri, parentUri, deletedAt })
+
+describe(resolveCanonicalOpThread, () => {
+  it('selects the oldest contiguous OP reply chain', () => {
+    const root = postUri(1)
+    const first = postUri(2)
+    const fork = postUri(3)
+    const second = postUri(4)
+
+    expect(
+      resolveCanonicalOpThread(root, [
+        reply(fork, root),
+        reply(second, first),
+        reply(first, root),
+      ]),
+    ).toEqual([root, first, second])
+  })
+
+  it('keeps a deleted middle reply while a descendant survives', () => {
+    const root = postUri(1)
+    const first = postUri(2)
+    const second = postUri(3)
+
+    expect(
+      resolveCanonicalOpThread(root, [
+        reply(first, root, deletedAt(4)),
+        reply(second, first),
+      ]),
+    ).toEqual([root, first, second])
+  })
+
+  it('only lets a reply newer than a tail deletion claim its slot', () => {
+    const root = postUri(1)
+    const deleted = postUri(2)
+    const bystander = postUri(3)
+    const replacement = postUri(5)
+
+    expect(
+      resolveCanonicalOpThread(root, [
+        reply(deleted, root, deletedAt(4)),
+        reply(bystander, root),
+        reply(replacement, root),
+      ]),
+    ).toEqual([root, replacement])
+  })
+
+  it('rejects cycles in denormalized reply rows', () => {
+    const root = postUri(1)
+    const first = postUri(2)
+
+    expect(
+      resolveCanonicalOpThread(root, [reply(first, root), reply(root, first)]),
+    ).toBeUndefined()
+  })
+})

--- a/packages/bsky/src/data-plane/server/op-thread.ts
+++ b/packages/bsky/src/data-plane/server/op-thread.ts
@@ -7,10 +7,6 @@ export type OpThreadReply = {
   deletedAt: string | null
 }
 
-// Matches the default production dataplane ceiling on OP reply rows fetched
-// per thread root.
-export const OP_THREAD_REPLY_LIMIT = 1000
-
 // Resolves the oldest contiguous line of OP replies from a thread root.
 // A deleted reply keeps its place while replies below it survive. Once
 // nothing survives below it, only a reply written after the deletion may

--- a/packages/bsky/src/data-plane/server/op-thread.ts
+++ b/packages/bsky/src/data-plane/server/op-thread.ts
@@ -1,0 +1,96 @@
+import { TID } from '@atproto/common'
+import { AtUri } from '@atproto/syntax'
+
+export type OpThreadReply = {
+  uri: string
+  parentUri: string
+  deletedAt: string | null
+}
+
+// Resolves the oldest contiguous line of OP replies from a thread root.
+// A deleted reply keeps its place while replies below it survive. Once
+// nothing survives below it, only a reply written after the deletion may
+// claim the vacated slot.
+export const resolveCanonicalOpThread = (
+  rootUri: string,
+  opReplies: OpThreadReply[],
+): string[] | undefined => {
+  const repliesByParent = new Map<string, string[]>()
+  const deletedAtByUri = new Map<string, number>()
+  for (const reply of opReplies) {
+    const siblings = repliesByParent.get(reply.parentUri) ?? []
+    siblings.push(reply.uri)
+    repliesByParent.set(reply.parentUri, siblings)
+    if (reply.deletedAt !== null) {
+      deletedAtByUri.set(reply.uri, new Date(reply.deletedAt).getTime())
+    }
+  }
+
+  // Sort replies (TID enables this) for each parent so we can
+  // deterministically pick the oldest reply.
+  for (const replies of repliesByParent.values()) {
+    replies.sort()
+  }
+
+  // Walk the oldest contiguous line of OP replies, mirroring the production
+  // dataplane. A deleted reply keeps its place while replies below it
+  // survive, so numbering stays stable. Once nothing survives below it the
+  // slot is up for grabs, but only a reply the OP wrote after that deletion
+  // may claim it: replies that already existed alongside the deleted one
+  // were never part of this chain and must not be promoted into it
+  // retroactively. The full chain is returned untrimmed by the above/below
+  // limits; the appview derives index/count from it.
+  //
+  // visited tracks the current path, so revisiting a URI means the
+  // denormalized rows describe a cycle rather than a tree.
+  const visited = new Set([rootUri])
+  let validOpThread = true
+  const resolve = (parentUri: string): string[] => {
+    let vacatedAt = 0
+    for (const reply of repliesByParent.get(parentUri) ?? []) {
+      if (visited.has(reply)) {
+        validOpThread = false
+        return []
+      }
+
+      if (vacatedAt !== 0 && !isOpReplyNewerThanTimestamp(reply, vacatedAt)) {
+        continue
+      }
+
+      visited.add(reply)
+
+      const below = resolve(reply)
+      if (!validOpThread) {
+        return []
+      }
+      const deletedAt = deletedAtByUri.get(reply)
+      if (deletedAt === undefined || below.length > 0) {
+        return [reply, ...below]
+      }
+
+      visited.delete(reply)
+      if (deletedAt > vacatedAt) {
+        vacatedAt = deletedAt
+      }
+    }
+    return []
+  }
+
+  const opThread = [rootUri, ...resolve(rootUri)]
+  // A chain of one is just the root; only threads with OP replies count.
+  return validOpThread && opThread.length > 1 ? opThread : undefined
+}
+
+// isOpReplyNewerThanTimestamp reports whether the post's rkey places its creation after ts.
+// The rkey is a TID, so this is the post's own claimed creation time rather
+// than when we observed it. An unparseable rkey is treated as not newer, which
+// keeps a malformed reply from claiming a vacated slot.
+const isOpReplyNewerThanTimestamp = (uri: string, ts: number): boolean => {
+  try {
+    const tid = TID.fromStr(new AtUri(uri).rkey)
+    // TID timestamps are in microseconds.
+    return tid.timestamp() / 1000 > ts
+  } catch {
+    return false
+  }
+}

--- a/packages/bsky/src/data-plane/server/op-thread.ts
+++ b/packages/bsky/src/data-plane/server/op-thread.ts
@@ -7,6 +7,10 @@ export type OpThreadReply = {
   deletedAt: string | null
 }
 
+// Matches the default production dataplane ceiling on OP reply rows fetched
+// per thread root.
+export const OP_THREAD_REPLY_LIMIT = 1000
+
 // Resolves the oldest contiguous line of OP replies from a thread root.
 // A deleted reply keeps its place while replies below it survive. Once
 // nothing survives below it, only a reply written after the deletion may
@@ -32,17 +36,8 @@ export const resolveCanonicalOpThread = (
     replies.sort()
   }
 
-  // Walk the oldest contiguous line of OP replies, mirroring the production
-  // dataplane. A deleted reply keeps its place while replies below it
-  // survive, so numbering stays stable. Once nothing survives below it the
-  // slot is up for grabs, but only a reply the OP wrote after that deletion
-  // may claim it: replies that already existed alongside the deleted one
-  // were never part of this chain and must not be promoted into it
-  // retroactively. The full chain is returned untrimmed by the above/below
-  // limits; the appview derives index/count from it.
-  //
-  // visited tracks the current path, so revisiting a URI means the
-  // denormalized rows describe a cycle rather than a tree.
+  // Track the current path so malformed denormalized rows cannot introduce a
+  // cycle into the result.
   const visited = new Set([rootUri])
   let validOpThread = true
   const resolve = (parentUri: string): string[] => {

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -9,10 +9,7 @@ import { dataplaneLogger } from '../../../logger.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { OpThread, PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
 import type { Database } from '../db/index.js'
-import {
-  OP_THREAD_REPLY_LIMIT,
-  resolveCanonicalOpThread,
-} from '../op-thread.js'
+import { resolveCanonicalOpThread } from '../op-thread.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   getBlockRecords: getRecords(db, app.bsky.graph.block),
@@ -132,27 +129,18 @@ const getOpThreads = async (
     .select((eb) => eb.fn.coalesce('replyRoot', 'uri').as('rootUri'))
     .distinct()
 
-  // The lateral limit bounds row work independently for each root. Fetch one
-  // past the ceiling so over-limit roots are distinguishable from roots that
-  // land exactly on it.
   const rows = await db.db
-    .selectFrom(requestedRoots.as('requested_root'))
-    .innerJoinLateral(
-      (eb) =>
-        eb
-          .selectFrom('op_thread_reply')
-          .select(['rootUri', 'uri', 'parentUri', 'deletedAt'])
-          .whereRef('rootUri', '=', 'requested_root.rootUri')
-          .orderBy('uri')
-          .limit(OP_THREAD_REPLY_LIMIT + 1)
-          .as('reply'),
-      (join) => join.onTrue(),
+    .selectFrom('op_thread_reply')
+    .innerJoin(
+      requestedRoots.as('requested_root'),
+      'requested_root.rootUri',
+      'op_thread_reply.rootUri',
     )
     .select([
-      'reply.rootUri',
-      'reply.uri',
-      'reply.parentUri',
-      'reply.deletedAt',
+      'op_thread_reply.rootUri',
+      'op_thread_reply.uri',
+      'op_thread_reply.parentUri',
+      'op_thread_reply.deletedAt',
     ])
     .execute()
 
@@ -167,35 +155,17 @@ const getOpThreads = async (
   }
 
   const opThreads: OpThread[] = []
-  const skippedRoots: string[] = []
   for (const [rootUri, replies] of repliesByRoot) {
-    if (replies.length > OP_THREAD_REPLY_LIMIT) {
-      skippedRoots.push(rootUri)
-      continue
-    }
-
     const opThread = resolveCanonicalOpThread(rootUri, replies)
     if (!opThread) continue
 
     opThreads.push(new OpThread({ rootUri, uris: opThread }))
   }
 
-  // Volume stats stay at debug so the hydration path pays nothing by default;
-  // raise the bsky:dp level to size batches during rollout. Hitting the
-  // ceiling is rare and actionable, so that warns.
-  const stats = {
-    uris: uris.length,
-    roots: repliesByRoot.size,
-    rows: rows.length,
-  }
-  if (skippedRoots.length) {
-    dataplaneLogger.warn(
-      { ...stats, skippedRoots },
-      'op thread reply ceiling hit, threads omitted for these roots',
-    )
-  } else {
-    dataplaneLogger.debug(stats, 'op threads resolved')
-  }
+  dataplaneLogger.debug(
+    { uris: uris.length, roots: repliesByRoot.size, rows: rows.length },
+    'op threads resolved',
+  )
 
   return opThreads
 }

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -7,7 +7,7 @@ import { AtUri } from '@atproto/syntax'
 import { app, chat, com } from '../../../lexicons/index.js'
 import { dataplaneLogger } from '../../../logger.js'
 import type { Service } from '../../../proto/bsky_connect.js'
-import { PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
+import { OpThread, PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
 import type { Database } from '../db/index.js'
 import {
   OP_THREAD_REPLY_LIMIT,
@@ -85,8 +85,12 @@ export const getPostRecords = (db: Database) => {
   return async (req: {
     uris: string[]
     includeOpThreadMetadata?: boolean
-  }): Promise<{ records: Record[]; meta: PostRecordMeta[] }> => {
-    const [{ records }, details, opThreadMetadata] = await Promise.all([
+  }): Promise<{
+    records: Record[]
+    meta: PostRecordMeta[]
+    opThreads: OpThread[]
+  }> => {
+    const [{ records }, details, opThreads] = await Promise.all([
       getBaseRecords(req),
       req.uris.length
         ? db.db
@@ -101,36 +105,26 @@ export const getPostRecords = (db: Database) => {
             ])
             .execute()
         : [],
-      req.includeOpThreadMetadata
-        ? getOpThreadMetadata(db, req.uris)
-        : new Map<string, OpThreadMetadata>(),
+      req.includeOpThreadMetadata ? getOpThreads(db, req.uris) : [],
     ])
     const byKey = keyBy(details, 'uri')
     const meta = req.uris.map((uri) => {
-      const thread = opThreadMetadata.get(uri)
       return new PostRecordMeta({
         violatesThreadGate: !!byKey.get(uri)?.violatesThreadGate,
         violatesEmbeddingRules: !!byKey.get(uri)?.violatesEmbeddingRules,
         hasThreadGate: !!byKey.get(uri)?.hasThreadGate,
         hasPostGate: !!byKey.get(uri)?.hasPostGate,
-        opThreadPostIndex: thread?.index,
-        opThreadPostCount: thread?.count,
       })
     })
-    return { records, meta }
+    return { records, meta, opThreads }
   }
 }
 
-type OpThreadMetadata = {
-  index: number
-  count: number
-}
-
-const getOpThreadMetadata = async (
+const getOpThreads = async (
   db: Database,
   uris: string[],
-): Promise<Map<string, OpThreadMetadata>> => {
-  if (!uris.length) return new Map()
+): Promise<OpThread[]> => {
+  if (!uris.length) return []
 
   const requestedRoots = db.db
     .selectFrom('post')
@@ -172,7 +166,7 @@ const getOpThreadMetadata = async (
     repliesByRoot.set(row.rootUri, replies)
   }
 
-  const metadata = new Map<string, OpThreadMetadata>()
+  const opThreads: OpThread[] = []
   const skippedRoots: string[] = []
   for (const [rootUri, replies] of repliesByRoot) {
     if (replies.length > OP_THREAD_REPLY_LIMIT) {
@@ -183,10 +177,7 @@ const getOpThreadMetadata = async (
     const opThread = resolveCanonicalOpThread(rootUri, replies)
     if (!opThread) continue
 
-    const count = opThread.length
-    for (let i = 0; i < count; i++) {
-      metadata.set(opThread[i], { index: i + 1, count })
-    }
+    opThreads.push(new OpThread({ rootUri, uris: opThread }))
   }
 
   // Volume stats stay at debug so the hydration path pays nothing by default;
@@ -200,13 +191,13 @@ const getOpThreadMetadata = async (
   if (skippedRoots.length) {
     dataplaneLogger.warn(
       { ...stats, skippedRoots },
-      'op thread reply ceiling hit, metadata omitted for these roots',
+      'op thread reply ceiling hit, threads omitted for these roots',
     )
   } else {
-    dataplaneLogger.debug(stats, 'op thread metadata resolved')
+    dataplaneLogger.debug(stats, 'op threads resolved')
   }
 
-  return metadata
+  return opThreads
 }
 
 const compositeTime = (

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -5,9 +5,11 @@ import { keyBy } from '@atproto/common'
 import { l } from '@atproto/lex'
 import { AtUri } from '@atproto/syntax'
 import { app, chat, com } from '../../../lexicons/index.js'
+import { dataplaneLogger } from '../../../logger.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
 import type { Database } from '../db/index.js'
+import { resolveCanonicalOpThread } from '../op-thread.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   getBlockRecords: getRecords(db, app.bsky.graph.block),
@@ -79,11 +81,12 @@ export const getPostRecords = (db: Database) => {
   const getBaseRecords = getRecords(db, app.bsky.feed.post)
   return async (req: {
     uris: string[]
+    includeOpThreadMetadata?: boolean
   }): Promise<{ records: Record[]; meta: PostRecordMeta[] }> => {
-    const [{ records }, details] = await Promise.all([
+    const [{ records }, details, opThreadMetadata] = await Promise.all([
       getBaseRecords(req),
       req.uris.length
-        ? await db.db
+        ? db.db
             .selectFrom('post')
             .where('uri', 'in', req.uris)
             .select([
@@ -95,18 +98,126 @@ export const getPostRecords = (db: Database) => {
             ])
             .execute()
         : [],
+      req.includeOpThreadMetadata
+        ? getOpThreadMetadata(db, req.uris)
+        : new Map<string, OpThreadMetadata>(),
     ])
     const byKey = keyBy(details, 'uri')
     const meta = req.uris.map((uri) => {
+      const thread = opThreadMetadata.get(uri)
       return new PostRecordMeta({
         violatesThreadGate: !!byKey.get(uri)?.violatesThreadGate,
         violatesEmbeddingRules: !!byKey.get(uri)?.violatesEmbeddingRules,
         hasThreadGate: !!byKey.get(uri)?.hasThreadGate,
         hasPostGate: !!byKey.get(uri)?.hasPostGate,
+        opThreadPostIndex: thread?.index,
+        opThreadPostCount: thread?.count,
       })
     })
     return { records, meta }
   }
+}
+
+type OpThreadMetadata = {
+  index: number
+  count: number
+}
+
+// Ceiling on OP replies fetched per thread root. op_thread_reply holds every
+// reply the OP wrote anywhere in their own thread, so a high-engagement thread
+// whose OP answers many commenters can carry far more rows than the canonical
+// chain ever uses. Resolving those on the hydration path is unbounded work, so
+// a root over this ceiling yields no metadata at all rather than metadata
+// derived from a truncated — and therefore wrong — set of replies.
+export const OP_THREAD_REPLY_LIMIT = 1000
+
+const getOpThreadMetadata = async (
+  db: Database,
+  uris: string[],
+): Promise<Map<string, OpThreadMetadata>> => {
+  if (!uris.length) return new Map()
+
+  const requestedRoots = db.db
+    .selectFrom('post')
+    .where('uri', 'in', uris)
+    .select((eb) => eb.fn.coalesce('replyRoot', 'uri').as('rootUri'))
+    .distinct()
+
+  const ranked = db.db
+    .selectFrom('op_thread_reply')
+    .innerJoin(
+      requestedRoots.as('requested_root'),
+      'requested_root.rootUri',
+      'op_thread_reply.rootUri',
+    )
+    .select((eb) => [
+      'op_thread_reply.rootUri',
+      'op_thread_reply.uri',
+      'op_thread_reply.parentUri',
+      'op_thread_reply.deletedAt',
+      eb.fn
+        .agg<number>('row_number')
+        .over((ob) =>
+          ob
+            .partitionBy('op_thread_reply.rootUri')
+            .orderBy('op_thread_reply.uri'),
+        )
+        .as('rank'),
+    ])
+
+  // Fetch one row past the ceiling so an over-limit root is distinguishable
+  // from one that lands exactly on it.
+  const rows = await db.db
+    .selectFrom(ranked.as('ranked'))
+    .selectAll()
+    .where('rank', '<=', OP_THREAD_REPLY_LIMIT + 1)
+    .execute()
+
+  const repliesByRoot = new Map<
+    string,
+    { uri: string; parentUri: string; deletedAt: string | null }[]
+  >()
+  for (const row of rows) {
+    const replies = repliesByRoot.get(row.rootUri) ?? []
+    replies.push(row)
+    repliesByRoot.set(row.rootUri, replies)
+  }
+
+  const metadata = new Map<string, OpThreadMetadata>()
+  const skippedRoots: string[] = []
+  for (const [rootUri, replies] of repliesByRoot) {
+    if (replies.length > OP_THREAD_REPLY_LIMIT) {
+      skippedRoots.push(rootUri)
+      continue
+    }
+
+    const opThread = resolveCanonicalOpThread(rootUri, replies)
+    if (!opThread) continue
+
+    const count = opThread.length
+    for (let i = 0; i < count; i++) {
+      metadata.set(opThread[i], { index: i + 1, count })
+    }
+  }
+
+  // Volume stats stay at debug so the hydration path pays nothing by default;
+  // raise the bsky:dp level to size batches during rollout. Hitting the
+  // ceiling is rare and actionable, so that warns.
+  const stats = {
+    uris: uris.length,
+    roots: repliesByRoot.size,
+    rows: rows.length,
+  }
+  if (skippedRoots.length) {
+    dataplaneLogger.warn(
+      { ...stats, skippedRoots },
+      'op thread reply ceiling hit, metadata omitted for these roots',
+    )
+  } else {
+    dataplaneLogger.debug(stats, 'op thread metadata resolved')
+  }
+
+  return metadata
 }
 
 const compositeTime = (

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -9,7 +9,10 @@ import { dataplaneLogger } from '../../../logger.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
 import type { Database } from '../db/index.js'
-import { resolveCanonicalOpThread } from '../op-thread.js'
+import {
+  OP_THREAD_REPLY_LIMIT,
+  resolveCanonicalOpThread,
+} from '../op-thread.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   getBlockRecords: getRecords(db, app.bsky.graph.block),
@@ -123,14 +126,6 @@ type OpThreadMetadata = {
   count: number
 }
 
-// Ceiling on OP replies fetched per thread root. op_thread_reply holds every
-// reply the OP wrote anywhere in their own thread, so a high-engagement thread
-// whose OP answers many commenters can carry far more rows than the canonical
-// chain ever uses. Resolving those on the hydration path is unbounded work, so
-// a root over this ceiling yields no metadata at all rather than metadata
-// derived from a truncated — and therefore wrong — set of replies.
-export const OP_THREAD_REPLY_LIMIT = 1000
-
 const getOpThreadMetadata = async (
   db: Database,
   uris: string[],
@@ -143,34 +138,28 @@ const getOpThreadMetadata = async (
     .select((eb) => eb.fn.coalesce('replyRoot', 'uri').as('rootUri'))
     .distinct()
 
-  const ranked = db.db
-    .selectFrom('op_thread_reply')
-    .innerJoin(
-      requestedRoots.as('requested_root'),
-      'requested_root.rootUri',
-      'op_thread_reply.rootUri',
-    )
-    .select((eb) => [
-      'op_thread_reply.rootUri',
-      'op_thread_reply.uri',
-      'op_thread_reply.parentUri',
-      'op_thread_reply.deletedAt',
-      eb.fn
-        .agg<number>('row_number')
-        .over((ob) =>
-          ob
-            .partitionBy('op_thread_reply.rootUri')
-            .orderBy('op_thread_reply.uri'),
-        )
-        .as('rank'),
-    ])
-
-  // Fetch one row past the ceiling so an over-limit root is distinguishable
-  // from one that lands exactly on it.
+  // The lateral limit bounds row work independently for each root. Fetch one
+  // past the ceiling so over-limit roots are distinguishable from roots that
+  // land exactly on it.
   const rows = await db.db
-    .selectFrom(ranked.as('ranked'))
-    .selectAll()
-    .where('rank', '<=', OP_THREAD_REPLY_LIMIT + 1)
+    .selectFrom(requestedRoots.as('requested_root'))
+    .innerJoinLateral(
+      (eb) =>
+        eb
+          .selectFrom('op_thread_reply')
+          .select(['rootUri', 'uri', 'parentUri', 'deletedAt'])
+          .whereRef('rootUri', '=', 'requested_root.rootUri')
+          .orderBy('uri')
+          .limit(OP_THREAD_REPLY_LIMIT + 1)
+          .as('reply'),
+      (join) => join.onTrue(),
+    )
+    .select([
+      'reply.rootUri',
+      'reply.uri',
+      'reply.parentUri',
+      'reply.deletedAt',
+    ])
     .execute()
 
   const repliesByRoot = new Map<

--- a/packages/bsky/src/data-plane/server/routes/threads.ts
+++ b/packages/bsky/src/data-plane/server/routes/threads.ts
@@ -1,7 +1,10 @@
 import type { ServiceImpl } from '@connectrpc/connect'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
-import { resolveCanonicalOpThread } from '../op-thread.js'
+import {
+  OP_THREAD_REPLY_LIMIT,
+  resolveCanonicalOpThread,
+} from '../op-thread.js'
 import { getAncestorsAndSelfQb, getDescendentsQb } from '../util.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
@@ -39,8 +42,13 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .selectFrom('op_thread_reply')
       .select(['uri', 'parentUri', 'deletedAt'])
       .where('rootUri', '=', rootUri)
+      .orderBy('uri')
+      .limit(OP_THREAD_REPLY_LIMIT + 1)
       .execute()
-    const opThread = resolveCanonicalOpThread(rootUri, opReplies)
+    const opThread =
+      opReplies.length > OP_THREAD_REPLY_LIMIT
+        ? undefined
+        : resolveCanonicalOpThread(rootUri, opReplies)
 
     return {
       uris,

--- a/packages/bsky/src/data-plane/server/routes/threads.ts
+++ b/packages/bsky/src/data-plane/server/routes/threads.ts
@@ -1,10 +1,7 @@
 import type { ServiceImpl } from '@connectrpc/connect'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
-import {
-  OP_THREAD_REPLY_LIMIT,
-  resolveCanonicalOpThread,
-} from '../op-thread.js'
+import { resolveCanonicalOpThread } from '../op-thread.js'
 import { getAncestorsAndSelfQb, getDescendentsQb } from '../util.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
@@ -42,13 +39,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .selectFrom('op_thread_reply')
       .select(['uri', 'parentUri', 'deletedAt'])
       .where('rootUri', '=', rootUri)
-      .orderBy('uri')
-      .limit(OP_THREAD_REPLY_LIMIT + 1)
       .execute()
-    const opThread =
-      opReplies.length > OP_THREAD_REPLY_LIMIT
-        ? undefined
-        : resolveCanonicalOpThread(rootUri, opReplies)
+    const opThread = resolveCanonicalOpThread(rootUri, opReplies)
 
     return {
       uris,

--- a/packages/bsky/src/data-plane/server/routes/threads.ts
+++ b/packages/bsky/src/data-plane/server/routes/threads.ts
@@ -1,8 +1,7 @@
 import type { ServiceImpl } from '@connectrpc/connect'
-import { TID } from '@atproto/common'
-import { AtUri } from '@atproto/syntax'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
+import { resolveCanonicalOpThread } from '../op-thread.js'
 import { getAncestorsAndSelfQb, getDescendentsQb } from '../util.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
@@ -41,88 +40,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .select(['uri', 'parentUri', 'deletedAt'])
       .where('rootUri', '=', rootUri)
       .execute()
-
-    const repliesByParent = new Map<string, string[]>()
-    const deletedAtByUri = new Map<string, number>()
-    for (const reply of opReplies) {
-      const siblings = repliesByParent.get(reply.parentUri) ?? []
-      siblings.push(reply.uri)
-      repliesByParent.set(reply.parentUri, siblings)
-      if (reply.deletedAt !== null) {
-        deletedAtByUri.set(reply.uri, new Date(reply.deletedAt).getTime())
-      }
-    }
-    // Sort replies (TID enables this) for each parent so we can
-    // deterministically pick the oldest reply.
-    for (const replies of repliesByParent.values()) {
-      replies.sort()
-    }
-
-    // Walk the oldest contiguous line of OP replies, mirroring the production
-    // dataplane. A deleted reply keeps its place while replies below it
-    // survive, so numbering stays stable. Once nothing survives below it the
-    // slot is up for grabs, but only a reply the OP wrote after that deletion
-    // may claim it: replies that already existed alongside the deleted one
-    // were never part of this chain and must not be promoted into it
-    // retroactively. The full chain is returned untrimmed by the above/below
-    // limits; the appview derives index/count from it.
-    //
-    // visited tracks the current path, so revisiting a URI means the
-    // denormalized rows describe a cycle rather than a tree.
-    const visited = new Set([rootUri])
-    let validOpThread = true
-    const resolve = (parentUri: string): string[] => {
-      let vacatedAt = 0
-      // sorted already, so siblings are oldest first
-      for (const reply of repliesByParent.get(parentUri) ?? []) {
-        if (visited.has(reply)) {
-          validOpThread = false
-          return []
-        }
-
-        if (vacatedAt !== 0 && !isOpReplyNewerThanTimestamp(reply, vacatedAt)) {
-          continue
-        }
-
-        visited.add(reply)
-
-        const below = resolve(reply)
-        if (!validOpThread) {
-          return []
-        }
-        const deletedAt = deletedAtByUri.get(reply)
-        if (deletedAt === undefined || below.length > 0) {
-          return [reply, ...below]
-        }
-
-        visited.delete(reply)
-        if (deletedAt > vacatedAt) {
-          vacatedAt = deletedAt
-        }
-      }
-      return []
-    }
-    const opThreadUris = [rootUri, ...resolve(rootUri)]
+    const opThread = resolveCanonicalOpThread(rootUri, opReplies)
 
     return {
       uris,
-      // A chain of one is just the root; only threads with OP replies count.
-      opThread:
-        validOpThread && opThreadUris.length > 1 ? opThreadUris : undefined,
+      opThread,
     }
   },
 })
-
-// isOpReplyNewerThanTimestamp reports whether the post's rkey places its creation after ts.
-// The rkey is a TID, so this is the post's own claimed creation time rather
-// than when we observed it. An unparseable rkey is treated as not newer, which
-// keeps a malformed reply from claiming a vacated slot.
-const isOpReplyNewerThanTimestamp = (uri: string, ts: number): boolean => {
-  try {
-    const tid = TID.fromStr(new AtUri(uri).rkey)
-    // TID timestamps are in microseconds.
-    return tid.timestamp() / 1000 > ts
-  } catch {
-    return false
-  }
-}

--- a/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
+++ b/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type SeedClient, TestNetwork } from '@atproto/dev-env'
+import { OP_THREAD_REPLY_LIMIT } from '../../src/data-plane/server/routes/records.js'
+
+describe('data plane OP thread metadata', () => {
+  let network: TestNetwork
+  let sc: SeedClient<TestNetwork>
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_op_thread_metadata',
+    })
+    sc = network.getSeedClient()
+    await sc.createAccount('threadop', {
+      handle: 'threadop.test',
+      email: 'threadop@test.com',
+      password: 'threadop-pass',
+    })
+    await network.processAll()
+  })
+
+  afterAll(async () => network?.close())
+
+  it('returns aligned canonical metadata only when requested', async () => {
+    const op = sc.dids.threadop
+    const root = await sc.post(op, 'root')
+    const first = await sc.reply(op, root.ref, root.ref, 'first')
+    const fork = await sc.reply(op, root.ref, root.ref, 'fork')
+    const second = await sc.reply(op, root.ref, first.ref, 'second')
+
+    const otherRoot = await sc.post(op, 'other root')
+    const otherReply = await sc.reply(
+      op,
+      otherRoot.ref,
+      otherRoot.ref,
+      'other reply',
+    )
+    const standalone = await sc.post(op, 'standalone')
+    await network.processAll()
+
+    const missing = `at://${op}/app.bsky.feed.post/missing`
+    const uris = [
+      second.ref.uriStr,
+      root.ref.uriStr,
+      missing,
+      fork.ref.uriStr,
+      first.ref.uriStr,
+      otherReply.ref.uriStr,
+      otherRoot.ref.uriStr,
+      standalone.ref.uriStr,
+    ]
+
+    const withoutMetadata = await network.bsky.ctx.dataplane.getPostRecords({
+      uris,
+    })
+    expect(
+      withoutMetadata.meta.map((item) => [
+        item.opThreadPostIndex,
+        item.opThreadPostCount,
+      ]),
+    ).toEqual(uris.map(() => [undefined, undefined]))
+
+    const withMetadata = await network.bsky.ctx.dataplane.getPostRecords({
+      uris,
+      includeOpThreadMetadata: true,
+    })
+    expect(
+      withMetadata.meta.map((item) => [
+        item.opThreadPostIndex,
+        item.opThreadPostCount,
+      ]),
+    ).toEqual([
+      [3, 3],
+      [1, 3],
+      [undefined, undefined],
+      [undefined, undefined],
+      [2, 3],
+      [2, 2],
+      [1, 2],
+      [undefined, undefined],
+    ])
+  })
+
+  it('drops metadata for roots carrying more OP replies than the ceiling', async () => {
+    const op = sc.dids.threadop
+    const root = await sc.post(op, 'capped root')
+    const first = await sc.reply(op, root.ref, root.ref, 'capped first')
+    await network.processAll()
+
+    const rootUri = root.ref.uriStr
+    const uris = [rootUri, first.ref.uriStr]
+    // Off-chain filler: every row replies to the root's sibling branch, so it
+    // never joins the canonical chain and only inflates the row count.
+    const padRoot = async (from: number, to: number) => {
+      await network.bsky.db.db
+        .insertInto('op_thread_reply')
+        .values(
+          Array.from({ length: to - from }, (_, i) => ({
+            rootUri,
+            uri: `${rootUri}-filler-${from + i}`,
+            parentUri: `${rootUri}-detached`,
+            deletedAt: null,
+          })),
+        )
+        .execute()
+    }
+
+    const getIndices = async () => {
+      const res = await network.bsky.ctx.dataplane.getPostRecords({
+        uris,
+        includeOpThreadMetadata: true,
+      })
+      return res.meta.map((item) => [
+        item.opThreadPostIndex,
+        item.opThreadPostCount,
+      ])
+    }
+
+    // One real reply is already indexed, so pad up to exactly the ceiling.
+    await padRoot(0, OP_THREAD_REPLY_LIMIT - 1)
+    expect(await getIndices()).toEqual([
+      [1, 2],
+      [2, 2],
+    ])
+
+    // One row past it, and the root yields nothing rather than a chain
+    // resolved from a truncated reply set.
+    await padRoot(OP_THREAD_REPLY_LIMIT - 1, OP_THREAD_REPLY_LIMIT)
+    expect(await getIndices()).toEqual([
+      [undefined, undefined],
+      [undefined, undefined],
+    ])
+  })
+})

--- a/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
+++ b/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type SeedClient, TestNetwork } from '@atproto/dev-env'
-import { OP_THREAD_REPLY_LIMIT } from '../../src/data-plane/server/op-thread.js'
 
 describe('data plane OP thread metadata', () => {
   let network: TestNetwork
@@ -69,34 +68,26 @@ describe('data plane OP thread metadata', () => {
     })
   })
 
-  it('applies the reply-row ceiling consistently', async () => {
+  it('resolves threads with more than 1,000 OP reply rows', async () => {
     const op = sc.dids.threadop
-    const root = await sc.post(op, 'capped root')
-    const first = await sc.reply(op, root.ref, root.ref, 'capped first')
+    const root = await sc.post(op, 'large root')
+    const first = await sc.reply(op, root.ref, root.ref, 'first')
     await network.processAll()
 
     const rootUri = root.ref.uriStr
     const uris = [rootUri, first.ref.uriStr]
-    // Off-chain filler: every row replies to the root's sibling branch, so it
-    // never joins the canonical chain and only inflates the row count.
     const detachedParent = `${rootUri}-detached`
-    const padRoot = async (
-      from: number,
-      to: number,
-      deletedAt: string | null = null,
-    ) => {
-      await network.bsky.db.db
-        .insertInto('op_thread_reply')
-        .values(
-          Array.from({ length: to - from }, (_, i) => ({
-            rootUri,
-            uri: `${rootUri}-filler-${from + i}`,
-            parentUri: detachedParent,
-            deletedAt,
-          })),
-        )
-        .execute()
-    }
+    await network.bsky.db.db
+      .insertInto('op_thread_reply')
+      .values(
+        Array.from({ length: 1000 }, (_, i) => ({
+          rootUri,
+          uri: `${rootUri}-filler-${i}`,
+          parentUri: detachedParent,
+          deletedAt: null,
+        })),
+      )
+      .execute()
 
     const getOpThreads = async () => {
       const res = await network.bsky.ctx.dataplane.getPostRecords({
@@ -114,20 +105,7 @@ describe('data plane OP thread metadata', () => {
       return res.opThread
     }
 
-    // One real reply is already indexed, so pad up to exactly the ceiling.
-    await padRoot(0, OP_THREAD_REPLY_LIMIT - 1)
     expect(await getOpThreads()).toEqual([[rootUri, first.ref.uriStr]])
     expect(await getOpThread()).toEqual([rootUri, first.ref.uriStr])
-
-    // Tombstones count toward the same ceiling as live replies, matching the
-    // production dataplane. Both routes omit the canonical thread rather than
-    // resolve it from a truncated row set.
-    await padRoot(
-      OP_THREAD_REPLY_LIMIT - 1,
-      OP_THREAD_REPLY_LIMIT,
-      new Date().toISOString(),
-    )
-    expect(await getOpThreads()).toEqual([])
-    expect(await getOpThread()).toEqual([])
   })
 })

--- a/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
+++ b/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
@@ -21,7 +21,7 @@ describe('data plane OP thread metadata', () => {
 
   afterAll(async () => network?.close())
 
-  it('returns aligned canonical metadata only when requested', async () => {
+  it('returns complete canonical threads only when requested', async () => {
     const op = sc.dids.threadop
     const root = await sc.post(op, 'root')
     const first = await sc.reply(op, root.ref, root.ref, 'first')
@@ -53,32 +53,20 @@ describe('data plane OP thread metadata', () => {
     const withoutMetadata = await network.bsky.ctx.dataplane.getPostRecords({
       uris,
     })
-    expect(
-      withoutMetadata.meta.map((item) => [
-        item.opThreadPostIndex,
-        item.opThreadPostCount,
-      ]),
-    ).toEqual(uris.map(() => [undefined, undefined]))
+    expect(withoutMetadata.opThreads).toEqual([])
 
     const withMetadata = await network.bsky.ctx.dataplane.getPostRecords({
       uris,
       includeOpThreadMetadata: true,
     })
     expect(
-      withMetadata.meta.map((item) => [
-        item.opThreadPostIndex,
-        item.opThreadPostCount,
-      ]),
-    ).toEqual([
-      [3, 3],
-      [1, 3],
-      [undefined, undefined],
-      [undefined, undefined],
-      [2, 3],
-      [2, 2],
-      [1, 2],
-      [undefined, undefined],
-    ])
+      Object.fromEntries(
+        withMetadata.opThreads.map((thread) => [thread.rootUri, thread.uris]),
+      ),
+    ).toEqual({
+      [root.ref.uriStr]: [root.ref.uriStr, first.ref.uriStr, second.ref.uriStr],
+      [otherRoot.ref.uriStr]: [otherRoot.ref.uriStr, otherReply.ref.uriStr],
+    })
   })
 
   it('applies the reply-row ceiling consistently', async () => {
@@ -110,15 +98,12 @@ describe('data plane OP thread metadata', () => {
         .execute()
     }
 
-    const getIndices = async () => {
+    const getOpThreads = async () => {
       const res = await network.bsky.ctx.dataplane.getPostRecords({
         uris,
         includeOpThreadMetadata: true,
       })
-      return res.meta.map((item) => [
-        item.opThreadPostIndex,
-        item.opThreadPostCount,
-      ])
+      return res.opThreads.map((thread) => thread.uris)
     }
     const getOpThread = async () => {
       const res = await network.bsky.ctx.dataplane.getThread({
@@ -131,10 +116,7 @@ describe('data plane OP thread metadata', () => {
 
     // One real reply is already indexed, so pad up to exactly the ceiling.
     await padRoot(0, OP_THREAD_REPLY_LIMIT - 1)
-    expect(await getIndices()).toEqual([
-      [1, 2],
-      [2, 2],
-    ])
+    expect(await getOpThreads()).toEqual([[rootUri, first.ref.uriStr]])
     expect(await getOpThread()).toEqual([rootUri, first.ref.uriStr])
 
     // Tombstones count toward the same ceiling as live replies, matching the
@@ -145,10 +127,7 @@ describe('data plane OP thread metadata', () => {
       OP_THREAD_REPLY_LIMIT,
       new Date().toISOString(),
     )
-    expect(await getIndices()).toEqual([
-      [undefined, undefined],
-      [undefined, undefined],
-    ])
+    expect(await getOpThreads()).toEqual([])
     expect(await getOpThread()).toEqual([])
   })
 })

--- a/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
+++ b/packages/bsky/tests/data-plane/op-thread-metadata.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type SeedClient, TestNetwork } from '@atproto/dev-env'
-import { OP_THREAD_REPLY_LIMIT } from '../../src/data-plane/server/routes/records.js'
+import { OP_THREAD_REPLY_LIMIT } from '../../src/data-plane/server/op-thread.js'
 
 describe('data plane OP thread metadata', () => {
   let network: TestNetwork
@@ -81,7 +81,7 @@ describe('data plane OP thread metadata', () => {
     ])
   })
 
-  it('drops metadata for roots carrying more OP replies than the ceiling', async () => {
+  it('applies the reply-row ceiling consistently', async () => {
     const op = sc.dids.threadop
     const root = await sc.post(op, 'capped root')
     const first = await sc.reply(op, root.ref, root.ref, 'capped first')
@@ -91,15 +91,20 @@ describe('data plane OP thread metadata', () => {
     const uris = [rootUri, first.ref.uriStr]
     // Off-chain filler: every row replies to the root's sibling branch, so it
     // never joins the canonical chain and only inflates the row count.
-    const padRoot = async (from: number, to: number) => {
+    const detachedParent = `${rootUri}-detached`
+    const padRoot = async (
+      from: number,
+      to: number,
+      deletedAt: string | null = null,
+    ) => {
       await network.bsky.db.db
         .insertInto('op_thread_reply')
         .values(
           Array.from({ length: to - from }, (_, i) => ({
             rootUri,
             uri: `${rootUri}-filler-${from + i}`,
-            parentUri: `${rootUri}-detached`,
-            deletedAt: null,
+            parentUri: detachedParent,
+            deletedAt,
           })),
         )
         .execute()
@@ -115,6 +120,14 @@ describe('data plane OP thread metadata', () => {
         item.opThreadPostCount,
       ])
     }
+    const getOpThread = async () => {
+      const res = await network.bsky.ctx.dataplane.getThread({
+        postUri: rootUri,
+        above: 0,
+        below: 0,
+      })
+      return res.opThread
+    }
 
     // One real reply is already indexed, so pad up to exactly the ceiling.
     await padRoot(0, OP_THREAD_REPLY_LIMIT - 1)
@@ -122,13 +135,20 @@ describe('data plane OP thread metadata', () => {
       [1, 2],
       [2, 2],
     ])
+    expect(await getOpThread()).toEqual([rootUri, first.ref.uriStr])
 
-    // One row past it, and the root yields nothing rather than a chain
-    // resolved from a truncated reply set.
-    await padRoot(OP_THREAD_REPLY_LIMIT - 1, OP_THREAD_REPLY_LIMIT)
+    // Tombstones count toward the same ceiling as live replies, matching the
+    // production dataplane. Both routes omit the canonical thread rather than
+    // resolve it from a truncated row set.
+    await padRoot(
+      OP_THREAD_REPLY_LIMIT - 1,
+      OP_THREAD_REPLY_LIMIT,
+      new Date().toISOString(),
+    )
     expect(await getIndices()).toEqual([
       [undefined, undefined],
       [undefined, undefined],
     ])
+    expect(await getOpThread()).toEqual([])
   })
 })


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->

Number one request for the canonical thread numbering beta feature is for it to apply to feeds as well.

Part one of two. See also https://github.com/bluesky-social/tango/pull/1329.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Yes, `gpt-5.6-sol` and review by Claude Opus 5.
