### PR TITLE
Stop the reset-password screen repeating itself

### DIFF
--- a/.changeset/reset-password-updated-copy.md
+++ b/.changeset/reset-password-updated-copy.md
@@ -1,0 +1,7 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+The reset-password confirmation screen no longer says "your password was
+updated" three times over — as a card title, a subtitle and a heading — before
+telling the user what to do next.

--- a/packages/oauth/oauth-provider-ui/src/components/reset-password-view.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/reset-password-view.tsx
@@ -120,15 +120,9 @@ export function ResetPasswordView({
     return (
       <AuthShell
         title={msg`Password Updated`}
-        subtitle={<Trans>Your password has been updated!</Trans>}
+        subtitle={<Trans>You can now sign in with your new password.</Trans>}
       >
         <div className="text-center">
-          <h2 className="pb-2 text-xl font-bold">
-            <Trans>Password updated!</Trans>
-          </h2>
-          <p className="pb-4">
-            <Trans>You can now sign in with your new password.</Trans>
-          </p>
           {onBack && (
             <Button onClick={() => onBack()}>
               <Trans>Okay</Trans>

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -858,10 +858,6 @@ msgstr "Password strength indicator"
 msgid "Password Updated"
 msgstr "Password Updated"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "Password updated!"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
@@ -1478,10 +1474,6 @@ msgstr "Your email address needs to be verified."
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Your full username will be: {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "Your password has been updated!"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -849,10 +849,6 @@ msgstr "Indicador de fortaleza de la contraseña"
 msgid "Password Updated"
 msgstr "Contraseña actualizada"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "¡Contraseña actualizada!"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "Contraseña con al menos {MIN_PASSWORD_LENGTH, plural, other {# caracteres}}"
@@ -1469,10 +1465,6 @@ msgstr ""
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Tu nombre de usuario completo será: {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "¡Tu contraseña ha sido actualizada!"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -858,10 +858,6 @@ msgstr "Indicateur de complexité du mot de passe"
 msgid "Password Updated"
 msgstr "Mot de passe mis à jour"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "Mot de passe mis à jour !"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "Mot de passe d'au moins {MIN_PASSWORD_LENGTH, plural, other {# caractères}}"
@@ -1478,10 +1474,6 @@ msgstr "Votre adresse email doit être vérifiée."
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Votre nom d'utilisateur complet sera : {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "Votre mot de passe a été mis à jour !"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -858,10 +858,6 @@ msgstr "パスワード強度表示"
 msgid "Password Updated"
 msgstr "パスワード更新"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "パスワードが更新されました！"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "パスワードは{MIN_PASSWORD_LENGTH, plural, other {#文字}}以上"
@@ -1478,10 +1474,6 @@ msgstr "メールアドレスを確認する必要があります。"
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "あなたのフルユーザー名： {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "パスワードが更新されました！"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -849,10 +849,6 @@ msgstr "비밀번호 강도 표시자"
 msgid "Password Updated"
 msgstr "비밀번호 변경됨"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "비밀번호를 변경했습니다!"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "비밀번호는 {MIN_PASSWORD_LENGTH, plural, other {#자}} 이상이어야 합니다"
@@ -1469,10 +1465,6 @@ msgstr ""
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "내 전체 사용자 이름: {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "비밀번호를 변경했습니다!"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -858,10 +858,6 @@ msgstr "Indikator för lösenordsstyrka"
 msgid "Password Updated"
 msgstr "Lösenordet har uppdaterats"
 
-#: src/components/reset-password-view.tsx
-msgid "Password updated!"
-msgstr "Lösenordet har uppdaterats!"
-
 #: src/components/forms/fields/new-password-field.tsx
 msgid "Password with at least {MIN_PASSWORD_LENGTH, plural, other {# characters}}"
 msgstr "Lösenord med minst {MIN_PASSWORD_LENGTH, plural, other {# tecken}}"
@@ -1478,10 +1474,6 @@ msgstr "Din e-postadress behöver verifieras."
 #: src/components/forms/fields/handle-field.tsx
 msgid "Your full username will be: {0}"
 msgstr "Ditt fullständiga användarnamn blir: {0}"
-
-#: src/components/reset-password-view.tsx
-msgid "Your password has been updated!"
-msgstr "Ditt lösenord har uppdaterats!"
 
 #: src/components/reactivate-account-dialog.tsx
 msgid "Your profile, posts, feeds, and lists will become visible again across the Atmosphere network — that includes the Bluesky app and any other Atmosphere app you use with this account."

--- a/packages/pds/tests/oauth.test.ts
+++ b/packages/pds/tests/oauth.test.ts
@@ -181,7 +181,10 @@ describe('oauth', () => {
 
     await page.assertTitle('Mot de passe mis à jour')
 
-    await page.ensureTextVisibility('Mot de passe mis à jour !', 'h2')
+    await page.ensureTextVisibility(
+      'Vous pouvez maintenant vous connecter avec votre nouveau mot de passe.',
+      'p',
+    )
   })
 
   it('restores the reset-password step after a page refresh', async () => {


### PR DESCRIPTION
The confirmation screen announced the same thing three times — a "Password
Updated" card title, a "Your password has been updated!" subtitle, and a
"Password updated!" heading — before reaching the one line the user
actually needs.

The shell's title and subtitle now carry the whole message, matching the
other two steps of the flow, which are title + subtitle + body. The inner
`<h2>` also made this the only auth screen with a heading element inside
the card, so removing it is a consistency win as well as a copy one.

No new strings: this reuses two existing msgids and orphans two.
`packages/pds/tests/oauth.test.ts` asserted on the removed `<h2>`, so it
now asserts the subtitle instead.
