### PR TITLE
Fix pagination

### DIFF
--- a/.changeset/dull-states-spend.md
+++ b/.changeset/dull-states-spend.md
@@ -1,5 +1,0 @@
----
-'@atproto/bsky': patch
----
-
-Refill paginated AppView responses after filtering and omit dataplane cursors when no additional raw rows exist.

--- a/.changeset/dull-states-spend.md
+++ b/.changeset/dull-states-spend.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Refill paginated AppView responses after filtering and omit dataplane cursors when no additional raw rows exist.

--- a/.changeset/eighty-turkeys-guess.md
+++ b/.changeset/eighty-turkeys-guess.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Fix pagination behavior

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -13,6 +13,7 @@
     "**/.classpath",
     "**/.settings",
     "**/.claude/worktrees",
+    "../worktrees/atproto/**",
   ],
   "languages": {
     "JavaScript": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -13,7 +13,6 @@
     "**/.classpath",
     "**/.settings",
     "**/.claude/worktrees",
-    "../worktrees/atproto/**",
   ],
   "languages": {
     "JavaScript": {

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -12,7 +12,7 @@ import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getSuggestions = createPipeline(
@@ -33,10 +33,16 @@ export default function (server: Server, ctx: AppContext) {
           ? req.headers['x-bsky-topics'].join(',')
           : req.headers['x-bsky-topics'],
       })
-      const { resHeaders: resultHeaders, ...result } = await getSuggestions(
-        { ...params, hydrateCtx, headers },
-        ctx,
-      )
+      const { resHeaders: resultHeaders, ...result } = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getSuggestions(
+            { ...params, cursor, limit, hydrateCtx, headers },
+            ctx,
+          ),
+        items: (r) => r.actors,
+      })
       const suggestionsResHeaders = noUndefinedVals({
         'content-language': resultHeaders?.get('content-language'),
       })

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -17,7 +17,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders, resolveSearchV2Override } from '../../../util.js'
+import { fillPage, resHeaders, resolveSearchV2Override } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const searchActors = createPipeline(
@@ -44,14 +44,22 @@ export default function (server: Server, ctx: AppContext) {
           }),
         ),
       })
-      const results = await searchActors(
-        {
-          ...params,
-          hydrateCtx,
-          isV2Override: resolveSearchV2Override(req, ctx.cfg),
-        },
-        ctx,
-      )
+      const results = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          searchActors(
+            {
+              ...params,
+              cursor,
+              limit,
+              hydrateCtx,
+              isV2Override: resolveSearchV2Override(req, ctx.cfg),
+            },
+            ctx,
+          ),
+        items: (r) => r.actors,
+      })
       return {
         encoding: 'application/json',
         body: results,

--- a/packages/bsky/src/api/app/bsky/bookmark/getBookmarks.ts
+++ b/packages/bsky/src/api/app/bsky/bookmark/getBookmarks.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../pipeline.js'
 import type { BookmarkInfo } from '../../../../proto/bsky_pb.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getBookmarks = createPipeline(
@@ -34,7 +34,13 @@ export default function (server: Server, ctx: AppContext) {
         viewer,
       })
 
