### PR TITLE
Allows the $type property of the LexiconDoc type

### DIFF
--- a/.changeset/eight-owls-divide.md
+++ b/.changeset/eight-owls-divide.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lexicon': patch
+---
+
+Allows the $type property of the LexiconDoc type

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -430,7 +430,7 @@ export const lexiconDoc = z
     revision: z.number().optional(),
     description: z.string().optional(),
     defs: z.record(z.string(), lexUserType),
-    $type: z.string().optional(),
+    $type: z.literal('com.atproto.lexicon.schema').optional(),
   })
   .refine(
     (doc) => {

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -430,6 +430,7 @@ export const lexiconDoc = z
     revision: z.number().optional(),
     description: z.string().optional(),
     defs: z.record(z.string(), lexUserType),
+    $type: z.string().optional(),
   })
   .refine(
     (doc) => {


### PR DESCRIPTION
## What & why

After installing the lexicon using `@atproto/lex` and generating code using `@atproto/lex-cli`, a type error occurs due to the `$type` property. To resolve this, we will modify the `LexiconDoc` type so that it accepts the `$type` property.
fix #5388 

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling. 
