### PR TITLE
bsky: cancel outgoing requests when caller disconnects

### DIFF
--- a/.changeset/bsky-cancel-outbound-on-disconnect.md
+++ b/.changeset/bsky-cancel-outbound-on-disconnect.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Abort upstream calls made by read endpoints when the client disconnects. Feed, search, and suggestion queries now forward the request's cancellation signal to their outbound calls, so a caller hanging up no longer leaves those requests running.

--- a/.changeset/xrpc-server-cancel-on-disconnect.md
+++ b/.changeset/xrpc-server-cancel-on-disconnect.md
@@ -1,0 +1,5 @@
+---
+'@atproto/xrpc-server': minor
+---
+
+Cancel in-flight query handlers when the client disconnects. Queries now receive an `AbortSignal` on the handler context that fires when the caller hangs up, so upstream work can be aborted instead of held open. This applies to queries, not procedures.

--- a/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
+++ b/packages/bsky/src/api/app/bsky/actor/getSuggestions.ts
@@ -23,7 +23,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.actor.getSuggestions, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ params, auth, req }) => {
+    handler: async ({ params, auth, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ viewer, labelers })
@@ -38,7 +38,7 @@ export default function (server: Server, ctx: AppContext) {
         limit: params.limit,
         fetch: ({ cursor, limit }) =>
           getSuggestions(
-            { ...params, cursor, limit, hydrateCtx, headers },
+            { ...params, cursor, limit, hydrateCtx, headers, signal },
             ctx,
           ),
         items: (r) => r.actors,
@@ -70,6 +70,7 @@ const skeleton = async (input: {
       app.bsky.unspecced.getSuggestionsSkeleton,
       {
         headers: params.headers,
+        signal: params.signal,
         params: {
           relativeToDid: viewer,
           viewer: viewer ?? undefined,
@@ -158,6 +159,7 @@ type Context = {
 type Params = app.bsky.actor.getSuggestions.$Params & {
   hydrateCtx: HydrateCtx
   headers: HeadersMap
+  signal: AbortSignal
 }
 
 type Skeleton = {

--- a/packages/bsky/src/api/app/bsky/actor/searchActors.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActors.ts
@@ -28,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.actor.searchActors, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const { viewer, includeTakedowns, skipViewerBlocks } =
         ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
@@ -54,6 +54,7 @@ export default function (server: Server, ctx: AppContext) {
               cursor,
               limit,
               hydrateCtx,
+              signal,
               isV2Override: resolveSearchV2Override(req, ctx.cfg),
             },
             ctx,
@@ -88,6 +89,7 @@ const skeletonV1 = async (
         limit: params.limit,
         viewer: params.hydrateCtx.viewer ?? undefined,
       },
+      { signal: params.signal },
     )
     return {
       dids: res.actors.map(({ did }) => did as DidString),
@@ -175,6 +177,7 @@ type Context = {
 
 type Params = app.bsky.actor.searchActors.$Params & {
   hydrateCtx: HydrateCtx
+  signal: AbortSignal
   isV2Override: boolean
 }
 

--- a/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
+++ b/packages/bsky/src/api/app/bsky/actor/searchActorsTypeahead.ts
@@ -27,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.actor.searchActorsTypeahead, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ params, auth, req }) => {
+    handler: async ({ params, auth, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -44,6 +44,7 @@ export default function (server: Server, ctx: AppContext) {
         {
           ...params,
           hydrateCtx,
+          signal,
           isV2Override: resolveSearchV2Override(req, ctx.cfg),
         },
         ctx,
@@ -76,6 +77,7 @@ const skeletonV1 = async (
         limit: params.limit,
         viewer: params.hydrateCtx.viewer ?? undefined,
       },
+      { signal: params.signal },
     )
     return {
       dids: actors.map(({ did }) => did),
@@ -162,6 +164,7 @@ type Context = {
 
 type Params = app.bsky.actor.searchActorsTypeahead.$Params & {
   hydrateCtx: HydrateCtx
+  signal: AbortSignal
   isV2Override: boolean
 }
 

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -51,7 +51,7 @@ export default function (server: Server, ctx: AppContext) {
       },
       skipAudCheck: true,
     }),
-    handler: async ({ params, auth, req }) => {
+    handler: async ({ params, auth, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -72,7 +72,10 @@ export default function (server: Server, ctx: AppContext) {
       // @NOTE feed cursors should not be affected by appview swap
       // Do not refill filtered pages. Overfetching from algorithmic feeds can
       // advance their state and prevent omitted items from appearing later.
-      const result = await getFeed({ ...params, hydrateCtx, headers }, ctx)
+      const result = await getFeed(
+        { ...params, hydrateCtx, headers, signal },
+        ctx,
+      )
       const {
         timerSkele,
         timerHydr,
@@ -182,6 +185,7 @@ type Context = AppContext
 type Params = app.bsky.feed.getFeed.$Params & {
   hydrateCtx: HydrateCtx
   headers: HeadersMap
+  signal: AbortSignal
 }
 
 type Skeleton = {
@@ -283,7 +287,7 @@ const skeletonFromFeedGen = async (
   // @TODO currently passthrough auth headers from pds
   const result = await xrpcSafe(endpoint, app.bsky.feed.getFeedSkeleton, {
     strictResponseProcessing: false,
-    signal: AbortSignal.timeout(10_000),
+    signal: AbortSignal.any([params.signal, AbortSignal.timeout(10_000)]),
     headers,
     params: {
       feed: params.feed,

--- a/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
+++ b/packages/bsky/src/api/app/bsky/feed/searchPosts.ts
@@ -36,7 +36,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.feed.searchPosts, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const { viewer, isModService, skipViewerBlocks } =
         ctx.authVerifier.parseCreds(auth)
 
@@ -62,6 +62,7 @@ export default function (server: Server, ctx: AppContext) {
               cursor,
               limit,
               hydrateCtx,
+              signal,
               isModService,
               isV2Override: resolveSearchV2Override(req, ctx.cfg),
             },
@@ -105,6 +106,7 @@ const skeletonV1 = async (
         url: params.url,
         viewer: params.hydrateCtx.viewer ?? undefined,
       },
+      { signal: params.signal },
     )
     return {
       posts: res.posts.map(({ uri }) => uri as AtUriString),
@@ -272,6 +274,7 @@ type Context = {
 
 type Params = app.bsky.feed.searchPosts.$Params & {
   hydrateCtx: HydrateCtx
+  signal: AbortSignal
   isModService: boolean
   isV2Override: boolean
 }

--- a/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getSuggestedFollowsByActor.ts
@@ -28,7 +28,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.graph.getSuggestedFollowsByActor, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -58,7 +58,7 @@ export default function (server: Server, ctx: AppContext) {
       })
 
       const { contentLanguage, ...body } = await getSuggestedFollowsByActor(
-        { ...params, hydrateCtx, headers },
+        { ...params, hydrateCtx, headers, signal },
         ctx,
       )
 
@@ -97,6 +97,7 @@ const skeleton = async (
         relativeToDid,
       },
       headers: params.headers,
+      signal: params.signal,
     },
   )
 
@@ -162,6 +163,7 @@ type Context = {
 type Params = app.bsky.graph.getSuggestedFollowsByActor.$Params & {
   hydrateCtx: HydrateCtx
   headers: HeadersMap
+  signal: AbortSignal
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/graph/searchStarterPacks.ts
@@ -29,7 +29,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.graph.searchStarterPacks, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const { viewer, includeTakedowns, skipViewerBlocks } =
         ctx.authVerifier.parseCreds(auth)
       const labelers = ctx.reqLabelers(req)
@@ -55,6 +55,7 @@ export default function (server: Server, ctx: AppContext) {
               cursor,
               limit,
               hydrateCtx,
+              signal,
               isV2Override: resolveSearchV2Override(req, ctx.cfg),
             },
             ctx,
@@ -86,6 +87,7 @@ const skeletonV1 = async (
         limit: params.limit,
         viewer: params.hydrateCtx.viewer ?? undefined,
       },
+      { signal: params.signal },
     )
     return {
       uris: res.starterPacks.map(({ uri }) => uri),
@@ -174,6 +176,7 @@ type Context = {
 
 type Params = app.bsky.graph.searchStarterPacks.$Params & {
   hydrateCtx: HydrateCtx
+  signal: AbortSignal
   isV2Override: boolean
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getOnboardingSuggestedStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getOnboardingSuggestedStarterPacks.ts
@@ -27,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getOnboardingSuggestedStarterPacks, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
@@ -42,6 +42,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -66,7 +67,7 @@ const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (
   const skeleton = await ctx.topicsClient.call(
     app.bsky.unspecced.getOnboardingSuggestedStarterPacksSkeleton,
     { limit: params.limit, viewer: params.hydrateCtx.viewer ?? undefined },
-    { headers: params.headers },
+    { headers: params.headers, signal: params.signal },
   )
 
   // @TODO Make sure upstream always provides this
@@ -138,6 +139,7 @@ type Context = {
 type Params = app.bsky.unspecced.getOnboardingSuggestedStarterPacks.$Params & {
   hydrateCtx: HydrateCtx
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState =

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedFeeds.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedFeeds.ts
@@ -17,7 +17,7 @@ export default function (server: Server, ctx: AppContext) {
   const getFeeds = createPipeline(skeleton, hydration, noRules, presentation)
   server.add(app.bsky.unspecced.getSuggestedFeeds, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
@@ -32,6 +32,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -61,6 +62,7 @@ const skeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -93,6 +95,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedFeeds.$Params & {
   hydrateCtx: HydrateCtx
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedOnboardingUsers.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedOnboardingUsers.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedOnboardingUsers, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -44,6 +44,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -70,6 +71,7 @@ const skeleton = async (input: SkeletonFnInput<Context, Params>) => {
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -133,6 +135,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedOnboardingUsers.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
   category?: string
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedStarterPacks.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedStarterPacks.ts
@@ -27,7 +27,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedStarterPacks, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
@@ -42,6 +42,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -71,6 +72,7 @@ const skeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 
@@ -140,6 +142,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedStarterPacks.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsers.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedUsers, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -50,6 +50,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -79,6 +80,7 @@ const skeletonFromDiscover = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -102,6 +104,7 @@ const skeletonFromTopics = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -173,6 +176,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedUsers.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
   category?: string
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForDiscover.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForDiscover.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedUsersForDiscover, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -47,6 +47,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -74,6 +75,7 @@ const skeletonFromGetSuggestedUsersSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -96,6 +98,7 @@ const skeletonFromGetSuggestedUsersForDiscoverSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -167,6 +170,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedUsersForDiscover.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForExplore.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForExplore.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedUsersForExplore, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -47,6 +47,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -75,6 +76,7 @@ const skeletonFromGetSuggestedUsersSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -98,6 +100,7 @@ const skeletonFromGetSuggestedUsersForExploreSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -169,6 +172,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedUsersForExplore.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
   category?: string
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForSeeMore.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getSuggestedUsersForSeeMore.ts
@@ -26,7 +26,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getSuggestedUsersForSeeMore, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
@@ -47,6 +47,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -75,6 +76,7 @@ const skeletonFromGetSuggestedUsersSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -98,6 +100,7 @@ const skeletonFromGetSuggestedUsersForSeeMoreSkeleton = async (
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -169,6 +172,7 @@ type Context = {
 type Params = app.bsky.unspecced.getSuggestedUsersForSeeMore.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
   category?: string
 }
 

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrendingTopics.ts
@@ -22,7 +22,7 @@ export default function (server: Server, ctx: AppContext) {
   )
   server.add(app.bsky.unspecced.getTrendingTopics, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
@@ -34,6 +34,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -61,6 +62,7 @@ const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 }
@@ -91,6 +93,7 @@ type Context = {
 type Params = Omit<app.bsky.unspecced.getTrendingTopics.$Params, 'viewer'> & {
   hydrateCtx: HydrateCtx
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState = app.bsky.unspecced.getTrendingTopics.$OutputBody

--- a/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getTrends.ts
@@ -21,7 +21,7 @@ export default function (server: Server, ctx: AppContext) {
   const getTrends = createPipeline(skeleton, hydration, noBlocks, presentation)
   server.add(app.bsky.unspecced.getTrends, {
     auth: ctx.authVerifier.standardOptional,
-    handler: async ({ auth, params, req }) => {
+    handler: async ({ auth, params, req, signal }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
@@ -36,6 +36,7 @@ export default function (server: Server, ctx: AppContext) {
           ...params,
           hydrateCtx,
           headers,
+          signal,
         },
         ctx,
       )
@@ -63,6 +64,7 @@ const skeleton: SkeletonFn<Context, Params, SkeletonState> = async (input) => {
     },
     {
       headers: params.headers,
+      signal: params.signal,
     },
   )
 
@@ -142,6 +144,7 @@ type Context = {
 type Params = app.bsky.unspecced.getTrendingTopics.$Params & {
   hydrateCtx: HydrateCtx & { viewer: string | null }
   headers: Record<string, string>
+  signal: AbortSignal
 }
 
 type SkeletonState = app.bsky.unspecced.getTrendsSkeleton.$OutputBody

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -537,11 +537,16 @@ export class Server {
           next(XRPCError.fromError(output))
         }
       } catch (err: unknown) {
-        // A client disconnect aborts the controller: the rejection is expected
-        // and the socket is already closed, so skip the error response/logging.
+        // Once the client has disconnected the socket is closed and no
+        // response is deliverable, so we don't forward the rejection. We key on
+        // the abort flag rather than the error's type on purpose: cancellation
+        // surfaces in different shapes (fetch AbortError, Connect-RPC "canceled"
+        // ConnectError, ...) and matching on one would miss the others. The
+        // error is still logged so a genuine error racing with a disconnect
+        // leaves a trace rather than vanishing.
         if (controller.signal.aborted) {
           log.info(
-            { method: req.method, url: req.url },
+            { method: req.method, url: req.url, err },
             'request aborted after client disconnect',
           )
           return

--- a/packages/xrpc-server/src/server.ts
+++ b/packages/xrpc-server/src/server.ts
@@ -378,6 +378,9 @@ export class Server {
         await this.globalRateLimiter.handle({
           req,
           res,
+          // The rate limiter does not use the signal; supply a non-aborting one
+          // to satisfy the handler context shape.
+          signal: new AbortController().signal,
           auth: undefined,
           params: {},
           input: undefined,
@@ -446,6 +449,21 @@ export class Server {
     validateResOutput: null | OutputVerifierInternal<O>,
   ): RequestHandler {
     return async function (req, res, next) {
+      const controller = new AbortController()
+      // Only queries (GET) are cancelled when the client disconnects.
+      // Procedures may modify state, so a mid-flight abort could leave it
+      // half-applied; let those run to completion.
+      const onClose =
+        req.method === 'GET'
+          ? () => {
+              if (!res.writableFinished) controller.abort()
+            }
+          : undefined
+      if (onClose) {
+        // 'close' won't replay for a late listener; if already closed, abort now.
+        if (res.destroyed) onClose()
+        else res.once('close', onClose)
+      }
       try {
         // parse & validate params
         const params = paramsVerifier(req)
@@ -464,6 +482,7 @@ export class Server {
           auth,
           req,
           res,
+          signal: controller.signal,
           resetRouteRateLimits: async () => routeLimiter?.reset(ctx),
         }
 
@@ -518,6 +537,15 @@ export class Server {
           next(XRPCError.fromError(output))
         }
       } catch (err: unknown) {
+        // A client disconnect aborts the controller: the rejection is expected
+        // and the socket is already closed, so skip the error response/logging.
+        if (controller.signal.aborted) {
+          log.info(
+            { method: req.method, url: req.url },
+            'request aborted after client disconnect',
+          )
+          return
+        }
         // Express will not call the next middleware (errorMiddleware in this case)
         // if the value passed to next is false-y (e.g. null, undefined, 0).
         // Hence we replace it with an InternalServerError.
@@ -526,6 +554,8 @@ export class Server {
         } else {
           next(err)
         }
+      } finally {
+        if (onClose) res.off('close', onClose)
       }
     }
   }

--- a/packages/xrpc-server/src/types.ts
+++ b/packages/xrpc-server/src/types.ts
@@ -117,6 +117,7 @@ export type HandlerContext<
 > = MethodAuthContext<P> & {
   auth: A
   input: I
+  signal: AbortSignal
   resetRouteRateLimits: () => Promise<void>
 }
 

--- a/packages/xrpc-server/tests/queries.test.ts
+++ b/packages/xrpc-server/tests/queries.test.ts
@@ -1,4 +1,5 @@
-import type * as http from 'node:http'
+import { once } from 'node:events'
+import * as http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import type { LexiconDoc } from '@atproto/lexicon'
 import { XrpcClient } from '@atproto/xrpc'
@@ -9,6 +10,14 @@ import {
   closeServer,
   createServer,
 } from './_util.js'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
 
 const LEXICONS = [
   {
@@ -70,6 +79,30 @@ const LEXICONS = [
       },
     },
   },
+  {
+    lexicon: 1,
+    id: 'io.example.postPing',
+    defs: {
+      main: {
+        type: 'procedure',
+        input: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: { message: { type: 'string' } },
+          },
+        },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            required: ['message'],
+            properties: { message: { type: 'string' } },
+          },
+        },
+      },
+    },
+  },
 ] as const satisfies LexiconDoc[]
 
 const handlers = {
@@ -87,6 +120,12 @@ const handlers = {
       encoding: 'application/json',
       body: { message: ctx.params.message },
       headers: { 'x-test-header-name': 'test-value' },
+    }
+  },
+  'io.example.postPing': () => {
+    return {
+      encoding: 'application/json',
+      body: { message: 'pong' },
     }
   },
 }
@@ -135,6 +174,90 @@ for (const buildServer of [buildMethodLexicons, buildAddLexicons]) {
       )
       expect(res.data?.message).toBe('hello world')
       expect(res.headers['x-test-header-name']).toEqual('test-value')
+    })
+
+    test('aborts the handler signal when the client disconnects', async () => {
+      let handlerSignal: AbortSignal | undefined
+      const started = deferred<void>()
+      const aborted = deferred<void>()
+      const server = await buildServer(LEXICONS, {
+        ...handlers,
+        'io.example.pingOne': async (ctx: xrpcServer.HandlerContext) => {
+          handlerSignal = ctx.signal
+          ctx.signal.addEventListener('abort', () => aborted.resolve(), {
+            once: true,
+          })
+          started.resolve()
+          await aborted.promise
+          return { encoding: 'text/plain', body: ctx.params.message }
+        },
+      })
+      await using localServer = await createServer(server)
+      const { port } = localServer.address() as AddressInfo
+      const request = http.get(
+        `http://localhost:${port}/xrpc/io.example.pingOne?message=hello`,
+      )
+      request.on('error', () => {})
+
+      await started.promise
+      expect(handlerSignal?.aborted).toBe(false)
+      request.destroy()
+      await aborted.promise
+      expect(handlerSignal?.aborted).toBe(true)
+    })
+
+    test('does not abort the handler signal after a completed response', async () => {
+      let handlerSignal: AbortSignal | undefined
+      const server = await buildServer(LEXICONS, {
+        ...handlers,
+        'io.example.pingOne': (ctx: xrpcServer.HandlerContext) => {
+          handlerSignal = ctx.signal
+          return { encoding: 'text/plain', body: ctx.params.message }
+        },
+      })
+      await using localServer = await createServer(server)
+      const { port } = localServer.address() as AddressInfo
+      const response = await new Promise<http.IncomingMessage>((resolve) => {
+        http.get(
+          `http://localhost:${port}/xrpc/io.example.pingOne?message=hello`,
+          resolve,
+        )
+      })
+      response.resume()
+      await once(response, 'end')
+
+      expect(handlerSignal?.aborted).toBe(false)
+    })
+
+    test('does not abort a procedure when the client disconnects', async () => {
+      let handlerSignal: AbortSignal | undefined
+      const started = deferred<void>()
+      const proceed = deferred<void>()
+      const server = await buildServer(LEXICONS, {
+        ...handlers,
+        'io.example.postPing': async (ctx: xrpcServer.HandlerContext) => {
+          handlerSignal = ctx.signal
+          started.resolve()
+          await proceed.promise
+          return { encoding: 'application/json', body: { message: 'pong' } }
+        },
+      })
+      await using localServer = await createServer(server)
+      const { port } = localServer.address() as AddressInfo
+      const request = http.request(
+        `http://localhost:${port}/xrpc/io.example.postPing`,
+        { method: 'POST', headers: { 'content-type': 'application/json' } },
+      )
+      request.on('error', () => {})
+      request.end(JSON.stringify({ message: 'hello' }))
+
+      await started.promise
+      expect(handlerSignal?.aborted).toBe(false)
+      request.destroy()
+      // Give the 'close' event a chance to fire before asserting.
+      await new Promise((r) => setTimeout(r, 50))
+      expect(handlerSignal?.aborted).toBe(false)
+      proceed.resolve()
     })
   })
 }


### PR DESCRIPTION
When a client hangs up mid-request, the appview kept its upstream calls running to completion — holding a request slot open on work whose result can no longer be delivered. A slow or unreachable upstream host could then tie up slots across the fleet.

- xrpc-server now provides an `AbortSignal` on the query handler context that fires when the caller disconnects.
- Cancellation is scoped to queries. Procedures run to completion so a disconnect can't leave a write half-applied.
- The appview's feed, search, and suggestion read handlers forward that signal to their outbound calls, so those requests are aborted when the caller leaves.

Read handlers that reach the dataplane over Connect-RPC aren't wired up here. Threading the signal through there is a larger change, so it's deferred as a follow-up.