### PR TITLE
bsky: use a connection timeout for iris and topics requests

### DIFF
--- a/.changeset/iris-topics-connect-timeout.md
+++ b/.changeset/iris-topics-connect-timeout.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Use a connection timeout for requests to iris and topics.

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -6,12 +6,12 @@ import cors from 'cors'
 import { Etcd3 } from 'etcd3'
 import express from 'express'
 import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
+import { Agent as UndiciAgent, fetch as undiciFetch } from 'undici'
 import { DAY, SECOND } from '@atproto/common'
 import type { Keypair } from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
 import { Client } from '@atproto/lex'
 import { createServer } from '@atproto/xrpc-server'
-import { timedFetch } from '@atproto-labs/fetch-node'
 import { createBlobDispatcher } from './api/blob-dispatcher.js'
 import API, {
   blobResolver,
@@ -55,6 +55,26 @@ export * from './data-plane/index.js'
 export { BackgroundQueue } from './data-plane/server/background.js'
 export { Database } from './data-plane/server/db/index.js'
 export { Redis } from './redis.js'
+
+/**
+ * Builds a fetch that bounds the connection phase only. Once connected, the
+ * request is not bounded here.
+ *
+ * Uses undici's own fetch rather than the global one, since the dispatcher must
+ * come from the same undici as the fetch it is passed to, and the undici we
+ * depend on is not the one Node embeds.
+ */
+function connectTimeoutFetch(connectTimeout: number) {
+  const dispatcher = new UndiciAgent({ connectTimeout })
+  return (input: unknown, init: unknown) =>
+    undiciFetch(
+      input as never,
+      {
+        ...(init as object),
+        dispatcher,
+      } as never,
+    ) as Promise<Response>
+}
 
 export class BskyAppView {
   public ctx: AppContext
@@ -136,6 +156,7 @@ export class BskyAppView {
             headers: config.topicsApiKey
               ? { authorization: `Bearer ${config.topicsApiKey}` }
               : undefined,
+            fetch: connectTimeoutFetch(SECOND),
           },
           {
             // Trust internal services to send us well-formed responses
@@ -149,9 +170,7 @@ export class BskyAppView {
       ? new Client(
           {
             service: config.irisUrl,
-            // Bound the whole request: connecting, waiting for the response,
-            // and reading its body.
-            fetch: timedFetch(SECOND),
+            fetch: connectTimeoutFetch(SECOND),
           },
           {
             // Trust internal services to send us well-formed responses


### PR DESCRIPTION
Follow up to #5454, which added a 1s timeout to iris using `timedFetch`. That bounds the whole request, including reading the response body. This narrows it to the connection phase only, and applies the same to the topics client.

Both clients back endpoints where the call happens in the skeleton step of the pipeline, so a hang there hangs the whole request: `getTrends`, `getTrendingTopics` for iris, and `getSuggestedUsers`, `getSuggestedFeeds`, `getSuggestedStarterPacks`, `getOnboardingSuggestedStarterPacks` for topics.

Implementation note: `connectTimeout` only exists on an undici `Agent`, and it has to be paired with undici's own `fetch`. Node embeds undici 7 while we depend on undici 8, and passing an undici 8 `Agent` to the global `fetch` fails at runtime with `invalid onRequestStart method`. The casts are because `@atproto/lex` types its `fetch` option against Node's globals.

Verified end to end through a real `Client` against a live server: normal calls succeed, and an unreachable host throws `UND_ERR_CONNECT_TIMEOUT`, wrapped by the library as `XrpcFetchError`. Note undici retries the address once, so the practical ceiling is ~2x the configured value.
