### PR TITLE
Fix ascending report pagination tie-breaker

### DIFF
--- a/.changeset/tidy-report-pages.md
+++ b/.changeset/tidy-report-pages.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Fix ascending report pagination when multiple reports share a timestamp.

--- a/packages/ozone/src/mod-service/report.ts
+++ b/packages/ozone/src/mod-service/report.ts
@@ -127,6 +127,7 @@ export async function queryReports(
       sortField === 'updatedAt' ? 'r.updatedAt' : 'r.createdAt',
       sortDirection,
     )
+    // Keep the tie-breaker aligned with the primary sort for consistent keyset pagination and index scans.
     .orderBy('r.id', sortDirection)
 
   const limit = params.limit ?? 50

--- a/packages/ozone/src/mod-service/report.ts
+++ b/packages/ozone/src/mod-service/report.ts
@@ -127,7 +127,7 @@ export async function queryReports(
       sortField === 'updatedAt' ? 'r.updatedAt' : 'r.createdAt',
       sortDirection,
     )
-    .orderBy('r.id', 'desc')
+    .orderBy('r.id', sortDirection)
 
   const limit = params.limit ?? 50
   if (params.cursor) {

--- a/packages/ozone/tests/query-reports.test.ts
+++ b/packages/ozone/tests/query-reports.test.ts
@@ -316,6 +316,64 @@ describe('query-reports', () => {
       }
     })
 
+    it('paginates reports with identical timestamps in ascending order', async () => {
+      const db = network.ozone.ctx.db.db
+      const reports = await db
+        .selectFrom('report')
+        .select(['id', 'createdAt'])
+        .where('did', '=', sc.dids.bob)
+        .where('recordPath', '=', '')
+        .where('subjectMessageId', 'is', null)
+        .where('subjectConvoId', 'is', null)
+        .orderBy('id', 'asc')
+        .execute()
+      const createdAt = new Date('2026-01-01T00:00:00.000Z').toISOString()
+
+      await db
+        .updateTable('report')
+        .set({ createdAt })
+        .where(
+          'id',
+          'in',
+          reports.map((report) => report.id),
+        )
+        .execute()
+
+      try {
+        const firstPage = await modClient.queryReports({
+          status: 'open',
+          subject: sc.dids.bob,
+          sortField: 'createdAt',
+          sortDirection: 'asc',
+          limit: 2,
+        })
+        const secondPage = await modClient.queryReports({
+          status: 'open',
+          subject: sc.dids.bob,
+          sortField: 'createdAt',
+          sortDirection: 'asc',
+          limit: 2,
+          cursor: firstPage.cursor,
+        })
+
+        expect(
+          [...firstPage.reports, ...secondPage.reports].map(
+            (report) => report.id,
+          ),
+        ).toEqual(reports.map((report) => report.id))
+      } finally {
+        await Promise.all(
+          reports.map((report) =>
+            db
+              .updateTable('report')
+              .set({ createdAt: report.createdAt })
+              .where('id', '=', report.id)
+              .execute(),
+          ),
+        )
+      }
+    })
+
     it('includes subject details in report view', async () => {
       const response = await modClient.queryReports({
         status: 'open',


### PR DESCRIPTION
## Summary

There is a risk that mismatched sort direction in keyset columns will lead to skipped or missed reports. This will make the sort direction in both columns the same to avoid that.

This was added so that [ozone#561](https://github.com/bluesky-social/ozone/pull/561) can show oldest reports reliably.

## Testing

- `pnpm exec eslint packages/ozone/src/mod-service/report.ts packages/ozone/tests/query-reports.test.ts`
- integration test could not run locally because Docker and `DB_TEST_POSTGRES_URL` are unavailable
- package build is blocked by unrelated `isolatedDeclarations` errors in `packages/lex/lex-schema`