### PR TITLE
Wrap long handles, simplify delete account dialog copy

### DIFF
--- a/.changeset/wrap-long-handles-in-copy.md
+++ b/.changeset/wrap-long-handles-in-copy.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Let a long username wrap instead of overflowing the copy that quotes it, and drop it from the delete-account dialog's title.

--- a/packages/oauth/oauth-provider-ui/src/components/delete-account-dialog.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/delete-account-dialog.tsx
@@ -69,13 +69,7 @@ export function DeleteAccountDialog({
 
   const dismissable = !requestPending && !confirmSubmitting
 
-  const title = handle ? (
-    <Trans>
-      Delete account <Handle handle={handle} />
-    </Trans>
-  ) : (
-    <Trans>Delete account</Trans>
-  )
+  const title = <Trans>Delete account</Trans>
 
   if (step === Step.FinalConfirm) {
     return (

--- a/packages/oauth/oauth-provider-ui/src/components/utils/handle.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/utils/handle.tsx
@@ -41,7 +41,7 @@ export function Handle({
     <span
       {...props}
       className={clsx(
-        { 'whitespace-nowrap': !isInvalid },
+        'break-words',
         // @NOTE We use pseudo elements here so that selecting the handle text
         // (or checking in tests) ignores the "⚠"/"@" prefix, which are only
         // meant to be visual indicators for the handle. We use pseudo element

--- a/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/en/messages.po
@@ -406,10 +406,6 @@ msgstr "Delete"
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr "Delete account <0/>"
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr "Delete my account"

--- a/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/es/messages.po
@@ -406,10 +406,6 @@ msgstr "Eliminar"
 msgid "Delete account"
 msgstr ""
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr ""
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr ""

--- a/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/fr/messages.po
@@ -406,10 +406,6 @@ msgstr "Supprimer"
 msgid "Delete account"
 msgstr "Supprimer le compte"
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr "Supprimer le compte <0/>"
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr "Supprimer mon compte"

--- a/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ja/messages.po
@@ -406,10 +406,6 @@ msgstr "削除"
 msgid "Delete account"
 msgstr "アカウントを削除"
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr "アカウントを削除 <0/>"
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr "アカウントを削除"

--- a/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ko/messages.po
@@ -406,10 +406,6 @@ msgstr "삭제"
 msgid "Delete account"
 msgstr ""
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr ""
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr ""

--- a/packages/oauth/oauth-provider-ui/src/locales/ro/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/ro/messages.po
@@ -411,10 +411,6 @@ msgstr "Șterge"
 msgid "Delete account"
 msgstr "Ștergere cont"
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr "Ștergeți contul <0/>"
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr "Șterge-mi contul"

--- a/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
+++ b/packages/oauth/oauth-provider-ui/src/locales/sv/messages.po
@@ -406,10 +406,6 @@ msgstr "Radera"
 msgid "Delete account"
 msgstr "Radera konto"
 
-#: src/components/delete-account-dialog.tsx
-msgid "Delete account <0/>"
-msgstr "Radera kontot <0/>"
-
 #: src/components/delete-account-confirm-form.tsx
 msgid "Delete my account"
 msgstr "Radera mitt konto"


### PR DESCRIPTION
## What & why

- `Handle` forced `whitespace-nowrap`, so a long custom-domain username ran past the right edge of every dialog that quotes it — delete account, consent, About. This is the username half of #5377, which fixed the same thing for email addresses.
- It now uses `break-words`, so a username still sits on one line whenever it fits and only breaks when it would otherwise overflow.
- Single-line contexts (settings rows, `AccountSummary`, `AccountCard`, account menu) pass `truncate` and still ellipsize — unchanged.
- The delete-account dialog's title is now just "Delete account". A long handle wrapped to three bold lines and pushed the copy below the fold; the account is still named on the final confirmation. Drops one msgid (`Delete account <0/>`), adds none.

### Delete-account dialog at 320px

| Before | After |
| --- | --- |
| <img width="320" height="720" alt="before-delete-dialog" src="https://github.com/user-attachments/assets/2ebabccd-e9ad-4ef9-8f5a-a6fb2a5fa545" /> | <img width="320" height="720" alt="after-title-plain" src="https://github.com/user-attachments/assets/ae9a2597-e63f-470f-9764-8e5e51aec073" /> |

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass (94 in `oauth-provider-ui`). No new test — the change is CSS classes and one static string.
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling. — Yes, Claude Code (Opus 5).
