### PR TITLE
chore(oauth-provider): upgrade cookie to 2.x, drop @types/cookie

### DIFF
--- a/.changeset/hot-paws-dress.md
+++ b/.changeset/hot-paws-dress.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider': patch
+---
+
+Upgrade `cookie` to 2.x and drop `@types/cookie`

--- a/packages/oauth/oauth-provider/package.json
+++ b/packages/oauth/oauth-provider/package.json
@@ -80,7 +80,7 @@
     "@hapi/address": "^5.1.1",
     "@hapi/bourne": "^3.0.0",
     "@hapi/content": "^6.0.0",
-    "cookie": "^0.7.0",
+    "cookie": "^2.0.1",
     "disposable-email-domains-js": "^1.5.0",
     "forwarded": "^0.2.0",
     "http-errors": "^2.0.0",
@@ -90,7 +90,6 @@
   },
   "devDependencies": {
     "@atproto-labs/rolldown-plugin-bundle-manifest": "workspace:^",
-    "@types/cookie": "^0.6.0",
     "@types/forwarded": "0.1.3",
     "@types/http-errors": "^2.0.4",
     "@types/send": "^0.17.4",

--- a/packages/oauth/oauth-provider/src/device/device-manager.ts
+++ b/packages/oauth/oauth-provider/src/device/device-manager.ts
@@ -270,7 +270,9 @@ export class DeviceManager {
       maxAge: value
         ? this.options.cookie.age == null
           ? undefined
-          : this.options.cookie.age / 1000
+          : // "cookie" requires an integer `maxAge`, but `age` (in ms) is not
+            // guaranteed to be a multiple of 1000
+            Math.floor(this.options.cookie.age / 1000)
         : 0,
       httpOnly: true,
       path: '/',

--- a/packages/oauth/oauth-provider/src/lib/http/request.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/request.ts
@@ -3,9 +3,9 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 // SyntaxError: The requested module '@hapi/accept' does not provide an export named 'languages'
 import * as accept from '@hapi/accept'
 import {
-  type CookieSerializeOptions,
-  parse as parseCookie,
-  serialize as serializeCookie,
+  type SerializeOptions as CookieSerializeOptions,
+  parseCookie,
+  stringifySetCookie,
 } from 'cookie'
 import forwarded from 'forwarded'
 import createHttpError from 'http-errors'
@@ -118,7 +118,11 @@ export function setCookie(
   value: string,
   options?: CookieSerializeOptions,
 ) {
-  appendHeader(res, 'Set-Cookie', serializeCookie(cookieName, value, options))
+  appendHeader(
+    res,
+    'Set-Cookie',
+    stringifySetCookie({ name: cookieName, value, ...options }),
+  )
 }
 
 export function getCookie(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  cookie: ^0.7.2
+  express>cookie: ^0.7.2
   opentelemetry-plugin-better-sqlite3>@opentelemetry/core: ^1.30.0
 
 importers:
@@ -1621,8 +1621,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       cookie:
-        specifier: ^0.7.2
-        version: 0.7.2
+        specifier: ^2.0.1
+        version: 2.0.1
       disposable-email-domains-js:
         specifier: ^1.5.0
         version: 1.5.0
@@ -1645,9 +1645,6 @@ importers:
       '@atproto-labs/rolldown-plugin-bundle-manifest':
         specifier: workspace:^
         version: link:../../internal/rolldown-plugin-bundle-manifest
-      '@types/cookie':
-        specifier: ^0.6.0
-        version: 0.6.0
       '@types/forwarded':
         specifier: 0.1.3
         version: 0.1.3
@@ -5585,9 +5582,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/cors@2.8.12':
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
 
@@ -6740,6 +6734,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   core-js-compat@3.50.0:
     resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
@@ -15006,8 +15004,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
-  '@types/cookie@0.6.0': {}
-
   '@types/cors@2.8.12': {}
 
   '@types/cors@2.8.19':
@@ -16192,6 +16188,8 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie@0.7.2: {}
+
+  cookie@2.0.1: {}
 
   core-js-compat@3.50.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,5 +23,9 @@ allowBuilds:
   rolldown: true
 
 overrides:
-  cookie: ^0.7.2
+  # Force express 4's vulnerable transitive cookie to a patched version. Do not
+  # apply repo-wide: @atproto/oauth-provider directly depends on cookie 2.x.
+  # TODO: remove this override once express is upgraded to 5.x (which already
+  # depends on a patched cookie) or dropped entirely (see #5341).
+  express>cookie: ^0.7.2
   opentelemetry-plugin-better-sqlite3>@opentelemetry/core: ^1.30.0


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

this bumps `cookie` from 0.7.0 to 2.0.1 in the `oauth-provider` package and drops `@types/cookie` since cookie ships its own types now. 

the 2.x api renames a couple things so i migrated to `parseCookie` / `stringifySetCookie`, and added a `Math.floor()` on maxAge because 2.x throws on non-integers. 

the fun part was that a global pnpm override was silently pinning cookie to 0.7.2, so i scoped it to `express>cookie` instead, express keeps its patched version and oauth-provider gets 2.0.1. left a TODO noting the override can go away once express 5 lands. full build, unit tests and the pds oauth integration tests all pass.

related: #5341

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [ ] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
