### PR TITLE
Expose canonical OP thread numbering on feed items

### DIFF
--- a/.changeset/warm-feeds-count.md
+++ b/.changeset/warm-feeds-count.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Expose canonical OP thread numbering on feed items.

--- a/.changeset/warm-feeds-count.md
+++ b/.changeset/warm-feeds-count.md
@@ -1,5 +1,6 @@
 ---
 '@atproto/bsky': patch
+'@atproto/dev-env': patch
 ---
 
 Expose canonical OP thread numbering on feed items.

--- a/packages/bsky/src/feature-gates/gates.ts
+++ b/packages/bsky/src/feature-gates/gates.ts
@@ -13,7 +13,6 @@ export enum Gate {
   SuggestedUsersForSeeMoreEnable = 'suggested_users:for_see_more:enable',
   SearchV2Enable = 'search:v2:enable',
   IrisFeed = 'iris:feed:enable',
-  TrendingTopicsV2 = 'trending_topics_v2',
   OpThreadMetadataEnable = 'op_thread_metadata:enable',
 
   // temp

--- a/packages/bsky/src/feature-gates/gates.ts
+++ b/packages/bsky/src/feature-gates/gates.ts
@@ -13,6 +13,8 @@ export enum Gate {
   SuggestedUsersForSeeMoreEnable = 'suggested_users:for_see_more:enable',
   SearchV2Enable = 'search:v2:enable',
   IrisFeed = 'iris:feed:enable',
+  TrendingTopicsV2 = 'trending_topics_v2',
+  OpThreadMetadataEnable = 'op_thread_metadata:enable',
 
   // temp
   AATest = 'aa-test-appview',

--- a/packages/bsky/src/hydration/feed.ts
+++ b/packages/bsky/src/hydration/feed.ts
@@ -29,6 +29,8 @@ export type Post = RecordInfo<PostRecord> & {
   violatesEmbeddingRules: boolean
   hasThreadGate: boolean
   hasPostGate: boolean
+  opThreadPostIndex?: number
+  opThreadPostCount?: number
   tags: Set<string>
   /**
    * Debug information for internal development
@@ -107,6 +109,7 @@ export type FeedItem = {
 
 export type GetPostsHydrationOptions = {
   processDynamicTagsForView?: 'thread' | 'search'
+  includeOpThreadMetadata?: boolean
 }
 
 export class FeedHydrator {
@@ -133,11 +136,23 @@ export class FeedHydrator {
               uris: need,
               viewerDid: viewer ?? undefined,
               processDynamicTagsForView: options.processDynamicTagsForView,
+              includeOpThreadMetadata: options.includeOpThreadMetadata,
             }
           : {
               uris: need,
+              includeOpThreadMetadata: options.includeOpThreadMetadata,
             },
       )
+      const opThreadMetadata = new Map<
+        string,
+        { index: number; count: number }
+      >()
+      for (const { uris } of res.opThreads) {
+        const count = uris.length
+        for (let i = 0; i < count; i++) {
+          opThreadMetadata.set(uris[i], { index: i + 1, count })
+        }
+      }
 
       for (let i = 0; i < need.length; i++) {
         const record = parseRecord(
@@ -149,6 +164,7 @@ export class FeedHydrator {
         const violatesEmbeddingRules = res.meta[i].violatesEmbeddingRules
         const hasThreadGate = res.meta[i].hasThreadGate
         const hasPostGate = res.meta[i].hasPostGate
+        const opThread = opThreadMetadata.get(need[i])
         const tags = new Set<string>(res.records[i].tags ?? [])
         const debug = { tags: Array.from(tags) }
 
@@ -161,6 +177,8 @@ export class FeedHydrator {
                 violatesEmbeddingRules,
                 hasThreadGate,
                 hasPostGate,
+                opThreadPostIndex: opThread?.index,
+                opThreadPostCount: opThread?.count,
                 tags,
                 debug,
               }

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -813,6 +813,13 @@ export class Hydrator {
     const posts = await this.feed.getPosts(
       items.map((item) => item.post.uri),
       ctx.includeTakedowns,
+      undefined,
+      undefined,
+      {
+        includeOpThreadMetadata: ctx.features.checkGate(
+          ctx.features.Gate.OpThreadMetadataEnable,
+        ),
+      },
     )
     const rootUris: AtUriString[] = []
     const parentUris: AtUriString[] = []
@@ -841,7 +848,7 @@ export class Hydrator {
     const repostUris = mapDefined(items, (item) => item.repost?.uri)
     const [postState, repostProfileState, reposts] = await Promise.all([
       this.hydratePosts(postAndReplyRefs, ctx, {
-        posts: posts.merge(replies), // avoids refetches of posts
+        posts: replies.merge(posts), // avoids refetches while preserving feed-item metadata
       }),
       this.hydrateProfiles(
         [...repostUris.map(didFromUri), ...replyParentAuthors],

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -1096,6 +1096,8 @@ export class Views {
       post,
       reason,
       reply,
+      opThreadPostIndex: postInfo?.opThreadPostIndex,
+      opThreadPostCount: postInfo?.opThreadPostCount,
     }
   }
 

--- a/packages/bsky/src/views/types.ts
+++ b/packages/bsky/src/views/types.ts
@@ -94,7 +94,12 @@ export type PostgateRecord = app.bsky.feed.postgate.Main
 export const isPostgateDisableRuleType =
   app.bsky.feed.postgate.disableRule.$isTypeOf
 
-export type FeedViewPost = app.bsky.feed.defs.FeedViewPost
+// Temporary off-Lexicon fields used to expose canonical OP thread numbering
+// on feed items while the public response schema remains unchanged.
+export type FeedViewPost = app.bsky.feed.defs.FeedViewPost & {
+  opThreadPostIndex?: number
+  opThreadPostCount?: number
+}
 export type ReasonPin = app.bsky.feed.defs.ReasonPin
 export type ReasonRepost = app.bsky.feed.defs.ReasonRepost
 export type ReplyRef = app.bsky.feed.defs.ReplyRef

--- a/packages/bsky/src/views/types.ts
+++ b/packages/bsky/src/views/types.ts
@@ -94,8 +94,8 @@ export type PostgateRecord = app.bsky.feed.postgate.Main
 export const isPostgateDisableRuleType =
   app.bsky.feed.postgate.disableRule.$isTypeOf
 
-// Temporary off-Lexicon fields used to expose canonical OP thread numbering
-// on feed items while the public response schema remains unchanged.
+// TODO Temporary off-Lexicon fields used to expose canonical OP thread
+// numbering on feed items while the public response schema remains unchanged.
 export type FeedViewPost = app.bsky.feed.defs.FeedViewPost & {
   opThreadPostIndex?: number
   opThreadPostCount?: number

--- a/packages/bsky/tests/views/op-thread-feed-metadata.test.ts
+++ b/packages/bsky/tests/views/op-thread-feed-metadata.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { type SeedClient, TestNetwork } from '@atproto/dev-env'
+import { Gate } from '../../src/feature-gates/gates.js'
+
+type FeedItemWithOpThreadMetadata = {
+  post: { uri: string }
+  opThreadPostIndex?: number
+  opThreadPostCount?: number
+}
+
+describe('OP thread feed metadata', () => {
+  let network: TestNetwork
+  let sc: SeedClient<TestNetwork>
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_op_thread_feed_metadata',
+    })
+    vi.spyOn(network.bsky.ctx.featureGatesClient, 'scope').mockReturnValue({
+      Gate,
+      checkGate: (gate) => gate === Gate.OpThreadMetadataEnable,
+      checkGates: (gates) =>
+        new Map(
+          gates.map((gate) => [gate, gate === Gate.OpThreadMetadataEnable]),
+        ),
+    })
+    sc = network.getSeedClient()
+    await sc.createAccount('threadop', {
+      handle: 'threadop.test',
+      email: 'threadop@test.com',
+      password: 'threadop-pass',
+    })
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    vi.restoreAllMocks()
+    await network?.close()
+  })
+
+  it('exposes canonical numbering on feed items', async () => {
+    const op = sc.dids.threadop
+    const root = await sc.post(op, 'root')
+    const first = await sc.reply(op, root.ref, root.ref, 'first')
+    const second = await sc.reply(op, root.ref, first.ref, 'second')
+    await network.processAll()
+
+    const res = await network.bsky.getAgent().api.app.bsky.feed.getAuthorFeed({
+      actor: op,
+    })
+    const byUri = new Map(
+      res.data.feed.map((item) => [
+        item.post.uri,
+        item as FeedItemWithOpThreadMetadata,
+      ]),
+    )
+
+    expect(
+      [root, first, second].map(({ ref }) => {
+        const item = byUri.get(ref.uriStr)
+        return [item?.opThreadPostIndex, item?.opThreadPostCount]
+      }),
+    ).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ])
+  })
+})

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -69,6 +69,7 @@ export class TestNetwork extends TestNetworkNoAppView {
     const bsync = await TestBsync.create({
       apiKeys: [bsyncApiKey],
       dbUrl: dbPostgresUrl,
+      dbSchema: `bsync_${dbPostgresSchema}`,
     })
 
     const bsky = await TestBsky.create({


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->

Part two of two. Requires https://github.com/bluesky-social/tango/pull/1329.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Yes, `gpt-5.6-sol` and review by Claude Opus 5.
