### PR TITLE
Add content visibility lexicon

### DIFF
--- a/.changeset/green-dogs-hide.md
+++ b/.changeset/green-dogs-hide.md
@@ -1,0 +1,5 @@
+---
+"@atproto/api": patch
+---
+
+Add the `app.bsky.actor.contentVisibility` lexicon.

--- a/.changeset/green-dogs-hide.md
+++ b/.changeset/green-dogs-hide.md
@@ -2,4 +2,4 @@
 "@atproto/api": patch
 ---
 
-Add the `app.bsky.actor.contentVisibility` lexicon.
+Add the `app.bsky.actor.contentVisibilityDeclaration` lexicon.

--- a/lexicons/app/bsky/actor/contentVisibility.json
+++ b/lexicons/app/bsky/actor/contentVisibility.json
@@ -12,7 +12,7 @@
         "properties": {
           "hideFromAlgorithmicRecommendations": {
             "type": "boolean",
-            "description": "Whether the account requests that its posts be hidden from algorithmic recommendations. Absence of a record implies false."
+            "description": "Whether the account requests that its posts be hidden from algorithmic recommendations. Consumers must treat a missing record as false."
           }
         }
       }

--- a/lexicons/app/bsky/actor/contentVisibility.json
+++ b/lexicons/app/bsky/actor/contentVisibility.json
@@ -1,0 +1,21 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.actor.contentVisibility",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A declaration of an account's preferences for appearing in content discovery surfaces.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["hideFromAlgorithmicRecommendations"],
+        "properties": {
+          "hideFromAlgorithmicRecommendations": {
+            "type": "boolean",
+            "description": "Whether the account requests that its posts be hidden from algorithmic recommendations. Absence of a record implies false."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/actor/contentVisibilityDeclaration.json
+++ b/lexicons/app/bsky/actor/contentVisibilityDeclaration.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "app.bsky.actor.contentVisibility",
+  "id": "app.bsky.actor.contentVisibilityDeclaration",
   "defs": {
     "main": {
       "type": "record",


### PR DESCRIPTION
## Summary

Enable account-level visibility discovery opt-in.

- add the singleton `app.bsky.actor.contentVisibilityDeclaration/self` record
- define the required `hideFromAlgorithmicRecommendations` boolean
- document that an absent record implies `false`
- add an `@atproto/api` patch changeset