### PR TITLE
ozone: fix stats advisory lock lifecycle

### DIFF
--- a/.changeset/fuzzy-lions-lock.md
+++ b/.changeset/fuzzy-lions-lock.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Keep stats materialization advisory locks on one database session and scope them by database and schema.

--- a/packages/ozone/src/daemon/locks.ts
+++ b/packages/ozone/src/daemon/locks.ts
@@ -1,0 +1,4 @@
+// Stable seeds for pg advisory locks used to coordinate daemon work across
+// instances. Each daemon hashes its seed with the database and schema.
+export const STATS_COMPUTER_LOCK_ID = 7_239_401
+export const MATERIALIZED_VIEW_REFRESH_LOCK_ID = 7_239_402

--- a/packages/ozone/src/daemon/stats-computer.ts
+++ b/packages/ozone/src/daemon/stats-computer.ts
@@ -1,8 +1,8 @@
-import { sql } from 'kysely'
 import { MINUTE } from '@atproto/common'
-import { type Database, STATS_COMPUTER_LOCK_ID } from '../db/index.js'
+import type { Database } from '../db/index.js'
 import { dbLogger } from '../logger.js'
 import type { ReportStatsServiceCreator } from '../report/stats.js'
+import { STATS_COMPUTER_LOCK_ID } from './locks.js'
 
 /**
  * Background daemon that materializes report statistics on an interval (default is 15 minutes).
@@ -64,26 +64,58 @@ export class StatsComputer {
   }
 
   private async materializeStats() {
-    const lockResult = await sql<{
-      locked: boolean
-    }>`SELECT pg_try_advisory_lock(${STATS_COMPUTER_LOCK_ID}) as locked`.execute(
-      this.db.db,
-    )
-    const acquired = lockResult.rows[0]?.locked === true
-    if (!acquired) {
-      dbLogger.info(
-        'stats materialization skipped, another instance holds lock',
-      )
-      return
-    }
+    let discardClient = false
+    let locked = false
+    const client = await this.db.pool.connect()
+    const lockScope = this.db.schema ?? 'public'
 
     try {
+      const lockResult = await client
+        .query<{ locked: boolean }>(
+          `SELECT pg_try_advisory_lock(
+            hashtextextended(current_database() || ':' || $2::text, $1)
+          ) as locked`,
+          [STATS_COMPUTER_LOCK_ID, lockScope],
+        )
+        .catch((err) => {
+          // The server may have acquired the lock before the query failed.
+          discardClient = true
+          throw err
+        })
+      locked = lockResult.rows[0]?.locked === true
+      if (!locked) {
+        dbLogger.info(
+          'stats materialization skipped, another instance holds lock',
+        )
+        return
+      }
+
       const statsService = this.reportStatsServiceCreator(this.db)
       await statsService.materializeAll()
     } finally {
-      await sql`SELECT pg_advisory_unlock(${STATS_COMPUTER_LOCK_ID})`.execute(
-        this.db.db,
-      )
+      try {
+        if (locked) {
+          const unlockResult = await client.query<{ unlocked: boolean }>(
+            `SELECT pg_advisory_unlock(
+              hashtextextended(current_database() || ':' || $2::text, $1)
+            ) as unlocked`,
+            [STATS_COMPUTER_LOCK_ID, lockScope],
+          )
+          if (unlockResult.rows[0]?.unlocked !== true) {
+            dbLogger.warn('stats materialization lock was not held at release')
+          }
+        }
+      } catch (err) {
+        discardClient = true
+        dbLogger.warn({ err }, 'failed to release stats materialization lock')
+      } finally {
+        if (discardClient) {
+          // Destroy an uncertain session so it cannot leak the lock.
+          client.release(true)
+        } else {
+          client.release()
+        }
+      }
     }
   }
 

--- a/packages/ozone/src/db/index.ts
+++ b/packages/ozone/src/db/index.ts
@@ -20,10 +20,10 @@ import { CtxMigrationProvider } from './migrations/provider.js'
 import type { DatabaseSchema, DatabaseSchemaType } from './schema/index.js'
 import type { PgOptions } from './types.js'
 
-// Stable pg advisory lock IDs used to coordinate daemon work across
-// instances. Centralized here so IDs can never silently collide.
-export const STATS_COMPUTER_LOCK_ID = 7_239_401
-export const MATERIALIZED_VIEW_REFRESH_LOCK_ID = 7_239_402
+export {
+  MATERIALIZED_VIEW_REFRESH_LOCK_ID,
+  STATS_COMPUTER_LOCK_ID,
+} from '../daemon/locks.js'
 
 export class Database {
   pool: PgPool

--- a/packages/ozone/tests/stats-computer.test.ts
+++ b/packages/ozone/tests/stats-computer.test.ts
@@ -1,0 +1,126 @@
+import { jest } from '@jest/globals'
+import { STATS_COMPUTER_LOCK_ID } from '../src/daemon/locks.js'
+import { StatsComputer } from '../src/daemon/stats-computer.js'
+import type { Database } from '../src/db/index.js'
+import { dbLogger } from '../src/logger.js'
+
+describe('stats computer', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('holds and releases the schema-scoped lock on one session', async () => {
+    const query = jest
+      .fn<(...args: unknown[]) => Promise<{ rows: unknown[] }>>()
+      .mockResolvedValueOnce({ rows: [{ locked: true }] })
+      .mockResolvedValueOnce({ rows: [{ unlocked: true }] })
+    const release = jest.fn()
+    const db = {
+      pool: { connect: jest.fn(async () => ({ query, release })) },
+      schema: 'ozone_stats_computer',
+    } as unknown as Database
+    const materializeAll = jest.fn(async () => undefined)
+    const computer = new StatsComputer(
+      db,
+      () => ({ materializeAll }) as never,
+      15,
+    )
+
+    await (computer as any).materializeStats()
+
+    expect(materializeAll).toHaveBeenCalledTimes(1)
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      STATS_COMPUTER_LOCK_ID,
+      'ozone_stats_computer',
+    ])
+    expect(query.mock.calls[1]?.[1]).toEqual([
+      STATS_COMPUTER_LOCK_ID,
+      'ozone_stats_computer',
+    ])
+    expect(release).toHaveBeenCalledWith()
+  })
+
+  it('does not let an unlock failure replace a materialization error', async () => {
+    const query = jest
+      .fn<(...args: unknown[]) => Promise<{ rows: unknown[] }>>()
+      .mockResolvedValueOnce({ rows: [{ locked: true }] })
+      .mockRejectedValueOnce(new Error('connection lost'))
+    const release = jest.fn()
+    const db = {
+      pool: { connect: jest.fn(async () => ({ query, release })) },
+      schema: undefined,
+    } as unknown as Database
+    const computer = new StatsComputer(
+      db,
+      () =>
+        ({
+          materializeAll: jest.fn(async () => {
+            throw new Error('materialization failed')
+          }),
+        }) as never,
+      15,
+    )
+    const warn = jest.spyOn(dbLogger, 'warn')
+
+    await expect((computer as any).materializeStats()).rejects.toThrow(
+      'materialization failed',
+    )
+
+    expect(query.mock.calls[0]?.[1]).toEqual([STATS_COMPUTER_LOCK_ID, 'public'])
+    expect(warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'failed to release stats materialization lock',
+    )
+    expect(release).toHaveBeenCalledWith(true)
+  })
+
+  it('discards the session when lock acquisition fails', async () => {
+    const query = jest.fn(async () => {
+      throw new Error('connection lost')
+    })
+    const release = jest.fn()
+    const db = {
+      pool: { connect: jest.fn(async () => ({ query, release })) },
+      schema: 'ozone_stats_computer',
+    } as unknown as Database
+    const materializeAll = jest.fn(async () => undefined)
+    const computer = new StatsComputer(
+      db,
+      () => ({ materializeAll }) as never,
+      15,
+    )
+
+    await expect((computer as any).materializeStats()).rejects.toThrow(
+      'connection lost',
+    )
+
+    expect(materializeAll).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledWith(true)
+  })
+
+  it('returns a known-unlocked session to the pool', async () => {
+    const query = jest
+      .fn<(...args: unknown[]) => Promise<{ rows: unknown[] }>>()
+      .mockResolvedValueOnce({ rows: [{ locked: true }] })
+      .mockResolvedValueOnce({ rows: [{ unlocked: false }] })
+    const release = jest.fn()
+    const db = {
+      pool: { connect: jest.fn(async () => ({ query, release })) },
+      schema: 'ozone_stats_computer',
+    } as unknown as Database
+    const computer = new StatsComputer(
+      db,
+      () => ({ materializeAll: jest.fn(async () => undefined) }) as never,
+      15,
+    )
+    const warn = jest.spyOn(dbLogger, 'warn')
+
+    await (computer as any).materializeStats()
+
+    expect(warn).toHaveBeenCalledWith(
+      'stats materialization lock was not held at release',
+    )
+    expect(release).toHaveBeenCalledWith()
+  })
+})


### PR DESCRIPTION
## Summary

- hold the stats advisory lock on one PostgreSQL session for the full cycle
- scope the lock by database and schema to prevent parallel test schemas from contending
- discard the pooled session only when a query error leaves its lock state uncertain

## Testing

- targeted Jest regression tests
- targeted ESLint
- Roast review