### PR TITLE
Add URL.canParse fallback to lex-password-session

### DIFF
--- a/.changeset/tidy-urls-parse.md
+++ b/.changeset/tidy-urls-parse.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-password-session': patch
+---
+
+Support browsers without `URL.canParse` when reading PDS endpoints.

--- a/packages/lex/lex-password-session/src/password-session-utils.test.ts
+++ b/packages/lex/lex-password-session/src/password-session-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { DidString, HandleString } from '@atproto/lex-schema'
 import { LexServerAuthError } from '@atproto/lex-server'
 import { extractPdsEndpoint } from './util.js'
@@ -184,6 +184,27 @@ describe(extractPdsEndpoint, () => {
     expect(extractPdsEndpoint(validDidDoc('https://pds.example.com'))).toBe(
       'https://pds.example.com',
     )
+  })
+
+  it('supports environments without URL.canParse', async () => {
+    const LegacyURL = class extends URL {}
+    Object.defineProperty(LegacyURL, 'canParse', { value: undefined })
+    vi.stubGlobal('URL', LegacyURL)
+
+    try {
+      vi.resetModules()
+      const legacyModule = await import('./util.js')
+
+      expect(
+        legacyModule.extractPdsEndpoint(validDidDoc('https://pds.example.com')),
+      ).toBe('https://pds.example.com')
+      expect(
+        legacyModule.extractPdsEndpoint(validDidDoc('not-a-url')),
+      ).toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+      vi.resetModules()
+    }
   })
 
   it('returns null when no service array is present', () => {

--- a/packages/lex/lex-password-session/src/util.ts
+++ b/packages/lex/lex-password-session/src/util.ts
@@ -41,8 +41,19 @@ export function extractPdsEndpoint(didDoc?: LexMap): string | null {
     ifString((service as any)?.id)?.endsWith('#atproto_pds'),
   )
   const pdsEndpoint = ifString((pdsService as any)?.serviceEndpoint)
-  return pdsEndpoint && URL.canParse(pdsEndpoint) ? pdsEndpoint : null
+  return pdsEndpoint && canParseUrl(pdsEndpoint) ? pdsEndpoint : null
 }
+
+const canParseUrl =
+  URL.canParse ??
+  ((url: string) => {
+    try {
+      new URL(url)
+      return true
+    } catch {
+      return false
+    }
+  })
 
 const ifString = <T>(v: T) =>
   (typeof v === 'string' ? v : undefined) as unknown extends T


### PR DESCRIPTION
## Summary

`@atproto/lex-password-session` calls `URL.canParse` while extracting the PDS endpoint from a session DID document. Safari before 17.4 does not provide that API, so session restoration can crash even when the package is transpiled.

Fall back to constructing a `URL` when `URL.canParse` is unavailable, matching the existing behavior in `@atproto/common-web`. Includes regression coverage and a patch changeset.

Related to bluesky-social/social-app#11553 and [APP-2939](https://linear.app/blueskyweb/issue/APP-2939).

## Test plan

- In Safari before 17.4, restore a password session whose DID document contains a valid PDS service endpoint and confirm the app initializes successfully.