### PR TITLE
Generate "token" as string values (in addition to the type)

### DIFF
--- a/.agents/skills/lex-schema/SKILL.md
+++ b/.agents/skills/lex-schema/SKILL.md
@@ -208,14 +208,13 @@ response — prefer it over sprinkling per-call options. See
 
 ## Tokens
 
-A Lexicon `token` def compiles to a schema instance whose constant is `$token`
-(the instance also stringifies to it). Prefer `$token` — it sits with the other
-`$`-prefixed schema constants, and [STYLE_GUIDE.md](../../../STYLE_GUIDE.md)
-prescribes it. The `.value` property resolves to the same string, so older call
-sites using it are correct, just not the house spelling:
+A Lexicon `token` def exports its schema in camelCase and its string value in
+PascalCase. The PascalCase export shares its name with the string literal type:
 
 ```ts
-app.bsky.graph.defs.curatelist.$token // 'app.bsky.graph.defs#curatelist'
+app.bsky.graph.defs.curatelist // TokenSchema
+app.bsky.graph.defs.Curatelist // 'app.bsky.graph.defs#curatelist'
+type Curatelist = app.bsky.graph.defs.Curatelist
 ```
 
 ## Declaring schemas with `l`

--- a/.agents/skills/lex-schema/SKILL.md
+++ b/.agents/skills/lex-schema/SKILL.md
@@ -61,7 +61,9 @@ type PostView = app.bsky.feed.defs.PostView // type
 
 **Never write NSID string literals.** Use `$type` / `$lxm` / `$token`: the
 schema stays the single source of truth and each constant is one shared string