-      const result = await getBookmarks({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getBookmarks({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.bookmarks,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/contact/getMatches.ts
+++ b/packages/bsky/src/api/app/bsky/contact/getMatches.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../pipeline.js'
 import type { RolodexClient } from '../../../../rolodex.js'
 import type { Views } from '../../../../views/index.js'
+import { fillPage } from '../../../util.js'
 import { assertRolodexOrThrowUnimplemented, callRolodexClient } from './util.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -32,7 +33,13 @@ export default function (server: Server, ctx: AppContext) {
         viewer,
       })
 
-      const result = await getMatches({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getMatches({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.matches,
+      })
 
       return {
         encoding: 'application/json',
@@ -91,7 +98,7 @@ const presentation = (input: {
   const matches = mapDefined(skeleton.subjects, (did) =>
     ctx.views.profile(did, hydration),
   )
-  return { matches }
+  return { matches, cursor: skeleton.cursor }
 }
 
 type Context = {

--- a/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorFeeds.ts
@@ -12,7 +12,7 @@ import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline, noRules } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getActorFeeds = createPipeline(
@@ -27,7 +27,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await getActorFeeds({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getActorFeeds({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.feeds,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -14,7 +14,7 @@ import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getActorLikes = createPipeline(
@@ -30,7 +30,13 @@ export default function (server: Server, ctx: AppContext) {
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
-      const result = await getActorLikes({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getActorLikes({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.feed,
+      })
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -17,7 +17,7 @@ import { createPipeline } from '../../../../pipeline.js'
 import { FeedType } from '../../../../proto/bsky_pb.js'
 import { safePinnedPost, uriToDid } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getAuthorFeed = createPipeline(
@@ -39,7 +39,13 @@ export default function (server: Server, ctx: AppContext) {
         skipViewerBlocks,
       })
 
-      const result = await getAuthorFeed({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getAuthorFeed({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.feed,
+      })
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -32,7 +32,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { GetIdentityByDidResponse } from '../../../../proto/bsky_pb.js'
-import { BSKY_USER_AGENT, fillPage, resHeaders } from '../../../util.js'
+import { BSKY_USER_AGENT, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getFeed = createPipeline(
@@ -70,13 +70,9 @@ export default function (server: Server, ctx: AppContext) {
           : req.headers['x-bsky-topics'],
       })
       // @NOTE feed cursors should not be affected by appview swap
-      const result = await fillPage({
-        cursor: params.cursor,
-        limit: params.limit,
-        fetch: ({ cursor, limit }) =>
-          getFeed({ ...params, cursor, limit, hydrateCtx, headers }, ctx),
-        items: (r) => r.feed,
-      })
+      // Do not refill filtered pages. Overfetching from algorithmic feeds can
+      // advance their state and prevent omitted items from appearing later.
+      const result = await getFeed({ ...params, hydrateCtx, headers }, ctx)
       const {
         timerSkele,
         timerHydr,
@@ -322,8 +318,10 @@ const skeletonFromFeedGen = async (
     ...skele,
     resHeaders: contentLang ? { 'content-language': contentLang } : undefined,
     feedItems,
-    // Prevents loops if the custom feed echoes the input cursor back.
-    cursor: cursor === params.cursor ? undefined : cursor,
+    // An empty feed-generator page ends pagination even if it includes a cursor.
+    // Also prevent loops if the custom feed echoes the input cursor back.
+    cursor:
+      feedSkele.length === 0 || cursor === params.cursor ? undefined : cursor,
   }
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -32,7 +32,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { GetIdentityByDidResponse } from '../../../../proto/bsky_pb.js'
-import { BSKY_USER_AGENT, resHeaders } from '../../../util.js'
+import { BSKY_USER_AGENT, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getFeed = createPipeline(
@@ -70,16 +70,23 @@ export default function (server: Server, ctx: AppContext) {
           : req.headers['x-bsky-topics'],
       })
       // @NOTE feed cursors should not be affected by appview swap
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getFeed({ ...params, cursor, limit, hydrateCtx, headers }, ctx),
+        items: (r) => r.feed,
+      })
       const {
         timerSkele,
         timerHydr,
         resHeaders: feedResHeaders,
-        ...result
-      } = await getFeed({ ...params, hydrateCtx, headers }, ctx)
+        ...body
+      } = result
 
       return {
         encoding: 'application/json',
-        body: result,
+        body,
         headers: {
           ...feedResHeaders,
           ...resHeaders({ labelers: hydrateCtx.labelers }),

--- a/packages/bsky/src/api/app/bsky/feed/getLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getLikes.ts
@@ -17,7 +17,7 @@ import { app } from '../../../../lexicons/index.js'
 import { type RulesFnInput, createPipeline } from '../../../../pipeline.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getLikes = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -33,7 +33,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getLikes({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getLikes({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.likes,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -15,7 +15,7 @@ import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import { uriToDid } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getListFeed = createPipeline(
@@ -31,7 +31,13 @@ export default function (server: Server, ctx: AppContext) {
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
-      const result = await getListFeed({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getListFeed({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.feed,
+      })
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 

--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -12,7 +12,7 @@ import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import { uriToDid } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getQuotes = createPipeline(
@@ -33,7 +33,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getQuotes({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getQuotes({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.posts,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getRepostedBy.ts
@@ -12,7 +12,7 @@ import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getRepostedBy = createPipeline(
@@ -33,7 +33,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getRepostedBy({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getRepostedBy({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.repostedBy,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getSuggestedFeeds.ts
@@ -4,7 +4,7 @@ import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(app.bsky.feed.getSuggestedFeeds, {
@@ -12,26 +12,33 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-
-      // @NOTE no need to coordinate the cursor for appview swap, as v1 doesn't use the cursor
-      const suggestedRes = await ctx.dataplane.getSuggestedFeeds({
-        actorDid: viewer ?? undefined,
-        limit: params.limit,
-        cursor: params.cursor,
-      })
-      const uris = suggestedRes.uris as AtUriString[]
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const hydration = await ctx.hydrator.hydrateFeedGens(uris, hydrateCtx)
-      const feedViews = mapDefined(uris, (uri) =>
-        ctx.views.feedGenerator(uri, hydration),
-      )
+
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: async ({ cursor, limit }) => {
+          // @NOTE no need to coordinate the cursor for appview swap, as v1 doesn't use the cursor
+          const suggestedRes = await ctx.dataplane.getSuggestedFeeds({
+            actorDid: viewer ?? undefined,
+            cursor,
+            limit,
+          })
+          const uris = suggestedRes.uris as AtUriString[]
+          const hydration = await ctx.hydrator.hydrateFeedGens(uris, hydrateCtx)
+          return {
+            feeds: mapDefined(uris, (uri) =>
+              ctx.views.feedGenerator(uri, hydration),
+            ),
+            cursor: parseString(suggestedRes.cursor),
+          }
+        },
+        items: (r) => r.feeds,
+      })
 
       return {
         encoding: 'application/json',
-        body: {
-          feeds: feedViews,
-          cursor: parseString(suggestedRes.cursor),
-        },
+        body: result,
         headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -13,7 +13,7 @@ import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getTimeline = createPipeline(
@@ -34,7 +34,13 @@ export default function (server: Server, ctx: AppContext) {
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
 
-      const result = await getTimeline({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getTimeline({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.feed,
+      })
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -25,7 +25,7 @@ import {
 import { SearchSortOrder } from '../../../../proto/bsky_pb.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders, resolveSearchV2Override } from '../../../util.js'
+import { fillPage, resHeaders, resolveSearchV2Override } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const searchPosts = createPipeline(
@@ -52,15 +52,23 @@ export default function (server: Server, ctx: AppContext) {
           }),
         ),
       })
-      const results = await searchPosts(
-        {
-          ...params,
-          hydrateCtx,
-          isModService,
-          isV2Override: resolveSearchV2Override(req, ctx.cfg),
-        },
-        ctx,
-      )
+      const results = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          searchPosts(
+            {
+              ...params,
+              cursor,
+              limit,
+              hydrateCtx,
+              isModService,
+              isV2Override: resolveSearchV2Override(req, ctx.cfg),
+            },
+            ctx,
+          ),
+        items: (r) => r.posts,
+      })
       return {
         encoding: 'application/json',
         body: results,

--- a/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPostsV2.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../../proto/bsky_pb.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders, resolveSearchV2Override } from '../../../util.js'
+import { fillPage, resHeaders, resolveSearchV2Override } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const searchPostsV2 = createPipeline(
@@ -75,17 +75,26 @@ export default function (server: Server, ctx: AppContext) {
         throw new ForbiddenError('Request forbidden by administrative rules.')
       }
 
-      const results = await searchPostsV2(
-        {
-          ...params,
-          // Default to curated 'top' ranking when unset; the backend rejects an
-          // unspecified sort order.
-          sort: params.sort ?? 'top',
-          hydrateCtx,
-          isModService,
-        },
-        ctx,
-      )
+      const results = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        maxRequests: viewer ? undefined : 1,
+        fetch: ({ cursor, limit }) =>
+          searchPostsV2(
+            {
+              ...params,
+              cursor,
+              limit,
+              // Default to curated 'top' ranking when unset; the backend rejects an
+              // unspecified sort order.
+              sort: params.sort ?? 'top',
+              hydrateCtx,
+              isModService,
+            },
+            ctx,
+          ),
+        items: (r) => r.posts,
+      })
       return {
         encoding: 'application/json',
         body: results,

--- a/packages/bsky/src/api/app/bsky/graph/getActorStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getActorStarterPacks.ts
@@ -14,7 +14,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getActorStarterPacks = createPipeline(
@@ -35,7 +35,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getActorStarterPacks({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getActorStarterPacks({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.starterPacks,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getBlocks.ts
@@ -15,7 +15,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getBlocks = createPipeline(skeleton, hydration, noRules, presentation)
@@ -25,7 +25,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await getBlocks({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getBlocks({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.blocks,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollowers.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../pipeline.js'
 import { uriToDid as didFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getFollowers = createPipeline(
@@ -39,41 +39,30 @@ export default function (server: Server, ctx: AppContext) {
         skipViewerBlocks,
       })
 
-      const result = await getFollowers({ ...params, hydrateCtx }, ctx)
-      const followers = result.followers
-      let cursor = result.cursor
-      for (
-        let fetches = 1;
-        fetches < MAX_PAGE_FILL_FETCHES &&
-        cursor &&
-        followers.length < params.limit;
-        fetches++
-      ) {
-        const previousCursor = cursor
-        const page = await getFollowers(
-          {
-            ...params,
-            cursor,
-            limit: params.limit - followers.length,
-            hydrateCtx,
-          },
-          ctx,
-        )
-        followers.push(...page.followers)
-        cursor = page.cursor
-        if (cursor === previousCursor) break
-      }
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getFollowers(
+            {
+              ...params,
+              cursor,
+              limit,
+              hydrateCtx,
+            },
+            ctx,
+          ),
+        items: (r) => r.followers,
+      })
 
       return {
         encoding: 'application/json',
-        body: { ...result, followers, cursor },
+        body: result,
         headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },
   })
 }
-
-const MAX_PAGE_FILL_FETCHES = 10
 
 const skeleton = async (
   input: SkeletonFnInput<Context, Params>,

--- a/packages/bsky/src/api/app/bsky/graph/getFollows.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getFollows.ts
@@ -16,7 +16,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getFollows = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -34,7 +34,13 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       // @TODO ensure canViewTakedowns gets threaded through and applied properly
-      const result = await getFollows({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getFollows({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.follows,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -19,7 +19,7 @@ import {
 import type { ListItemInfo } from '../../../../proto/bsky_pb.js'
 import { uriToDid as didFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getList = createPipeline(skeleton, hydration, noBlocks, presentation)
@@ -36,7 +36,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getList({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getList({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.items,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListBlocks.ts
@@ -15,7 +15,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getListBlocks = createPipeline(
@@ -30,7 +30,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await getListBlocks({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getListBlocks({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.lists,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListMutes.ts
@@ -15,7 +15,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getListMutes = createPipeline(
@@ -30,7 +30,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await getListMutes({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getListMutes({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.lists,
+      })
       return {
         encoding: 'application/json',
         body: result,

--- a/packages/bsky/src/api/app/bsky/graph/getLists.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getLists.ts
@@ -13,7 +13,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 const CURATELIST = app.bsky.graph.defs.curatelist.value
 const MODLIST = app.bsky.graph.defs.modlist.value
@@ -37,7 +37,13 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
-      const result = await getLists({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getLists({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.lists,
+      })
 
       return {
         encoding: 'application/json',
@@ -90,8 +96,8 @@ const filterPurposes = (
   if (purposes.includes('curatelist')) acceptedPurposes.add(CURATELIST)
   if (purposes.includes(CURATELIST)) acceptedPurposes.add(CURATELIST)
 
-  // @NOTE: While we don't support filtering on the dataplane, this might result in empty pages.
-  // Despite the empty pages, the pagination still can enumerate all items for the specified filters.
+  // Purpose filtering happens after dataplane pagination. fillPage requests
+  // subsequent dataplane pages to replace lists filtered out here.
   skeleton.listUris = skeleton.listUris.filter((uri) => {
     const list = hydration.lists?.get(uri)
     return acceptedPurposes.has(list?.record.purpose)

--- a/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getListsWithMembership.ts
@@ -16,7 +16,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 const CURATELIST = app.bsky.graph.defs.curatelist.value
 const MODLIST = app.bsky.graph.defs.modlist.value
@@ -37,10 +37,13 @@ export default function (server: Server, ctx: AppContext) {
         labelers,
         viewer,
       })
-      const result = await getListsWithMembership(
-        { ...params, hydrateCtx },
-        ctx,
-      )
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getListsWithMembership({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.listsWithMembership,
+      })
 
       return {
         encoding: 'application/json',
@@ -98,8 +101,8 @@ const filterPurposes = (
   if (purposes.includes('curatelist')) acceptedPurposes.add(CURATELIST)
   if (purposes.includes(CURATELIST)) acceptedPurposes.add(CURATELIST)
 
-  // @NOTE: While we don't support filtering on the dataplane, this might result in empty pages.
-  // Despite the empty pages, the pagination still can enumerate all items for the specified filters.
+  // Purpose filtering happens after dataplane pagination. fillPage requests
+  // subsequent dataplane pages to replace lists filtered out here.
   skeleton.listUris = skeleton.listUris.filter((uri) => {
     const list = hydration.lists?.get(uri)
     return acceptedPurposes.has(list?.record.purpose)

--- a/packages/bsky/src/api/app/bsky/graph/getMutes.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getMutes.ts
@@ -15,7 +15,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getMutes = createPipeline(skeleton, hydration, noRules, presentation)
@@ -25,7 +25,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await getMutes({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getMutes({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.mutes,
+      })
       return {
         encoding: 'application/json',
         body: result,
@@ -35,12 +41,6 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-// Bounds dataplane round trips per request when filling pages. A page can
-// only run short when it contains scoped mutes, so this is only reached by
-// viewers with many consecutive scoped mutes; the client just paginates
-// again from the returned cursor.
-const MAX_PAGE_FILL_FETCHES = 10
-
 const skeleton = async (
   input: SkeletonFnInput<Context, Params>,
 ): Promise<SkeletonState> => {
@@ -48,29 +48,23 @@ const skeleton = async (
   if (clearlyBadCursor(params.cursor)) {
     return { mutedDids: [] }
   }
+  const res = await ctx.hydrator.dataplane.getMutes({
+    actorDid: params.hydrateCtx.viewer,
+    cursor: params.cursor,
+    limit: params.limit,
+  })
+
   // only fully muted accounts are enumerated: scoped mutes (only reposts /
-  // only quoteposts) are filtered out. Since scoped entries still consume
-  // cursor range, keep fetching until the page holds at least `limit` full
-  // mutes. Whole dataplane pages are appended, so the response may exceed
-  // `limit`; this keeps the returned cursor a plain dataplane cursor.
-  const mutedDids: DidString[] = []
-  let cursor = params.cursor
-  for (let i = 0; i < MAX_PAGE_FILL_FETCHES; i++) {
-    const res = await ctx.hydrator.dataplane.getMutes({
-      actorDid: params.hydrateCtx.viewer,
-      cursor,
-      limit: params.limit,
-    })
-    const fullMuteDids = res.mutes.length
-      ? res.mutes
-          .filter((mute) => !mute.onlyReposts && !mute.onlyQuoteposts)
-          .map((mute) => mute.did)
-      : res.dids
-    mutedDids.push(...(fullMuteDids as DidString[]))
-    cursor = res.cursor || undefined
-    if (!cursor || mutedDids.length >= params.limit) break
+  // only quoteposts) are filtered out.
+  const mutedDids = res.mutes.length
+    ? res.mutes
+        .filter((mute) => !mute.onlyReposts && !mute.onlyQuoteposts)
+        .map((mute) => mute.did)
+    : res.dids
+  return {
+    mutedDids: mutedDids as DidString[],
+    cursor: res.cursor || undefined,
   }
-  return { mutedDids, cursor }
 }
 
 const hydration = async (

--- a/packages/bsky/src/api/app/bsky/graph/getStarterPacksWithMembership.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getStarterPacksWithMembership.ts
@@ -16,7 +16,7 @@ import {
   noRules,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const getStarterPacksWithMembership = createPipeline(
@@ -34,10 +34,16 @@ export default function (server: Server, ctx: AppContext) {
         labelers,
         viewer,
       })
-      const result = await getStarterPacksWithMembership(
-        { ...params, hydrateCtx },
-        ctx,
-      )
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          getStarterPacksWithMembership(
+            { ...params, cursor, limit, hydrateCtx },
+            ctx,
+          ),
+        items: (r) => r.starterPacksWithMembership,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../pipeline.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders, resolveSearchV2Override } from '../../../util.js'
+import { fillPage, resHeaders, resolveSearchV2Override } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const searchStarterPacks = createPipeline(
@@ -45,14 +45,22 @@ export default function (server: Server, ctx: AppContext) {
           }),
         ),
       })
-      const results = await searchStarterPacks(
-        {
-          ...params,
-          hydrateCtx,
-          isV2Override: resolveSearchV2Override(req, ctx.cfg),
-        },
-        ctx,
-      )
+      const results = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          searchStarterPacks(
+            {
+              ...params,
+              cursor,
+              limit,
+              hydrateCtx,
+              isV2Override: resolveSearchV2Override(req, ctx.cfg),
+            },
+            ctx,
+          ),
+        items: (r) => r.starterPacks,
+      })
       return {
         encoding: 'application/json',
         body: results,

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacksV2.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacksV2.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../pipeline.js'
 import { uriToDid as creatorFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const searchStarterPacksV2 = createPipeline(
@@ -46,7 +46,13 @@ export default function (server: Server, ctx: AppContext) {
         ),
       })
 
-      const results = await searchStarterPacksV2({ ...params, hydrateCtx }, ctx)
+      const results = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          searchStarterPacksV2({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.starterPacks,
+      })
       return {
         encoding: 'application/json',
         body: results,

--- a/packages/bsky/src/api/app/bsky/notification/listActivitySubscriptions.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listActivitySubscriptions.ts
@@ -15,7 +15,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { Views } from '../../../../views/index.js'
-import { clearlyBadCursor, resHeaders } from '../../../util.js'
+import { clearlyBadCursor, fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const listActivitySubscriptions = createPipeline(
@@ -34,10 +34,16 @@ export default function (server: Server, ctx: AppContext) {
         viewer,
       })
 
-      const result = await listActivitySubscriptions(
-        { ...params, hydrateCtx },
-        ctx,
-      )
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          listActivitySubscriptions(
+            { ...params, cursor, limit, hydrateCtx },
+            ctx,
+          ),
+        items: (r) => r.subscriptions,
+      })
 
       return {
         encoding: 'application/json',

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -19,7 +19,7 @@ import type { Notification } from '../../../../proto/bsky_pb.js'
 import { uriToDid as didFromUri } from '../../../../util/uris.js'
 import type { Views } from '../../../../views/index.js'
 import { isPostRecordType } from '../../../../views/types.js'
-import { resHeaders } from '../../../util.js'
+import { fillPage, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
   const listNotifications = createPipeline(
@@ -34,7 +34,13 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await listNotifications({ ...params, hydrateCtx }, ctx)
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: ({ cursor, limit }) =>
+          listNotifications({ ...params, cursor, limit, hydrateCtx }, ctx),
+        items: (r) => r.notifications,
+      })
       return {
         encoding: 'application/json',
         body: result,
@@ -54,43 +60,17 @@ const paginateNotifications = async (opts: {
 }) => {
   const { ctx, priority, reasons, limit, viewer } = opts
 
-  // if not filtering, then just pass through the response from dataplane
-  if (!reasons) {
-    const res = await ctx.hydrator.dataplane.getNotifications({
-      actorDid: viewer,
-      priority,
-      cursor: opts.cursor,
-      limit,
-    })
-    return {
-      notifications: res.notifications,
-      cursor: res.cursor,
-    }
-  }
-
-  let nextCursor: string | undefined = opts.cursor
-  let toReturn: Notification[] = []
-  const maxAttempts = 10
-  const attemptSize = Math.ceil(limit / 2)
-  for (let i = 0; i < maxAttempts; i++) {
-    const res = await ctx.hydrator.dataplane.getNotifications({
-      actorDid: viewer,
-      priority,
-      cursor: nextCursor,
-      limit,
-    })
-    const filtered = res.notifications.filter((notif) =>
-      reasons.includes(notif.reason),
-    )
-    toReturn = [...toReturn, ...filtered]
-    nextCursor = res.cursor ?? undefined
-    if (toReturn.length >= attemptSize || !nextCursor) {
-      break
-    }
-  }
+  const res = await ctx.hydrator.dataplane.getNotifications({
+    actorDid: viewer,
+    priority,
+    cursor: opts.cursor,
+    limit,
+  })
   return {
-    notifications: toReturn,
-    cursor: nextCursor,
+    notifications: reasons
+      ? res.notifications.filter((notif) => reasons.includes(notif.reason))
+      : res.notifications,
+    cursor: res.cursor,
   }
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -7,6 +7,7 @@ import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import {
   clearlyBadCursor,
+  fillPage,
   resHeaders,
   resolveSearchV2Override,
 } from '../../../util.js'
@@ -39,57 +40,60 @@ export default function (server: Server, ctx: AppContext) {
         }
       }
 
-      let uris: AtUriString[]
-      let cursor: string | undefined
-
       const isV2Override = resolveSearchV2Override(req, ctx.cfg)
 
       const query = params.query?.trim() ?? ''
-      if (query) {
-        const useV2 =
-          features.checkGate(features.Gate.SearchV2Enable) || isV2Override
-        // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
-        if (useV2) {
-          const res = await ctx.dataplane
-            .searchFeedGeneratorsV2({
-              params: {
-                query,
-                viewer: viewer ?? undefined,
-                limit: params.limit,
-              },
+      const result = await fillPage({
+        cursor: params.cursor,
+        limit: params.limit,
+        fetch: async ({ cursor, limit }) => {
+          let uris: AtUriString[]
+          let nextCursor: string | undefined
+          if (query) {
+            const useV2 =
+              features.checkGate(features.Gate.SearchV2Enable) || isV2Override
+            // Surface dataplane InvalidArgument errors as a 400 rather than a 500.
+            if (useV2) {
+              const res = await ctx.dataplane
+                .searchFeedGeneratorsV2({
+                  params: {
+                    query,
+                    viewer: viewer ?? undefined,
+                    limit,
+                  },
+                })
+                .catch(asInvalidRequest())
+              uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
+            } else {
+              const res = await ctx.dataplane
+                .searchFeedGenerators({ query, limit })
+                .catch(asInvalidRequest())
+              uris = res.uris as AtUriString[]
+            }
+          } else {
+            const res = await ctx.dataplane.getSuggestedFeeds({
+              actorDid: viewer ?? undefined,
+              cursor,
+              limit,
             })
-            .catch(asInvalidRequest())
-          uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
-        } else {
-          const res = await ctx.dataplane
-            .searchFeedGenerators({
-              query,
-              limit: params.limit,
-            })
-            .catch(asInvalidRequest())
-          uris = res.uris as AtUriString[]
-        }
-      } else {
-        const res = await ctx.dataplane.getSuggestedFeeds({
-          actorDid: viewer ?? undefined,
-          limit: params.limit,
-          cursor: params.cursor,
-        })
-        uris = res.uris as AtUriString[]
-        cursor = parseString(res.cursor)
-      }
+            uris = res.uris as AtUriString[]
+            nextCursor = parseString(res.cursor)
+          }
 
-      const hydration = await ctx.hydrator.hydrateFeedGens(uris, hydrateCtx)
-      const feedViews = mapDefined(uris, (uri) =>
-        ctx.views.feedGenerator(uri, hydration),
-      )
+          const hydration = await ctx.hydrator.hydrateFeedGens(uris, hydrateCtx)
+          return {
+            feeds: mapDefined(uris, (uri) =>
+              ctx.views.feedGenerator(uri, hydration),
+            ),
+            cursor: nextCursor,
+          }
+        },
+        items: (r) => r.feeds,
+      })
 
       return {
         encoding: 'application/json',
-        body: {
-          feeds: feedViews,
-          cursor,
-        },
+        body: result,
         headers: resHeaders({ labelers: hydrateCtx.labelers }),
       }
     },

--- a/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPopularFeedGenerators.ts
@@ -59,11 +59,13 @@ export default function (server: Server, ctx: AppContext) {
                   params: {
                     query,
                     viewer: viewer ?? undefined,
+                    cursor,
                     limit,
                   },
                 })
                 .catch(asInvalidRequest())
               uris = res.feedGenerators.map(({ uri }) => uri) as AtUriString[]
+              nextCursor = parseString(res.pageInfo?.cursor)
             } else {
               const res = await ctx.dataplane
                 .searchFeedGenerators({ query, limit })

--- a/packages/bsky/src/api/util.test.ts
+++ b/packages/bsky/src/api/util.test.ts
@@ -69,7 +69,7 @@ describe('fillPage', () => {
 
     await expect(
       fillPage({ cursor: undefined, limit: 1, fetch, items: (r) => r.items }),
-    ).resolves.toEqual({ items: [], cursor: 'a' })
+    ).resolves.toEqual({ items: [], cursor: undefined })
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/bsky/src/api/util.test.ts
+++ b/packages/bsky/src/api/util.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fillPage } from './util.js'
+
+describe('fillPage', () => {
+  it('returns a terminal short page without refilling', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue({ items: [1], cursor: undefined, metadata: 'first' })
+
+    await expect(
+      fillPage({ cursor: undefined, limit: 3, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [1], cursor: undefined, metadata: 'first' })
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith({ cursor: undefined, limit: 3 })
+  })
+
+  it('fills across filtered and empty pages', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [1], cursor: 'a', metadata: 'first' })
+      .mockResolvedValueOnce({ items: [], cursor: 'b' })
+      .mockResolvedValueOnce({ items: [2, 3], cursor: 'c' })
+
+    await expect(
+      fillPage({ cursor: 'start', limit: 3, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [1, 2, 3], cursor: 'c', metadata: 'first' })
+    expect(fetch).toHaveBeenNthCalledWith(1, { cursor: 'start', limit: 3 })
+    expect(fetch).toHaveBeenNthCalledWith(2, { cursor: 'a', limit: 2 })
+    expect(fetch).toHaveBeenNthCalledWith(3, { cursor: 'b', limit: 2 })
+  })
+
+  it('preserves the cursor when the request bound is reached', async () => {
+    const fetch = vi.fn(async ({ cursor }: { cursor?: string }) => ({
+      items: [],
+      cursor: `${cursor ?? ''}x`,
+    }))
+
+    const result = await fillPage({
+      cursor: 'a',
+      limit: 1,
+      fetch,
+      items: (r) => r.items,
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(10)
+    expect(result).toEqual({ items: [], cursor: 'axxxxxxxxxx' })
+  })
+
+  it('accepts a custom request bound', async () => {
+    const fetch = vi.fn(async ({ cursor }: { cursor?: string }) => ({
+      items: [],
+      cursor: `${cursor ?? ''}x`,
+    }))
+
+    const result = await fillPage({
+      cursor: 'a',
+      limit: 1,
+      maxRequests: 2,
+      fetch,
+      items: (r) => r.items,
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({ items: [], cursor: 'axx' })
+  })
+
+  it('stops on a repeated cursor', async () => {
+    const fetch = vi.fn().mockResolvedValue({ items: [], cursor: 'a' })
+
+    await expect(
+      fillPage({ cursor: undefined, limit: 1, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [], cursor: 'a' })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -29,6 +29,47 @@ export const clearlyBadCursor = (cursor?: string) => {
   return !!cursor?.includes('::')
 }
 
+const DEFAULT_FILL_PAGE_MAX_REQUESTS = 10
+
+type PageFetch<R extends { cursor?: string }> = (params: {
+  cursor?: string
+  limit: number
+}) => Promise<R>
+
+export const fillPage = async <
+  F extends PageFetch<{ cursor?: string }>,
+  T,
+>(opts: {
+  cursor?: string
+  limit: number
+  maxRequests?: number
+  fetch: F
+  items: (result: Awaited<ReturnType<F>>) => T[]
+}): Promise<Awaited<ReturnType<F>>> => {
+  const maxRequests = opts.maxRequests ?? DEFAULT_FILL_PAGE_MAX_REQUESTS
+  const result = (await opts.fetch({
+    cursor: opts.cursor,
+    limit: opts.limit,
+  })) as Awaited<ReturnType<F>>
+  const items = opts.items(result)
+  let cursor = result.cursor
+  for (
+    let requests = 1;
+    requests < maxRequests && cursor && items.length < opts.limit;
+    requests++
+  ) {
+    const previousCursor = cursor
+    const page = (await opts.fetch({
+      cursor,
+      limit: opts.limit - items.length,
+    })) as Awaited<ReturnType<F>>
+    items.push(...opts.items(page))
+    cursor = page.cursor
+    if (!cursor || cursor === previousCursor) break
+  }
+  return { ...result, cursor } as Awaited<ReturnType<F>>
+}
+
 // @TEMPORARY backdoor to force search v2 via a request header, gated by the
 // BSKY_SEARCH_V2_OVERRIDE_HEADER env var. Remove once search v2 is fully rolled out.
 const SEARCH_V2_OVERRIDE_HEADER = 'x-bsky-search-v2-override'

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -65,7 +65,11 @@ export const fillPage = async <
     })) as Awaited<ReturnType<F>>
     items.push(...opts.items(page))
     cursor = page.cursor
-    if (!cursor || cursor === previousCursor) break
+    if (cursor === previousCursor) {
+      cursor = undefined
+      break
+    }
+    if (!cursor) break
   }
   return { ...result, cursor } as Awaited<ReturnType<F>>
 }

--- a/packages/bsky/src/data-plane/server/db/pagination.test.ts
+++ b/packages/bsky/src/data-plane/server/db/pagination.test.ts
@@ -1,0 +1,80 @@
+import { sql } from 'kysely'
+import { describe, expect, it } from 'vitest'
+import { GenericKeyset, GenericSingleKey } from './pagination.js'
+
+type Row = { primary: string; secondary: string }
+
+class TestKeyset extends GenericKeyset<Row, Row> {
+  labelResult(result: Row) {
+    return result
+  }
+  labeledResultToCursor(labeled: Row) {
+    return labeled
+  }
+  cursorToLabeledResult(cursor: Row) {
+    return cursor
+  }
+}
+
+class TestSingleKey extends GenericSingleKey<
+  { primary: string },
+  { primary: string }
+> {
+  labelResult(result: { primary: string }) {
+    return result
+  }
+  labeledResultToCursor(labeled: { primary: string }) {
+    return labeled
+  }
+  cursorToLabeledResult(cursor: { primary: string }) {
+    return cursor
+  }
+}
+
+const cases: [
+  string,
+  (length: number) => { items: unknown[]; cursor?: string },
+][] = [
+  [
+    'keyset',
+    (length) =>
+      new TestKeyset(sql.ref('primary'), sql.ref('secondary')).page(
+        makeKeysetRows(length),
+        3,
+      ),
+  ],
+  [
+    'single key',
+    (length) =>
+      new TestSingleKey(sql.ref('primary')).page(makeSingleKeyRows(length), 3),
+  ],
+]
+
+describe.each(cases)('%s page', (_, pageRows) => {
+  it.each([
+    ['empty', 0, undefined],
+    ['short terminal', 2, undefined],
+    ['exact-limit terminal', 3, undefined],
+    ['nonterminal', 4, '2'],
+  ] as const)('%s page', (_, rowCount, expectedCursorPart) => {
+    const page = pageRows(rowCount)
+
+    expect(page.items).toHaveLength(Math.min(rowCount, 3))
+    if (expectedCursorPart === undefined) {
+      expect(page.cursor).toBeUndefined()
+    } else {
+      expect(page.cursor).toContain(expectedCursorPart)
+    }
+  })
+})
+
+function makeKeysetRows(length: number): Row[] {
+  return Array.from({ length }, (_, i) => ({
+    primary: `${i}`,
+    secondary: `${i}`,
+  }))
+}
+
+function makeSingleKeyRows(length: number): { primary: string }[] {
+  return Array.from({ length }, (_, i) => ({ primary: `${i}` }))
+}

--- a/packages/bsky/src/data-plane/server/db/pagination.ts
+++ b/packages/bsky/src/data-plane/server/db/pagination.ts
@@ -36,6 +36,19 @@ export abstract class GenericKeyset<R, LR extends KeysetLabeledResult> {
     if (!result) return
     return this.pack(this.labelResult(result))
   }
+  page<Result extends R>(
+    results: Result[],
+    limit: number,
+  ): { items: Result[]; cursor?: string } {
+    const items = results.slice(0, limit)
+    return {
+      items,
+      cursor:
+        results.length > limit && items.length
+          ? this.packFromResult(items[items.length - 1])
+          : undefined,
+    }
+  }
   pack(labeled?: LR): string | undefined {
     if (!labeled) return
     const cursor = this.labeledResultToCursor(labeled)
@@ -94,7 +107,7 @@ export abstract class GenericKeyset<R, LR extends KeysetLabeledResult> {
     const { limit, cursor, direction = 'desc', tryIndex, nullsLast } = opts
     const keysetSql = this.getSql(this.unpack(cursor), direction, tryIndex)
     return qb
-      .$if(!!limit, (q) => q.limit(limit as number))
+      .$if(!!limit, (q) => q.limit((limit as number) + 1))
       .$if(!nullsLast, (q) =>
         q.orderBy(this.primary, direction).orderBy(this.secondary, direction),
       )
@@ -203,6 +216,19 @@ export abstract class GenericSingleKey<R, LR extends SingleKeyLabeledResult> {
     if (!result) return
     return this.pack(this.labelResult(result))
   }
+  page<Result extends R>(
+    results: Result[],
+    limit: number,
+  ): { items: Result[]; cursor?: string } {
+    const items = results.slice(0, limit)
+    return {
+      items,
+      cursor:
+        results.length > limit && items.length
+          ? this.packFromResult(items[items.length - 1])
+          : undefined,
+    }
+  }
   pack(labeled?: LR): string | undefined {
     if (!labeled) return
     const cursor = this.labeledResultToCursor(labeled)
@@ -248,7 +274,7 @@ export abstract class GenericSingleKey<R, LR extends SingleKeyLabeledResult> {
     const { limit, cursor, direction = 'desc', nullsLast } = opts
     const keySql = this.getSql(this.unpack(cursor), direction)
     return qb
-      .$if(!!limit, (q) => q.limit(limit as number))
+      .$if(!!limit, (q) => q.limit((limit as number) + 1))
       .$if(!nullsLast, (q) => q.orderBy(this.primary, direction))
       .$if(!!nullsLast, (q) =>
         q.orderBy(

--- a/packages/bsky/src/data-plane/server/routes/activity-subscription.ts
+++ b/packages/bsky/src/data-plane/server/routes/activity-subscription.ts
@@ -74,11 +74,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor,
       limit,
     })
-    const res = await builder.execute()
-    const dids = res.map(({ subjectDid }) => subjectDid)
+    const page = key.page(await builder.execute(), limit)
+    const dids = page.items.map(({ subjectDid }) => subjectDid)
     return {
       dids,
-      cursor: key.packFromResult(res),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/blocks.ts
+++ b/packages/bsky/src/data-plane/server/routes/blocks.ts
@@ -48,10 +48,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const blocks = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
     return {
-      blockUris: blocks.map((b) => b.uri),
-      cursor: keyset.packFromResult(blocks),
+      blockUris: page.items.map((b) => b.uri),
+      cursor: page.cursor,
     }
   },
 
@@ -117,11 +117,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor,
       keyset,
     })
-    const lists = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      listUris: lists.map((l) => l.uri),
-      cursor: keyset.packFromResult(lists),
+      listUris: page.items.map((l) => l.uri),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/bookmarks.ts
+++ b/packages/bsky/src/data-plane/server/routes/bookmarks.ts
@@ -26,13 +26,13 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       limit,
     })
 
-    const res = await builder.execute()
+    const page = key.page(await builder.execute(), limit)
     return {
-      bookmarks: res.map((b) => ({
+      bookmarks: page.items.map((b) => ({
         key: b.key,
         subject: b.subjectUri,
       })),
-      cursor: key.packFromResult(res),
+      cursor: page.cursor,
     }
   },
 

--- a/packages/bsky/src/data-plane/server/routes/drafts.ts
+++ b/packages/bsky/src/data-plane/server/routes/drafts.ts
@@ -21,15 +21,15 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       limit,
     })
 
-    const res = await builder.execute()
+    const page = key.page(await builder.execute(), limit)
     return {
-      drafts: res.map((d): PlainMessage<DraftInfo> => ({
+      drafts: page.items.map((d): PlainMessage<DraftInfo> => ({
         key: d.key,
         payload: Buffer.from(d.payload),
         createdAt: Timestamp.fromDate(new Date(d.createdAt)),
         updatedAt: Timestamp.fromDate(new Date(d.updatedAt)),
       })),
-      cursor: key.packFromResult(res),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/feed-gens.ts
+++ b/packages/bsky/src/data-plane/server/routes/feed-gens.ts
@@ -55,6 +55,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       db,
       req.params?.query ?? '',
       req.params?.limit ?? 25,
+      req.params?.cursor,
     )
     return {
       feedGenerators: uris.map((uri) => ({ uri, score: 0 })),
@@ -71,6 +72,7 @@ const searchFeedGeneratorsImpl = async (
   db: Database,
   query: string,
   limit: number,
+  cursor?: string,
 ) => {
   const { ref } = db.db.dynamic
   const trimmed = query.trim()
@@ -82,7 +84,7 @@ const searchFeedGeneratorsImpl = async (
     ref('feed_generator.createdAt'),
     ref('feed_generator.cid'),
   )
-  builder = paginate(builder, { limit, keyset })
+  builder = paginate(builder, { limit, cursor, keyset })
   const page = keyset.page(await builder.execute(), limit)
   return {
     uris: page.items.map((f) => f.uri),

--- a/packages/bsky/src/data-plane/server/routes/feed-gens.ts
+++ b/packages/bsky/src/data-plane/server/routes/feed-gens.ts
@@ -22,11 +22,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor,
       keyset,
     })
-    const feeds = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: feeds.map((f) => f.uri),
-      cursor: keyset.packFromResult(feeds),
+      uris: page.items.map((f) => f.uri),
+      cursor: page.cursor,
     }
   },
 
@@ -35,12 +35,14 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .selectFrom('suggested_feed')
       .orderBy('suggested_feed.order', 'asc')
       .$if(!!req.cursor, (q) => q.where('order', '>', parseInt(req.cursor, 10)))
-      .limit(req.limit || 50)
+      .limit((req.limit || 50) + 1)
       .selectAll()
       .execute()
+    const limit = req.limit || 50
+    const items = feeds.slice(0, limit)
     return {
-      uris: feeds.map((f) => f.uri),
-      cursor: feeds.at(-1)?.order.toString(),
+      uris: items.map((f) => f.uri),
+      cursor: feeds.length > limit ? items.at(-1)?.order.toString() : undefined,
     }
   },
 
@@ -81,9 +83,9 @@ const searchFeedGeneratorsImpl = async (
     ref('feed_generator.cid'),
   )
   builder = paginate(builder, { limit, keyset })
-  const feeds = await builder.execute()
+  const page = keyset.page(await builder.execute(), limit)
   return {
-    uris: feeds.map((f) => f.uri),
-    cursor: keyset.packFromResult(feeds),
+    uris: page.items.map((f) => f.uri),
+    cursor: page.cursor,
   }
 }

--- a/packages/bsky/src/data-plane/server/routes/feeds.ts
+++ b/packages/bsky/src/data-plane/server/routes/feeds.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import type { ServiceImpl } from '@connectrpc/connect'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { FeedType } from '../../../proto/bsky_pb.js'
@@ -79,11 +80,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const feedItems = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      items: feedItems.map(feedItemFromRow),
-      cursor: keyset.packFromResult(feedItems),
+      items: page.items.map(feedItemFromRow),
+      cursor: page.cursor,
     }
   },
 
@@ -115,7 +116,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .selectAll('feed_item')
 
     selfQb = paginate(selfQb, {
-      limit: Math.min(limit, 10),
+      limit,
       cursor,
       keyset,
       tryIndex: true,
@@ -126,18 +127,44 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       selfQb.execute(),
     ])
 
-    const feedItems = [...followRes, ...selfRes]
-      .sort((a, b) => {
-        if (a.sortAt > b.sortAt) return -1
-        if (a.sortAt < b.sortAt) return 1
-        return a.cid > b.cid ? -1 : 1
-      })
-      .slice(0, limit)
+    // Use own posts to fill space left by followed-account posts. When followed-account
+    // posts already fill the page, still allow up to 10 own posts into the merged results.
+    const selfLimit = Math.max(
+      // Allow up to 10 own posts even when followed-account posts can fill the page.
+      Math.min(limit, 10),
+      // Allow enough own posts to fill the slots not occupied by followed-account posts.
+      limit - Math.min(followRes.length, limit),
+    )
 
-    return {
-      items: feedItems.map(feedItemFromRow),
-      cursor: keyset.packFromResult(feedItems),
+    // The extra own post proves that another page exists, but is not part of this page.
+    const selfHasMore = selfRes.length > selfLimit
+
+    const selfItems = selfRes.slice(0, selfLimit)
+    const feedItems = [...followRes, ...selfItems].sort((a, b) => {
+      if (a.sortAt > b.sortAt) return -1
+      if (a.sortAt < b.sortAt) return 1
+      return a.cid > b.cid ? -1 : 1
+    })
+
+    const page = keyset.page(feedItems, limit)
+    if (page.items.length === 0) {
+      return { items: [], cursor: undefined }
     }
+    const items = page.items.map(feedItemFromRow)
+
+    // The combined results exceeded the requested limit.
+    if (page.cursor) {
+      return { items, cursor: page.cursor }
+    }
+
+    // Own posts exceeded their separate cap, but the combined results did not exceed the requested limit.
+    if (selfHasMore) {
+      const lastItem = page.items.at(-1)
+      assert(lastItem)
+      return { items, cursor: keyset.packFromResult(lastItem) }
+    }
+
+    return { items, cursor: undefined }
   },
 
   async getListFeed(req) {
@@ -157,11 +184,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
       tryIndex: true,
     })
-    const feedItems = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      items: feedItems.map((item) => ({ uri: item.uri, cid: item.cid })),
-      cursor: keyset.packFromResult(feedItems),
+      items: page.items.map((item) => ({ uri: item.uri, cid: item.cid })),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/follows.ts
+++ b/packages/bsky/src/data-plane/server/routes/follows.ts
@@ -47,14 +47,14 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       tryIndex: true,
     })
 
-    const followers = await followersReq.execute()
+    const page = keyset.page(await followersReq.execute(), limit)
     return {
-      followers: followers.map((f) => ({
+      followers: page.items.map((f) => ({
         uri: f.uri,
         actorDid: f.creatorDid,
         subjectDid: f.subjectDid,
       })),
-      cursor: keyset.packFromResult(followers),
+      cursor: page.cursor,
     }
   },
   async getFollows(req) {
@@ -82,15 +82,15 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       tryIndex: true,
     })
 
-    const follows = await followsReq.execute()
+    const page = keyset.page(await followsReq.execute(), limit)
 
     return {
-      follows: follows.map((f) => ({
+      follows: page.items.map((f) => ({
         uri: f.uri,
         actorDid: f.creatorDid,
         subjectDid: f.subjectDid,
       })),
-      cursor: keyset.packFromResult(follows),
+      cursor: page.cursor,
     }
   },
 

--- a/packages/bsky/src/data-plane/server/routes/likes.ts
+++ b/packages/bsky/src/data-plane/server/routes/likes.ts
@@ -27,11 +27,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const likes = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: likes.map((l) => l.uri),
-      cursor: keyset.packFromResult(likes),
+      uris: page.items.map((l) => l.uri),
+      cursor: page.cursor,
     }
   },
 
@@ -79,14 +79,14 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const likes = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      likes: likes.map((l) => ({
+      likes: page.items.map((l) => ({
         uri: l.uri,
         subject: l.subject,
       })),
-      cursor: keyset.packFromResult(likes),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/lists.ts
+++ b/packages/bsky/src/data-plane/server/routes/lists.ts
@@ -20,10 +20,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
       tryIndex: true,
     })
-    const lists = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
     return {
-      listUris: lists.map((item) => item.uri),
-      cursor: keyset.packFromResult(lists),
+      listUris: page.items.map((item) => item.uri),
+      cursor: page.cursor,
     }
   },
 
@@ -47,13 +47,13 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       tryIndex: true,
     })
 
-    const listItems = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
     return {
-      listitems: listItems.map((item) => ({
+      listitems: page.items.map((item) => ({
         uri: item.uri,
         did: item.subjectDid,
       })),
-      cursor: keyset.packFromResult(listItems),
+      cursor: page.cursor,
     }
   },
 

--- a/packages/bsky/src/data-plane/server/routes/mutes.ts
+++ b/packages/bsky/src/data-plane/server/routes/mutes.ts
@@ -50,16 +50,16 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const mutes = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      dids: mutes.map((m) => m.did),
-      mutes: mutes.map((m) => ({
+      dids: page.items.map((m) => m.did),
+      mutes: page.items.map((m) => ({
         did: m.did,
         onlyReposts: m.onlyReposts,
         onlyQuoteposts: m.onlyQuoteposts,
       })),
-      cursor: keyset.packFromResult(mutes),
+      cursor: page.cursor,
     }
   },
 
@@ -114,11 +114,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor,
       keyset,
     })
-    const lists = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      listUris: lists.map((l) => l.uri),
-      cursor: keyset.packFromResult(lists),
+      listUris: page.items.map((l) => l.uri),
+      cursor: page.cursor,
     }
   },
 

--- a/packages/bsky/src/data-plane/server/routes/notifs.ts
+++ b/packages/bsky/src/data-plane/server/routes/notifs.ts
@@ -58,8 +58,8 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       limit,
     })
 
-    const notifsRes = await builder.execute()
-    const notifications = notifsRes.map((notif) => ({
+    const page = key.page(await builder.execute(), limit)
+    const notifications = page.items.map((notif) => ({
       recipientDid: actorDid,
       uri: notif.uri,
       reason: notif.reason,
@@ -69,7 +69,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     }))
     return {
       notifications,
-      cursor: key.packFromResult(notifsRes),
+      cursor: page.cursor,
     }
   },
 

--- a/packages/bsky/src/data-plane/server/routes/quotes.ts
+++ b/packages/bsky/src/data-plane/server/routes/quotes.ts
@@ -22,11 +22,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const quotes = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: quotes.map((q) => q.uri),
-      cursor: keyset.packFromResult(quotes),
+      uris: page.items.map((q) => q.uri),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/reposts.ts
+++ b/packages/bsky/src/data-plane/server/routes/reposts.ts
@@ -21,11 +21,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const reposts = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: reposts.map((l) => l.uri),
-      cursor: keyset.packFromResult(reposts),
+      uris: page.items.map((l) => l.uri),
+      cursor: page.cursor,
     }
   },
 
@@ -66,11 +66,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       keyset,
     })
 
-    const reposts = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: reposts.map((l) => l.uri),
-      cursor: keyset.packFromResult(reposts),
+      uris: page.items.map((l) => l.uri),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/src/data-plane/server/routes/search.ts
+++ b/packages/bsky/src/data-plane/server/routes/search.ts
@@ -32,11 +32,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => {
       tryIndex: true,
     })
 
-    const res = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      dids: res.map((row) => row.did),
-      cursor: keyset.packFromResult(res),
+      dids: page.items.map((row) => row.did),
+      cursor: page.cursor,
     }
   }
 
@@ -76,10 +76,10 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => {
       tryIndex: true,
     })
 
-    const res = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
     return {
-      uris: res.map((row) => row.uri),
-      cursor: keyset.packFromResult(res),
+      uris: page.items.map((row) => row.uri),
+      cursor: page.cursor,
     }
   }
 
@@ -107,11 +107,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => {
       tryIndex: true,
     })
 
-    const res = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: res.map((row) => row.uri),
-      cursor: keyset.packFromResult(res),
+      uris: page.items.map((row) => row.uri),
+      cursor: page.cursor,
     }
   }
 

--- a/packages/bsky/src/data-plane/server/routes/starter-packs.ts
+++ b/packages/bsky/src/data-plane/server/routes/starter-packs.ts
@@ -22,11 +22,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       cursor,
       keyset,
     })
-    const starterPacks = await builder.execute()
+    const page = keyset.page(await builder.execute(), limit)
 
     return {
-      uris: starterPacks.map((sp) => sp.uri),
-      cursor: keyset.packFromResult(starterPacks),
+      uris: page.items.map((sp) => sp.uri),
+      cursor: page.cursor,
     }
   },
 })

--- a/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
+++ b/packages/bsky/tests/__snapshots__/feed-generation.test.ts.snap
@@ -2434,7 +2434,6 @@ exports[`feed generation > getFeedGenerators > describes multiple feed gens 1`] 
 
 exports[`feed generation > getSuggestedFeeds > returns list of suggested feed generators 1`] = `
 {
-  "cursor": "4",
   "feeds": [
     {
       "cid": "cids(0)",

--- a/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
+++ b/packages/bsky/tests/data-plane/__snapshots__/indexing.test.ts.snap
@@ -54,7 +54,6 @@ exports[`indexing > indexRepo > updates indexes when records change. 1`] = `
     },
   },
   {
-    "cursor": "0000000000000__bafycid",
     "feed": [
       {
         "post": {
@@ -579,7 +578,6 @@ exports[`indexing > indexRepo > updates indexes when records change. 1`] = `
     ],
   },
   {
-    "cursor": "0000000000000__bafycid",
     "follows": [
       {
         "associated": {

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -297,6 +297,36 @@ describe('feed generation', () => {
     expect(forSnapshot(paginatedAll)).toMatchSnapshot()
   })
 
+  it('getActorFeeds returns a cursor only when more feeds are available', async () => {
+    const exact = await network.bsky.ctx.dataplane.getActorFeeds({
+      actorDid: alice,
+      limit: 10,
+    })
+    expect(exact.uris).toHaveLength(10)
+    expect(exact.cursor).toBe('')
+
+    const over = await network.bsky.ctx.dataplane.getActorFeeds({
+      actorDid: alice,
+      limit: 9,
+    })
+    expect(over.uris).toHaveLength(9)
+    expect(over.cursor).not.toBe('')
+
+    const terminal = await agent.app.bsky.feed.getActorFeeds({
+      actor: alice,
+      limit: 9,
+    })
+    expect(terminal.data.feeds).toHaveLength(9)
+    expect(terminal.data.cursor).toBeUndefined()
+
+    const trimmed = await agent.app.bsky.feed.getActorFeeds({
+      actor: alice,
+      limit: 8,
+    })
+    expect(trimmed.data.feeds).toHaveLength(8)
+    expect(trimmed.data.cursor).toBeDefined()
+  })
+
   it('embeds feed generator records in posts', async () => {
     const res = await pdsAgent.api.app.bsky.feed.post.create(
       { repo: sc.dids.bob },
@@ -588,6 +618,38 @@ describe('feed generation', () => {
       expect(forSnapshot(resEven.data)).toMatchSnapshot()
       expect(resEven.data.feeds.map((fg) => fg.uri)).not.toContain(feedUriPrime) // taken-down
     })
+
+    it('fills the page after filtering and returns a cursor only when more feeds are available', async () => {
+      const exact = await network.bsky.ctx.dataplane.getSuggestedFeeds({
+        limit: 4,
+      })
+      expect(exact.uris).toHaveLength(4)
+      expect(exact.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.getSuggestedFeeds({
+        limit: 3,
+      })
+      expect(over.uris).toHaveLength(3)
+      expect(over.cursor).not.toBe('')
+
+      await network.bsky.db.db
+        .updateTable('suggested_feed')
+        .set({ order: 0 })
+        .where('uri', '=', feedUriPrime)
+        .execute()
+      const terminal = await agent.app.bsky.feed.getSuggestedFeeds({ limit: 3 })
+      expect(terminal.data.feeds).toHaveLength(3)
+      expect(terminal.data.cursor).toBeUndefined()
+      await network.bsky.db.db
+        .updateTable('suggested_feed')
+        .set({ order: 4 })
+        .where('uri', '=', feedUriPrime)
+        .execute()
+
+      const trimmed = await agent.app.bsky.feed.getSuggestedFeeds({ limit: 2 })
+      expect(trimmed.data.feeds).toHaveLength(2)
+      expect(trimmed.data.cursor).toBeDefined()
+    })
   })
 
   describe('getPopularFeedGenerators', () => {
@@ -657,6 +719,30 @@ describe('feed generation', () => {
         resFull.data.feeds,
       )
     })
+
+    it('uses bounded feed-generator pages and refills filtered suggestions', async () => {
+      await network.bsky.db.db
+        .updateTable('suggested_feed')
+        .set({ order: 0 })
+        .where('uri', '=', feedUriPrime)
+        .execute()
+      const exact = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+        limit: 3,
+      })
+      expect(exact.data.feeds).toHaveLength(3)
+      expect(exact.data.cursor).toBeUndefined()
+      await network.bsky.db.db
+        .updateTable('suggested_feed')
+        .set({ order: 4 })
+        .where('uri', '=', feedUriPrime)
+        .execute()
+
+      const over = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+        limit: 2,
+      })
+      expect(over.data.feeds).toHaveLength(2)
+      expect(over.data.cursor).toBeDefined()
+    })
   })
 
   describe('getFeed', () => {
@@ -719,6 +805,25 @@ describe('feed generation', () => {
         sc.posts[sc.dids.dan][1].ref.uriStr,
       ])
       expect(forSnapshot(paginatedAll)).toMatchSnapshot()
+    })
+
+    it('refills after an empty filtered skeleton segment', async () => {
+      const res = await agent.api.app.bsky.feed.getFeed(
+        { feed: feedUriAll, cursor: '2', limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyFeedGetFeed,
+            gen.did,
+          ),
+        },
+      )
+
+      expect(res.data.feed.map((item) => item.post.uri)).toEqual([
+        sc.posts[sc.dids.carol][0].ref.uriStr,
+        sc.replies[sc.dids.carol][0].ref.uriStr,
+      ])
+      expect(res.data.cursor).toBe('5')
     })
 
     it('paginates, handling feed not respecting limit.', async () => {

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -1,5 +1,13 @@
 import assert from 'node:assert'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 import {
   AppBskyFeedDefs,
   type AppBskyFeedGetActorFeeds,
@@ -48,6 +56,7 @@ describe('feed generation', () => {
   beforeAll(async () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'bsky_feed_generation',
+      bsky: { searchV2OverrideHeader: 'test' },
     })
 
     agent = network.bsky.getAgent()
@@ -692,6 +701,65 @@ describe('feed generation', () => {
         },
       )
       expect(res.data.feeds.map((f) => f.uri)).toEqual([feedUriAll])
+    })
+
+    it('paginates v2 feed-generator search', async () => {
+      const dataplaneFirst =
+        await network.bsky.ctx.dataplane.searchFeedGeneratorsV2({
+          params: { query: '', limit: 1 },
+        })
+      const dataplaneSecond =
+        await network.bsky.ctx.dataplane.searchFeedGeneratorsV2({
+          params: {
+            query: '',
+            cursor: dataplaneFirst.pageInfo?.cursor,
+            limit: 1,
+          },
+        })
+
+      expect(dataplaneFirst.pageInfo?.cursor).not.toBe('')
+      expect(dataplaneSecond.feedGenerators[0].uri).not.toBe(
+        dataplaneFirst.feedGenerators[0].uri,
+      )
+
+      const search = vi
+        .spyOn(network.bsky.ctx.dataplane, 'searchFeedGeneratorsV2')
+        .mockImplementation(async ({ params }) => ({
+          feedGenerators: [
+            { uri: params?.cursor ? feedUriEven : feedUriAll, score: 0 },
+          ],
+          pageInfo: {
+            cursor: params?.cursor ? '' : 'next',
+            hitsTotal: 2n,
+          },
+        }))
+      const headers = {
+        ...(await network.serviceHeaders(
+          sc.dids.bob,
+          ids.AppBskyUnspeccedGetPopularFeedGenerators,
+        )),
+        'x-bsky-search-v2-override': 'test',
+      }
+      const first = await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
+        { query: 'feed', limit: 1 },
+        { headers },
+      )
+      const second =
+        await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
+          { query: 'feed', cursor: first.data.cursor, limit: 1 },
+          { headers },
+        )
+
+      expect(first.data.cursor).toBeDefined()
+      expect(second.data.feeds).toHaveLength(1)
+      expect(second.data.feeds[0].uri).not.toBe(first.data.feeds[0].uri)
+      expect(search).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          params: expect.objectContaining({ cursor: 'next' }),
+        }),
+      )
+      search.mockRestore()
     })
 
     it('paginates', async () => {

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -1,13 +1,5 @@
 import assert from 'node:assert'
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
   AppBskyFeedDefs,
   type AppBskyFeedGetActorFeeds,
@@ -722,44 +714,19 @@ describe('feed generation', () => {
         dataplaneFirst.feedGenerators[0].uri,
       )
 
-      const search = vi
-        .spyOn(network.bsky.ctx.dataplane, 'searchFeedGeneratorsV2')
-        .mockImplementation(async ({ params }) => ({
-          feedGenerators: [
-            { uri: params?.cursor ? feedUriEven : feedUriAll, score: 0 },
-          ],
-          pageInfo: {
-            cursor: params?.cursor ? '' : 'next',
-            hitsTotal: 2n,
-          },
-        }))
-      const headers = {
-        ...(await network.serviceHeaders(
-          sc.dids.bob,
-          ids.AppBskyUnspeccedGetPopularFeedGenerators,
-        )),
-        'x-bsky-search-v2-override': 'test',
-      }
-      const first = await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
-        { query: 'feed', limit: 1 },
-        { headers },
+      const override = { 'x-bsky-search-v2-override': 'test' }
+      const first = await agent.app.bsky.unspecced.getPopularFeedGenerators(
+        { query: 'Bad Pagination', limit: 1 },
+        { headers: override },
       )
-      const second =
-        await agent.api.app.bsky.unspecced.getPopularFeedGenerators(
-          { query: 'feed', cursor: first.data.cursor, limit: 1 },
-          { headers },
-        )
+      const second = await agent.app.bsky.unspecced.getPopularFeedGenerators(
+        { query: 'Bad Pagination', cursor: first.data.cursor, limit: 1 },
+        { headers: override },
+      )
 
       expect(first.data.cursor).toBeDefined()
       expect(second.data.feeds).toHaveLength(1)
       expect(second.data.feeds[0].uri).not.toBe(first.data.feeds[0].uri)
-      expect(search).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          params: expect.objectContaining({ cursor: 'next' }),
-        }),
-      )
-      search.mockRestore()
     })
 
     it('paginates', async () => {

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -36,6 +36,7 @@ describe('feed generation', () => {
   let feedUriOdd: string // Unsupported by feed gen
   let feedUriBadPaginationLimit: string
   let feedUriBadPaginationCursor: string
+  let feedUriEmptyPageWithCursor: string
   let feedUriPrime: string // Taken-down
   let feedUriPrimeRef: RecordRef
   let feedUriNeedsAuth: string
@@ -66,6 +67,12 @@ describe('feed generation', () => {
       'app.bsky.feed.generator',
       'bad-pagination-cursor',
     )
+    const emptyPageWithCursorUri = AtUri.make(
+      alice,
+      'app.bsky.feed.generator',
+      'empty-page-with-cursor',
+    )
+    feedUriEmptyPageWithCursor = emptyPageWithCursorUri.toString()
     const evenUri = AtUri.make(alice, 'app.bsky.feed.generator', 'even')
     const primeUri = AtUri.make(alice, 'app.bsky.feed.generator', 'prime')
     const needsAuthUri = AtUri.make(
@@ -87,6 +94,9 @@ describe('feed generation', () => {
       ),
       [feedUriBadPaginationCursor.toString()]: feedGenHandler(
         'bad-pagination-cursor',
+      ),
+      [emptyPageWithCursorUri.toString()]: feedGenHandler(
+        'empty-page-with-cursor',
       ),
       [primeUri.toString()]: feedGenHandler('prime'),
       [needsAuthUri.toString()]: feedGenHandler('needs-auth'),
@@ -807,7 +817,7 @@ describe('feed generation', () => {
       expect(forSnapshot(paginatedAll)).toMatchSnapshot()
     })
 
-    it('refills after an empty filtered skeleton segment', async () => {
+    it('does not refill an empty filtered skeleton segment', async () => {
       const res = await agent.api.app.bsky.feed.getFeed(
         { feed: feedUriAll, cursor: '2', limit: 2 },
         {
@@ -821,9 +831,8 @@ describe('feed generation', () => {
 
       expect(res.data.feed.map((item) => item.post.uri)).toEqual([
         sc.posts[sc.dids.carol][0].ref.uriStr,
-        sc.replies[sc.dids.carol][0].ref.uriStr,
       ])
-      expect(res.data.cursor).toBe('5')
+      expect(res.data.cursor).toBe('4')
     })
 
     it('paginates, handling feed not respecting limit.', async () => {
@@ -877,6 +886,34 @@ describe('feed generation', () => {
 
       expect(res.data.cursor).toBeUndefined()
       expect(res.data.feed).toHaveLength(2)
+    })
+
+    it('returns empty cursor when the feed generator returns an empty page', async () => {
+      await pdsAgent.api.app.bsky.feed.generator.create(
+        { repo: alice, rkey: 'empty-page-with-cursor' },
+        {
+          did: gen.did,
+          displayName: 'Empty Page With Cursor',
+          description: 'Returns an empty page with a cursor',
+          createdAt: new Date().toISOString(),
+        },
+        sc.getHeaders(alice),
+      )
+      await network.processAll()
+
+      const res = await agent.api.app.bsky.feed.getFeed(
+        { feed: feedUriEmptyPageWithCursor, limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyFeedGetFeed,
+            gen.did,
+          ),
+        },
+      )
+
+      expect(res.data.feed).toHaveLength(0)
+      expect(res.data.cursor).toBeUndefined()
     })
 
     it('resolves contents of taken-down feed.', async () => {
@@ -972,6 +1009,7 @@ describe('feed generation', () => {
         | 'prime'
         | 'bad-pagination-limit'
         | 'bad-pagination-cursor'
+        | 'empty-page-with-cursor'
         | 'needs-auth'
         | 'accepts-interactions'
         | 'pinned',
@@ -989,6 +1027,15 @@ describe('feed generation', () => {
                 },
               },
             ],
+          } satisfies app.bsky.feed.getFeedSkeleton.$OutputBody,
+        }
+      }
+      if (feedName === 'empty-page-with-cursor') {
+        return {
+          encoding: 'application/json',
+          body: {
+            feed: [],
+            cursor: 'next',
           } satisfies app.bsky.feed.getFeedSkeleton.$OutputBody,
         }
       }

--- a/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/block-lists.test.ts.snap
@@ -339,7 +339,6 @@ exports[`pds views with blocking from block lists > blocks thread reply 1`] = `
 
 exports[`pds views with blocking from block lists > returns a users own list blocks 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "lists": [
     {
       "cid": "cids(0)",
@@ -450,7 +449,6 @@ exports[`pds views with blocking from block lists > returns a users own list blo
 
 exports[`pds views with blocking from block lists > returns lists associated with a user 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "lists": [
     {
       "cid": "cids(0)",
@@ -560,7 +558,6 @@ exports[`pds views with blocking from block lists > returns lists associated wit
 
 exports[`pds views with blocking from block lists > returns the contents of a list 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "items": [
     {
       "subject": {

--- a/packages/bsky/tests/views/__snapshots__/follows.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/follows.test.ts.snap
@@ -418,7 +418,6 @@ exports[`pds follow views > fetches followers 5`] = `
 
 exports[`pds follow views > fetches follows 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "follows": [
     {
       "associated": {
@@ -539,7 +538,6 @@ exports[`pds follow views > fetches follows 1`] = `
 
 exports[`pds follow views > fetches follows 2`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "follows": [
     {
       "associated": {
@@ -614,7 +612,6 @@ exports[`pds follow views > fetches follows 2`] = `
 
 exports[`pds follow views > fetches follows 3`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "follows": [
     {
       "associated": {
@@ -666,7 +663,6 @@ exports[`pds follow views > fetches follows 3`] = `
 
 exports[`pds follow views > fetches follows 4`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "follows": [
     {
       "associated": {
@@ -764,7 +760,6 @@ exports[`pds follow views > fetches follows 4`] = `
 
 exports[`pds follow views > fetches follows 5`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "follows": [
     {
       "associated": {

--- a/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/likes.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`pds like views > fetches post likes 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "likes": [
     {
       "actor": {
@@ -104,7 +103,6 @@ exports[`pds like views > fetches post likes 1`] = `
 
 exports[`pds like views > fetches reply likes 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "likes": [
     {
       "actor": {

--- a/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/mute-lists.test.ts.snap
@@ -362,7 +362,6 @@ exports[`bsky views with mutes from mute lists > flags mutes in threads 1`] = `
 
 exports[`bsky views with mutes from mute lists > returns a users own list mutes 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "lists": [
     {
       "cid": "cids(0)",
@@ -471,7 +470,6 @@ exports[`bsky views with mutes from mute lists > returns a users own list mutes 
 
 exports[`bsky views with mutes from mute lists > returns lists associated with a user 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "lists": [
     {
       "cid": "cids(0)",
@@ -580,7 +578,6 @@ exports[`bsky views with mutes from mute lists > returns lists associated with a
 
 exports[`bsky views with mutes from mute lists > returns the contents of a list 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "items": [
     {
       "subject": {

--- a/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/notifications.test.ts.snap
@@ -619,7 +619,6 @@ exports[`notification views > fetches notifications omitting mentions and replie
 
 exports[`notification views > fetches notifications with default priority 1`] = `
 {
-  "cursor": "1970-01-01T00:00:00.000Z",
   "notifications": [
     {
       "author": {
@@ -853,7 +852,6 @@ exports[`notification views > fetches notifications with default priority 1`] = 
 
 exports[`notification views > fetches notifications with explicit priority 1`] = `
 {
-  "cursor": "1970-01-01T00:00:00.000Z",
   "notifications": [
     {
       "author": {
@@ -1087,7 +1085,6 @@ exports[`notification views > fetches notifications with explicit priority 1`] =
 
 exports[`notification views > fetches notifications with explicit priority 2`] = `
 {
-  "cursor": "1970-01-01T00:00:00.000Z",
   "notifications": [
     {
       "author": {

--- a/packages/bsky/tests/views/__snapshots__/quotes.test.ts.snap
+++ b/packages/bsky/tests/views/__snapshots__/quotes.test.ts.snap
@@ -100,7 +100,6 @@ exports[`pds quote views > decrements quote count when a quote is deleted 1`] = 
 
 exports[`pds quote views > does not return post when quote is deleted 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "posts": [
     {
       "author": {
@@ -223,7 +222,6 @@ exports[`pds quote views > does not return post when quote is deleted 1`] = `
 
 exports[`pds quote views > fetches post quotes 1`] = `
 {
-  "cursor": "0000000000000__bafycid",
   "posts": [
     {
       "author": {

--- a/packages/bsky/tests/views/actor-likes.test.ts
+++ b/packages/bsky/tests/views/actor-likes.test.ts
@@ -58,7 +58,44 @@ describe('bsky actor likes feed views', () => {
     ).rejects.toThrow('Profile not found')
   })
 
+  it('paginates actor likes and omits the terminal cursor', async () => {
+    const headers = await network.serviceHeaders(
+      bob,
+      ids.AppBskyFeedGetActorLikes,
+    )
+    const first = await agent.api.app.bsky.feed.getActorLikes(
+      { actor: bob, limit: 2 },
+      { headers },
+    )
+    const second = await agent.api.app.bsky.feed.getActorLikes(
+      { actor: bob, limit: 2, cursor: first.data.cursor },
+      { headers },
+    )
+
+    expect(first.data.feed).toHaveLength(2)
+    expect(first.data.cursor).toBeDefined()
+    expect(second.data.feed).toHaveLength(1)
+    expect(second.data.cursor).toBeUndefined()
+
+    const exact = await network.bsky.ctx.dataplane.getActorLikes({
+      actorDid: bob,
+      limit: 3,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getActorLikes({
+      actorDid: bob,
+      limit: 2,
+    })
+    expect(exact.likes).toHaveLength(3)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.likes).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
   it('viewer has blocked author of liked post(s)', async () => {
+    const olderVisible = await sc.post(carol, 'older visible liked post')
+    await sc.like(bob, olderVisible.ref, {
+      createdAt: '2000-01-01T00:00:00.000Z',
+    })
     const bobBlocksAlice = await pdsAgent.api.app.bsky.graph.block.create(
       {
         repo: bob, // bob blocks alice
@@ -75,7 +112,7 @@ describe('bsky actor likes feed views', () => {
     const {
       data: { feed },
     } = await agent.api.app.bsky.feed.getActorLikes(
-      { actor: sc.accounts[bob].handle },
+      { actor: sc.accounts[bob].handle, limit: 2 },
       {
         headers: await network.serviceHeaders(
           bob,
@@ -84,11 +121,8 @@ describe('bsky actor likes feed views', () => {
       },
     )
 
-    expect(
-      feed.every((item) => {
-        return item.post.author.did !== alice
-      }),
-    ).toBe(true)
+    expect(feed).toHaveLength(2)
+    expect(feed.every((item) => item.post.author.did === carol)).toBe(true)
 
     // unblock
     await pdsAgent.api.app.bsky.graph.block.delete(

--- a/packages/bsky/tests/views/actor-search.test.ts
+++ b/packages/bsky/tests/views/actor-search.test.ts
@@ -1,7 +1,12 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { type AppBskyActorSearchActors, type AtpAgent, ids } from '@atproto/api'
 import { wait } from '@atproto/common'
-import { type SeedClient, TestNetwork, usersBulkSeed } from '@atproto/dev-env'
+import {
+  type SeedClient,
+  TestNetwork,
+  basicSeed,
+  usersBulkSeed,
+} from '@atproto/dev-env'
 import { forSnapshot, paginateAll, stripViewer } from '../_util.js'
 
 // @NOTE skipped to help with CI failures
@@ -257,5 +262,68 @@ describe.skip('pds actor search views', () => {
     expect(handles).toContain('carlos6.test')
     expect(handles).toContain('carolina-mcderm77.test')
     expect(handles).not.toContain('cara-wiegand69.test')
+  })
+})
+
+describe('actor search pagination', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_actor_search_pagination',
+    })
+    agent = network.bsky.getAgent()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+  })
+
+  beforeEach(async () => network.processAll())
+  afterAll(async () => network?.close())
+
+  it('fills the page after filtering actors and returns a cursor only when more actors are available', async () => {
+    const full = await network.bsky.ctx.dataplane.searchActors({
+      term: '.test',
+      limit: 100,
+    })
+    expect(full.dids.length).toBeGreaterThan(2)
+
+    const exact = await network.bsky.ctx.dataplane.searchActors({
+      term: '.test',
+      limit: full.dids.length,
+    })
+    expect(exact.dids).toHaveLength(full.dids.length)
+    expect(exact.cursor).toBe('')
+
+    const over = await network.bsky.ctx.dataplane.searchActors({
+      term: '.test',
+      limit: full.dids.length - 1,
+    })
+    expect(over.dids).toHaveLength(full.dids.length - 1)
+    expect(over.cursor).not.toBe('')
+
+    const headers = await network.serviceHeaders(
+      sc.dids.alice,
+      ids.AppBskyActorSearchActors,
+    )
+    const terminal = await agent.app.bsky.actor.searchActors(
+      { term: '.test', limit: full.dids.length },
+      { headers },
+    )
+    expect(terminal.data.actors).toHaveLength(full.dids.length)
+    expect(terminal.data.cursor).toBeUndefined()
+
+    await network.bsky.ctx.dataplane.takedownActor({ did: full.dids[0] })
+    const refilled = await agent.app.bsky.actor.searchActors(
+      { term: '.test', limit: 2 },
+      { headers },
+    )
+    expect(refilled.data.actors).toHaveLength(2)
+    expect(refilled.data.actors.map((actor) => actor.did)).not.toContain(
+      full.dids[0],
+    )
+    expect(refilled.data.cursor).toBeDefined()
+    await network.bsky.ctx.dataplane.untakedownActor({ did: full.dids[0] })
   })
 })

--- a/packages/bsky/tests/views/author-feed.test.ts
+++ b/packages/bsky/tests/views/author-feed.test.ts
@@ -154,6 +154,8 @@ describe('pds author feed views', () => {
     paginatedAll.forEach((res) =>
       expect(res.feed.length).toBeLessThanOrEqual(2),
     )
+    expect(paginatedAll[0].cursor).toBeDefined()
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.feed.getAuthorFeed(
       { actor: sc.accounts[alice].handle },
@@ -167,6 +169,82 @@ describe('pds author feed views', () => {
 
     expect(full.data.feed.length).toEqual(4)
     expect(results(paginatedAll)).toEqual(results([full.data]))
+
+    const exact = await network.bsky.ctx.dataplane.getAuthorFeed({
+      actorDid: alice,
+      limit: 4,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getAuthorFeed({
+      actorDid: alice,
+      limit: 2,
+    })
+    expect(exact.items).toHaveLength(4)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.items).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('fills a limited author feed after an entirely filtered page', async () => {
+    const author = await sc.createAccount('author-feed-page-fill', {
+      handle: 'author-fill.test',
+      email: 'author-feed-page-fill@example.com',
+      password: 'hunter2',
+    })
+    const older = await sc.post(
+      author.did,
+      'older visible author post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-01-01T00:00:00.000Z' },
+    )
+    const newer = await sc.post(
+      author.did,
+      'newer visible author post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-01-02T00:00:00.000Z' },
+    )
+    const filtered1 = await sc.post(
+      author.did,
+      'filtered author post 1',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-01-03T00:00:00.000Z' },
+    )
+    const filtered2 = await sc.post(
+      author.did,
+      'filtered author post 2',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-01-04T00:00:00.000Z' },
+    )
+    await network.processAll()
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered1.ref.uriStr,
+    })
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered2.ref.uriStr,
+    })
+
+    const { data } = await agent.api.app.bsky.feed.getAuthorFeed(
+      { actor: author.did, limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          dan,
+          ids.AppBskyFeedGetAuthorFeed,
+        ),
+      },
+    )
+
+    expect(data.feed.map((item) => item.post.uri)).toEqual([
+      newer.ref.uriStr,
+      older.ref.uriStr,
+    ])
+    expect(data.cursor).toBeUndefined()
   })
 
   it('fetches results unauthed.', async () => {

--- a/packages/bsky/tests/views/block-lists.test.ts
+++ b/packages/bsky/tests/views/block-lists.test.ts
@@ -553,6 +553,20 @@ describe('pds views with blocking from block lists', () => {
   })
 
   it('paginates getListBlocks', async () => {
+    const exact = await network.bsky.ctx.dataplane.getBlocklistSubscriptions({
+      actorDid: dan,
+      limit: 2,
+    })
+    const nonterminal =
+      await network.bsky.ctx.dataplane.getBlocklistSubscriptions({
+        actorDid: dan,
+        limit: 1,
+      })
+    expect(exact.listUris).toHaveLength(2)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.listUris).toHaveLength(1)
+    expect(nonterminal.cursor).not.toBe('')
+
     const full = await agent.api.app.bsky.graph.getListBlocks(
       {},
       {
@@ -581,7 +595,31 @@ describe('pds views with blocking from block lists', () => {
       },
     )
     const combined = [...first.data.lists, ...second.data.lists]
+    expect(first.data.lists).toHaveLength(1)
+    expect(first.data.cursor).toBeDefined()
+    expect(second.data.cursor).toBeUndefined()
     expect(combined).toEqual(full.data.lists)
+
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: otherListUri,
+    })
+    try {
+      const filtered = await agent.api.app.bsky.graph.getListBlocks(
+        { limit: 1 },
+        {
+          headers: await network.serviceHeaders(
+            dan,
+            ids.AppBskyGraphGetListBlocks,
+          ),
+        },
+      )
+      expect(filtered.data.lists.map((list) => list.uri)).toEqual([listUri])
+      expect(filtered.data.cursor).toBeUndefined()
+    } finally {
+      await network.bsky.ctx.dataplane.untakedownRecord({
+        recordUri: otherListUri,
+      })
+    }
   })
 
   it('does not apply "curate" blocklists', async () => {

--- a/packages/bsky/tests/views/blocks.test.ts
+++ b/packages/bsky/tests/views/blocks.test.ts
@@ -774,7 +774,7 @@ describe('pds views with blocking', () => {
   })
 
   it('returns a list of blocks', async () => {
-    await pdsAgent.api.app.bsky.graph.block.create(
+    const danBlockAlice = await pdsAgent.api.app.bsky.graph.block.create(
       { repo: dan },
       { createdAt: new Date().toISOString(), subject: alice },
       sc.getHeaders(dan),
@@ -788,6 +788,37 @@ describe('pds views with blocking', () => {
     )
     const dids = res.data.blocks.map((block) => block.did).sort()
     expect(dids).toEqual([alice, carol].sort())
+
+    const exact = await network.bsky.ctx.dataplane.getBlocks({
+      actorDid: dan,
+      limit: 2,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getBlocks({
+      actorDid: dan,
+      limit: 1,
+    })
+    expect(exact.blockUris).toHaveLength(2)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.blockUris).toHaveLength(1)
+    expect(nonterminal.cursor).not.toBe('')
+
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: danBlockAlice.uri,
+    })
+    try {
+      const filtered = await agent.api.app.bsky.graph.getBlocks(
+        { limit: 1 },
+        {
+          headers: await network.serviceHeaders(dan, ids.AppBskyGraphGetBlocks),
+        },
+      )
+      expect(filtered.data.blocks.map((block) => block.did)).toEqual([carol])
+      expect(filtered.data.cursor).toBeUndefined()
+    } finally {
+      await network.bsky.ctx.dataplane.untakedownRecord({
+        recordUri: danBlockAlice.uri,
+      })
+    }
   })
 
   it('paginates getBlocks', async () => {
@@ -804,6 +835,9 @@ describe('pds views with blocking', () => {
       { headers: await network.serviceHeaders(dan, ids.AppBskyGraphGetBlocks) },
     )
     const combined = [...first.data.blocks, ...second.data.blocks]
+    expect(first.data.blocks).toHaveLength(1)
+    expect(first.data.cursor).toBeDefined()
+    expect(second.data.cursor).toBeUndefined()
     expect(combined).toEqual(full.data.blocks)
   })
 

--- a/packages/bsky/tests/views/bookmarks.test.ts
+++ b/packages/bsky/tests/views/bookmarks.test.ts
@@ -272,6 +272,8 @@ describe('appview bookmarks views', () => {
       paginatedRes.forEach((res) =>
         expect(res.bookmarks.length).toBeLessThanOrEqual(2),
       )
+      expect(paginatedRes[0].cursor).toBeDefined()
+      expect(paginatedRes.at(-1)?.cursor).toBeUndefined()
 
       const full = results([fullRes.data])
       assertPostViews(full)
@@ -295,6 +297,63 @@ describe('appview bookmarks views', () => {
         uri: sc.posts[alice][0].ref.uriStr,
         cid: sc.posts[alice][0].ref.cidStr,
       })
+    })
+
+    it('only returns a dataplane cursor when another bookmark exists', async () => {
+      for (const post of [
+        sc.posts[alice][0],
+        sc.posts[alice][1],
+        sc.posts[bob][0],
+      ]) {
+        await create(alice, post.ref)
+      }
+      await network.processAll()
+
+      const exact = await network.bsky.ctx.dataplane.getActorBookmarks({
+        actorDid: alice,
+        limit: 3,
+      })
+      const nonterminal = await network.bsky.ctx.dataplane.getActorBookmarks({
+        actorDid: alice,
+        limit: 2,
+      })
+
+      expect(exact.bookmarks).toHaveLength(3)
+      expect(exact.cursor).toBe('')
+      expect(nonterminal.bookmarks).toHaveLength(2)
+      expect(nonterminal.cursor).not.toBe('')
+    })
+
+    it('fills a page after unsupported bookmarked records are filtered', async () => {
+      const older = await sc.post(alice, 'older bookmarked post')
+      const newer = await sc.post(alice, 'newer bookmarked post')
+      const filtered1 = await sc.post(alice, 'filtered bookmarked post 1')
+      const filtered2 = await sc.post(alice, 'filtered bookmarked post 2')
+      for (const post of [older, newer, filtered1, filtered2]) {
+        await create(alice, post.ref)
+      }
+      await network.processAll()
+      for (const [post, unsupported] of [
+        [filtered1, sc.follows[alice][bob]],
+        [filtered2, sc.follows[alice][carol]],
+      ] as const) {
+        await db.db
+          .updateTable('bookmark')
+          .set({
+            subjectUri: unsupported.uriStr,
+            subjectCid: unsupported.cidStr,
+          })
+          .where('subjectUri', '=', post.ref.uriStr)
+          .execute()
+      }
+
+      const { data } = await get(alice, 2)
+
+      expect(data.bookmarks.map((bookmark) => bookmark.subject.uri)).toEqual([
+        newer.ref.uriStr,
+        older.ref.uriStr,
+      ])
+      expect(data.cursor).toBeUndefined()
     })
 
     it('shows posts and blocked posts correctly', async () => {

--- a/packages/bsky/tests/views/contact-matches.test.ts
+++ b/packages/bsky/tests/views/contact-matches.test.ts
@@ -1,0 +1,81 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { type AtpAgent, ids } from '@atproto/api'
+import { type SeedClient, TestNetwork, basicSeed } from '@atproto/dev-env'
+import { GetMatchesResponse } from '../../src/proto/rolodex_pb.js'
+
+describe('contact matches', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let sc: SeedClient
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_contact_matches',
+      bsky: { rolodexUrl: 'http://localhost:1' },
+    })
+    agent = network.bsky.getAgent()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+    await sc.createAccount('eve', {
+      handle: 'eve.test',
+      email: 'eve@test.com',
+      password: 'eve-pass',
+    })
+    await sc.createProfile(sc.dids.eve, 'Eve', 'Eve profile')
+    await sc.block(sc.dids.alice, sc.dids.bob)
+  })
+
+  beforeEach(async () => network.processAll())
+  afterAll(async () => network?.close())
+
+  it('fills the page after filtering blocked matches and returns a cursor only when more matches are available', async () => {
+    const subjects = [sc.dids.bob, sc.dids.carol, sc.dids.dan, sc.dids.eve]
+    const getMatches = vi
+      .spyOn(network.bsky.server.ctx.rolodexClient!, 'getMatches')
+      .mockImplementation(async ({ cursor, limit }) => {
+        const offset = cursor ? Number(cursor) : 0
+        const items = subjects.slice(offset, offset + (limit ?? 50))
+        const next = offset + items.length
+        return new GetMatchesResponse({
+          subjects: items,
+          cursor: next < subjects.length ? String(next) : '',
+        })
+      })
+    const headers = await network.serviceHeaders(
+      sc.dids.alice,
+      ids.AppBskyContactGetMatches,
+    )
+
+    const exact = await agent.app.bsky.contact.getMatches(
+      { limit: 3 },
+      { headers },
+    )
+    expect(exact.data.matches.map((match) => match.did)).toEqual([
+      sc.dids.carol,
+      sc.dids.dan,
+      sc.dids.eve,
+    ])
+    expect(exact.data.cursor).toBeUndefined()
+    expect(getMatches).toHaveBeenCalledTimes(2)
+
+    getMatches.mockClear()
+    const over = await agent.app.bsky.contact.getMatches(
+      { limit: 2 },
+      { headers },
+    )
+    expect(over.data.matches.map((match) => match.did)).toEqual([
+      sc.dids.carol,
+      sc.dids.dan,
+    ])
+    expect(over.data.cursor).toBe('3')
+    expect(getMatches).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/bsky/tests/views/drafts.test.ts
+++ b/packages/bsky/tests/views/drafts.test.ts
@@ -298,6 +298,8 @@ describe('appview drafts views', () => {
       paginatedRes.forEach((res) =>
         expect(res.drafts.length).toBeLessThanOrEqual(2),
       )
+      expect(paginatedRes[0].cursor).toBeDefined()
+      expect(paginatedRes.at(-1)?.cursor).toBe('')
 
       const full = results([fullRes.data])
       const paginated = results(paginatedRes)
@@ -312,6 +314,19 @@ describe('appview drafts views', () => {
       // Check pagination ordering (most recent first).
       expect(paginated.at(0)?.id).toBe(full.at(0)?.id)
       expect(paginated.at(-1)?.id).toBe(full.at(-1)?.id)
+
+      const exact = await network.bsky.ctx.dataplane.getActorDrafts({
+        actorDid: alice,
+        limit: 7,
+      })
+      const nonterminal = await network.bsky.ctx.dataplane.getActorDrafts({
+        actorDid: alice,
+        limit: 2,
+      })
+      expect(exact.drafts).toHaveLength(7)
+      expect(exact.cursor).toBe('')
+      expect(nonterminal.drafts).toHaveLength(2)
+      expect(nonterminal.cursor).not.toBe('')
     })
   })
 

--- a/packages/bsky/tests/views/follows.test.ts
+++ b/packages/bsky/tests/views/follows.test.ts
@@ -155,6 +155,36 @@ describe('pds follow views', () => {
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
 
+  it('getFollowers only returns a cursor when another raw row exists', async () => {
+    const exact = await network.bsky.ctx.dataplane.getFollowers({
+      actorDid: alice,
+      limit: 4,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getFollowers({
+      actorDid: alice,
+      limit: 2,
+    })
+    expect(exact.followers).toHaveLength(4)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.followers).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('getFollows only returns a cursor when another raw row exists', async () => {
+    const exact = await network.bsky.ctx.dataplane.getFollows({
+      actorDid: alice,
+      limit: 4,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getFollows({
+      actorDid: alice,
+      limit: 2,
+    })
+    expect(exact.follows).toHaveLength(4)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.follows).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
   it('fills a page after filtering followers', async () => {
     const subject = await sc.createAccount('page-fill-subject', {
       handle: 'fill-sub.test',
@@ -212,6 +242,67 @@ describe('pds follow views', () => {
       newerVisible.did,
       olderVisible.did,
     ])
+    expect(res.data.cursor).toBeUndefined()
+  })
+
+  it('fills a page after filtering follows', async () => {
+    const subject = await sc.createAccount('follows-fill-subject', {
+      handle: 'follows-fill-sub.test',
+      email: 'follows-fill-subject@example.com',
+      password: 'hunter2',
+    })
+    const olderVisible = await sc.createAccount('follows-fill-visible-older', {
+      handle: 'follows-fill-old.test',
+      email: 'follows-fill-visible-older@example.com',
+      password: 'hunter2',
+    })
+    const newerVisible = await sc.createAccount('follows-fill-visible-newer', {
+      handle: 'follows-fill-new.test',
+      email: 'follows-fill-visible-newer@example.com',
+      password: 'hunter2',
+    })
+    const takenDown = await sc.createAccount('follows-fill-taken-down', {
+      handle: 'follows-fill-down.test',
+      email: 'follows-fill-taken-down@example.com',
+      password: 'hunter2',
+    })
+    const blocked = await sc.createAccount('follows-fill-blocked', {
+      handle: 'follows-fill-block.test',
+      email: 'follows-fill-blocked@example.com',
+      password: 'hunter2',
+    })
+
+    await sc.follow(subject.did, olderVisible.did, {
+      createdAt: '2025-02-01T00:00:00.000Z',
+    })
+    await sc.follow(subject.did, newerVisible.did, {
+      createdAt: '2025-02-02T00:00:00.000Z',
+    })
+    await sc.follow(subject.did, takenDown.did, {
+      createdAt: '2025-02-03T00:00:00.000Z',
+    })
+    await sc.follow(subject.did, blocked.did, {
+      createdAt: '2025-02-04T00:00:00.000Z',
+    })
+    await sc.block(subject.did, blocked.did)
+    await network.processAll()
+    await network.bsky.ctx.dataplane.takedownActor({ did: takenDown.did })
+
+    const res = await agent.api.app.bsky.graph.getFollows(
+      { actor: subject.did, limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          subject.did,
+          ids.AppBskyGraphGetFollows,
+        ),
+      },
+    )
+
+    expect(res.data.follows.map((follow) => follow.did)).toEqual([
+      newerVisible.did,
+      olderVisible.did,
+    ])
+    expect(res.data.cursor).toBeUndefined()
   })
 
   it('fetches followers unauthed', async () => {

--- a/packages/bsky/tests/views/likes.test.ts
+++ b/packages/bsky/tests/views/likes.test.ts
@@ -102,6 +102,8 @@ describe('pds like views', () => {
     paginatedAll.forEach((res) =>
       expect(res.likes.length).toBeLessThanOrEqual(2),
     )
+    expect(paginatedAll[0].cursor).toBeDefined()
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.feed.getLikes(
       { uri: sc.posts[alice][1].ref.uriStr },
@@ -110,6 +112,20 @@ describe('pds like views', () => {
 
     expect(full.data.likes.length).toEqual(4)
     expect(results(paginatedAll)).toEqual(results([full.data]))
+
+    const exact = await network.bsky.ctx.dataplane.getLikesBySubjectSorted({
+      subject: { uri: sc.posts[alice][1].ref.uriStr },
+      limit: 4,
+    })
+    const nonterminal =
+      await network.bsky.ctx.dataplane.getLikesBySubjectSorted({
+        subject: { uri: sc.posts[alice][1].ref.uriStr },
+        limit: 2,
+      })
+    expect(exact.uris).toHaveLength(4)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.uris).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
   })
 
   it('fetches post likes unauthed', async () => {
@@ -195,5 +211,16 @@ describe('pds like views', () => {
       sc.dids.dan,
       sc.dids.bob,
     ])
+
+    const filled = await agent.app.bsky.feed.getLikes(
+      { uri: sc.posts[alice][1].ref.uriStr, limit: 3 },
+      { headers: await network.serviceHeaders(bob, ids.AppBskyFeedGetLikes) },
+    )
+    expect(filled.data.likes.map((like) => like.actor.did)).toStrictEqual([
+      sc.dids.eve,
+      sc.dids.dan,
+      sc.dids.bob,
+    ])
+    expect(filled.data.cursor).toBeUndefined()
   })
 })

--- a/packages/bsky/tests/views/list-feed.test.ts
+++ b/packages/bsky/tests/views/list-feed.test.ts
@@ -88,6 +88,8 @@ describe('list feed views', () => {
     paginatedAll.forEach((res) =>
       expect(res.feed.length).toBeLessThanOrEqual(2),
     )
+    expect(paginatedAll[0].cursor).toBeDefined()
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.feed.getListFeed(
       { list: listRef.uriStr },
@@ -101,6 +103,84 @@ describe('list feed views', () => {
 
     expect(full.data.feed.length).toEqual(7)
     expect(results(paginatedAll)).toEqual(results([full.data]))
+
+    const exact = await network.bsky.ctx.dataplane.getListFeed({
+      listUri: listRef.uriStr,
+      limit: 7,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getListFeed({
+      listUri: listRef.uriStr,
+      limit: 2,
+    })
+    expect(exact.items).toHaveLength(7)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.items).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('fills a limited list feed after an entirely filtered page', async () => {
+    const member = await sc.createAccount('list-feed-page-fill-member', {
+      handle: 'list-fill.test',
+      email: 'list-feed-page-fill-member@example.com',
+      password: 'hunter2',
+    })
+    const fillList = await sc.createList(alice, 'page fill list', 'curate')
+    await sc.addToList(alice, member.did, fillList)
+    const older = await sc.post(
+      member.did,
+      'older visible list post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-02-01T00:00:00.000Z' },
+    )
+    const newer = await sc.post(
+      member.did,
+      'newer visible list post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-02-02T00:00:00.000Z' },
+    )
+    const filtered1 = await sc.post(
+      member.did,
+      'filtered list post 1',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-02-03T00:00:00.000Z' },
+    )
+    const filtered2 = await sc.post(
+      member.did,
+      'filtered list post 2',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-02-04T00:00:00.000Z' },
+    )
+    await network.processAll()
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered1.ref.uriStr,
+    })
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered2.ref.uriStr,
+    })
+
+    const { data } = await agent.api.app.bsky.feed.getListFeed(
+      { list: fillList.uriStr, limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          carol,
+          ids.AppBskyFeedGetListFeed,
+        ),
+      },
+    )
+
+    expect(data.feed.map((item) => item.post.uri)).toEqual([
+      newer.ref.uriStr,
+      older.ref.uriStr,
+    ])
+    expect(data.cursor).toBeUndefined()
   })
 
   it('fetches results unauthed', async () => {

--- a/packages/bsky/tests/views/lists.test.ts
+++ b/packages/bsky/tests/views/lists.test.ts
@@ -104,6 +104,36 @@ describe('bsky actor likes feed views', () => {
   beforeEach(async () => network.processAll())
   afterAll(async () => network?.close())
 
+  it('getActorLists only returns a cursor when another raw row exists', async () => {
+    const exact = await network.bsky.ctx.dataplane.getActorLists({
+      actorDid: eve,
+      limit: 7,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getActorLists({
+      actorDid: eve,
+      limit: 2,
+    })
+    expect(exact.listUris).toHaveLength(7)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.listUris).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('getListMembers only returns a cursor when another raw row exists', async () => {
+    const exact = await network.bsky.ctx.dataplane.getListMembers({
+      listUri: curateList,
+      limit: 3,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getListMembers({
+      listUri: curateList,
+      limit: 2,
+    })
+    expect(exact.listitems).toHaveLength(3)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.listitems).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
   it('does not include reference lists in getActorLists', async () => {
     const view = await agent.app.bsky.graph.getLists({
       actor: eve,
@@ -168,6 +198,11 @@ describe('bsky actor likes feed views', () => {
       paginatedAll.forEach((res) =>
         expect(res.lists.length).toBeLessThanOrEqual(2),
       )
+      expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
+      if (expected > 2) {
+        expect(paginatedAll[0].lists).toHaveLength(2)
+        expect(paginatedAll[0].cursor).toBeDefined()
+      }
 
       const full = await agent.app.bsky.graph.getLists(
         { actor: eve, purposes },
@@ -200,12 +235,13 @@ describe('bsky actor likes feed views', () => {
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
     const refView = await agent.app.bsky.graph.getList(
-      { list: referenceList },
+      { list: referenceList, limit: 2 },
       {
         headers: await network.serviceHeaders(frankie, ids.AppBskyGraphGetList),
       },
     )
     expect(refView.data.items.length).toBe(2)
+    expect(refView.data.cursor).toBeUndefined()
     expect(forSnapshot(refView.data.items)).toMatchSnapshot()
   })
 
@@ -387,6 +423,11 @@ describe('bsky actor likes feed views', () => {
         paginatedAll.forEach((res) =>
           expect(res.listsWithMembership.length).toBeLessThanOrEqual(2),
         )
+        expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
+        if (expected > 2) {
+          expect(paginatedAll[0].listsWithMembership).toHaveLength(2)
+          expect(paginatedAll[0].cursor).toBeDefined()
+        }
 
         const full = await agent.app.bsky.graph.getListsWithMembership(
           { actor: eve, purposes },

--- a/packages/bsky/tests/views/mute-lists.test.ts
+++ b/packages/bsky/tests/views/mute-lists.test.ts
@@ -354,6 +354,20 @@ describe('bsky views with mutes from mute lists', () => {
   })
 
   it('paginates getListMutes', async () => {
+    const exact = await network.bsky.ctx.dataplane.getMutelistSubscriptions({
+      actorDid: dan,
+      limit: 2,
+    })
+    const nonterminal =
+      await network.bsky.ctx.dataplane.getMutelistSubscriptions({
+        actorDid: dan,
+        limit: 1,
+      })
+    expect(exact.listUris).toHaveLength(2)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.listUris).toHaveLength(1)
+    expect(nonterminal.cursor).not.toBe('')
+
     const full = await agent.api.app.bsky.graph.getListMutes(
       {},
       {
@@ -382,7 +396,31 @@ describe('bsky views with mutes from mute lists', () => {
       },
     )
     const combined = [...first.data.lists, ...second.data.lists]
+    expect(first.data.lists).toHaveLength(1)
+    expect(first.data.cursor).toBeDefined()
+    expect(second.data.cursor).toBeUndefined()
     expect(combined).toEqual(full.data.lists)
+
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: otherListUri,
+    })
+    try {
+      const filtered = await agent.api.app.bsky.graph.getListMutes(
+        { limit: 1 },
+        {
+          headers: await network.serviceHeaders(
+            dan,
+            ids.AppBskyGraphGetListMutes,
+          ),
+        },
+      )
+      expect(filtered.data.lists.map((list) => list.uri)).toEqual([listUri])
+      expect(filtered.data.cursor).toBeUndefined()
+    } finally {
+      await network.bsky.ctx.dataplane.untakedownRecord({
+        recordUri: otherListUri,
+      })
+    }
   })
 
   it('allows unsubscribing from a mute list', async () => {

--- a/packages/bsky/tests/views/mutes.test.ts
+++ b/packages/bsky/tests/views/mutes.test.ts
@@ -245,9 +245,22 @@ describe('mute views', () => {
           ),
         },
       )
-      expect(page.mutes.length).toBeGreaterThanOrEqual(2)
+      expect(page.mutes).toHaveLength(2)
       expect(page.mutes.some((mute) => mute.did === dan)).toBe(false)
       expect(page.cursor).toBeDefined()
+
+      const { data: terminalPage } = await agent.api.app.bsky.graph.getMutes(
+        { limit: 8 },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyGraphGetMutes,
+          ),
+        },
+      )
+      expect(terminalPage.mutes).toHaveLength(8)
+      expect(terminalPage.mutes.some((mute) => mute.did === dan)).toBe(false)
+      expect(terminalPage.cursor).toBeUndefined()
 
       const timeline = await agent.api.app.bsky.feed.getTimeline(
         { limit: 100 },
@@ -618,6 +631,21 @@ describe('mute views', () => {
     expect(forSnapshot(view.mutes)).toMatchSnapshot()
   })
 
+  it('getMutes only returns a dataplane cursor when another raw row exists', async () => {
+    const exact = await network.bsky.ctx.dataplane.getMutes({
+      actorDid: alice,
+      limit: 8,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getMutes({
+      actorDid: alice,
+      limit: 2,
+    })
+    expect(exact.mutes).toHaveLength(8)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.mutes).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
   it('paginates.', async () => {
     const results = (results: AppBskyGraphGetMutes.OutputSchema[]) =>
       results.flatMap((res) => res.mutes)
@@ -634,12 +662,10 @@ describe('mute views', () => {
       return view
     }
 
-    // pages hold at least `limit` full mutes when more remain, and may
-    // exceed it when server-side filling appends a whole underlying page
     const paginatedAll = await paginateAll(paginator)
-    paginatedAll.slice(0, -1).forEach((res) => {
-      expect(res.mutes.length).toBeGreaterThanOrEqual(2)
-    })
+    paginatedAll.forEach((res) => expect(res.mutes).toHaveLength(2))
+    paginatedAll.slice(0, -1).forEach((res) => expect(res.cursor).toBeDefined())
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.graph.getMutes(
       {},

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -499,6 +499,42 @@ describe('notification views', () => {
     expect(results(paginatedAll)).toEqual(results([full.data]))
   })
 
+  it('returns a cursor only when more notifications are available', async () => {
+    const exact = await network.bsky.ctx.dataplane.getNotifications({
+      actorDid: alice,
+      priority: false,
+      limit: 13,
+    })
+    expect(exact.notifications).toHaveLength(13)
+    expect(exact.cursor).toBe('')
+
+    const over = await network.bsky.ctx.dataplane.getNotifications({
+      actorDid: alice,
+      priority: false,
+      limit: 12,
+    })
+    expect(over.notifications).toHaveLength(12)
+    expect(over.cursor).not.toBe('')
+
+    const headers = await network.serviceHeaders(
+      alice,
+      ids.AppBskyNotificationListNotifications,
+    )
+    const terminal = await agent.app.bsky.notification.listNotifications(
+      { priority: false, limit: 13 },
+      { headers },
+    )
+    expect(terminal.data.notifications).toHaveLength(13)
+    expect(terminal.data.cursor).toBeUndefined()
+
+    const trimmed = await agent.app.bsky.notification.listNotifications(
+      { priority: false, limit: 12 },
+      { headers },
+    )
+    expect(trimmed.data.notifications).toHaveLength(12)
+    expect(trimmed.data.cursor).toBeDefined()
+  })
+
   it('fetches notification count with a last-seen', async () => {
     const full = await agent.api.app.bsky.notification.listNotifications(
       {},
@@ -782,6 +818,7 @@ describe('notification views', () => {
     }
 
     const paginatedAll = await paginateAll(paginator)
+    expect(paginatedAll[0].notifications).toHaveLength(2)
     paginatedAll.forEach((res) =>
       expect(res.notifications.length).toBeLessThanOrEqual(2),
     )
@@ -1393,7 +1430,6 @@ describe('notification views', () => {
 
       const { data: listData } = await list(actorDid)
       expect(listData).toEqual({
-        cursor: expect.any(String),
         subscriptions: [
           expect.objectContaining({
             did: subjectDid,
@@ -1425,7 +1461,6 @@ describe('notification views', () => {
 
       const { data: listData } = await list(actorDid)
       expect(listData).toEqual({
-        cursor: expect.any(String),
         subscriptions: [
           expect.objectContaining({
             did: subjectDid,
@@ -1467,6 +1502,31 @@ describe('notification views', () => {
       await put(actorDid, blocked, val) // blocked is removed from the list.
       await network.processAll()
 
+      const exact =
+        await network.bsky.ctx.dataplane.getActivitySubscriptionDids({
+          actorDid,
+          limit: 6,
+        })
+      expect(exact.dids).toHaveLength(6)
+      expect(exact.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.getActivitySubscriptionDids(
+        {
+          actorDid,
+          limit: 5,
+        },
+      )
+      expect(over.dids).toHaveLength(5)
+      expect(over.cursor).not.toBe('')
+
+      const terminal = await list(actorDid, { limit: 5 })
+      expect(terminal.data.subscriptions).toHaveLength(5)
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await list(actorDid, { limit: 4 })
+      expect(trimmed.data.subscriptions).toHaveLength(4)
+      expect(trimmed.data.cursor).toBeDefined()
+
       const results = (
         results: AppBskyNotificationListActivitySubscriptions.OutputSchema[],
       ) =>
@@ -1482,6 +1542,7 @@ describe('notification views', () => {
       }
 
       const paginatedAll = await paginateAll(paginator)
+      expect(paginatedAll[0].subscriptions).toHaveLength(limit)
       paginatedAll.forEach((res) =>
         expect(res.subscriptions.length).toBeLessThanOrEqual(limit),
       )

--- a/packages/bsky/tests/views/post-search.test.ts
+++ b/packages/bsky/tests/views/post-search.test.ts
@@ -36,6 +36,7 @@ describe('appview search', () => {
       bsky: {
         searchTagsHide: new Set([TAG_HIDE]),
         searchTagsHideAll: new Set([TAG_ALWAYS_HIDE]),
+        searchV2OverrideHeader: 'test',
       },
     })
     agent = network.bsky.getAgent()
@@ -79,6 +80,116 @@ describe('appview search', () => {
 
   beforeEach(async () => network.processAll())
   afterAll(async () => network?.close())
+
+  describe('pagination', () => {
+    it('searchPosts fills the page after filtering and returns a cursor only when more posts are available', async () => {
+      const exact = await network.bsky.ctx.dataplane.searchPosts({
+        term: 'doggo',
+        limit: 3,
+      })
+      expect(exact.uris).toHaveLength(3)
+      expect(exact.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.searchPosts({
+        term: 'doggo',
+        limit: 2,
+      })
+      expect(over.uris).toHaveLength(2)
+      expect(over.cursor).not.toBe('')
+
+      const terminal = await agent.app.bsky.feed.searchPosts(
+        { q: 'doggo', sort: 'top', limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            carol,
+            ids.AppBskyFeedSearchPosts,
+          ),
+        },
+      )
+      expect(terminal.data.posts.map((post) => post.uri)).toEqual(
+        nonTaggedResults,
+      )
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await agent.app.bsky.feed.searchPosts(
+        { q: 'doggo', sort: 'top', limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyFeedSearchPosts,
+          ),
+        },
+      )
+      expect(trimmed.data.posts).toHaveLength(2)
+      expect(trimmed.data.cursor).toBeDefined()
+    })
+
+    it('searchPostsV2 bounds pages and limits unauthenticated search to one request', async () => {
+      const exact = await network.bsky.ctx.dataplane.searchPostsV2({
+        params: { query: 'doggo', limit: 3 },
+      })
+      expect(exact.posts).toHaveLength(3)
+      expect(exact.pageInfo?.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.searchPostsV2({
+        params: { query: 'doggo', limit: 2 },
+      })
+      expect(over.posts).toHaveLength(2)
+      expect(over.pageInfo?.cursor).not.toBe('')
+
+      const override = { 'x-bsky-search-v2-override': 'test' }
+      const unauthenticated = await agent.app.bsky.feed.searchPostsV2(
+        { query: 'doggo', sort: 'top', limit: 2 },
+        { headers: override },
+      )
+      expect(unauthenticated.data.posts).toHaveLength(1)
+      expect(unauthenticated.data.cursor).toBeDefined()
+
+      await expect(
+        agent.app.bsky.feed.searchPostsV2(
+          {
+            query: 'doggo',
+            sort: 'top',
+            limit: 2,
+            cursor: unauthenticated.data.cursor,
+          },
+          { headers: override },
+        ),
+      ).rejects.toThrow('Request forbidden by administrative rules.')
+
+      const terminal = await agent.app.bsky.feed.searchPostsV2(
+        { query: 'doggo', sort: 'top', limit: 2 },
+        {
+          headers: {
+            ...(await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPostsV2,
+            )),
+            ...override,
+          },
+        },
+      )
+      expect(terminal.data.posts.map((post) => post.uri)).toEqual(
+        nonTaggedResults,
+      )
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await agent.app.bsky.feed.searchPostsV2(
+        { query: 'doggo', sort: 'top', limit: 2 },
+        {
+          headers: {
+            ...(await network.serviceHeaders(
+              alice,
+              ids.AppBskyFeedSearchPostsV2,
+            )),
+            ...override,
+          },
+        },
+      )
+      expect(trimmed.data.posts).toHaveLength(2)
+      expect(trimmed.data.cursor).toBeDefined()
+    })
+  })
 
   describe(`post search with 'top' sort`, () => {
     type TestCase = {

--- a/packages/bsky/tests/views/quotes.test.ts
+++ b/packages/bsky/tests/views/quotes.test.ts
@@ -75,6 +75,71 @@ describe('pds quote views', () => {
     )
 
     expect(alicePostQuotes2.data.posts.length).toBe(2)
+    expect(alicePostQuotes2.data.cursor).toBeUndefined()
+
+    const exact = await network.bsky.ctx.dataplane.getQuotesBySubjectSorted({
+      subject: { uri: sc.posts[alice][1].ref.uriStr },
+      limit: 5,
+    })
+    const nonterminal =
+      await network.bsky.ctx.dataplane.getQuotesBySubjectSorted({
+        subject: { uri: sc.posts[alice][1].ref.uriStr },
+        limit: 3,
+      })
+    expect(exact.uris).toHaveLength(5)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.uris).toHaveLength(3)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('fills a limited quotes page after an entirely filtered page', async () => {
+    const subject = await sc.post(alice, 'quote page fill subject')
+    const older = await sc.post(
+      bob,
+      'older visible quote',
+      undefined,
+      undefined,
+      subject.ref,
+      { createdAt: '2030-04-01T00:00:00.000Z' },
+    )
+    const newer = await sc.post(
+      carol,
+      'newer visible quote',
+      undefined,
+      undefined,
+      subject.ref,
+      { createdAt: '2030-04-02T00:00:00.000Z' },
+    )
+    await sc.post(
+      sc.dids.dan,
+      'filtered quote 1',
+      undefined,
+      undefined,
+      subject.ref,
+      { createdAt: '2030-04-03T00:00:00.000Z' },
+    )
+    await sc.post(eve, 'filtered quote 2', undefined, undefined, subject.ref, {
+      createdAt: '2030-04-04T00:00:00.000Z',
+    })
+    await sc.block(sc.dids.dan, alice)
+    await sc.block(eve, alice)
+    await network.processAll()
+
+    const { data } = await agent.api.app.bsky.feed.getQuotes(
+      { uri: subject.ref.uriStr, limit: 2 },
+      {
+        headers: await network.serviceHeaders(alice, ids.AppBskyFeedGetQuotes),
+      },
+    )
+
+    expect(data.posts.map((post) => post.uri)).toEqual([
+      newer.ref.uriStr,
+      older.ref.uriStr,
+    ])
+    expect(data.cursor).toBeUndefined()
+
+    await sc.unblock(sc.dids.dan, alice)
+    await sc.unblock(eve, alice)
   })
 
   it('does not return post when quote is deleted', async () => {

--- a/packages/bsky/tests/views/reposts.test.ts
+++ b/packages/bsky/tests/views/reposts.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { type AppBskyFeedGetRepostedBy, type AtpAgent, ids } from '@atproto/api'
 import { type SeedClient, TestNetwork, repostsSeed } from '@atproto/dev-env'
+import type { DidString } from '@atproto/syntax'
 import { forSnapshot, paginateAll, stripViewer } from '../_util.js'
 
 describe('pds repost views', () => {
@@ -9,8 +10,8 @@ describe('pds repost views', () => {
   let sc: SeedClient
 
   // account dids, for convenience
-  let alice: string
-  let bob: string
+  let alice: DidString
+  let bob: DidString
 
   beforeAll(async () => {
     network = await TestNetwork.create({
@@ -78,6 +79,8 @@ describe('pds repost views', () => {
     paginatedAll.forEach((res) =>
       expect(res.repostedBy.length).toBeLessThanOrEqual(2),
     )
+    expect(paginatedAll[0].cursor).toBeDefined()
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.feed.getRepostedBy(
       { uri: sc.posts[alice][2].ref.uriStr },
@@ -91,6 +94,71 @@ describe('pds repost views', () => {
 
     expect(full.data.repostedBy.length).toEqual(4)
     expect(results(paginatedAll)).toEqual(results([full.data]))
+
+    const exact = await network.bsky.ctx.dataplane.getRepostsBySubject({
+      subject: { uri: sc.posts[alice][2].ref.uriStr },
+      limit: 4,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getRepostsBySubject({
+      subject: { uri: sc.posts[alice][2].ref.uriStr },
+      limit: 2,
+    })
+    expect(exact.uris).toHaveLength(4)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.uris).toHaveLength(2)
+    expect(nonterminal.cursor).not.toBe('')
+
+    const actorReposts = await network.bsky.ctx.dataplane.getActorReposts({
+      actorDid: sc.dids.dan,
+      limit: 4,
+    })
+    const actorRepostsNonterminal =
+      await network.bsky.ctx.dataplane.getActorReposts({
+        actorDid: sc.dids.dan,
+        limit: 2,
+      })
+    expect(actorReposts.uris).toHaveLength(4)
+    expect(actorReposts.cursor).toBe('')
+    expect(actorRepostsNonterminal.uris).toHaveLength(2)
+    expect(actorRepostsNonterminal.cursor).not.toBe('')
+  })
+
+  it('fills a limited reposted-by page after an entirely filtered page', async () => {
+    const subject = await sc.post(alice, 'repost page fill subject')
+    await sc.repost(bob, subject.ref, {
+      createdAt: '2030-05-01T00:00:00.000Z',
+    })
+    await sc.repost(sc.dids.carol, subject.ref, {
+      createdAt: '2030-05-02T00:00:00.000Z',
+    })
+    await sc.repost(sc.dids.dan, subject.ref, {
+      createdAt: '2030-05-03T00:00:00.000Z',
+    })
+    await sc.repost(sc.dids.eve, subject.ref, {
+      createdAt: '2030-05-04T00:00:00.000Z',
+    })
+    await sc.block(sc.dids.dan, alice)
+    await sc.block(sc.dids.eve, alice)
+    await network.processAll()
+
+    const { data } = await agent.api.app.bsky.feed.getRepostedBy(
+      { uri: subject.ref.uriStr, limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          alice,
+          ids.AppBskyFeedGetRepostedBy,
+        ),
+      },
+    )
+
+    expect(data.repostedBy.map((actor) => actor.did)).toEqual([
+      sc.dids.carol,
+      bob,
+    ])
+    expect(data.cursor).toBeUndefined()
+
+    await sc.unblock(sc.dids.dan, alice)
+    await sc.unblock(sc.dids.eve, alice)
   })
 
   it('fetches reposted-by unauthed', async () => {

--- a/packages/bsky/tests/views/starter-packs.test.ts
+++ b/packages/bsky/tests/views/starter-packs.test.ts
@@ -99,6 +99,36 @@ describe('starter packs', () => {
     expect(forSnapshot(data.starterPacks)).toMatchSnapshot()
   })
 
+  it('returns a cursor only when more actor starter packs are available', async () => {
+    const exact = await network.bsky.ctx.dataplane.getActorStarterPacks({
+      actorDid: sc.dids.alice,
+      limit: 3,
+    })
+    expect(exact.uris).toHaveLength(3)
+    expect(exact.cursor).toBe('')
+
+    const over = await network.bsky.ctx.dataplane.getActorStarterPacks({
+      actorDid: sc.dids.alice,
+      limit: 2,
+    })
+    expect(over.uris).toHaveLength(2)
+    expect(over.cursor).not.toBe('')
+
+    const terminal = await agent.app.bsky.graph.getActorStarterPacks({
+      actor: sc.dids.alice,
+      limit: 3,
+    })
+    expect(terminal.data.starterPacks).toHaveLength(3)
+    expect(terminal.data.cursor).toBeUndefined()
+
+    const trimmed = await agent.app.bsky.graph.getActorStarterPacks({
+      actor: sc.dids.alice,
+      limit: 2,
+    })
+    expect(trimmed.data.starterPacks).toHaveLength(2)
+    expect(trimmed.data.cursor).toBeDefined()
+  })
+
   it('gets starter pack used on profile detail', async () => {
     const { data: profile } = await agent.api.app.bsky.actor.getProfile({
       actor: sc.dids.newskie1,
@@ -266,6 +296,36 @@ describe('starter packs', () => {
   })
 
   describe('searchStarterPacks', () => {
+    it('returns a cursor only when more starter packs are available', async () => {
+      const exact = await network.bsky.ctx.dataplane.searchStarterPacks({
+        term: 'starter',
+        limit: 4,
+      })
+      expect(exact.uris).toHaveLength(4)
+      expect(exact.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.searchStarterPacks({
+        term: 'starter',
+        limit: 3,
+      })
+      expect(over.uris).toHaveLength(3)
+      expect(over.cursor).not.toBe('')
+
+      const terminal = await agent.app.bsky.graph.searchStarterPacks({
+        q: 'starter',
+        limit: 4,
+      })
+      expect(terminal.data.starterPacks).toHaveLength(4)
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await agent.app.bsky.graph.searchStarterPacks({
+        q: 'starter',
+        limit: 3,
+      })
+      expect(trimmed.data.starterPacks).toHaveLength(3)
+      expect(trimmed.data.cursor).toBeDefined()
+    })
+
     it('searches starter packs and returns paginated', async () => {
       const { data: page0 } = await agent.app.bsky.graph.searchStarterPacks({
         q: 'starter',
@@ -317,9 +377,53 @@ describe('starter packs', () => {
         expect.objectContaining({ uri: sp4.uriStr }),
       ])
     })
+
+    it('refills through an empty filtered intermediate page', async () => {
+      const { data } = await agent.app.bsky.graph.searchStarterPacks(
+        { q: 'starter', limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.frankie,
+            ids.AppBskyGraphSearchStarterPacks,
+          ),
+        },
+      )
+      expect(data.starterPacks).toMatchObject([
+        expect.objectContaining({ uri: sp4.uriStr }),
+      ])
+      expect(data.cursor).toBeUndefined()
+    })
   })
 
   describe('searchStarterPacksV2', () => {
+    it('returns a cursor only when more starter packs are available', async () => {
+      const exact = await network.bsky.ctx.dataplane.searchStarterPacksV2({
+        params: { query: 'starter', limit: 4 },
+      })
+      expect(exact.starterPacks).toHaveLength(4)
+      expect(exact.pageInfo?.cursor).toBe('')
+
+      const over = await network.bsky.ctx.dataplane.searchStarterPacksV2({
+        params: { query: 'starter', limit: 3 },
+      })
+      expect(over.starterPacks).toHaveLength(3)
+      expect(over.pageInfo?.cursor).not.toBe('')
+
+      const terminal = await agent.app.bsky.graph.searchStarterPacksV2({
+        q: 'starter',
+        limit: 4,
+      })
+      expect(terminal.data.starterPacks).toHaveLength(4)
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await agent.app.bsky.graph.searchStarterPacksV2({
+        q: 'starter',
+        limit: 3,
+      })
+      expect(trimmed.data.starterPacks).toHaveLength(3)
+      expect(trimmed.data.cursor).toBeDefined()
+    })
+
     it('returns fully hydrated starter pack views', async () => {
       const { data } = await agent.app.bsky.graph.searchStarterPacksV2({
         q: 'starter',
@@ -363,6 +467,22 @@ describe('starter packs', () => {
       expect(data.starterPacks).toMatchObject([
         expect.objectContaining({ uri: sp4.uriStr }),
       ])
+    })
+
+    it('refills through an empty filtered intermediate page', async () => {
+      const { data } = await agent.app.bsky.graph.searchStarterPacksV2(
+        { q: 'starter', limit: 2 },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.frankie,
+            ids.AppBskyGraphSearchStarterPacksV2,
+          ),
+        },
+      )
+      expect(data.starterPacks).toMatchObject([
+        expect.objectContaining({ uri: sp4.uriStr }),
+      ])
+      expect(data.cursor).toBeUndefined()
     })
   })
 
@@ -493,6 +613,26 @@ describe('starter packs', () => {
         a.starterPack.uri > b.starterPack.uri ? 1 : -1,
       )
       expect(sortedPaginated).toEqual(sortedFull)
+    })
+
+    it('returns a cursor only when more actor starter packs are available', async () => {
+      const headers = await network.serviceHeaders(
+        sc.dids.alice,
+        ids.AppBskyGraphGetStarterPacksWithMembership,
+      )
+      const terminal = await agent.app.bsky.graph.getStarterPacksWithMembership(
+        { actor: sc.dids.bob, limit: 3 },
+        { headers },
+      )
+      expect(terminal.data.starterPacksWithMembership).toHaveLength(3)
+      expect(terminal.data.cursor).toBeUndefined()
+
+      const trimmed = await agent.app.bsky.graph.getStarterPacksWithMembership(
+        { actor: sc.dids.bob, limit: 2 },
+        { headers },
+      )
+      expect(trimmed.data.starterPacksWithMembership).toHaveLength(2)
+      expect(trimmed.data.cursor).toBeDefined()
     })
   })
 })

--- a/packages/bsky/tests/views/suggestions.test.ts
+++ b/packages/bsky/tests/views/suggestions.test.ts
@@ -64,7 +64,7 @@ describe('pds user search views', () => {
     expect(result.data.actors.length).toBe(0)
   })
 
-  it('paginates', async () => {
+  it('paginates and refills after filtering followed and requesting actors', async () => {
     const result1 = await agent.api.app.bsky.actor.getSuggestions(
       { limit: 2 },
       {
@@ -74,11 +74,13 @@ describe('pds user search views', () => {
         ),
       },
     )
-    expect(result1.data.actors.length).toBe(1)
+    expect(result1.data.actors.length).toBe(2)
     expect(result1.data.actors[0].handle).toEqual('bob.test')
+    expect(result1.data.actors[1].handle).toEqual('dan.test')
+    expect(result1.data.cursor).toBeDefined()
 
-    const result2 = await agent.api.app.bsky.actor.getSuggestions(
-      { limit: 2, cursor: result1.data.cursor },
+    const terminal = await agent.api.app.bsky.actor.getSuggestions(
+      { limit: 3 },
       {
         headers: await network.serviceHeaders(
           sc.dids.carol,
@@ -86,20 +88,20 @@ describe('pds user search views', () => {
         ),
       },
     )
-    expect(result2.data.actors.length).toBe(1)
-    expect(result2.data.actors[0].handle).toEqual('dan.test')
+    expect(terminal.data.actors).toHaveLength(2)
+    expect(terminal.data.cursor).toBeUndefined()
 
-    const result3 = await agent.api.app.bsky.actor.getSuggestions(
-      { limit: 2, cursor: result2.data.cursor },
+    const empty = await agent.api.app.bsky.actor.getSuggestions(
+      { limit: 1 },
       {
         headers: await network.serviceHeaders(
-          sc.dids.carol,
+          sc.dids.alice,
           ids.AppBskyActorGetSuggestions,
         ),
       },
     )
-    expect(result3.data.actors.length).toBe(0)
-    expect(result3.data.cursor).toBeUndefined()
+    expect(empty.data.actors).toEqual([])
+    expect(empty.data.cursor).toBeUndefined()
   })
 
   it('fetches suggestions unauthed', async () => {

--- a/packages/bsky/tests/views/timeline.test.ts
+++ b/packages/bsky/tests/views/timeline.test.ts
@@ -163,6 +163,8 @@ describe('timeline views', () => {
     paginatedAll.forEach((res) =>
       expect(res.feed.length).toBeLessThanOrEqual(4),
     )
+    expect(paginatedAll[0].cursor).toBeDefined()
+    expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
 
     const full = await agent.api.app.bsky.feed.getTimeline(
       {
@@ -178,6 +180,281 @@ describe('timeline views', () => {
 
     expect(full.data.feed.length).toEqual(7)
     expect(results(paginatedAll)).toEqual(results([full.data]))
+
+    const exact = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: carol,
+      limit: 7,
+    })
+    const nonterminal = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: carol,
+      limit: 4,
+    })
+    expect(exact.items).toHaveLength(7)
+    expect(exact.cursor).toBe('')
+    expect(nonterminal.items).toHaveLength(4)
+    expect(nonterminal.cursor).not.toBe('')
+  })
+
+  it('returns an empty page when there are no posts', async () => {
+    const viewer = await sc.createAccount('tl-empty-page', {
+      handle: 'tl-empty-page.test',
+      email: 'tl-empty-page@example.com',
+      password: 'hunter2',
+    })
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(0)
+    expect(page.cursor).toBe('')
+  })
+
+  it('returns all own posts when there are fewer than the requested limit', async () => {
+    const viewer = await sc.createAccount('tl-own-page', {
+      handle: 'tl-own-page.test',
+      email: 'tl-own-page@example.com',
+      password: 'hunter2',
+    })
+    for (let i = 0; i < 15; i++) {
+      await sc.post(viewer.did, `own timeline post ${i}`)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(15)
+    expect(page.cursor).toBe('')
+  })
+
+  it('returns no cursor when own posts exactly fill the requested limit', async () => {
+    const viewer = await sc.createAccount('tl-own-exact', {
+      handle: 'tl-own-exact.test',
+      email: 'tl-own-exact@example.com',
+      password: 'hunter2',
+    })
+    for (let i = 0; i < 20; i++) {
+      await sc.post(viewer.did, `exact own timeline post ${i}`)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(20)
+    expect(page.cursor).toBe('')
+  })
+
+  it('returns a cursor when own posts exceed the requested limit', async () => {
+    const viewer = await sc.createAccount('tl-own-overflow', {
+      handle: 'tl-own-overflow.test',
+      email: 'tl-own-overflow@example.com',
+      password: 'hunter2',
+    })
+    const postUris = new Set<string>()
+    for (let i = 0; i < 21; i++) {
+      const post = await sc.post(viewer.did, `overflow own timeline post ${i}`)
+      postUris.add(post.ref.uriStr)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(20)
+    expect(page.cursor).not.toBe('')
+
+    const nextPage = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+      cursor: page.cursor,
+    })
+    expect(nextPage.items).toHaveLength(1)
+    expect(nextPage.cursor).toBe('')
+    expect(
+      new Set([...page.items, ...nextPage.items].map((item) => item.uri)),
+    ).toEqual(postUris)
+  })
+
+  it('uses own posts to fill space without displacing followed-account posts', async () => {
+    const viewer = await sc.createAccount('tl-own-fill', {
+      handle: 'tl-own-fill.test',
+      email: 'tl-own-fill@example.com',
+      password: 'hunter2',
+    })
+    const author = await sc.createAccount('tl-follow-fill', {
+      handle: 'tl-follow-fill.test',
+      email: 'tl-follow-fill@example.com',
+      password: 'hunter2',
+    })
+    await sc.follow(viewer.did, author.did)
+    const followedPostUris: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const post = await sc.post(author.did, `followed timeline post ${i}`)
+      followedPostUris.push(post.ref.uriStr)
+    }
+    const ownPostUris: string[] = []
+    for (let i = 0; i < 20; i++) {
+      const post = await sc.post(viewer.did, `own fill timeline post ${i}`)
+      ownPostUris.push(post.ref.uriStr)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(20)
+    expect(page.cursor).not.toBe('')
+    const returnedUris = new Set(page.items.map((item) => item.uri))
+    expect(followedPostUris.every((uri) => returnedUris.has(uri))).toBe(true)
+    expect(ownPostUris.filter((uri) => returnedUris.has(uri))).toHaveLength(15)
+  })
+
+  it('returns no cursor when followed-account and own posts exactly fill the requested limit', async () => {
+    const viewer = await sc.createAccount('tl-mixed-exact', {
+      handle: 'tl-mixed-exact.test',
+      email: 'tl-mixed-exact@example.com',
+      password: 'hunter2',
+    })
+    const author = await sc.createAccount('tl-mixed-author', {
+      handle: 'tl-mixed-author.test',
+      email: 'tl-mixed-author@example.com',
+      password: 'hunter2',
+    })
+    await sc.follow(viewer.did, author.did)
+    for (let i = 0; i < 5; i++) {
+      await sc.post(author.did, `exact followed timeline post ${i}`)
+    }
+    for (let i = 0; i < 15; i++) {
+      await sc.post(viewer.did, `exact own fill timeline post ${i}`)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(20)
+    expect(page.cursor).toBe('')
+  })
+
+  it('caps own posts at 10 when followed-account posts can fill the page', async () => {
+    const viewer = await sc.createAccount('tl-own-cap', {
+      handle: 'tl-own-cap.test',
+      email: 'tl-own-cap@example.com',
+      password: 'hunter2',
+    })
+    const author = await sc.createAccount('tl-cap-author', {
+      handle: 'tl-cap-author.test',
+      email: 'tl-cap-author@example.com',
+      password: 'hunter2',
+    })
+    await sc.follow(viewer.did, author.did)
+    const followedPostUris = new Set<string>()
+    for (let i = 0; i < 20; i++) {
+      const post = await sc.post(author.did, `capped followed post ${i}`)
+      followedPostUris.add(post.ref.uriStr)
+    }
+    const ownPostUris = new Set<string>()
+    for (let i = 0; i < 20; i++) {
+      const post = await sc.post(viewer.did, `capped own post ${i}`)
+      ownPostUris.add(post.ref.uriStr)
+    }
+    await network.processAll()
+
+    const page = await network.bsky.ctx.dataplane.getTimeline({
+      actorDid: viewer.did,
+      limit: 20,
+    })
+
+    expect(page.items).toHaveLength(20)
+    expect(page.cursor).not.toBe('')
+    expect(page.items.filter((item) => ownPostUris.has(item.uri))).toHaveLength(
+      10,
+    )
+    expect(
+      page.items.filter((item) => followedPostUris.has(item.uri)),
+    ).toHaveLength(10)
+  })
+
+  it('fills a limited timeline after an entirely filtered page', async () => {
+    const viewer = await sc.createAccount('timeline-page-fill-viewer', {
+      handle: 'tl-fill-viewer.test',
+      email: 'timeline-page-fill-viewer@example.com',
+      password: 'hunter2',
+    })
+    const author = await sc.createAccount('timeline-page-fill-author', {
+      handle: 'tl-fill-author.test',
+      email: 'timeline-page-fill-author@example.com',
+      password: 'hunter2',
+    })
+    await sc.follow(viewer.did, author.did)
+    const older = await sc.post(
+      author.did,
+      'older visible timeline post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-03-01T00:00:00.000Z' },
+    )
+    const newer = await sc.post(
+      author.did,
+      'newer visible timeline post',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-03-02T00:00:00.000Z' },
+    )
+    const filtered1 = await sc.post(
+      author.did,
+      'filtered timeline post 1',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-03-03T00:00:00.000Z' },
+    )
+    const filtered2 = await sc.post(
+      author.did,
+      'filtered timeline post 2',
+      undefined,
+      undefined,
+      undefined,
+      { createdAt: '2030-03-04T00:00:00.000Z' },
+    )
+    await network.processAll()
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered1.ref.uriStr,
+    })
+    await network.bsky.ctx.dataplane.takedownRecord({
+      recordUri: filtered2.ref.uriStr,
+    })
+
+    const { data } = await agent.api.app.bsky.feed.getTimeline(
+      { algorithm: REVERSE_CHRON, limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          viewer.did,
+          ids.AppBskyFeedGetTimeline,
+        ),
+      },
+    )
+
+    expect(data.feed.map((item) => item.post.uri)).toEqual([
+      newer.ref.uriStr,
+      older.ref.uriStr,
+    ])
+    expect(data.cursor).toBeUndefined()
   })
 
   it('agrees what the first item is for limit=1 and other limits', async () => {

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -346,7 +346,6 @@ exports[`proxies view requests actor.getSuggestions 1`] = `
       },
     },
   ],
-  "cursor": "1:2:3",
 }
 `;
 
@@ -634,7 +633,6 @@ exports[`proxies view requests actor.searchActorTypeahead 1`] = `
 
 exports[`proxies view requests feed.getAuthorFeed 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "feed": [
     {
       "post": {
@@ -1034,7 +1032,6 @@ exports[`proxies view requests feed.getFeedGenerators 1`] = `
 
 exports[`proxies view requests feed.getLikes 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "likes": [
     {
       "actor": {
@@ -1110,7 +1107,6 @@ exports[`proxies view requests feed.getLikes 1`] = `
 
 exports[`proxies view requests feed.getListFeed 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "feed": [
     {
       "post": {
@@ -2166,7 +2162,6 @@ exports[`proxies view requests feed.getPosts 1`] = `
 
 exports[`proxies view requests feed.getRepostedBy 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "repostedBy": [
     {
       "associated": {
@@ -2193,7 +2188,6 @@ exports[`proxies view requests feed.getRepostedBy 1`] = `
 
 exports[`proxies view requests feed.getTimeline 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "feed": [
     {
       "post": {
@@ -4238,7 +4232,6 @@ exports[`proxies view requests graph.getBlocks 1`] = `
       },
     },
   ],
-  "cursor": "0000000000000::bafycid",
 }
 `;
 
@@ -4334,7 +4327,6 @@ exports[`proxies view requests graph.getFollowers 1`] = `
 
 exports[`proxies view requests graph.getFollows 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "follows": [
     {
       "associated": {
@@ -4419,7 +4411,6 @@ exports[`proxies view requests graph.getFollows 1`] = `
 
 exports[`proxies view requests graph.getList 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "items": [
     {
       "subject": {
@@ -4523,7 +4514,6 @@ exports[`proxies view requests graph.getList 1`] = `
 
 exports[`proxies view requests graph.getListBlocks 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "lists": [
     {
       "cid": "cids(0)",
@@ -4566,7 +4556,6 @@ exports[`proxies view requests graph.getListBlocks 1`] = `
 
 exports[`proxies view requests graph.getLists 1`] = `
 {
-  "cursor": "0000000000000::bafycid",
   "lists": [
     {
       "cid": "cids(0)",

--- a/packages/pds/tests/proxied/views.test.ts
+++ b/packages/pds/tests/proxied/views.test.ts
@@ -279,18 +279,8 @@ describe('proxies view requests', () => {
         headers: { ...sc.getHeaders(alice) },
       },
     )
-    const pt2 = await agent.app.bsky.feed.getRepostedBy(
-      {
-        uri: postUri,
-        cursor: pt1.data.cursor,
-      },
-      {
-        headers: { ...sc.getHeaders(alice) },
-      },
-    )
-    expect([...pt1.data.repostedBy, ...pt2.data.repostedBy]).toEqual(
-      res.data.repostedBy,
-    )
+    expect(pt1.data.repostedBy).toEqual(res.data.repostedBy)
+    expect(pt1.data.cursor).toBeUndefined()
   })
 
   it('feed.getPosts', async () => {
@@ -598,11 +588,6 @@ describe('proxies view requests', () => {
       { headers: sc.getHeaders(bob) },
     )
     expect(forSnapshot(pt1.data)).toMatchSnapshot()
-    const pt2 = await agent.app.bsky.graph.getListBlocks(
-      { cursor: pt1.data.cursor },
-      { headers: sc.getHeaders(bob) },
-    )
-    expect(pt2.data.lists).toEqual([])
-    expect(pt2.data.cursor).not.toBeDefined()
+    expect(pt1.data.cursor).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Motivation

We have a lot of inconsistency, and in a few places that inconsistency leads to bugs. Ex of a recently reported bug: user opens /followers and sees "You have no followers", while they know they do. What happened is that the appview fetched a page of followers from the dataplane, and later applied rules (remove blocks, takendown, etc). In that specific case, all items were removed, so appview returned [] + a cursor. The app understood the empty array as pagination finished, and gave up, even though it had a cursor.

## Goals

1. dataplane: Give an exact meaning to the dataplane returning or not a cursor: it means there are more pages (avoids making a final call to just get an empty page).
2. appview: Make the appview try to honor the limit that was asked for, instead of doing only 1 attempt and then returning fewer results.
3. app: Make the app consistently paginate based on the presence of a cursor, not based on the result array.

## The proposal

1. dataplane: overfetches by one, so it knows whether there is a next page. It does not return the extra item, but uses it to determine whether to return a cursor (which is the cursor pointing to the last item actually returned).
2. appview: tries to honor the limit that was asked for. If after applying rules it sees it doesn't have a full page to return, it loads more. It tries this up to a few times (suggestion: 10). But the important thing: even though it didn't fill the page, it returns the cursor, which is the canonical way of saying there is a next page.
3. app: always bases whether there is a next page on the presence of the cursor, never on the contents of the list.

## Implementation

1. dataplane: https://github.com/bluesky-social/tango/pull/1330. The changes are mainly overfetching by 1 and using that to determine the presence of cursor on the reply. There are a few corner cases it might not handle (specifically related to certain caches), but I believe this is good to go, and I believe we could make improvements as needed later.
2. appview: https://github.com/bluesky-social/atproto/pull/5375/changes#r3760733594. Introduces a fillPage helper and wraps 32 endpoints in it, and does the approach of 10 attempts to fill the page. This adds little complexity, and removes complexity from 3 endpoints which implemented that ad-hoc.
3. app: https://github.com/bluesky-social/social-app/pull/11448. To be reviewed by app folks, should always use the cursor to determine whether there are more pages.
