### PR TITLE
oauth-provider-ui: restore live normalization of the OTP code field

### DIFF
--- a/.changeset/token-field-normalize.md
+++ b/.changeset/token-field-normalize.md
@@ -1,0 +1,5 @@
+---
+'@atproto/oauth-provider-ui': patch
+---
+
+Restore live normalization of the one-time code input (uppercase, strip characters outside the base32 alphabet, insert the hyphen) and refocus the input after requesting a new code.

--- a/packages/oauth/oauth-provider-ui/src/components/forms/fields/token-field.tsx
+++ b/packages/oauth/oauth-provider-ui/src/components/forms/fields/token-field.tsx
@@ -1,6 +1,8 @@
 import { Trans } from '@lingui/react/macro'
 import { TicketIcon } from 'lucide-react'
-import { OTP_CODE_PATTERN } from '#/lib/form-patterns.ts'
+import { useRef } from 'react'
+import { useMergedRefs } from '#/hooks/use-merged-refs.ts'
+import { OTP_CODE_PATTERN, formatOtpCode } from '#/lib/form-patterns.ts'
 import { RequestCodeButton } from '../request-code-button.tsx'
 import { TextField, type TextFieldProps } from './text-field.tsx'
 
@@ -14,24 +16,23 @@ export type TokenFieldProps = Omit<
   onResend?: () => void | PromiseLike<void>
 }
 
