### PR TITLE
Pass beta user state to GrowthBook

### DIFF
--- a/.changeset/fuzzy-betas-grow.md
+++ b/.changeset/fuzzy-betas-grow.md
@@ -1,0 +1,6 @@
+---
+'@atproto/bsky': patch
+'@atproto/pds': patch
+---
+
+Forward the client beta-user header to AppView and include it in GrowthBook targeting attributes.

--- a/packages/bsky/src/feature-gates/index.test.ts
+++ b/packages/bsky/src/feature-gates/index.test.ts
@@ -1,0 +1,29 @@
+import type express from 'express'
+import { describe, expect, it } from 'vitest'
+import { FeatureGatesClient } from './index.js'
+
+describe('FeatureGatesClient', () => {
+  it('parses the beta user header into the user context', () => {
+    const client = new FeatureGatesClient({})
+    const headers: Record<string, string> = {
+      'x-bsky-device-id': 'device-123',
+      'x-bsky-session-id': 'session-456',
+      'x-bsky-is-beta-user': 'TRUE',
+    }
+    const req = {
+      header: (name: string) => headers[name.toLowerCase()],
+    } as unknown as express.Request
+
+    expect(
+      client.parseUserContextFromHandler({
+        viewer: 'did:example:alice',
+        req,
+      }),
+    ).toEqual({
+      did: 'did:example:alice',
+      deviceId: 'device-123',
+      sessionId: 'session-456',
+      isBetaUser: true,
+    })
+  })
+})

--- a/packages/bsky/src/feature-gates/index.ts
+++ b/packages/bsky/src/feature-gates/index.ts
@@ -32,6 +32,7 @@ const REFETCH_INTERVAL = 60e3 // 1 minute
  */
 const ANALYTICS_HEADER_DEVICE_ID = 'X-Bsky-Device-Id'
 const ANALYTICS_HEADER_SESSION_ID = 'X-Bsky-Session-Id'
+const BSKY_HEADER_IS_BETA_USER = 'X-Bsky-Is-Beta-User'
 
 export { type ScopedFeatureGatesClient } from './types.js'
 
@@ -225,11 +226,14 @@ export class FeatureGatesClient {
   }): UserContext {
     const deviceId = req.header(ANALYTICS_HEADER_DEVICE_ID)
     const sessionId = req.header(ANALYTICS_HEADER_SESSION_ID)
+    const isBetaUser =
+      req.header(BSKY_HEADER_IS_BETA_USER)?.toLowerCase() === 'true'
 
     return normalizeUserContext({
       did: viewer,
       deviceId,
       sessionId,
+      isBetaUser,
     })
   }
 }

