### PR TITLE
Support AbortSignal implementations without throwIfAborted

### DIFF
--- a/.changeset/tidy-spiders-abort.md
+++ b/.changeset/tidy-spiders-abort.md
@@ -1,0 +1,5 @@
+---
+'@atproto/lex-client': patch
+---
+
+Avoid requiring `AbortSignal.throwIfAborted()` for compatibility with React Native.

--- a/packages/lex/lex-client/src/client.ts
+++ b/packages/lex/lex-client/src/client.ts
@@ -44,6 +44,7 @@ import {
   getDefaultRecordKey,
   getLiteralRecordKey,
   mergeHeaders,
+  throwIfAborted,
 } from './util.js'
 import {
   type WriteOperation,
@@ -1206,7 +1207,7 @@ export class Client {
     const schema = getMain(ns)
 
     do {
-      options.signal?.throwIfAborted()
+      throwIfAborted(options.signal)
 
       const { body } = await this.listRecords(schema.$type, {
         ...options,

--- a/packages/lex/lex-client/src/util.ts
+++ b/packages/lex/lex-client/src/util.ts
@@ -286,20 +286,23 @@ export function mergeHeaders(
 }
 
 function getAbortReason(signal: AbortSignal): unknown {
-  return (
-    signal.reason ??
-    (typeof DOMException !== 'undefined'
-      ? new DOMException('Aborted', 'AbortError')
-      : new Error('Aborted'))
-  )
+  if ('reason' in signal) return signal.reason
+  return typeof DOMException !== 'undefined'
+    ? new DOMException('Aborted', 'AbortError')
+    : new Error('Aborted')
 }
 
 /**
- * Throws when a signal is aborted without requiring the optional
- * `AbortSignal.throwIfAborted()` API.
+ * Uses the native `AbortSignal.throwIfAborted()` when available, falling back
+ * for older implementations such as React Native's `abort-controller`.
  */
 export function throwIfAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) throw getAbortReason(signal)
+  if (!signal) return
+  if (typeof signal.throwIfAborted === 'function') {
+    signal.throwIfAborted()
+    return
+  }
+  if (signal.aborted) throw getAbortReason(signal)
 }
 
 export function wait(

--- a/packages/lex/lex-client/src/util.ts
+++ b/packages/lex/lex-client/src/util.ts
@@ -285,12 +285,29 @@ export function mergeHeaders(
   return result
 }
 
+function getAbortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    (typeof DOMException !== 'undefined'
+      ? new DOMException('Aborted', 'AbortError')
+      : new Error('Aborted'))
+  )
+}
+
+/**
+ * Throws when a signal is aborted without requiring the optional
+ * `AbortSignal.throwIfAborted()` API.
+ */
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw getAbortReason(signal)
+}
+
 export function wait(
   ms: number,
   { signal }: { signal?: AbortSignal } = {},
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    signal?.throwIfAborted()
+    throwIfAborted(signal)
 
     const cleanup = () => {
       clearTimeout(timeout)
@@ -304,14 +321,8 @@ export function wait(
 
     const onAbort = () => {
       cleanup()
-      reject(
-        // @NOTE the signal exists, and the reason should be set at this point.
-        signal?.reason ??
-          // React Native does not have DOMException
-          (typeof DOMException !== 'undefined'
-            ? new DOMException('Aborted', 'AbortError')
-            : new Error('Aborted')),
-      )
+      // @NOTE the signal exists because this listener came from it.
+      reject(getAbortReason(signal!))
     }
 
     signal?.addEventListener('abort', onAbort)

--- a/packages/lex/lex-client/src/xrpc.ts
+++ b/packages/lex/lex-client/src/xrpc.ts
@@ -27,6 +27,7 @@ import {
   buildXrpcRequestHeaders,
   isAsyncIterable,
   isBlobLike,
+  throwIfAborted,
   toReadableStream,
   wait,
 } from './util.js'
@@ -220,7 +221,7 @@ export async function xrpcSafe<const M extends Query | Procedure>(
   const method: M = getMain(ns)
 
   for (let counter = 1; ; counter++) {
-    options.signal?.throwIfAborted()
+    throwIfAborted(options.signal)
     try {
       const agent = buildAgent(agentOpts)
       const url = xrpcRequestUrl(method, options)


### PR DESCRIPTION
## Summary

- avoid requiring the optional AbortSignal.throwIfAborted method in lex-client
- preserve native abort reasons with a cross-platform fallback
- use the compatibility helper for requests, retries, waits, and paginated record iteration

React Native uses abort-controller@3, whose signals do not implement throwIfAborted. Passing one to lex-client currently throws before the request begins.

Related to APP-2938 and bluesky-social/social-app#11564.

## Test plan

- Use a React Native AbortSignal for a client request and confirm the request begins normally and still aborts when its controller is aborted.