### PR TITLE
Fix `rebuild-repo` PDS script. Type check services ts files.

### DIFF
--- a/.changeset/floppy-sides-swim.md
+++ b/.changeset/floppy-sides-swim.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Fix `rebuild-repo` script

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
-.git
-
 **/*.log
+**/.gitignore
 **/.DS_Store
 **/Dockerfile
 **/node_modules
@@ -8,6 +7,11 @@
 **/*.tsbuildinfo
 **/tests
 **/*.test.ts
+
+.git
+
+# services dev
+services/*/tsconfig.json
 
 # buf
 packages/bsky/src/proto

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -34,7 +34,14 @@ import {
 } from './auth-verifier.js'
 import { BackgroundQueue } from './background.js'
 import { BskyAppView } from './bsky-app-view.js'
-import type { ServerConfig, ServerSecrets } from './config/index.js'
+import {
+  type ServerConfig,
+  type ServerEnvironment,
+  type ServerSecrets,
+  envToCfg,
+  envToSecrets,
+  readEnv,
+} from './config/index.js'
 import { Crawlers } from './crawlers.js'
 import { DidSqliteCache } from './did-cache/index.js'
 import { DiskBlobStore } from './disk-blobstore.js'
@@ -129,6 +136,14 @@ export class AppContext implements AsyncDisposable {
     this.oauthProvider = opts.oauthProvider
     this.plcRotationKey = opts.plcRotationKey
     this.cfg = opts.cfg
+  }
+
+  static async fromEnv(
+    env: ServerEnvironment = readEnv(),
+  ): Promise<AppContext> {
+    const cfg = envToCfg(env)
+    const secrets = envToSecrets(env)
+    return AppContext.fromConfig(cfg, secrets)
   }
 
   static async fromConfig(

--- a/packages/pds/src/scripts/index.ts
+++ b/packages/pds/src/scripts/index.ts
@@ -1,5 +1,5 @@
 import { publishIdentity, publishIdentityFromFile } from './publish-identity.js'
-import { rebuildRepo } from './rebuild-repo.js'
+import { rebuildRepoScript } from './rebuild-repo.js'
 import {
   rotateKeys,
   rotateKeysFromFile,
@@ -9,7 +9,7 @@ import { sequencerRecovery } from './sequencer-recovery/index.js'
 import { repairRepos } from './sequencer-recovery/repair-repos.js'
 
 export const scripts = {
-  'rebuild-repo': rebuildRepo,
+  'rebuild-repo': rebuildRepoScript,
   'sequencer-recovery': sequencerRecovery,
   'recovery-repair-repos': repairRepos,
   'rotate-keys': rotateKeys,
@@ -17,4 +17,4 @@ export const scripts = {
   'rotate-keys-recovery': rotateKeysRecovery,
   'publish-identity': publishIdentity,
   'publish-identity-file': publishIdentityFromFile,
-}
+} satisfies Record<string, (ctx: any, args: string[]) => Promise<void>>

--- a/services/bsky/tsconfig.json
+++ b/services/bsky/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["../../tsconfig/node.tsconfig.json"],
+  "include": ["./**/*.ts"],
+  "exclude": ["./node_modules"],
+  "references": [{ "path": "../../packages/bsync/tsconfig.build.json" }],
+  "compilerOptions": {
+    "rootDir": "./",
+    "noEmit": true,
+  },
+}

--- a/services/bsync/tsconfig.json
+++ b/services/bsync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../tsconfig/node.tsconfig.json"],
+  "include": ["./**/*.ts"],
+  "exclude": ["./node_modules"],
+  "references": [
+    { "path": "../../packages/bsky/tsconfig.build.json" },
+    { "path": "../../packages/crypto/tsconfig.build.json" },
+  ],
+  "compilerOptions": {
+    "rootDir": "./",
+    "noEmit": true,
+  },
+}

--- a/services/ozone/tsconfig.json
+++ b/services/ozone/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["../../tsconfig/node.tsconfig.json"],
+  "include": ["./**/*.ts"],
+  "exclude": ["./node_modules"],
+  "references": [
+    { "path": "../../packages/aws/tsconfig.build.json" },
+    { "path": "../../packages/ozone/tsconfig.build.json" },
+  ],
+  "compilerOptions": {
+    "rootDir": "./",
+    "noEmit": true,
+  },
+}

--- a/services/pds/run-script.ts
+++ b/services/pds/run-script.ts
@@ -1,18 +1,13 @@
-import {
-  AppContext,
-  envToCfg,
-  envToSecrets,
-  readEnv,
-  scripts,
-} from '@atproto/pds'
+import { AppContext, scripts } from '@atproto/pds'
 
 const main = async () => {
-  const env = readEnv()
-  const cfg = envToCfg(env)
-  const secrets = envToSecrets(env)
-  const ctx = await AppContext.fromConfig(cfg, secrets)
+  const ctx = await AppContext.fromEnv()
   const scriptName = process.argv[2]
-  const script = scripts[scriptName ?? '']
+  const script:
+    undefined | ((ctx: AppContext, args: string[]) => Promise<void>) =
+    Object.hasOwn(scripts, scriptName)
+      ? scripts[scriptName as keyof typeof scripts]
+      : undefined
   if (!script) {
     throw new Error(`could not find script: ${scriptName}`)
   }

--- a/services/pds/tsconfig.json
+++ b/services/pds/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["../../tsconfig/node.tsconfig.json"],
+  "include": ["./**/*.ts"],
+  "exclude": ["./node_modules"],
+  "references": [{ "path": "../../packages/pds/tsconfig.build.json" }],
+  "compilerOptions": {
+    "rootDir": "./",
+    "noEmit": true,
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,5 +58,9 @@
     { "path": "./packages/ws-client" },
     { "path": "./packages/xrpc" },
     { "path": "./packages/xrpc-server" },
+    { "path": "./services/bsky" },
+    { "path": "./services/bsync" },
+    { "path": "./services/ozone" },
+    { "path": "./services/pds" },
   ],
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Adds TS type checking for `services/**/*.ts` files (and fixes an error that was detected thanks to it).

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
