### PR TITLE
xrpc-server: accept empty chunked request bodies

### DIFF
--- a/.changeset/empty-bodies-forward.md
+++ b/.changeset/empty-bodies-forward.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': patch
+---
+
+Allow requests with empty chunked transfer encoding when a method expects no input.

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert'
-import { once } from 'node:events'
 import type { IncomingMessage, OutgoingMessage } from 'node:http'
 import { type Duplex, type Readable, pipeline } from 'node:stream'
 import {
@@ -248,11 +247,7 @@ export function createLexiconInputVerifier<I extends Input = Input>(
   if (def.type === 'query' || !def.input) {
     return async (req) => {
       // @NOTE We allow (and ignore) "empty" bodies
-      if (await hasNonEmptyBody(req)) {
-        throw new InvalidRequestError(
-          `A request body was provided when none was expected`,
-        )
-      }
+      await assertEmptyBody(req)
 
       return undefined as I
     }
@@ -322,12 +317,7 @@ export function createSchemaInputVerifier<M extends l.Procedure | l.Query>(
   if (!input?.encoding) {
     //
     return async (req) => {
-      if (await hasNonEmptyBody(req)) {
-        // @NOTE we *could* also discard the body here instead of throwing an error
-        throw new InvalidRequestError(
-          `A request body was provided when none was expected`,
-        )
-      }
+      await assertEmptyBody(req)
 
       return undefined as LexMethodInput<M>
     }
@@ -534,30 +524,34 @@ function getBodyPresence(req: IncomingMessage): BodyPresence {
   return 'missing'
 }
 
-async function hasNonEmptyBody(req: IncomingMessage): Promise<boolean> {
+async function assertEmptyBody(req: IncomingMessage): Promise<void> {
   const presence = getBodyPresence(req)
-  if (presence !== 'present') return false
-  if (req.headers['transfer-encoding'] == null) return true
-
-  // @NOTE Transfer-Encoding only signals framing; a chunked body may be empty.
-  if (req.readableEnded) return req.readableLength > 0
-
-  const controller = new AbortController()
-  let hasData: boolean
-  try {
-    hasData = await Promise.race([
-      once(req, 'data', { signal: controller.signal }).then(() => true),
-      once(req, 'end', { signal: controller.signal }).then(() => false),
-      once(req, 'aborted', { signal: controller.signal }).then(() => {
-        throw new InvalidRequestError('Request aborted')
-      }),
-    ])
-  } finally {
-    controller.abort()
+  if (presence !== 'present') return
+  if (req.headers['transfer-encoding'] == null) {
+    throw new InvalidRequestError(
+      `A request body was provided when none was expected`,
+    )
   }
 
-  if (hasData) req.resume()
-  return hasData
+  // @NOTE Transfer-Encoding only signals framing; a chunked body may be empty.
+  let hasData = false
+  try {
+    for await (const chunk of req) {
+      if (chunk.length > 0) hasData = true
+    }
+  } catch (cause) {
+    throw new InvalidRequestError(
+      'Failed to process unexpected request body',
+      undefined,
+      { cause },
+    )
+  }
+
+  if (hasData) {
+    throw new InvalidRequestError(
+      `A request body was provided when none was expected`,
+    )
+  }
 }
 
 function createBodyParser(inputEncoding: string, options: RouteOptions) {

--- a/packages/xrpc-server/src/util.ts
+++ b/packages/xrpc-server/src/util.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import { once } from 'node:events'
 import type { IncomingMessage, OutgoingMessage } from 'node:http'
 import { type Duplex, type Readable, pipeline } from 'node:stream'
 import {
@@ -247,7 +248,7 @@ export function createLexiconInputVerifier<I extends Input = Input>(
   if (def.type === 'query' || !def.input) {
     return async (req) => {
       // @NOTE We allow (and ignore) "empty" bodies
-      if (getBodyPresence(req) === 'present') {
+      if (await hasNonEmptyBody(req)) {
         throw new InvalidRequestError(
           `A request body was provided when none was expected`,
         )
@@ -321,7 +322,7 @@ export function createSchemaInputVerifier<M extends l.Procedure | l.Query>(
   if (!input?.encoding) {
     //
     return async (req) => {
-      if (getBodyPresence(req) === 'present') {
+      if (await hasNonEmptyBody(req)) {
         // @NOTE we *could* also discard the body here instead of throwing an error
         throw new InvalidRequestError(
           `A request body was provided when none was expected`,
@@ -531,6 +532,32 @@ function getBodyPresence(req: IncomingMessage): BodyPresence {
   if (req.headers['content-length'] === '0') return 'empty'
   if (req.headers['content-length'] != null) return 'present'
   return 'missing'
+}
+
+async function hasNonEmptyBody(req: IncomingMessage): Promise<boolean> {
+  const presence = getBodyPresence(req)
+  if (presence !== 'present') return false
+  if (req.headers['transfer-encoding'] == null) return true
+
+  // @NOTE Transfer-Encoding only signals framing; a chunked body may be empty.
+  if (req.readableEnded) return req.readableLength > 0
+
+  const controller = new AbortController()
+  let hasData: boolean
+  try {
+    hasData = await Promise.race([
+      once(req, 'data', { signal: controller.signal }).then(() => true),
+      once(req, 'end', { signal: controller.signal }).then(() => false),
+      once(req, 'aborted', { signal: controller.signal }).then(() => {
+        throw new InvalidRequestError('Request aborted')
+      }),
+    ])
+  } finally {
+    controller.abort()
+  }
+
+  if (hasData) req.resume()
+  return hasData
 }
 
 function createBodyParser(inputEncoding: string, options: RouteOptions) {

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -1,15 +1,16 @@
 import assert from 'node:assert'
-import { type Server, request } from 'node:http'
+import { type IncomingMessage, type Server, request } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { Readable } from 'node:stream'
 import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
 import { jest } from '@jest/globals'
 import { cidForCbor } from '@atproto/common'
 import { randomBytes } from '@atproto/crypto'
-import type { LexiconDoc } from '@atproto/lexicon'
+import { type LexiconDoc, Lexicons } from '@atproto/lexicon'
 import { ResponseType, XrpcClient } from '@atproto/xrpc'
 import * as xrpcServer from '../src/index.js'
 import { logger } from '../src/logger.js'
+import { createLexiconInputVerifier } from '../src/util.js'
 import {
   buildAddLexicons,
   buildMethodLexicons,
@@ -130,6 +131,50 @@ const handlers = {
   },
   'io.example.noInput': () => undefined,
 }
+
+function createNoInputVerifier() {
+  const lexicons = new Lexicons(structuredClone(LEXICONS))
+  const def = lexicons.getDef('io.example.noInput')
+  assert(def?.type === 'procedure')
+  return createLexiconInputVerifier('io.example.noInput', def, {}, lexicons)
+}
+
+describe('no-input verifier body draining', () => {
+  test('drains a non-empty chunked body before rejecting it', async () => {
+    const verify = createNoInputVerifier()
+    const req = new Readable({ read() {} }) as IncomingMessage
+    req.headers = { 'transfer-encoding': 'chunked' }
+
+    let settled = false
+    const verification = verify(req as never, undefined as never).finally(
+      () => (settled = true),
+    )
+    req.push('unexpected')
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(settled).toBe(false)
+
+    req.push(null)
+    await expect(verification).rejects.toMatchObject({
+      type: ResponseType.InvalidRequest,
+      message: 'A request body was provided when none was expected',
+    })
+  })
+
+  test('wraps errors while draining an unexpected body', async () => {
+    const verify = createNoInputVerifier()
+    const req = new Readable({ read() {} }) as IncomingMessage
+    req.headers = { 'transfer-encoding': 'chunked' }
+
+    const verification = verify(req as never, undefined as never)
+    req.destroy(new Error('read failed'))
+
+    await expect(verification).rejects.toMatchObject({
+      type: ResponseType.InvalidRequest,
+      message: 'Failed to process unexpected request body',
+      cause: expect.objectContaining({ message: 'read failed' }),
+    })
+  })
+})
 
 for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
   describe(buildServer, () => {

--- a/packages/xrpc-server/tests/bodies.test.ts
+++ b/packages/xrpc-server/tests/bodies.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import type * as http from 'node:http'
+import { type Server, request } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { Readable } from 'node:stream'
 import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
@@ -93,6 +93,15 @@ const LEXICONS = [
       },
     },
   },
+  {
+    lexicon: 1,
+    id: 'io.example.noInput',
+    defs: {
+      main: {
+        type: 'procedure',
+      },
+    },
+  },
 ] as const satisfies LexiconDoc[]
 
 const handlers = {
@@ -119,11 +128,12 @@ const handlers = {
       body: { cid: cid.toString() },
     }
   },
+  'io.example.noInput': () => undefined,
 }
 
 for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
   describe(buildServer, () => {
-    let s: http.Server
+    let s: Server
     let client: XrpcClient
     let url: string
     beforeAll(async () => {
@@ -159,6 +169,29 @@ for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
         message: 'Request encoding (Content-Type) required but not provided',
       })
     })
+
+    test('allows an empty chunked body when no input is expected', async () => {
+      const response = await sendChunkedRequest(
+        `${url}/xrpc/io.example.noInput`,
+      )
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toBe('')
+    })
+
+    test('rejects a non-empty chunked body when no input is expected', async () => {
+      const response = await sendChunkedRequest(
+        `${url}/xrpc/io.example.noInput`,
+        'unexpected',
+      )
+
+      expect(response.statusCode).toBe(400)
+      expect(JSON.parse(response.body)).toMatchObject({
+        error: 'InvalidRequest',
+        message: 'A request body was provided when none was expected',
+      })
+    })
+
     test('validates required input properties', async () => {
       await expect(
         client.call('io.example.validationTest', {}, {}),
@@ -569,6 +602,33 @@ for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
       })
     })
   })
+}
+
+function sendChunkedRequest(url: string, body?: string) {
+  return new Promise<{ body: string; statusCode: number }>(
+    (resolve, reject) => {
+      const req = request(
+        url,
+        {
+          method: 'POST',
+          headers: { 'transfer-encoding': 'chunked' },
+        },
+        (res) => {
+          res.setEncoding('utf8')
+          let responseBody = ''
+          res.on('data', (chunk) => (responseBody += chunk))
+          res.on('error', reject)
+          res.on('end', () => {
+            resolve({ body: responseBody, statusCode: res.statusCode ?? 0 })
+          })
+        },
+      )
+
+      req.on('error', reject)
+      if (body !== undefined) req.write(body)
+      req.end()
+    },
+  )
 }
 
 const bytesToReadableStream = (bytes: Uint8Array): ReadableStream => {


### PR DESCRIPTION
## What & why

Some proxies add `Transfer-Encoding: chunked` to requests even when they send no body. The header describes framing, so treating it alone as proof of a non-empty body rejects valid no-input XRPC calls.

For methods without input, this waits for either body data or the end of the request stream. Empty chunked requests are accepted, while non-empty requests remain rejected. Tests cover both the legacy and schema-based server paths.

Fixes #3267.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling.

OpenAI Codex assisted with the implementation and tests. I reviewed the full diff and validation results.