### PR TITLE
Simplify the sign-up username step

### DIFF
--- a/.changeset/plain-domain-picker.md
+++ b/.changeset/plain-domain-picker.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Simplify the sign-up username step. The domain is no longer a listbox nested inside the text input: with several domains available it becomes a list of radio rows under the input, and with only one it becomes a preview of the resulting username. The two validation rows collapse into a single hint, and the terms-of-service disclaimer moves to the final step, which is the step that creates the account.

--- a/packages/oauth/oauth-provider-ui/src/components/forms/fields/handle-field.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/fields/handle-field.tsx
@@ -1,3 +1,4 @@
+import { plural } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { AtSignIcon } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
@@ -150,7 +151,13 @@ export function HandleField({
           !segment || valid ? 'text-muted-foreground' : 'text-destructive',
         )}
       >
-        {t`Use ${minLength}–${maxLength} letters, numbers or hyphens`}
+        {/* @NOTE The noun agrees with the end of the range, so the plural is
+          driven by `maxLength`. Locales with more than two plural categories
+          need the form even though the count is never one here. */}
+        {t`Use ${minLength}–${plural(maxLength, {
+          one: '# letter, number or hyphen',
+          other: '# letters, numbers or hyphens',
+        })}`}
       </p>
 
       {domains.length > 1 ? (

--- a/packages/oauth/oauth-provider-ui/src/components/forms/fields/handle-field.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/fields/handle-field.tsx
@@ -1,16 +1,8 @@
-import { plural } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
-import { AtSignIcon, CheckIcon, XIcon } from 'lucide-react'
+import { AtSignIcon } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
 import { Input } from '#/components/ui/input.tsx'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '#/components/ui/select.tsx'
-import { Handle } from '#/components/utils/handle.tsx'
+import { RadioGroup, RadioGroupItem } from '#/components/ui/radio-group.tsx'
 import { HANDLE_SEGMENT_PATTERN } from '#/lib/form-patterns.ts'
 import {
   MAX_FULL_LENGTH,
@@ -37,10 +29,17 @@ export type HandleFieldProps = {
  * suffix — so the form's values hold exactly what the user sees in each.
  * Callers join them with `composeHandle`.
  *
+ * The two controls stack rather than share a row. A domain beside the input
+ * has to shrink, clip or wrap depending on how long it happens to be, so the
+ * same field looked different per deployment. Full-width radio rows fit any
+ * domain identically, show every option at once instead of hiding them behind
+ * a listbox, and leave the input the whole line. The preview underneath is
+ * what ties the two back together.
+ *
  * Deliberately not wrapped in a `Field.Root`: a Field binds every control
- * inside it to the field's own name, which would make the Select submit under
+ * inside it to the field's own name, which would make the domain submit under
  * `handle` and clobber the segment. The length and charset rules are shown by
- * `ValidationMessage` below instead of a `Field.Error`.
+ * the hint below instead of a `Field.Error`.
  */
 export function HandleField({
   label,
@@ -72,9 +71,34 @@ export function HandleField({
   const maxLength = domain
     ? Math.min(MAX_LENGTH, MAX_FULL_LENGTH - domain.length)
     : MAX_LENGTH
-  const validLength = segment.length >= minLength && segment.length <= maxLength
-  const validCharset = /^[a-z0-9][a-z0-9-]+[a-z0-9]$/.test(segment)
-  const full = domain && validLength && validCharset ? segment + domain : ''
+  const valid =
+    segment.length >= minLength &&
+    segment.length <= maxLength &&
+    /^[a-z0-9][a-z0-9-]+[a-z0-9]$/.test(segment)
+
+  // Stands in for the segment before anything is typed, so the preview can
+  // show a whole handle from the start rather than a gap or a grey bar.
+  const exampleSegment = t`yourname`
+
+  // @NOTE The conditional below is placeholder {0} of this Trans block, and
+  // the msgid it produces is the one the catalogs already carry. Do not add or
+  // reorder elements inside it.
+  const preview = (
+    <Trans>
+      Your full username will be:{' '}
+      {segment ? (
+        <span className="text-foreground block break-all font-medium">
+          @{segment}
+          {domain}
+        </span>
+      ) : (
+        <span className="block break-all">
+          @{exampleSegment}
+          {domain}
+        </span>
+      )}
+    </Trans>
+  )
 
   return (
     <div className="flex flex-col gap-2">
@@ -87,22 +111,6 @@ export function HandleField({
         </label>
       )}
 
-      <div>
-        <ValidationMessage hasValue={!!segment} valid={validLength}>
-          {t`Between ${plural(minLength, {
-            zero: '0',
-            one: 'one',
-            other: '#',
-          })} and ${plural(maxLength, {
-            one: 'one character',
-            other: '# characters',
-          })}`}
-        </ValidationMessage>
-        <ValidationMessage hasValue={!!segment} valid={validCharset}>
-          <Trans>Only letters, numbers, and hyphens</Trans>
-        </ValidationMessage>
-      </div>
-
       <div className="relative flex items-center">
         <span
           aria-hidden
@@ -114,6 +122,7 @@ export function HandleField({
           id="handle"
           name="handle"
           title={t`Type your username`}
+          placeholder={exampleSegment}
           type="text"
           pattern={HANDLE_SEGMENT_PATTERN}
           minLength={MIN_LENGTH}
@@ -125,54 +134,69 @@ export function HandleField({
           dir="auto"
           autoFocus={autoFocus}
           required={required}
-          className={cn('pl-10', domains.length > 1 && 'pr-40')}
+          aria-describedby="handle-hint"
+          className="pl-10"
           value={segment}
           onChange={(event) => setSegment(event.target.value.toLowerCase())}
         />
-
-        {/* @NOTE Holds the domain itself rather than an index, so
-          `Select.Value` renders it without a mapping function. */}
-        {domains.length > 1 && (
-          <div className="absolute right-1">
-            <Select
-              name="domain"
-              value={domain ?? ''}
-              onValueChange={(value) => setDomain(value as ValidDomain)}
-            >
-              <SelectTrigger size="sm" aria-label={t`Select domain`}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {domains.map((d) => (
-                  <SelectItem key={d} value={d}>
-                    {d}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
       </div>
 
-      {domains.length <= 1 && (
-        <input type="hidden" name="domain" value={domain ?? ''} />
-      )}
+      {/* @NOTE One line stating both rules, always rendered, so the row height
+        never changes under the cursor mid-click — only its colour does. */}
+      <p
+        id="handle-hint"
+        className={cn(
+          'text-xs',
+          !segment || valid ? 'text-muted-foreground' : 'text-destructive',
+        )}
+      >
+        {t`Use ${minLength}–${maxLength} letters, numbers or hyphens`}
+      </p>
 
-      {/* @NOTE The conditional below is placeholder <0> of this Trans block.
-        Do not add or reorder elements inside it. */}
-      <span className="text-muted-foreground truncate text-sm">
-        <Trans>
-          Your full username will be:{' '}
-          {full ? (
-            <Handle className="text-foreground" handle={full} />
-          ) : (
-            <span
-              aria-hidden
-              className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle"
-            />
-          )}
-        </Trans>
-      </span>
+      {domains.length > 1 ? (
+        <>
+          {/* @NOTE The radio value is the domain itself, so Base UI's own
+            hidden input submits under `domain` with no mapping and no second
+            source of truth. */}
+          <RadioGroup
+            name="domain"
+            value={domain ?? ''}
+            onValueChange={(value) => setDomain(value as ValidDomain)}
+            aria-label={t`Select domain`}
+            className="mt-1 gap-2"
+          >
+            {domains.map((d) => (
+              <label
+                key={d}
+                htmlFor={`domain-${d}`}
+                className={cn(
+                  'flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors',
+                  'has-[:focus-visible]:ring-ring has-[:focus-visible]:ring-2',
+                  d === domain
+                    ? 'border-primary bg-accent/50'
+                    : 'border-input hover:bg-accent/40',
+                )}
+              >
+                <RadioGroupItem id={`domain-${d}`} value={d} />
+                <span className="text-sm font-medium">{d}</span>
+              </label>
+            ))}
+          </RadioGroup>
+
+          <p className="text-muted-foreground mt-1 text-sm">{preview}</p>
+        </>
+      ) : (
+        <>
+          <input type="hidden" name="domain" value={domain ?? ''} />
+
+          {/* @NOTE With no choice to make, the preview is the only thing
+            showing the domain at all, so it gets a surface of its own rather
+            than sitting as one more line of grey copy. */}
+          <p className="bg-muted text-muted-foreground mt-1 rounded-lg px-3 py-2.5 text-sm">
+            {preview}
+          </p>
+        </>
+      )}
     </div>
   )
 }
@@ -183,47 +207,4 @@ export function composeHandle(values: {
   domain?: unknown
 }): string {
   return `${String(values.handle ?? '')}${String(values.domain ?? '')}`
-}
-
-function ValidationMessage({
-  hasValue,
-  valid,
-  children,
-}: {
-  hasValue: boolean
-  valid: boolean
-  children: ReactNode
-}) {
-  const { t } = useLingui()
-  return (
-    <p
-      className={cn(
-        'flex items-center gap-1 text-xs',
-        !hasValue
-          ? 'text-muted-foreground'
-          : valid
-            ? 'text-success'
-            : 'text-destructive',
-      )}
-    >
-      {/* @NOTE The indicator always occupies the same box, including before
-        the user types. Reserving the space keeps the row height constant so
-        the layout cannot shift under the cursor mid-click. */}
-      <span
-        aria-hidden
-        className="inline-flex size-3 items-center justify-center"
-      >
-        {hasValue ? (
-          valid ? (
-            <CheckIcon aria-label={t`Valid`} className="size-3" />
-          ) : (
-            <XIcon aria-label={t`Invalid`} className="size-3" />
-          )
-        ) : (
-          <span className="bg-muted-foreground/40 size-1.5 rounded-full" />
-        )}
-      </span>
-      {children}
-    </p>
-  )
 }

--- a/packages/oauth/oauth-provider-ui/src/components/forms/sign-up-wizard.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/sign-up-wizard.tsx
@@ -13,6 +13,13 @@ export type WizardRenderProps<TStepData> = {
    */
   current: boolean
 
+  /**
+   * Whether submitting this step completes the wizard, ie. whether `next`
+   * calls `onDone` rather than advancing. A step that carries copy about the
+   * outcome — a consent disclaimer, say — shows it only when this is set.
+   */
+  atLast: boolean
+
   prev?: () => void
   prevLabel: ReactNode
 
@@ -113,6 +120,8 @@ export function SignUpWizard<const T extends readonly any[]>({
   const stepProps: WizardRenderProps<any> = {
     // The current UI only displays the current title & content.
     current: true,
+
+    atLast,
 
     prevLabel: (atFirst && backLabel) || prevLabel || <Trans>Back</Trans>,
     prev: atFirst ? onBack : toPrev,

--- a/packages/oauth/oauth-provider-ui/src/components/sign-up-handle-form.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/sign-up-handle-form.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/react/macro'
 import type { HandleString } from '@atproto/syntax'
-import { Notice } from '#/components/feedback/notice.tsx'
 import {
   HandleField,
   composeHandle,
@@ -58,12 +57,15 @@ export function SignUpHandleForm({
         autoFocus
       />
 
-      <Notice role="note">
+      {/* @NOTE Plain copy rather than a `Notice`: this is background about a
+        later step, not something to act on now, and an alert surface next to
+        the field it follows read as a warning about what was just typed. */}
+      <p className="text-muted-foreground text-sm">
         <Trans>
           You can change this username to any domain name you control after your
           account is set up.
         </Trans>
-      </Notice>
+      </p>
 
       {children}
     </FormShell>

--- a/packages/oauth/oauth-provider-ui/src/components/sign-up-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/sign-up-view.tsx
@@ -48,6 +48,11 @@ export function SignUpView({
     Partial<SignUpCredentialsData & SignUpHandleData & SignUpHcaptchaData>
   >({})
 
+  // @NOTE Only the last step creates the account, so only the last step states
+  // what creating one agrees to. Which step that is depends on whether hCaptcha
+  // is configured, so the wizard decides it (`atLast`) rather than this list.
+  const disclaimer = <SignUpDisclaimer links={links} />
+
   return (
     <AuthShell
       title={msg({ message: 'Sign up' })}
@@ -74,7 +79,7 @@ export function SignUpView({
           // issue with the email address (e.g. already in use).
           {
             titleRender: () => <Trans>Choose a username</Trans>,
-            contentRender: ({ prev, prevLabel, next, nextLabel }) => (
+            contentRender: ({ atLast, prev, prevLabel, next, nextLabel }) => (
               <SignUpHandleForm
                 className="grow"
                 domains={availableUserDomains}
@@ -88,13 +93,13 @@ export function SignUpView({
                   next(data)
                 }}
               >
-                <SignUpDisclaimer links={links} />
+                {atLast && disclaimer}
               </SignUpHandleForm>
             ),
           },
           {
             titleRender: () => <Trans>Your account</Trans>,
-            contentRender: ({ prev, prevLabel, next, nextLabel }) => (
+            contentRender: ({ atLast, prev, prevLabel, next, nextLabel }) => (
               <SignUpCredentialsForm
                 className="grow"
                 onBack={prev}
@@ -105,13 +110,13 @@ export function SignUpView({
                 handler={next}
                 inviteCodeRequired={inviteCodeRequired}
               >
-                <SignUpDisclaimer links={links} />
+                {atLast && disclaimer}
               </SignUpCredentialsForm>
             ),
           },
           hcaptchaSiteKey != null && {
             titleRender: () => <Trans>Verify you are human</Trans>,
-            contentRender: ({ prev, prevLabel, next, nextLabel }) => (
+            contentRender: ({ atLast, prev, prevLabel, next, nextLabel }) => (
               <SignUpHcaptchaForm
                 className="grow"
                 siteKey={hcaptchaSiteKey}
@@ -122,7 +127,7 @@ export function SignUpView({
                 onValues={(val) => setPending((old) => ({ ...old, ...val }))}
                 handler={next}
               >
-                <SignUpDisclaimer links={links} />
+                {atLast && disclaimer}
               </SignUpHcaptchaForm>
             ),
           },

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -226,10 +226,6 @@ msgstr "Authorized"
 msgid "Back"
 msgstr "Back"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Blob storage"
@@ -693,10 +689,6 @@ msgstr "If you update your email address, email 2FA (if enabled) will be disable
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr "If you're trying to change your handle or email, do so before you deactivate."
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "Invalid"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr "Invalid Handle"
@@ -836,10 +828,6 @@ msgstr "No matches"
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "Okay"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "Only letters, numbers, and hyphens"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1277,6 +1265,10 @@ msgstr "Upload files"
 msgid "URL"
 msgstr "URL"
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr "Use {minLength}–{maxLength} letters, numbers or hyphens"
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr "Use a default username"
@@ -1296,10 +1288,6 @@ msgstr "Username or email address"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr "Username updated"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "Valid"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1482,7 +1470,7 @@ msgstr "Your email address has been verified."
 msgid "Your email address needs to be verified."
 msgstr "Your email address needs to be verified."
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Your full username will be: {0}"
@@ -1506,3 +1494,7 @@ msgstr "Your session has expired. Please sign in again."
 #: src/data/handle.ts
 msgid "Your username has been updated."
 msgstr "Your username has been updated."
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
+msgstr "yourname"

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -1266,8 +1266,8 @@ msgid "URL"
 msgstr "URL"
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
-msgstr "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
+msgstr "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
 
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -1257,7 +1257,7 @@ msgid "URL"
 msgstr ""
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
 msgstr ""
 
 #: src/components/update-handle-dialog.tsx

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -226,10 +226,6 @@ msgstr ""
 msgid "Back"
 msgstr "Volver"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "Entre {minLength, plural, other {#}} y {maxLength, plural, other {# caracteres}}"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Almacenamiento de blobs"
@@ -684,10 +680,6 @@ msgstr ""
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr ""
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "Inválido"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr ""
@@ -827,10 +819,6 @@ msgstr ""
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "Aceptar"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "Solo letras, números y guiones"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1268,6 +1256,10 @@ msgstr "Subir archivos"
 msgid "URL"
 msgstr ""
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr ""
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr ""
@@ -1287,10 +1279,6 @@ msgstr "Nombre de usuario o dirección de correo electrónico"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr ""
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "Válido"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1473,7 +1461,7 @@ msgstr ""
 msgid "Your email address needs to be verified."
 msgstr ""
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Tu nombre de usuario completo será: {0}"
@@ -1496,4 +1484,8 @@ msgstr ""
 
 #: src/data/handle.ts
 msgid "Your username has been updated."
+msgstr ""
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
 msgstr ""

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -226,10 +226,6 @@ msgstr "Autorisée"
 msgid "Back"
 msgstr "Retour"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "Entre {minLength, plural, zero {0} one {un} other {#}} et {maxLength, plural, one {un caractère} other {# caractères}}"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Stockage de fichiers"
@@ -693,10 +689,6 @@ msgstr "Si vous mettez à jour votre adresse email, la 2FA par email (si activé
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr "Si vous souhaitez changer votre pseudo ou votre adresse email, faites-le avant de désactiver votre compte."
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "Invalide"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr "Pseudo invalide"
@@ -836,10 +828,6 @@ msgstr "Aucun résultat"
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "OK"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "Uniquement des lettres, des chiffres et des traits d'union"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1277,6 +1265,10 @@ msgstr "Téléverser des fichiers"
 msgid "URL"
 msgstr "URL"
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr "Utilisez {minLength} à {maxLength} lettres, chiffres ou tirets"
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr "Utiliser un nom d'utilisateur par défaut"
@@ -1296,10 +1288,6 @@ msgstr "Nom d'utilisateur ou adresse email"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr "Nom d'utilisateur modifié"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "Valide"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1482,7 +1470,7 @@ msgstr "Votre adresse email a été vérifiée."
 msgid "Your email address needs to be verified."
 msgstr "Votre adresse email doit être vérifiée."
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Votre nom d'utilisateur complet sera : {0}"
@@ -1506,3 +1494,7 @@ msgstr "Votre session a expiré. Veuillez vous reconnecter."
 #: src/data/handle.ts
 msgid "Your username has been updated."
 msgstr "Votre nom d'utilisateur a été mis à jour."
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
+msgstr "votrenom"

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -1266,8 +1266,8 @@ msgid "URL"
 msgstr "URL"
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
-msgstr "Utilisez {minLength} à {maxLength} lettres, chiffres ou tirets"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
+msgstr "Utilisez {minLength} à {maxLength, plural, one {# lettre, chiffre ou tiret} other {# lettres, chiffres ou tirets}}"
 
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -1266,7 +1266,7 @@ msgid "URL"
 msgstr "URL"
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
 msgstr ""
 
 #: src/components/update-handle-dialog.tsx

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -226,10 +226,6 @@ msgstr "承認日"
 msgid "Back"
 msgstr "戻る"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "{minLength, plural, other {#文字}}以上、{maxLength, plural, other {#文字}}以下"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Blobストレージ"
@@ -693,10 +689,6 @@ msgstr "メールアドレスを更新すると、メールでの2要素認証(�
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr "ハンドルやメールアドレスを変えるのであれば、無効化の前に変更してください。"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "無効"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr "無効なハンドル"
@@ -836,10 +828,6 @@ msgstr "一致なし"
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "OK"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "英数字とハイフンのみ"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1277,6 +1265,10 @@ msgstr "ファイルのアップロード"
 msgid "URL"
 msgstr "URL"
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr ""
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr "デフォルトのユーザー名を使用"
@@ -1296,10 +1288,6 @@ msgstr "ユーザー名またはメールアドレス"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr "ユーザー名更新"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "有効"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1482,7 +1470,7 @@ msgstr "メールアドレスが確認されました。"
 msgid "Your email address needs to be verified."
 msgstr "メールアドレスを確認する必要があります。"
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "あなたのフルユーザー名： {0}"
@@ -1506,3 +1494,7 @@ msgstr "セッションの有効期限が切れました。もう一度サイン
 #: src/data/handle.ts
 msgid "Your username has been updated."
 msgstr "ユーザー名が更新されました。"
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
+msgstr ""

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -1257,7 +1257,7 @@ msgid "URL"
 msgstr ""
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
 msgstr ""
 
 #: src/components/update-handle-dialog.tsx

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -226,10 +226,6 @@ msgstr ""
 msgid "Back"
 msgstr "뒤로"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "{minLength, plural, other {#}}~{maxLength, plural, other {#}}자 사이"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Blob 스토리지"
@@ -684,10 +680,6 @@ msgstr ""
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr ""
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "사용 불가"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr ""
@@ -827,10 +819,6 @@ msgstr ""
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "확인"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "영문자, 숫자, 하이픈만 사용할 수 있습니다"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1268,6 +1256,10 @@ msgstr "파일 업로드"
 msgid "URL"
 msgstr ""
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr ""
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr ""
@@ -1287,10 +1279,6 @@ msgstr "사용자 이름 또는 이메일 주소"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr ""
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "사용 가능"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1473,7 +1461,7 @@ msgstr ""
 msgid "Your email address needs to be verified."
 msgstr ""
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "내 전체 사용자 이름: {0}"
@@ -1496,4 +1484,8 @@ msgstr "세션이 만료되었습니다. 다시 로그인해 주세요."
 
 #: src/data/handle.ts
 msgid "Your username has been updated."
+msgstr ""
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
 msgstr ""

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -1266,7 +1266,7 @@ msgid "URL"
 msgstr "URL"
 
 #: src/components/forms/fields/handle-field.tsx
-msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgid "Use {minLength}–{maxLength, plural, one {# letter, number or hyphen} other {# letters, numbers or hyphens}}"
 msgstr ""
 
 #: src/components/update-handle-dialog.tsx

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -226,10 +226,6 @@ msgstr ""
 msgid "Back"
 msgstr "Tillbaka"
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Between {minLength, plural, zero {0} one {one} other {#}} and {maxLength, plural, one {one character} other {# characters}}"
-msgstr "Mellan {minLength, plural, other {#}} och {maxLength, plural, other {# tecken}}"
-
 #: src/components/utils/scope-description.tsx
 msgid "Blob storage"
 msgstr "Blob-lagring"
@@ -693,10 +689,6 @@ msgstr "Om du uppdaterar din e-postadress kommer tvåfaktorsautentisering via e-
 msgid "If you're trying to change your handle or email, do so before you deactivate."
 msgstr "Om du vill ändra ditt användarnamn eller din e-postadress måste du göra det innan du inaktiverar kontot."
 
-#: src/components/forms/fields/handle-field.tsx
-msgid "Invalid"
-msgstr "Ogiltigt"
-
 #: src/components/utils/handle.tsx
 msgid "Invalid Handle"
 msgstr "Ogiltigt användarnamn"
@@ -836,10 +828,6 @@ msgstr ""
 #: src/components/reset-password-view.tsx
 msgid "Okay"
 msgstr "OK"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Only letters, numbers, and hyphens"
-msgstr "Endast bokstäver, siffror och bindestreck"
 
 #: src/components/delete-account-confirm-form.tsx
 #: src/components/forms/fields/password-field.tsx
@@ -1277,6 +1265,10 @@ msgstr "Uppladdning av filer"
 msgid "URL"
 msgstr "URL"
 
+#: src/components/forms/fields/handle-field.tsx
+msgid "Use {minLength}–{maxLength} letters, numbers or hyphens"
+msgstr ""
+
 #: src/components/update-handle-dialog.tsx
 msgid "Use a default username"
 msgstr "Använd ett användarnamn med standarddomän"
@@ -1296,10 +1288,6 @@ msgstr "Användarnamn eller e-postadress"
 #: src/data/handle.ts
 msgid "Username updated"
 msgstr "Användarnamn uppdaterat"
-
-#: src/components/forms/fields/handle-field.tsx
-msgid "Valid"
-msgstr "Giltigt"
 
 #: src/components/forms/input-handle-custom-instructions.tsx
 msgid "Value"
@@ -1482,7 +1470,7 @@ msgstr "Din e-postadress har verifierats."
 msgid "Your email address needs to be verified."
 msgstr "Din e-postadress behöver verifieras."
 
-#. placeholder {0}: full ? ( <Handle className="text-foreground" handle={full} /> ) : ( <span aria-hidden className="bg-muted-foreground inline-block h-[1em] w-24 rounded-md align-middle" /> )
+#. placeholder {0}: segment ? ( <span className="text-foreground block break-all font-medium"> @{segment} {domain} </span> ) : ( <span className="block break-all"> @{exampleSegment} {domain} </span> )
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Ditt fullständiga användarnamn blir: {0}"
@@ -1506,3 +1494,7 @@ msgstr "Din session har gått ut. Logga in igen."
 #: src/data/handle.ts
 msgid "Your username has been updated."
 msgstr "Ditt användarnamn har uppdaterats."
+
+#: src/components/forms/fields/handle-field.tsx
+msgid "yourname"
+msgstr ""


### PR DESCRIPTION
## Summary

The sign-up step that asks for a username puts the domain in a listbox inside
the text input. This layout has three problems:

- A listbox inside a text box is not a control that users know.
- The listbox covers the right end of the input. A click there does not put
  the cursor in the text.
- The width of the listbox changes with the length of the domain. A server
  with long domains gets a very small input, and a server with short domains
  gets a large one. The same field thus looks different on each deployment.

This PR puts the domain below the input. If the server has more than one
domain, the UI shows one radio row for each domain. If the server has only one
domain, the UI shows a preview of the resulting username. Radio rows have the
same width for all domains, and they show all of the options at the same time.

The step also had two rows of validation rules above the input. This PR
replaces the two rows with one hint. The hint keeps its position and changes
only its colour, thus the layout does not move while the user clicks.

The terms-of-service text moves to the last step of the wizard, because the
last step is the step that creates the account.

## Screenshots

### More than one domain

| Before | After |
| --- | --- |
| <img width="360" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/00-before.png"> | <img width="360" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/01-multi-empty.png"> |

With a username:

<img width="360" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/02-multi-typed.png">

### Only one domain

There are no radio rows. The preview gets a surface of its own, because it is
the only part of the step that shows the domain.

| Empty | With a username |
| --- | --- |
| <img width="360" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/03-single-empty.png"> | <img width="360" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/04-single-typed.png"> |

### Account manager

The dialog that changes the username of an account uses the same field.

<img width="420" src="https://raw.githubusercontent.com/bigmoves/atproto/assets/oauth-handle-field/05-account-dialog.png">

## Notes for the reviewer

- The value of each radio is the domain. Base UI thus submits the correct
  value under the name `domain`, and no code maps an index to a domain. The
  layout with one domain keeps the hidden input.
- The names of the controls do not change. They are `handle` and `domain`, as
  before.
- The preview keeps the message id that the catalogs already contain, thus the
  five translations of that message stay correct.
- `atLast` is new in the render props of the wizard. The configuration of
  hCaptcha controls which step is the last one, thus the wizard supplies this
  value and the list of steps does not calculate it.

## Test plan

- `packages/pds`: `oauth.test.ts` gives 7 passed of 7.
- `packages/pds`: `account-manager.test.ts` gives 13 passed of 13.
- `packages/oauth/oauth-provider-ui`: `pnpm test` gives 94 passed of 94.
- `tsc --build`, `pnpm run build:ui`, ESLint and Prettier are clean.
- `pnpm i18n` adds one message and removes four. French is complete.
