### PR TITLE
Drop the auth card frame on small viewports

### DIFF
--- a/.changeset/cardless-auth-screens-on-phones.md
+++ b/.changeset/cardless-auth-screens-on-phones.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Drop the card frame from the authorization screens on small viewports. Below `sm` (40rem) the card's surface, ring and radius are removed and the branding background image is replaced by the card surface — with no opaque card left to sit on, copy over a background image would be illegible. This covers the OAuth popup, which `@atproto/oauth-client-browser` opens at 600x600 by default: the window is already the dialog, so the card inside it was a card inside a card, with the background image showing only as slivers down either side. Below `xs` (30rem) the content additionally runs edge to edge and the footer is pinned to the bottom of the viewport, with the content centred in the space above it. At or above 40rem the screens are unchanged.

--- a/packages/oauth/oauth-provider-ui/CLAUDE.md
+++ b/packages/oauth/oauth-provider-ui/CLAUDE.md
@@ -194,6 +194,26 @@ the `.auth-background` rule in `src/style.css` paints that image over the neutra
 the plain `muted` surface it always was. The card keeps its own opaque surface so
 copy stays legible over any background.
 
+`AuthShell` narrows to the page in two independent steps, so there are three
+layouts, not two:
+
+- **Below `sm` (40rem)** the card _frame_ goes — surface, ring, radius, and the
+  footer's fill and top border. `.auth-background` follows it, dropping the
+  branding image and painting `card` instead of `muted`: with no opaque card
+  left, copy over a photo is illegible. Content stays capped at `max-w-sm`. This
+  is the OAuth popup case — `oauth-client-browser` opens `width=600,height=600`
+  by default, so the window is already the dialog and a card inside it is a card
+  inside a card, with the background image reduced to slivers down either side.
+- **Below `xs` (30rem)** the content additionally runs edge to edge: page
+  padding off, width cap off, card spacing up to 24px. The footer is pinned to
+  the bottom of the viewport while the content stays centred in the space above
+  it — both come from `mt-auto`, one on the card's first child and one on the
+  footer.
+
+Keep these two steps separate. Collapsing them to a single `sm` breakpoint
+stretches a 600px popup's inputs to the full window width; collapsing them to a
+single `xs` one puts the card back in the popup.
+
 The mock pages inject the same variables a branded deployment would, so
 `pnpm dev:ui` demonstrates branding without a PDS.
 

