### PR TITLE
pds: honour atproto-proxy in getFeed and read-after-write; serve app.bsky handlers without a default app view

### DIFF
--- a/.changeset/quiet-feeds-target.md
+++ b/.changeset/quiet-feeds-target.md
@@ -1,0 +1,5 @@
+---
+'@atproto/pds': patch
+---
+
+Honour the `atproto-proxy` header when resolving the feed generator in `app.bsky.feed.getFeed`, when hydrating record embeds during read-after-write, and in the `getPostThread` not-found fallback, instead of always using the configured app view. Register `app.bsky.actor.getPreferences`/`putPreferences` and the other `app.bsky.*` handlers even when no app view is configured, so a PDS without `PDS_BSKY_APP_VIEW_URL` still serves preferences locally and proxies explicitly targeted requests.

--- a/packages/pds/src/api/app/bsky/actor/getPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/getPreferences.ts
@@ -6,19 +6,18 @@ import { app } from '../../../../lexicons/index.js'
 import {
   bareDidFromProxyTo,
   computeProxyTo,
+  computeProxyToOrSelf,
+  isLocalAppViewRequest,
   pipethrough,
 } from '../../../../pipethrough.js'
 
 export default function (server: Server, ctx: AppContext) {
-  const { bskyAppView } = ctx
-  if (!bskyAppView) return
-
   server.add(app.bsky.actor.getPreferences, {
     auth: ctx.authVerifier.authorizationOrModService({
       additional: [AuthScope.Takendown],
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.getPreferences.$lxm
-        const aud = computeProxyTo(ctx, req, lxm)
+        const aud = computeProxyToOrSelf(ctx, req, lxm)
         permissions.assertRpc({ aud, lxm })
       },
     }),
@@ -31,9 +30,9 @@ export default function (server: Server, ctx: AppContext) {
       // If the request has a proxy header different from the bsky app view,
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
-      const lxm = app.bsky.actor.getPreferences.$lxm
-      const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
+      if (!isLocalAppViewRequest(ctx, req)) {
+        const lxm = app.bsky.actor.getPreferences.$lxm
+        const aud = computeProxyTo(ctx, req, lxm)
         if (isModerator) {
           throw new InvalidRequestError(
             'Moderator requests cannot be proxied to other app views',

--- a/packages/pds/src/api/app/bsky/actor/getProfile.ts
+++ b/packages/pds/src/api/app/bsky/actor/getProfile.ts
@@ -8,8 +8,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.actor.getProfile, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {

--- a/packages/pds/src/api/app/bsky/actor/getProfiles.ts
+++ b/packages/pds/src/api/app/bsky/actor/getProfiles.ts
@@ -8,8 +8,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.actor.getProfiles, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {

--- a/packages/pds/src/api/app/bsky/actor/putPreferences.ts
+++ b/packages/pds/src/api/app/bsky/actor/putPreferences.ts
@@ -6,19 +6,18 @@ import { app } from '../../../../lexicons/index.js'
 import {
   bareDidFromProxyTo,
   computeProxyTo,
+  computeProxyToOrSelf,
+  isLocalAppViewRequest,
   pipethrough,
 } from '../../../../pipethrough.js'
 
 export default function (server: Server, ctx: AppContext) {
-  const { bskyAppView } = ctx
-  if (!bskyAppView) return
-
   server.add(app.bsky.actor.putPreferences, {
     auth: ctx.authVerifier.authorization({
       checkTakedown: true,
       authorize: (permissions, { req }) => {
         const lxm = app.bsky.actor.putPreferences.$lxm
-        const aud = computeProxyTo(ctx, req, lxm)
+        const aud = computeProxyToOrSelf(ctx, req, lxm)
         permissions.assertRpc({ aud, lxm })
       },
     }),
@@ -28,9 +27,9 @@ export default function (server: Server, ctx: AppContext) {
       // If the request has a proxy header different from the bsky app view,
       // we need to proxy the request to the requested app view.
       // @TODO This behavior should not be implemented as part of the XRPC framework
-      const lxm = app.bsky.actor.putPreferences.$lxm
-      const aud = computeProxyTo(ctx, req, lxm)
-      if (aud !== `${bskyAppView.did}#bsky_appview`) {
+      if (!isLocalAppViewRequest(ctx, req)) {
+        const lxm = app.bsky.actor.putPreferences.$lxm
+        const aud = computeProxyTo(ctx, req, lxm)
         // Phase 1 of service auth updates: outbound JWT keeps bare-DID aud.
         return pipethrough(ctx, req, {
           iss: did,

--- a/packages/pds/src/api/app/bsky/feed/getActorLikes.ts
+++ b/packages/pds/src/api/app/bsky/feed/getActorLikes.ts
@@ -8,8 +8,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.feed.getActorLikes, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {

--- a/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -8,8 +8,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.feed.getAuthorFeed, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {

--- a/packages/pds/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/pds/src/api/app/bsky/feed/getFeed.ts
@@ -6,9 +6,6 @@ import { app, com } from '../../../../lexicons/index.js'
 import { computeProxyTo, pipethrough } from '../../../../pipethrough.js'
 
 export default function (server: Server, ctx: AppContext) {
-  const { bskyAppView } = ctx
-  if (!bskyAppView) return
-
   server.add(app.bsky.feed.getFeed, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {
@@ -23,7 +20,8 @@ export default function (server: Server, ctx: AppContext) {
 
       const feedUrl = new AtUri(params.feed)
 
-      const data = await bskyAppView.client.call(com.atproto.repo.getRecord, {
+      const appView = await ctx.resolveAppView(req, app.bsky.feed.getFeed.$lxm)
+      const data = await appView.client.call(com.atproto.repo.getRecord, {
         repo: feedUrl.host,
         collection: feedUrl.collectionSafe,
         rkey: feedUrl.rkeySafe,

--- a/packages/pds/src/api/app/bsky/feed/getPostThread.ts
+++ b/packages/pds/src/api/app/bsky/feed/getPostThread.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { isHandleString, type l } from '@atproto/lex'
 import { AtUri, type AtUriString } from '@atproto/syntax'
 import type { Server } from '@atproto/xrpc-server'
@@ -18,8 +17,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.feed.getPostThread, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {
@@ -46,7 +43,7 @@ export default function (server: Server, ctx: AppContext) {
           err instanceof PipethroughUpstreamError &&
           err.error === 'NotFound'
         ) {
-          const { auth, params } = reqCtx
+          const { auth, params, req } = reqCtx
           const requester = auth.credentials.did
 
           const rev = err.headers?.['atproto-repo-rev']
@@ -64,10 +61,13 @@ export default function (server: Server, ctx: AppContext) {
           }
           if (uri.hostname !== requester) throw err
 
+          const appView = await ctx.resolveAppView(
+            req,
+            app.bsky.feed.getPostThread.$lxm,
+          )
           const local = await ctx.actorStore.read(requester, (store) => {
-            const localViewer = ctx.localViewer(store)
+            const localViewer = ctx.localViewer(store, appView)
             return readAfterWriteNotFound(
-              ctx,
               localViewer,
               params,
               requester,
@@ -182,7 +182,6 @@ const threadPostView = async (
 // ---------------------
 
 const readAfterWriteNotFound = async (
-  ctx: AppContext,
   localViewer: LocalViewer,
   params: app.bsky.feed.getPostThread.$Params,
   requester: string,
@@ -207,13 +206,12 @@ const readAfterWriteNotFound = async (
   )
   thread = await addPostsToThread(localViewer, thread, rest)
   const highestParent = getHighestParent(thread)
-  if (highestParent) {
+  if (highestParent && localViewer.bskyAppView) {
     try {
-      assert(ctx.bskyAppView)
-      const parentsRes = await ctx.bskyAppView.client.call(
+      const parentsRes = await localViewer.bskyAppView.client.call(
         app.bsky.feed.getPostThread,
         { uri: highestParent, parentHeight: params.parentHeight, depth: 0 },
-        await ctx.appviewAuthHeaders(
+        await localViewer.serviceAuthHeaders(
           requester,
           app.bsky.feed.getPostThread.$lxm,
         ),

--- a/packages/pds/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/pds/src/api/app/bsky/feed/getTimeline.ts
@@ -8,8 +8,6 @@ import {
 } from '../../../../read-after-write/index.js'
 
 export default function (server: Server, ctx: AppContext) {
-  if (!ctx.bskyAppView) return
-
   server.add(app.bsky.feed.getTimeline, {
     auth: ctx.authVerifier.authorization({
       authorize: (permissions, { req }) => {

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -50,7 +50,7 @@ import { ImageUrlBuilder } from './image/image-url-builder.js'
 import { fetchLogger, lexiconResolverLogger, oauthLogger } from './logger.js'
 import { ServerMailer } from './mailer/index.js'
 import { ModerationMailer } from './mailer/moderation.js'
-import { buildProxyAgent } from './pipethrough.js'
+import { buildProxyAgent, parseProxyInfo } from './pipethrough.js'
 import {
   LocalViewer,
   type LocalViewerCreator,
@@ -537,6 +537,27 @@ export class AppContext implements AsyncDisposable {
   async appviewAuthHeaders(did: string, lxm: string) {
     assert(this.bskyAppView)
     return this.serviceAuthHeaders(did, this.bskyAppView.did, lxm)
+  }
+
+  /**
+   * The app view targeted by a request: the one named by its `atproto-proxy`
+   * header, or the configured default when the header is absent. The
+   * configured instance is reused when the header names it, so its client
+   * (and image CDN settings) are shared.
+   */
+  async resolveAppView(
+    req: express.Request,
+    lxm: string,
+  ): Promise<BskyAppView> {
+    const { did, url } = await parseProxyInfo(this, req, lxm)
+    if (this.bskyAppView && this.bskyAppView.did === did) {
+      return this.bskyAppView
+    }
+    return new BskyAppView({
+      did,
+      url,
+      validateResponse: this.cfg.service.devMode,
+    })
   }
 
   async entrywayAuthHeaders(req: express.Request, did: string, lxm: string) {

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -267,6 +267,41 @@ export function computeProxyTo(
   throw new InvalidRequestError(`No service configured for ${lxm}`)
 }
 
+/**
+ * Like {@link computeProxyTo}, for methods this PDS can serve itself: when no
+ * `atproto-proxy` header is present and no default app view is configured, the
+ * request is served locally and the PDS is its own audience.
+ */
+export function computeProxyToOrSelf(
+  ctx: AppContext,
+  req: Request,
+  lxm: string,
+): string {
+  const proxyToHeader = req.header('atproto-proxy')
+  if (proxyToHeader) return proxyToHeader
+
+  const service = defaultService(ctx, lxm)
+  if (service.serviceInfo) {
+    return `${service.serviceInfo.did}#${service.serviceId}`
+  }
+
+  return `${ctx.cfg.service.did}#atproto_pds`
+}
+
+/**
+ * Whether a request should be served by this PDS rather than proxied: either it
+ * carries no `atproto-proxy` header, or the header names the configured app
+ * view.
+ */
+export function isLocalAppViewRequest(ctx: AppContext, req: Request): boolean {
+  const proxyToHeader = req.header('atproto-proxy')
+  if (!proxyToHeader) return true
+  const { bskyAppView } = ctx.cfg
+  return (
+    bskyAppView != null && proxyToHeader === `${bskyAppView.did}#bsky_appview`
+  )
+}
+
 // Bare-DID portion of `proxyTo`, suitable as a service-auth JWT audience
 // (Phase 1 of service auth updates).
 export function bareDidFromProxyTo(proxyTo: string): string {

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -1,9 +1,10 @@
 import type express from 'express'
 import { type LexValue, l } from '@atproto/lex'
 import { lexParse } from '@atproto/lex-json'
-import type {
-  HandlerPipeThrough,
-  HandlerPipeThroughBuffer,
+import {
+  type HandlerPipeThrough,
+  type HandlerPipeThroughBuffer,
+  parseReqNsid,
 } from '@atproto/xrpc-server'
 import type { AppContext } from '../context.js'
 import { readStickyLogger as log } from '../logger.js'
@@ -40,7 +41,9 @@ export const pipethroughReadAfterWrite = async <
   const { req, auth } = reqCtx
   const requester = auth.credentials.did
   const method = l.getMain(ns)
+  const lxm = parseReqNsid(req)
 
+  const appView = await ctx.resolveAppView(req, lxm)
   const streamRes = await pipethrough(ctx, req, { iss: requester })
 
   const rev = streamRes.headers['atproto-repo-rev']
@@ -72,7 +75,7 @@ export const pipethroughReadAfterWrite = async <
 
       const parsedRes = result.value as l.InferMethodOutputBody<M, never>
 
-      const localViewer = ctx.localViewer(store)
+      const localViewer = ctx.localViewer(store, appView)
 
       const data = await munge(localViewer, parsedRes, local, requester)
       return formatMungedResponse(data, getLocalLag(local))

--- a/packages/pds/src/read-after-write/viewer.ts
+++ b/packages/pds/src/read-after-write/viewer.ts
@@ -17,6 +17,7 @@ type CommonSignedUris = 'avatar' | 'banner' | 'feed_thumbnail' | 'feed_fullsize'
 
 export type LocalViewerCreator = (
   actorStoreReader: ActorStoreReader,
+  bskyAppView?: BskyAppView,
 ) => LocalViewer
 
 export class LocalViewer {
@@ -36,8 +37,8 @@ export class LocalViewer {
     imageUrlBuilder: ImageUrlBuilder,
     bskyAppView?: BskyAppView,
   ): LocalViewerCreator {
-    return (actorStore) =>
-      new LocalViewer(actorStore, accountManager, imageUrlBuilder, bskyAppView)
+    return (actorStore, appView = bskyAppView) =>
+      new LocalViewer(actorStore, accountManager, imageUrlBuilder, appView)
   }
 
   getImageUrl(pattern: CommonSignedUris, cid: string) {

--- a/packages/pds/tests/proxied/feedgen.test.ts
+++ b/packages/pds/tests/proxied/feedgen.test.ts
@@ -3,12 +3,14 @@ import { type SeedClient, TestNetwork } from '@atproto/dev-env'
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { forSnapshot } from '../_util.js'
 import basicSeed from '../seeds/basic.js'
+import { ProxyServer } from './proxy-server.js'
 
 describe('feedgen proxy view', () => {
   let network: TestNetwork
   let agent: AtpAgent
   let sc: SeedClient
   let feedUri: AtUri
+  let altAppView: ProxyServer
 
   beforeAll(async () => {
     network = await TestNetwork.create({
@@ -48,9 +50,17 @@ describe('feedgen proxy view', () => {
       sc.getHeaders(sc.dids.alice),
     )
     await network.processAll()
+
+    altAppView = await ProxyServer.create(
+      network.pds.ctx.plcClient,
+      network.pds.ctx.plcRotationKey,
+      'bsky_appview',
+      { upstream: network.bsky.url },
+    )
   })
 
   afterAll(async () => {
+    await altAppView?.close()
     await network?.close()
   })
 
@@ -62,5 +72,28 @@ describe('feedgen proxy view', () => {
       },
     )
     expect(forSnapshot(feed)).toMatchSnapshot()
+  })
+
+  it('resolves the feed generator through the app view named by the proxy header', async () => {
+    const { data: expected } = await agent.api.app.bsky.feed.getFeed(
+      { feed: feedUri.toString() },
+      { headers: { ...sc.getHeaders(sc.dids.alice) } },
+    )
+    const { data: feed } = await agent.api.app.bsky.feed.getFeed(
+      { feed: feedUri.toString() },
+      {
+        headers: {
+          ...sc.getHeaders(sc.dids.alice),
+          'atproto-proxy': `${altAppView.did}#bsky_appview`,
+        },
+      },
+    )
+    expect(feed).toEqual(expected)
+
+    const paths = altAppView.requests.map((r) => r.url.split('?')[0])
+    expect(paths).toEqual([
+      '/xrpc/com.atproto.repo.getRecord',
+      '/xrpc/app.bsky.feed.getFeed',
+    ])
   })
 })

--- a/packages/pds/tests/proxied/no-default-appview.test.ts
+++ b/packages/pds/tests/proxied/no-default-appview.test.ts
@@ -1,0 +1,170 @@
+import { AtUri, type AtpAgent } from '@atproto/api'
+import { type SeedClient, TestNetwork } from '@atproto/dev-env'
+import { InvalidRequestError } from '@atproto/xrpc-server'
+import basicSeed from '../seeds/basic.js'
+import { ProxyServer } from './proxy-server.js'
+
+/**
+ * A PDS with no `PDS_BSKY_APP_VIEW_URL`: nothing is proxied unless the client
+ * names a target, while everything the PDS owns is still served.
+ */
+describe('pds without a default app view', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let sc: SeedClient
+  let feedUri: AtUri
+  let appView: ProxyServer
+
+  beforeAll(async () => {
+    appView = await ProxyServer.listen('bsky_appview')
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'proxy_no_default_appview',
+      bsky: { alternateAudienceDids: [appView.did] },
+      pds: {
+        bskyAppViewUrl: undefined,
+        bskyAppViewDid: undefined,
+        bskyAppViewCdnUrlPattern: undefined,
+      },
+    })
+    agent = network.pds.getAgent()
+    sc = network.getSeedClient()
+    await basicSeed(sc, { addModLabels: network.bsky })
+
+    feedUri = AtUri.make(sc.dids.alice, 'app.bsky.feed.generator', 'mutuals')
+    const feedGen = await network.createFeedGen({
+      [feedUri.toString()]: ({ params }) => {
+        if (params.feed !== feedUri.toString()) {
+          throw new InvalidRequestError('Unknown feed')
+        }
+        return {
+          encoding: 'application/json',
+          body: {
+            feed: [
+              { post: sc.posts[sc.dids.alice][0].ref.uriStr },
+              { post: sc.posts[sc.dids.carol][0].ref.uriStr },
+            ],
+          },
+        }
+      },
+    })
+    await agent.api.app.bsky.feed.generator.create(
+      { repo: sc.dids.alice, rkey: feedUri.rkey },
+      {
+        did: feedGen.did,
+        displayName: 'Test feed',
+        createdAt: new Date().toISOString(),
+      },
+      sc.getHeaders(sc.dids.alice),
+    )
+    await network.processAll()
+
+    appView.options.upstream = network.bsky.url
+    await appView.register(network.pds.ctx.plcClient)
+  })
+
+  afterAll(async () => {
+    await appView?.close()
+    await network?.close()
+  })
+
+  it('is not configured with an app view', () => {
+    expect(network.pds.ctx.cfg.bskyAppView).toBeNull()
+    expect(network.pds.ctx.bskyAppView).toBeUndefined()
+  })
+
+  it('serves preferences locally', async () => {
+    await agent.api.app.bsky.actor.putPreferences(
+      {
+        preferences: [
+          { $type: 'app.bsky.actor.defs#adultContentPref', enabled: true },
+        ],
+      },
+      { headers: sc.getHeaders(sc.dids.alice), encoding: 'application/json' },
+    )
+    const { data } = await agent.api.app.bsky.actor.getPreferences(
+      {},
+      { headers: sc.getHeaders(sc.dids.alice) },
+    )
+    expect(data.preferences).toEqual([
+      { $type: 'app.bsky.actor.defs#adultContentPref', enabled: true },
+    ])
+  })
+
+  it('serves local records without falling through', async () => {
+    const post = sc.posts[sc.dids.alice][0].ref
+    const { data } = await agent.api.com.atproto.repo.getRecord({
+      repo: post.uri.host,
+      collection: post.uri.collection,
+      rkey: post.uri.rkey,
+    })
+    expect(data.uri).toEqual(post.uriStr)
+
+    await expect(
+      agent.api.com.atproto.repo.getRecord({
+        repo: post.uri.host,
+        collection: post.uri.collection,
+        rkey: 'missing',
+      }),
+    ).rejects.toMatchObject({ error: 'RecordNotFound' })
+
+    await expect(
+      agent.api.com.atproto.repo.getRecord({
+        repo: 'did:plc:notlocalnotlocalnotlocal',
+        collection: post.uri.collection,
+        rkey: post.uri.rkey,
+      }),
+    ).rejects.toMatchObject({
+      error: 'InvalidRequest',
+      message: 'Could not locate record',
+    })
+  })
+
+  it('rejects untargeted app view requests', async () => {
+    await expect(
+      agent.api.app.bsky.feed.getTimeline(
+        {},
+        { headers: sc.getHeaders(sc.dids.alice) },
+      ),
+    ).rejects.toMatchObject({
+      error: 'InvalidRequest',
+      message: 'No service configured for app.bsky.feed.getTimeline',
+    })
+    await expect(
+      agent.api.app.bsky.feed.getFeed(
+        { feed: feedUri.toString() },
+        { headers: sc.getHeaders(sc.dids.alice) },
+      ),
+    ).rejects.toMatchObject({
+      error: 'InvalidRequest',
+      message: 'No service configured for app.bsky.feed.getFeed',
+    })
+  })
+
+  it('proxies targeted app view requests', async () => {
+    const headers = {
+      ...sc.getHeaders(sc.dids.alice),
+      'atproto-proxy': `${appView.did}#bsky_appview`,
+    }
+    const { data: profile } = await agent.api.app.bsky.actor.getProfile(
+      { actor: sc.dids.alice },
+      { headers },
+    )
+    expect(profile.did).toEqual(sc.dids.alice)
+
+    const { data: feed } = await agent.api.app.bsky.feed.getFeed(
+      { feed: feedUri.toString() },
+      { headers },
+    )
+    expect(feed.feed.map((item) => item.post.uri)).toEqual([
+      sc.posts[sc.dids.alice][0].ref.uriStr,
+      sc.posts[sc.dids.carol][0].ref.uriStr,
+    ])
+
+    const paths = appView.requests.map((r) => r.url.split('?')[0])
+    expect(paths).toEqual([
+      '/xrpc/app.bsky.actor.getProfile',
+      '/xrpc/com.atproto.repo.getRecord',
+      '/xrpc/app.bsky.feed.getFeed',
+    ])
+  })
+})

--- a/packages/pds/tests/proxied/proxy-header.test.ts
+++ b/packages/pds/tests/proxied/proxy-header.test.ts
@@ -1,11 +1,4 @@
 import assert from 'node:assert'
-import { once } from 'node:events'
-import type http from 'node:http'
-import type { AddressInfo } from 'node:net'
-import * as plc from '@did-plc/lib'
-import express from 'express'
-import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
-import type { Keypair } from '@atproto/crypto'
 import {
   type SeedClient,
   TestNetworkNoAppView,
@@ -14,6 +7,7 @@ import {
 import type { DidString } from '@atproto/syntax'
 import { verifyJwt } from '@atproto/xrpc-server'
 import { parseProxyHeader } from '../../src/pipethrough.js'
+import { ProxyServer } from './proxy-server.js'
 
 describe('proxy header', () => {
   let network: TestNetworkNoAppView
@@ -170,73 +164,3 @@ describe('proxy header', () => {
     expect(res.status).toBe(501)
   })
 })
-
-type ProxyReq = {
-  url: string
-  auth: string | undefined
-}
-
-class ProxyServer {
-  private terminator: HttpTerminator
-
-  constructor(
-    server: http.Server,
-    public url: string,
-    public did: string,
-    public requests: ProxyReq[],
-  ) {
-    this.terminator = createHttpTerminator({ server })
-  }
-
-  static async create(
-    plcClient: plc.Client,
-    keypair: Keypair,
-    serviceId: string,
-  ): Promise<ProxyServer> {
-    const requests: ProxyReq[] = []
-    const app = express()
-
-    // This is a PDS endpoint which uses a manual pipethrough() in its handler
-    app.get('/xrpc/app.bsky.actor.getPreferences', (req, res) => {
-      res.sendStatus(501)
-    })
-
-    app.get('*', (req, res) => {
-      requests.push({
-        url: req.url,
-        auth: req.header('authorization'),
-      })
-      res.sendStatus(200)
-    })
-
-    const server = app.listen(0)
-    await once(server, 'listening')
-
-    const { port } = server.address() as AddressInfo
-
-    const url = `http://localhost:${port}`
-    const plcOp = await plc.signOperation(
-      {
-        type: 'plc_operation',
-        rotationKeys: [keypair.did()],
-        alsoKnownAs: [],
-        verificationMethods: {},
-        services: {
-          [serviceId]: {
-            type: 'TestAtprotoService',
-            endpoint: url,
-          },
-        },
-        prev: null,
-      },
-      keypair,
-    )
-    const did = await plc.didForCreateOp(plcOp)
-    await plcClient.sendOperation(did, plcOp)
-    return new ProxyServer(server, url, did, requests)
-  }
-
-  async close(): Promise<void> {
-    await this.terminator.terminate()
-  }
-}

--- a/packages/pds/tests/proxied/proxy-server.ts
+++ b/packages/pds/tests/proxied/proxy-server.ts
@@ -1,0 +1,149 @@
+import { once } from 'node:events'
+import type http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import * as plc from '@did-plc/lib'
+import express from 'express'
+import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
+import { type Keypair, Secp256k1Keypair } from '@atproto/crypto'
+import type { DidString } from '@atproto/syntax'
+
+export type ProxyReq = {
+  url: string
+  auth: string | undefined
+}
+
+export type ProxyServerOptions = {
+  /**
+   * When set, requests are forwarded to this URL and the upstream response is
+   * relayed back, so the server can stand in for another service (e.g. as an
+   * alternate app view). Otherwise every request is answered with 200. May be
+   * assigned after the server is listening.
+   */
+  upstream?: string
+}
+
+/**
+ * An HTTP service registered on the test PLC under its own DID, so it can be
+ * named in an `atproto-proxy` header. Every request it receives is recorded.
+ */
+export class ProxyServer {
+  private terminator: HttpTerminator
+
+  constructor(
+    server: http.Server,
+    public url: string,
+    public did: DidString,
+    public requests: ProxyReq[],
+    public options: ProxyServerOptions,
+    private plcOp: plc.Operation,
+  ) {
+    this.terminator = createHttpTerminator({ server })
+  }
+
+  /**
+   * Start listening and derive the DID, without publishing it yet. Useful when
+   * the DID must be known before the network it will be registered on exists.
+   */
+  static async listen(
+    serviceId: string,
+    options: ProxyServerOptions = {},
+    keypair?: Keypair,
+  ): Promise<ProxyServer> {
+    const requests: ProxyReq[] = []
+    const app = express()
+
+    // This is a PDS endpoint which uses a manual pipethrough() in its handler
+    app.get('/xrpc/app.bsky.actor.getPreferences', (req, res) => {
+      res.sendStatus(501)
+    })
+
+    app.get('*', (req, res, next) => {
+      requests.push({
+        url: req.url,
+        auth: req.header('authorization'),
+      })
+      if (!options.upstream) {
+        res.sendStatus(200)
+        return
+      }
+      forward(options.upstream, req, res).catch(next)
+    })
+
+    const server = app.listen(0)
+    await once(server, 'listening')
+
+    const { port } = server.address() as AddressInfo
+
+    const url = `http://localhost:${port}`
+    const rotationKey = keypair ?? (await Secp256k1Keypair.create())
+    const plcOp = await plc.signOperation(
+      {
+        type: 'plc_operation',
+        rotationKeys: [rotationKey.did()],
+        alsoKnownAs: [],
+        verificationMethods: {},
+        services: {
+          [serviceId]: {
+            type: 'TestAtprotoService',
+            endpoint: url,
+          },
+        },
+        prev: null,
+      },
+      rotationKey,
+    )
+    const did = (await plc.didForCreateOp(plcOp)) as DidString
+    return new ProxyServer(server, url, did, requests, options, plcOp)
+  }
+
+  static async create(
+    plcClient: plc.Client,
+    keypair: Keypair,
+    serviceId: string,
+    options: ProxyServerOptions = {},
+  ): Promise<ProxyServer> {
+    const server = await ProxyServer.listen(serviceId, options, keypair)
+    await server.register(plcClient)
+    return server
+  }
+
+  async register(plcClient: plc.Client): Promise<void> {
+    await plcClient.sendOperation(this.did, this.plcOp)
+  }
+
+  async close(): Promise<void> {
+    await this.terminator.terminate()
+  }
+}
+
+const FORWARDED_REQUEST_HEADERS = [
+  'authorization',
+  'accept-language',
+  'atproto-accept-labelers',
+] as const
+
+const SKIPPED_RESPONSE_HEADERS = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+])
+
+async function forward(
+  upstream: string,
+  req: express.Request,
+  res: express.Response,
+) {
+  const headers: Record<string, string> = {}
+  for (const name of FORWARDED_REQUEST_HEADERS) {
+    const value = req.header(name)
+    if (value) headers[name] = value
+  }
+  const upstreamRes = await fetch(new URL(req.url, upstream), { headers })
+  const body = Buffer.from(await upstreamRes.arrayBuffer())
+  res.status(upstreamRes.status)
+  upstreamRes.headers.forEach((value, name) => {
+    if (!SKIPPED_RESPONSE_HEADERS.has(name)) res.setHeader(name, value)
+  })
+  res.send(body)
+}

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -10,8 +10,10 @@ import {
 } from '@atproto/api'
 import { type RecordRef, type SeedClient, TestNetwork } from '@atproto/dev-env'
 import type { DidString } from '@atproto/syntax'
+import { verifyJwt } from '@atproto/xrpc-server'
 import type { app } from '../../src/lexicons/index.js'
 import basicSeed from '../seeds/basic.js'
+import { ProxyServer } from './proxy-server.js'
 
 describe('proxy read after write', () => {
   let network: TestNetwork
@@ -21,10 +23,16 @@ describe('proxy read after write', () => {
   let alice: DidString
   let carol: DidString
 
+  let altAppView: ProxyServer
+
   beforeAll(async () => {
+    altAppView = await ProxyServer.listen('bsky_appview')
     network = await TestNetwork.create({
       dbPostgresSchema: 'proxy_read_after_write',
+      bsky: { alternateAudienceDids: [altAppView.did] },
     })
+    altAppView.options.upstream = network.bsky.url
+    await altAppView.register(network.pds.ctx.plcClient)
     agent = network.pds.getAgent()
     sc = network.getSeedClient()
     await basicSeed(sc, { addModLabels: network.bsky })
@@ -35,7 +43,10 @@ describe('proxy read after write', () => {
   })
 
   beforeEach(async () => network.processAll())
-  afterAll(async () => network?.close())
+  afterAll(async () => {
+    await altAppView?.close()
+    await network?.close()
+  })
 
   it('handles read after write on profiles', async () => {
     await sc.updateProfile(alice, { displayName: 'blah' })
@@ -273,6 +284,60 @@ describe('proxy read after write', () => {
     const { record } = embed
     assert('uri' in record) // @TODO: assert based in "$type"
     expect(record.uri).toEqual(sc.posts[alice][0].ref.uriStr)
+  })
+
+  it('hydrates record embeds through the app view named by the proxy header', async () => {
+    const replyRes = await agent.api.app.bsky.feed.post.create(
+      { repo: alice },
+      {
+        text: 'blah',
+        reply: {
+          root: sc.posts[sc.dids.dan][0].ref.raw,
+          parent: sc.posts[sc.dids.dan][0].ref.raw,
+        },
+        embed: {
+          $type: 'app.bsky.embed.record',
+          record: sc.posts[alice][1].ref.raw,
+        },
+        createdAt: new Date().toISOString(),
+      },
+      sc.getHeaders(alice),
+    )
+    altAppView.requests.length = 0
+    const res = await agent.api.app.bsky.feed.getPostThread(
+      { uri: sc.posts[sc.dids.dan][0].ref.uriStr },
+      {
+        headers: {
+          ...sc.getHeaders(alice),
+          'atproto-proxy': `${altAppView.did}#bsky_appview`,
+        },
+      },
+    )
+    assert(AppBskyFeedDefs.isThreadViewPost(res.data.thread))
+    assert(res.data.thread.replies, 'replies is undefined')
+    const { replies } = res.data.thread
+    expect(replies.length).toBe(1)
+    assert(AppBskyFeedDefs.isThreadViewPost(replies[0]))
+    expect(replies[0].post.uri).toEqual(replyRes.uri)
+    const embed = replies[0].post.embed
+    assert(AppBskyEmbedRecord.isView(embed))
+    assert('uri' in embed.record)
+    expect(embed.record.uri).toEqual(sc.posts[alice][1].ref.uriStr)
+
+    const paths = altAppView.requests.map((r) => r.url.split('?')[0])
+    expect(paths).toEqual([
+      '/xrpc/app.bsky.feed.getPostThread',
+      '/xrpc/app.bsky.feed.getPosts',
+    ])
+    const getPosts = altAppView.requests[1]
+    assert(getPosts.auth)
+    const verified = await verifyJwt(
+      getPosts.auth.replace('Bearer ', ''),
+      altAppView.did,
+      'app.bsky.feed.getPosts',
+      (iss) => network.pds.ctx.idResolver.did.resolveAtprotoKey(iss, true),
+    )
+    expect(verified.iss).toBe(alice)
   })
 
   it('handles read after write on getTimeline', async () => {


### PR DESCRIPTION
## What & why

The PDS should only talk to an app view the client asked for. This makes the remaining places that hardcoded the configured `PDS_BSKY_APP_VIEW_URL` honour the `atproto-proxy` header instead, and lets a PDS with no configured app view still serve what it owns.

Context: a PDS with `PDS_BSKY_APP_VIEW_URL` unset already refuses untargeted `app.bsky.*` requests (`No service configured for …`) and proxies targeted ones through the catch-all. But a few handlers bypassed that: they reached `ctx.bskyAppView` directly regardless of the header, and every `app.bsky.*` handler — including `getPreferences`/`putPreferences`, which are served from the actor store — was skipped at registration when no app view was configured, so a strict PDS couldn't serve its own preferences.

No behaviour change for a PDS with an app view configured and clients that either send no header or name that app view: `ctx.resolveAppView()` returns the existing `BskyAppView` instance in that case.

<details>
<summary>What changed</summary>

- `AppContext.resolveAppView(req, lxm)`: the app view named by `atproto-proxy`, falling back to the configured default; reuses the configured instance when the header names it, otherwise builds a `BskyAppView` for the resolved service endpoint.
- `app.bsky.feed.getFeed`: the feed generator record lookup now goes to the resolved app view (previously always the configured one, even when the header named another — the skeleton pipethrough already honoured the header).
- read-after-write: `pipethroughReadAfterWrite` and the `getPostThread` not-found fallback create the `LocalViewer` with the resolved app view, so record-embed hydration (`getPosts`/`getFeedGenerator`/`getList`) and parent-thread fetches go to the same service the request was proxied to, with service auth `aud` to match. `LocalViewerCreator` takes an optional app view override.
- `app.bsky.actor.getPreferences`/`putPreferences`: registered unconditionally. Served locally when there is no header or the header names the configured app view (`isLocalAppViewRequest`); proxied otherwise, as before. For the OAuth scope check with no header and no configured app view the audience is `${cfg.service.did}#atproto_pds` (`computeProxyToOrSelf`) — the PDS is serving the request itself. Flagging this as the one place I picked a semantic; happy to change it.
- The other `app.bsky.*` wrappers (`getProfile(s)`, `getTimeline`, `getAuthorFeed`, `getActorLikes`, `getPostThread`) are registered unconditionally too. Without a header and without a default they throw the same `InvalidRequest` the catch-all would; with a header they proxy (and read-after-write applies) even on a PDS with no default app view.
- `registerPush`/`unregisterPush` are untouched: they only act when the header explicitly names the configured app view, and fall to the catch-all otherwise.
- `ctx.appviewAuthHeaders` no longer has callers in-tree; left in place since `AppContext` is exported.

</details>

<details>
<summary>Tests</summary>

- `tests/proxied/proxy-server.ts`: the `ProxyServer` helper from `proxy-header.test.ts`, extracted, with an optional `upstream` that forwards requests so it can stand in as an alternate app view (registered as a bsky `alternateAudienceDids` entry so forwarded service-auth JWTs verify), and a `listen()`/`register()` split so its DID is known before the network exists.
- `feedgen.test.ts`: `getFeed` with a header naming the alternate app view — the `getRecord` for the feed generator lands there, response snapshot identical to the default path.
- `read-after-write.test.ts`: `getPostThread` with a record embed through the alternate app view — the `getPosts` hydration call lands there with a service-auth JWT for that DID.
- `no-default-appview.test.ts`: a `TestNetwork` whose PDS has no app view configured: preferences round-trip locally, `getRecord` never falls through, untargeted `getTimeline`/`getFeed` are rejected with `No service configured`, targeted `getProfile`/`getFeed` proxy correctly (snapshot identical to the default path).

</details>

## Related

- #2221 — the direction this follows: the client names the app view via a header; the PDS should not pick one itself.
- #4193 — `pipethrough()` cannot forward procedure bodies, so `putPreferences` proxied to a non-default app view still fails with `Proxying of POST requests is not supported`. Out of scope here; this PR neither fixes nor changes that.
- #4175 — the local-vs-proxied rule for preferences (served locally unless the header names a *different* app view) is preserved unchanged; this PR only extends it to the no-default case.
- #4801 touches `read-after-write/util.ts` as well; the overlap is a few lines around `pipethroughReadAfterWrite`.

Note: `resolveAppView` builds a `BskyAppView` (and its client) per request for targets other than the configured one. If that matters at scale, a small cache keyed by service URL would be the follow-up.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling. — Yes: written with Claude Code (Claude Fable 5), reviewed and tested locally.
