### PR TITLE
APP-2879: Add AppView OpenTelemetry metrics

### DIFF
--- a/.changeset/slow-dots-observe.md
+++ b/.changeset/slow-dots-observe.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add optional OpenTelemetry setup and instrument AppView's ConnectRPC dataplane client.

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -23,13 +23,19 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./telemetry": {
+      "types": "./dist/telemetry.d.ts",
+      "default": "./dist/telemetry.js"
+    },
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": ">=22"
   },
   "dependencies": {
     "@atproto-labs/fetch-node": "workspace:^",
+    "@atproto-labs/opentelemetry-node": "workspace:^",
     "@atproto-labs/xrpc-utils": "workspace:^",
     "@atproto/api": "workspace:^",
     "@atproto/common": "workspace:^",
@@ -49,6 +55,7 @@
     "@noble/curves": "^1.7.0",
     "@growthbook/growthbook": "^1.6.2",
     "@hapi/address": "^5.1.1",
+    "@opentelemetry/api": "^1.9.1",
     "@types/http-errors": "^2.0.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/packages/bsky/src/data-plane/client/index.ts
+++ b/packages/bsky/src/data-plane/client/index.ts
@@ -10,7 +10,7 @@ import {
 import { createGrpcTransport } from '@connectrpc/connect-node'
 import { Service } from '../../proto/bsky_connect.js'
 import type { HostList } from './hosts.js'
-import { callerInterceptor } from './util.js'
+import { callerInterceptor, otelInterceptor } from './util.js'
 
 export * from './hosts.js'
 export * from './util.js'
@@ -106,7 +106,7 @@ const createBaseClient = (
     httpVersion,
     acceptCompression: [],
     nodeOptions: { rejectUnauthorized },
-    interceptors: [callerInterceptor('appview')],
+    interceptors: [otelInterceptor, callerInterceptor('appview')],
   })
   return createPromiseClient(Service, transport)
 }