-/** Normalises free-typed input into the `XXXXX-XXXXX` OTP shape. */
-export function formatToken(value: string) {
-  const normalized = value.toUpperCase().replaceAll(/[^A-Z2-7]/g, '')
-  if (normalized.length <= 5) return normalized
-  return `${normalized.slice(0, 5)}-${normalized.slice(5, 10)}`
-}
-
 export function TokenField({
   example = OTP_CODE_EXAMPLE,
   onResend,
   icon = <TicketIcon className="size-5" />,
   title = example,
   autoFocus = false,
+  ref,
+  onChange,
   ...props
 }: TokenFieldProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const mergedRef = useMergedRefs(inputRef, ref)
+
   return (
     <TextField
       {...props}
+      ref={mergedRef}
       icon={icon}
       type="text"
       autoFocus={autoFocus}
@@ -45,6 +46,28 @@ export function TokenField({
       pattern={OTP_CODE_PATTERN}
       placeholder={example}
       title={title}
+      // @NOTE Runs before Base UI's own change handler (`mergeProps` calls the
+      // outer handler first), so rewriting the element's value here is what
+      // Base UI, a controlled `value`, and `FormShell`'s `onInput` all observe.
+      onChange={(event) => {
+        const input = event.currentTarget
+        const { value, selectionStart, selectionEnd } = input
+
+        const formatted = formatOtpCode(value)
+        if (formatted !== value) {
+          input.value = formatted
+
+          // Keep the caret where it was relative to the characters that
+          // survived formatting, rather than letting it jump to the end.
+          const pos = selectionEnd ?? selectionStart
+          if (pos != null) {
+            const caret = formatOtpCode(value.slice(0, pos)).length
+            input.setSelectionRange(caret, caret)
+          }
+        }
+
+        onChange?.(event)
+      }}
       below={
         onResend && (
           <span className="inline-flex items-center text-xs">
@@ -58,6 +81,9 @@ export function TokenField({
               <RequestCodeButton
                 action={async () => {
                   await onResend()
+                  // Next tick, so the button's disabled state has been applied
+                  // (after the next render) before focus moves to the input.
+                  if (autoFocus) setTimeout(() => inputRef.current?.focus())
                 }}
                 variant="link"
                 size="sm"

--- a/packages/oauth/oauth-provider-ui/src/hooks/use-merged-refs.ts
+++ b/packages/oauth/oauth-provider-ui/src/hooks/use-merged-refs.ts
@@ -1,0 +1,23 @@
+import { type Ref, useMemo } from 'react'
+
+function mergeRefs<T>(...refs: Array<Ref<T> | undefined>): Ref<T> {
+  return (value) => {
+    const cleanups = refs.map((ref) => {
+      if (typeof ref === 'function') return ref(value)
+      if (ref) {
+        ref.current = value
+        return () => {
+          ref.current = null
+        }
+      }
+    })
+
+    return () => {
+      for (const cleanup of cleanups) cleanup?.()
+    }
+  }
+}
+
+export function useMergedRefs<T>(...refs: Array<Ref<T> | undefined>): Ref<T> {
+  return useMemo(() => mergeRefs(...refs), refs)
+}

--- a/packages/oauth/oauth-provider-ui/src/lib/form-patterns.test.ts
+++ b/packages/oauth/oauth-provider-ui/src/lib/form-patterns.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { OTP_CODE_PATTERN, formatOtpCode } from './form-patterns.ts'
+
+describe(formatOtpCode, () => {
+  const matchesPattern = (value: string) =>
+    new RegExp(`^(?:${OTP_CODE_PATTERN})$`).test(value)
+
+  it('uppercases and inserts the hyphen', () => {
+    expect(formatOtpCode('abcde23456')).toBe('ABCDE-23456')
+  })
+
+  it('leaves a well-formed code untouched', () => {
+    expect(formatOtpCode('ABCDE-23456')).toBe('ABCDE-23456')
+  })
+
+  it('does not insert the hyphen before the sixth character', () => {
+    expect(formatOtpCode('abc')).toBe('ABC')
+    expect(formatOtpCode('abcde')).toBe('ABCDE')
+    expect(formatOtpCode('abcde-')).toBe('ABCDE')
+  })
+
+  it('strips characters outside the base32 alphabet', () => {
+    expect(formatOtpCode(' abc de - 234 56 ')).toBe('ABCDE-23456')
+    expect(formatOtpCode('a0b1c8d9e2')).toBe('ABCDE-2')
+  })
+
+  it('truncates to ten characters', () => {
+    expect(formatOtpCode('ABCDE-23456-ZZZZZ')).toBe('ABCDE-23456')
+  })
+
+  it('produces values accepted by the pattern once complete', () => {
+    expect(matchesPattern(formatOtpCode('abcde23456'))).toBe(true)
+    expect(matchesPattern(formatOtpCode('abcde2345'))).toBe(false)
+  })
+})

--- a/packages/oauth/oauth-provider-ui/src/lib/form-patterns.ts
+++ b/packages/oauth/oauth-provider-ui/src/lib/form-patterns.ts
@@ -21,6 +21,18 @@ export const HANDLE_SEGMENT_PATTERN = '[a-z0-9][a-z0-9\\-]+[a-z0-9]'
 export const OTP_CODE_PATTERN = '[A-Z2-7]{5}-[A-Z2-7]{5}'
 
 /**
+ * Normalises free-typed input into the {@link OTP_CODE_PATTERN} shape:
+ * uppercases, drops every character outside the base32 alphabet (spaces,
+ * stray punctuation, a pasted hyphen), inserts the hyphen after the fifth
+ * character, and truncates to ten characters.
+ */
+export function formatOtpCode(value: string): string {
+  const normalized = value.toUpperCase().replaceAll(/[^A-Z2-7]/g, '')
+  if (normalized.length <= 5) return normalized
+  return `${normalized.slice(0, 5)}-${normalized.slice(5, 10)}`
+}
+
+/**
  * Email, handle (with at least one dot), or DID.
  *
  * @NOTE All three alternatives sit inside one group. The regex this replaced


### PR DESCRIPTION
## Summary

The OAuth provider UI redesign (#5305) replaced `InputToken` with `TokenField` and extracted the old `fix()` helper into an exported `formatToken()` — but never called it. The one-time code input became a plain text field: `abcde12345` no longer self-corrected to `ABCDE-23456`, it just failed the native `pattern` check on submit. The `autoCapitalize="characters"` hint made it *look* like it still normalised on mobile keyboards, while doing nothing on desktop.

This restores the behaviour:

- **`lib/form-patterns.ts`** — the normaliser now lives here as `formatOtpCode`, next to `OTP_CODE_PATTERN`, so both share a single base32 alphabet. Unit tests added (`form-patterns.test.ts`).
- **`TokenField`** — adds an `onChange` that rewrites `event.currentTarget.value` with the formatted value (uppercase, strip characters outside `[A-Z2-7]`, insert the hyphen after the fifth character, truncate to ten) and repositions the caret relative to the characters that survived formatting, then forwards to the caller's `onChange`. Base UI's `mergeProps` runs the outer handler before `Field.Control`'s own, so Base UI's dirty/validity tracking, the controlled `value` in `sign-in-form.tsx`, and `FormShell`'s `onInput` mirror all observe the formatted value.
- Restores refocusing the input after a successful resend (when `autoFocus`), which the old `InputToken` did; brings back `useMergedRefs` for the input ref.
- **Resend row re-wrap (second commit)** — the "Didn't receive a code? Click here to resend. Retry in Ns" row re-wrapped whenever the cooldown started or ended: the row was `inline-flex` (so the sentence was squeezed to min-content beside the button — "Didn't receive a / code?" at narrow widths) and the "Retry in Ns" span was only mounted during the cooldown, so the button changed width at both edges. The row is now laid out as prose, and `RequestCodeButton` gains an opt-in `reserveCooldownWidth` that keeps the countdown span mounted but `invisible` while idle (sized to the full cooldown). Only the inline resend link opts in; the standalone primary buttons are unchanged.
- Changeset: patch for `@atproto/oauth-provider-ui`.

## Test plan

- [x] `pnpm run test` in `packages/oauth/oauth-provider-ui` — 100 tests pass, including 6 new `formatOtpCode` cases
- [x] `pnpm run build` + `tsc --noEmit` clean for the package
- [x] Resend row measured in the mock at a 375px viewport (343px dialog): before, the sentence wrapped to two lines and the row went 32px → 18px when the countdown expired; after, the row is 34px with identical geometry idle vs. cooling, and the reserved span is `visibility: hidden` while idle so it stays out of the button's accessible name
- [x] `pnpm i18n` — no msgid changes
- [x] Manually in the `pnpm dev:ui` mock, on the sign-in 2FA field (controlled path): typing `abc de-234 56zz` → `ABCDE-23456` (`checkValidity()` true); pasting `qwert 34567` → `QWERT-34567`; inserting `x` at `A|BC` → `AX|BC` with caret held; a mid-string `!` is stripped without the caret jumping
- [ ] `packages/pds/tests/{oauth,account-manager}.test.ts` (puppeteer) — unchanged, but worth watching in CI since they type OTP codes into this field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

