### PR TITLE
Ozone-side strike application and account cascade

### DIFF
--- a/.changeset/calm-ospreys-strike.md
+++ b/.changeset/calm-ospreys-strike.md
@@ -1,0 +1,6 @@
+---
+'@atproto/api': minor
+'@atproto/ozone': minor
+---
+
+Add opt-in server-side strike calculation and transactional account cascades for moderation takedowns.

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -417,6 +417,10 @@
           "type": "string",
           "format": "datetime",
           "description": "When the strike should expire. If not provided, the strike never expires."
+        },
+        "applyStrikes": {
+          "type": "boolean",
+          "description": "If true, Ozone calculates strikes and any account-level cascade from its instance settings."
         }
       }
     },

--- a/packages/ozone/src/api/moderation/emitEvent.ts
+++ b/packages/ozone/src/api/moderation/emitEvent.ts
@@ -27,7 +27,15 @@ import {
 import type { HandlerInput } from '../../lexicon/types/tools/ozone/moderation/emitEvent.js'
 import { httpLogger } from '../../logger.js'
 import { processReportAction } from '../../mod-service/report.js'
-import { subjectFromInput } from '../../mod-service/subject.js'
+import { RepoSubject, subjectFromInput } from '../../mod-service/subject.js'
+import type {
+  SeverityLevelConfig,
+  StrikeThresholds,
+} from '../../mod-service/strike.js'
+import {
+  SeverityLevelSettingKey,
+  StrikeThresholdSettingKey,
+} from '../../setting/constants.js'
 import type { SettingService } from '../../setting/service.js'
 import { TagService } from '../../tag-service/index.js'
 import { getTagForReport } from '../../tag-service/util.js'
@@ -55,12 +63,29 @@ const handleModerationEvent = async ({
   const { event, externalId } = input.body
   const isAcknowledgeEvent = isModEventAcknowledge(event)
   const isTakedownEvent = isModEventTakedown(event)
+  const takedownEvent = isTakedownEvent ? event : undefined
   const isReverseTakedownEvent = isModEventReverseTakedown(event)
   const isLabelEvent = isModEventLabel(event)
   const subject = subjectFromInput(
     input.body.subject,
     input.body.subjectBlobCids,
   )
+
+  if (takedownEvent?.applyStrikes) {
+    if (!takedownEvent.severityLevel || !takedownEvent.policies?.length) {
+      throw new InvalidRequestError(
+        'applyStrikes requires severityLevel and policies',
+      )
+    }
+    if (
+      takedownEvent.strikeCount !== undefined ||
+      takedownEvent.strikeExpiresAt !== undefined
+    ) {
+      throw new InvalidRequestError(
+        'applyStrikes cannot be combined with strikeCount or strikeExpiresAt',
+      )
+    }
+  }
 
   if (isAgeAssuranceEvent(event) && !subject.isRepo()) {
     throw new InvalidRequestError('Invalid subject type')
@@ -225,6 +250,10 @@ const handleModerationEvent = async ({
 
   const moderationEvent = await db.transaction(async (dbTxn) => {
     const moderationTxn = ctx.modService(dbTxn)
+    const strikeTxn = ctx.strikeService(dbTxn)
+    let strikeCascade:
+      | { duration: number | null | undefined; needsTakedown: boolean }
+      | undefined
 
     if (externalId) {
       const existingEvent = await moderationTxn.getEventByExternalId(
@@ -256,12 +285,59 @@ const handleModerationEvent = async ({
       }
     }
 
+    if (takedownEvent?.applyStrikes) {
+      await strikeTxn.lockSubject(subject.did)
+      const settings = await ctx.settingService(dbTxn).query({
+        scope: 'instance',
+        did: ctx.cfg.service.did,
+        keys: [SeverityLevelSettingKey, StrikeThresholdSettingKey],
+        limit: 2,
+      })
+      const severityLevels = settings.options.find(
+        (option) => option.key === SeverityLevelSettingKey,
+      )?.value as Record<string, SeverityLevelConfig> | undefined
+      const thresholds = settings.options.find(
+        (option) => option.key === StrikeThresholdSettingKey,
+      )?.value as StrikeThresholds | undefined
+      const severityConfig = severityLevels?.[takedownEvent.severityLevel!]
+      if (!severityConfig) {
+        throw new InvalidRequestError(
+          `Unknown severity level: ${takedownEvent.severityLevel}`,
+        )
+      }
+      if (!thresholds) {
+        throw new InvalidRequestError('Strike thresholds are not configured')
+      }
+
+      const previous = await strikeTxn.getActiveStrikeCount(subject.did)
+      const computed = await strikeTxn.computeStrike({
+        subjectDid: subject.did,
+        policies: takedownEvent.policies!,
+        severityLevel: takedownEvent.severityLevel!,
+        config: severityConfig,
+        createdAt: new Date(),
+      })
+      takedownEvent.strikeCount = computed.strikeCount
+      takedownEvent.strikeExpiresAt = computed.strikeExpiresAt
+      strikeCascade = {
+        duration: computed.needsTakedown
+          ? null
+          : strikeTxn.getCrossedThreshold({
+              previous,
+              current: previous + computed.strikeCount,
+              thresholds,
+            }),
+        needsTakedown: computed.needsTakedown,
+      }
+    }
+
     const result = await moderationTxn.logEvent({
       event,
       subject,
       createdBy,
       modTool: input.body.modTool,
       externalId,
+      requireStrikeUpdate: !!takedownEvent?.applyStrikes,
     })
 
     // Update reports if reportAction was provided
@@ -329,6 +405,72 @@ const handleModerationEvent = async ({
         )
       } else if (isReverseTakedownEvent) {
         await moderationTxn.reverseTakedownRecord(subject)
+      }
+    }
+
+    const shouldCascade =
+      subject.isRecord() &&
+      strikeCascade &&
+      (strikeCascade.needsTakedown || strikeCascade.duration !== undefined)
+    if (shouldCascade) {
+      const cascadeDecision = strikeCascade!
+      const repoSubject = new RepoSubject(subject.did)
+      const accountStatus = await moderationTxn.getStatus(repoSubject)
+      const duration = cascadeDecision.needsTakedown
+        ? null
+        : cascadeDecision.duration!
+      const proposedExpiry =
+        duration === null
+          ? null
+          : new Date(Date.now() + duration * 60 * 60 * 1000).toISOString()
+      const isPermanent =
+        accountStatus?.takendown && !accountStatus.suspendUntil
+      const extendsSuspension =
+        !!accountStatus?.suspendUntil &&
+        (proposedExpiry === null || proposedExpiry > accountStatus.suspendUntil)
+
+      if (!isPermanent && (!accountStatus?.takendown || extendsSuspension)) {
+        if (accountStatus?.takendown) {
+          await moderationTxn.logEvent({
+            event: {
+              $type: 'tools.ozone.moderation.defs#modEventReverseTakedown',
+              comment:
+                '[STRIKE_CASCADE]: Replacing an active suspension with a longer strike tier',
+            },
+            subject: repoSubject,
+            createdBy,
+            modTool: input.body.modTool,
+            additionalMeta: {
+              strikeCascade: true,
+              sourceEventId: result.event.id,
+            },
+          })
+          await moderationTxn.reverseTakedownRepo(repoSubject)
+        }
+
+        const cascade = await moderationTxn.logEvent({
+          event: {
+            $type: 'tools.ozone.moderation.defs#modEventTakedown',
+            comment: `[STRIKE_CASCADE]: Account action triggered by record event ${result.event.id}`,
+            durationInHours: duration ?? undefined,
+            policies: takedownEvent?.policies,
+            severityLevel: takedownEvent?.severityLevel,
+            targetServices: takedownEvent?.targetServices,
+          },
+          subject: repoSubject,
+          createdBy,
+          modTool: input.body.modTool,
+          additionalMeta: {
+            strikeCascade: true,
+            sourceEventId: result.event.id,
+          },
+        })
+        await moderationTxn.takedownRepo(
+          repoSubject,
+          cascade.event.id,
+          new Set(takedownEvent?.targetServices),
+          duration !== null,
+        )
       }
     }
 

--- a/packages/ozone/src/mod-service/index.ts
+++ b/packages/ozone/src/mod-service/index.ts
@@ -492,6 +492,8 @@ export class ModerationService {
     createdAt?: Date
     modTool?: ToolsOzoneModerationDefs.ModTool
     externalId?: string
+    additionalMeta?: Record<string, string | number | boolean>
+    requireStrikeUpdate?: boolean
   }): Promise<{
     event: ModerationEventRow
     subjectStatus: ModerationSubjectStatusRow | null
@@ -504,6 +506,8 @@ export class ModerationService {
       externalId,
       createdAt = new Date(),
       modTool,
+      additionalMeta,
+      requireStrikeUpdate = false,
     } = info
 
     const createLabelVals =
@@ -515,7 +519,9 @@ export class ModerationService {
         ? event.negateLabelVals.join(' ')
         : undefined
 
-    const meta: Record<string, string | number | boolean> = {}
+    const meta: Record<string, string | number | boolean> = {
+      ...additionalMeta,
+    }
 
     const addedTags = isModEventTag(event) ? jsonb(event.add) : null
     const removedTags = isModEventTag(event) ? jsonb(event.remove) : null
@@ -636,9 +642,8 @@ export class ModerationService {
 
     const subjectInfo = subject.info()
 
-    // Store severityLevel, strikeCount, and strikeExpiresAt if provided
-    // These values should be calculated by the client based on configuration
-    // processNewEvent will update the account_strike table with the new strike count
+    // Legacy callers provide strike values; applyStrikes callers have them
+    // calculated by Ozone before reaching this storage path.
     let severityLevel: string | null = null
     let strikeCount: number | null = null
     let strikeExpiresAt: string | null = null
@@ -742,6 +747,10 @@ export class ModerationService {
 
     // Updates are only needed if strikeCount is numeric (in some cases even 0)
     if (modEvent.strikeCount !== null) {
+      if (requireStrikeUpdate) {
+        await this.strikeService.updateSubjectStrikeCount(modEvent.subjectDid)
+        return { event: modEvent, subjectStatus }
+      }
       try {
         await this.strikeService.updateSubjectStrikeCount(modEvent.subjectDid)
       } catch (error) {

--- a/packages/ozone/src/mod-service/strike.ts
+++ b/packages/ozone/src/mod-service/strike.ts
@@ -1,4 +1,16 @@
+import { sql } from 'kysely'
+import { InvalidRequestError } from '@atproto/xrpc-server'
 import type { Database } from '../db/index.js'
+
+export type SeverityLevelConfig = {
+  strikeCount?: number
+  firstOccurrenceStrikeCount?: number
+  strikeOnOccurrence?: number
+  needsTakedown?: boolean
+  expiresInDays?: number
+}
+
+export type StrikeThresholds = Record<string, number | null>
 
 export type StrikeServiceCreator = (db: Database) => StrikeService
 
@@ -9,6 +21,115 @@ export class StrikeService {
     return (db: Database) => {
       return new StrikeService(db)
     }
+  }
+
+  async lockSubject(subjectDid: string): Promise<void> {
+    await sql`select pg_advisory_xact_lock(hashtext(${subjectDid}))`.execute(
+      this.db.db,
+    )
+  }
+
+  async getActiveStrikeCount(subjectDid: string): Promise<number> {
+    const now = new Date().toISOString()
+    const result = await this.db.db
+      .selectFrom('moderation_event')
+      .where('subjectDid', '=', subjectDid)
+      .where('strikeCount', 'is not', null)
+      .where((eb) =>
+        eb.or([
+          eb('strikeExpiresAt', 'is', null),
+          eb('strikeExpiresAt', '>', now),
+        ]),
+      )
+      .select((eb) => eb.fn.sum<number>('strikeCount').as('count'))
+      .executeTakeFirst()
+    return Number(result?.count ?? 0)
+  }
+
+  async computeStrike(input: {
+    subjectDid: string
+    policies: string[]
+    severityLevel: string
+    config: SeverityLevelConfig
+    createdAt: Date
+  }): Promise<{
+    strikeCount: number
+    strikeExpiresAt?: string
+    needsTakedown: boolean
+  }> {
+    const { subjectDid, policies, severityLevel, config, createdAt } = input
+    if (
+      !config.needsTakedown &&
+      config.strikeCount === undefined &&
+      config.firstOccurrenceStrikeCount === undefined
+    ) {
+      throw new InvalidRequestError(
+        `Severity level has no strike configuration: ${severityLevel}`,
+      )
+    }
+
+    const prior = await this.db.db
+      .selectFrom('moderation_event')
+      .where('subjectDid', '=', subjectDid)
+      .where('action', 'in', [
+        'tools.ozone.moderation.defs#modEventTakedown',
+        'tools.ozone.moderation.defs#modEventEmail',
+      ])
+      .where(sql<boolean>`meta->>'strikeCascade' is distinct from 'true'`)
+      .where((eb) =>
+        eb.or(
+          policies.map((policy) =>
+            eb(
+              sql<boolean>`${policy} = any(string_to_array(meta->>'policies', ','))`,
+              '=',
+              true,
+            ),
+          ),
+        ),
+      )
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .executeTakeFirstOrThrow()
+    const occurrence = Number(prior.count) + 1
+
+    let strikeCount = config.strikeCount ?? 0
+    if (occurrence === 1 && config.firstOccurrenceStrikeCount !== undefined) {
+      strikeCount = config.firstOccurrenceStrikeCount
+    } else if (
+      config.strikeOnOccurrence !== undefined &&
+      occurrence < config.strikeOnOccurrence
+    ) {
+      strikeCount = 0
+    }
+
+    const strikeExpiresAt =
+      config.expiresInDays !== undefined && config.expiresInDays > 0
+        ? new Date(
+            createdAt.getTime() + config.expiresInDays * 24 * 60 * 60 * 1000,
+          ).toISOString()
+        : undefined
+    return {
+      strikeCount: config.needsTakedown ? 0 : strikeCount,
+      strikeExpiresAt,
+      needsTakedown: !!config.needsTakedown,
+    }
+  }
+
+  getCrossedThreshold(input: {
+    previous: number
+    current: number
+    thresholds: StrikeThresholds
+  }): number | null | undefined {
+    const crossed = Object.entries(input.thresholds)
+      .map(([threshold, duration]) => ({
+        threshold: Number(threshold),
+        duration,
+      }))
+      .filter(
+        ({ threshold }) =>
+          input.previous < threshold && threshold <= input.current,
+      )
+      .sort((a, b) => b.threshold - a.threshold)[0]
+    return crossed?.duration
   }
 
   /**

--- a/packages/ozone/src/setting/constants.ts
+++ b/packages/ozone/src/setting/constants.ts
@@ -1,3 +1,4 @@
 export const ProtectedTagSettingKey = 'tools.ozone.setting.protectedTags'
 export const PolicyListSettingKey = 'tools.ozone.setting.policyList'
 export const SeverityLevelSettingKey = 'tools.ozone.setting.severityLevels'
+export const StrikeThresholdSettingKey = 'tools.ozone.setting.strikeThresholds'

--- a/packages/ozone/src/setting/validators.ts
+++ b/packages/ozone/src/setting/validators.ts
@@ -5,6 +5,7 @@ import {
   PolicyListSettingKey,
   ProtectedTagSettingKey,
   SeverityLevelSettingKey,
+  StrikeThresholdSettingKey,
 } from './constants.js'
 
 export const settingValidators = new Map<
@@ -326,6 +327,40 @@ export const settingValidators = new Map<
               `First occurrence strike count must be a non-negative integer for severity level ${key}`,
             )
           }
+        }
+      }
+    },
+  ],
+  [
+    StrikeThresholdSettingKey,
+    async (setting: Partial<Selectable<Setting>>) => {
+      if (setting.managerRole !== 'tools.ozone.team.defs#roleAdmin') {
+        throw new InvalidRequestError(
+          'Only admins should be able to manage strike thresholds',
+        )
+      }
+      if (
+        !setting.value ||
+        typeof setting.value !== 'object' ||
+        Array.isArray(setting.value)
+      ) {
+        throw new InvalidRequestError('Invalid value')
+      }
+      for (const [threshold, duration] of Object.entries(setting.value)) {
+        if (!/^[1-9]\d*$/.test(threshold)) {
+          throw new InvalidRequestError(
+            `Strike threshold must be a positive integer: ${threshold}`,
+          )
+        }
+        if (
+          duration !== null &&
+          (typeof duration !== 'number' ||
+            !Number.isInteger(duration) ||
+            duration < 1)
+        ) {
+          throw new InvalidRequestError(
+            `Strike threshold duration must be a positive integer or null: ${threshold}`,
+          )
         }
       }
     },

--- a/packages/ozone/tests/account-strikes.test.ts
+++ b/packages/ozone/tests/account-strikes.test.ts
@@ -6,7 +6,10 @@ import {
   basicSeed,
 } from '@atproto/dev-env'
 import { ids } from '../src/lexicon/lexicons.js'
-import { SeverityLevelSettingKey } from '../src/setting/constants.js'
+import {
+  SeverityLevelSettingKey,
+  StrikeThresholdSettingKey,
+} from '../src/setting/constants.js'
 import { forSnapshot } from './_util.js'
 
 const strikeConfig = {
@@ -50,6 +53,22 @@ describe('account-strikes', () => {
         ),
       },
     )
+    await agent.tools.ozone.setting.upsertOption(
+      {
+        scope: 'instance',
+        key: StrikeThresholdSettingKey,
+        value: { '3': 72, '6': 168, '9': null },
+        description: 'Account suspension tiers',
+        managerRole: 'tools.ozone.team.defs#roleAdmin',
+      },
+      {
+        encoding: 'application/json',
+        headers: await network.ozone.modHeaders(
+          ids.ToolsOzoneSettingUpsertOption,
+          'admin',
+        ),
+      },
+    )
   }
 
   beforeAll(async () => {
@@ -66,6 +85,58 @@ describe('account-strikes', () => {
 
   afterAll(async () => {
     await network?.close()
+  })
+
+  it('computes strikes and cascades a crossed threshold to the account', async () => {
+    for (const post of sc.posts[sc.dids.bob].slice(0, 2)) {
+      await modClient.emitEvent({
+        event: {
+          $type: 'tools.ozone.moderation.defs#modEventTakedown',
+          severityLevel: 'sev-2',
+          policies: ['spam-policy'],
+          applyStrikes: true,
+          comment: 'Automated record takedown',
+        },
+        subject: {
+          $type: 'com.atproto.repo.strongRef',
+          uri: post.ref.uriStr,
+          cid: post.ref.cidStr,
+        },
+      })
+    }
+
+    const statuses = await modClient.queryStatuses({ subject: sc.dids.bob })
+    expect(statuses.subjectStatuses[0].accountStrike?.activeStrikeCount).toBe(4)
+    expect(statuses.subjectStatuses[0].takendown).toBe(true)
+    expect(statuses.subjectStatuses[0].suspendUntil).toBeDefined()
+
+    const events = await modClient.queryEvents({
+      subject: sc.dids.bob,
+      includeAllUserRecords: true,
+    })
+    const cascade = events.events.find(
+      (item) =>
+        item.subject.$type === 'com.atproto.admin.defs#repoRef' &&
+        item.event.$type === 'tools.ozone.moderation.defs#modEventTakedown',
+    )
+    expect(cascade?.event.durationInHours).toBe(72)
+  })
+
+  it('rejects mixed server and client strike calculation', async () => {
+    await expect(
+      modClient.emitEvent({
+        event: {
+          $type: 'tools.ozone.moderation.defs#modEventTakedown',
+          severityLevel: 'sev-2',
+          policies: ['spam-policy'],
+          applyStrikes: true,
+          strikeCount: 2,
+        },
+        subject: repoSubject(sc.dids.carol),
+      }),
+    ).rejects.toThrow(
+      'applyStrikes cannot be combined with strikeCount or strikeExpiresAt',
+    )
   })
 
   it('tracks strikes and exposes them through queryStatuses and queryEvents', async () => {


### PR DESCRIPTION
Summary:
- calculate opted-in strikes server-side
- cascade threshold crossings to account actions transactionally
- add validated strike threshold settings

Follow-ups: indigo https://github.com/bluesky-social/indigo/pull/1448, tango https://github.com/bluesky-social/tango/pull/1471, osprey https://github.com/bluesky-social/osprey-atproto-internal/pull/323 and https://github.com/bluesky-social/osprey/pull/85

Tests: Ozone build; focused integration test added.

Merge/deploy order: 1/5 — merge and deploy Ozone first; seed strikeThresholds before enabling rules.