### PR TITLE
Sets up Iris staging routing

### DIFF
--- a/.changeset/bright-irises-route.md
+++ b/.changeset/bright-irises-route.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Route configured staging feeds through Iris staging.

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.test.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { DidString } from '@atproto/lex'
 import { Gate } from '../../../../feature-gates/gates.js'
-import { irisUrlForFeed } from './getFeed.js'
+import { irisStagingUrlForFeed, irisUrlForFeed } from './getFeed.js'
 
 const IRIS_URL = 'http://iris.internal.invalid'
+const IRIS_STAGING_URL = 'http://iris-staging.internal.invalid'
 const ALLOWLISTED = 'at://did:plc:feedgen/app.bsky.feed.generator/whats-hot'
 const OTHER_FEED = 'at://did:plc:someone/app.bsky.feed.generator/custom'
 
@@ -86,5 +87,37 @@ describe('irisUrlForFeed', () => {
       irisUrlForFeed(cfg, params)
       expect(checkGate).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('irisStagingUrlForFeed', () => {
+  const stagingCfg = ({
+    irisStagingConfigured = true,
+    allowlistConfigured = true,
+  } = {}) => ({
+    irisStagingUrl: irisStagingConfigured ? IRIS_STAGING_URL : undefined,
+    irisStagingFeedUris: allowlistConfigured
+      ? new Set([ALLOWLISTED])
+      : undefined,
+  })
+
+  it('routes an allowlisted feed to iris staging', () => {
+    const url = irisStagingUrlForFeed(stagingCfg(), { feed: ALLOWLISTED })
+    expect(url).toBe(IRIS_STAGING_URL)
+  })
+
+  it('does not route a feed that is not allowlisted', () => {
+    const url = irisStagingUrlForFeed(stagingCfg(), { feed: OTHER_FEED })
+    expect(url).toBeUndefined()
+  })
+
+  it('does not route when iris staging is not configured', () => {
+    const cfg = stagingCfg({ irisStagingConfigured: false })
+    expect(irisStagingUrlForFeed(cfg, { feed: ALLOWLISTED })).toBeUndefined()
+  })
+
+  it('does not route when no allowlist is configured', () => {
+    const cfg = stagingCfg({ allowlistConfigured: false })
+    expect(irisStagingUrlForFeed(cfg, { feed: ALLOWLISTED })).toBeUndefined()
   })
 })

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -215,12 +215,25 @@ export const irisUrlForFeed = (
   return irisUrl
 }
 
+/**
+ * Iris staging's endpoint, when it should serve this request in place of the
+ * feed's registered feed generator.
+ */
+export const irisStagingUrlForFeed = (
+  cfg: Pick<ServerConfig, 'irisStagingUrl' | 'irisStagingFeedUris'>,
+  params: { feed: string },
+): string | undefined =>
+  cfg.irisStagingFeedUris?.has(params.feed) ? cfg.irisStagingUrl : undefined
+
 const resolveSkeletonEndpoint = async (
   ctx: Context,
   params: Params,
 ): Promise<string> => {
   const irisUrl = irisUrlForFeed(ctx.cfg, params)
   if (irisUrl) return irisUrl
+
+  const irisStagingUrl = irisStagingUrlForFeed(ctx.cfg, params)
+  if (irisStagingUrl) return irisStagingUrl
 
   const { feed } = params
   const found = await ctx.hydrator.feed.getFeedGens([feed], true)

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -70,6 +70,8 @@ export interface ServerConfigValues {
   topicsApiKey?: string
   irisUrl?: string
   irisFeedUris?: Set<string> // `iris:feed:enable` gate to serve via iris instead of seeemore
+  irisStagingUrl?: string
+  irisStagingFeedUris?: Set<string> // serve via iris staging instead of the registered feed generator
   cdnUrl?: string
   videoPlaylistUrlPattern?: string
   videoThumbnailUrlPattern?: string
@@ -175,6 +177,10 @@ export class ServerConfig {
     const topicsApiKey = process.env.BSKY_TOPICS_API_KEY
     const irisUrl = process.env.BSKY_IRIS_URL || undefined
     const irisFeedUris = new Set(envList(process.env.BSKY_IRIS_FEED_URIS))
+    const irisStagingUrl = process.env.BSKY_IRIS_STAGING_URL || undefined
+    const irisStagingFeedUris = new Set(
+      envList(process.env.BSKY_IRIS_STAGING_FEED_URIS),
+    )
     const dataplaneUrls =
       overrides?.dataplaneUrls ?? envList(process.env.BSKY_DATAPLANE_URLS)
     const dataplaneUrlsEtcdKeyPrefix =
@@ -369,6 +375,8 @@ export class ServerConfig {
       topicsApiKey,
       irisUrl,
       irisFeedUris,
+      irisStagingUrl,
+      irisStagingFeedUris,
       didPlcUrl,
       labelsFromIssuerDids,
       handleResolveNameservers,
@@ -561,6 +569,14 @@ export class ServerConfig {
 
   get irisFeedUris() {
     return this.cfg.irisFeedUris
+  }
+
+  get irisStagingUrl() {
+    return this.cfg.irisStagingUrl
+  }
+
+  get irisStagingFeedUris() {
+    return this.cfg.irisStagingFeedUris
   }
 
   get cdnUrl() {


### PR DESCRIPTION
Iris is a recommendation service, currently gated while in testing. This
commit creates another routing so developers can have a staging
environment with no public accessible URL when needed; it mus be
accessible by the AppView. It is fully optional.