--- a/packages/oauth/oauth-provider-ui/src/components/layouts/auth-shell.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/layouts/auth-shell.tsx
@@ -60,14 +60,30 @@ export function AuthShell({
         : undefined
 
   return (
-    <div className="auth-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
+    <div className="auth-background max-xs:p-0 flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
       {documentTitleString && <title>{documentTitleString}</title>}
 
       <div
         {...props}
-        className={cn('flex w-full max-w-sm flex-col', className)}
+        className={cn(
+          'max-xs:max-w-none max-xs:flex-1 flex w-full max-w-sm flex-col',
+          className,
+        )}
       >
-        <Card>
+        {/* Two separate steps, because they answer different questions.
+            Below `sm` the card frame goes away — no surface, ring or radius —
+            since a viewport barely wider than the card has nothing to frame the
+            card *against*. This is the OAuth popup case: the window is already
+            the dialog.
+            Below `xs` the content additionally runs edge to edge, which only
+            makes sense once the viewport is phone-width; keeping the `max-w-sm`
+            cap in between stops a 600px popup from stretching its inputs to
+            the full window width.
+            @NOTE The two `mt-auto`s (here and on the footer) split the free
+            space evenly, which centres the content in the area above a footer
+            pinned to the bottom of the viewport. The first child is targeted by
+            position because it varies: logo, header or content. */}
+        <Card className="max-xs:flex-1 max-xs:[&>*:first-child]:mt-auto max-xs:[--card-spacing:--spacing(6)] max-sm:rounded-none max-sm:bg-transparent max-sm:ring-0">
           {(logo || name) && (
             <div className="px-(--card-spacing) flex items-center justify-center gap-2 pt-2 font-medium">
               {logo && (
@@ -98,7 +114,7 @@ export function AuthShell({
 
           <CardContent>{children}</CardContent>
 
-          <CardFooter className="flex-col justify-center gap-3">
+          <CardFooter className="max-xs:mt-auto flex-col justify-center gap-3 max-sm:border-t-0 max-sm:bg-transparent">
             <LocaleSelector />
             {links?.length ? (
               <div className="text-muted-foreground flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs">

--- a/packages/oauth/oauth-provider-ui/src/style.css
+++ b/packages/oauth/oauth-provider-ui/src/style.css
@@ -6,6 +6,12 @@
 
 @theme inline {
   --space-screen: 100vh;
+
+  /* Phone-sized viewports. Below this the auth screens run edge to edge (see
+   * AuthShell); Tailwind's `sm` (40rem) is too wide for that — a form stretched
+   * to 620px reads as a broken desktop layout, not a mobile one. Dropping the
+   * card *frame* happens at `sm`, one step earlier. */
+  --breakpoint-xs: 30rem;
 }
 
 /* ---------------------------------------------------------------------------
@@ -160,6 +166,18 @@
   /* auth background: dark */
   .auth-background {
     background-image: var(--branding-background-dark-image, none);
+  }
+}
+
+/* Below `sm` the card frame is dropped (see AuthShell), so the page surface
+ * becomes the card surface and the branding image goes with it: with no opaque
+ * card left to sit on, copy over a photo is illegible, and in a 600px OAuth
+ * popup the image only ever showed as slivers down either side anyway.
+ * @NOTE Must stay after the dark rule above: same specificity, later wins. */
+@media (width < 40rem) {
+  .auth-background {
+    background-color: var(--card);
+    background-image: none;
   }
 }
 


### PR DESCRIPTION
## What & why

Motivation for this came from here https://bsky.app/profile/aka.dad/post/3msoi46tp2d2s, also I think it does look better without the card on smaller screens. Could go either way though. The old UI was actually more like this.

--

On small viewports the authorization screens render a card inside a card: an opaque, rounded, ringed panel that occupies nearly the whole window, floating over a background image that is almost entirely hidden behind it. The frame costs horizontal space and reads as a shrunken desktop layout rather than one built for the size it's in.

The frame is now dropped in two independent steps.

**Below `sm` (40rem)** the card's surface, ring and radius go, along with the footer's fill and top border, and `.auth-background` swaps the branding image for the card surface — with no opaque card left to sit on, copy over a background image would be illegible. Content stays capped at `max-w-sm`.

**Below `xs` (30rem)** the content additionally runs edge to edge, and the footer is pinned to the bottom of the viewport with the content centred in the space above it.

### The popup is the reason for two steps

`@atproto/oauth-client-browser` opens the authorization window at `width=600,height=600` by default ([`browser-oauth-client.ts#L300`](https://github.com/bluesky-social/atproto/blob/main/packages/oauth/oauth-client-browser/src/browser-oauth-client.ts#L300)), so the popup is already the dialog. Inside it the card was a card inside a card, and the branding image only ever showed as slivers down either side:

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/07-popup-before.png" width="330"> <img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/08-popup-after.png" width="330">

Collapsing the two steps into one breaks one case or the other: at `sm` alone, the 600px popup stretches its inputs to the full window width; at `xs` alone, the card comes back in the popup.

### Phones

**Sign-in — before / after (390px)**

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/01-before-sign-in.png" width="330"> <img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/02-after-sign-in.png" width="330">

**Password form — before / after (390px)**

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/03-before-password.png" width="330"> <img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/04-after-password.png" width="330">

**Dark mode — before / after (390px)**

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/05-before-dark.png" width="330"> <img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/06-after-dark.png" width="330">

### Above 40rem, nothing changes

The before and after screenshots at 700px and at 1280px are byte-identical.

<img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/09-unchanged-700.png" width="330"> <img src="https://raw.githubusercontent.com/bigmoves/atproto/assets/mobile-cardless-auth/10-unchanged-desktop.png" width="380">

### Layout note

The footer is pinned to the bottom with the content centred above it, on phones only. Three vertical layouts were tried: centring the whole block (the desktop behaviour) left dead space above *and* below; top-aligning the content with a pinned footer looked right on the sign-in form but left a large void under the two-line error screen. What's here uses `mt-auto` on both the card's first child and the footer, which splits the free space evenly — the footer lands at the bottom and the content centres in what remains. That holds for both the error screen and the sign-up wizard.

### Scope

`AuthShell` only, so this covers the authorization flow plus the error and cookie-error pages. The account-manager screens use `AccountShell` and are unaffected.

Checked at 390px and 430px, in a real 600×600 popup (sign-in, password, consent), and at the 480/640 boundaries; light and dark; and overflow at 390×520 and in the popup's consent screen, both of which scroll with nothing clipped.

## Checklist

- [ ] `pnpm build --force && pnpm verify` passes
- [ ] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling.