### PR TITLE
Add URL.canParse fallback to lex-resolver

### DIFF
--- a/.changeset/calm-urls-resolve.md
+++ b/.changeset/calm-urls-resolve.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-resolver': patch
+---
+
+Support runtimes without `URL.canParse` when validating PDS service endpoints.

--- a/.changeset/tidy-urls-parse.md
+++ b/.changeset/tidy-urls-parse.md
@@ -1,5 +1,6 @@
 ---
 '@atproto/lex-password-session': patch
+'@atproto/lex-resolver': patch
 ---
 
-Support browsers without `URL.canParse` when reading PDS endpoints.
+Support browsers without `URL.canParse` when reading PDS service endpoints.

--- a/.changeset/tidy-urls-parse.md
+++ b/.changeset/tidy-urls-parse.md
@@ -1,6 +1,5 @@
 ---
 '@atproto/lex-password-session': patch
-'@atproto/lex-resolver': patch
 ---
 
-Support browsers without `URL.canParse` when reading PDS service endpoints.
+Support browsers without `URL.canParse` when reading PDS endpoints.

--- a/packages/lex/lex-resolver/src/lex-resolver.ts
+++ b/packages/lex/lex-resolver/src/lex-resolver.ts
@@ -27,6 +27,7 @@ import {
 } from '@atproto-labs/did-resolver'
 import { LexResolverError } from './lex-resolver-error.js'
 import { com } from './lexicons/index.js'
+import { canParseUrl } from './util.js'
 
 /**
  * Result returned when successfully resolving a lexicon document.
@@ -431,7 +432,7 @@ export class LexResolver {
         )
       })
 
-    if (!key || !pds || !URL.canParse(pds.serviceEndpoint)) {
+    if (!key || !pds || !canParseUrl(pds.serviceEndpoint)) {
       throw new LexResolverError(
         nsid,
         `No atproto PDS service endpoint or signing key found in ${did} DID document`,

--- a/packages/lex/lex-resolver/src/util.test.ts
+++ b/packages/lex/lex-resolver/src/util.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('canParseUrl', () => {
+  it('supports environments without URL.canParse', async () => {
+    const LegacyURL = class extends URL {}
+    Object.defineProperty(LegacyURL, 'canParse', { value: undefined })
+    vi.stubGlobal('URL', LegacyURL)
+    vi.resetModules()
+
+    const { canParseUrl } = await import('./util.js')
+
+    expect(canParseUrl('https://pds.example.com')).toBe(true)
+    expect(canParseUrl('not-a-url')).toBe(false)
+  })
+})

--- a/packages/lex/lex-resolver/src/util.ts
+++ b/packages/lex/lex-resolver/src/util.ts
@@ -1,0 +1,10 @@
+export const canParseUrl =
+  URL.canParse ??
+  ((url: string) => {
+    try {
+      new URL(url)
+      return true
+    } catch {
+      return false
+    }
+  })


### PR DESCRIPTION
## Summary

`@atproto/lex-resolver` calls `URL.canParse` while validating the PDS service endpoint from a resolved DID document. Runtimes without that API throw before the resolver can fetch the Lexicon record.

Use the `URL` constructor as a fallback, matching `@atproto/common-web` and the fix merged in #5446. Includes focused regression coverage and a separate patch changeset for `@atproto/lex-resolver`.

Related to bluesky-social/social-app#11553 and [APP-2939](https://linear.app/blueskyweb/issue/APP-2939).