### PR TITLE
Allow using `string` value as `toDatetimeString` input

### DIFF
--- a/.changeset/sour-lands-worry.md
+++ b/.changeset/sour-lands-worry.md
@@ -1,0 +1,5 @@
+---
+'@atproto/syntax': patch
+---
+
+Allow using `string` value as `toDatetimeString` input

--- a/packages/syntax/src/datetime.ts
+++ b/packages/syntax/src/datetime.ts
@@ -184,7 +184,8 @@ export function currentDatetimeString(): DatetimeString {
  * @throws InvalidDatetimeError if the input date is not a valid atproto datetime (eg, it is too far in the future or past, or it normalizes to a negative year).
  * @see {@link DatetimeString}
  */
-export function toDatetimeString(date: Date): DatetimeString {
+export function toDatetimeString(input: Date | string): DatetimeString {
+  const date = typeof input === 'string' ? new Date(input) : input
   return asAtprotoDate(date).toISOString()
 }
 

--- a/packages/syntax/tests/datetime.test.ts
+++ b/packages/syntax/tests/datetime.test.ts
@@ -6,6 +6,7 @@ import {
   isDatetimeStringLenient,
   normalizeDatetime,
   normalizeDatetimeAlways,
+  toDatetimeString,
 } from '../src/index.js'
 import { readInteropFile } from './_utils.ts'
 
@@ -263,5 +264,20 @@ describe(normalizeDatetimeAlways, () => {
     test.each(interopInvalidParse)('%s', (dt) => {
       expect(normalizeDatetimeAlways(dt)).toEqual('1970-01-01T00:00:00.000Z')
     })
+  })
+})
+
+describe(toDatetimeString, () => {
+  describe('Interop valid', () => {
+    test.each(interopValid)('%s', (date) => {
+      const datetimeString = toDatetimeString(date)
+      expect(datetimeString).toBe(normalizeDatetime(date))
+    })
+  })
+
+  it('allows Date input', () => {
+    const date = new Date('2023-01-01T12:34:56Z')
+    const datetimeString = toDatetimeString(date)
+    expect(datetimeString).toBe('2023-01-01T12:34:56.000Z')
   })
 })


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

Allows `toDatetimeString` to be called with a string.

```ts
// before
toDatetimeString(new Date(myString))

// after
toDatetimeString(myString)
```


## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
