### PR TITLE
APP-2933: implement reference-list opt-outs in AppView

### DIFF
--- a/.changeset/calm-lists-opt-out.md
+++ b/.changeset/calm-lists-opt-out.md
@@ -1,0 +1,6 @@
+---
+'@atproto/api': patch
+'@atproto/bsky': patch
+---
+
+Add reference-list opt-out records and enforce them in AppView list, list feed, and starter-pack views.

--- a/lexicons/app/bsky/authFullApp.json
+++ b/lexicons/app/bsky/authFullApp.json
@@ -133,6 +133,7 @@
             "app.bsky.graph.list",
             "app.bsky.graph.listblock",
             "app.bsky.graph.listitem",
+            "app.bsky.graph.referencelistoptout",
             "app.bsky.graph.starterpack",
             "app.bsky.notification.declaration"
           ]

--- a/lexicons/app/bsky/graph/defs.json
+++ b/lexicons/app/bsky/graph/defs.json
@@ -53,7 +53,12 @@
       "required": ["uri", "subject"],
       "properties": {
         "uri": { "type": "string", "format": "at-uri" },
-        "subject": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        "subject": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" },
+        "subjectOptedOut": {
+          "type": "boolean",
+          "const": true,
+          "description": "Set to true when the subject has opted out of appearing in the reference list. Only set when the viewer owns the list."
+        }
       }
     },
     "starterPackView": {
@@ -132,7 +137,12 @@
       "type": "object",
       "properties": {
         "muted": { "type": "boolean" },
-        "blocked": { "type": "string", "format": "at-uri" }
+        "blocked": { "type": "string", "format": "at-uri" },
+        "referenceListOptOut": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "The authenticated viewer's app.bsky.graph.referencelistoptout record URI for this reference list. Only set for reference lists. A client can delete this record to undo the opt-out."
+        }
       }
     },
     "notFoundActor": {

--- a/lexicons/app/bsky/graph/referencelistoptout.json
+++ b/lexicons/app/bsky/graph/referencelistoptout.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.referencelistoptout",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record requesting that its author be omitted from the public presentation of a reference list. This record is only enforced when the subject list's current purpose is app.bsky.graph.defs#referencelist. AppView indexes at most one record per actor and list pair, and ignores duplicate records.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Canonical, DID-based AT URI of the app.bsky.graph.list record from which the author requests omission."
+          },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -619,6 +619,7 @@ message GetBlockExistenceResponse {
 message ListItemInfo {
   string uri = 1;
   string did = 2;
+  bool subject_opted_out = 3;
 }
 
 // - Return dids of users in list A
@@ -627,6 +628,7 @@ message GetListMembersRequest {
   string list_uri = 1;
   int32 limit = 2;
   string cursor = 3;
+  string viewer_did = 4;
 }
 
 message GetListMembersResponse {
@@ -667,6 +669,15 @@ message GetActorListsRequest {
 message GetActorListsResponse {
   repeated string list_uris = 1;
   string cursor = 2;
+}
+
+message GetReferencelistoptoutsByActorAndSubjectsRequest {
+  string actor_did = 1;
+  repeated string subject_uris = 2;
+}
+
+message GetReferencelistoptoutsByActorAndSubjectsResponse {
+  repeated string uris = 1;
 }
 
 //
@@ -1704,6 +1715,7 @@ service Service {
   rpc GetListMembers(GetListMembersRequest) returns (GetListMembersResponse);
   rpc GetListMembership(GetListMembershipRequest) returns (GetListMembershipResponse);
   rpc GetListCount(GetListCountRequest) returns (GetListCountResponse);
+  rpc GetReferencelistoptoutsByActorAndSubjects(GetReferencelistoptoutsByActorAndSubjectsRequest) returns (GetReferencelistoptoutsByActorAndSubjectsResponse);
 
   // Mutes
   rpc GetActorMutesActor(GetActorMutesActorRequest) returns (GetActorMutesActorResponse);

--- a/packages/bsky/src/api/app/bsky/graph/getList.ts
+++ b/packages/bsky/src/api/app/bsky/graph/getList.ts
@@ -63,6 +63,7 @@ const skeleton = async (
     listUri: params.list,
     limit: params.limit,
     cursor: params.cursor,
+    viewerDid: params.hydrateCtx.viewer ?? undefined,
   })
   return {
     listUri: params.list,
@@ -108,12 +109,20 @@ const presentation = (
   const { ctx, skeleton, hydration } = input
   const { listUri, listitems, cursor } = skeleton
   const list = ctx.views.list(listUri, hydration)
-  const items = mapDefined(listitems, ({ uri, did }) =>
-    ctx.views.listItemView(uri as AtUriString, did as DidString, hydration),
-  )
   if (!list) {
     throw new InvalidRequestError('List not found')
   }
+  const showOptOuts =
+    hydration.ctx?.viewer === didFromUri(listUri) &&
+    list.purpose === app.bsky.graph.defs.Referencelist
+  const items = mapDefined(listitems, ({ uri, did, subjectOptedOut }) =>
+    ctx.views.listItemView(
+      uri as AtUriString,
+      did as DidString,
+      hydration,
+      showOptOuts && subjectOptedOut,
+    ),
+  )
   return { list, items, cursor }
 }
 

--- a/packages/bsky/src/data-plane/server/db/database-schema.ts
+++ b/packages/bsky/src/data-plane/server/db/database-schema.ts
@@ -33,6 +33,7 @@ import type * as profileAgg from './tables/profile-agg.js'
 import type * as profile from './tables/profile.js'
 import type * as quote from './tables/quote.js'
 import type * as record from './tables/record.js'
+import type * as referenceListOptOut from './tables/reference-list-opt-out.js'
 import type * as repost from './tables/repost.js'
 import type * as starterPack from './tables/starter-pack.js'
 import type * as subscription from './tables/subscription.js'
@@ -69,6 +70,7 @@ export type DatabaseSchemaType = duplicateRecord.PartialDB &
   actorState.PartialDB &
   actorSync.PartialDB &
   record.PartialDB &
+  referenceListOptOut.PartialDB &
   notification.PartialDB &
   notificationPushToken.PartialDB &
   didCache.PartialDB &

--- a/packages/bsky/src/data-plane/server/db/migrations/20260827T200000000Z-reference-list-opt-outs.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/20260827T200000000Z-reference-list-opt-outs.ts
@@ -1,0 +1,27 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('reference_list_opt_out')
+    .addColumn('uri', 'varchar', (col) => col.primaryKey())
+    .addColumn('cid', 'varchar', (col) => col.notNull())
+    .addColumn('creator', 'varchar', (col) => col.notNull())
+    .addColumn('subjectUri', 'varchar', (col) => col.notNull())
+    .addColumn('createdAt', 'varchar', (col) => col.notNull())
+    .addColumn('indexedAt', 'varchar', (col) => col.notNull())
+    .addColumn('sortAt', 'varchar', (col) =>
+      col
+        .generatedAlwaysAs(sql`least("createdAt", "indexedAt")`)
+        .stored()
+        .notNull(),
+    )
+    .addUniqueConstraint('reference_list_opt_out_unique_subject', [
+      'creator',
+      'subjectUri',
+    ])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('reference_list_opt_out').execute()
+}

--- a/packages/bsky/src/data-plane/server/db/migrations/index.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/index.ts
@@ -61,3 +61,4 @@ export * as _20260604T224952774Z from './20260604T224952774Z-post-embed-gallery-
 export * as _20260618T200000000Z from './20260618T200000000Z-add-mute-scope.js'
 export * as _20260729T223157563Z from './20260729T223157563Z-add-op-thread-reply.js'
 export * as _20260819T170000000Z from './20260819T170000000Z-add-like-subject-sort-index.js'
+export * as _20260827T200000000Z from './20260827T200000000Z-reference-list-opt-outs.js'

--- a/packages/bsky/src/data-plane/server/db/tables/reference-list-opt-out.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/reference-list-opt-out.ts
@@ -1,0 +1,15 @@
+import type { GeneratedAlways } from 'kysely'
+
+export const tableName = 'reference_list_opt_out'
+
+export interface ReferenceListOptOut {
+  uri: string
+  cid: string
+  creator: string
+  subjectUri: string
+  createdAt: string
+  indexedAt: string
+  sortAt: GeneratedAlways<string>
+}
+
+export type PartialDB = { [tableName]: ReferenceListOptOut }

--- a/packages/bsky/src/data-plane/server/indexing/index.ts
+++ b/packages/bsky/src/data-plane/server/indexing/index.ts
@@ -30,6 +30,7 @@ import * as NotifDeclaration from './plugins/notif-declaration.js'
 import * as Postgate from './plugins/post-gate.js'
 import * as Post from './plugins/post.js'
 import * as Profile from './plugins/profile.js'
+import * as ReferenceListOptOut from './plugins/reference-list-opt-out.js'
 import * as Repost from './plugins/repost.js'
 import * as StarterPack from './plugins/starter-pack.js'
 import * as Status from './plugins/status.js'
@@ -47,6 +48,7 @@ export class IndexingService {
     profile: Profile.PluginType
     list: List.PluginType
     listItem: ListItem.PluginType
+    referenceListOptOut: ReferenceListOptOut.PluginType
     listBlock: ListBlock.PluginType
     block: Block.PluginType
     feedGenerator: FeedGenerator.PluginType
@@ -74,6 +76,10 @@ export class IndexingService {
       profile: Profile.makePlugin(this.db, this.background),
       list: List.makePlugin(this.db, this.background),
       listItem: ListItem.makePlugin(this.db, this.background),
+      referenceListOptOut: ReferenceListOptOut.makePlugin(
+        this.db,
+        this.background,
+      ),
       listBlock: ListBlock.makePlugin(this.db, this.background),
       block: Block.makePlugin(this.db, this.background),
       feedGenerator: FeedGenerator.makePlugin(this.db, this.background),
@@ -325,6 +331,10 @@ export class IndexingService {
     // lists
     await this.db.db
       .deleteFrom('list_item')
+      .where('creator', '=', did)
+      .execute()
+    await this.db.db
+      .deleteFrom('reference_list_opt_out')
       .where('creator', '=', did)
       .execute()
     await this.db.db.deleteFrom('list').where('creator', '=', did).execute()

--- a/packages/bsky/src/data-plane/server/indexing/plugins/reference-list-opt-out.ts
+++ b/packages/bsky/src/data-plane/server/indexing/plugins/reference-list-opt-out.ts
@@ -1,0 +1,106 @@
+import type { Selectable } from 'kysely'
+import type { Cid } from '@atproto/lex'
+import { AtUri, normalizeDatetimeAlways } from '@atproto/syntax'
+import { app } from '../../../../lexicons/index.js'
+import type { BackgroundQueue } from '../../background.js'
+import type {
+  DatabaseSchema,
+  DatabaseSchemaType,
+} from '../../db/database-schema.js'
+import type { Database } from '../../db/index.js'
+import { RecordProcessor } from '../processor.js'
+
+type IndexedReferenceListOptOut = Selectable<
+  DatabaseSchemaType['reference_list_opt_out']
+>
+
+const parseSubject = (subject: string): AtUri | null => {
+  try {
+    const uri = new AtUri(subject)
+    if (
+      !uri.did ||
+      !uri.rkeySafe ||
+      uri.collection !== app.bsky.graph.list.$type ||
+      uri.pathname.split('/').filter(Boolean).length !== 2 ||
+      uri.search ||
+      uri.hash ||
+      uri.toString() !== subject
+    ) {
+      return null
+    }
+    return uri
+  } catch {
+    return null
+  }
+}
+
+const insertFn = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+  cid: Cid,
+  obj: app.bsky.graph.referencelistoptout.Main,
+  timestamp: string,
+): Promise<IndexedReferenceListOptOut | null> => {
+  const subject = parseSubject(obj.subject)
+  if (!subject) return null
+  const inserted = await db
+    .insertInto('reference_list_opt_out')
+    .values({
+      uri: uri.toString(),
+      cid: cid.toString(),
+      creator: uri.host,
+      subjectUri: subject.toString(),
+      createdAt: normalizeDatetimeAlways(obj.createdAt),
+      indexedAt: timestamp,
+    })
+    .onConflict((oc) => oc.doNothing())
+    .returningAll()
+    .executeTakeFirst()
+  return inserted || null
+}
+
+const findDuplicate = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+  obj: app.bsky.graph.referencelistoptout.Main,
+): Promise<AtUri | null> => {
+  const subject = parseSubject(obj.subject)
+  if (!subject) return null
+  const found = await db
+    .selectFrom('reference_list_opt_out')
+    .where('creator', '=', uri.host)
+    .where('subjectUri', '=', subject.toString())
+    .select('uri')
+    .executeTakeFirst()
+  return found ? new AtUri(found.uri) : null
+}
+
+const deleteFn = async (
+  db: DatabaseSchema,
+  uri: AtUri,
+): Promise<IndexedReferenceListOptOut | null> => {
+  const deleted = await db
+    .deleteFrom('reference_list_opt_out')
+    .where('uri', '=', uri.toString())
+    .returningAll()
+    .executeTakeFirst()
+  return deleted || null
+}
+
+export type PluginType = ReturnType<typeof makePlugin>
+export const makePlugin = (
+  db: Database,
+  background: BackgroundQueue<Database>,
+) => {
+  return new RecordProcessor(db, background, {
+    schema: app.bsky.graph.referencelistoptout.main,
+    insertFn,
+    findDuplicate,
+    deleteFn,
+    notifsForInsert: () => [],
+    notifsForDelete: () => ({ notifs: [], toDelete: [] }),
+    promoteDuplicateOnDelete: false,
+  })
+}
+
+export default makePlugin

--- a/packages/bsky/src/data-plane/server/indexing/processor.ts
+++ b/packages/bsky/src/data-plane/server/indexing/processor.ts
@@ -36,6 +36,7 @@ type RecordProcessorOptions<TSchema extends l.RecordSchema, TRow> = {
     replacedBy: TRow | null,
   ) => { notifs: Notif[]; toDelete: string[] }
   updateAggregates?: (db: DatabaseSchema, obj: TRow) => Promise<void>
+  promoteDuplicateOnDelete?: boolean
 }
 
 type Notif = Insertable<Notification>
@@ -195,6 +196,9 @@ export class RecordProcessor<TSchema extends l.RecordSchema, TRow> {
         .execute()
       return this.handleNotifs({ deleted })
     } else {
+      if (this.options.promoteDuplicateOnDelete === false) {
+        return this.handleNotifs({ deleted })
+      }
       const found = await this.db
         .selectFrom('duplicate_record')
         .innerJoin('record', 'record.uri', 'duplicate_record.uri')

--- a/packages/bsky/src/data-plane/server/routes/feeds.ts
+++ b/packages/bsky/src/data-plane/server/routes/feeds.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import type { ServiceImpl } from '@connectrpc/connect'
+import { app } from '../../../lexicons/index.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { FeedType } from '../../../proto/bsky_pb.js'
 import type { Database } from '../db/index.js'
@@ -170,12 +171,31 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getListFeed(req) {
     const { listUri, cursor, limit } = req
     const { ref } = db.db.dynamic
+    const list = await db.db
+      .selectFrom('list')
+      .where('uri', '=', listUri)
+      .select('purpose')
+      .executeTakeFirst()
 
     let builder = db.db
       .selectFrom('post')
       .selectAll('post')
       .innerJoin('list_item', 'list_item.subjectDid', 'post.creator')
       .where('list_item.listUri', '=', listUri)
+
+    if (list?.purpose === app.bsky.graph.defs.Referencelist) {
+      builder = builder.where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('reference_list_opt_out')
+              .select('uri')
+              .whereRef('reference_list_opt_out.creator', '=', 'post.creator')
+              .where('reference_list_opt_out.subjectUri', '=', listUri),
+          ),
+        ),
+      )
+    }
 
     const keyset = new TimeCidKeyset(ref('post.sortAt'), ref('post.cid'))
     builder = paginate(builder, {

--- a/packages/bsky/src/data-plane/server/routes/lists.ts
+++ b/packages/bsky/src/data-plane/server/routes/lists.ts
@@ -1,5 +1,6 @@
 import type { ServiceImpl } from '@connectrpc/connect'
 import { keyBy } from '@atproto/common'
+import { app } from '../../../lexicons/index.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
 import { TimeCidKeyset, paginate } from '../db/pagination.js'
@@ -28,12 +29,37 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   },
 
   async getListMembers(req) {
-    const { listUri, cursor, limit } = req
+    const { listUri, cursor, limit, viewerDid } = req
     const { ref } = db.db.dynamic
+    const list = await db.db
+      .selectFrom('list')
+      .where('uri', '=', listUri)
+      .select(['creator', 'purpose'])
+      .executeTakeFirst()
+    const isReferenceList = list?.purpose === app.bsky.graph.defs.Referencelist
+    const isOwner = isReferenceList && list.creator === viewerDid
     let builder = db.db
       .selectFrom('list_item')
       .where('listUri', '=', listUri)
       .selectAll()
+
+    if (isReferenceList && !isOwner) {
+      builder = builder.where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('reference_list_opt_out')
+              .select('uri')
+              .whereRef(
+                'reference_list_opt_out.creator',
+                '=',
+                'list_item.subjectDid',
+              )
+              .where('reference_list_opt_out.subjectUri', '=', listUri),
+          ),
+        ),
+      )
+    }
 
     const keyset = new TimeCidKeyset(
       ref('list_item.sortAt'),
@@ -48,10 +74,25 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     })
 
     const page = keyset.page(await builder.execute(), limit)
