### PR TITLE
Send correct error message when handle collides with deactivated account

### DIFF
--- a/.changeset/deactivated-handles-stay-reserved.md
+++ b/.changeset/deactivated-handles-stay-reserved.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Report a handle or email belonging to a deactivated or taken down account as an `InvalidRequest` from `com.atproto.server.createAccount`, instead of failing with an `InternalServerError` once the insert hits the unique index.

--- a/.changeset/name-the-handle-on-handle-conflict.md
+++ b/.changeset/name-the-handle-on-handle-conflict.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Name the handle, rather than the email, when account creation conflicts on the handle.

--- a/packages/pds/src/account-manager/helpers/account.ts
+++ b/packages/pds/src/account-manager/helpers/account.ts
@@ -140,7 +140,9 @@ export const registerActor = async (
       .returning('did'),
   )
   if (!registered) {
-    throw new UserAlreadyExistsError()
+    throw new UserAlreadyExistsError(
+      'Handle is already in use, please choose a different handle.',
+    )
   }
 }
 

--- a/packages/pds/src/api/com/atproto/server/createAccount.ts
+++ b/packages/pds/src/api/com/atproto/server/createAccount.ts
@@ -247,9 +247,14 @@ const validateInputsForLocalPds = async (
   }
 
   // check that the handle and email are available
+  //
+  // `actor_handle_lower_idx` and `account_email_lower_idx` enforce handle and
+  // email uniqueness across taken down and deactivated accounts as well, so we
+  // must check for them when surfacing handle availability.
+  const availability = { includeTakenDown: true, includeDeactivated: true }
   const [handleAccnt, emailAcct] = await Promise.all([
-    ctx.accountManager.getAccount(handle),
-    ctx.accountManager.getAccountByEmail(email),
+    ctx.accountManager.getAccount(handle, availability),
+    ctx.accountManager.getAccountByEmail(email, availability),
   ])
   if (handleAccnt) {
     throw new InvalidRequestError(`Handle already taken: ${handle}`)

--- a/packages/pds/tests/account.test.ts
+++ b/packages/pds/tests/account.test.ts
@@ -308,6 +308,41 @@ describe('account', () => {
     ).rejects.toThrow('Handle already taken: bob.test')
   })
 
+  it('disallows the email and handle of a deactivated account', async () => {
+    const email = 'dan@test.com'
+    const handle = 'dan.test'
+    const password = 'test123'
+    const { data: account } = await agent.api.com.atproto.server.createAccount({
+      email,
+      handle,
+      password,
+    })
+
+    await agent.api.com.atproto.server.deactivateAccount(
+      {},
+      {
+        encoding: 'application/json',
+        headers: { authorization: `Bearer ${account.accessJwt}` },
+      },
+    )
+
+    await expect(
+      agent.api.com.atproto.server.createAccount({
+        email: 'erin@test.com',
+        handle,
+        password,
+      }),
+    ).rejects.toThrow(`Handle already taken: ${handle}`)
+
+    await expect(
+      agent.api.com.atproto.server.createAccount({
+        email,
+        handle: 'erin.test',
+        password,
+      }),
+    ).rejects.toThrow(`Email already taken: ${email}`)
+  })
+
   it('validates input through lexicon schema', async () => {
     for (const invalidHandle of [
       'did:john',


### PR DESCRIPTION
## What & why

This PR fixes two related issues:

### Generic errors sent when handle collides with deactivated or taken down accounts

If a user tried to make a new account using the handle of a deactivated or taken down account, the handle is initially shown as available and then the creation ultimately fails with a generic `Internal Server Error`, providing the user no input into what went wrong.

`com.atproto.server.createAccount` checked handle and email availability with `getAccount()/getAccountByEmail()` and no availability flags, so both queries skipped deactivated and taken down accounts. The unique indexes behind those columns (`actor_handle_lower_idx`, `account_email_lower_idx`) cover every row, so a signup passed the check and then tripped the index inside registerActor/registerAccount, surfacing to the client as a bare `InternalServerError` instead of the `InvalidRequestError` the check would have raised. `validateHandleUpdate()` already performs this pessimistic check.

### Sending incorrect conflict message

If a user tried to create an account with the same handle as an existing account, the error message would name the `email` as the collision rather than the `handle`.


## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling. - Claude Code (Opus 5). Code reviewed by hand, PR body written by hand..