-instance (see [STYLE_GUIDE.md](../../../STYLE_GUIDE.md#lexicons)).
+instance (see [STYLE_GUIDE.md](../../../STYLE_GUIDE.md#lexicons)). Tokens are
+also available as PascalCase export (e.g., `app.bsky.feed.defs.RequestLess`),
+prefer this over the `$token` notation.
 
 ## Validation methods
 

--- a/.changeset/bright-dryers-grow.md
+++ b/.changeset/bright-dryers-grow.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-builder': patch
+---
+
+Generate "token" as string values (in addition to the type)

--- a/.changeset/bright-dryers-grow.md
+++ b/.changeset/bright-dryers-grow.md
@@ -1,4 +1,5 @@
 ---
+'@atproto/lex': patch
 '@atproto/lex-builder': patch
 ---
 

--- a/.changeset/late-ducks-admire.md
+++ b/.changeset/late-ducks-admire.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-builder': patch
+---
+
+Prevent exporting the same identifier twice when generating an exported string

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -61,11 +61,11 @@ Prettier (`pnpm run style`) and ESLint (`pnpm run lint`) enforce what can be enf
 
 - **Never write NSID string literals** in a package that uses `@atproto/lex`. Import the generated schema and use the constant it exposes:
 
-  | Lexicon definition               | Use                                     |
-  | -------------------------------- | --------------------------------------- |
-  | record / typed object            | `app.bsky.feed.post.$type`              |
-  | query / procedure / subscription | `app.bsky.feed.getPosts.$lxm`           |
-  | token                            | `app.bsky.feed.defs.requestLess.$token` |
+  | Lexicon definition               | Use                                                                                     |
+  | -------------------------------- | --------------------------------------------------------------------------------------- |
+  | record / typed object            | `app.bsky.feed.post.$type`                                                              |
+  | query / procedure / subscription | `app.bsky.feed.getPosts.$lxm`                                                           |
+  | token                            | `app.bsky.feed.defs.requestLess.$token` or `app.bsky.feed.defs.RequestLess` (preferred) |
 
   Each constant is emitted once per schema, so every reference shares one string instance instead of duplicating the literal at each call site — and the schema stays the single source of truth.
 

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -1,3 +1,4 @@
+import type { read } from 'node:fs'
 import {
   type JSDocStructure,
   type OptionalKind,
@@ -37,7 +38,7 @@ import {
   type ResolvedRef,
   getPublicIdentifiers,
 } from './ref-resolver.js'
-import { asNamespaceExport } from './ts-lang.js'
+import { asNamespaceExport, isSafeLocalIdentifier } from './ts-lang.js'
 
 /**
  * Configuration options for the {@link LexDefBuilder} class.
@@ -97,18 +98,33 @@ export class LexDefBuilder {
   private addExportedString(
     name: string,
     initializer: string,
-    docs?: OptionalKind<JSDocStructure>,
+    docs?: (OptionalKind<JSDocStructure> | string)[],
   ) {
+    // @TODO We could convert the name to a safe identifier here, and export
+    // it as a namespace export, if we ever actually need to support unsafe
+    // identifiers. For now, we just throw an error if the name is not a valid
+    // TypeScript identifier.
+    if (!isSafeLocalIdentifier(name)) {
+      throw new Error(`Identifier ${name} is not a valid TypeScript identifier`)
+    }
+
+    if (
+      this.file.getVariableDeclaration(name) ||
+      this.file.getTypeAlias(name)
+    ) {
+      throw new Error(`Duplicate identifier ${name} for definition ${name}`)
+    }
+
     this.file.addVariableStatement({
       declarationKind: VariableDeclarationKind.Const,
-      docs: docs ? [docs] : undefined,
+      docs,
       declarations: [{ name, initializer }],
     })
 
     this.file.addTypeAlias({
       name,
       type: `typeof ${name}`,
-      docs: docs ? [docs] : undefined,
+      docs,
     })
 
     this.file.addExportDeclaration({
@@ -384,7 +400,13 @@ export class LexDefBuilder {
       validationUtils: true,
     })
 
-    this.addExportedString(ref.typeName, markPure(`${ref.varName}.value`))
+    const pub = getPublicIdentifiers(hash)
+
+    this.addExportedString(
+      pub.typeName,
+      markPure(`${ref.varName}.value`),
+      compileDocs(def.description),
+    )
   }
 
   private async addArray(hash: string, def: LexiconArray) {

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -104,12 +104,15 @@ export class LexDefBuilder {
     // identifiers. For now, we just throw an error if the name is not a valid
     // TypeScript identifier.
     if (!isSafeLocalIdentifier(name)) {
-      throw new Error(`Identifier ${name} is not a valid TypeScript identifier`)
+      throw new Error(`Identifier ${name} is not a safe TypeScript identifier`)
     }
 
     if (
       this.file.getVariableDeclaration(name) ||
-      this.file.getTypeAlias(name)
+      this.file.getTypeAlias(name) ||
+      this.file
+        .getExportDeclarations()
+        .some((exp) => exp.getNamedExports().some((e) => e.getName() === name))
     ) {
       throw new Error(`Duplicate identifier ${name}`)
     }

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -97,40 +97,43 @@ export class LexDefBuilder {
   private addExportedString(
     name: string,
     initializer: string,
-    docs?: (OptionalKind<JSDocStructure> | string)[],
+    {
+      docs,
+    }: {
+      docs?: (OptionalKind<JSDocStructure> | string)[]
+    } = {},
   ) {
-    // @TODO We could convert the name to a safe identifier here, and export
-    // it as a namespace export, if we ever actually need to support unsafe
-    // identifiers. For now, we just throw an error if the name is not a valid
-    // TypeScript identifier.
-    if (!isSafeLocalIdentifier(name)) {
-      throw new Error(`Identifier ${name} is not a safe TypeScript identifier`)
-    }
-
     if (
-      this.file.getVariableDeclaration(name) ||
-      this.file.getTypeAlias(name) ||
       this.file
         .getExportDeclarations()
         .some((exp) => exp.getNamedExports().some((e) => e.getName() === name))
     ) {
-      throw new Error(`Duplicate identifier ${name}`)
+      throw new Error(`Duplicate export ${name}`)
     }
+
+    const identifier = isSafeLocalIdentifier(name)
+      ? name
+      : this.refResolver.nextSafeDefinitionIdentifier(name)
 
     this.file.addVariableStatement({
       declarationKind: VariableDeclarationKind.Const,
       docs,
-      declarations: [{ name, initializer }],
+      declarations: [{ name: identifier, initializer }],
     })
 
     this.file.addTypeAlias({
-      name,
-      type: `typeof ${name}`,
+      name: identifier,
+      type: `typeof ${identifier}`,
       docs,
     })
 
     this.file.addExportDeclaration({
-      namedExports: [{ name }],
+      namedExports: [
+        {
+          name: identifier,
+          alias: name === identifier ? undefined : asNamespaceExport(name),
+        },
+      ],
     })
   }
 
@@ -404,11 +407,9 @@ export class LexDefBuilder {
 
     const pub = getPublicIdentifiers(hash)
 
-    this.addExportedString(
-      pub.typeName,
-      markPure(`${ref.varName}.value`),
-      compileDocs(def.description),
-    )
+    this.addExportedString(pub.typeName, markPure(`${ref.varName}.value`), {
+      docs: compileDocs(def.description),
+    })
   }
 
   private async addArray(hash: string, def: LexiconArray) {

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -1,4 +1,3 @@
-import type { read } from 'node:fs'
 import {
   type JSDocStructure,
   type OptionalKind,

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -379,11 +379,12 @@ export class LexDefBuilder {
   }
 
   private async addToken(hash: string, def: LexiconToken) {
-    await this.addSchema(hash, def, {
+    const ref = await this.addSchema(hash, def, {
       schema: markPure(`l.token($nsid, ${JSON.stringify(hash)})`),
-      type: JSON.stringify(l.$type(this.doc.id, hash)),
       validationUtils: true,
     })
+
+    this.addExportedString(ref.typeName, markPure(`${ref.varName}.value`))
   }
 
   private async addArray(hash: string, def: LexiconArray) {

--- a/packages/lex/lex-builder/src/lex-def-builder.ts
+++ b/packages/lex/lex-builder/src/lex-def-builder.ts
@@ -111,7 +111,7 @@ export class LexDefBuilder {
       this.file.getVariableDeclaration(name) ||
       this.file.getTypeAlias(name)
     ) {
-      throw new Error(`Duplicate identifier ${name} for definition ${name}`)
+      throw new Error(`Duplicate identifier ${name}`)
     }
 
     this.file.addVariableStatement({

--- a/packages/lex/lex-builder/src/ref-resolver.ts
+++ b/packages/lex/lex-builder/src/ref-resolver.ts
@@ -103,7 +103,7 @@ export class RefResolver {
   )
 
   #defCounters = new Map<string, number>()
-  private nextSafeDefinitionIdentifier(name: string): string {
+  nextSafeDefinitionIdentifier(name: string): string {
     // use camelCase version of the hash as base name
     const nameSafe =
       startsWithLower(name) && isValidJsIdentifier(name)

--- a/packages/lex/lex-builder/src/ref-resolver.ts
+++ b/packages/lex/lex-builder/src/ref-resolver.ts
@@ -103,7 +103,7 @@ export class RefResolver {
   )
 
   #defCounters = new Map<string, number>()
-  private nextSafeDefinitionIdentifier(name: string) {
+  private nextSafeDefinitionIdentifier(name: string): string {
     // use camelCase version of the hash as base name
     const nameSafe =
       startsWithLower(name) && isValidJsIdentifier(name)

--- a/packages/lex/lex/README.md
+++ b/packages/lex/lex/README.md
@@ -264,6 +264,24 @@ function renderPost(p: app.bsky.feed.post.Main) {
 }
 ```
 
+Token definitions also export their string value in PascalCase, using the same
+name as their string literal type. The token's camelCase export remains the
+runtime schema:
+
+```typescript
+import * as app from './lexicons/app.js'
+
+const requestLess = app.bsky.feed.defs.RequestLess
+// 'app.bsky.feed.defs#requestLess'
+
+type RequestLess = app.bsky.feed.defs.RequestLess
+
+app.bsky.feed.defs.requestLess // TokenSchema
+app.bsky.feed.defs.requestLess.$validate('foo') // throws
+app.bsky.feed.defs.requestLess.$safeValidate('foo') // ValidationFailure
+app.bsky.feed.defs.requestLess.$token === requestLess // true
+```
+
 ### Building data
 
 It is recommended to use the generated builders to create data that conforms to the schema. TypeScript ensures that all required fields are present at compile time.


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Currently, tokens runtime values need to be accessed through the schema:

```ts
com.atproto.moderation.defs.reasonAppeal.value
```

while the type can be accessed using a dedicated name-space value

```ts
function foo(token: com.atproto.moderation.defs.ReasonAppeal) {
  // ...
}

// Notice the "inconsistency"
foo(com.atproto.moderation.defs.reasonAppeal.value)
```

This PR allows the type export to be used as a runtime value as well:

```ts
function foo(token: com.atproto.moderation.defs.ReasonAppeal) {
  // ...
}

foo(com.atproto.moderation.defs.ReasonAppeal)

const token: com.atproto.moderation.defs.ReasonAppeal =
  com.atproto.moderation.defs.ReasonAppeal
```

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