+    const optedOut = new Set<string>()
+    if (isOwner && page.items.length > 0) {
+      const rows = await db.db
+        .selectFrom('reference_list_opt_out')
+        .where(
+          'creator',
+          'in',
+          page.items.map((item) => item.subjectDid),
+        )
+        .where('subjectUri', '=', listUri)
+        .select('creator')
+        .execute()
+      rows.forEach((row) => optedOut.add(row.creator))
+    }
     return {
       listitems: page.items.map((item) => ({
         uri: item.uri,
         did: item.subjectDid,
+        subjectOptedOut: optedOut.has(item.subjectDid),
       })),
       cursor: page.cursor,
     }
@@ -84,5 +125,23 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     return {
       count: res?.count,
     }
+  },
+
+  async getReferencelistoptoutsByActorAndSubjects(req) {
+    const { actorDid, subjectUris } = req
+    if (subjectUris.length === 0) return { uris: [] }
+    const rows = await db.db
+      .selectFrom('reference_list_opt_out')
+      .innerJoin('list', 'list.uri', 'reference_list_opt_out.subjectUri')
+      .where('reference_list_opt_out.creator', '=', actorDid)
+      .where('reference_list_opt_out.subjectUri', 'in', subjectUris)
+      .where('list.purpose', '=', app.bsky.graph.defs.Referencelist)
+      .select([
+        'reference_list_opt_out.subjectUri as subjectUri',
+        'reference_list_opt_out.uri as uri',
+      ])
+      .execute()
+    const bySubject = keyBy(rows, 'subjectUri')
+    return { uris: subjectUris.map((uri) => bySubject.get(uri)?.uri ?? '') }
   },
 })

