### PR TITLE
Cleans up trending topic experiment

### DIFF
--- a/.changeset/tidy-trends-ungate.md
+++ b/.changeset/tidy-trends-ungate.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Serve all trending topics traffic from iris and remove the experiment gate

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
@@ -25,16 +25,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({
-        labelers,
-        viewer,
-        features: ctx.featureGatesClient.scope(
-          ctx.featureGatesClient.parseUserContextFromHandler({
-            viewer,
-            req,
-          }),
-        ),
-      })
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
       })
@@ -57,19 +48,12 @@ export default function (server: Server, ctx: AppContext) {
 const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
   const { params, ctx } = input
 
-  // Route treatment users to iris (trending-topics v2), everyone else stays on
-  // the existing hot-topic service.
-  const useIris = params.hydrateCtx.features.checkGate(
-    params.hydrateCtx.features.Gate.TrendingTopicsV2,
-  )
-  const topicsClient = (useIris && ctx.irisClient) || ctx.topicsClient
-
-  if (!topicsClient) {
+  if (!ctx.irisClient) {
     // Use 501 instead of 500 as these are not considered retry-able by clients
     throw new MethodNotImplementedError('Topics agent not available')
   }
 
-  return topicsClient.call(
+  return ctx.irisClient.call(
     app.bsky.unspecced.getTrendingTopics,
     {
       limit: params.limit,
@@ -101,7 +85,6 @@ const presentation: PresentationFn<
 type Context = {
   hydrator: Hydrator
   views: Views
-  topicsClient: Client | undefined
   irisClient: Client | undefined
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -24,16 +24,7 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ auth, params, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({
-        labelers,
-        viewer,
-        features: ctx.featureGatesClient.scope(
-          ctx.featureGatesClient.parseUserContextFromHandler({
-            viewer,
-            req,
-          }),
-        ),
-      })
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
         'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
@@ -59,19 +50,12 @@ export default function (server: Server, ctx: AppContext) {
 const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
   const { params, ctx } = input
 
-  // Route treatment users to iris (trending-topics v2), everyone else stays on
-  // the existing hot-topic service.
-  const useIris = params.hydrateCtx.features.checkGate(
-    params.hydrateCtx.features.Gate.TrendingTopicsV2,
-  )
-  const topicsClient = (useIris && ctx.irisClient) || ctx.topicsClient
-
-  if (!topicsClient) {
+  if (!ctx.irisClient) {
     // Use 501 instead of 500 as these are not considered retry-able by clients
     throw new MethodNotImplementedError('Topics agent not available')
   }
 
-  const skeleton = await topicsClient.call(
+  const skeleton = await ctx.irisClient.call(
     app.bsky.unspecced.getTrendsSkeleton,
     {
       limit: params.limit,
@@ -152,7 +136,6 @@ const presentation: PresentationFn<
 type Context = {
   hydrator: Hydrator
   views: Views
-  topicsClient: Client | undefined
   irisClient: Client | undefined
 }
 

--- a/packages/bsky/src/feature-gates/gates.ts
+++ b/packages/bsky/src/feature-gates/gates.ts
@@ -12,7 +12,6 @@ export enum Gate {
   SuggestedUsersForDiscoverEnable = 'suggested_users:for_discover:enable',
   SuggestedUsersForSeeMoreEnable = 'suggested_users:for_see_more:enable',
   SearchV2Enable = 'search:v2:enable',
-  TrendingTopicsV2 = 'trending_topics_v2',
 
   // temp
   AATest = 'aa-test-appview',

--- a/packages/bsky/tests/views/get-trends.test.ts
+++ b/packages/bsky/tests/views/get-trends.test.ts
@@ -27,8 +27,7 @@ describe('getTrends', () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'bsky_tests_get_trends_test_b',
       bsky: {
-        topicsUrl: mockTrendServer.url,
-        topicsApiKey: 'test',
+        irisUrl: mockTrendServer.url,
       },
     })
     agent = network.bsky.getAgent()


### PR DESCRIPTION

Basically reverts the gate added in #5346 setting Iris as the single server for trending topics.
