### PR TITLE
ozone/mod-inbox: `tools.ozone.inbox.appealActionedSubject`

### DIFF
--- a/.changeset/tidy-ravens-appeal.md
+++ b/.changeset/tidy-ravens-appeal.md
@@ -1,0 +1,6 @@
+---
+'@atproto/ozone': minor
+'@atproto/api': minor
+---
+
+Add an endpoint for creating moderation appeals linked to specific actions.

--- a/lexicons/tools/ozone/inbox/appealActionedSubject.json
+++ b/lexicons/tools/ozone/inbox/appealActionedSubject.json
@@ -1,0 +1,66 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.inbox.appealActionedSubject",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Appeal a moderation action affecting the user's account or content. Either actionId or subject is required.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "actionId": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Moderation action being appealed. Either this or subject is required."
+            },
+            "subject": {
+              "type": "union",
+              "refs": [
+                "com.atproto.admin.defs#repoRef",
+                "com.atproto.repo.strongRef"
+              ],
+              "description": "Subject being appealed. Either this or actionId is required."
+            },
+            "reason": {
+              "type": "string",
+              "maxGraphemes": 2000,
+              "maxLength": 20000,
+              "description": "Optional explanation supplied by the user."
+            },
+            "modTool": {
+              "type": "ref",
+              "ref": "com.atproto.moderation.createReport#modTool"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "tools.ozone.inbox.defs#subjectView"
+        }
+      },
+      "errors": [
+        {
+          "name": "InvalidAppealTarget",
+          "description": "Invalid appeal target input."
+        },
+        {
+          "name": "AlreadyAppealed",
+          "description": "An active appeal already exists for this action."
+        },
+        {
+          "name": "NotAppealable",
+          "description": "The target cannot be appealed."
+        },
+        {
+          "name": "AppealWindowExpired",
+          "description": "The appeal window for this action has closed."
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/tools/ozone/inbox/defs.json
+++ b/lexicons/tools/ozone/inbox/defs.json
@@ -1,0 +1,166 @@
+{
+  "lexicon": 1,
+  "id": "tools.ozone.inbox.defs",
+  "defs": {
+    "subjectView": {
+      "type": "object",
+      "description": "A subject belonging to the viewer that has moderation actions against it.",
+      "required": ["src", "subject", "enforcement", "createdAt", "updatedAt"],
+      "properties": {
+        "src": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the moderation service that took the actions."
+        },
+        "subject": {
+          "type": "union",
+          "refs": [
+            "com.atproto.admin.defs#repoRef",
+            "com.atproto.repo.strongRef"
+          ]
+        },
+        "enforcement": {
+          "type": "ref",
+          "ref": "#enforcementView"
+        },
+        "appeal": {
+          "type": "ref",
+          "ref": "#appealView"
+        },
+        "availableActions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "knownValues": ["appeal"]
+          }
+        },
+        "latestAction": {
+          "type": "ref",
+          "ref": "#actionView"
+        },
+        "actionCount": {
+          "type": "integer"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "enforcementView": {
+      "type": "object",
+      "description": "The current enforcement state of a subject.",
+      "required": ["state"],
+      "properties": {
+        "state": {
+          "type": "string",
+          "knownValues": [
+            "none",
+            "labeled",
+            "removed",
+            "suspended",
+            "takendown"
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "knownValues": ["network", "app", "labelOnly"]
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Active label values on the subject, excluding negated and expired labels."
+        }
+      }
+    },
+    "appealView": {
+      "type": "object",
+      "description": "The state of the viewer's appeal against the actions on a subject.",
+      "required": ["state"],
+      "properties": {
+        "state": {
+          "type": "string",
+          "knownValues": [
+            "none",
+            "pending",
+            "resolved",
+            "superseded",
+            "expired"
+          ]
+        },
+        "appealedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "resolvedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the appeal's report was closed."
+        },
+        "note": {
+          "type": "string",
+          "description": "Moderator explanation, from the publicNote on the closing activity. Absent if none was written."
+        },
+        "appealableUntil": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    },
+    "actionView": {
+      "type": "object",
+      "description": "A single moderation action taken against a subject.",
+      "required": ["id", "type", "createdAt"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Action ID (moderation event ID)."
+        },
+        "type": {
+          "type": "string",
+          "description": "Public action type."
+        },
+        "scope": {
+          "type": "string",
+          "knownValues": ["network", "app", "labelOnly"]
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "reversedAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Label values, for labelApplied/labelRemoved."
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Policies that were applied in this action."
+        }
+      }
+    }
+  }
+}

--- a/packages/ozone/src/api/inbox/appealActionedSubject.ts
+++ b/packages/ozone/src/api/inbox/appealActionedSubject.ts
@@ -1,0 +1,109 @@
+import {
+  ForbiddenError,
+  InternalServerError,
+  InvalidRequestError,
+} from '@atproto/xrpc-server'
+import type { AppContext } from '../../context.js'
+import {
+  fileAppeal,
+  isAppealWindowOpen,
+  isAppealableEvent,
+} from '../../inbox/appeal.js'
+import { hydrateSubjectView } from '../../inbox/views.js'
+import type { Server } from '../../lexicon/index.js'
+import { REASONAPPEAL } from '../../lexicon/types/tools/ozone/report/defs.js'
+import {
+  subjectFromEventRow,
+  subjectFromInput,
+} from '../../mod-service/subject.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.tools.ozone.inbox.appealActionedSubject({
+    auth: ctx.authVerifier.standard,
+    handler: async ({ input, auth }) => {
+      const { actionId, subject: subjectInput } = input.body
+      const requester =
+        'iss' in auth.credentials ? auth.credentials.iss : ctx.cfg.service.did
+
+      // validate input
+      if ((actionId === undefined) === (subjectInput === undefined)) {
+        throw new InvalidRequestError(
+          'Exactly one of actionId or subject is required',
+          'InvalidAppealTarget',
+        )
+      }
+
+      // find action
+      const action =
+        actionId === undefined
+          ? undefined
+          : await ctx.modService(ctx.db).getEvent(actionId)
+      if (actionId !== undefined && !action) {
+        throw new ForbiddenError(
+          'Moderation action is not appealable',
+          'NotAppealable',
+        )
+      }
+
+      // validate action event
+      if (action) {
+        if (requester !== action.subjectDid) {
+          throw new ForbiddenError(
+            'Moderation action is not appealable',
+            'NotAppealable',
+          )
+        }
+        if (!isAppealableEvent(action.action)) {
+          throw new ForbiddenError('Target is not appealable', 'NotAppealable')
+        }
+        if (
+          !isAppealWindowOpen(
+            action.createdAt,
+            ctx.cfg.inbox.appealWindowMonths,
+          )
+        ) {
+          throw new ForbiddenError(
+            'Appeal window has expired',
+            'AppealWindowExpired',
+          )
+        }
+      }
+
+      // parse subject and validate
+      const subject = action
+        ? subjectFromEventRow(action)
+        : subjectFromInput(subjectInput!)
+      if (requester !== subject.did) {
+        throw new ForbiddenError('Target is not appealable', 'NotAppealable')
+      }
+
+      await ctx.moderationServiceProfile().validateReasonType(REASONAPPEAL)
+
+      await fileAppeal(ctx, {
+        requester,
+        subject,
+        actionId: input.body.actionId,
+        reason: input.body.reason,
+        modTool: input.body.modTool,
+      })
+
+      // The appeal report ID stays internal: callers track the appeal through
+      // the subject view. Read after the commit so the view reflects the appeal
+      // that was just filed, and treat a missing snapshot as a bug rather than
+      // papering over it - the subject provably has moderation history, since
+      // the write above just added to it.
+      const view = await hydrateSubjectView(
+        ctx.db,
+        subject,
+        ctx.cfg.service.did,
+        ctx.cfg.inbox,
+      )
+      if (!view) {
+        throw new InternalServerError(
+          'Appeal was recorded but its subject could not be read back',
+        )
+      }
+      return { encoding: 'application/json', body: view }
+    },
+  })
+}

--- a/packages/ozone/src/api/index.ts
+++ b/packages/ozone/src/api/index.ts
@@ -6,6 +6,7 @@ import createTemplate from './communication/createTemplate.js'
 import deleteTemplate from './communication/deleteTemplate.js'
 import listTemplates from './communication/listTemplates.js'
 import updateTemplate from './communication/updateTemplate.js'
+import appealActionedSubject from './inbox/appealActionedSubject.js'
 import fetchLabels from './label/fetchLabels.js'
 import queryLabels from './label/queryLabels.js'
 import subscribeLabels from './label/subscribeLabels.js'
