### PR TITLE
Sync multipart video upload lexicons

### DIFF
--- a/.changeset/bright-videos-upload.md
+++ b/.changeset/bright-videos-upload.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': minor
+---
+
+Add multipart video upload lexicons and document all video processing job states.

--- a/lexicons/app/bsky/video/abortUpload.json
+++ b/lexicons/app/bsky/video/abortUpload.json
@@ -1,0 +1,55 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.abortUpload",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Abort an upload only while it is created, releasing its quota reservation immediately. Terminal sessions are unchanged and return their terminal outcome. A finishing session returns UploadNotReady.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["jobId"],
+          "properties": {
+            "jobId": { "type": "string", "minLength": 1, "maxLength": 256 }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["state"],
+          "properties": {
+            "state": {
+              "type": "string",
+              "maxLength": 32,
+              "knownValues": ["aborted", "completed", "failed", "expired"]
+            },
+            "completedJobId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "description": "Present only when state is completed."
+            },
+            "failureReason": {
+              "type": "string",
+              "maxLength": 1024,
+              "description": "Present only when state is failed."
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "UploadNotFound",
+          "description": "The job ID is unknown or aged out of retention; known terminal sessions return their outcome and are never reported as not found."
+        },
+        {
+          "name": "UploadNotReady",
+          "description": "A finish is in progress; check getUploadStatus and retry."
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/app/bsky/video/defs.json
+++ b/lexicons/app/bsky/video/defs.json
@@ -11,7 +11,17 @@
         "state": {
           "type": "string",
           "description": "The state of the video processing job. All values not listed as a known value indicate that the job is in process.",
-          "knownValues": ["JOB_STATE_COMPLETED", "JOB_STATE_FAILED"]
+          "knownValues": [
+            "JOB_STATE_CREATED",
+            "JOB_STATE_ENCODING",
+            "JOB_STATE_ENCODED",
+            "JOB_STATE_SCANNING",
+            "JOB_STATE_SCANNED",
+            "JOB_STATE_UPLOADING",
+            "JOB_STATE_UPLOADED",
+            "JOB_STATE_COMPLETED",
+            "JOB_STATE_FAILED"
+          ]
         },
         "progress": {
           "type": "integer",

--- a/lexicons/app/bsky/video/finishUpload.json
+++ b/lexicons/app/bsky/video/finishUpload.json
@@ -1,0 +1,73 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.finishUpload",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Finish an upload. This call is idempotent and safe to retry. On deduplication completedJobId may differ from the input jobId; poll getJobStatus with completedJobId. Probe-based validation failures surface later as JOB_STATE_FAILED from getJobStatus, not as errors from this call.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["jobId"],
+          "properties": {
+            "jobId": { "type": "string", "minLength": 1, "maxLength": 256 }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["completedJobId", "jobStatus"],
+          "properties": {
+            "completedJobId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "description": "The processing job to poll with getJobStatus; on deduplication this may differ from the input jobId."
+            },
+            "jobStatus": {
+              "type": "ref",
+              "ref": "app.bsky.video.defs#jobStatus"
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "UploadNotFound",
+          "description": "The job ID is unknown or aged out of retention; known terminal sessions are never reported as not found."
+        },
+        {
+          "name": "UploadExpired",
+          "description": "The upload session expired before finalization began."
+        },
+        {
+          "name": "MissingParts",
+          "description": "Not all parts are recorded; the error message lists the missing part numbers."
+        },
+        {
+          "name": "UploadNotReady",
+          "description": "A finish is in progress; check getUploadStatus and retry."
+        },
+        {
+          "name": "UnsupportedContentType",
+          "description": "The assembled object's detected content type is not supported."
+        },
+        {
+          "name": "UploadFailed",
+          "description": "The session is known to have failed; the error carries its failure reason."
+        },
+        {
+          "name": "UploadAborted",
+          "description": "The session is known to have been aborted."
+        },
+        {
+          "name": "ServiceOverloaded",
+          "description": "The service is draining or temporarily at capacity; retry later."
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/app/bsky/video/getUploadStatus.json
+++ b/lexicons/app/bsky/video/getUploadStatus.json
@@ -1,0 +1,75 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.getUploadStatus",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get the authoritative status of the upload phase. Terminal states remain readable. completedJobId and jobStatus are present only for completed sessions; failureReason is present only for failed sessions.",
+      "parameters": {
+        "type": "params",
+        "required": ["jobId"],
+        "properties": {
+          "jobId": { "type": "string", "minLength": 1, "maxLength": 256 }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "jobId",
+            "partSizeBytes",
+            "partCount",
+            "receivedParts",
+            "expiresAt",
+            "state"
+          ],
+          "properties": {
+            "jobId": { "type": "string", "minLength": 1, "maxLength": 256 },
+            "partSizeBytes": { "type": "integer" },
+            "partCount": { "type": "integer" },
+            "receivedParts": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "expiresAt": { "type": "string", "format": "datetime" },
+            "state": {
+              "type": "string",
+              "maxLength": 32,
+              "knownValues": [
+                "created",
+                "finishing",
+                "completed",
+                "failed",
+                "aborted",
+                "expired"
+              ]
+            },
+            "completedJobId": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "description": "Present only when state is completed; may differ from jobId on deduplication."
+            },
+            "jobStatus": {
+              "type": "ref",
+              "ref": "app.bsky.video.defs#jobStatus",
+              "description": "Present only when state is completed."
+            },
+            "failureReason": {
+              "type": "string",
+              "maxLength": 1024,
+              "description": "Present only when state is failed."
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "UploadNotFound",
+          "description": "The job ID is unknown or aged out of retention; known terminal sessions remain readable and are never reported as not found."
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/app/bsky/video/startUpload.json
+++ b/lexicons/app/bsky/video/startUpload.json
@@ -1,0 +1,94 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.startUpload",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Start a multipart video upload. The declared size is exact, while optional media properties are advisory and used only for early failure; the authoritative probe runs asynchronously after upload.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["sizeBytes", "mimeType"],
+          "properties": {
+            "sizeBytes": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Exact byte size of the complete upload-ready video file before it is split into parts."
+            },
+            "mimeType": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 255,
+              "description": "Declared MIME type of the video."
+            },
+            "name": {
+              "type": "string",
+              "maxLength": 256,
+              "description": "Optional client-provided file name."
+            },
+            "durationMs": {
+              "type": "integer",
+              "description": "Advisory, non-authoritative duration used only for early failure; the authoritative probe runs asynchronously after upload."
+            },
+            "width": {
+              "type": "integer",
+              "description": "Advisory, non-authoritative width used only for early failure; the authoritative probe runs asynchronously after upload."
+            },
+            "height": {
+              "type": "integer",
+              "description": "Advisory, non-authoritative height used only for early failure; the authoritative probe runs asynchronously after upload."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["jobId", "partSizeBytes", "partCount", "expiresAt"],
+          "properties": {
+            "jobId": { "type": "string", "minLength": 1, "maxLength": 256 },
+            "partSizeBytes": { "type": "integer" },
+            "partCount": { "type": "integer" },
+            "expiresAt": { "type": "string", "format": "datetime" }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "UnsupportedContentType",
+          "description": "The declared MIME type is not supported."
+        },
+        {
+          "name": "VideoTooLarge",
+          "description": "The exact file size exceeds the per-file cap or remaining daily byte allowance."
+        },
+        {
+          "name": "VideoTooLong",
+          "description": "The advisory declared duration exceeds the limit."
+        },
+        {
+          "name": "BadAspectRatio",
+          "description": "The advisory declared dimensions have an unsupported aspect ratio."
+        },
+        {
+          "name": "DailyLimitExceeded",
+          "description": "The daily video or byte allowance, including active reservations, is exhausted."
+        },
+        {
+          "name": "TooManyOpenUploads",
+          "description": "The account has reached its open multipart upload limit."
+        },
+        {
+          "name": "UploadForbidden",
+          "description": "The account is not permitted to upload video."
+        },
+        {
+          "name": "ServiceOverloaded",
+          "description": "The service is draining, at capacity, or temporarily unable to create the multipart upload."
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/app/bsky/video/uploadPart.json
+++ b/lexicons/app/bsky/video/uploadPart.json
@@ -1,0 +1,70 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.uploadPart",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Upload one part. Parts are idempotent and may be retried or re-sent while the session is created. Each expected length is derived from the upload size and part size, and Content-Length must match exactly. ETags are never exposed to clients.",
+      "parameters": {
+        "type": "params",
+        "required": ["jobId", "partNumber"],
+        "properties": {
+          "jobId": { "type": "string", "minLength": 1, "maxLength": 256 },
+          "partNumber": { "type": "integer", "minimum": 1 }
+        }
+      },
+      "input": {
+        "encoding": "application/octet-stream"
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["partNumber", "sizeBytes"],
+          "properties": {
+            "partNumber": { "type": "integer", "minimum": 1 },
+            "sizeBytes": { "type": "integer" }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "UploadNotFound",
+          "description": "The job ID is unknown or aged out of retention; known terminal sessions are never reported as not found."
+        },
+        {
+          "name": "UploadExpired",
+          "description": "The upload session expired before completion."
+        },
+        {
+          "name": "InvalidPartNumber",
+          "description": "The part number is outside the upload's valid part range."
+        },
+        {
+          "name": "PartSizeMismatch",
+          "description": "Content-Length does not exactly match the expected size for this part."
+        },
+        {
+          "name": "UploadNotReady",
+          "description": "A finish is in progress; check getUploadStatus and retry."
+        },
+        {
+          "name": "UploadFailed",
+          "description": "The session is known to have failed; the error carries its failure reason."
+        },
+        {
+          "name": "UploadAborted",
+          "description": "The session is known to have been aborted."
+        },
+        {
+          "name": "UploadAlreadyCompleted",
+          "description": "The session is known to have already completed."
+        },
+        {
+          "name": "ServiceOverloaded",
+          "description": "The service is draining or temporarily at capacity; retry on another worker."
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the five multipart video upload lexicons approved in bluesky-social/bsky#14
- synchronize all implemented `getJobStatus` lifecycle known values from bluesky-social/bsky#15
- add an `@atproto/api` minor changeset for the new public client surface

## Testing

- `pnpm codegen`
- `pnpm run style`
- `pnpm run lint`
- `pnpm run build` in `packages/api`
- `goat lex lint` passes all five new lexicons; `defs.json` retains its five pre-existing `unlimited-string` findings without adding breaking constraints
- `pnpm run test` in `packages/api`: 330 tests pass; four suites fail during local module loading because installed `kysely` does not export `Migrator`

Closes: https://github.com/bluesky-social/atproto/issues/5292

Source PRs: [bsky#14](https://github.com/bluesky-social/bsky/pull/14), [bsky#15](https://github.com/bluesky-social/bsky/pull/15)

Linear: [APP-2779](https://linear.app/blueskyweb/issue/APP-2779/publish-multipart-upload-lexicons), [APP-2817](https://linear.app/blueskyweb/issue/APP-2817/sync-getjobstatus-state-knownvalues)

Forgot permissions update: https://github.com/bluesky-social/atproto/pull/5385