--- a/packages/bsky/src/feature-gates/types.ts
+++ b/packages/bsky/src/feature-gates/types.ts
@@ -8,6 +8,7 @@ export type UserContext = {
   did?: string | null
   deviceId?: string | null
   sessionId?: string | null
+  isBetaUser?: boolean | null
 }
 
 /**
@@ -19,6 +20,7 @@ export type NormalizedUserContext = {
   did?: string
   deviceId: string
   sessionId: string
+  isBetaUser: boolean
 }
 
 /**

--- a/packages/bsky/src/feature-gates/utils.test.ts
+++ b/packages/bsky/src/feature-gates/utils.test.ts
@@ -7,6 +7,7 @@ describe('normalizeUserContext', () => {
     expect(ctx.did).toBeUndefined()
     expect(ctx.deviceId).toMatch(/^anon-/)
     expect(ctx.sessionId).toMatch(/^anon-/)
+    expect(ctx.isBetaUser).toBe(false)
   })
 
   it('with did', () => {
@@ -32,10 +33,12 @@ describe('normalizeUserContext', () => {
     const ctx = normalizeUserContext({
       deviceId: 'device-456',
       sessionId: 'session-789',
+      isBetaUser: true,
     })
     expect(ctx.did).toBeUndefined()
     expect(ctx.deviceId).toBe('device-456')
     expect(ctx.sessionId).toBe('session-789')
+    expect(ctx.isBetaUser).toBe(true)
   })
 })
 
@@ -57,10 +60,17 @@ describe('mergeUserContexts', () => {
   })
 
   it('base context with did, override with same did', () => {
-    const base = normalizeUserContext({ did: 'did:example:123' })
-    const merged = mergeUserContexts(base, { did: 'did:example:123' })
+    const base = normalizeUserContext({
+      did: 'did:example:123',
+      isBetaUser: true,
+    })
+    const merged = mergeUserContexts(base, {
+      did: 'did:example:123',
+      isBetaUser: false,
+    })
     expect(merged.did).toBe('did:example:123')
     expect(merged.deviceId).toBe('did:example:123')
     expect(merged.sessionId).toBe(base.sessionId)
+    expect(merged.isBetaUser).toBe(false)
   })
 })

--- a/packages/bsky/src/feature-gates/utils.ts
+++ b/packages/bsky/src/feature-gates/utils.ts
@@ -38,6 +38,7 @@ export function normalizeUserContext(
     did,
     deviceId,
     sessionId,
+    isBetaUser: userContext.isBetaUser ?? false,
   }
 }
 
@@ -92,6 +93,7 @@ export function mergeUserContexts(
     did,
     deviceId,
     sessionId,
+    isBetaUser: overrides?.isBetaUser ?? base.isBetaUser,
   }
 }
 
@@ -112,6 +114,7 @@ export function extractUserContextFromGrowthbookUserContext(
     did: userContext.attributes?.did,
     deviceId: userContext.attributes?.deviceId,
     sessionId: userContext.attributes?.sessionId,
+    isBetaUser: userContext.attributes?.isBetaUser,
   })
 }
 

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -125,6 +125,7 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         'accept-encoding': req.headers['accept-encoding'] || 'identity',
         'accept-language': req.headers['accept-language'],
         'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
+        'x-bsky-is-beta-user': req.headers['x-bsky-is-beta-user'],
         'x-bsky-topics': req.headers['x-bsky-topics'],
 
         'content-type': body && req.headers['content-type'],
@@ -216,6 +217,7 @@ export async function pipethrough(
     headers: {
       'accept-language': req.headers['accept-language'],
       'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
+      'x-bsky-is-beta-user': req.headers['x-bsky-is-beta-user'],
       'x-bsky-topics': req.headers['x-bsky-topics'],
 
       // Because we sometimes need to interpret the response (e.g. during

--- a/packages/pds/tests/proxied/proxy-header.test.ts
+++ b/packages/pds/tests/proxied/proxy-header.test.ts
@@ -93,6 +93,7 @@ describe('proxy header', () => {
       headers: {
         ...sc.getHeaders(alice),
         'atproto-proxy': `${proxyServer.did}#atproto_test`,
+        'x-bsky-is-beta-user': 'true',
       },
     })
     const req = proxyServer.requests.at(-1)
@@ -107,6 +108,7 @@ describe('proxy header', () => {
     )
     expect(verified.aud).toBe(proxyServer.did)
     expect(verified.iss).toBe(alice)
+    expect(req.isBetaUser).toBe('true')
   })
 
   it('fails on a non-existant did', async () => {
@@ -164,16 +166,19 @@ describe('proxy header', () => {
       headers: {
         ...sc.getHeaders(alice),
         'atproto-proxy': `${proxyServer.did}#atproto_test`,
+        'x-bsky-is-beta-user': 'false',
       },
     })
     await res.arrayBuffer() // drain
     expect(res.status).toBe(501)
+    expect(proxyServer.requests.at(-1)?.isBetaUser).toBe('false')
   })
 })
 
 type ProxyReq = {
   url: string
   auth: string | undefined
+  isBetaUser: string | undefined
 }
 
 class ProxyServer {
@@ -198,14 +203,12 @@ class ProxyServer {
 
     // This is a PDS endpoint which uses a manual pipethrough() in its handler
     app.get('/xrpc/app.bsky.actor.getPreferences', (req, res) => {
+      requests.push(toProxyReq(req))
       res.sendStatus(501)
     })
 
     app.get('*', (req, res) => {
-      requests.push({
-        url: req.url,
-        auth: req.header('authorization'),
-      })
+      requests.push(toProxyReq(req))
       res.sendStatus(200)
     })
 
@@ -238,5 +241,13 @@ class ProxyServer {
 
   async close(): Promise<void> {
     await this.terminator.terminate()
+  }
+}
+
+function toProxyReq(req: express.Request): ProxyReq {
+  return {
+    url: req.url,
+    auth: req.header('authorization'),
+    isBetaUser: req.header('x-bsky-is-beta-user'),
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->

GrowthBook evaluations in AppView currently lack awareness of whether someone has opted into the beta program. This prevents feature flags and experiments from consistently targeting beta users.

The client already knows this state, and it is not security-sensitive or used for authorization, so forwarding it with requests provides the context GrowthBook needs without adding preference lookups or cross-service latency.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
