### PR TITLE
bsky: configure dispatcher for iris/topics/blobber

### DIFF
--- a/.changeset/cool-boats-wish.md
+++ b/.changeset/cool-boats-wish.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Issue iris and topics requests through the global fetch, using long-lived dispatchers that are closed on shutdown.

--- a/.changeset/solid-things-juggle.md
+++ b/.changeset/solid-things-juggle.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add a `BSKY_PROXY_CONNECT_TIMEOUT` option, bounding the connection phase of blob proxy requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ For working with that SDK, invoke the focused skills under [.agents/skills/](.ag
 
 - Node ≥22 runtime floor; build/dev default to Node 24 (`.nvmrc`). Use `node --enable-source-maps` for production-style runs.
 - TypeScript compilation uses the native TS7 `tsc` (the standard `typescript` package). There is no per-package `typescript` devDependency — it is hoisted at the root. Note TS7 has no stable programmatic API yet; tools needing one must pin TS6.
-- **Every package touched by a change needs a changeset entry.** Add a file under [.changeset/](.changeset/) listing each modified package with an appropriate bump level (pre-v1 breaking changes are `minor` and everything else `patch`, post-v1 `major` for breaking changes, `minor` for new public API, `patch` otherwise). Dependency-only bumps are generated automatically — don't list them by hand.
+- **Every package touched by a change needs a changeset entry.** Add a file under [.changeset/](.changeset/) listing each modified package with an appropriate bump level (pre-v1 breaking changes are `minor` and everything else `patch`, post-v1 `major` for breaking changes, `minor` for new public API, `patch` otherwise). Dependency-only bumps are generated automatically — don't list them by hand. Create that file with `pnpm changeset`.
 
 ## Agent files
 

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -77,6 +77,9 @@
     "structured-headers": "^1.0.1",
     "uint8arrays": "^5.0.0",
     "undici": "^8.5.0",
+    "undici_v6": "npm:undici@^6.x",
+    "undici_v7": "npm:undici@^7.x",
+    "undici_v8": "npm:undici@^8.x",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/packages/bsky/src/api/blob-dispatcher.ts
+++ b/packages/bsky/src/api/blob-dispatcher.ts
@@ -6,6 +6,7 @@ import { RETRYABLE_HTTP_STATUS_CODES } from '../util/retry.js'
 export function createBlobDispatcher(cfg: ServerConfig): Dispatcher {
   const baseDispatcher = new Agent({
     allowH2: cfg.proxyAllowHTTP2, // This is experimental
+    connectTimeout: cfg.proxyConnectTimeout,
     headersTimeout: cfg.proxyHeadersTimeout,
     maxResponseSize: cfg.proxyMaxResponseSize,
     bodyTimeout: cfg.proxyBodyTimeout,

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -107,6 +107,7 @@ export interface ServerConfigValues {
   // http proxy agent
   disableSsrfProtection?: boolean
   proxyAllowHTTP2?: boolean
+  proxyConnectTimeout?: number
   proxyHeadersTimeout?: number
   proxyBodyTimeout?: number
   proxyMaxResponseSize?: number
@@ -278,6 +279,8 @@ export class ServerConfig {
       : debugMode
 
     const proxyAllowHTTP2 = process.env.BSKY_PROXY_ALLOW_HTTP2 === 'true'
+    const proxyConnectTimeout =
+      parseInt(process.env.BSKY_PROXY_CONNECT_TIMEOUT || '', 10) || undefined
     const proxyHeadersTimeout =
       parseInt(process.env.BSKY_PROXY_HEADERS_TIMEOUT || '', 10) || undefined
     const proxyBodyTimeout =
@@ -417,6 +420,7 @@ export class ServerConfig {
       notificationsDelayMs,
       disableSsrfProtection,
       proxyAllowHTTP2,
+      proxyConnectTimeout,
       proxyHeadersTimeout,
       proxyBodyTimeout,
       proxyMaxResponseSize,
@@ -689,6 +693,10 @@ export class ServerConfig {
 
   get proxyAllowHTTP2(): boolean {
     return this.cfg.proxyAllowHTTP2 ?? false
+  }
+
+  get proxyConnectTimeout(): number | undefined {
+    return this.cfg.proxyConnectTimeout
   }
 
   get proxyHeadersTimeout(): number {

--- a/packages/bsky/src/index.ts
+++ b/packages/bsky/src/index.ts
@@ -6,7 +6,6 @@ import cors from 'cors'
 import { Etcd3 } from 'etcd3'
 import express from 'express'
 import { type HttpTerminator, createHttpTerminator } from 'http-terminator'
-import { Agent as UndiciAgent, fetch as undiciFetch } from 'undici'
 import { DAY, SECOND } from '@atproto/common'
 import type { Keypair } from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
@@ -45,6 +44,11 @@ import {
   createRolodexClient,
 } from './rolodex.js'
 import { createStashClient } from './stash.js'
+import {
+  type UndiciAgent,
+  createUndiciAgent,
+  dispatcherFetch,
+} from './undici.js'
 import { Views } from './views/index.js'
 import { VideoUriBuilder } from './views/util.js'
 
@@ -56,35 +60,21 @@ export { BackgroundQueue } from './data-plane/server/background.js'
 export { Database } from './data-plane/server/db/index.js'
 export { Redis } from './redis.js'
 
-/**
- * Builds a fetch that bounds the connection phase only. Once connected, the
- * request is not bounded here.
- *
- * Uses undici's own fetch rather than the global one, since the dispatcher must
- * come from the same undici as the fetch it is passed to, and the undici we
- * depend on is not the one Node embeds.
- */
-function connectTimeoutFetch(connectTimeout: number) {
-  const dispatcher = new UndiciAgent({ connectTimeout })
-  return (input: unknown, init: unknown) =>
-    undiciFetch(
-      input as never,
-      {
-        ...(init as object),
-        dispatcher,
-      } as never,
-    ) as Promise<Response>
-}
-
 export class BskyAppView {
   public ctx: AppContext
   public app: express.Application
   public server?: http.Server
   private terminator?: HttpTerminator
+  private dispatchers: UndiciAgent[]
 
-  constructor(opts: { ctx: AppContext; app: express.Application }) {
+  constructor(opts: {
+    ctx: AppContext
+    app: express.Application
+    dispatchers?: UndiciAgent[]
+  }) {
     this.ctx = opts.ctx
     this.app = opts.app
+    this.dispatchers = opts.dispatchers ?? []
   }
 
   static create(opts: {
@@ -149,6 +139,13 @@ export class BskyAppView {
         )
       : undefined
 
+    // @NOTE These bound the connection phase (TCP + TLS) only; once connected,
+    // the request is not bounded here. They are kept for the lifetime of the
+    // service (pooling connections), and closed on `destroy()`.
+    // An unused agent holds no socket, so they can be built unconditionally.
+    const topicsDispatcher = createUndiciAgent({ connectTimeout: SECOND })
+    const irisDispatcher = createUndiciAgent({ connectTimeout: SECOND })
+
     const topicsClient = config.topicsUrl
       ? new Client(
           {
@@ -156,7 +153,7 @@ export class BskyAppView {
             headers: config.topicsApiKey
               ? { authorization: `Bearer ${config.topicsApiKey}` }
               : undefined,
-            fetch: connectTimeoutFetch(SECOND),
+            fetch: dispatcherFetch(topicsDispatcher),
           },
           {
             // Trust internal services to send us well-formed responses
@@ -170,7 +167,7 @@ export class BskyAppView {
       ? new Client(
           {
             service: config.irisUrl,
-            fetch: connectTimeoutFetch(SECOND),
+            fetch: dispatcherFetch(irisDispatcher),
           },
           {
             // Trust internal services to send us well-formed responses
@@ -310,7 +307,11 @@ export class BskyAppView {
     app.use(error.handler)
     app.use('/external', external.createRouter(ctx))
 
-    return new BskyAppView({ ctx, app })
+    return new BskyAppView({
+      ctx,
+      app,
+      dispatchers: [topicsDispatcher, irisDispatcher],
+    })
   }
 
   async start(): Promise<http.Server> {
@@ -335,7 +336,11 @@ export class BskyAppView {
       try {
         await this.terminator?.terminate()
       } finally {
-        await this.ctx.etcd?.close()
+        try {
+          await this.ctx.etcd?.close()
+        } finally {
+          await Promise.all(this.dispatchers.map((d) => d.close()))
+        }
       }
     }
   }

--- a/packages/bsky/src/undici.ts
+++ b/packages/bsky/src/undici.ts
@@ -1,0 +1,61 @@
+import { Agent as Undici6Agent } from 'undici_v6' // NodeJS 22
+import { Agent as Undici7Agent } from 'undici_v7' // NodeJS 24
+import { Agent as Undici8Agent } from 'undici_v8' // NodeJS 26
+
+export type UndiciAgent = Undici6Agent | Undici7Agent | Undici8Agent
+
+/**
+ * The subset of undici's `Agent.Options` that is stable across the undici major
+ * versions supported here.
+ */
+export type UndiciAgentOptions = {
+  /** Milliseconds allowed for the connection phase (TCP + TLS). */
+  connectTimeout?: number
+}
+
+/**
+ * Builds an undici {@link UndiciAgent} from the same major version of undici as
+ * the one embedded in the running NodeJS.
+ *
+ * @note Major versions of undici are not guaranteed to be backwards compatible,
+ * so a dispatcher can only be passed to a `fetch()` backed by the same major
+ * version. Since `globalThis.fetch` is backed by the undici NodeJS embeds, the
+ * dispatcher must be built from that same major version, which is not
+ * necessarily the version this package depends on.
+ */
+export function createUndiciAgent(options?: UndiciAgentOptions): UndiciAgent {
+  const major = Number(process.versions.undici?.split('.')[0])
+
+  // @NOTE We deliberately do not fall back to the most recent Agent for unknown
+  // versions: a mismatched dispatcher interface would fail at runtime.
+  switch (major) {
+    case 6:
+      return new Undici6Agent(options)
+    case 7:
+      return new Undici7Agent(options)
+    case 8:
+      return new Undici8Agent(options)
+    default:
+      throw new Error(
+        `Unsupported undici version: ${process.versions.undici}. Expected NodeJS to embed undici 6, 7, or 8.`,
+      )
+  }
+}
+
+/**
+ * Wraps the global fetch so that every request is issued through the given
+ * undici dispatcher.
+ */
+export function dispatcherFetch(
+  dispatcher: UndiciAgent,
+): typeof globalThis.fetch {
+  return (input, init) =>
+    globalThis.fetch(input, {
+      ...init,
+      // @ts-ignore `dispatcher` is not part of the WHATWG `RequestInit`, but
+      // undici (which backs `globalThis.fetch` in NodeJS) does honor it. The
+      // dispatcher comes from `createUndiciAgent`, so its interface matches the
+      // undici backing that fetch.
+      dispatcher,
+    })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,15 @@ importers:
       undici:
         specifier: ^8.5.0
         version: 8.5.0
+      undici_v6:
+        specifier: npm:undici@^6.x
+        version: undici@6.19.8
+      undici_v7:
+        specifier: npm:undici@^7.x
+        version: undici@7.28.0
+      undici_v8:
+        specifier: npm:undici@^8.x
+        version: undici@8.5.0
       zod:
         specifier: 3.23.8
         version: 3.23.8


### PR DESCRIPTION
Follow-up to #5455, which gave the iris and topics clients a connect-phase timeout.

To carry the `connectTimeout`, that fetch needed an undici `Agent`, and a dispatcher can only be passed to a `fetch()` backed by the same undici major. The undici we depend on is not the one NodeJS embeds, so the code reached for undici's own `fetch` rather than the global one — dragging a second HTTP stack into these two call paths, with its own pools and defaults.

Instead, pick the `Agent` class matching the undici NodeJS embeds (`process.versions.undici`), which makes the dispatcher safe to hand to the global fetch. Same approach as `unicastFetchWrap` in `@atproto-labs/fetch-node`, which needs it for the SSRF lookup hook.

Also closes both agents on shutdown; they were leaked before.