--- a/packages/bsky/src/hydration/graph.ts
+++ b/packages/bsky/src/hydration/graph.ts
@@ -20,9 +20,7 @@ import {
 export type List = RecordInfo<ListRecord>
 export type Lists = HydrationMap<AtUriString, List>
 
-export type ListItem = RecordInfo<ListItemRecord> & {
-  subjectOptedOut?: true
-}
+export type ListItem = RecordInfo<ListItemRecord>
 export type ListItems = HydrationMap<AtUriString, ListItem>
 
 export type ListViewerState = {

--- a/packages/bsky/src/hydration/graph.ts
+++ b/packages/bsky/src/hydration/graph.ts
@@ -20,13 +20,16 @@ import {
 export type List = RecordInfo<ListRecord>
 export type Lists = HydrationMap<AtUriString, List>
 
-export type ListItem = RecordInfo<ListItemRecord>
+export type ListItem = RecordInfo<ListItemRecord> & {
+  subjectOptedOut?: true
+}
 export type ListItems = HydrationMap<AtUriString, ListItem>
 
 export type ListViewerState = {
   viewerMuted?: string // @TODO AtUriString ?
   viewerListBlockUri?: AtUriString
   viewerInList?: string // @TODO AtUriString ?
+  referenceListOptOutUri?: AtUriString
 }
 
 export type ListViewerStates = HydrationMap<AtUriString, ListViewerState>
@@ -159,19 +162,26 @@ export class GraphHydrator {
     const map: ListViewerStates = new HydrationMap()
     if (!uris.length) return map
 
-    const mutesAndBlocks = await Promise.all(
-      uris.map((uri) => this.getMutesAndBlocks(uri, viewer)),
-    )
-    const listMemberships = await this.dataplane.getListMembership({
-      actorDid: viewer,
-      listUris: uris,
-    })
+    const [mutesAndBlocks, listMemberships, referenceListOptOuts] =
+      await Promise.all([
+        Promise.all(uris.map((uri) => this.getMutesAndBlocks(uri, viewer))),
+        this.dataplane.getListMembership({
+          actorDid: viewer,
+          listUris: uris,
+        }),
+        this.dataplane.getReferencelistoptoutsByActorAndSubjects({
+          actorDid: viewer,
+          subjectUris: uris,
+        }),
+      ])
     for (let i = 0; i < uris.length; i++) {
       const uri = uris[i]
       map.set(uri, {
         viewerMuted: mutesAndBlocks[i].muted ? uri : undefined,
         viewerListBlockUri: mutesAndBlocks[i].listBlockUri || undefined,
         viewerInList: listMemberships.listitemUris[i],
+        referenceListOptOutUri: (referenceListOptOuts.uris[i] || undefined) as
+          AtUriString | undefined,
       })
     }
 

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -133,6 +133,8 @@ export type HydrateCtxVals = {
   features: ScopedFeatureGatesClient
 }
 
+export type ListItemSubjectOptOuts = HydrationMap<AtUriString, true>
+
 export type HydrationState = {
   ctx?: HydrateCtx
   actors?: Actors
@@ -153,7 +155,7 @@ export type HydrationState = {
   listMemberships?: ListMembershipStates
   listViewers?: ListViewerStates
   listItems?: ListItems
-  listItemSubjectOptOuts?: HydrationMap<AtUriString, true>
+  listItemSubjectOptOuts?: ListItemSubjectOptOuts
   likes?: Likes
   likeBlocks?: LikeBlocks
   labels?: Labels
@@ -1226,7 +1228,7 @@ export class Hydrator {
     // hydrate sampled list items
     const listItemState = await this.hydrateListItems(listItemUris, ctx)
     // @NOTE Subject opt-outs come from list membership, not list item records.
-    const listItemSubjectOptOuts = new HydrationMap<AtUriString, true>()
+    const listItemSubjectOptOuts: ListItemSubjectOptOuts = new HydrationMap()
     listsMembers.forEach((members) => {
       members.listitems.forEach((item) => {
         if (item.subjectOptedOut) {

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -1167,7 +1167,11 @@ export class Hydrator {
       this.hydrateFeedGens(feedUris, ctx),
       this.hydrateLists(listUris, ctx),
       ...listUris.map((uri) =>
-        this.dataplane.getListMembers({ listUri: uri, limit: 50 }),
+        this.dataplane.getListMembers({
+          listUri: uri,
+          limit: 50,
+          viewerDid: ctx.viewer ?? undefined,
+        }),
       ),
     ])
     // collect list info
@@ -1220,6 +1224,13 @@ export class Hydrator {
     })
     // hydrate sampled list items
     const listItemState = await this.hydrateListItems(listItemUris, ctx)
+    listsMembers.forEach((members) => {
+      members.listitems.forEach((item) => {
+        if (!item.subjectOptedOut) return
+        const hydrated = listItemState.listItems?.get(item.uri as AtUriString)
+        if (hydrated) hydrated.subjectOptedOut = true
+      })
+    })
     return mergeManyStates(
       starterPackState,
       feedGenState,

--- a/packages/bsky/src/hydration/hydrator.ts
+++ b/packages/bsky/src/hydration/hydrator.ts
@@ -153,6 +153,7 @@ export type HydrationState = {
   listMemberships?: ListMembershipStates
   listViewers?: ListViewerStates
   listItems?: ListItems
+  listItemSubjectOptOuts?: HydrationMap<AtUriString, true>
   likes?: Likes
   likeBlocks?: LikeBlocks
   labels?: Labels
@@ -1224,11 +1225,13 @@ export class Hydrator {
     })
     // hydrate sampled list items
     const listItemState = await this.hydrateListItems(listItemUris, ctx)
+    // @NOTE Subject opt-outs come from list membership, not list item records.
+    const listItemSubjectOptOuts = new HydrationMap<AtUriString, true>()
     listsMembers.forEach((members) => {
       members.listitems.forEach((item) => {
-        if (!item.subjectOptedOut) return
-        const hydrated = listItemState.listItems?.get(item.uri as AtUriString)
-        if (hydrated) hydrated.subjectOptedOut = true
+        if (item.subjectOptedOut) {
+          listItemSubjectOptOuts.set(item.uri as AtUriString, true)
+        }
       })
     })
     return mergeManyStates(
@@ -1236,6 +1239,7 @@ export class Hydrator {
       feedGenState,
       listState,
       listItemState,
+      { listItemSubjectOptOuts },
     )
   }
 
@@ -1883,6 +1887,10 @@ export const mergeStates = (
     ),
     listViewers: mergeMaps(stateA.listViewers, stateB.listViewers),
     listItems: mergeMaps(stateA.listItems, stateB.listItems),
+    listItemSubjectOptOuts: mergeMaps(
+      stateA.listItemSubjectOptOuts,
+      stateB.listItemSubjectOptOuts,
+    ),
     likes: mergeMaps(stateA.likes, stateB.likes),
     likeBlocks: mergeMaps(stateA.likeBlocks, stateB.likeBlocks),
     labels: mergeMaps(stateA.labels, stateB.labels),

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -778,6 +778,10 @@ export class Views {
         ? {
             muted: !!listViewer.viewerMuted,
             blocked: listViewer.viewerListBlockUri,
+            referenceListOptOut:
+              list.record.purpose === app.bsky.graph.defs.Referencelist
+                ? listViewer.referenceListOptOutUri
+                : undefined,
           }
         : undefined,
     }
@@ -787,10 +791,11 @@ export class Views {
     uri: AtUriString,
     did: DidString,
     state: HydrationState,
+    subjectOptedOut?: boolean,
   ): Un$Typed<ListItemView> | undefined {
     const subject = this.profile(did, state)
     if (!subject) return
-    return { uri, subject }
+    return { uri, subject, subjectOptedOut: subjectOptedOut || undefined }
   }
 
   starterPackBasic(
@@ -828,12 +833,18 @@ export class Views {
       this.feedGenerator(feed.uri, state),
     )
     const list = this.listBasic(sp.record.list, state)
+    const showSubjectOptOuts =
+      state.ctx?.viewer === creatorFromUri(sp.record.list) &&
+      list?.purpose === app.bsky.graph.defs.Referencelist
     const listItemsSample = mapDefined(agg?.listItemSampleUris ?? [], (uri) => {
       const li = state.listItems?.get(uri)
       if (!li) return
-      const subject = this.profile(li.record.subject, state)
-      if (!subject) return
-      return { uri, subject }
+      return this.listItemView(
+        uri,
+        li.record.subject,
+        state,
+        showSubjectOptOuts && li.subjectOptedOut,
+      )
     })
     return {
       ...basicView,

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -843,7 +843,7 @@ export class Views {
         uri,
         li.record.subject,
         state,
-        showSubjectOptOuts && li.subjectOptedOut,
+        showSubjectOptOuts && !!state.listItemSubjectOptOuts?.get(uri),
       )
     })
     return {

--- a/packages/bsky/tests/data-plane/duplicate-records.test.ts
+++ b/packages/bsky/tests/data-plane/duplicate-records.test.ts
@@ -153,4 +153,59 @@ describe('duplicate record', () => {
     count = await countRecords(db, 'follow')
     expect(count).toBe(0)
   })
+
+  it('does not promote duplicate reference-list opt-outs', async () => {
+    const subject = AtUri.make(
+      'did:example:bob',
+      ids.AppBskyGraphList,
+      TID.nextStr(),
+    )
+    const coll = ids.AppBskyGraphReferencelistoptout
+    const uris: AtUri[] = []
+    for (let i = 0; i < 2; i++) {
+      const optOut = {
+        $type: coll,
+        subject: subject.toString(),
+        createdAt: new Date().toISOString(),
+      }
+      const uri = AtUri.make(did, coll, TID.nextStr())
+      const cid = await cidForCbor(optOut)
+      await network.bsky.sub.indexingSvc.indexRecord(
+        uri,
+        cid,
+        optOut,
+        WriteOpAction.Create,
+        optOut.createdAt,
+      )
+      uris.push(uri)
+    }
+
+    expect(await countRecords(db, 'reference_list_opt_out')).toBe(1)
+    await network.bsky.sub.indexingSvc.deleteRecord(uris[0], false)
+    expect(await countRecords(db, 'reference_list_opt_out')).toBe(0)
+  })
+
+  it('does not index invalid reference-list opt-out subjects', async () => {
+    const coll = ids.AppBskyGraphReferencelistoptout
+    const subjects = [
+      AtUri.make('alice.test', ids.AppBskyGraphList, TID.nextStr()),
+      AtUri.make('did:example:bob', ids.AppBskyFeedPost, TID.nextStr()),
+    ]
+    for (const subject of subjects) {
+      const optOut = {
+        $type: coll,
+        subject: subject.toString(),
+        createdAt: new Date().toISOString(),
+      }
+      await network.bsky.sub.indexingSvc.indexRecord(
+        AtUri.make(did, coll, TID.nextStr()),
+        await cidForCbor(optOut),
+        optOut,
+        WriteOpAction.Create,
+        optOut.createdAt,
+      )
+    }
+
+    expect(await countRecords(db, 'reference_list_opt_out')).toBe(0)
+  })
 })

--- a/packages/bsky/tests/views/reference-list-opt-outs.test.ts
+++ b/packages/bsky/tests/views/reference-list-opt-outs.test.ts
@@ -1,0 +1,309 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { type AtpAgent, ids } from '@atproto/api'
+import {
+  type RecordRef,
+  type SeedClient,
+  TestNetwork,
+  basicSeed,
+} from '@atproto/dev-env'
+import { AtUri } from '@atproto/syntax'
+
+describe('reference-list opt-outs', () => {
+  let network: TestNetwork
+  let agent: AtpAgent
+  let sc: SeedClient
+  let referenceList: RecordRef
+  let curateList: RecordRef
+  let moderationList: RecordRef
+  let malformedList: RecordRef
+  let missingListUri: string
+  let optOutUri: string
+  const starterPackUris: string[] = []
+
+  beforeAll(async () => {
+    network = await TestNetwork.create({
+      dbPostgresSchema: 'bsky_views_reference_list_opt_outs',
+    })
+    agent = network.bsky.getAgent()
+    sc = network.getSeedClient()
+    await basicSeed(sc)
+
+    referenceList = await sc.createList(
+      sc.dids.alice,
+      'reference list',
+      'reference',
+    )
+    curateList = await sc.createList(sc.dids.alice, 'curate list', 'curate')
+    moderationList = await sc.createList(
+      sc.dids.alice,
+      'moderation list',
+      'mod',
+    )
+    malformedList = await sc.createList(
+      sc.dids.alice,
+      'malformed list',
+      'reference',
+      { purpose: 'invalid-list-purpose' },
+    )
+    for (const list of [referenceList, curateList]) {
+      await sc.addToList(sc.dids.alice, sc.dids.bob, list)
+      await sc.addToList(sc.dids.alice, sc.dids.carol, list)
+    }
+    for (const list of [moderationList, malformedList]) {
+      await sc.addToList(sc.dids.alice, sc.dids.bob, list)
+    }
+
+    const optOut = await sc.agent.app.bsky.graph.referencelistoptout.create(
+      { repo: sc.dids.bob },
+      {
+        subject: referenceList.uriStr,
+        createdAt: new Date().toISOString(),
+      },
+      sc.getHeaders(sc.dids.bob),
+    )
+    optOutUri = optOut.uri
+    missingListUri = `at://${sc.dids.alice}/${ids.AppBskyGraphList}/missing`
+    for (const subject of [
+      curateList.uriStr,
+      moderationList.uriStr,
+      malformedList.uriStr,
+      missingListUri,
+    ]) {
+      await sc.agent.app.bsky.graph.referencelistoptout.create(
+        { repo: sc.dids.bob },
+        { subject, createdAt: new Date().toISOString() },
+        sc.getHeaders(sc.dids.bob),
+      )
+    }
+
+    for (const name of ['shared list pack one', 'shared list pack two']) {
+      const pack = await sc.agent.app.bsky.graph.starterpack.create(
+        { repo: sc.dids.alice },
+        {
+          name,
+          list: referenceList.uriStr,
+          createdAt: new Date().toISOString(),
+        },
+        sc.getHeaders(sc.dids.alice),
+      )
+      starterPackUris.push(pack.uri)
+    }
+
+    await sc.post(sc.dids.bob, 'opted-out member post')
+    await sc.post(sc.dids.carol, 'visible member post')
+    await network.processAll()
+  })
+
+  afterAll(async () => network?.close())
+
+  it('filters members for public viewers and annotates them for the owner', async () => {
+    const owner = await agent.app.bsky.graph.getList(
+      { list: referenceList.uriStr },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.alice,
+          ids.AppBskyGraphGetList,
+        ),
+      },
+    )
+    const nonOwner = await agent.app.bsky.graph.getList(
+      { list: referenceList.uriStr },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.carol,
+          ids.AppBskyGraphGetList,
+        ),
+      },
+    )
+    const anonymous = await agent.app.bsky.graph.getList({
+      list: referenceList.uriStr,
+    })
+
+    expect(owner.data.list.listItemCount).toBe(2)
+    expect(owner.data.items).toHaveLength(2)
+    expect(
+      owner.data.items.find((item) => item.subject.did === sc.dids.bob),
+    ).toMatchObject({ subjectOptedOut: true })
+    for (const view of [nonOwner, anonymous]) {
+      expect(view.data.list.listItemCount).toBe(2)
+      expect(view.data.items.map((item) => item.subject.did)).toEqual([
+        sc.dids.carol,
+      ])
+      expect(view.data.items[0].subjectOptedOut).toBeUndefined()
+    }
+
+    const limited = await agent.app.bsky.graph.getList({
+      list: referenceList.uriStr,
+      limit: 1,
+    })
+    expect(limited.data.items).toHaveLength(1)
+    expect(limited.data.cursor).toBeUndefined()
+  })
+
+  it('hydrates the indexed opt-out URI as viewer state', async () => {
+    const { data } = await agent.app.bsky.graph.getList(
+      { list: referenceList.uriStr },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.bob,
+          ids.AppBskyGraphGetList,
+        ),
+      },
+    )
+
+    expect(data.list.viewer?.referenceListOptOut).toBe(optOutUri)
+  })
+
+  it('filters reference-list feeds for every viewer without viewer context', async () => {
+    const requests = [
+      agent.app.bsky.feed.getListFeed({ list: referenceList.uriStr }),
+      agent.app.bsky.feed.getListFeed(
+        { list: referenceList.uriStr },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.alice,
+            ids.AppBskyFeedGetListFeed,
+          ),
+        },
+      ),
+      agent.app.bsky.feed.getListFeed(
+        { list: referenceList.uriStr },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.carol,
+            ids.AppBskyFeedGetListFeed,
+          ),
+        },
+      ),
+    ]
+
+    for (const response of await Promise.all(requests)) {
+      expect(
+        response.data.feed.some((item) => item.post.author.did === sc.dids.bob),
+      ).toBe(false)
+      expect(
+        response.data.feed.some(
+          (item) => item.post.author.did === sc.dids.carol,
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it('shares owner annotations across starter packs backed by one list', async () => {
+    using getListMembers = vi.spyOn(
+      network.bsky.ctx.dataplane,
+      'getListMembers',
+    )
+    const { data } = await agent.app.bsky.graph.getStarterPacksWithMembership(
+      { actor: sc.dids.bob },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.alice,
+          ids.AppBskyGraphGetStarterPacksWithMembership,
+        ),
+      },
+    )
+
+    const sharedPacks = data.starterPacksWithMembership.filter(
+      ({ starterPack }) => starterPackUris.includes(starterPack.uri),
+    )
+    expect(sharedPacks).toHaveLength(2)
+    for (const { starterPack } of sharedPacks) {
+      expect(starterPack.list?.listItemCount).toBe(2)
+      expect(
+        starterPack.listItemsSample?.find(
+          (item) => item.subject.did === sc.dids.bob,
+        ),
+      ).toMatchObject({ subjectOptedOut: true })
+    }
+    expect(
+      getListMembers.mock.calls.filter(
+        ([req]) => req.listUri === referenceList.uriStr,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('filters opted-out subjects from non-owner starter-pack samples', async () => {
+    const { data } = await agent.app.bsky.graph.getStarterPack(
+      { starterPack: starterPackUris[0] },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.carol,
+          ids.AppBskyGraphGetStarterPack,
+        ),
+      },
+    )
+
+    expect(data.starterPack.list?.listItemCount).toBe(2)
+    expect(
+      data.starterPack.listItemsSample?.map((item) => item.subject.did),
+    ).toEqual([sc.dids.carol])
+  })
+
+  it('does not apply opt-outs to non-reference lists', async () => {
+    const { data: listData } = await agent.app.bsky.graph.getList(
+      { list: curateList.uriStr },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.bob,
+          ids.AppBskyGraphGetList,
+        ),
+      },
+    )
+    const { data: feedData } = await agent.app.bsky.feed.getListFeed({
+      list: curateList.uriStr,
+    })
+
+    expect(listData.items.map((item) => item.subject.did)).toContain(
+      sc.dids.bob,
+    )
+    expect(listData.list.viewer?.referenceListOptOut).toBeUndefined()
+    expect(
+      feedData.feed.some((item) => item.post.author.did === sc.dids.bob),
+    ).toBe(true)
+  })
+
+  it('does not expose state for moderation, malformed, or missing lists', async () => {
+    for (const list of [moderationList, malformedList]) {
+      const { data } = await agent.app.bsky.graph.getList(
+        { list: list.uriStr },
+        {
+          headers: await network.serviceHeaders(
+            sc.dids.bob,
+            ids.AppBskyGraphGetList,
+          ),
+        },
+      )
+      expect(data.items.map((item) => item.subject.did)).toContain(sc.dids.bob)
+      expect(data.items[0].subjectOptedOut).toBeUndefined()
+      expect(data.list.viewer?.referenceListOptOut).toBeUndefined()
+    }
+
+    const internal =
+      await network.bsky.ctx.dataplane.getReferencelistoptoutsByActorAndSubjects(
+        { actorDid: sc.dids.bob, subjectUris: [missingListUri] },
+      )
+    expect(internal.uris).toEqual([''])
+  })
+
+  it('restores visibility after deleting the indexed opt-out', async () => {
+    const uri = new AtUri(optOutUri)
+    await sc.agent.app.bsky.graph.referencelistoptout.delete(
+      { repo: sc.dids.bob, rkey: uri.rkey },
+      sc.getHeaders(sc.dids.bob),
+    )
+    await network.processAll()
+
+    const { data } = await agent.app.bsky.graph.getList(
+      { list: referenceList.uriStr },
+      {
+        headers: await network.serviceHeaders(
+          sc.dids.bob,
+          ids.AppBskyGraphGetList,
+        ),
+      },
+    )
+    expect(data.items.map((item) => item.subject.did)).toContain(sc.dids.bob)
+    expect(data.list.viewer?.referenceListOptOut).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- sync the `app.bsky.graph.referencelistoptout` and `app.bsky.graph.defs` public contracts plus the Tango read contracts
- pass viewer context through list and starter-pack member hydration, expose owner-only opt-out annotations, and hydrate the indexed opt-out URI in list viewer state
- add mock dataplane indexing, member/feed filtering, duplicate lifecycle behavior, and purpose-aware viewer-state lookup while preserving raw counts and memberships

## Dependencies
- Tango dataplane contracts and filtering: https://github.com/bluesky-social/tango/pull/1468
- public lexicon source: https://github.com/bluesky-social/bsky/pull/35

## Testing
- `pnpm run codegen`
- `pnpm run build:ts --force`
- `pnpm run verify`
- `pnpm test tests/data-plane/duplicate-records.test.ts tests/views/reference-list-opt-outs.test.ts tests/views/lists.test.ts tests/views/list-feed.test.ts tests/views/starter-packs.test.ts`
- post-rebase focused tests: 13 passed
- roast review: no findings

Linear: https://linear.app/blueskyweb/issue/APP-2933/implement-referencelist-opt-out-in-appview