### PR TITLE
Serialize stale test port cleanup

### DIFF
--- a/.changeset/lucky-pandas-rest.md
+++ b/.changeset/lucky-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+'@atproto/dev-env': patch
+---
+
+Serialize stale test-port reservation sweeps and remove owner files left by terminated workers.

--- a/packages/dev-env/src/get-port.ts
+++ b/packages/dev-env/src/get-port.ts
@@ -9,9 +9,11 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import getAvailablePort from 'get-port'
 
+const SWEEP_INTERVAL_MS = 1_000
+const SWEEP_LOCK_PATTERN = /^\.sweep-(\d+)$/
 const lockDir = join(
   tmpdir(),
   `atproto-dev-env-ports-${process.getuid?.() ?? 'unknown'}`,
@@ -30,14 +32,70 @@ const isProcessRunning = (pid: number) => {
   }
 }
 
-const initializeLockDir = async () => {
-  await mkdir(lockDir, { recursive: true })
-  await writeFile(ownerPath, String(process.pid), { flag: 'wx' })
+export const acquireSweepLock = async (
+  lockDir: string,
+  ownerPath: string,
+  generation = Math.floor(Date.now() / SWEEP_INTERVAL_MS),
+): Promise<(() => Promise<void>) | undefined> => {
+  const sweepPath = join(lockDir, `.sweep-${generation}`)
 
+  try {
+    await link(ownerPath, sweepPath)
+  } catch (err) {
+    if (err?.['code'] === 'EEXIST') return
+    throw err
+  }
+
+  try {
+    const entries = await readdir(lockDir)
+    for (const entry of entries) {
+      const match = SWEEP_LOCK_PATTERN.exec(entry)
+      if (!match || entry === basename(sweepPath)) continue
+
+      const otherSweepPath = join(lockDir, entry)
+      try {
+        const pid = Number.parseInt(await readFile(otherSweepPath, 'utf8'), 10)
+        if (Number.isSafeInteger(pid) && isProcessRunning(pid)) {
+          await unlink(sweepPath)
+          return
+        }
+        // Sweep generations are never reclaimed, so an inactive marker can
+        // be removed without racing a new owner of the same path.
+        await unlink(otherSweepPath)
+      } catch (err) {
+        if (err?.['code'] !== 'ENOENT') throw err
+      }
+    }
+
+    return async () => {
+      try {
+        await unlink(sweepPath)
+      } catch (err) {
+        if (err?.['code'] !== 'ENOENT') throw err
+      }
+    }
+  } catch (err) {
+    try {
+      await unlink(sweepPath)
+    } catch (cleanupErr) {
+      if (cleanupErr?.['code'] !== 'ENOENT') throw cleanupErr
+    }
+    throw err
+  }
+}
+
+export const sweepStaleReservations = async (
+  lockDir: string,
+  ownerPath: string,
+) => {
   const entries = await readdir(lockDir)
   await Promise.all(
     entries
-      .filter((entry) => /^\d+$/.test(entry))
+      .filter(
+        (entry) =>
+          entry !== basename(ownerPath) &&
+          (/^\d+$/.test(entry) || entry.startsWith('.owner-')),
+      )
       .map(async (entry) => {
         const lockPath = join(lockDir, entry)
         try {
@@ -50,6 +108,20 @@ const initializeLockDir = async () => {
         }
       }),
   )
+}
+
+const initializeLockDir = async () => {
+  await mkdir(lockDir, { recursive: true })
+  await writeFile(ownerPath, String(process.pid), { flag: 'wx' })
+
+  const releaseSweepLock = await acquireSweepLock(lockDir, ownerPath)
+  if (!releaseSweepLock) return
+
+  try {
+    await sweepStaleReservations(lockDir, ownerPath)
+  } finally {
+    await releaseSweepLock()
+  }
 }
 
 process.once('exit', () => {

--- a/packages/ozone/tests/get-port.test.ts
+++ b/packages/ozone/tests/get-port.test.ts
@@ -1,0 +1,72 @@
+import {
+  link,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  acquireSweepLock,
+  sweepStaleReservations,
+} from '../../dev-env/src/get-port.js'
+
+describe('test port reservations', () => {
+  let lockDir: string
+
+  beforeEach(async () => {
+    lockDir = await mkdtemp(join(tmpdir(), 'atproto-get-port-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(lockDir, { recursive: true, force: true })
+  })
+
+  const createOwner = async (name: string, pid = process.pid) => {
+    const path = join(lockDir, name)
+    await writeFile(path, String(pid))
+    return path
+  }
+
+  it('allows only one stale-lock sweep at a time', async () => {
+    const firstOwner = await createOwner('.owner-first')
+    const secondOwner = await createOwner('.owner-second')
+
+    const releaseFirst = await acquireSweepLock(lockDir, firstOwner, 100)
+    expect(releaseFirst).toBeDefined()
+    await expect(
+      acquireSweepLock(lockDir, secondOwner, 100),
+    ).resolves.toBeUndefined()
+    await expect(
+      acquireSweepLock(lockDir, secondOwner, 101),
+    ).resolves.toBeUndefined()
+
+    await releaseFirst?.()
+    const releaseSecond = await acquireSweepLock(lockDir, secondOwner, 101)
+    expect(releaseSecond).toBeDefined()
+    await releaseSecond?.()
+  })
+
+  it('reaps stale port and owner links without touching live owners', async () => {
+    const currentOwner = await createOwner('.owner-current')
+    const otherLiveOwner = await createOwner('.owner-live')
+    const staleOwner = await createOwner('.owner-stale', 999_999)
+    await link(staleOwner, join(lockDir, '4100'))
+    await link(otherLiveOwner, join(lockDir, '4200'))
+
+    await sweepStaleReservations(lockDir, currentOwner)
+
+    const entries = await readdir(lockDir)
+    expect(entries).toEqual(
+      expect.arrayContaining(['.owner-current', '.owner-live', '4200']),
+    )
+    expect(entries).not.toEqual(
+      expect.arrayContaining(['.owner-stale', '4100']),
+    )
+    await expect(readFile(join(lockDir, '4200'), 'utf8')).resolves.toBe(
+      String(process.pid),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- serialize stale reservation sweeps across worker processes
- reap owner files left by terminated workers
- keep a failed sweeper from permanently blocking future cleanup

## Testing

- targeted Jest regression tests
- targeted TypeScript and ESLint checks
- Roast review