### PR TITLE
Clean up partial dev-env startup

### DIFF
--- a/.changeset/tidy-pandas-rest.md
+++ b/.changeset/tidy-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+'@atproto/dev-env': patch
+---
+
+Clean up services when test-network startup fails partway.

--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -47,6 +47,7 @@
     "@atproto/xrpc-server": "workspace:^",
     "@did-plc/lib": "^0.0.1",
     "@did-plc/server": "^0.0.1",
+    "core-js": "^3.50.0",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",
     "get-port": "^5.1.1",
@@ -56,11 +57,13 @@
     "undici": "^8.5.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13"
+    "@types/express": "^4.17.13",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "start": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps dist/bin.js",
+    "test": "vitest run",
     "dev": "../dev-infra/with-test-redis-and-db.sh node --enable-source-maps --watch dist/bin.js"
   }
 }

--- a/packages/dev-env/src/bsync.ts
+++ b/packages/dev-env/src/bsync.ts
@@ -63,4 +63,8 @@ export class TestBsync {
   async close() {
     await this.service.destroy()
   }
+
+  async [Symbol.asyncDispose]() {
+    await this.close()
+  }
 }

--- a/packages/dev-env/src/core-js.d.ts
+++ b/packages/dev-env/src/core-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'core-js/proposals/explicit-resource-management'

--- a/packages/dev-env/src/introspect.ts
+++ b/packages/dev-env/src/introspect.ts
@@ -59,4 +59,8 @@ export class IntrospectServer {
   async close() {
     await this.terminator.terminate()
   }
+
+  async [Symbol.asyncDispose]() {
+    await this.close()
+  }
 }

--- a/packages/dev-env/src/network-no-appview.ts
+++ b/packages/dev-env/src/network-no-appview.ts
@@ -1,3 +1,4 @@
+import './polyfill.js'
 import type { SkeletonHandler } from '@atproto/pds'
 import { TestFeedGen } from './feed-gen.js'
 import { TestPds } from './pds.js'
