### PR TITLE
Forward request headers through PDS service proxies.

### DIFF
--- a/.changeset/quiet-proxies-forward.md
+++ b/.changeset/quiet-proxies-forward.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Forward all `x-atproto-*` request headers through PDS service proxies.

--- a/.changeset/silly-topics-forward.md
+++ b/.changeset/silly-topics-forward.md
@@ -1,0 +1,5 @@
+---
+"@atproto/bsky": patch
+---
+
+Forward `x-atproto-bsky-topics` alongside the legacy `x-bsky-topics` header.

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -11,6 +11,7 @@ import type {
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 import { fillPage, resHeaders } from '../../../util.js'
 
@@ -29,9 +30,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const { resHeaders: resultHeaders, ...result } = await fillPage({
         cursor: params.cursor,

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -32,6 +32,7 @@ import {
   createPipeline,
 } from '../../../../pipeline.js'
 import type { GetIdentityByDidResponse } from '../../../../proto/bsky_pb.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import { BSKY_USER_AGENT, resHeaders } from '../../../util.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -65,9 +66,7 @@ export default function (server: Server, ctx: AppContext) {
         'user-agent': BSKY_USER_AGENT,
         authorization: req.headers['authorization'],
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       // @NOTE feed cursors should not be affected by appview swap
       // Do not refill filtered pages. Overfetching from algorithmic feeds can

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -16,6 +16,7 @@ import {
   type SkeletonFnInput,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 import { resHeaders } from '../../../util.js'
 
@@ -52,9 +53,7 @@ export default function (server: Server, ctx: AppContext) {
 
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
 
       const { contentLanguage, ...body } = await getSuggestedFollowsByActor(

--- a/packages/bsky/src/api/app/bsky/unspecced/getOnboardingSuggestedStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getOnboardingSuggestedStarterPacks.ts
@@ -16,6 +16,7 @@ import {
   type SkeletonFn,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -33,9 +34,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getOnboardingSuggestedStarterPacks(
         {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedFeeds.ts
@@ -11,6 +11,7 @@ import {
   createPipeline,
   noRules,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -23,9 +24,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getFeeds(
         {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedOnboardingUsers.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedOnboardingUsers.ts
@@ -15,6 +15,7 @@ import {
   type SkeletonFnInput,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -35,9 +36,7 @@ export default function (server: Server, ctx: AppContext) {
       })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getSuggestedOnboardingUsers(
         {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedStarterPacks.ts
@@ -16,6 +16,7 @@ import {
   type SkeletonFnInput,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -33,9 +34,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getSuggestedStarterPacks(
         {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
@@ -15,6 +15,7 @@ import {
   type SkeletonFnInput,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -41,9 +42,7 @@ export default function (server: Server, ctx: AppContext) {
       })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getSuggestedUsers(
         {

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -15,6 +15,7 @@ import {
   type SkeletonFn,
   createPipeline,
 } from '../../../../pipeline.js'
+import { getAtprotoPassthroughHeaders } from '../../../../util/headers.js'
 import type { Views } from '../../../../views/index.js'
 
 export default function (server: Server, ctx: AppContext) {
@@ -27,9 +28,7 @@ export default function (server: Server, ctx: AppContext) {
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
       const headers = noUndefinedVals({
         'accept-language': req.headers['accept-language'],
-        'x-bsky-topics': Array.isArray(req.headers['x-bsky-topics'])
-          ? req.headers['x-bsky-topics'].join(',')
-          : req.headers['x-bsky-topics'],
+        ...getAtprotoPassthroughHeaders(req),
       })
       const result = await getTrends(
         {

--- a/packages/bsky/src/util/headers.test.ts
+++ b/packages/bsky/src/util/headers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getAtprotoPassthroughHeaders } from './headers.js'
+
+describe(getAtprotoPassthroughHeaders, () => {
+  it('passes x-atproto headers and omits unrelated headers', () => {
+    expect(
+      getAtprotoPassthroughHeaders({
+        headers: {
+          'x-atproto-foo': 'foo',
+          'x-not-atproto': 'not forwarded',
+        },
+      }),
+    ).toEqual({ 'x-atproto-foo': 'foo' })
+  })
+
+  it('maps the legacy topics header to x-atproto-bsky-topics', () => {
+    expect(
+      getAtprotoPassthroughHeaders({
+        headers: { 'x-bsky-topics': ['one', 'two'] },
+      }),
+    ).toEqual({
+      'x-atproto-bsky-topics': 'one,two',
+      'x-bsky-topics': 'one,two',
+    })
+  })
+
+  it('prefers x-atproto-bsky-topics over the legacy topics header', () => {
+    expect(
+      getAtprotoPassthroughHeaders({
+        headers: {
+          'x-atproto-bsky-topics': 'new',
+          'x-bsky-topics': 'legacy',
+        },
+      }),
+    ).toEqual({
+      'x-atproto-bsky-topics': 'new',
+      'x-bsky-topics': 'legacy',
+    })
+  })
+})

--- a/packages/bsky/src/util/headers.ts
+++ b/packages/bsky/src/util/headers.ts
@@ -17,5 +17,13 @@ export function getAtprotoPassthroughHeaders(req: {
     }
   }
 
+  const topics =
+    req.headers['x-atproto-bsky-topics'] ?? req.headers[LEGACY_TOPIC_HEADER]
+  if (topics != null) {
+    headers['x-atproto-bsky-topics'] = Array.isArray(topics)
+      ? topics.join(',')
+      : topics
+  }
+
   return headers
 }

--- a/packages/bsky/src/util/headers.ts
+++ b/packages/bsky/src/util/headers.ts
@@ -1,0 +1,21 @@
+import type { IncomingHttpHeaders } from 'node:http'
+
+// @NOTE `x-bsky-topics` is deprecated; use `x-atproto-bsky-topics`.
+const LEGACY_TOPIC_HEADER = 'x-bsky-topics'
+
+export function getAtprotoPassthroughHeaders(req: {
+  headers: IncomingHttpHeaders
+}): Record<string, string> {
+  const headers: Record<string, string> = {}
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (
+      (name.startsWith('x-atproto-') || name === LEGACY_TOPIC_HEADER) &&
+      value != null
+    ) {
+      headers[name] = Array.isArray(value) ? value.join(',') : value
+    }
+  }
+
+  return headers
+}

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -258,11 +258,16 @@ export async function pipethrough(
 function getAtprotoPassthroughHeaders(
   headers: IncomingHttpHeaders,
 ): IncomingHttpHeaders {
-  return Object.fromEntries(
-    Object.entries(headers).filter(([name]) =>
-      name.toLowerCase().startsWith('x-atproto-'),
-    ),
-  )
+  // @NOTE node lower-cases all incoming header names, so a case-sensitive
+  // prefix check is sufficient here. This runs on the request hot path, so we
+  // build the result imperatively rather than via intermediate arrays.
+  const result: IncomingHttpHeaders = {}
+  for (const name in headers) {
+    if (name.startsWith('x-atproto-')) {
+      result[name] = headers[name]
+    }
+  }
+  return result
 }
 
 export function computeProxyTo(

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -125,6 +125,8 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         'accept-encoding': req.headers['accept-encoding'] || 'identity',
         'accept-language': req.headers['accept-language'],
         'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
+        ...getXAtprotoHeaders(req.headers),
+        // @NOTE deprecated; use `x-atproto-bsky-topics`
         'x-bsky-topics': req.headers['x-bsky-topics'],
 
         'content-type': body && req.headers['content-type'],
@@ -216,6 +218,8 @@ export async function pipethrough(
     headers: {
       'accept-language': req.headers['accept-language'],
       'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
+      ...getXAtprotoHeaders(req.headers),
+      // @NOTE deprecated; use `x-atproto-bsky-topics`
       'x-bsky-topics': req.headers['x-bsky-topics'],
 
       // Because we sometimes need to interpret the response (e.g. during
@@ -250,6 +254,14 @@ export async function pipethrough(
 
 // Request setup/formatting
 // -------------------
+
+function getXAtprotoHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) =>
+      name.toLowerCase().startsWith('x-atproto-'),
+    ),
+  )
+}
 
 export function computeProxyTo(
   ctx: AppContext,

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -125,7 +125,7 @@ export const proxyHandler = (ctx: AppContext): CatchallHandler => {
         'accept-encoding': req.headers['accept-encoding'] || 'identity',
         'accept-language': req.headers['accept-language'],
         'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
-        ...getXAtprotoHeaders(req.headers),
+        ...getAtprotoPassthroughHeaders(req.headers),
         // @NOTE deprecated; use `x-atproto-bsky-topics`
         'x-bsky-topics': req.headers['x-bsky-topics'],
 
@@ -218,7 +218,7 @@ export async function pipethrough(
     headers: {
       'accept-language': req.headers['accept-language'],
       'atproto-accept-labelers': req.headers['atproto-accept-labelers'],
-      ...getXAtprotoHeaders(req.headers),
+      ...getAtprotoPassthroughHeaders(req.headers),
       // @NOTE deprecated; use `x-atproto-bsky-topics`
       'x-bsky-topics': req.headers['x-bsky-topics'],
 
@@ -255,7 +255,9 @@ export async function pipethrough(
 // Request setup/formatting
 // -------------------
 
-function getXAtprotoHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+function getAtprotoPassthroughHeaders(
+  headers: IncomingHttpHeaders,
+): IncomingHttpHeaders {
   return Object.fromEntries(
     Object.entries(headers).filter(([name]) =>
       name.toLowerCase().startsWith('x-atproto-'),


### PR DESCRIPTION
Forwards all `x-atproto-*` headers through the PDS to connecting services. During the switchover, this PR dual-writes the old `x-bsky-topics` header and new `x-atproto-bsky-topics` header. We'll remove this later.

General note: this is not intended as a load bearing interface, but rather as a convenience for off-protocol and prototyping needs. We're keeping this scoped to `x-aptroto` for now as opposed to `x-*` to avoid functional overlap and unexpected header confusion.

Companion PR https://github.com/bluesky-social/social-app/pull/11571