### PR TITLE
Persist the OAuth Provider UI's selected interface language

### DIFF
--- a/.changeset/persist-locale-selection.md
+++ b/.changeset/persist-locale-selection.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Persist the interface language selected in the OAuth UI, so that it survives a page reload.

--- a/packages/oauth/oauth-provider-ui/CLAUDE.md
+++ b/packages/oauth/oauth-provider-ui/CLAUDE.md
@@ -208,6 +208,12 @@ form field is `code` but the API takes `token`.
 - A msgid that disappears and returns loses its translation. After extraction,
   check the _count_ of untranslated entries, not just the msgid diff.
 - Fill in French only; other locales are translated externally.
+- The locale is React state, so anything not persisted is lost on reload.
+  `LocaleProvider` restores an explicit selection from `localStorage`
+  (`locale-storage.ts`) and gives it precedence over the client's `ui_locales`
+  hint and `navigator.languages` — otherwise a reload of the authorization page
+  would undo the choice. A merely _detected_ locale is not stored, so it keeps
+  following the browser.
 
 ## The pds e2e contract
 

--- a/packages/oauth/oauth-provider-ui/src/locales/locale-provider.tsx
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-provider.tsx
@@ -11,6 +11,7 @@ import {
 // @NOTE run "pnpm run po:compile" to compile the messages from the PO files
 import { messages as en } from './en/messages.ts'
 import { loadMessages } from './load.ts'
+import { readStoredLocale, writeStoredLocale } from './locale-storage.ts'
 import { type Locale, detectLocale, isLocale, locales } from './locales.ts'
 
 export type LocaleContextValue = {
@@ -46,7 +47,9 @@ export function LocaleProvider({
 
   const [currentLocale, setCurrentLocale] = useState<string>(() => i18n.locale)
   const [desiredLocale, setDesiredLocale] = useState<Locale>(() => {
-    return detectLocale(userLocales)
+    // An explicit choice outranks both the client's `ui_locales` hint and the
+    // browser's languages, or it would not survive a reload of this page.
+    return readStoredLocale() ?? detectLocale(userLocales)
   })
 
   // A boolean that is used to avoid flickering of "en" content during initial
@@ -98,8 +101,13 @@ export function LocaleProvider({
       locale: currentLocale,
       locales,
       setLocale: (locale) => {
-        if (isLocale(locale)) setDesiredLocale(locale)
-        else throw new TypeError(`"${locale}" is not an available locale`)
+        if (!isLocale(locale)) {
+          throw new TypeError(`"${locale}" is not an available locale`)
+        }
+        // Only an explicit choice is persisted, so that a detected locale keeps
+        // following the browser's languages.
+        writeStoredLocale(locale)
+        setDesiredLocale(locale)
       },
     }),
     [locales, currentLocale],

--- a/packages/oauth/oauth-provider-ui/src/locales/locale-storage.test.ts
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-storage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readStoredLocale, writeStoredLocale } from './locale-storage.ts'
+
+function stubStorage(storage: unknown) {
+  vi.stubGlobal('localStorage', storage)
+}
+
+function fakeStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => void values.set(key, value),
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe(readStoredLocale, () => {
+  it('returns undefined when nothing was stored', () => {
+    stubStorage(fakeStorage())
+    expect(readStoredLocale()).toBeUndefined()
+  })
+
+  it('returns a previously stored locale', () => {
+    stubStorage(fakeStorage())
+    writeStoredLocale('fr')
+    expect(readStoredLocale()).toBe('fr')
+  })
+
+  it('ignores a stored value that is not an available locale', () => {
+    stubStorage({ getItem: () => 'kl' })
+    expect(readStoredLocale()).toBeUndefined()
+  })
+
+  it('returns undefined when storage access throws', () => {
+    stubStorage({
+      getItem: () => {
+        throw new Error('Access denied')
+      },
+    })
+    expect(readStoredLocale()).toBeUndefined()
+  })
+
+  it('returns undefined when there is no storage at all', () => {
+    stubStorage(undefined)
+    expect(readStoredLocale()).toBeUndefined()
+  })
+})
+
+describe(writeStoredLocale, () => {
+  it('does not throw when storage access is denied', () => {
+    stubStorage({
+      setItem: () => {
+        throw new Error('Access denied')
+      },
+    })
+    expect(() => writeStoredLocale('fr')).not.toThrow()
+  })
+
+  it('does not throw when there is no storage at all', () => {
+    stubStorage(undefined)
+    expect(() => writeStoredLocale('fr')).not.toThrow()
+  })
+})

--- a/packages/oauth/oauth-provider-ui/src/locales/locale-storage.ts
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-storage.ts
@@ -1,0 +1,30 @@
+import { type Locale, isLocale } from './locales.ts'
+
+// @NOTE Storage is scoped to the origin, so the choice made on the
+// authorization page also applies to the account page (and survives a reload of
+// either). The origin is shared with whatever else the PDS serves, hence the
+// `@@<package>(<key>)` namespacing used by `@atproto/oauth-client-browser`.
+const STORAGE_KEY = `@@atproto/oauth-provider-ui(locale)`
+
+/**
+ * Reading `localStorage` throws (rather than returning `null`) when the browser
+ * is configured to block storage access, so every access here is guarded.
+ */
+export function readStoredLocale(): Locale | undefined {
+  try {
+    const value = globalThis.localStorage?.getItem(STORAGE_KEY)
+    if (isLocale(value)) return value
+  } catch {
+    // Ignore
+  }
+  return undefined
+}
+
+export function writeStoredLocale(locale: Locale): void {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, locale)
+  } catch {
+    // Persisting the preference is best effort; the locale still applies to the
+    // current page.
+  }
+}


### PR DESCRIPTION
## What & why

Selecting an interface language in the OAuth provider UI did not survive a page
reload: the locale lived only in `LocaleProvider`'s React state, initialized from
`detectLocale(userLocales)`, so every load fell back to the client's `ui_locales`
hint or `navigator.languages` and discarded the user's choice.

An explicit selection is now persisted in `localStorage` (new
`src/locales/locale-storage.ts`) and takes precedence over both — otherwise a
reload of the authorization page, which re-supplies `ui_locales`, would undo it.
A merely *detected* locale is not stored, so it keeps following the browser.

Details:

- The key is `@@atproto/oauth-provider-ui(locale)`, following the
  `@@<package>(<key>)` namespacing `@atproto/oauth-client-browser` already uses
  for its `localStorage` entries — the origin is shared with whatever else the
  PDS serves.
- Every storage access is guarded: reading `localStorage` throws (rather than
  returning `null`) when a browser is configured to block storage, and an
  unrecognized stored value is ignored.
- Storage is origin-scoped, so a choice made on the authorization page also
  applies to the account page.

Verified against the mock UI (`pnpm dev:ui`): picking Français on the
authorization page and reloading comes back in French, and `/account` follows.

## Checklist

- [x] `pnpm verify` passes; built the touched package (`tsc --build` +
      `vite build`) rather than a full `pnpm build --force` of the repo
- [x] Tests pass, and new behavior is covered by tests
      (`src/locales/locale-storage.test.ts`; full package suite green)
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the
      tooling. — Yes: Claude Code (Opus 5).
