### PR TITLE
[oauth ui] Remove flags from language display

### DIFF
--- a/packages/oauth/oauth-provider-ui/src/locales/locale-provider.tsx
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-provider.tsx
@@ -14,7 +14,7 @@ import { loadMessages } from './load.ts'
 import { type Locale, detectLocale, isLocale, locales } from './locales.ts'
 
 export type LocaleContextValue = {
-  locale: string
+  locale: Locale
   locales: Partial<Record<Locale, { name: string; flag?: string }>>
   setLocale: (locale: Locale) => void
 }
@@ -30,7 +30,7 @@ export function useLocaleContext(): LocaleContextValue {
   return context
 }
 
-export function useCurrentLocale(): string {
+export function useCurrentLocale() {
   return useLocaleContext().locale
 }
 
@@ -44,7 +44,7 @@ export function LocaleProvider({
   // Bundle "en" messages with the app
   const i18n = useMemo(() => new I18n({ locale: 'en', messages: { en } }), [])
 
-  const [currentLocale, setCurrentLocale] = useState<string>(() => i18n.locale)
+  const [currentLocale, setCurrentLocale] = useState<Locale>(() => i18n.locale as Locale)
   const [desiredLocale, setDesiredLocale] = useState<Locale>(() => {
     return detectLocale(userLocales)
   })
@@ -64,7 +64,7 @@ export function LocaleProvider({
 
   // Keep currentLocale in sync with i18n's locale prop
   useEffect(() => {
-    const onChange = () => setCurrentLocale(i18n.locale)
+    const onChange = () => setCurrentLocale(i18n.locale as Locale)
     i18n.on('change', onChange)
     return () => i18n.removeListener('change', onChange)
   }, [i18n])

--- a/packages/oauth/oauth-provider-ui/src/locales/locale-selector.tsx
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-selector.tsx
@@ -20,7 +20,7 @@ export function LocaleSelector({ className }: LocaleSelectorProps) {
   return (
     <Select
       value={locale}
-      onValueChange={(value) => setLocale(value as keyof typeof locales)}
+      onValueChange={(value) => value && setLocale(value)}
     >
       <SelectTrigger
         size="sm"

--- a/packages/oauth/oauth-provider-ui/src/locales/locale-selector.tsx
+++ b/packages/oauth/oauth-provider-ui/src/locales/locale-selector.tsx
@@ -34,14 +34,14 @@ export function LocaleSelector({ className }: LocaleSelectorProps) {
           {(value) => {
             const entry = locales[value as keyof typeof locales]
             if (!entry) return value
-            return entry.flag ? `${entry.flag} ${entry.name}` : entry.name
+            return entry.name
           }}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {Object.entries(locales).map(([key, { name, flag }]) => (
+        {Object.entries(locales).map(([key, { name }]) => (
           <SelectItem key={key} value={key}>
-            {flag ? `${flag} ${name}` : name}
+            {name}
           </SelectItem>
         ))}
       </SelectContent>


### PR DESCRIPTION
Maybe this is bias coming from a british person, but languages do not map neatly to flags! imo we should just display the plain string, no flag

<img width="542" height="776" alt="Screenshot 2026-08-15 at 13 12 23" src="https://github.com/user-attachments/assets/f84fbee1-dd45-4e14-a1d1-882ed0d687d9" />
<img width="519" height="379" alt="Screenshot 2026-08-15 at 13 12 30" src="https://github.com/user-attachments/assets/0353af31-77e4-4871-a8ad-6bb3477a76c4" />

While I was touching it, I noticed `locale` was typed as string, so I typed it as `Locale`. This revealed that `onValueChange` can pass `null`, so I changed it so that it has to be truthy