@@ -77,6 +78,7 @@ export * as wellKnown from './well-known.js'
 
 export default function (server: Server, ctx: AppContext) {
   createReport(server, ctx)
+  appealActionedSubject(server, ctx)
   emitEvent(server, ctx)
   searchRepos(server, ctx)
   adminGetRecord(server, ctx)

--- a/packages/ozone/src/config/config.ts
+++ b/packages/ozone/src/config/config.ts
@@ -96,6 +96,10 @@ export const envToCfg = (env: OzoneEnvironment): OzoneConfig => {
     reportDurationMs: env.assignmentReportDurationMs ?? 5 * MINUTE,
   }
 
+  const inboxCfg: OzoneConfig['inbox'] = {
+    appealWindowMonths: env.inboxAppealWindowMonths ?? 6,
+  }
+
   const statsCfg: OzoneConfig['stats'] = {
     computerIntervalMinutes: env.statsComputerIntervalMinutes ?? 15,
   }
@@ -112,6 +116,7 @@ export const envToCfg = (env: OzoneEnvironment): OzoneConfig => {
     access: accessCfg,
     verifier: verifierCfg,
     assignments: assignmentsCfg,
+    inbox: inboxCfg,
     stats: statsCfg,
     jetstreamUrl: env.jetstreamUrl,
   }
@@ -128,6 +133,7 @@ export type OzoneConfig = {
   blobDivert: BlobDivertConfig | null
   access: AccessConfig
   assignments: AssignmentsConfig
+  inbox: InboxConfig
   stats: StatsConfig
   jetstreamUrl?: string
   verifier: VerifierConfig | null
@@ -205,6 +211,17 @@ export type VerifierConfig = {
   password: string
   jetstreamUrl?: string
   issuersToIndex?: string[]
+}
+
+export type InboxConfig = {
+  /**
+   * Calendar months a moderation action stays appealable, counted from the
+   * action. Defaults to 6.
+   *
+   * Configured rather than hardcoded so the window is a policy decision the
+   * deployment owns, and can be changed without shipping code.
+   */
+  appealWindowMonths: number
 }
 
 export type AssignmentsConfig = {

--- a/packages/ozone/src/config/env.ts
+++ b/packages/ozone/src/config/env.ts
@@ -48,6 +48,7 @@ export const readEnv = (): OzoneEnvironment => {
     jetstreamUrl: envStr('OZONE_JETSTREAM_URL'),
     assignmentQueueDurationMs: envInt('OZONE_ASSIGNMENT_QUEUE_DURATION_MS'),
     assignmentReportDurationMs: envInt('OZONE_ASSIGNMENT_REPORT_DURATION_MS'),
+    inboxAppealWindowMonths: envInt('OZONE_INBOX_APPEAL_WINDOW_MONTHS'),
     statsComputerIntervalMinutes: envInt(
       'OZONE_STATS_COMPUTER_INTERVAL_MINUTES',
     ),
@@ -56,6 +57,7 @@ export const readEnv = (): OzoneEnvironment => {
 
 export type OzoneEnvironment = {
   nodeEnv?: string
+  inboxAppealWindowMonths?: number
   devMode?: boolean
   version?: string
   port?: number

--- a/packages/ozone/src/db/migrations/20260828T013624457Z-inbox-appeal-indices.ts
+++ b/packages/ozone/src/db/migrations/20260828T013624457Z-inbox-appeal-indices.ts
@@ -1,0 +1,99 @@
+import { type Kysely, sql } from 'kysely'
+
+// The action types the moderation inbox reads. Kept as literals rather than
+// imported so the migration stays pinned to the shape of the index it built,
+// even if the application's list later changes.
+const INBOX_ACTIONS = sql`(
+  'tools.ozone.moderation.defs#modEventTakedown',
+  'tools.ozone.moderation.defs#modEventLabel',
+  'tools.ozone.moderation.defs#modEventEmail',
+  'tools.ozone.moderation.defs#modEventMuteReporter',
+  'tools.ozone.moderation.defs#revokeAccountCredentialsEvent',
+  'tools.ozone.moderation.defs#modEventReverseTakedown'
+)`
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // @NOTE: These queries should be run with the "CONCURRENTLY" option in
+  // production to avoid locking the table. This is not supported by Kysely.
+
+  // Reports are linked to the events that resolved them through a jsonb array,
+  // and appeal creation looks a report up by that link. Without a GIN index
+  // that containment test is a sequential scan of every report.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_report_action_event_ids
+    ON report USING gin ("actionEventIds" jsonb_path_ops)
+  `.execute(db)
+
+  // Appeal lookups span open and closed reports - a record gets one appeal
+  // ever, so a closed one still blocks - which the existing partial indexes on
+  // report deliberately do not cover.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_report_appeal_subject
+    ON report (did, "recordPath", id DESC)
+    WHERE "reportType" = 'tools.ozone.report.defs#reasonAppeal'
+  `.execute(db)
+
+  // The inbox reads a wider set of action types than the existing partial
+  // indexes on moderation_event, which cover takedown and label only. Without
+  // a matching predicate these reads fall back to scanning everything ever
+  // recorded against the subject.
+  // Chat messages and conversations also carry a null `subjectUri`, so the
+  // account index excludes them by name. Otherwise every chat event recorded
+  // against a DID sits in the index its account reads.
+  await sql`
+    CREATE INDEX IF NOT EXISTS moderation_event_inbox_account_idx
+    ON moderation_event ("subjectDid", id DESC)
+    INCLUDE ("createdAt")
+    WHERE "subjectUri" IS NULL
+      AND "subjectMessageId" IS NULL
+      AND "subjectConvoId" IS NULL
+      AND action IN ${INBOX_ACTIONS}
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS moderation_event_inbox_record_idx
+    ON moderation_event ("subjectUri", id DESC)
+    INCLUDE ("createdAt")
+    WHERE "subjectUri" IS NOT NULL AND action IN ${INBOX_ACTIONS}
+  `.execute(db)
+
+  // Chat subjects get their own indexes: the existing
+  // `moderation_event_message_id_idx` is restricted to report events and does
+  // not cover the actions the inbox reads.
+  await sql`
+    CREATE INDEX IF NOT EXISTS moderation_event_inbox_message_idx
+    ON moderation_event ("subjectMessageId", id DESC)
+    INCLUDE ("createdAt")
+    WHERE "subjectMessageId" IS NOT NULL AND action IN ${INBOX_ACTIONS}
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS moderation_event_inbox_convo_idx
+    ON moderation_event ("subjectConvoId", id DESC)
+    INCLUDE ("createdAt")
+    WHERE "subjectConvoId" IS NOT NULL
+      AND "subjectMessageId" IS NULL
+      AND action IN ${INBOX_ACTIONS}
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropIndex('moderation_event_inbox_convo_idx')
+    .ifExists()
+    .execute()
+  await db.schema
+    .dropIndex('moderation_event_inbox_message_idx')
+    .ifExists()
+    .execute()
+  await db.schema
+    .dropIndex('moderation_event_inbox_record_idx')
+    .ifExists()
+    .execute()
+  await db.schema
+    .dropIndex('moderation_event_inbox_account_idx')
+    .ifExists()
+    .execute()
+  await db.schema.dropIndex('idx_report_appeal_subject').ifExists().execute()
+  await db.schema.dropIndex('idx_report_action_event_ids').ifExists().execute()
+}

--- a/packages/ozone/src/db/migrations/index.ts
+++ b/packages/ozone/src/db/migrations/index.ts
@@ -45,3 +45,4 @@ export * as _20260602T120000000Z from './20260602T120000000Z-add-report-activity
 export * as _20260617T210022765Z from './20260617T210022765Z-add-report-isautomated.js'
 export * as _20260720T000000000Z from './20260720T000000000Z-add-convo-subjects-to-stats-views.js'
 export * as _20260731T000000000Z from './20260731T000000000Z-add-recommended-policies-to-report-queue.js'
+export * as _20260828T013624457Z from './20260828T013624457Z-inbox-appeal-indices.js'

--- a/packages/ozone/src/inbox/appeal.ts
+++ b/packages/ozone/src/inbox/appeal.ts
@@ -1,0 +1,384 @@
+import type { Expression, ExpressionBuilder, SqlBool } from 'kysely'
+import { AtUri } from '@atproto/syntax'
+import { ForbiddenError } from '@atproto/xrpc-server'
+import type { AppContext } from '../context.js'
+import type { Database } from '../db/index.js'
+import type { DatabaseSchemaType } from '../db/schema/index.js'
+import { jsonb } from '../db/types.js'
+import type { AppealView } from '../lexicon/types/tools/ozone/inbox/defs.js'
+import { REASONAPPEAL as APPEAL_REASON_TYPE } from '../lexicon/types/tools/ozone/report/defs.js'
+import type { ModSubject } from '../mod-service/subject.js'
+import type { ModerationSubjectStatusRow } from '../mod-service/types.js'
+import { findMatchingQueue } from '../queue/service.js'
+import { TagService } from '../tag-service/index.js'
+import { getTagForReport } from '../tag-service/util.js'
+
+export const TAKEDOWN = 'tools.ozone.moderation.defs#modEventTakedown'
+export const REVERSE_TAKEDOWN =
+  'tools.ozone.moderation.defs#modEventReverseTakedown'
+export const LABEL = 'tools.ozone.moderation.defs#modEventLabel'
+export const EMAIL = 'tools.ozone.moderation.defs#modEventEmail'
+export const MUTE_REPORTER = 'tools.ozone.moderation.defs#modEventMuteReporter'
+export const REVOKE_CREDENTIALS =
+  'tools.ozone.moderation.defs#revokeAccountCredentialsEvent'
+
+/**
+ * The subject's most recent `reasonAppeal` report, reduced to the columns the
+ * appeal state derives from. Deliberately excludes `actionNote` and everything
+ * else a moderator wrote for other moderators.
+ */
+export type AppealReport = {
+  id: number
+  status: string
+  createdAt: string
+  closedAt: string | null
+}
+
+export type AppealInput = {
+  subject: ModSubject
+  status: ModerationSubjectStatusRow | null
+  report: AppealReport | null
+  publicNote: string | null
+
+  /** Calendar months an action stays appealable, from `InboxConfig`. */
+  windowMonths: number
+  latestAppealableAt: string | null
+}
+
+export type AppealState = {
+  view: AppealView
+  availableActions: string[]
+}
+
+export const PUBLIC_EVENT_ACTIONS = [
+  TAKEDOWN,
+  LABEL,
+  EMAIL,
+  MUTE_REPORTER,
+  REVOKE_CREDENTIALS,
+  REVERSE_TAKEDOWN,
+] as const
+
+export const APPEALABLE_EVENT_ACTIONS = [TAKEDOWN, LABEL] as const
+
+export const isAppealableEvent = (action: string): boolean =>
+  (APPEALABLE_EVENT_ACTIONS as readonly string[]).includes(action)
+
+export const appealWindowEnd = (
+  actionCreatedAt: string,
+  windowMonths: number,
+): string => {
+  const end = new Date(actionCreatedAt)
+  const day = end.getUTCDate()
+  end.setUTCMonth(end.getUTCMonth() + windowMonths)
+  // Clamp a rollover: 31 Aug + 6 months is 28/29 Feb, not 2/3 Mar.
+  if (end.getUTCDate() !== day) end.setUTCDate(0)
+  return end.toISOString()
+}
+
+export const isAppealWindowOpen = (
+  actionCreatedAt: string,
+  windowMonths: number,
+  now = new Date(),
+): boolean => new Date(appealWindowEnd(actionCreatedAt, windowMonths)) > now
+
+/**
+ * Appeal state, derived entirely from data Ozone already records.
+ */
+export const toAppealState = ({
+  subject,
+  status,
+  report,
+  publicNote,
+  latestAppealableAt,
+  windowMonths,
+}: AppealInput): AppealState => {
+  const appealableUntil = latestAppealableAt
+    ? appealWindowEnd(latestAppealableAt, windowMonths)
+    : null
+  const windowOpen = !!appealableUntil && new Date(appealableUntil) > new Date()
+
+  let state: AppealView['state']
+  if (status?.appealed) {
+    state = 'pending'
+  } else if (report) {
+    // Cleared without the appeal being worked - a takedown or an automatic
+    // resolution reset the flag - rather than actually reviewed.
+    state = report.closedAt ? 'resolved' : 'superseded'
+  } else {
+    state = appealableUntil && !windowOpen ? 'expired' : 'none'
+  }
+
+  const view: AppealView = { state }
+  if (report) {
+    view.appealedAt = status?.lastAppealedAt ?? report.createdAt
+    if (report.closedAt) view.resolvedAt = report.closedAt
+  }
+  if (state === 'resolved' && publicNote) view.note = publicNote
+  if (appealableUntil) view.appealableUntil = appealableUntil
+
+  const availableActions =
+    windowOpen && !appealsExhausted(subject, report) ? ['appeal'] : []
+
+  return { view, availableActions }
+}
+
+/**
+ * Stable identity of a moderated subject, independent of which action touched
+ * it. Two appeals against the same record - or the same message, or the same
+ * conversation - share a key even when they name different action IDs.
+ */
+export const subjectKey = (subject: ModSubject): string => {
+  const { subjectDid, subjectMessageId, subjectConvoId } = subject.info()
+  if (subject.isMessage()) return `message:${subjectDid}:${subjectMessageId}`
+  if (subject.isConvo()) return `convo:${subjectDid}:${subjectConvoId}`
+  if (subject.isRecord()) return `record:${subjectDid}:${subject.recordPath}`
+  return `account:${subjectDid}`
+}
+
+/**
+ * Match report rows by that identity. Mirrors the subject normalization in
+ * `mod-service/report.ts`: `recordPath` is '' for accounts, messages, and
+ * conversations alike, so an account match has to exclude the chat columns.
+ */
+export const reportSubjectFilter = (
+  eb: ExpressionBuilder<DatabaseSchemaType, 'report'>,
+  subject: ModSubject,
+): Expression<SqlBool> => {
+  const { subjectDid, subjectMessageId, subjectConvoId } = subject.info()
+  if (subject.isMessage()) {
+    return eb.and([
+      eb('did', '=', subjectDid),
+      eb('subjectMessageId', '=', subjectMessageId),
+    ])
+  }
+  if (subject.isConvo()) {
+    return eb.and([
+      eb('did', '=', subjectDid),
+      eb('subjectConvoId', '=', subjectConvoId),
+      eb('subjectMessageId', 'is', null),
+    ])
+  }
+  if (subject.isRecord()) {
+    return eb.and([
+      eb('did', '=', subjectDid),
+      eb('recordPath', '=', subject.recordPath),
+    ])
+  }
+  return eb.and([
+    eb('did', '=', subjectDid),
+    eb('recordPath', '=', ''),
+    eb('subjectMessageId', 'is', null),
+    eb('subjectConvoId', 'is', null),
+  ])
+}
+
+/**
+ * Label rows are keyed by a single string: the record URI, or the DID for an
+ * account.
+ */
+export const subjectLabelUri = (subject: ModSubject): string =>
+  subject.info().subjectUri ?? subject.did
+
+/**
+ * Whether the subject has used up its appeals.
+ *
+ * Non-account subjects get one ever, closed or not. An account gets one at a
+ * time - and an appeal whose report is still open counts even when the
+ * `appealed` flag was cleared out from under it, which is what happens when a
+ * takedown supersedes an appeal nobody ever worked.
+ *
+ * The read path calls this to decide whether to offer `appeal`, and the write
+ * path calls it to decide whether to accept one. They have to be the same
+ * question: anything else advertises an appeal that submission will refuse.
+ */
+export const appealsExhausted = (
+  subject: ModSubject,
+  report: AppealReport | null,
+): boolean => {
+  if (!report) return false
+  return subject.isRepo() ? report.status !== 'closed' : true
+}
+
+/**
+ * Reject an appeal the subject is no longer entitled to.
+ *
+ * Answers the same question as the `availableActions` the read path
+ * advertises, through {@link appealsExhausted}, so the two cannot drift.
+ */
+export const assertAppealAllowed = async (
+  dbTxn: Database,
+  subject: ModSubject,
+) => {
+  dbTxn.assertTransaction()
+
+  const existing = await dbTxn.db
+    .selectFrom('report')
+    .where('reportType', '=', APPEAL_REASON_TYPE)
+    .where((eb) => reportSubjectFilter(eb, subject))
+    .orderBy('id', 'desc')
+    .select(['id', 'status', 'createdAt', 'closedAt'])
+    .executeTakeFirst()
+
+  if (appealsExhausted(subject, existing ?? null)) {
+    throw new ForbiddenError(
+      subject.isRepo()
+        ? 'Awaiting decision on previous appeal'
+        : 'This has already been appealed',
+      'AlreadyAppealed',
+    )
+  }
+}
+
+export type FileAppealInput = {
+  /** DID of the authenticated account filing the appeal. */
+  requester: string
+  /** The subject being appealed, already resolved and authorized. */
+  subject: ModSubject
+  /** The action being appealed, when the appeal names one. */
+  actionId?: number
+  /** Optional: an appeal is a request for review, not an argued case. */
+  reason?: string
+  modTool?: { name: string; meta?: { [_ in string]: unknown } }
+}
+
+/**
+ * Pick the queue an appeal should land in.
+ *
+ * A linked appeal inherits the queue of the report the appealed action
+ * resolved, but only when every candidate agrees - bulk and collateral actions
+ * can link one event to reports sitting in different queues, and guessing
+ * between them is worse than leaving the appeal for the router. An unlinked
+ * appeal falls back to whatever queue is configured to accept appeals.
+ *
+ * This is a read of best-effort routing data, so it deliberately runs outside
+ * the appeal transaction: holding the subject lock across a queue listing and
+ * a report scan would serialize unrelated appeals for no consistency gain, and
+ * if the routing data moves underneath us the router reassigns anyway.
+ */
+const selectQueue = async (
+  ctx: AppContext,
+  subject: ModSubject,
+  actionId: number | undefined,
+) => {
+  const sourceReports =
+    actionId === undefined
+      ? []
+      : await ctx.db.db
+          .selectFrom('report')
+          .where('reportType', '!=', APPEAL_REASON_TYPE)
+          .where('actionEventIds', '@>', jsonb([actionId]))
+          .select(['queueId', 'queuedAt'])
+          .execute()
+  const sourceQueues = new Set(
+    sourceReports
+      .map((source) => source.queueId)
+      .filter((queueId): queueId is number => queueId !== null),
+  )
+
+  const legacyQueue =
+    actionId === undefined
+      ? findMatchingQueue(
+          (await ctx.queueService(ctx.db).list({ limit: 1000, enabled: true }))
+            .queues,
+          subject.isRecord() ? 'record' : 'account',
+          subject.info().subjectUri
+            ? new AtUri(subject.info().subjectUri!).collection
+            : null,
+          APPEAL_REASON_TYPE,
+        )
+      : null
+
+  const queueId =
+    actionId === undefined
+      ? (legacyQueue?.id ?? -1)
+      : sourceQueues.size === 1
+        ? [...sourceQueues][0]
+        : -1
+
+  // An unrouted report carries no queue timestamp: `queuedAt` records when a
+  // report entered a queue, and matches the `queueId: -1` / `status: 'open'`
+  // shape the queue service uses for everything it cannot route.
+  return {
+    queueId,
+    queuedAt: queueId > 0 ? new Date().toISOString() : null,
+  }
+}
+
+/**
+ * File an appeal: validate the target, route it, and record it.
+ *
+ * An appeal is an ordinary `reasonAppeal` report, so it inherits the report
+ * lifecycle, queue routing, and activity machinery rather than introducing a
+ * parallel one. What makes it a *linked* appeal is `actionEventIds`, whose
+ * first entry is the action being challenged.
+ *
+ * Everything that must be atomic - the eligibility guard, the report event,
+ * the report row, and the tag - shares one transaction. Everything that need
+ * not be, is already done by the time it opens.
+ */
+export const fileAppeal = async (
+  ctx: AppContext,
+  { requester, subject, actionId, reason, modTool }: FileAppealInput,
+): Promise<{ reportId: number }> => {
+  const { queueId, queuedAt } = await selectQueue(ctx, subject, actionId)
+
+  const subjectInfo = subject.info()
+  const recordPath = subjectInfo.subjectUri
+    ? (() => {
+        const uri = new AtUri(subjectInfo.subjectUri)
+        return `${uri.collection}/${uri.rkey}`
+      })()
+    : ''
+
+  const reportId = await ctx.db.transaction(async (dbTxn) => {
+    await assertAppealAllowed(dbTxn, subject)
+
+    // create event and report row
+    const moderationTxn = ctx.modService(dbTxn)
+    const { event: reportEvent, subjectStatus } = await moderationTxn.report({
+      reason,
+      subject,
+      reasonType: APPEAL_REASON_TYPE,
+      reportedBy: requester,
+      modTool,
+    })
+    const now = reportEvent.createdAt
+    const inserted = await dbTxn.db
+      .insertInto('report')
+      .values({
+        eventId: reportEvent.id,
+        queueId,
+        queuedAt,
+        actionEventIds: actionId === undefined ? null : jsonb([actionId]),
+        actionNote: null,
+        isMuted:
+          !!reportEvent.meta?.isReporterMuted ||
+          !!reportEvent.meta?.isSubjectMuted,
+        isAutomated: modTool?.meta?.isAutomated === true,
+        status: queueId > 0 ? 'queued' : 'open',
+        reportType: APPEAL_REASON_TYPE,
+        did: subjectInfo.subjectDid,
+        recordPath,
+        subjectMessageId: subjectInfo.subjectMessageId,
+        subjectConvoId: subjectInfo.subjectConvoId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning('id')
+      .executeTakeFirstOrThrow()
+
+    // apply appeal tag
+    const tagService = new TagService(
+      subject,
+      subjectStatus,
+      ctx.cfg.service.did,
+      moderationTxn,
+    )
+    await tagService.evaluateForSubject([getTagForReport(APPEAL_REASON_TYPE)])
+
+    return inserted.id
+  })
+
+  return { reportId }
+}

--- a/packages/ozone/src/inbox/views.ts
+++ b/packages/ozone/src/inbox/views.ts
@@ -1,0 +1,492 @@
+import type { Expression, ExpressionBuilder, SqlBool } from 'kysely'
+import { sql } from 'kysely'
+import type { InboxConfig } from '../config/config.js'
+import type { Database } from '../db/index.js'
+import type { DatabaseSchemaType } from '../db/schema/index.js'
+import type {
+  ActionView,
+  EnforcementView,
+  SubjectView,
+} from '../lexicon/types/tools/ozone/inbox/defs.js'
+import { REASONAPPEAL } from '../lexicon/types/tools/ozone/report/defs.js'
+import { SUSPEND_LABEL, TAKEDOWN_LABEL } from '../mod-service/index.js'
+import type { ModSubject } from '../mod-service/subject.js'
+import type {
+  ModerationEventRow,
+  ModerationSubjectStatusRow,
+} from '../mod-service/types.js'
+import type { AppealReport } from './appeal.js'
+import {
+  APPEALABLE_EVENT_ACTIONS,
+  EMAIL,
+  LABEL,
+  MUTE_REPORTER,
+  PUBLIC_EVENT_ACTIONS,
+  REVERSE_TAKEDOWN,
+  REVOKE_CREDENTIALS,
+  TAKEDOWN,
+  reportSubjectFilter,
+  subjectLabelUri,
+  toAppealState,
+} from './appeal.js'
+
+/**
+ * Newest events mapped into the action history. The totals query supplies the
+ * exact count and first-action date, so this cap bounds the read without making
+ * either number wrong. It has to stay generous enough that a takedown and the
+ * reversal undoing it normally land in the same window.
+ */
+const EVENT_WINDOW = 50
+
+/** Everything one `subjectView` needs, as loaded from the database. */
+export type SubjectSnapshot = {
+  status: ModerationSubjectStatusRow | null
+  events: ModerationEventRow[]
+  /** Active, non-negated, unexpired label values on the subject. */
+  labels: string[]
+  /** Total public actions, exact even when `events` was capped. */
+  actionCount: number
+  firstActionAt: string | null
+  /** Newest action the user is allowed to appeal, if any. */
+  latestAppealableAt: string | null
+  appealReport: AppealReport | null
+  /** Latest nonempty `publicNote` from the appeal's close activities. */
+  appealPublicNote: string | null
+}
+
+type EventTotals = {
+  actionCount: number
+  firstActionAt: string | null
+  latestAppealableAt: string | null
+}
+
+const eventSubjectFilter = (
+  eb: ExpressionBuilder<DatabaseSchemaType, 'moderation_event'>,
+  subject: ModSubject,
+): Expression<SqlBool> => {
+  const {
+    subjectType,
+    subjectDid,
+    subjectUri,
+    subjectMessageId,
+    subjectConvoId,
+  } = subject.info()
+  if (subject.isMessage()) {
+    return eb.and([
+      eb('subjectDid', '=', subjectDid),
+      eb('subjectMessageId', '=', subjectMessageId),
+      eb('subjectConvoId', '=', subjectConvoId),
+    ])
+  }
+  if (subject.isConvo()) {
+    return eb.and([
+      eb('subjectDid', '=', subjectDid),
+      eb('subjectConvoId', '=', subjectConvoId),
+      eb('subjectMessageId', 'is', null),
+    ])
+  }
+  if (subject.isRecord()) {
+    return eb.and([
+      eb('subjectDid', '=', subjectDid),
+      eb('subjectUri', '=', subjectUri),
+    ])
+  }
+  return eb.and([
+    eb('subjectDid', '=', subjectDid),
+    eb('subjectType', '=', subjectType),
+  ])
+}
+
+/**
+ * Load the public moderation state needed to hydrate one subject view.
+ *
+ * Only public columns are read. Event comments, `report.actionNote`, and
+ * `report_activity.internalNote` are moderator-facing and never leave the
+ * database on this path.
+ */
+export const loadSubject = async (
+  db: Database,
+  subject: ModSubject,
+): Promise<SubjectSnapshot> => {
+  const appealable = sql.join(
+    APPEALABLE_EVENT_ACTIONS.map((action) => sql.lit(action)),
+  )
+
+  const [status, labelRows, events, totals, appealReport] = await Promise.all([
+    db.db
+      .selectFrom('moderation_subject_status')
+      .where('did', '=', subject.did)
+      .where('recordPath', '=', subject.recordPath ?? '')
+      .where('convoId', '=', subject.convoId ?? '')
+      .selectAll()
+      .executeTakeFirst(),
+
+    db.db
+      .selectFrom('label')
+      .where('uri', '=', subjectLabelUri(subject))
+      .where('neg', '=', false)
+      .where((eb) =>
+        eb.or([
+          eb('exp', 'is', null),
+          eb('exp', '>', new Date().toISOString()),
+        ]),
+      )
+      .select('val')
+      .execute(),
+
+    db.db
+      .selectFrom('moderation_event')
+      .where((eb) => eventSubjectFilter(eb, subject))
+      .where('action', 'in', [...PUBLIC_EVENT_ACTIONS])
+      .orderBy('id', 'desc')
+      .limit(EVENT_WINDOW)
+      .selectAll()
+      .execute(),
+
+    db.db
+      .selectFrom('moderation_event')
+      .where((eb) => eventSubjectFilter(eb, subject))
+      .where('action', 'in', [...PUBLIC_EVENT_ACTIONS])
+      .select([
+        sql<number>`count(*) FILTER (WHERE action <> ${REVERSE_TAKEDOWN})::int`.as(
+          'actionCount',
+        ),
+        sql<
+          string | null
+        >`min("createdAt") FILTER (WHERE action <> ${REVERSE_TAKEDOWN})`.as(
+          'firstActionAt',
+        ),
+        sql<
+          string | null
+        >`max("createdAt") FILTER (WHERE action IN (${appealable}))`.as(
+          'latestAppealableAt',
+        ),
+      ])
+      .executeTakeFirstOrThrow() as Promise<EventTotals>,
+
+    db.db
+      .selectFrom('report')
+      .where('reportType', '=', REASONAPPEAL)
+      .where((eb) => reportSubjectFilter(eb, subject))
+      .orderBy('id', 'desc')
+      .select(['id', 'status', 'createdAt', 'closedAt'])
+      .executeTakeFirst(),
+  ])
+
+  const publicNote = appealReport
+    ? await db.db
+        .selectFrom('report_activity')
+        .where('reportId', '=', appealReport.id)
+        .where('activityType', '=', 'closeActivity')
+        .where('publicNote', 'is not', null)
+        .where(sql<boolean>`length(trim("publicNote")) > 0`)
+        .orderBy('id', 'desc')
+        .select('publicNote')
+        .executeTakeFirst()
+    : undefined
+
+  return {
+    status: status ?? null,
+    events,
+    labels: labelRows.map((row) => row.val),
+    actionCount: totals.actionCount,
+    firstActionAt: totals.firstActionAt,
+    latestAppealableAt: totals.latestAppealableAt,
+    appealReport: appealReport ?? null,
+    appealPublicNote: publicNote?.publicNote ?? null,
+  }
+}
+
+export type SubjectViewInput = {
+  subject: ModSubject
+  /** DID of the moderation service the view speaks for. */
+  serviceDid: string
+  cfg: InboxConfig
+  snapshot: SubjectSnapshot
+}
+
+export type EnforcementViewInput = {
+  subject: ModSubject
+  status: ModerationSubjectStatusRow | null
+  /** Active, non-negated, unexpired label values on the subject. */
+  labels: string[]
+  /** Public action history, newest first, used only for the takedown's scope. */
+  actions: ActionView[]
+}
+
+const splitVals = (vals: string | null): string[] =>
+  vals?.length ? vals.split(' ').filter(Boolean) : []
+
+/** `!takedown` and `!suspend` are already carried by the enforcement state. */
+const withoutTakedownLabels = (vals: string[]): string[] =>
+  vals.filter((val) => val !== TAKEDOWN_LABEL && val !== SUSPEND_LABEL)
+
+const splitMeta = (row: ModerationEventRow, key: string): string[] => {
+  const raw = row.meta?.[key]
+  return typeof raw === 'string' && raw.length ? raw.split(',') : []
+}
+
+/**
+ * `targetServices` names where a takedown was applied; empty means everywhere.
+ * An appview-only takedown is visible in the app but leaves the record hosted,
+ * which is what `app` means here.
+ */
+const takedownScope = (row: ModerationEventRow): ActionView['scope'] => {
+  const services = splitMeta(row, 'targetServices')
+  if (!services.length) return 'network'
+  return services.includes('pds') ? 'network' : 'app'
+}
+
+const isAccountSubject = (row: ModerationEventRow): boolean =>
+  row.subjectType === 'com.atproto.admin.defs#repoRef'
+
+/** Public action type for one event, or null when it is not an entry. */
+export const publicActionType = (row: ModerationEventRow): string | null => {
+  switch (row.action) {
+    case TAKEDOWN:
+      if (!isAccountSubject(row)) return 'contentRemoved'
+      return row.durationInHours ? 'accountSuspended' : 'accountTakedown'
+    case LABEL:
+      return splitVals(row.createLabelVals).length
+        ? 'labelApplied'
+        : 'labelRemoved'
+    case EMAIL:
+      return 'communicationSent'
+    case MUTE_REPORTER:
+      return 'reportingRestricted'
+    case REVOKE_CREDENTIALS:
+      return 'credentialsRevoked'
+    default:
+      return null
+  }
+}
+
+const toActionView = (row: ModerationEventRow): ActionView | null => {
+  const type = publicActionType(row)
+  if (!type) return null
+
+  const view: ActionView = {
+    id: row.id,
+    type,
+    createdAt: row.createdAt,
+  }
+  if (row.expiresAt) view.expiresAt = row.expiresAt
+
+  if (row.action === TAKEDOWN) {
+    view.scope = takedownScope(row)
+    const policies = splitMeta(row, 'policies')
+    if (policies.length) view.policies = policies
+  }
+  if (row.action === EMAIL) {
+    const policies = splitMeta(row, 'policies')
+    if (policies.length) view.policies = policies
+  }
+  if (row.action === LABEL) {
+    view.scope = 'app'
+    const labels = withoutTakedownLabels(
+      type === 'labelApplied'
+        ? splitVals(row.createLabelVals)
+        : splitVals(row.negateLabelVals),
+    )
+    if (labels.length) view.labels = labels
+  }
+  return view
+}
+
+/**
+ * Map raw moderation events to the public action history, newest first.
+ *
+ * Reversals do not appear as actions. A `modEventReverseTakedown` stamps
+ * `reversedAt` on the newest takedown it undoes, and a label negation does the
+ * same to the `labelApplied` that put those values there - so the user sees
+ * "removed, then restored" as one action with an end date rather than as two
+ * unrelated events.
+ */
+export const toActionViews = (rows: ModerationEventRow[]): ActionView[] => {
+  // Oldest first, so a reversal always meets the action it undoes.
+  const ordered = [...rows].sort(
+    (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id - b.id,
+  )
+
+  const actions: ActionView[] = []
+  const openTakedowns: ActionView[] = []
+  const openLabels = new Map<string, ActionView>()
+
+  for (const row of ordered) {
+    if (row.action === REVERSE_TAKEDOWN) {
+      const takedown = openTakedowns.pop()
+      if (takedown) takedown.reversedAt = row.createdAt
+      continue
+    }
+
+    const view = toActionView(row)
+    if (!view) continue
+    actions.push(view)
+
+    if (row.action === TAKEDOWN) {
+      openTakedowns.push(view)
+    }
+    if (row.action === LABEL) {
+      for (const val of withoutTakedownLabels(splitVals(row.negateLabelVals))) {
+        const applied = openLabels.get(val)
+        if (applied) {
+          applied.reversedAt = row.createdAt
+          openLabels.delete(val)
+        }
+      }
+      for (const val of withoutTakedownLabels(splitVals(row.createLabelVals))) {
+        openLabels.set(val, view)
+      }
+    }
+  }
+
+  return actions.reverse()
+}
+
+const TAKEDOWN_TYPES = new Set([
+  'contentRemoved',
+  'accountSuspended',
+  'accountTakedown',
+])
+
+/**
+ * Current enforcement, as a single state.
+ *
+ * A subject can be labeled and taken down at once, so precedence decides which
+ * one `state` reports: takendown > suspended > removed > labeled > none. Which
+ * of `takendown` / `suspended` / `removed` applies is a question of subject
+ * type and duration, not of three separate flags - a record is `removed`, an
+ * account is `takendown`, and either becomes a suspension when the takedown
+ * carried a duration.
+ *
+ * `labels[]` carries the label values whichever state won, minus `!takedown`
+ * and `!suspend`: those are written straight to the label table by the
+ * takedown paths and already say what `state` says.
+ */
+export const toEnforcementView = ({
+  subject,
+  status,
+  labels,
+  actions,
+}: EnforcementViewInput): EnforcementView => {
+  const active = labels.filter(
+    (val) => val !== TAKEDOWN_LABEL && val !== SUSPEND_LABEL,
+  )
+  const suspendUntil = status?.suspendUntil
+  const temporary = !!suspendUntil && new Date(suspendUntil) > new Date()
+  const enforced = !!status?.takendown || temporary
+
+  let state: EnforcementView['state'] = 'none'
+  if (enforced) {
+    if (!subject.isRepo()) state = 'removed'
+    else state = temporary ? 'suspended' : 'takendown'
+  } else if (active.length) {
+    state = 'labeled'
+  }
+
+  const view: EnforcementView = { state }
+  if (state === 'none') return view
+
+  if (state === 'labeled') {
+    view.scope = 'app'
+  } else {
+    const takedown = actions.find(
+      (action) => TAKEDOWN_TYPES.has(action.type) && !action.reversedAt,
+    )
+    if (takedown?.scope) view.scope = takedown.scope
+    if (temporary && suspendUntil) view.expiresAt = suspendUntil
+  }
+
+  if (active.length) view.labels = active
+  return view
+}
+
+const latest = (...times: (string | null | undefined)[]): string | null => {
+  const known = times.filter((time): time is string => !!time)
+  if (!known.length) return null
+  return known.reduce((a, b) => (Date.parse(a) >= Date.parse(b) ? a : b))
+}
+
+/**
+ * Compose one `tools.ozone.inbox.defs#subjectView` from an already-loaded
+ * snapshot. Pure and synchronous: every query belongs to the caller, so the
+ * view rules can be read and tested without a database.
+ *
+ * Returns null when the subject has no moderation history at all - it has
+ * never been actioned and has no status row - which is not a subject the
+ * inbox has anything to say about.
+ *
+ * `isRead` is deliberately absent: it is a comparison against a per-section
+ * read watermark, and Ozone has nowhere to store one yet. Sending a value now
+ * would mean inventing the watermark.
+ */
+export const toSubjectView = ({
+  subject,
+  serviceDid,
+  snapshot,
+  cfg,
+}: SubjectViewInput): SubjectView | null => {
+  if (!snapshot.status && !snapshot.actionCount) return null
+
+  const actions = toActionViews(snapshot.events)
+  const enforcement = toEnforcementView({
+    subject,
+    status: snapshot.status,
+    labels: snapshot.labels,
+    actions,
+  })
+  const { view: appeal, availableActions } = toAppealState({
+    subject,
+    status: snapshot.status,
+    report: snapshot.appealReport,
+    publicNote: snapshot.appealPublicNote,
+    latestAppealableAt: snapshot.latestAppealableAt,
+    windowMonths: cfg.appealWindowMonths,
+  })
+
+  // The subject dates from its first action, not from whenever Ozone first
+  // opened a status row for it.
+  const createdAt =
+    snapshot.firstActionAt ??
+    snapshot.status?.createdAt ??
+    new Date().toISOString()
+  const updatedAt =
+    latest(
+      actions[0]?.createdAt,
+      appeal.appealedAt,
+      appeal.resolvedAt,
+      snapshot.status?.updatedAt,
+    ) ?? createdAt
+
+  const view: SubjectView = {
+    src: serviceDid,
+    subject: subject.lex(),
+    enforcement,
+    appeal,
+    availableActions,
+    createdAt,
+    updatedAt,
+  }
+  if (actions.length) {
+    view.latestAction = actions[0]
+    view.actionCount = snapshot.actionCount
+  }
+  return view
+}
+
+/**
+ * Load a subject and compose its view: the read path in one call, for callers
+ * that have a database and a subject and want the finished thing.
+ */
+export const hydrateSubjectView = async (
+  db: Database,
+  subject: ModSubject,
+  serviceDid: string,
+  cfg: InboxConfig,
+): Promise<SubjectView | null> =>
+  toSubjectView({
+    subject,
+    serviceDid,
+    cfg,
+    snapshot: await loadSubject(db, subject),
+  })

--- a/packages/ozone/tests/appeal-actioned-subject.test.ts
+++ b/packages/ozone/tests/appeal-actioned-subject.test.ts
@@ -1,0 +1,986 @@
+import type { AtpAgent } from '@atproto/api'
+import {
+  type ModeratorClient,
+  type SeedClient,
+  TestNetwork,
+  basicSeed,
+} from '@atproto/dev-env'
+import type { DidString } from '@atproto/syntax'
+import { jsonb } from '../src/db/types.js'
+import { appealWindowEnd } from '../src/inbox/appeal.js'
+import { hydrateSubjectView, loadSubject } from '../src/inbox/views.js'
+import { validateSubjectView } from '../src/lexicon/types/tools/ozone/inbox/defs.js'
+import { REASONAPPEAL } from '../src/lexicon/types/tools/ozone/report/defs.js'
+import {
+  ConvoSubject,
+  MessageSubject,
+  RecordSubject,
+  RepoSubject,
+} from '../src/mod-service/subject.js'
+
+describe('appealActionedSubject', () => {
+  let network: TestNetwork
+  let sc: SeedClient
+  let modClient: ModeratorClient
+  let ozoneAgent: AtpAgent
+  let proxyHeader: string
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'ozone_appeal_actioned_subject',
+    })
+    sc = network.getSeedClient()
+    modClient = network.ozone.getModClient()
+    ozoneAgent = network.ozone.getAgent()
+    // tools.ozone.inbox.* has no default route in the PDS, so every call from a
+    // regular user has to name the labeler explicitly.
+    proxyHeader = `${network.ozone.ctx.cfg.service.did}#atproto_labeler`
+    await basicSeed(sc)
+    await network.processAll()
+  })
+
+  afterAll(async () => {
+    await network?.close()
+  })
+
+  async function callAppeal(body: object, did: DidString) {
+    return sc.agent.call(
+      'tools.ozone.inbox.appealActionedSubject',
+      undefined,
+      { reason: 'Please reconsider this decision', ...body },
+      {
+        encoding: 'application/json',
+        headers: { ...sc.getHeaders(did), 'atproto-proxy': proxyHeader },
+      },
+    )
+  }
+
+  async function appeal(actionId: number, did: DidString) {
+    return callAppeal({ actionId }, did)
+  }
+
+  async function legacyAppeal(did: DidString) {
+    return callAppeal(
+      { subject: { $type: 'com.atproto.admin.defs#repoRef', did } },
+      did,
+    )
+  }
+
+  async function appealRecord(
+    ref: { uriStr: string; cidStr: string },
+    did: DidString,
+  ) {
+    return callAppeal(
+      {
+        subject: {
+          $type: 'com.atproto.repo.strongRef',
+          uri: ref.uriStr,
+          cid: ref.cidStr,
+        },
+      },
+      did,
+    )
+  }
+
+  // The response deliberately withholds the appeal report ID, so tests that
+  // need the underlying row look it up the way a moderator surface would.
+  async function latestAppealReport(did: DidString) {
+    return network.ozone.ctx.db.db
+      .selectFrom('report')
+      .where('reportType', '=', REASONAPPEAL)
+      .where('did', '=', did)
+      .orderBy('id', 'desc')
+      .selectAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  async function closeLatestAppeal(did: DidString) {
+    const report = await latestAppealReport(did)
+    await network.ozone.ctx.db.db
+      .updateTable('report')
+      .where('id', '=', report.id)
+      .set({ status: 'closed', closedAt: new Date().toISOString() })
+      .execute()
+    return report.id
+  }
+
+  // Match the client's own subject union rather than `object`, so a malformed
+  // literal in a test fails at build time instead of at request time.
+  type EmitSubject = Parameters<ModeratorClient['emitEvent']>[0]['subject']
+
+  async function takedown(subject: EmitSubject) {
+    return modClient.emitEvent({
+      event: { $type: 'tools.ozone.moderation.defs#modEventTakedown' },
+      subject,
+    })
+  }
+
+  async function label(subject: EmitSubject) {
+    return modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['!warn'],
+        negateLabelVals: [],
+      },
+      subject,
+    })
+  }
+
+  it('creates a linked appeal in the original report queue', async () => {
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: sc.posts[sc.dids.bob][0].ref.uriStr,
+      cid: sc.posts[sc.dids.bob][0].ref.cidStr,
+    }
+    const sourceReport = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventReport',
+        reportType: 'com.atproto.moderation.defs#reasonSpam',
+      },
+      subject,
+    })
+    const queue = await network.ozone.ctx
+      .queueService(network.ozone.ctx.db)
+      .create({
+        name: 'Appeal source queue',
+        description: null,
+        subjectTypes: ['record'],
+        collection: null,
+        reportTypes: ['com.atproto.moderation.defs#reasonSpam'],
+        recommendedPolicies: [],
+        createdBy: network.ozone.adminAccnt.did,
+      })
+    await network.ozone.ctx
+      .queueService(network.ozone.ctx.db)
+      .insertReportsFromEvents({
+        cursor: sourceReport.id - 1,
+        limit: 1,
+      })
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventTakedown',
+      },
+      subject,
+    })
+    const source = await network.ozone.ctx.db.db
+      .selectFrom('report')
+      .where('eventId', '=', sourceReport.id)
+      .select('id')
+      .executeTakeFirstOrThrow()
+    await network.ozone.ctx.db.db
+      .updateTable('report')
+      .where('id', '=', source.id)
+      .set({ actionEventIds: jsonb([action.id]) })
+      .execute()
+
+    const response = await appeal(action.id, sc.dids.bob)
+    const report = await latestAppealReport(sc.dids.bob)
+
+    expect(response.data).toMatchObject({
+      subject: { $type: 'com.atproto.repo.strongRef', uri: subject.uri },
+      appeal: { state: 'pending' },
+      // The appealed action, not the appeal, dates the subject.
+      createdAt: action.createdAt,
+    })
+    expect(report).toMatchObject({
+      queueId: queue.id,
+      status: 'queued',
+      reportType: REASONAPPEAL,
+      actionEventIds: [action.id],
+      did: sc.dids.bob,
+    })
+  })
+
+  it('does not reveal actions belonging to another user', async () => {
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventTakedown',
+      },
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.carol,
+      },
+    })
+
+    await expect(appeal(action.id, sc.dids.alice)).rejects.toMatchObject({
+      error: 'NotAppealable',
+    })
+  })
+
+  it('creates an unlinked subject appeal when actionId is omitted', async () => {
+    const response = await legacyAppeal(sc.dids.carol)
+    const report = await latestAppealReport(sc.dids.carol)
+
+    expect(response.data).toMatchObject({
+      subject: { $type: 'com.atproto.admin.defs#repoRef', did: sc.dids.carol },
+      appeal: { state: 'pending' },
+    })
+    expect(report).toMatchObject({
+      reportType: REASONAPPEAL,
+      actionEventIds: null,
+      did: sc.dids.carol,
+    })
+  })
+
+  it('requires exactly one appeal target', async () => {
+    await expect(callAppeal({}, sc.dids.alice)).rejects.toMatchObject({
+      error: 'InvalidAppealTarget',
+    })
+  })
+
+  it('rejects duplicate active appeals for the same action', async () => {
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: ['!warn'],
+        negateLabelVals: [],
+      },
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.alice,
+      },
+    })
+
+    await appeal(action.id, sc.dids.alice)
+    await expect(appeal(action.id, sc.dids.alice)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+  })
+
+  it('rejects moderation events that are not public decisions', async () => {
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventComment',
+        comment: 'Internal note',
+      },
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.alice,
+      },
+    })
+
+    await expect(appeal(action.id, sc.dids.alice)).rejects.toMatchObject({
+      error: 'NotAppealable',
+    })
+  })
+
+  it('allows a record only one appeal ever, closed appeals included', async () => {
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: sc.posts[sc.dids.dan][0].ref.uriStr,
+      cid: sc.posts[sc.dids.dan][0].ref.cidStr,
+    }
+    const first = await takedown(subject)
+    await appeal(first.id, sc.dids.dan)
+    await closeLatestAppeal(sc.dids.dan)
+
+    // A different action on the same record does not earn a second appeal.
+    const second = await label(subject)
+    await expect(appeal(second.id, sc.dids.dan)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+  })
+
+  it('matches an existing appeal by subject rather than by action', async () => {
+    const post = sc.posts[sc.dids.dan][1].ref
+    const action = await takedown({
+      $type: 'com.atproto.repo.strongRef',
+      uri: post.uriStr,
+      cid: post.cidStr,
+    })
+    await appeal(action.id, sc.dids.dan)
+
+    // Same record, reached through the legacy subject form.
+    await expect(appealRecord(post, sc.dids.dan)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+  })
+
+  it('lets an account appeal a later action once the previous appeal closes', async () => {
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: sc.dids.dan,
+    }
+    const first = await takedown(subject)
+    await appeal(first.id, sc.dids.dan)
+
+    const second = await label(subject)
+    await expect(appeal(second.id, sc.dids.dan)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+
+    const firstReportId = await closeLatestAppeal(sc.dids.dan)
+    await appeal(second.id, sc.dids.dan)
+    const secondReport = await latestAppealReport(sc.dids.dan)
+    expect(secondReport.id).not.toBe(firstReportId)
+  })
+
+  it('returns a subject view that satisfies the published lexicon', async () => {
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: sc.dids.bob,
+    }
+    const action = await takedown(subject)
+    const { data } = await appeal(action.id, sc.dids.bob)
+
+    expect(validateSubjectView(data).success).toBe(true)
+    expect(data).toEqual({
+      src: network.ozone.ctx.cfg.service.did,
+      subject,
+      enforcement: { state: 'takendown', scope: 'network' },
+      appeal: {
+        state: 'pending',
+        appealedAt: data.appeal.appealedAt,
+        appealableUntil: appealWindowEnd(
+          action.createdAt,
+          network.ozone.ctx.cfg.inbox.appealWindowMonths,
+        ),
+      },
+      availableActions: [],
+      latestAction: {
+        id: action.id,
+        type: 'accountTakedown',
+        scope: 'network',
+        createdAt: action.createdAt,
+      },
+      actionCount: 1,
+      createdAt: action.createdAt,
+      updatedAt: data.updatedAt,
+    })
+    // The appeal report ID stays server-side, and read state waits on a
+    // watermark Ozone does not store yet.
+    expect(data).not.toHaveProperty('reportId')
+    expect(data).not.toHaveProperty('isRead')
+  })
+
+  it('derives a suspension, its expiry, and the six-month appeal window', async () => {
+    const post = sc.posts[sc.dids.alice][0].ref
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: post.uriStr,
+      cid: post.cidStr,
+    }
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventTakedown',
+        durationInHours: 72,
+        policies: ['spam-automation'],
+      },
+      subject,
+    })
+    const { data } = await appeal(action.id, sc.dids.alice)
+
+    // A record takedown reads as "removed" whether or not it has a duration.
+    expect(data.enforcement).toMatchObject({ state: 'removed' })
+    expect(data.enforcement.expiresAt).toBeDefined()
+    expect(data.latestAction).toMatchObject({
+      type: 'contentRemoved',
+      policies: ['spam-automation'],
+    })
+    expect(data.appeal.appealableUntil).toBe(
+      appealWindowEnd(
+        action.createdAt,
+        network.ozone.ctx.cfg.inbox.appealWindowMonths,
+      ),
+    )
+  })
+
+  it('lets a takedown outrank a label while still listing it', async () => {
+    const post = sc.posts[sc.dids.alice][1].ref
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: post.uriStr,
+      cid: post.cidStr,
+    }
+    await label(subject)
+    const action = await takedown(subject)
+    const { data } = await appeal(action.id, sc.dids.alice)
+
+    expect(data.enforcement).toMatchObject({
+      state: 'removed',
+      labels: ['!warn'],
+    })
+    expect(data.actionCount).toBe(2)
+  })
+
+  it('folds a reversal into the action it undid rather than counting it', async () => {
+    const post = sc.posts[sc.dids.alice][2].ref
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: post.uriStr,
+      cid: post.cidStr,
+    }
+    await takedown(subject)
+    await modClient.emitEvent({
+      event: { $type: 'tools.ozone.moderation.defs#modEventReverseTakedown' },
+      subject,
+    })
+    const action = await takedown(subject)
+    const { data } = await appeal(action.id, sc.dids.alice)
+
+    // Two takedowns, one reversal: the reversal is not an action of its own.
+    expect(data.actionCount).toBe(2)
+    expect(data.latestAction).toMatchObject({
+      id: action.id,
+      type: 'contentRemoved',
+    })
+    expect(data.latestAction).not.toHaveProperty('reversedAt')
+  })
+
+  it('never leaks moderator-only text', async () => {
+    const post = sc.posts[sc.dids.carol][0].ref
+    const subject = {
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: post.uriStr,
+      cid: post.cidStr,
+    }
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventTakedown',
+        comment: 'MODERATOR-ONLY-REASONING',
+      },
+      subject,
+    })
+    const { data } = await appeal(action.id, sc.dids.carol)
+
+    expect(JSON.stringify(data)).not.toContain('MODERATOR-ONLY-REASONING')
+  })
+  it('refuses an unauthenticated caller', async () => {
+    await expect(
+      sc.agent.call(
+        'tools.ozone.inbox.appealActionedSubject',
+        undefined,
+        { reason: 'Please reconsider this decision', actionId: 1 },
+        {
+          encoding: 'application/json',
+          headers: { 'atproto-proxy': proxyHeader },
+        },
+      ),
+    ).rejects.toMatchObject({ status: 401 })
+  })
+
+  it('hides a nonexistent action behind the same error as an inaccessible one', async () => {
+    await expect(appeal(999_999, sc.dids.alice)).rejects.toMatchObject({
+      error: 'NotAppealable',
+    })
+  })
+
+  it("refuses to appeal another user's content", async () => {
+    const post = sc.posts[sc.dids.bob][1].ref
+    const action = await takedown({
+      $type: 'com.atproto.repo.strongRef',
+      uri: post.uriStr,
+      cid: post.cidStr,
+    })
+
+    await expect(appeal(action.id, sc.dids.alice)).rejects.toMatchObject({
+      error: 'NotAppealable',
+    })
+  })
+
+  it('rejects naming both an action and a subject', async () => {
+    await expect(
+      callAppeal(
+        {
+          actionId: 1,
+          subject: {
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: sc.dids.carol,
+          },
+        },
+        sc.dids.carol,
+      ),
+    ).rejects.toMatchObject({ error: 'InvalidAppealTarget' })
+  })
+
+  it('writes nothing when the appeal is rejected', async () => {
+    const account = await sc.createAccount('rollback', {
+      handle: 'rollback.test',
+      email: 'rollback@test.com',
+      password: 'rollback-pass',
+    })
+    const action = await takedown({
+      $type: 'com.atproto.admin.defs#repoRef',
+      did: account.did,
+    })
+    await appeal(action.id, account.did)
+
+    const countEvents = async () =>
+      network.ozone.ctx.db.db
+        .selectFrom('moderation_event')
+        .where('subjectDid', '=', account.did)
+        .select((eb) => eb.fn.countAll<string>().as('count'))
+        .executeTakeFirstOrThrow()
+
+    const before = await countEvents()
+    await expect(appeal(action.id, account.did)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+    // The rejected attempt must not leave a stray report event behind.
+    expect(await countEvents()).toEqual(before)
+  })
+
+  it('leaves the appeal unassigned when the source reports disagree', async () => {
+    const account = await sc.createAccount('ambiguous', {
+      handle: 'ambiguous.test',
+      email: 'ambiguous@test.com',
+      password: 'ambiguous-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const action = await takedown(subject)
+
+    // Two source reports linked to the same action, sitting in different
+    // queues: there is no single queue to inherit.
+    const [queueA, queueB] = await Promise.all(
+      ['Ambiguous queue A', 'Ambiguous queue B'].map((name) =>
+        network.ozone.ctx.queueService(network.ozone.ctx.db).create({
+          name,
+          description: null,
+          subjectTypes: ['account'],
+          collection: null,
+          reportTypes: ['com.atproto.moderation.defs#reasonSpam'],
+          recommendedPolicies: [],
+          createdBy: network.ozone.adminAccnt.did,
+        }),
+      ),
+    )
+    await network.ozone.ctx.db.db
+      .insertInto('report')
+      .values(
+        [queueA.id, queueB.id].map((queueId) => ({
+          eventId: action.id * 1000 + queueId,
+          queueId,
+          queuedAt: new Date().toISOString(),
+          actionEventIds: jsonb([action.id]),
+          actionNote: null,
+          isMuted: false,
+          isAutomated: false,
+          status: 'queued',
+          reportType: 'com.atproto.moderation.defs#reasonSpam',
+          did: account.did,
+          recordPath: '',
+          subjectMessageId: null,
+          subjectConvoId: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })),
+      )
+      .execute()
+
+    await appeal(action.id, account.did)
+    const report = await latestAppealReport(account.did)
+    expect(report).toMatchObject({
+      queueId: -1,
+      queuedAt: null,
+      status: 'open',
+    })
+  })
+
+  it('never inherits a queue from another appeal report', async () => {
+    const account = await sc.createAccount('appealsource', {
+      handle: 'appealsource.test',
+      email: 'appealsource@test.com',
+      password: 'appealsource-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const action = await takedown(subject)
+    const queue = await network.ozone.ctx
+      .queueService(network.ozone.ctx.db)
+      .create({
+        name: 'Appeal-only queue',
+        description: null,
+        subjectTypes: ['account'],
+        collection: null,
+        reportTypes: [REASONAPPEAL],
+        recommendedPolicies: [],
+        createdBy: network.ozone.adminAccnt.did,
+      })
+
+    // An existing appeal report in a queue, linked to the same action. It is
+    // not a source of truth for where a new appeal belongs.
+    await appeal(action.id, account.did)
+    const existing = await latestAppealReport(account.did)
+    await network.ozone.ctx.db.db
+      .updateTable('report')
+      .where('id', '=', existing.id)
+      .set({
+        queueId: queue.id,
+        status: 'closed',
+        closedAt: new Date().toISOString(),
+      })
+      .execute()
+
+    const second = await label(subject)
+    await appeal(second.id, account.did)
+    expect(await latestAppealReport(account.did)).toMatchObject({
+      queueId: -1,
+    })
+  })
+
+  it('accepts an appeal from a reporting-muted user and marks it muted', async () => {
+    const account = await sc.createAccount('muted', {
+      handle: 'muted.test',
+      email: 'muted@test.com',
+      password: 'muted-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventMuteReporter',
+        durationInHours: 24,
+      },
+      subject,
+    })
+    const action = await takedown(subject)
+
+    // A reporting mute applies to appeals too. The appeal is recorded, flagged,
+    // and left for the muted-report workflow to handle - it is not an
+    // unlimited channel around the mute, nor is it silently dropped.
+    await appeal(action.id, account.did)
+    expect(await latestAppealReport(account.did)).toMatchObject({
+      isMuted: true,
+    })
+  })
+
+  it('closes the appeal window six months after the action', async () => {
+    const account = await sc.createAccount('stale', {
+      handle: 'stale.test',
+      email: 'stale@test.com',
+      password: 'stale-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const stale = await takedown(subject)
+    const fresh = await label(subject)
+
+    const backdate = async (id: number, createdAt: string) =>
+      network.ozone.ctx.db.db
+        .updateTable('moderation_event')
+        .where('id', '=', id)
+        .set({ createdAt })
+        .execute()
+
+    const now = Date.now()
+    // A day past the window, and a day inside it.
+    await backdate(stale.id, new Date(now - 190 * 86_400_000).toISOString())
+    await backdate(fresh.id, new Date(now - 170 * 86_400_000).toISOString())
+
+    await expect(appeal(stale.id, account.did)).rejects.toMatchObject({
+      error: 'AppealWindowExpired',
+    })
+    await expect(appeal(fresh.id, account.did)).resolves.toBeDefined()
+  })
+
+  it('shows a resolved appeal with its public note and never the internal one', async () => {
+    const account = await sc.createAccount('resolved', {
+      handle: 'resolved.test',
+      email: 'resolved@test.com',
+      password: 'resolved-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const action = await takedown(subject)
+    await appeal(action.id, account.did)
+    const report = await latestAppealReport(account.did)
+
+    await ozoneAgent.api.tools.ozone.report.createActivity(
+      {
+        reportId: report.id,
+        activity: { $type: 'tools.ozone.report.defs#closeActivity' },
+        publicNote: 'We reviewed this again and the takedown stands.',
+        internalNote: 'MODERATOR-ONLY-RATIONALE',
+      },
+      {
+        encoding: 'application/json',
+        headers: await network.ozone.modHeaders(
+          'tools.ozone.report.createActivity',
+          'admin',
+        ),
+      },
+    )
+    await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventResolveAppeal',
+        comment: 'MODERATOR-ONLY-COMMENT',
+      },
+      subject,
+    })
+
+    const view = await hydrateSubjectView(
+      network.ozone.ctx.db,
+      new RepoSubject(account.did),
+      network.ozone.ctx.cfg.service.did,
+      network.ozone.ctx.cfg.inbox,
+    )
+
+    expect(validateSubjectView(view).success).toBe(true)
+    expect(view?.appeal).toMatchObject({
+      state: 'resolved',
+      note: 'We reviewed this again and the takedown stands.',
+    })
+    expect(view?.appeal?.resolvedAt).toBeDefined()
+    const serialized = JSON.stringify(view)
+    expect(serialized).not.toContain('MODERATOR-ONLY-RATIONALE')
+    expect(serialized).not.toContain('MODERATOR-ONLY-COMMENT')
+  })
+
+  it('returns nothing for a subject with no moderation history', async () => {
+    const view = await hydrateSubjectView(
+      network.ozone.ctx.db,
+      new RecordSubject(
+        `at://${sc.dids.dan}/app.bsky.feed.post/never-actioned`,
+        'bafyreiunknown',
+      ),
+      network.ozone.ctx.cfg.service.did,
+      network.ozone.ctx.cfg.inbox,
+    )
+    expect(view).toBeNull()
+  })
+  it('rejects a malformed appeal target', async () => {
+    // Below the lexicon's minimum.
+    await expect(callAppeal({ actionId: 0 }, sc.dids.alice)).rejects.toThrow()
+    // Not a subject shape the endpoint knows.
+    await expect(
+      callAppeal(
+        { subject: { $type: 'com.example.notASubject' } },
+        sc.dids.alice,
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('accepts a legacy appeal for a subject with no action history', async () => {
+    const account = await sc.createAccount('legacyrec', {
+      handle: 'legacyrec.test',
+      email: 'legacyrec@test.com',
+      password: 'legacyrec-pass',
+    })
+    const post = await sc.post(account.did, 'never actioned')
+
+    const { data } = await appealRecord(
+      { uriStr: post.ref.uriStr, cidStr: post.ref.cidStr },
+      account.did,
+    )
+
+    // The legacy form does not require an action, so the view has an appeal but
+    // no history to describe and nothing further to offer.
+    expect(validateSubjectView(data).success).toBe(true)
+    expect(data.appeal).toEqual({
+      state: 'pending',
+      appealedAt: data.appeal.appealedAt,
+    })
+    // Nothing appealable on record means no window to advertise.
+    expect(data.appeal).not.toHaveProperty('appealableUntil')
+    expect(data).not.toHaveProperty('latestAction')
+    expect(data).not.toHaveProperty('actionCount')
+    expect(data.availableActions).toEqual([])
+    // No source report to inherit from leaves the appeal unassigned.
+    expect(await latestAppealReport(account.did)).toMatchObject({ queueId: -1 })
+  })
+  it('loads subjects without leaking one subject into another', async () => {
+    const account = await sc.createAccount('batch', {
+      handle: 'batch.test',
+      email: 'batch@test.com',
+      password: 'batch-pass',
+    })
+    const postA = await sc.post(account.did, 'batch a')
+    const postB = await sc.post(account.did, 'batch b')
+
+    const ref = (post: { ref: { uriStr: string; cidStr: string } }) => ({
+      $type: 'com.atproto.repo.strongRef' as const,
+      uri: post.ref.uriStr,
+      cid: post.ref.cidStr,
+    })
+    // One action on the account, two on one of its records.
+    await takedown({
+      $type: 'com.atproto.admin.defs#repoRef',
+      did: account.did,
+    })
+    await label(ref(postA))
+    await takedown(ref(postA))
+
+    const subjects = [
+      new RepoSubject(account.did),
+      new RecordSubject(postA.ref.uriStr, postA.ref.cidStr),
+      new RecordSubject(postB.ref.uriStr, postB.ref.cidStr),
+    ]
+    const [accountSnapshot, postASnapshot, postBSnapshot] = await Promise.all(
+      subjects.map((subject) => loadSubject(network.ozone.ctx.db, subject)),
+    )
+
+    // The account's own history, not its records'.
+    expect(accountSnapshot).toMatchObject({
+      actionCount: 1,
+    })
+    expect(postASnapshot).toMatchObject({
+      actionCount: 2,
+    })
+    // A record nothing has happened to still gets an empty snapshot.
+    expect(postBSnapshot).toMatchObject({
+      actionCount: 0,
+      events: [],
+      appealReport: null,
+    })
+  })
+  it("keeps an account's chat moderation out of its account history", async () => {
+    const account = await sc.createAccount('chatty', {
+      handle: 'chatty.test',
+      email: 'chatty@test.com',
+      password: 'chatty-pass',
+    })
+    const convoId = 'convo-for-chatty'
+    const messageId = 'message-for-chatty'
+
+    // One action on the account, plus chat actions on the same DID. Messages
+    // and conversations both carry a null subjectUri, so they are only
+    // distinguishable from the account by their own id columns.
+    await takedown({
+      $type: 'com.atproto.admin.defs#repoRef',
+      did: account.did,
+    })
+    await takedown({
+      $type: 'chat.bsky.convo.defs#messageRef',
+      did: account.did,
+      convoId,
+      messageId,
+    })
+    // A label rather than a takedown: a message and its conversation share one
+    // subject status row, so the second takedown would be refused.
+    await label({
+      $type: 'chat.bsky.convo.defs#convoRef',
+      did: account.did,
+      convoId,
+    })
+
+    const subjects = [
+      new RepoSubject(account.did),
+      new MessageSubject(account.did, convoId, messageId),
+      new ConvoSubject(account.did, convoId),
+    ]
+    const [accountSnapshot, messageSnapshot, convoSnapshot] = await Promise.all(
+      subjects.map((subject) => loadSubject(network.ozone.ctx.db, subject)),
+    )
+
+    expect(accountSnapshot).toMatchObject({
+      actionCount: 1,
+    })
+    expect(messageSnapshot).toMatchObject({
+      actionCount: 1,
+    })
+    expect(convoSnapshot).toMatchObject({
+      actionCount: 1,
+    })
+  })
+  it('never offers an appeal that submission would refuse', async () => {
+    const account = await sc.createAccount('superseded', {
+      handle: 'superseded.test',
+      email: 'superseded@test.com',
+      password: 'superseded-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const action = await label(subject)
+    await appeal(action.id, account.did)
+
+    // A takedown clears `appealed` without anyone working the appeal, so its
+    // report is still open in a queue. The subject reads as superseded.
+    await takedown(subject)
+    const view = await hydrateSubjectView(
+      network.ozone.ctx.db,
+      new RepoSubject(account.did),
+      network.ozone.ctx.cfg.service.did,
+      network.ozone.ctx.cfg.inbox,
+    )
+    expect(view?.appeal?.state).toBe('superseded')
+
+    // The open appeal still blocks a new one, so the view must not advertise
+    // an appeal the endpoint is going to reject.
+    expect(view?.availableActions).toEqual([])
+    await expect(appeal(action.id, account.did)).rejects.toMatchObject({
+      error: 'AlreadyAppealed',
+    })
+  })
+  it('shows a moderator email in the history but does not let it be appealed', async () => {
+    const account = await sc.createAccount('emailed', {
+      handle: 'emailed.test',
+      email: 'emailed@test.com',
+      password: 'emailed-pass',
+    })
+    const subject = {
+      $type: 'com.atproto.admin.defs#repoRef' as const,
+      did: account.did,
+    }
+    const action = await modClient.emitEvent({
+      event: {
+        $type: 'tools.ozone.moderation.defs#modEventEmail',
+        subjectLine: 'About your recent post',
+        comment: 'warning',
+        strikeCount: 1,
+      },
+      subject,
+    })
+
+    // An email logs a communication; it asserts no enforcement to reverse.
+    await expect(appeal(action.id, account.did)).rejects.toMatchObject({
+      error: 'NotAppealable',
+    })
+
+    const view = await hydrateSubjectView(
+      network.ozone.ctx.db,
+      new RepoSubject(account.did),
+      network.ozone.ctx.cfg.service.did,
+      network.ozone.ctx.cfg.inbox,
+    )
+    // Still part of the history the user can see...
+    expect(view?.latestAction).toMatchObject({ type: 'communicationSent' })
+    expect(view?.actionCount).toBe(1)
+    // ...but it opens no appeal window and offers nothing.
+    expect(view?.appeal).toEqual({ state: 'none' })
+    expect(view?.availableActions).toEqual([])
+  })
+  it('accepts an appeal with no explanation', async () => {
+    const account = await sc.createAccount('terse', {
+      handle: 'terse.test',
+      email: 'terse@test.com',
+      password: 'terse-pass',
+    })
+    const action = await takedown({
+      $type: 'com.atproto.admin.defs#repoRef',
+      did: account.did,
+    })
+
+    // Filing an appeal is a request for review; making the user argue their
+    // case is not a precondition for getting one.
+    const { data } = await sc.agent.call(
+      'tools.ozone.inbox.appealActionedSubject',
+      undefined,
+      { actionId: action.id },
+      {
+        encoding: 'application/json',
+        headers: {
+          ...sc.getHeaders(account.did),
+          'atproto-proxy': proxyHeader,
+        },
+      },
+    )
+
+    expect(validateSubjectView(data).success).toBe(true)
+    expect(data.appeal).toMatchObject({ state: 'pending' })
+    const report = await latestAppealReport(account.did)
+    expect(report).toMatchObject({ reportType: REASONAPPEAL })
+  })
+})

--- a/packages/ozone/tests/inbox.test.ts
+++ b/packages/ozone/tests/inbox.test.ts
@@ -1,0 +1,463 @@
+import {
+  appealWindowEnd,
+  isAppealWindowOpen,
+  toAppealState,
+} from '../src/inbox/appeal.ts'
+import {
+  type SubjectSnapshot,
+  toActionViews,
+  toEnforcementView,
+  toSubjectView,
+} from '../src/inbox/views.ts'
+import { RecordSubject, RepoSubject } from '../src/mod-service/subject.ts'
+import type {
+  ModerationEventRow,
+  ModerationSubjectStatusRow,
+} from '../src/mod-service/types.ts'
+
+const ACCOUNT = new RepoSubject('did:plc:user')
+const RECORD = new RecordSubject(
+  'at://did:plc:user/app.bsky.feed.post/abc',
+  'bafyreiabc',
+)
+
+let nextId = 1
+const event = (
+  overrides: Partial<ModerationEventRow> = {},
+): ModerationEventRow => ({
+  id: nextId++,
+  action: 'tools.ozone.moderation.defs#modEventTakedown',
+  subjectType: 'com.atproto.admin.defs#repoRef',
+  subjectDid: 'did:plc:user',
+  subjectUri: null,
+  subjectCid: null,
+  subjectBlobCids: null,
+  subjectConvoId: null,
+  subjectMessageId: null,
+  createLabelVals: null,
+  negateLabelVals: null,
+  comment: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  createdBy: 'did:plc:mod',
+  durationInHours: null,
+  expiresAt: null,
+  meta: null,
+  addedTags: null,
+  removedTags: null,
+  legacyRefId: null,
+  modTool: null,
+  externalId: null,
+  severityLevel: null,
+  strikeCount: null,
+  strikeExpiresAt: null,
+  ...overrides,
+})
+
+const status = (
+  overrides: Partial<ModerationSubjectStatusRow> = {},
+): ModerationSubjectStatusRow =>
+  ({
+    id: 1,
+    did: 'did:plc:user',
+    recordPath: '',
+    convoId: '',
+    recordCid: null,
+    blobCids: null,
+    reviewState: 'tools.ozone.moderation.defs#reviewClosed',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lastReviewedBy: null,
+    lastReviewedAt: null,
+    lastReportedAt: null,
+    lastAppealedAt: null,
+    hostingUpdatedAt: null,
+    hostingDeletedAt: null,
+    hostingCreatedAt: null,
+    hostingDeactivatedAt: null,
+    hostingReactivatedAt: null,
+    hostingStatus: null,
+    muteUntil: null,
+    muteReportingUntil: null,
+    suspendUntil: null,
+    takendown: false,
+    appealed: null,
+    comment: null,
+    tags: null,
+    ageAssuranceState: 'unknown',
+    ...overrides,
+  }) as ModerationSubjectStatusRow
+
+const future = () => new Date(Date.now() + 86_400_000).toISOString()
+const past = () => new Date(Date.now() - 86_400_000).toISOString()
+
+describe('inbox appeal window', () => {
+  it('adds six calendar months', () => {
+    expect(appealWindowEnd('2026-01-15T12:00:00.000Z', 6)).toBe(
+      '2026-07-15T12:00:00.000Z',
+    )
+  })
+
+  it('clamps a month-end rollover rather than spilling into the next month', () => {
+    // 31 Aug + 6 months is the end of February, not 2/3 March.
+    expect(appealWindowEnd('2025-08-31T00:00:00.000Z', 6)).toBe(
+      '2026-02-28T00:00:00.000Z',
+    )
+  })
+
+  it('closes once the window has elapsed', () => {
+    expect(isAppealWindowOpen(past(), 6)).toBe(true)
+    expect(isAppealWindowOpen('2020-01-01T00:00:00.000Z', 6)).toBe(false)
+  })
+})
+
+describe('inbox action mapper', () => {
+  it('splits takedowns by subject type and duration', () => {
+    expect(toActionViews([event()])[0]).toMatchObject({
+      type: 'accountTakedown',
+    })
+    expect(toActionViews([event({ durationInHours: 72 })])[0]).toMatchObject({
+      type: 'accountSuspended',
+    })
+    expect(
+      toActionViews([
+        event({
+          subjectType: 'com.atproto.repo.strongRef',
+          subjectUri: RECORD.uri,
+        }),
+      ])[0],
+    ).toMatchObject({ type: 'contentRemoved' })
+  })
+
+  it('derives takedown scope from the services it targeted', () => {
+    const scopeOf = (targetServices?: string) =>
+      toActionViews([
+        event({ meta: targetServices ? { targetServices } : null }),
+      ])[0].scope
+
+    expect(scopeOf()).toBe('network')
+    expect(scopeOf('appview')).toBe('app')
+    expect(scopeOf('appview,pds')).toBe('network')
+  })
+
+  it('folds a reversal into the takedown it undoes', () => {
+    const actions = toActionViews([
+      event({ id: 1, createdAt: '2026-01-01T00:00:00.000Z' }),
+      event({
+        id: 2,
+        action: 'tools.ozone.moderation.defs#modEventReverseTakedown',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      }),
+    ])
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      type: 'accountTakedown',
+      reversedAt: '2026-01-02T00:00:00.000Z',
+    })
+  })
+
+  it('maps labels, hides the takedown labels, and pairs a negation', () => {
+    const actions = toActionViews([
+      event({
+        id: 1,
+        action: 'tools.ozone.moderation.defs#modEventLabel',
+        createLabelVals: '!warn !takedown',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }),
+      event({
+        id: 2,
+        action: 'tools.ozone.moderation.defs#modEventLabel',
+        negateLabelVals: '!warn',
+        createdAt: '2026-01-03T00:00:00.000Z',
+      }),
+    ])
+
+    // Newest first.
+    expect(actions.map((a) => a.type)).toEqual(['labelRemoved', 'labelApplied'])
+    expect(actions[1]).toMatchObject({
+      type: 'labelApplied',
+      scope: 'app',
+      labels: ['!warn'],
+      reversedAt: '2026-01-03T00:00:00.000Z',
+    })
+  })
+
+  it('maps emails and their policies, and drops internal event types', () => {
+    const actions = toActionViews([
+      event({
+        action: 'tools.ozone.moderation.defs#modEventEmail',
+        meta: { policies: 'spam-automation,impersonation' },
+      }),
+      event({ action: 'tools.ozone.moderation.defs#modEventComment' }),
+      event({ action: 'tools.ozone.moderation.defs#modEventReport' }),
+    ])
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      type: 'communicationSent',
+      policies: ['spam-automation', 'impersonation'],
+    })
+  })
+
+  it('never exposes moderator comments', () => {
+    const actions = toActionViews([event({ comment: 'internal reasoning' })])
+    expect(JSON.stringify(actions)).not.toContain('internal reasoning')
+  })
+})
+
+describe('inbox enforcement mapper', () => {
+  const enforcement = (
+    subject: RepoSubject | RecordSubject,
+    row: Partial<ModerationSubjectStatusRow>,
+    labels: string[] = [],
+    actions = [{ id: 1, type: 'accountTakedown', createdAt: '', scope: 'app' }],
+  ) =>
+    toEnforcementView({
+      subject,
+      status: status(row),
+      labels,
+      actions,
+    })
+
+  it('reports an account takedown, taking scope from the action', () => {
+    expect(enforcement(ACCOUNT, { takendown: true })).toEqual({
+      state: 'takendown',
+      scope: 'app',
+    })
+  })
+
+  it('reports a temporary account takedown as a suspension with an expiry', () => {
+    const suspendUntil = future()
+    expect(enforcement(ACCOUNT, { takendown: true, suspendUntil })).toEqual({
+      state: 'suspended',
+      scope: 'app',
+      expiresAt: suspendUntil,
+    })
+  })
+
+  it('reports a record takedown as removed', () => {
+    expect(enforcement(RECORD, { takendown: true })).toMatchObject({
+      state: 'removed',
+    })
+  })
+
+  it('lets a takedown outrank labels while still listing them', () => {
+    expect(
+      enforcement(ACCOUNT, { takendown: true }, ['!warn', '!takedown']),
+    ).toMatchObject({ state: 'takendown', labels: ['!warn'] })
+  })
+
+  it('falls back to labeled, then to none', () => {
+    expect(enforcement(ACCOUNT, {}, ['!warn'])).toEqual({
+      state: 'labeled',
+      scope: 'app',
+      labels: ['!warn'],
+    })
+    expect(enforcement(ACCOUNT, {})).toEqual({ state: 'none' })
+    // A takedown label on its own is enforcement state, not a label.
+    expect(enforcement(ACCOUNT, {}, ['!takedown'])).toEqual({ state: 'none' })
+  })
+
+  it('does not treat an elapsed suspension as enforcement', () => {
+    expect(enforcement(ACCOUNT, { suspendUntil: past() })).toEqual({
+      state: 'none',
+    })
+  })
+})
+
+describe('inbox appeal mapper', () => {
+  const appealable = past()
+  const appeal = (
+    subject: RepoSubject | RecordSubject,
+    args: {
+      appealed?: boolean | null
+      lastAppealedAt?: string | null
+      report?: {
+        id: number
+        status: string
+        createdAt: string
+        closedAt: string | null
+      } | null
+      publicNote?: string | null
+      latestAppealableAt?: string | null
+    } = {},
+  ) =>
+    toAppealState({
+      subject,
+      status: status({
+        appealed: args.appealed ?? null,
+        lastAppealedAt: args.lastAppealedAt ?? null,
+      }),
+      report: args.report ?? null,
+      publicNote: args.publicNote ?? null,
+      windowMonths: 6,
+      latestAppealableAt:
+        args.latestAppealableAt === undefined
+          ? appealable
+          : args.latestAppealableAt,
+    })
+
+  const openReport = {
+    id: 7,
+    status: 'open',
+    createdAt: '2026-01-02T00:00:00.000Z',
+    closedAt: null,
+  }
+  const closedReport = {
+    ...openReport,
+    status: 'closed',
+    closedAt: '2026-01-05T00:00:00.000Z',
+  }
+
+  it('offers an appeal when the window is open and none has been filed', () => {
+    const { view, availableActions } = appeal(ACCOUNT)
+    expect(view).toMatchObject({
+      state: 'none',
+      appealableUntil: appealWindowEnd(appealable, 6),
+    })
+    expect(availableActions).toEqual(['appeal'])
+  })
+
+  it('expires once the window elapses with no appeal', () => {
+    const { view, availableActions } = appeal(ACCOUNT, {
+      latestAppealableAt: '2020-01-01T00:00:00.000Z',
+    })
+    expect(view.state).toBe('expired')
+    expect(availableActions).toEqual([])
+  })
+
+  it('stays none when there is nothing appealable at all', () => {
+    const { view, availableActions } = appeal(ACCOUNT, {
+      latestAppealableAt: null,
+    })
+    expect(view).toEqual({ state: 'none' })
+    expect(availableActions).toEqual([])
+  })
+
+  it('reads pending off the same flag the submission guard writes', () => {
+    const { view, availableActions } = appeal(ACCOUNT, {
+      appealed: true,
+      lastAppealedAt: '2026-01-02T00:00:00.000Z',
+      report: openReport,
+    })
+    expect(view).toMatchObject({
+      state: 'pending',
+      appealedAt: '2026-01-02T00:00:00.000Z',
+    })
+    expect(availableActions).toEqual([])
+  })
+
+  it('resolves with the close date and the public note', () => {
+    const { view } = appeal(ACCOUNT, {
+      appealed: false,
+      report: closedReport,
+      publicNote: 'We reviewed this again and the post still violates policy.',
+    })
+    expect(view).toMatchObject({
+      state: 'resolved',
+      resolvedAt: closedReport.closedAt,
+      note: 'We reviewed this again and the post still violates policy.',
+    })
+  })
+
+  it('supersedes an appeal cleared without ever being closed', () => {
+    const { view } = appeal(ACCOUNT, { appealed: false, report: openReport })
+    expect(view.state).toBe('superseded')
+    expect(view).not.toHaveProperty('resolvedAt')
+    expect(view).not.toHaveProperty('note')
+  })
+
+  it('gives an account another appeal after the last one closes', () => {
+    expect(
+      appeal(ACCOUNT, { appealed: false, report: closedReport })
+        .availableActions,
+    ).toEqual(['appeal'])
+  })
+
+  it('never re-offers an appeal on a record', () => {
+    expect(
+      appeal(RECORD, { appealed: false, report: closedReport })
+        .availableActions,
+    ).toEqual([])
+  })
+})
+
+describe('inbox subject view', () => {
+  const snapshot = (
+    overrides: Partial<SubjectSnapshot> = {},
+  ): SubjectSnapshot => ({
+    status: status(),
+    events: [],
+    labels: [],
+    actionCount: 0,
+    firstActionAt: null,
+    latestAppealableAt: null,
+    appealReport: null,
+    appealPublicNote: null,
+    ...overrides,
+  })
+
+  const compose = (overrides: Partial<SubjectSnapshot> = {}) =>
+    toSubjectView({
+      subject: ACCOUNT,
+      serviceDid: 'did:plc:modservice',
+      cfg: { appealWindowMonths: 6 },
+      snapshot: snapshot(overrides),
+    })
+
+  it('returns nothing for a subject with no history at all', () => {
+    expect(compose({ status: null })).toBeNull()
+  })
+
+  it('dates the subject from its first action, not its status row', () => {
+    const view = compose({
+      firstActionAt: '2026-01-01T00:00:00.000Z',
+      actionCount: 1,
+      events: [event({ createdAt: '2026-03-01T00:00:00.000Z' })],
+    })
+
+    expect(view).toMatchObject({
+      src: 'did:plc:modservice',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+      actionCount: 1,
+      latestAction: { type: 'accountTakedown' },
+    })
+  })
+
+  it('reports the total action count even when the event window was capped', () => {
+    // One event loaded, many more behind it.
+    const view = compose({
+      actionCount: 500,
+      firstActionAt: '2020-01-01T00:00:00.000Z',
+      events: [event()],
+    })
+    expect(view?.actionCount).toBe(500)
+  })
+
+  it('omits the action fields entirely when there is no public history', () => {
+    const view = compose({ status: status({ appealed: true }) })
+    expect(view).not.toHaveProperty('latestAction')
+    expect(view).not.toHaveProperty('actionCount')
+    expect(view).not.toHaveProperty('isRead')
+  })
+
+  it('lets a later appeal move updatedAt past the newest action', () => {
+    const view = compose({
+      actionCount: 1,
+      firstActionAt: '2026-01-01T00:00:00.000Z',
+      events: [event({ createdAt: '2026-01-01T00:00:00.000Z' })],
+      status: status({
+        appealed: true,
+        lastAppealedAt: '2026-02-01T00:00:00.000Z',
+      }),
+      appealReport: {
+        id: 1,
+        status: 'open',
+        createdAt: '2026-02-01T00:00:00.000Z',
+        closedAt: null,
+      },
+    })
+    expect(view?.updatedAt).toBe('2026-02-01T00:00:00.000Z')
+  })
+})


### PR DESCRIPTION
## What & why

New `tools.ozone.inbox.appealActionedSubject` for mod inbox!

Updates how appeals are handled by attaching the decision being appealed and properly routing the appeal to the specialized queue that the actioned report was in.

The existing appeal path is still available (`com.atproto.moderation.createReport` with `tools.ozone.report.defs#reasonAppeal`)

## Checklist

- [ ] `pnpm build --force && pnpm verify` passes
- [ ] Tests pass, and new behavior is covered by tests
- [ ] A changeset is included for every package this touches
- [ ] Written with the help of an LLM or coding agent? Say so here, and name the tooling.