--- a/packages/bsky/src/data-plane/client/util.test.ts
+++ b/packages/bsky/src/data-plane/client/util.test.ts
@@ -1,11 +1,113 @@
-import type {
-  StreamRequest,
-  StreamResponse,
-  UnaryRequest,
-  UnaryResponse,
+import {
+  Code,
+  ConnectError,
+  type StreamRequest,
+  type StreamResponse,
+  type UnaryRequest,
+  type UnaryResponse,
 } from '@connectrpc/connect'
-import { describe, expect, it, vi } from 'vitest'
-import { callerInterceptor } from './util.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { callerInterceptor, otelInterceptor } from './util.js'
+
+const otel = vi.hoisted(() => {
+  const span = {
+    end: vi.fn(),
+    recordException: vi.fn(),
+    setAttributes: vi.fn(),
+    setStatus: vi.fn(),
+  }
+  return {
+    inject: vi.fn(),
+    record: vi.fn(),
+    span,
+    startActiveSpan: vi.fn(
+      (
+        _name: string,
+        _options: unknown,
+        callback: (activeSpan: typeof span) => unknown,
+      ) => callback(span),
+    ),
+  }
+})
+
+vi.mock('@opentelemetry/api', () => ({
+  SpanKind: { CLIENT: 2 },
+  SpanStatusCode: { ERROR: 2 },
+  ValueType: { DOUBLE: 1 },
+  context: { active: vi.fn(() => ({})) },
+  metrics: {
+    getMeter: () => ({ createHistogram: () => ({ record: otel.record }) }),
+  },
+  propagation: { inject: otel.inject },
+  trace: { getTracer: () => ({ startActiveSpan: otel.startActiveSpan }) },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const fakeRequest = () =>
+  ({
+    header: new Headers(),
+    method: { name: 'GetProfile' },
+    service: { typeName: 'bsky.Service' },
+  }) as UnaryRequest
+
+describe('otelInterceptor', () => {
+  it('records successful calls', async () => {
+    const req = fakeRequest()
+    const response = {} as UnaryResponse
+    const next = otelInterceptor(vi.fn(async () => response))
+
+    await expect(next(req)).resolves.toBe(response)
+
+    expect(otel.startActiveSpan).toHaveBeenCalledWith(
+      'bsky.Service/GetProfile',
+      {
+        kind: 2,
+        attributes: {
+          'rpc.method': 'GetProfile',
+          'rpc.service': 'bsky.Service',
+          'rpc.system': 'grpc',
+        },
+      },
+      expect.any(Function),
+    )
+    expect(otel.inject).toHaveBeenCalledWith(
+      expect.anything(),
+      req.header,
+      expect.anything(),
+    )
+    expect(otel.record).toHaveBeenCalledWith(expect.any(Number), {
+      'rpc.grpc.status_code': 0,
+      'rpc.method': 'GetProfile',
+      'rpc.service': 'bsky.Service',
+      'rpc.system': 'grpc',
+    })
+    expect(otel.span.end).toHaveBeenCalledOnce()
+  })
+
+  it('records Connect error status', async () => {
+    const err = new ConnectError('unavailable', Code.Unavailable)
+    const next = otelInterceptor(
+      vi.fn(async () => {
+        throw err
+      }),
+    )
+
+    await expect(next(fakeRequest())).rejects.toBe(err)
+
+    expect(otel.record).toHaveBeenCalledWith(expect.any(Number), {
+      'rpc.grpc.status_code': Code.Unavailable,
+      'rpc.method': 'GetProfile',
+      'rpc.service': 'bsky.Service',
+      'rpc.system': 'grpc',
+    })
+    expect(otel.span.recordException).toHaveBeenCalledWith(err)
+    expect(otel.span.setStatus).toHaveBeenCalledWith({ code: 2 })
+    expect(otel.span.end).toHaveBeenCalledOnce()
+  })
+})
 
 describe('callerInterceptor', () => {
   it('sets x-atlantis-caller header on the request', async () => {

--- a/packages/bsky/src/data-plane/client/util.ts
+++ b/packages/bsky/src/data-plane/client/util.ts
@@ -1,7 +1,68 @@
+import { performance } from 'node:perf_hooks'
 import { Code, ConnectError, type Interceptor } from '@connectrpc/connect'
+import {
+  type Attributes,
+  SpanKind,
+  SpanStatusCode,
+  type TextMapSetter,
+  ValueType,
+  context,
+  metrics,
+  propagation,
+  trace,
+} from '@opentelemetry/api'
 import * as ui8 from 'uint8arrays'
 import { getDidKeyFromMultibase } from '@atproto/identity'
 import { InvalidRequestError } from '@atproto/xrpc-server'
+
+const tracer = trace.getTracer('@atproto/bsky')
+const meter = metrics.getMeter('@atproto/bsky')
+const rpcClientDuration = meter.createHistogram('rpc.client.duration', {
+  description: 'Measures the duration of outbound RPC requests',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+})
+
+const headersSetter: TextMapSetter<Headers> = {
+  set(carrier, key, value) {
+    carrier.set(key, value)
+  },
+}
+
+export const otelInterceptor: Interceptor = (next) => async (req) => {
+  const attributes: Attributes = {
+    'rpc.system': 'grpc',
+    'rpc.service': req.service.typeName,
+    'rpc.method': req.method.name,
+  }
+  const spanName = `${req.service.typeName}/${req.method.name}`
+  const start = performance.now()
+
+  return tracer.startActiveSpan(
+    spanName,
+    { kind: SpanKind.CLIENT, attributes },
+    async (span) => {
+      propagation.inject(context.active(), req.header, headersSetter)
+      let statusCode = 0
+      try {
+        return await next(req)
+      } catch (err) {
+        statusCode = err instanceof ConnectError ? err.code : Code.Unknown
+        span.setStatus({ code: SpanStatusCode.ERROR })
+        span.recordException(err instanceof Error ? err : String(err))
+        throw err
+      } finally {
+        const completedAttributes = {
+          ...attributes,
+          'rpc.grpc.status_code': statusCode,
+        }
+        span.setAttributes(completedAttributes)
+        rpcClientDuration.record(performance.now() - start, completedAttributes)
+        span.end()
+      }
+    },
+  )
+}
 
 export const callerInterceptor =
   (caller: string): Interceptor =>

--- a/packages/bsky/src/telemetry.ts
+++ b/packages/bsky/src/telemetry.ts
@@ -1,0 +1,7 @@
+import pkg from '@atproto/bsky/package.json' with { type: 'json' }
+import { setup } from '@atproto-labs/opentelemetry-node'
+
+setup(() => ({
+  name: pkg.name,
+  version: pkg.version,
+}))

--- a/packages/bsky/tsconfig.build.json
+++ b/packages/bsky/tsconfig.build.json
@@ -9,6 +9,7 @@
     { "path": "../did/tsconfig.build.json" },
     { "path": "../identity/tsconfig.build.json" },
     { "path": "../internal/fetch-node/tsconfig.build.json" },
+    { "path": "../internal/opentelemetry-node/tsconfig.build.json" },
     { "path": "../internal/xrpc-utils/tsconfig.build.json" },
     { "path": "../lex/lex/tsconfig.build.json" },
     { "path": "../repo/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       '@atproto-labs/fetch-node':
         specifier: workspace:^
         version: link:../internal/fetch-node
+      '@atproto-labs/opentelemetry-node':
+        specifier: workspace:^
+        version: link:../internal/opentelemetry-node
       '@atproto-labs/xrpc-utils':
         specifier: workspace:^
         version: link:../internal/xrpc-utils
@@ -444,6 +447,9 @@ importers:
       '@noble/curves':
         specifier: ^1.7.0
         version: 1.8.0
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@types/http-errors':
         specifier: ^2.0.1
         version: 2.0.4

--- a/services/bsky/Dockerfile
+++ b/services/bsky/Dockerfile
@@ -95,7 +95,7 @@ ENV NODE_ENV=production
 
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
 USER node
-CMD ["node", "--heapsnapshot-signal=SIGUSR2", "--enable-source-maps", "--import=./tracer.ts", "api.ts"]
+CMD ["node", "--heapsnapshot-signal=SIGUSR2", "--enable-source-maps", "--import=./tracer.ts", "--import=@atproto/bsky/telemetry", "api.ts"]
 
 LABEL org.opencontainers.image.source=https://github.com/bluesky-social/atproto
 LABEL org.opencontainers.image.description="Bsky App View"


### PR DESCRIPTION
## Summary

- add optional OpenTelemetry setup for AppView
- instrument the ConnectRPC dataplane client with spans, trace propagation, and RPC duration metrics
- preload telemetry in the AppView service image

## Testing

- `pnpm run build` in `packages/bsky`
- `pnpm test src/data-plane/client/util.test.ts` in `packages/bsky`
- targeted ESLint and Prettier checks

https://linear.app/blueskyweb/issue/APP-2879/improve-appview-otel