### PR TITLE
internal/xrpc-utils: drop redundant @atproto/xrpc dependency

### DIFF
--- a/.changeset/pink-poems-attend.md
+++ b/.changeset/pink-poems-attend.md
@@ -1,0 +1,6 @@
+---
+'@atproto/bsky': patch
+'@atproto/pds': patch
+---
+
+Use `isUnicastIpHostname` instead of its deprecated `isUnicastIp` alias.

--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/xrpc-utils': patch
+---
+
+Drop the `@atproto/xrpc` dependency by importing `ResponseType` from `@atproto/xrpc-server`, which re-exports it. No behavior change.

--- a/packages/bsky/src/api/blob-dispatcher.ts
+++ b/packages/bsky/src/api/blob-dispatcher.ts
@@ -1,5 +1,5 @@
 import { Agent, type Dispatcher, Pool, interceptors } from 'undici'
-import { isUnicastIp, unicastLookup } from '@atproto-labs/fetch-node'
+import { isUnicastIpHostname, unicastLookup } from '@atproto-labs/fetch-node'
 import type { ServerConfig } from '../config.js'
 import { RETRYABLE_HTTP_STATUS_CODES } from '../util/retry.js'
 
@@ -17,7 +17,7 @@ export function createBlobDispatcher(cfg: ServerConfig): Dispatcher {
           if (protocol !== 'https:') {
             throw new Error(`Forbidden protocol "${protocol}"`)
           }
-          if (isUnicastIp(hostname) === false) {
+          if (isUnicastIpHostname(hostname) === false) {
             throw new Error('Hostname resolved to non-unicast address')
           }
           return new Pool(origin, opts)

--- a/packages/internal/xrpc-utils/package.json
+++ b/packages/internal/xrpc-utils/package.json
@@ -33,7 +33,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@atproto/xrpc": "workspace:^",
     "@atproto/xrpc-server": "workspace:^"
   },
   "scripts": {

--- a/packages/internal/xrpc-utils/src/accept.ts
+++ b/packages/internal/xrpc-utils/src/accept.ts
@@ -1,6 +1,6 @@
-import { ResponseType } from '@atproto/xrpc'
 import {
   InvalidRequestError,
+  ResponseType,
   XRPCError as XRPCServerError,
 } from '@atproto/xrpc-server'
 

--- a/packages/internal/xrpc-utils/tsconfig.build.json
+++ b/packages/internal/xrpc-utils/tsconfig.build.json
@@ -1,10 +1,7 @@
 {
   "extends": ["../../../tsconfig/node.tsconfig.json"],
   "include": ["./src"],
-  "references": [
-    { "path": "../../xrpc-server/tsconfig.build.json" },
-    { "path": "../../xrpc/tsconfig.build.json" },
-  ],
+  "references": [{ "path": "../../xrpc-server/tsconfig.build.json" }],
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -20,7 +20,7 @@ import {
   excludeErrorResult,
   parseReqNsid,
 } from '@atproto/xrpc-server'
-import { isUnicastIp, unicastLookup } from '@atproto-labs/fetch-node'
+import { isUnicastIpHostname, unicastLookup } from '@atproto-labs/fetch-node'
 import { buildProxiedContentEncoding } from '@atproto-labs/xrpc-utils'
 import { isAccessPrivileged } from './auth-scope.js'
 import type { ProxyConfig } from './config/config.js'
@@ -42,7 +42,7 @@ export function buildProxyAgent(cfg: ProxyConfig): Dispatcher {
           if (protocol !== 'https:') {
             throw new Error(`Forbidden protocol "${protocol}"`)
           }
-          if (isUnicastIp(hostname) === false) {
+          if (isUnicastIpHostname(hostname) === false) {
             throw new Error('Hostname resolved to non-unicast address')
           }
           return new Pool(origin, opts)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -965,9 +965,6 @@ importers:
 
   packages/internal/xrpc-utils:
     dependencies:
-      '@atproto/xrpc':
-        specifier: workspace:^
-        version: link:../../xrpc
       '@atproto/xrpc-server':
         specifier: workspace:^
         version: link:../../xrpc-server


### PR DESCRIPTION
## What & why

`ResponseType` was the only symbol `@atproto-labs/xrpc-utils` used from `@atproto/xrpc`, and `@atproto/xrpc-server` — which the package already depends on — re-exports it. Importing it from there lets the extra dependency and its tsconfig project reference go away. Same enum, no behavior change.

Also switches the last two in-repo callers of the deprecated `isUnicastIp` alias (`pds` pipethrough, `bsky` blob-dispatcher) to `isUnicastIpHostname`. The alias itself stays in `@atproto-labs/fetch-node` — it's published, so removing it would break external consumers.

Both changes are behavior-preserving, so there's nothing new to cover with tests.

## Checklist

- [x] `pnpm build && pnpm verify` passes
- [x] A changeset is included for every package this touches
