### PR TITLE
bsky: add timeout to iris requests

### DIFF
--- a/.changeset/iris-connect-timeout.md
+++ b/.changeset/iris-connect-timeout.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add a 1.5s connection timeout to requests to iris.

--- a/.changeset/iris-connect-timeout.md
+++ b/.changeset/iris-connect-timeout.md
@@ -2,4 +2,4 @@
 '@atproto/bsky': patch
 ---
 
-Add a 1.5s connection timeout to requests to iris.
+Add a 1s timeout to requests to iris.

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -6,12 +6,12 @@ import cors from 'cors'
 import { Etcd3 } from 'etcd3'
 import express from 'express'
 import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
-import { Agent as UndiciAgent, fetch as undiciFetch } from 'undici'
 import { DAY, SECOND } from '@atproto/common'
 import type { Keypair } from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
 import { Client } from '@atproto/lex'
 import { createServer } from '@atproto/xrpc-server'
+import { timedFetch } from '@atproto-labs/fetch-node'
 import { createBlobDispatcher } from './api/blob-dispatcher.js'
 import API, {
   blobResolver,
@@ -149,23 +149,9 @@ export class BskyAppView {
       ? new Client(
           {
             service: config.irisUrl,
-            // Bound the connection phase only. Once connected, requests to
-            // iris are not bounded here. Uses undici's own fetch rather than
-            // the global one, since the dispatcher must come from the same
-            // undici version as the fetch it is passed to.
-            fetch: (() => {
-              const dispatcher = new UndiciAgent({
-                connectTimeout: 1.5 * SECOND,
-              })
-              return (input, init) =>
-                undiciFetch(
-                  input as never,
-                  {
-                    ...init,
-                    dispatcher,
-                  } as never,
-                ) as Promise<Response>
-            })(),
+            // Bound the whole request: connecting, waiting for the response,
+            // and reading its body.
+            fetch: timedFetch(SECOND),
           },
           {
             // Trust internal services to send us well-formed responses

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -6,6 +6,7 @@ import cors from 'cors'
 import { Etcd3 } from 'etcd3'
 import express from 'express'
 import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
+import { Agent as UndiciAgent, fetch as undiciFetch } from 'undici'
 import { DAY, SECOND } from '@atproto/common'
 import type { Keypair } from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
@@ -148,6 +149,23 @@ export class BskyAppView {
       ? new Client(
           {
             service: config.irisUrl,
+            // Bound the connection phase only. Once connected, requests to
+            // iris are not bounded here. Uses undici's own fetch rather than
+            // the global one, since the dispatcher must come from the same
+            // undici version as the fetch it is passed to.
+            fetch: (() => {
+              const dispatcher = new UndiciAgent({
+                connectTimeout: 1.5 * SECOND,
+              })
+              return (input, init) =>
+                undiciFetch(
+                  input as never,
+                  {
+                    ...init,
+                    dispatcher,
+                  } as never,
+                ) as Promise<Response>
+            })(),
           },
           {
             // Trust internal services to send us well-formed responses


### PR DESCRIPTION
`getTrendingTopics` and `getTrends` both call iris through `ctx.irisClient`, and that call had no timeout. If iris becomes unreachable or slow, the request hangs, and since this is the skeleton step of the pipeline, the whole request hangs with it.

This adds a 1s timeout using `timedFetch` from `@atproto-labs/fetch`. It bounds the whole request: connecting, waiting for the response, and reading its body.

A note on what this is not: I originally wanted a timeout on the connection phase only. That requires an undici `Agent`, and it doesn't work cleanly here. We depend on undici 8, Node 24 embeds undici 7, and passing an undici 8 `Agent` to the global `fetch` fails at runtime with `invalid onRequestStart method`. Making it work means calling undici 8's own `fetch` too, which then needs casts, since `@atproto/lex` types its `fetch` option against Node's globals. That was the first commit here, and `timedFetch` replaces it: no casts, no new dependency.

