### PR TITLE
Fix DID-targeted feature gates on feed endpoints

### DIFF
--- a/.changeset/calm-feeds-scope.md
+++ b/.changeset/calm-feeds-scope.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Pass authenticated user context to feature gates on feed requests.

--- a/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getActorLikes.ts
@@ -28,7 +28,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({ viewer, req }),
+        ),
+      })
 
       const result = await fillPage({
         cursor: params.cursor,

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -37,6 +37,9 @@ export default function (server: Server, ctx: AppContext) {
         viewer,
         includeTakedowns,
         skipViewerBlocks,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({ viewer, req }),
+        ),
       })
 
       const result = await fillPage({

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -29,7 +29,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({ viewer, req }),
+        ),
+      })
 
       const result = await fillPage({
         cursor: params.cursor,

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -32,7 +32,13 @@ export default function (server: Server, ctx: AppContext) {
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
-      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+        features: ctx.featureGatesClient.scope(
+          ctx.featureGatesClient.parseUserContextFromHandler({ viewer, req }),
+        ),
+      })
 
       const result = await fillPage({
         cursor: params.cursor,

--- a/packages/bsky/tests/views/op-thread-feed-metadata.test.ts
+++ b/packages/bsky/tests/views/op-thread-feed-metadata.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { type SeedClient, TestNetwork } from '@atproto/dev-env'
+import { ids } from '@atproto/api'
+import { type RecordRef, type SeedClient, TestNetwork } from '@atproto/dev-env'
+import type { DidString } from '@atproto/syntax'
 import { Gate } from '../../src/feature-gates/gates.js'
 
 type FeedItemWithOpThreadMetadata = {
@@ -11,18 +13,14 @@ type FeedItemWithOpThreadMetadata = {
 describe('OP thread feed metadata', () => {
   let network: TestNetwork
   let sc: SeedClient<TestNetwork>
+  let op: DidString
+  let viewer: DidString
+  let posts: RecordRef[]
+  let list: RecordRef
 
   beforeAll(async () => {
     network = await TestNetwork.create({
       dbPostgresSchema: 'bsky_op_thread_feed_metadata',
-    })
-    vi.spyOn(network.bsky.ctx.featureGatesClient, 'scope').mockReturnValue({
-      Gate,
-      checkGate: (gate) => gate === Gate.OpThreadMetadataEnable,
-      checkGates: (gates) =>
-        new Map(
-          gates.map((gate) => [gate, gate === Gate.OpThreadMetadataEnable]),
-        ),
     })
     sc = network.getSeedClient()
     await sc.createAccount('threadop', {
@@ -30,40 +28,117 @@ describe('OP thread feed metadata', () => {
       email: 'threadop@test.com',
       password: 'threadop-pass',
     })
-    await network.processAll()
-  })
-
-  afterAll(async () => {
-    vi.restoreAllMocks()
-    await network?.close()
-  })
-
-  it('exposes canonical numbering on feed items', async () => {
-    const op = sc.dids.threadop
+    await sc.createAccount('viewer', {
+      handle: 'viewer.test',
+      email: 'viewer@test.com',
+      password: 'viewer-pass',
+    })
+    op = sc.dids.threadop
+    viewer = sc.dids.viewer
+    await sc.follow(viewer, op)
+    list = await sc.createList(viewer, 'OPs', 'curate')
+    await sc.addToList(viewer, op, list)
     const root = await sc.post(op, 'root')
     const first = await sc.reply(op, root.ref, root.ref, 'first')
     const second = await sc.reply(op, root.ref, first.ref, 'second')
+    posts = [root.ref, first.ref, second.ref]
+    for (const post of posts) {
+      await sc.like(viewer, post)
+    }
     await network.processAll()
+  })
 
-    const res = await network.bsky.getAgent().api.app.bsky.feed.getAuthorFeed({
-      actor: op,
-    })
-    const byUri = new Map(
-      res.data.feed.map((item) => [
-        item.post.uri,
-        item as FeedItemWithOpThreadMetadata,
-      ]),
-    )
+  afterAll(async () => network?.close())
 
-    expect(
-      [root, first, second].map(({ ref }) => {
-        const item = byUri.get(ref.uriStr)
-        return [item?.opThreadPostIndex, item?.opThreadPostCount]
-      }),
-    ).toEqual([
-      [1, 3],
-      [2, 3],
-      [3, 3],
+  it('exposes canonical numbering on DID-targeted feed requests', async () => {
+    using scope = vi
+      .spyOn(network.bsky.ctx.featureGatesClient, 'scope')
+      .mockImplementation((userContext) => {
+        const enabled = userContext.did === viewer
+        return {
+          Gate,
+          checkGate: (gate) => enabled && gate === Gate.OpThreadMetadataEnable,
+          checkGates: (gates) =>
+            new Map(
+              gates.map((gate) => [
+                gate,
+                enabled && gate === Gate.OpThreadMetadataEnable,
+              ]),
+            ),
+        }
+      })
+
+    const agent = network.bsky.getAgent()
+    const [authorFeed, timeline, listFeed, actorLikes] = await Promise.all([
+      agent.api.app.bsky.feed.getAuthorFeed(
+        { actor: op },
+        {
+          headers: await network.serviceHeaders(
+            viewer,
+            ids.AppBskyFeedGetAuthorFeed,
+          ),
+        },
+      ),
+      agent.api.app.bsky.feed.getTimeline(
+        {},
+        {
+          headers: await network.serviceHeaders(
+            viewer,
+            ids.AppBskyFeedGetTimeline,
+          ),
+        },
+      ),
+      agent.api.app.bsky.feed.getListFeed(
+        { list: list.uriStr },
+        {
+          headers: await network.serviceHeaders(
+            viewer,
+            ids.AppBskyFeedGetListFeed,
+          ),
+        },
+      ),
+      agent.api.app.bsky.feed.getActorLikes(
+        { actor: viewer },
+        {
+          headers: await network.serviceHeaders(
+            viewer,
+            ids.AppBskyFeedGetActorLikes,
+          ),
+        },
+      ),
     ])
+
+    expect(scope.mock.calls.map(([context]) => context.did)).toEqual([
+      viewer,
+      viewer,
+      viewer,
+      viewer,
+    ])
+
+    for (const [name, response] of Object.entries({
+      authorFeed,
+      timeline,
+      listFeed,
+      actorLikes,
+    })) {
+      const byUri = new Map(
+        response.data.feed.map((item) => [
+          item.post.uri,
+          item as FeedItemWithOpThreadMetadata,
+        ]),
+      )
+      expect(
+        posts.map((post) => {
+          const item = byUri.get(post.uriStr)
+          return [item?.opThreadPostIndex, item?.opThreadPostCount]
+        }),
+        name,
+      ).toEqual([
+        [1, 3],
+        [2, 3],
+        [3, 3],
+      ])
+    }
+    expect(scope).toHaveBeenCalledTimes(4)
   })
 })


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Ensures feed requests evaluate gates using the authenticated viewer context and adds regression coverage for all affected endpoints.

Feed hydration fell back to anonymous feature-gate context on several endpoints, so DID-targeted gates never matched. This prevented gated metadata such as OP thread numbering from appearing despite eligible users being enrolled.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Yes, `gpt-5.6-sol`
