### PR TITLE
Reduce dataplane calls when refilling pages

### DIFF
--- a/.changeset/silly-buttons-repeat.md
+++ b/.changeset/silly-buttons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Reduce dataplane calls when refilling paginated responses. Pages are now served once they hold half of the requested limit, and `listNotifications` reads the viewer's priority setting and last-seen time once per request instead of once per page.

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -31,14 +31,31 @@ export default function (server: Server, ctx: AppContext) {
   server.add(app.bsky.notification.listNotifications, {
     auth: ctx.authVerifier.standard,
     handler: async ({ params, auth, req }) => {
+      if (params.seenAt) {
+        throw new InvalidRequestError('The seenAt parameter is unsupported')
+      }
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+
+      // @NOTE the viewer's priority setting and last-seen time don't change
+      // across the pages that fillPage() may fetch, so they're read once here
+      // rather than on every page.
+      const priority = params.priority ?? (await getPriority(ctx, viewer))
+      const lastSeenRes = await ctx.hydrator.dataplane.getNotificationSeen({
+        actorDid: viewer,
+        priority,
+      })
+      const lastSeen = lastSeenRes.timestamp?.toDate()
+
       const result = await fillPage({
         cursor: params.cursor,
         limit: params.limit,
         fetch: ({ cursor, limit }) =>
-          listNotifications({ ...params, cursor, limit, hydrateCtx }, ctx),
+          listNotifications(
+            { ...params, cursor, limit, hydrateCtx, priority, lastSeen },
+            ctx,
+          ),
         items: (r) => r.notifications,
       })
       return {
@@ -95,34 +112,24 @@ const skeleton = async (
   input: SkeletonFnInput<Context, Params>,
 ): Promise<SkeletonState> => {
   const { params, ctx } = input
-  if (params.seenAt) {
-    throw new InvalidRequestError('The seenAt parameter is unsupported')
-  }
-
   const originalCursor = params.cursor
   const delayedCursor = delayCursor(
     originalCursor,
     ctx.cfg.notificationsDelayMs,
   )
   const viewer = params.hydrateCtx.viewer
-  const priority = params.priority ?? (await getPriority(ctx, viewer))
-  const [res, lastSeenRes] = await Promise.all([
-    paginateNotifications({
-      ctx,
-      priority,
-      reasons: params.reasons,
-      cursor: delayedCursor,
-      limit: params.limit,
-      viewer,
-    }),
-    ctx.hydrator.dataplane.getNotificationSeen({
-      actorDid: viewer,
-      priority,
-    }),
-  ])
+  const { priority } = params
+  const res = await paginateNotifications({
+    ctx,
+    priority,
+    reasons: params.reasons,
+    cursor: delayedCursor,
+    limit: params.limit,
+    viewer,
+  })
   // @NOTE for the first page of results if there's no last-seen time, consider top notification unread
   // rather than all notifications. bit of a hack to be more graceful when seen times are out of sync.
-  let lastSeenDate = lastSeenRes.timestamp?.toDate()
+  let lastSeenDate = params.lastSeen
   if (!lastSeenDate && !originalCursor) {
     lastSeenDate = res.notifications.at(0)?.timestamp?.toDate()
   }
@@ -233,8 +240,13 @@ type Context = {
   cfg: ServerConfig
 }
 
-type Params = app.bsky.notification.listNotifications.$Params & {
+type Params = Omit<
+  app.bsky.notification.listNotifications.$Params,
+  'priority'
+> & {
   hydrateCtx: HydrateCtxWithViewer
+  priority: boolean
+  lastSeen?: Date
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/util.test.ts
+++ b/packages/bsky/src/api/util.test.ts
@@ -17,16 +17,41 @@ describe('fillPage', () => {
   it('fills across filtered and empty pages', async () => {
     const fetch = vi
       .fn()
-      .mockResolvedValueOnce({ items: [1], cursor: 'a', metadata: 'first' })
+      .mockResolvedValueOnce({ items: [], cursor: 'a', metadata: 'first' })
       .mockResolvedValueOnce({ items: [], cursor: 'b' })
-      .mockResolvedValueOnce({ items: [2, 3], cursor: 'c' })
+      .mockResolvedValueOnce({ items: [1, 2], cursor: 'c' })
 
     await expect(
       fillPage({ cursor: 'start', limit: 3, fetch, items: (r) => r.items }),
-    ).resolves.toEqual({ items: [1, 2, 3], cursor: 'c', metadata: 'first' })
+    ).resolves.toEqual({ items: [1, 2], cursor: 'c', metadata: 'first' })
     expect(fetch).toHaveBeenNthCalledWith(1, { cursor: 'start', limit: 3 })
-    expect(fetch).toHaveBeenNthCalledWith(2, { cursor: 'a', limit: 2 })
-    expect(fetch).toHaveBeenNthCalledWith(3, { cursor: 'b', limit: 2 })
+    expect(fetch).toHaveBeenNthCalledWith(2, { cursor: 'a', limit: 3 })
+    expect(fetch).toHaveBeenNthCalledWith(3, { cursor: 'b', limit: 3 })
+  })
+
+  it('stops refilling once half of the page is filled', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [1], cursor: 'a' })
+      .mockResolvedValueOnce({ items: [2], cursor: 'b' })
+      .mockResolvedValueOnce({ items: [3], cursor: 'c' })
+
+    await expect(
+      fillPage({ cursor: undefined, limit: 4, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [1, 2], cursor: 'b' })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('refills a single item page, since half of it rounds up', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], cursor: 'a' })
+      .mockResolvedValueOnce({ items: [1], cursor: 'b' })
+
+    await expect(
+      fillPage({ cursor: undefined, limit: 1, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [1], cursor: 'b' })
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('preserves the cursor when the request bound is reached', async () => {

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -47,6 +47,9 @@ export const fillPage = async <
   items: (result: Awaited<ReturnType<F>>) => T[]
 }): Promise<Awaited<ReturnType<F>>> => {
   const maxRequests = opts.maxRequests ?? DEFAULT_FILL_PAGE_MAX_REQUESTS
+  // Refilling is only worth its cost while the page is mostly empty: a page
+  // that already holds half of what was asked for is served as is.
+  const enoughItems = Math.ceil(opts.limit / 2)
   const result = (await opts.fetch({
     cursor: opts.cursor,
     limit: opts.limit,
@@ -55,7 +58,7 @@ export const fillPage = async <
   let cursor = result.cursor
   for (
     let requests = 1;
-    requests < maxRequests && cursor && items.length < opts.limit;
+    requests < maxRequests && cursor && items.length < enoughItems;
     requests++
   ) {
     const previousCursor = cursor

--- a/packages/bsky/tests/feed-generation.test.ts
+++ b/packages/bsky/tests/feed-generation.test.ts
@@ -342,18 +342,28 @@ describe('feed generation', () => {
     expect(over.uris).toHaveLength(9)
     expect(over.cursor).not.toBe('')
 
-    const terminal = await agent.app.bsky.feed.getActorFeeds({
+    // The taken-down feed is filtered out, leaving 8 of the 9 requested. That
+    // is already half of the limit, so the page is served with a cursor.
+    const short = await agent.app.bsky.feed.getActorFeeds({
       actor: alice,
       limit: 9,
     })
-    expect(terminal.data.feeds).toHaveLength(9)
+    expect(short.data.feeds).toHaveLength(8)
+    expect(short.data.cursor).toBeDefined()
+
+    const terminal = await agent.app.bsky.feed.getActorFeeds({
+      actor: alice,
+      limit: 9,
+      cursor: short.data.cursor,
+    })
+    expect(terminal.data.feeds).toHaveLength(1)
     expect(terminal.data.cursor).toBeUndefined()
 
     const trimmed = await agent.app.bsky.feed.getActorFeeds({
       actor: alice,
       limit: 8,
     })
-    expect(trimmed.data.feeds).toHaveLength(8)
+    expect(trimmed.data.feeds).toHaveLength(7)
     expect(trimmed.data.cursor).toBeDefined()
   })
 
@@ -649,7 +659,7 @@ describe('feed generation', () => {
       expect(resEven.data.feeds.map((fg) => fg.uri)).not.toContain(feedUriPrime) // taken-down
     })
 
-    it('fills the page after filtering and returns a cursor only when more feeds are available', async () => {
+    it('serves a page short of the limit after filtering, and returns a cursor only when more feeds are available', async () => {
       const exact = await network.bsky.ctx.dataplane.getSuggestedFeeds({
         limit: 4,
       })
@@ -662,13 +672,22 @@ describe('feed generation', () => {
       expect(over.uris).toHaveLength(3)
       expect(over.cursor).not.toBe('')
 
+      // Moving the taken-down feed to the head of the results leaves 2 of the
+      // 3 requested, already half of the limit, so the page is served short.
       await network.bsky.db.db
         .updateTable('suggested_feed')
         .set({ order: 0 })
         .where('uri', '=', feedUriPrime)
         .execute()
-      const terminal = await agent.app.bsky.feed.getSuggestedFeeds({ limit: 3 })
-      expect(terminal.data.feeds).toHaveLength(3)
+      const short = await agent.app.bsky.feed.getSuggestedFeeds({ limit: 3 })
+      expect(short.data.feeds).toHaveLength(2)
+      expect(short.data.cursor).toBeDefined()
+
+      const terminal = await agent.app.bsky.feed.getSuggestedFeeds({
+        limit: 3,
+        cursor: short.data.cursor,
+      })
+      expect(terminal.data.feeds).toHaveLength(1)
       expect(terminal.data.cursor).toBeUndefined()
       await network.bsky.db.db
         .updateTable('suggested_feed')
@@ -784,17 +803,26 @@ describe('feed generation', () => {
       )
     })
 
-    it('uses bounded feed-generator pages and refills filtered suggestions', async () => {
+    it('uses bounded feed generator pages and serves filtered suggestions short of the limit', async () => {
+      // Moving the taken-down feed to the head of the results leaves 2 of the
+      // 3 requested, already half of the limit, so the page is served short.
       await network.bsky.db.db
         .updateTable('suggested_feed')
         .set({ order: 0 })
         .where('uri', '=', feedUriPrime)
         .execute()
-      const exact = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+      const short = await agent.app.bsky.unspecced.getPopularFeedGenerators({
         limit: 3,
       })
-      expect(exact.data.feeds).toHaveLength(3)
-      expect(exact.data.cursor).toBeUndefined()
+      expect(short.data.feeds).toHaveLength(2)
+      expect(short.data.cursor).toBeDefined()
+
+      const terminal = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+        limit: 3,
+        cursor: short.data.cursor,
+      })
+      expect(terminal.data.feeds).toHaveLength(1)
+      expect(terminal.data.cursor).toBeUndefined()
       await network.bsky.db.db
         .updateTable('suggested_feed')
         .set({ order: 4 })

--- a/packages/bsky/tests/views/actor-likes.test.ts
+++ b/packages/bsky/tests/views/actor-likes.test.ts
@@ -112,7 +112,7 @@ describe('bsky actor likes feed views', () => {
     const {
       data: { feed },
     } = await agent.api.app.bsky.feed.getActorLikes(
-      { actor: sc.accounts[bob].handle, limit: 2 },
+      { actor: sc.accounts[bob].handle, limit: 3 },
       {
         headers: await network.serviceHeaders(
           bob,

--- a/packages/bsky/tests/views/actor-search.test.ts
+++ b/packages/bsky/tests/views/actor-search.test.ts
@@ -282,7 +282,7 @@ describe('actor search pagination', () => {
   beforeEach(async () => network.processAll())
   afterAll(async () => network?.close())
 
-  it('fills the page after filtering actors and returns a cursor only when more actors are available', async () => {
+  it('serves a page short of the limit after filtering actors, and returns a cursor only when more actors are available', async () => {
     const full = await network.bsky.ctx.dataplane.searchActors({
       term: '.test',
       limit: 100,
@@ -314,16 +314,18 @@ describe('actor search pagination', () => {
     expect(terminal.data.actors).toHaveLength(full.dids.length)
     expect(terminal.data.cursor).toBeUndefined()
 
+    // Taking down the head actor leaves one of the two requested, which is
+    // already half of the limit, so the page is served as is.
     await network.bsky.ctx.dataplane.takedownActor({ did: full.dids[0] })
-    const refilled = await agent.app.bsky.actor.searchActors(
+    const short = await agent.app.bsky.actor.searchActors(
       { term: '.test', limit: 2 },
       { headers },
     )
-    expect(refilled.data.actors).toHaveLength(2)
-    expect(refilled.data.actors.map((actor) => actor.did)).not.toContain(
+    expect(short.data.actors).toHaveLength(1)
+    expect(short.data.actors.map((actor) => actor.did)).not.toContain(
       full.dids[0],
     )
-    expect(refilled.data.cursor).toBeDefined()
+    expect(short.data.cursor).toBeDefined()
     await network.bsky.ctx.dataplane.untakedownActor({ did: full.dids[0] })
   })
 })

--- a/packages/bsky/tests/views/contact-matches.test.ts
+++ b/packages/bsky/tests/views/contact-matches.test.ts
@@ -36,7 +36,7 @@ describe('contact matches', () => {
   beforeEach(async () => network.processAll())
   afterAll(async () => network?.close())
 
-  it('fills the page after filtering blocked matches and returns a cursor only when more matches are available', async () => {
+  it('serves a page short of the limit after filtering blocked matches, and returns a cursor only when more matches are available', async () => {
     const subjects = [sc.dids.bob, sc.dids.carol, sc.dids.dan, sc.dids.eve]
     const getMatches = vi
       .spyOn(network.bsky.server.ctx.rolodexClient!, 'getMatches')
@@ -54,28 +54,29 @@ describe('contact matches', () => {
       ids.AppBskyContactGetMatches,
     )
 
-    const exact = await agent.app.bsky.contact.getMatches(
+    // Blocked bob heads the first underlying page, leaving two of the three
+    // requested. That is already half of the limit, so the page is served as
+    // is, without a second call to rolodex.
+    const short = await agent.app.bsky.contact.getMatches(
       { limit: 3 },
       { headers },
     )
-    expect(exact.data.matches.map((match) => match.did)).toEqual([
+    expect(short.data.matches.map((match) => match.did)).toEqual([
       sc.dids.carol,
       sc.dids.dan,
-      sc.dids.eve,
     ])
-    expect(exact.data.cursor).toBeUndefined()
-    expect(getMatches).toHaveBeenCalledTimes(2)
+    expect(short.data.cursor).toBe('3')
+    expect(getMatches).toHaveBeenCalledOnce()
 
     getMatches.mockClear()
-    const over = await agent.app.bsky.contact.getMatches(
-      { limit: 2 },
+    const terminal = await agent.app.bsky.contact.getMatches(
+      { limit: 3, cursor: short.data.cursor },
       { headers },
     )
-    expect(over.data.matches.map((match) => match.did)).toEqual([
-      sc.dids.carol,
-      sc.dids.dan,
+    expect(terminal.data.matches.map((match) => match.did)).toEqual([
+      sc.dids.eve,
     ])
-    expect(over.data.cursor).toBe('3')
-    expect(getMatches).toHaveBeenCalledTimes(2)
+    expect(terminal.data.cursor).toBeUndefined()
+    expect(getMatches).toHaveBeenCalledOnce()
   })
 })

--- a/packages/bsky/tests/views/likes.test.ts
+++ b/packages/bsky/tests/views/likes.test.ts
@@ -212,15 +212,29 @@ describe('pds like views', () => {
       sc.dids.bob,
     ])
 
-    const filled = await agent.app.bsky.feed.getLikes(
+    // Filtering carol out leaves this page short of the requested 3, but it
+    // already holds half of them, so it is served with a cursor for the rest.
+    const short = await agent.app.bsky.feed.getLikes(
       { uri: sc.posts[alice][1].ref.uriStr, limit: 3 },
       { headers: await network.serviceHeaders(bob, ids.AppBskyFeedGetLikes) },
     )
-    expect(filled.data.likes.map((like) => like.actor.did)).toStrictEqual([
+    expect(short.data.likes.map((like) => like.actor.did)).toStrictEqual([
       sc.dids.eve,
       sc.dids.dan,
+    ])
+    expect(short.data.cursor).toBeDefined()
+
+    const rest = await agent.app.bsky.feed.getLikes(
+      {
+        uri: sc.posts[alice][1].ref.uriStr,
+        limit: 3,
+        cursor: short.data.cursor,
+      },
+      { headers: await network.serviceHeaders(bob, ids.AppBskyFeedGetLikes) },
+    )
+    expect(rest.data.likes.map((like) => like.actor.did)).toStrictEqual([
       sc.dids.bob,
     ])
-    expect(filled.data.cursor).toBeUndefined()
+    expect(rest.data.cursor).toBeUndefined()
   })
 })

--- a/packages/bsky/tests/views/lists.test.ts
+++ b/packages/bsky/tests/views/lists.test.ts
@@ -200,7 +200,7 @@ describe('bsky actor likes feed views', () => {
       )
       expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
       if (expected > 2) {
-        expect(paginatedAll[0].lists).toHaveLength(2)
+        expect(paginatedAll[0].lists.length).toBeGreaterThan(0)
         expect(paginatedAll[0].cursor).toBeDefined()
       }
 
@@ -235,7 +235,7 @@ describe('bsky actor likes feed views', () => {
     expect(forSnapshot(curView.data.items)).toMatchSnapshot()
 
     const refView = await agent.app.bsky.graph.getList(
-      { list: referenceList, limit: 2 },
+      { list: referenceList, limit: 3 },
       {
         headers: await network.serviceHeaders(frankie, ids.AppBskyGraphGetList),
       },
@@ -425,7 +425,7 @@ describe('bsky actor likes feed views', () => {
         )
         expect(paginatedAll.at(-1)?.cursor).toBeUndefined()
         if (expected > 2) {
-          expect(paginatedAll[0].listsWithMembership).toHaveLength(2)
+          expect(paginatedAll[0].listsWithMembership.length).toBeGreaterThan(0)
           expect(paginatedAll[0].cursor).toBeDefined()
         }
 

--- a/packages/bsky/tests/views/mutes.test.ts
+++ b/packages/bsky/tests/views/mutes.test.ts
@@ -233,9 +233,9 @@ describe('mute views', () => {
       )
       expect(mutes.mutes.some((mute) => mute.did === dan)).toBe(false)
 
-      // pages are filled server-side: dan's scoped mute is the most recent
-      // and occupies the head of the first underlying page, but the page
-      // still comes back with at least `limit` full mutes.
+      // dan's scoped mute is the most recent and occupies the head of the
+      // first underlying page. Filtering it out leaves one mute, which is
+      // already half of the requested limit, so the page is served short.
       const { data: page } = await agent.api.app.bsky.graph.getMutes(
         { limit: 2 },
         {
@@ -245,11 +245,11 @@ describe('mute views', () => {
           ),
         },
       )
-      expect(page.mutes).toHaveLength(2)
+      expect(page.mutes).toHaveLength(1)
       expect(page.mutes.some((mute) => mute.did === dan)).toBe(false)
       expect(page.cursor).toBeDefined()
 
-      const { data: terminalPage } = await agent.api.app.bsky.graph.getMutes(
+      const { data: fullPage } = await agent.api.app.bsky.graph.getMutes(
         { limit: 8 },
         {
           headers: await network.serviceHeaders(
@@ -258,8 +258,20 @@ describe('mute views', () => {
           ),
         },
       )
-      expect(terminalPage.mutes).toHaveLength(8)
-      expect(terminalPage.mutes.some((mute) => mute.did === dan)).toBe(false)
+      expect(fullPage.mutes).toHaveLength(7)
+      expect(fullPage.mutes.some((mute) => mute.did === dan)).toBe(false)
+      expect(fullPage.cursor).toBeDefined()
+
+      const { data: terminalPage } = await agent.api.app.bsky.graph.getMutes(
+        { limit: 8, cursor: fullPage.cursor },
+        {
+          headers: await network.serviceHeaders(
+            alice,
+            ids.AppBskyGraphGetMutes,
+          ),
+        },
+      )
+      expect(terminalPage.mutes).toHaveLength(1)
       expect(terminalPage.cursor).toBeUndefined()
 
       const timeline = await agent.api.app.bsky.feed.getTimeline(

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -818,7 +818,7 @@ describe('notification views', () => {
     }
 
     const paginatedAll = await paginateAll(paginator)
-    expect(paginatedAll[0].notifications).toHaveLength(2)
+    expect(paginatedAll[0].notifications.length).toBeGreaterThan(0)
     paginatedAll.forEach((res) =>
       expect(res.notifications.length).toBeLessThanOrEqual(2),
     )
@@ -1519,12 +1519,21 @@ describe('notification views', () => {
       expect(over.dids).toHaveLength(5)
       expect(over.cursor).not.toBe('')
 
-      const terminal = await list(actorDid, { limit: 5 })
-      expect(terminal.data.subscriptions).toHaveLength(5)
+      // The blocked subscriber is filtered out, so this page is short of the
+      // requested limit and carries a cursor onto the remaining subscriber.
+      const filtered = await list(actorDid, { limit: 5 })
+      expect(filtered.data.subscriptions).toHaveLength(4)
+      expect(filtered.data.cursor).toBeDefined()
+
+      const terminal = await list(actorDid, {
+        limit: 5,
+        cursor: filtered.data.cursor,
+      })
+      expect(terminal.data.subscriptions).toHaveLength(1)
       expect(terminal.data.cursor).toBeUndefined()
 
       const trimmed = await list(actorDid, { limit: 4 })
-      expect(trimmed.data.subscriptions).toHaveLength(4)
+      expect(trimmed.data.subscriptions).toHaveLength(3)
       expect(trimmed.data.cursor).toBeDefined()
 
       const results = (
@@ -1542,7 +1551,7 @@ describe('notification views', () => {
       }
 
       const paginatedAll = await paginateAll(paginator)
-      expect(paginatedAll[0].subscriptions).toHaveLength(limit)
+      expect(paginatedAll[0].subscriptions.length).toBeGreaterThan(0)
       paginatedAll.forEach((res) =>
         expect(res.subscriptions.length).toBeLessThanOrEqual(limit),
       )

--- a/packages/bsky/tests/views/post-search.test.ts
+++ b/packages/bsky/tests/views/post-search.test.ts
@@ -82,7 +82,7 @@ describe('appview search', () => {
   afterAll(async () => network?.close())
 
   describe('pagination', () => {
-    it('searchPosts fills the page after filtering and returns a cursor only when more posts are available', async () => {
+    it('searchPosts serves a page short of the limit after filtering, and returns a cursor only when more posts are available', async () => {
       const exact = await network.bsky.ctx.dataplane.searchPosts({
         term: 'doggo',
         limit: 3,
@@ -97,7 +97,9 @@ describe('appview search', () => {
       expect(over.uris).toHaveLength(2)
       expect(over.cursor).not.toBe('')
 
-      const terminal = await agent.app.bsky.feed.searchPosts(
+      // The tagged post sits between the two visible ones, so the first page
+      // holds one of the two requested. That is already half of the limit.
+      const short = await agent.app.bsky.feed.searchPosts(
         { q: 'doggo', sort: 'top', limit: 2 },
         {
           headers: await network.serviceHeaders(
@@ -106,9 +108,23 @@ describe('appview search', () => {
           ),
         },
       )
-      expect(terminal.data.posts.map((post) => post.uri)).toEqual(
-        nonTaggedResults,
+      expect(short.data.posts.map((post) => post.uri)).toEqual([
+        nonTaggedResults[0],
+      ])
+      expect(short.data.cursor).toBeDefined()
+
+      const terminal = await agent.app.bsky.feed.searchPosts(
+        { q: 'doggo', sort: 'top', limit: 2, cursor: short.data.cursor },
+        {
+          headers: await network.serviceHeaders(
+            carol,
+            ids.AppBskyFeedSearchPosts,
+          ),
+        },
       )
+      expect(terminal.data.posts.map((post) => post.uri)).toEqual([
+        nonTaggedResults[1],
+      ])
       expect(terminal.data.cursor).toBeUndefined()
 
       const trimmed = await agent.app.bsky.feed.searchPosts(
@@ -157,7 +173,9 @@ describe('appview search', () => {
         ),
       ).rejects.toThrow('Request forbidden by administrative rules.')
 
-      const terminal = await agent.app.bsky.feed.searchPostsV2(
+      // The tagged post sits between the two visible ones, so the first page
+      // holds one of the two requested. That is already half of the limit.
+      const short = await agent.app.bsky.feed.searchPostsV2(
         { query: 'doggo', sort: 'top', limit: 2 },
         {
           headers: {
@@ -169,9 +187,31 @@ describe('appview search', () => {
           },
         },
       )
-      expect(terminal.data.posts.map((post) => post.uri)).toEqual(
-        nonTaggedResults,
+      expect(short.data.posts.map((post) => post.uri)).toEqual([
+        nonTaggedResults[0],
+      ])
+      expect(short.data.cursor).toBeDefined()
+
+      const terminal = await agent.app.bsky.feed.searchPostsV2(
+        {
+          query: 'doggo',
+          sort: 'top',
+          limit: 2,
+          cursor: short.data.cursor,
+        },
+        {
+          headers: {
+            ...(await network.serviceHeaders(
+              carol,
+              ids.AppBskyFeedSearchPostsV2,
+            )),
+            ...override,
+          },
+        },
       )
+      expect(terminal.data.posts.map((post) => post.uri)).toEqual([
+        nonTaggedResults[1],
+      ])
       expect(terminal.data.cursor).toBeUndefined()
 
       const trimmed = await agent.app.bsky.feed.searchPostsV2(

--- a/packages/bsky/tests/views/starter-packs.test.ts
+++ b/packages/bsky/tests/views/starter-packs.test.ts
@@ -379,19 +379,30 @@ describe('starter packs', () => {
     })
 
     it('refills through an empty filtered intermediate page', async () => {
-      const { data } = await agent.app.bsky.graph.searchStarterPacks(
-        { q: 'starter', limit: 2 },
-        {
-          headers: await network.serviceHeaders(
-            sc.dids.frankie,
-            ids.AppBskyGraphSearchStarterPacks,
-          ),
-        },
+      const headers = await network.serviceHeaders(
+        sc.dids.frankie,
+        ids.AppBskyGraphSearchStarterPacks,
       )
-      expect(data.starterPacks).toMatchObject([
+
+      // Only sp4 survives the creator block, and it is already half of the
+      // requested limit, so the page is served with a cursor.
+      const short = await agent.app.bsky.graph.searchStarterPacks(
+        { q: 'starter', limit: 2 },
+        { headers },
+      )
+      expect(short.data.starterPacks).toMatchObject([
         expect.objectContaining({ uri: sp4.uriStr }),
       ])
-      expect(data.cursor).toBeUndefined()
+      expect(short.data.cursor).toBeDefined()
+
+      // The remaining starter packs are all filtered out, so refilling walks
+      // every following page and returns nothing.
+      const terminal = await agent.app.bsky.graph.searchStarterPacks(
+        { q: 'starter', limit: 2, cursor: short.data.cursor },
+        { headers },
+      )
+      expect(terminal.data.starterPacks).toEqual([])
+      expect(terminal.data.cursor).toBeUndefined()
     })
   })
 
@@ -470,19 +481,30 @@ describe('starter packs', () => {
     })
 
     it('refills through an empty filtered intermediate page', async () => {
-      const { data } = await agent.app.bsky.graph.searchStarterPacksV2(
-        { q: 'starter', limit: 2 },
-        {
-          headers: await network.serviceHeaders(
-            sc.dids.frankie,
-            ids.AppBskyGraphSearchStarterPacksV2,
-          ),
-        },
+      const headers = await network.serviceHeaders(
+        sc.dids.frankie,
+        ids.AppBskyGraphSearchStarterPacksV2,
       )
-      expect(data.starterPacks).toMatchObject([
+
+      // Only sp4 survives the creator block, and it is already half of the
+      // requested limit, so the page is served with a cursor.
+      const short = await agent.app.bsky.graph.searchStarterPacksV2(
+        { q: 'starter', limit: 2 },
+        { headers },
+      )
+      expect(short.data.starterPacks).toMatchObject([
         expect.objectContaining({ uri: sp4.uriStr }),
       ])
-      expect(data.cursor).toBeUndefined()
+      expect(short.data.cursor).toBeDefined()
+
+      // The remaining starter packs are all filtered out, so refilling walks
+      // every following page and returns nothing.
+      const terminal = await agent.app.bsky.graph.searchStarterPacksV2(
+        { q: 'starter', limit: 2, cursor: short.data.cursor },
+        { headers },
+      )
+      expect(terminal.data.starterPacks).toEqual([])
+      expect(terminal.data.cursor).toBeUndefined()
     })
   })
 

--- a/packages/bsky/tests/views/suggestions.test.ts
+++ b/packages/bsky/tests/views/suggestions.test.ts
@@ -74,12 +74,26 @@ describe('pds user search views', () => {
         ),
       },
     )
-    expect(result1.data.actors.length).toBe(2)
+    expect(result1.data.actors.length).toBe(1)
     expect(result1.data.actors[0].handle).toEqual('bob.test')
-    expect(result1.data.actors[1].handle).toEqual('dan.test')
     expect(result1.data.cursor).toBeDefined()
 
-    const terminal = await agent.api.app.bsky.actor.getSuggestions(
+    const result2 = await agent.api.app.bsky.actor.getSuggestions(
+      { limit: 2, cursor: result1.data.cursor },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.carol,
+          ids.AppBskyActorGetSuggestions,
+        ),
+      },
+    )
+    expect(result2.data.actors.length).toBe(1)
+    expect(result2.data.actors[0].handle).toEqual('dan.test')
+
+    // Two of the three requested actors survive filtering, which is already
+    // half of the limit, so the page is served with a cursor even though
+    // following it yields nothing.
+    const short = await agent.api.app.bsky.actor.getSuggestions(
       { limit: 3 },
       {
         headers: await network.serviceHeaders(
@@ -88,7 +102,19 @@ describe('pds user search views', () => {
         ),
       },
     )
-    expect(terminal.data.actors).toHaveLength(2)
+    expect(short.data.actors).toHaveLength(2)
+    expect(short.data.cursor).toBeDefined()
+
+    const terminal = await agent.api.app.bsky.actor.getSuggestions(
+      { limit: 3, cursor: short.data.cursor },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.carol,
+          ids.AppBskyActorGetSuggestions,
+        ),
+      },
+    )
+    expect(terminal.data.actors).toHaveLength(0)
     expect(terminal.data.cursor).toBeUndefined()
 
     const empty = await agent.api.app.bsky.actor.getSuggestions(


### PR DESCRIPTION
Follow-up to #5375. After that rolled out, `bsky.GetNotifications`, `bsky.GetNotificationSeen` and `bsky.GetTimeline` showed a relevant increase in calls, since `fillPage()` re-runs the whole pipeline up to 10 times per request.

Two changes:

1. `fillPage()` stops refilling once the page holds half of the requested limit (`Math.ceil(limit / 2)`), instead of trying to fill it completely. It still returns a cursor, which is the canonical way of saying there is a next page, so clients that keep paginating get the rest.
2. `listNotifications()` reads the viewer's priority setting (`GetActors`, cache bypassed) and last-seen time (`GetNotificationSeen`) once per request instead of once per page. Neither value changes across the pages `fillPage()` fetches, so those calls were pure amplification.

`isRead` behavior is unchanged. The last-seen fallback (when the viewer has no stored seen timestamp, use the first notification's timestamp) only ever applied to the cursorless first page, and refill pages always carry a cursor, so they were already reported as read.

## Test changes

The heuristic means a request no longer guarantees a full page, so the assertions from #5375 that proved refilling had to change. Most are now an explicit short page plus a follow-up request with the cursor, asserting the remaining items are reachable.

Full bsky suite passes.