@@ -11,26 +12,31 @@ export class TestNetworkNoAppView implements AsyncDisposable {
   constructor(
     public plc: TestPlc,
     public pds: TestPds,
+    protected readonly disposables?: AsyncDisposableStack,
   ) {}
 
   static async create(
     params: Partial<TestServerParams> = {},
   ): Promise<TestNetworkNoAppView> {
-    const plc = await TestPlc.create(params.plc ?? {})
-    const pds = await TestPds.create({
-      didPlcUrl: plc.url,
-      ...params.pds,
-    })
+    await using disposables = new AsyncDisposableStack()
+    const plc = disposables.use(await TestPlc.create(params.plc ?? {}))
+    const pds = disposables.use(
+      await TestPds.create({
+        didPlcUrl: plc.url,
+        ...params.pds,
+      }),
+    )
 
     mockNetworkUtilities(pds)
 
-    return new TestNetworkNoAppView(plc, pds)
+    return new TestNetworkNoAppView(plc, pds, disposables.move())
   }
 
   async createFeedGen(
     feeds: Record<string, SkeletonHandler>,
   ): Promise<TestFeedGen> {
     const fg = await TestFeedGen.create(this.plc.url, feeds)
+    this.disposables?.use(fg)
     this.feedGens.push(fg)
     return fg
   }
@@ -46,7 +52,12 @@ export class TestNetworkNoAppView implements AsyncDisposable {
   }
 
   async close() {
-    // @TODO Use disposable stack to implement this
+    if (this.disposables) {
+      await this.disposables.disposeAsync()
+      return
+    }
+
+    // Keep direct construction backwards-compatible with the previous cleanup path.
     const errors = await Promise.allSettled(
       this.feedGens.map((fg) => fg.close()),
     ).then((results) =>

--- a/packages/dev-env/src/network.ts
+++ b/packages/dev-env/src/network.ts
@@ -27,8 +27,9 @@ export class TestNetwork extends TestNetworkNoAppView {
     public bsky: TestBsky,
     public ozone: TestOzone,
     public introspect?: IntrospectServer,
+    disposables?: AsyncDisposableStack,
   ) {
-    super(plc, pds)
+    super(plc, pds, disposables)
   }
 
   static async create(
@@ -41,18 +42,23 @@ export class TestNetwork extends TestNetworkNoAppView {
     const dbPostgresSchema =
       params.dbPostgresSchema || process.env.DB_POSTGRES_SCHEMA
 
-    const plc = await TestPlc.create(params.plc ?? {})
+    await using disposables = new AsyncDisposableStack()
+    await using temporaryDisposables = new AsyncDisposableStack()
+
+    const plc = disposables.use(await TestPlc.create(params.plc ?? {}))
 
     const bskyPort = params.bsky?.port ?? (await getPort())
     const pdsPort = params.pds?.port ?? (await getPort())
     const ozonePort = params.ozone?.port ?? (await getPort())
 
-    const thirdPartyPds = await TestPds.create({
-      didPlcUrl: plc.url,
-      ...params.pds,
-      inviteRequired: false,
-      port: await getPort(),
-    })
+    const thirdPartyPds = temporaryDisposables.use(
+      await TestPds.create({
+        didPlcUrl: plc.url,
+        ...params.pds,
+        inviteRequired: false,
+        port: await getPort(),
+      }),
+    )
 
     const ozoneUrl = `http://localhost:${ozonePort}`
 
@@ -66,63 +72,71 @@ export class TestNetwork extends TestNetworkNoAppView {
       await LexiconAuthorityProfile.create(thirdPartyPds)
 
     const bsyncApiKey = 'bsync-api-key'
-    const bsync = await TestBsync.create({
-      apiKeys: [bsyncApiKey],
-      dbUrl: dbPostgresUrl,
-      dbSchema: `bsync_${dbPostgresSchema}`,
-    })
+    const bsync = disposables.use(
+      await TestBsync.create({
+        apiKeys: [bsyncApiKey],
+        dbUrl: dbPostgresUrl,
+        dbSchema: `bsync_${dbPostgresSchema}`,
+      }),
+    )
 
-    const bsky = await TestBsky.create({
-      port: bskyPort,
-      plcUrl: plc.url,
-      pdsPort,
-      bsyncApiKey,
-      bsyncUrl: bsync.url,
-      rolodexUrl: process.env.BSKY_ROLODEX_URL,
-      rolodexIgnoreBadTls: true,
-      repoProvider: `ws://localhost:${pdsPort}`,
-      dbPostgresSchema: `appview_${dbPostgresSchema}`,
-      dbPostgresUrl,
-      redisHost,
-      modServiceDid: ozoneServiceProfile.did,
-      labelsFromIssuerDids: [ozoneServiceProfile.did, EXAMPLE_LABELER],
-      // Using a static private key results in a static DID, which is useful for e2e tests with the social-app repo.
-      privateKey:
-        '3f916c70dc69e4c5e83877f013325b11ecac31742e6a42f5c4fb240d0703d9d5=',
-      ...params.bsky,
-    })
+    const bsky = disposables.use(
+      await TestBsky.create({
+        port: bskyPort,
+        plcUrl: plc.url,
+        pdsPort,
+        bsyncApiKey,
+        bsyncUrl: bsync.url,
+        rolodexUrl: process.env.BSKY_ROLODEX_URL,
+        rolodexIgnoreBadTls: true,
+        repoProvider: `ws://localhost:${pdsPort}`,
+        dbPostgresSchema: `appview_${dbPostgresSchema}`,
+        dbPostgresUrl,
+        redisHost,
+        modServiceDid: ozoneServiceProfile.did,
+        labelsFromIssuerDids: [ozoneServiceProfile.did, EXAMPLE_LABELER],
+        // Using a static private key results in a static DID, which is useful for e2e tests with the social-app repo.
+        privateKey:
+          '3f916c70dc69e4c5e83877f013325b11ecac31742e6a42f5c4fb240d0703d9d5=',
+        ...params.bsky,
+      }),
+    )
 
-    const pds = await TestPds.create({
-      port: pdsPort,
-      didPlcUrl: plc.url,
-      bskyAppViewUrl: bsky.url,
-      bskyAppViewDid: bsky.ctx.cfg.serverDid,
-      modServiceUrl: ozoneUrl,
-      modServiceDid: ozoneServiceProfile.did,
-      lexiconDidAuthority: lexiconAuthorityProfile.did,
-      ...params.pds,
-    })
+    const pds = disposables.use(
+      await TestPds.create({
+        port: pdsPort,
+        didPlcUrl: plc.url,
+        bskyAppViewUrl: bsky.url,
+        bskyAppViewDid: bsky.ctx.cfg.serverDid,
+        modServiceUrl: ozoneUrl,
+        modServiceDid: ozoneServiceProfile.did,
+        lexiconDidAuthority: lexiconAuthorityProfile.did,
+        ...params.pds,
+      }),
+    )
 
     // mock before any events start flowing from pds so that we don't miss e.g. any handle resolutions.
     mockNetworkUtilities(pds, bsky)
 
-    const ozone = await TestOzone.create({
-      port: ozonePort,
-      plcUrl: plc.url,
-      signingKey: ozoneServiceProfile.key,
-      serverDid: ozoneServiceProfile.did,
-      dbPostgresSchema: `ozone_${dbPostgresSchema || 'db'}`,
-      dbPostgresUrl,
-      appviewUrl: bsky.url,
-      appviewDid: bsky.ctx.cfg.serverDid,
-      appviewPushEvents: true,
-      pdsUrl: pds.url,
-      pdsDid: pds.ctx.cfg.service.did,
-      verifierDid: ozoneServiceProfile.did,
-      verifierUrl: pds.url,
-      verifierPassword: 'temp',
-      ...params.ozone,
-    })
+    const ozone = disposables.use(
+      await TestOzone.create({
+        port: ozonePort,
+        plcUrl: plc.url,
+        signingKey: ozoneServiceProfile.key,
+        serverDid: ozoneServiceProfile.did,
+        dbPostgresSchema: `ozone_${dbPostgresSchema || 'db'}`,
+        dbPostgresUrl,
+        appviewUrl: bsky.url,
+        appviewDid: bsky.ctx.cfg.serverDid,
+        appviewPushEvents: true,
+        pdsUrl: pds.url,
+        pdsDid: pds.ctx.cfg.service.did,
+        verifierDid: ozoneServiceProfile.did,
+        verifierUrl: pds.url,
+        verifierPassword: 'temp',
+        ...params.ozone,
+      }),
+    )
 
     await ozoneServiceProfile.migrateTo(pds)
     await ozoneServiceProfile.createRecords()
@@ -138,7 +152,7 @@ export class TestNetwork extends TestNetworkNoAppView {
     await ozone.processAll()
     await bsky.sub.processAll()
     await bsky.bsyncSub.processAll(await bsync.getStreamHeads())
-    await thirdPartyPds.close()
+    await temporaryDisposables.disposeAsync()
 
     // Weird but if we do this before pds.processAll() somehow appview loses this user and tests in different parts fail because appview doesn't return this user in various contexts anymore
     const ozoneVerifierPassword =
@@ -149,17 +163,27 @@ export class TestNetwork extends TestNetworkNoAppView {
 
     let introspect: IntrospectServer | undefined = undefined
     if (params.introspect?.port) {
-      introspect = await IntrospectServer.start(
-        params.introspect.port,
-        plc,
-        pds,
-        bsync,
-        bsky,
-        ozone,
+      introspect = disposables.use(
+        await IntrospectServer.start(
+          params.introspect.port,
+          plc,
+          pds,
+          bsync,
+          bsky,
+          ozone,
+        ),
       )
     }
 
-    return new TestNetwork(plc, pds, bsync, bsky, ozone, introspect)
+    return new TestNetwork(
+      plc,
+      pds,
+      bsync,
+      bsky,
+      ozone,
+      introspect,
+      disposables.move(),
+    )
   }
 
   async processFullSubscription(timeout = 5000) {
@@ -226,15 +250,19 @@ export class TestNetwork extends TestNetworkNoAppView {
     try {
       await this.processAll()
     } finally {
-      await allFulfilled([
-        ...this.feedGens.map(async (fg) => fg.close()),
-        this.ozone.close(),
-        this.bsky.close(),
-        this.bsync.close(),
-        this.pds.close(),
-        this.plc.close(),
-        this.introspect?.close(),
-      ])
+      if (this.disposables) {
+        await super.close()
+      } else {
+        await allFulfilled([
+          ...this.feedGens.map(async (fg) => fg.close()),
+          this.ozone.close(),
+          this.bsky.close(),
+          this.bsync.close(),
+          this.pds.close(),
+          this.plc.close(),
+          this.introspect?.close(),
+        ])
+      }
     }
   }
 

--- a/packages/dev-env/src/plc.ts
+++ b/packages/dev-env/src/plc.ts
@@ -30,4 +30,8 @@ export class TestPlc {
   async close() {
     await this.server.destroy()
   }
+
+  async [Symbol.asyncDispose]() {
+    await this.close()
+  }
 }

--- a/packages/dev-env/src/polyfill.ts
+++ b/packages/dev-env/src/polyfill.ts
@@ -1,0 +1,1 @@
+import 'core-js/proposals/explicit-resource-management'

--- a/packages/dev-env/tests/network-no-appview.test.ts
+++ b/packages/dev-env/tests/network-no-appview.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TestNetworkNoAppView } from '../src/network-no-appview.js'
+import { TestPds } from '../src/pds.js'
+import { TestPlc } from '../src/plc.js'
+
+describe(TestNetworkNoAppView, () => {
+  it('closes the PLC when PDS startup fails', async () => {
+    const failure = new Error('PDS startup failed')
+    const closePlc = vi.fn(async () => {})
+    const plc = {
+      url: 'http://localhost:1234',
+      [Symbol.asyncDispose]: closePlc,
+    } as unknown as TestPlc
+
+    using plcCreate = vi.spyOn(TestPlc, 'create').mockResolvedValue(plc)
+    using pdsCreate = vi.spyOn(TestPds, 'create').mockRejectedValue(failure)
+
+    await expect(TestNetworkNoAppView.create()).rejects.toBe(failure)
+
+    expect(plcCreate).toHaveBeenCalledOnce()
+    expect(pdsCreate).toHaveBeenCalledOnce()
+    expect(closePlc).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/dev-env/tests/network.test.ts
+++ b/packages/dev-env/tests/network.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TestNetwork } from '../src/network.js'
+import { TestPds } from '../src/pds.js'
+import { TestPlc } from '../src/plc.js'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe(TestNetwork, () => {
+  it('closes the PLC when the first dependent service fails', async () => {
+    vi.stubEnv('DB_POSTGRES_URL', 'postgres://test')
+    vi.stubEnv('REDIS_HOST', 'localhost')
+
+    const failure = new Error('PDS startup failed')
+    const closePlc = vi.fn(async () => {})
+    const plc = {
+      url: 'http://localhost:1234',
+      [Symbol.asyncDispose]: closePlc,
+    } as unknown as TestPlc
+
+    using plcCreate = vi.spyOn(TestPlc, 'create').mockResolvedValue(plc)
+    using pdsCreate = vi.spyOn(TestPds, 'create').mockRejectedValue(failure)
+
+    await expect(TestNetwork.create()).rejects.toBe(failure)
+
+    expect(plcCreate).toHaveBeenCalledOnce()
+    expect(pdsCreate).toHaveBeenCalledOnce()
+    expect(closePlc).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/dev-env/tsconfig.build.json
+++ b/packages/dev-env/tsconfig.build.json
@@ -17,6 +17,7 @@
     { "path": "../xrpc-server/tsconfig.build.json" },
   ],
   "compilerOptions": {
+    "lib": ["ES2023", "ESNext.Disposable"],
     "rootDir": "./src",
     "outDir": "./dist",
     // @TODO Change to true and fix implicit any errors

--- a/packages/dev-env/tsconfig.json
+++ b/packages/dev-env/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
 }

--- a/packages/dev-env/tsconfig.test.json
+++ b/packages/dev-env/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../tsconfig/vitest.tsconfig.json"],
+  "include": ["./tests", "./src/**/*.test.ts", "./src/core-js.d.ts"],
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable", "ESNext.Disposable"],
+    "rootDir": ".",
+  },
+  "references": [{ "path": "./tsconfig.build.json" }],
+}

--- a/packages/dev-env/vitest.config.ts
+++ b/packages/dev-env/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       '@did-plc/server':
         specifier: ^0.0.1
         version: 0.0.1
+      core-js:
+        specifier: ^3.50.0
+        version: 3.50.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -738,6 +741,9 @@ importers:
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.21
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.19.17)(jiti@2.7.0)(terser@5.44.0)(yaml@2.8.1))
 
   packages/did:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     projects: [
       'packages/aws',
       'packages/common',
+      'packages/dev-env',
       'packages/internal/*',
       'packages/lex/*',
       'packages/lexicon-resolver',


### PR DESCRIPTION
Fixes #5252.

- Track started dev-env services with AsyncDisposableStack.
- Transfer cleanup ownership to the returned network and dispose partial startups in reverse order.
- Polyfill the API for Node 22 and add failure-injection tests for both network factories.
- Preserve the existing cleanup path for direct constructor calls.

Tests:
- pnpm build
- pnpm verify
- pnpm --filter @atproto/dev-env test
- dev-env tests on Node 22