### PR TITLE
bsky: count fail-open hydration failures

### DIFF
--- a/.changeset/hip-donkeys-shave.md
+++ b/.changeset/hip-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add a `hydration_failed` counter for the fail-open hydration steps (known likers, known followers, activity subscriptions)

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -56,6 +56,7 @@
     "@growthbook/growthbook": "^1.6.2",
     "@hapi/address": "^5.1.1",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.219.0",
     "@types/http-errors": "^2.0.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/packages/bsky/src/events.ts
+++ b/packages/bsky/src/events.ts
@@ -1,0 +1,67 @@
+import { type Meter, ValueType, diag, metrics } from '@opentelemetry/api'
+import { type Logger, SeverityNumber, logs } from '@opentelemetry/api-logs'
+import { eventsLogger } from './logger.js'
+
+const meter: Meter = metrics.getMeter('@atproto/bsky')
+const logger: Logger = logs.getLogger('@atproto/bsky')
+
+export type HydrationSource =
+  'known_likers' | 'known_followers' | 'activity_subscriptions'
+
+/**
+ * Central hub for reporting AppView business events. Each method reports a
+ * single event to every relevant sink in one call:
+ *
+ *  1. a pino logger      → stdout/stderr (docker logs)
+ *  2. an OTEL counter    → aggregated metric (low-cardinality dimensions only)
+ *  3. the OTEL Logs SDK  → structured, trace-correlated log record (full detail)
+ *
+ * @note High-cardinality attributes (e.g. `did`, `uri`) belong in the pino and
+ * OTEL log records but must stay OUT of the counters, whose attributes must
+ * remain low-cardinality to avoid a metric-series explosion.
+ *
+ * @note The OTEL counters and log records are no-ops unless the corresponding
+ * OTEL exporter is configured, so calling these methods is always safe and
+ * essentially free when telemetry is disabled.
+ */
+class EventReporter {
+  #hydrationFailedCounter = meter.createCounter<{
+    source: HydrationSource
+    reason: 'timeout' | 'error'
+  }>('hydration_failed', {
+    description:
+      'Number of fail-open hydration steps that did not produce a result',
+    valueType: ValueType.INT,
+  })
+
+  /**
+   * Fans a single event out to both the pino logger (stdout/stderr) and the
+   * OTEL Logs SDK (structured record).
+   *
+   * @note this method should never throw
+   */
+  #log(
+    eventName: string,
+    attributes: Record<string, string | number | boolean | undefined>,
+  ) {
+    try {
+      logger.emit({
+        eventName,
+        severityNumber: SeverityNumber.INFO,
+        attributes,
+      })
+      eventsLogger.info({ eventName, ...attributes })
+    } catch (err) {
+      diag.error(`Failed to log event ${eventName}:`, err)
+    }
+  }
+
+  hydrationFailed({ source, err }: { source: HydrationSource; err: unknown }) {
+    const reason =
+      err instanceof Error && err.name === 'TimeoutError' ? 'timeout' : 'error'
+    this.#log('hydration.failed', { source, reason })
+    this.#hydrationFailedCounter.add(1, { source, reason })
+  }
+}
+
+export const events: EventReporter = new EventReporter()

--- a/packages/bsky/src/hydration/actor.ts
+++ b/packages/bsky/src/hydration/actor.ts
@@ -10,6 +10,7 @@ import {
   normalizeHandle,
 } from '@atproto/syntax'
 import type { DataPlaneClient } from '../data-plane/client/index.js'
+import { events } from '../events.js'
 import { app, chat, com } from '../lexicons/index.js'
 import type {
   ActivitySubscription,
@@ -527,8 +528,9 @@ export class ActorHydrator {
             : undefined,
         )
       }
-    } catch {
+    } catch (err) {
       // ignore errors and return empty map
+      events.hydrationFailed({ source: 'known_followers', err })
     }
 
     return map
@@ -568,8 +570,9 @@ export class ActorHydrator {
           map.set(did, undefined)
         }
       }
-    } catch {
+    } catch (err) {
       // ignore errors and return empty map
+      events.hydrationFailed({ source: 'activity_subscriptions', err })
     }
 
     return map

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -8,6 +8,7 @@ import {
   type UriString,
 } from '@atproto/syntax'
 import type { DataPlaneClient } from '../data-plane/client/index.js'
+import { events } from '../events.js'
 import type {
   FeatureGatesClient,
   ScopedFeatureGatesClient,
@@ -1070,6 +1071,7 @@ export class Hydrator {
       return knownLikers
     } catch (err) {
       hydrationLogger.error({ err }, 'Failed to hydrate known likers')
+      events.hydrationFailed({ source: 'known_likers', err })
       return undefined
     }
   }

--- a/packages/bsky/src/logger.ts
+++ b/packages/bsky/src/logger.ts
@@ -23,6 +23,8 @@ export const viewsLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky:views')
 export const httpLogger: ReturnType<typeof subsystemLogger> =
   subsystemLogger('bsky')
+export const eventsLogger: ReturnType<typeof subsystemLogger> =
+  subsystemLogger('bsky:events')
 
 export const loggerMiddleware = pinoHttp({
   logger: httpLogger,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.219.0
+        version: 0.219.0
       '@types/http-errors':
         specifier: ^2.0.1
         version: 2.0.4
@@ -16274,7 +16277,7 @@ snapshots:
       '@datadog/pprof': 5.14.1
       '@datadog/wasm-js-rewriter': 5.0.1
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/api-logs': 0.219.0
       oxc-parser: 0.129.0
     transitivePeerDependencies:
       - '@openfeature/server-sdk'


### PR DESCRIPTION
Three hydration steps run with `AbortSignal.timeout(100)` and fail open. Two of them swallow the error silently, and the third only logs it. Either way, we have no way to see how often that happens in production.

This adds a `hydration_failed` counter, with attributes:

1. `source`: `known_likers`, `known_followers`, `activity_subscriptions`.
2. `reason`: `timeout` or `error`. The catch blocks swallow every error, not just timeouts, so a counter named after timeouts alone would be lying.

Six timeseries in total. Lands in VictoriaMetrics as `hydration_failed_total`.

The call sites:

1. `Hydrator.hydrateKnownLikers` in `packages/bsky/src/hydration/hydrator.ts`.
2. `ActorHydrator.getKnownFollowers` in `packages/bsky/src/hydration/actor.ts`.
3. `ActorHydrator.getActivitySubscriptions` in `packages/bsky/src/hydration/actor.ts`.

Also adds `packages/bsky/src/events.ts`, which bsky didn't have. It follows `packages/pds/src/events.ts` and the template in STYLE_GUIDE.md, so it writes the event to pino and to the OTEL Logs API on top of the counter. That log half is arguable here - there is no high-cardinality detail to carry, `source` and `reason` are the whole event - so it can come out along with the `@opentelemetry/api-logs` dependency if we'd rather keep this to just the counter.