### PR TITLE
Fixes sync CI workflow

### DIFF
--- a/.github/workflows/sync-internal.yaml
+++ b/.github/workflows/sync-internal.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -26,6 +27,5 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "test@users.noreply.github.com"
-          git config --unset-all http.https://github.com/.extraheader
           git remote add internal https://x-access-token:${TOKEN}@github.com/bluesky-social/atproto-internal.git
           git push internal main --force


### PR DESCRIPTION



apparently after #5329 (GitHhub Actions bump `v4` -> `v7`) our sync step is broken on `git config --unset-all http.https://github.com/.extraheader`. I am invetsigating it and trying to replace that with a new `v7` config.