### PR TITLE
Harden Ozone PDS requests against SSRF

### DIFF
--- a/.changeset/tough-pandas-listen.md
+++ b/.changeset/tough-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'@atproto/ozone': patch
+---
+
+Harden outbound Ozone requests to PDS and did:web endpoints.

--- a/packages/ozone/package.json
+++ b/packages/ozone/package.json
@@ -29,6 +29,7 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@atproto-labs/fetch-node": "workspace:^",
     "@atproto/api": "workspace:^",
     "@atproto/common": "workspace:^",
     "@atproto/crypto": "workspace:^",

--- a/packages/ozone/src/context.ts
+++ b/packages/ozone/src/context.ts
@@ -133,10 +133,12 @@ export class AppContext {
       plcUrl: cfg.identity.plcUrl,
       didCache,
     })
-    idResolver.did = new SafeDidResolver({
-      plcUrl: cfg.identity.plcUrl,
-      didCache,
-    })
+    if (!cfg.service.devMode) {
+      idResolver.did = new SafeDidResolver({
+        plcUrl: cfg.identity.plcUrl,
+        didCache,
+      })
+    }
 
     const createAuthHeaders = (aud: string, lxm: string) =>
       createServiceAuthHeaders({
@@ -151,6 +153,7 @@ export class AppContext {
       ? new BlobDiverter(db, {
           idResolver,
           serviceConfig: cfg.blobDivert,
+          devMode: cfg.service.devMode,
         })
       : undefined
     const eventPusher = new EventPusher(db, createAuthHeaders, {

--- a/packages/ozone/src/context.ts
+++ b/packages/ozone/src/context.ts
@@ -34,6 +34,7 @@ import {
   ReportStatsService,
   type ReportStatsServiceCreator,
 } from './report/stats.js'
+import { SafeDidResolver } from './safe-fetch.js'
 import {
   SafelinkRuleService,
   type SafelinkRuleServiceCreator,
@@ -129,6 +130,10 @@ export class AppContext {
       cfg.identity.cacheMaxTTL,
     )
     const idResolver = new IdResolver({
+      plcUrl: cfg.identity.plcUrl,
+      didCache,
+    })
+    idResolver.did = new SafeDidResolver({
       plcUrl: cfg.identity.plcUrl,
       didCache,
     })

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -14,8 +14,7 @@ import type { Database } from '../db/index.js'
 import { createSafeFetch } from '../safe-fetch.js'
 import { retryHttp } from '../util.js'
 
-const MAX_BLOB_SIZE = 100 * 1024 * 1024
-const safeBlobFetch = createSafeFetch(MAX_BLOB_SIZE)
+const safeBlobFetch = createSafeFetch()
 
 export class BlobDiverter {
   serviceConfig: BlobDivertConfig

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -85,7 +85,6 @@ export class BlobDiverter {
         stream: verifier,
       }
     } catch (err) {
-      // Typically un-supported content encoding
       await blobResponse.body?.cancel()
       throw err
     }

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -1,4 +1,4 @@
-import { Readable, Transform, type TransformCallback } from 'node:stream'
+import { Readable } from 'node:stream'
 import { finished, pipeline } from 'node:stream/promises'
 import { CID } from 'multiformats/cid'
 import * as undici from 'undici'
@@ -11,12 +11,15 @@ import type { IdResolver } from '@atproto/identity'
 import { ResponseType, XRPCError } from '@atproto/xrpc'
 import type { BlobDivertConfig } from '../config/index.js'
 import type { Database } from '../db/index.js'
-import { createSafeFetch } from '../safe-fetch.js'
+import { BodyTimeoutTransform, createSafeFetch } from '../safe-fetch.js'
 import { retryHttp } from '../util.js'
 
 const BLOB_HEADERS_TIMEOUT = 30e3
 const BLOB_BODY_TIMEOUT = 120e3
-const safeBlobFetch = createSafeFetch()
+const BLOB_RESPONSE_MAX_SIZE = 100 * 1024 * 1024
+const safeBlobFetch = createSafeFetch({
+  responseMaxSize: BLOB_RESPONSE_MAX_SIZE,
+})
 
 export class BlobDiverter {
   serviceConfig: BlobDivertConfig
@@ -156,51 +159,6 @@ export class BlobDiverter {
         { cause: err },
       )
     })
-  }
-}
-
-class BodyTimeoutTransform extends Transform {
-  private timer: NodeJS.Timeout | undefined
-
-  constructor(private readonly timeout: number) {
-    super()
-    this.resetTimer()
-  }
-
-  override _transform(
-    chunk: unknown,
-    encoding: BufferEncoding,
-    callback: TransformCallback,
-  ) {
-    this.resetTimer()
-    callback(null, chunk)
-  }
-
-  override _flush(callback: TransformCallback) {
-    this.clearTimer()
-    callback()
-  }
-
-  override _destroy(
-    error: Error | null,
-    callback: (error?: Error | null) => void,
-  ) {
-    this.clearTimer()
-    callback(error)
-  }
-
-  private resetTimer() {
-    this.clearTimer()
-    this.timer = setTimeout(
-      () => this.destroy(new Error('Blob body timeout')),
-      this.timeout,
-    )
-    this.timer.unref()
-  }
-
-  private clearTimer() {
-    if (this.timer) clearTimeout(this.timer)
-    this.timer = undefined
   }
 }
 

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -14,8 +14,8 @@ import type { Database } from '../db/index.js'
 import { createSafeFetch } from '../safe-fetch.js'
 import { retryHttp } from '../util.js'
 
-const BLOB_HEADERS_TIMEOUT = 10e3
-const BLOB_BODY_TIMEOUT = 30e3
+const BLOB_HEADERS_TIMEOUT = 30e3
+const BLOB_BODY_TIMEOUT = 120e3
 const safeBlobFetch = createSafeFetch()
 
 export class BlobDiverter {

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -21,16 +21,19 @@ const safeBlobFetch = createSafeFetch()
 export class BlobDiverter {
   serviceConfig: BlobDivertConfig
   idResolver: IdResolver
+  private readonly fetch: typeof globalThis.fetch
 
   constructor(
     public db: Database,
     services: {
       idResolver: IdResolver
       serviceConfig: BlobDivertConfig
+      devMode?: boolean
     },
   ) {
     this.serviceConfig = services.serviceConfig
     this.idResolver = services.idResolver
+    this.fetch = services.devMode ? globalThis.fetch : safeBlobFetch
   }
 
   /**
@@ -46,7 +49,7 @@ export class BlobDiverter {
     )
     headersTimer.unref()
 
-    const blobResponse = await safeBlobFetch(blobUrl, {
+    const blobResponse = await this.fetch(blobUrl, {
       signal: headersController.signal,
     })
       .catch((err) => {

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'node:stream'
+import { Readable, Transform, type TransformCallback } from 'node:stream'
 import { finished, pipeline } from 'node:stream/promises'
 import { CID } from 'multiformats/cid'
 import * as undici from 'undici'
@@ -14,6 +14,8 @@ import type { Database } from '../db/index.js'
 import { createSafeFetch } from '../safe-fetch.js'
 import { retryHttp } from '../util.js'
 
+const BLOB_HEADERS_TIMEOUT = 10e3
+const BLOB_BODY_TIMEOUT = 30e3
 const safeBlobFetch = createSafeFetch()
 
 export class BlobDiverter {
@@ -37,9 +39,20 @@ export class BlobDiverter {
   async getBlob(options: GetBlobOptions): Promise<Blob> {
     const blobUrl = getBlobUrl(options)
 
-    const blobResponse = await safeBlobFetch(blobUrl).catch((err) => {
-      throw asXrpcClientError(err, `Error fetching blob ${options.cid}`)
+    const headersController = new AbortController()
+    const headersTimer = setTimeout(
+      () => headersController.abort(),
+      BLOB_HEADERS_TIMEOUT,
+    )
+    headersTimer.unref()
+
+    const blobResponse = await safeBlobFetch(blobUrl, {
+      signal: headersController.signal,
     })
+      .catch((err) => {
+        throw asXrpcClientError(err, `Error fetching blob ${options.cid}`)
+      })
+      .finally(() => clearTimeout(headersTimer))
 
     if (blobResponse.status !== 200) {
       await blobResponse.body?.cancel()
@@ -58,9 +71,11 @@ export class BlobDiverter {
       const type = blobResponse.headers.get('content-type')
       const verifier = new VerifyCidTransform(CID.parse(options.cid))
 
-      void pipeline([Readable.fromWeb(blobResponse.body), verifier]).catch(
-        (_err) => {},
-      )
+      void pipeline([
+        Readable.fromWeb(blobResponse.body),
+        new BodyTimeoutTransform(BLOB_BODY_TIMEOUT),
+        verifier,
+      ]).catch((_err) => {})
 
       return {
         type: type ?? 'application/octet-stream',
@@ -139,6 +154,51 @@ export class BlobDiverter {
         { cause: err },
       )
     })
+  }
+}
+
+class BodyTimeoutTransform extends Transform {
+  private timer: NodeJS.Timeout | undefined
+
+  constructor(private readonly timeout: number) {
+    super()
+    this.resetTimer()
+  }
+
+  override _transform(
+    chunk: unknown,
+    encoding: BufferEncoding,
+    callback: TransformCallback,
+  ) {
+    this.resetTimer()
+    callback(null, chunk)
+  }
+
+  override _flush(callback: TransformCallback) {
+    this.clearTimer()
+    callback()
+  }
+
+  override _destroy(
+    error: Error | null,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.clearTimer()
+    callback(error)
+  }
+
+  private resetTimer() {
+    this.clearTimer()
+    this.timer = setTimeout(
+      () => this.destroy(new Error('Blob body timeout')),
+      this.timeout,
+    )
+    this.timer.unref()
+  }
+
+  private clearTimer() {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
   }
 }
 

--- a/packages/ozone/src/daemon/blob-diverter.ts
+++ b/packages/ozone/src/daemon/blob-diverter.ts
@@ -1,18 +1,21 @@
-import type { Readable } from 'node:stream'
+import { Readable } from 'node:stream'
 import { finished, pipeline } from 'node:stream/promises'
 import { CID } from 'multiformats/cid'
 import * as undici from 'undici'
 import {
   VerifyCidTransform,
   allFulfilled,
-  createDecoders,
   getPdsEndpoint,
 } from '@atproto/common'
 import type { IdResolver } from '@atproto/identity'
 import { ResponseType, XRPCError } from '@atproto/xrpc'
 import type { BlobDivertConfig } from '../config/index.js'
 import type { Database } from '../db/index.js'
+import { createSafeFetch } from '../safe-fetch.js'
 import { retryHttp } from '../util.js'
+
+const MAX_BLOB_SIZE = 100 * 1024 * 1024
+const safeBlobFetch = createSafeFetch(MAX_BLOB_SIZE)
 
 export class BlobDiverter {
   serviceConfig: BlobDivertConfig
@@ -35,43 +38,38 @@ export class BlobDiverter {
   async getBlob(options: GetBlobOptions): Promise<Blob> {
     const blobUrl = getBlobUrl(options)
 
-    const blobResponse = await undici
-      .request(blobUrl, {
-        headersTimeout: 10e3,
-        bodyTimeout: 30e3,
-      })
-      .catch((err) => {
-        throw asXrpcClientError(err, `Error fetching blob ${options.cid}`)
-      })
+    const blobResponse = await safeBlobFetch(blobUrl).catch((err) => {
+      throw asXrpcClientError(err, `Error fetching blob ${options.cid}`)
+    })
 
-    if (blobResponse.statusCode !== 200) {
-      await blobResponse.body.dump()
+    if (blobResponse.status !== 200) {
+      await blobResponse.body?.cancel()
       throw new XRPCError(
-        blobResponse.statusCode,
+        blobResponse.status,
         undefined,
         `Error downloading blob ${options.cid}`,
       )
     }
 
     try {
-      const type = blobResponse.headers['content-type']
-      const encoding = blobResponse.headers['content-encoding']
+      if (!blobResponse.body) {
+        throw new Error('Blob response has no body')
+      }
 
+      const type = blobResponse.headers.get('content-type')
       const verifier = new VerifyCidTransform(CID.parse(options.cid))
 
-      void pipeline([
-        blobResponse.body,
-        ...createDecoders(encoding),
-        verifier,
-      ]).catch((_err) => {})
+      void pipeline([Readable.fromWeb(blobResponse.body), verifier]).catch(
+        (_err) => {},
+      )
 
       return {
-        type: typeof type === 'string' ? type : 'application/octet-stream',
+        type: type ?? 'application/octet-stream',
         stream: verifier,
       }
     } catch (err) {
       // Typically un-supported content encoding
-      await blobResponse.body.dump()
+      await blobResponse.body?.cancel()
       throw err
     }
   }

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -59,9 +59,11 @@ export class DaemonContext {
     const idResolver = new IdResolver({
       plcUrl: cfg.identity.plcUrl,
     })
-    idResolver.did = new SafeDidResolver({
-      plcUrl: cfg.identity.plcUrl,
-    })
+    if (!cfg.service.devMode) {
+      idResolver.did = new SafeDidResolver({
+        plcUrl: cfg.identity.plcUrl,
+      })
+    }
 
     const appviewAgent = new AtpAgent({ service: cfg.appview.url })
     const createAuthHeaders = (aud: string, lxm: string) =>

--- a/packages/ozone/src/daemon/context.ts
+++ b/packages/ozone/src/daemon/context.ts
@@ -10,6 +10,7 @@ import { ModerationService } from '../mod-service/index.js'
 import { StrikeService } from '../mod-service/strike.js'
 import { QueueService } from '../queue/service.js'
 import { ReportStatsService } from '../report/stats.js'
+import { SafeDidResolver } from '../safe-fetch.js'
 import { ScheduledActionService } from '../scheduled-action/service.js'
 import { SettingService } from '../setting/service.js'
 import { TeamService } from '../team/index.js'
@@ -56,6 +57,9 @@ export class DaemonContext {
     const signingKeyId = await getSigningKeyId(db, signingKey.did())
 
     const idResolver = new IdResolver({
+      plcUrl: cfg.identity.plcUrl,
+    })
+    idResolver.did = new SafeDidResolver({
       plcUrl: cfg.identity.plcUrl,
     })
 

--- a/packages/ozone/src/mod-service/util.ts
+++ b/packages/ozone/src/mod-service/util.ts
@@ -1,4 +1,3 @@
-import net from 'node:net'
 import { sql } from 'kysely'
 import AtpAgent from '@atproto/api'
 import { cborEncode, noUndefinedVals } from '@atproto/common'
@@ -7,6 +6,10 @@ import type { IdResolver } from '@atproto/identity'
 import type { LabelRow } from '../db/schema/label.js'
 import type { DbRef } from '../db/types.js'
 import type { Label } from '../lexicon/types/com/atproto/label/defs.js'
+import { createSafeFetch } from '../safe-fetch.js'
+
+const MAX_PDS_RESPONSE_SIZE = 10 * 1024 * 1024
+const safePdsFetch = createSafeFetch(MAX_PDS_RESPONSE_SIZE)
 
 export type SignedLabel = Label & { sig: Uint8Array }
 
@@ -68,13 +71,6 @@ export const signLabel = async (
   }
 }
 
-export const isSafeUrl = (url: URL) => {
-  if (url.protocol !== 'https:') return false
-  if (!url.hostname || url.hostname === 'localhost') return false
-  if (net.isIP(url.hostname) !== 0) return false
-  return true
-}
-
 export const getPdsAgentForRepo = async (
   idResolver: IdResolver,
   did: string,
@@ -82,11 +78,17 @@ export const getPdsAgentForRepo = async (
 ) => {
   const { pds } = await idResolver.did.resolveAtprotoData(did)
   const url = new URL(pds)
-  if (!devMode && !isSafeUrl(url)) {
+  if (!devMode && url.protocol !== 'https:') {
     return { url, agent: null }
   }
 
-  return { url, agent: new AtpAgent({ service: url }) }
+  return {
+    url,
+    agent: new AtpAgent({
+      service: url,
+      fetch: devMode ? globalThis.fetch : safePdsFetch,
+    }),
+  }
 }
 
 export const dateFromDatetime = (datetime: Date) => {

--- a/packages/ozone/src/mod-service/util.ts
+++ b/packages/ozone/src/mod-service/util.ts
@@ -8,8 +8,7 @@ import type { DbRef } from '../db/types.js'
 import type { Label } from '../lexicon/types/com/atproto/label/defs.js'
 import { createSafeFetch } from '../safe-fetch.js'
 
-const MAX_PDS_RESPONSE_SIZE = 10 * 1024 * 1024
-const safePdsFetch = createSafeFetch(MAX_PDS_RESPONSE_SIZE)
+const safePdsFetch = createSafeFetch()
 
 export type SignedLabel = Label & { sig: Uint8Array }
 

--- a/packages/ozone/src/safe-fetch.ts
+++ b/packages/ozone/src/safe-fetch.ts
@@ -1,10 +1,10 @@
 import { safeFetchWrap } from '@atproto-labs/fetch-node'
 
-export const createSafeFetch = (responseMaxSize: number) => {
+export const createSafeFetch = () => {
   const safeFetch = safeFetchWrap({
     allowImplicitRedirect: true,
     allowIpHost: false,
-    responseMaxSize,
+    responseMaxSize: Infinity,
     timeout: 30e3,
   })
 

--- a/packages/ozone/src/safe-fetch.ts
+++ b/packages/ozone/src/safe-fetch.ts
@@ -1,0 +1,13 @@
+import { safeFetchWrap } from '@atproto-labs/fetch-node'
+
+export const createSafeFetch = (responseMaxSize: number) => {
+  const safeFetch = safeFetchWrap({
+    allowImplicitRedirect: true,
+    allowIpHost: false,
+    responseMaxSize,
+    timeout: 30e3,
+  })
+
+  return (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) =>
+    safeFetch(input, { ...init, redirect: 'error' })
+}

--- a/packages/ozone/src/safe-fetch.ts
+++ b/packages/ozone/src/safe-fetch.ts
@@ -1,13 +1,53 @@
-import { safeFetchWrap } from '@atproto-labs/fetch-node'
+import {
+  DidResolver,
+  type DidResolverOpts,
+  PoorlyFormattedDidError,
+  UnsupportedDidWebPathError,
+} from '@atproto/identity'
+import { type Fetch, safeFetchWrap } from '@atproto-labs/fetch-node'
 
-export const createSafeFetch = () => {
+const DID_DOC_PATH = '/.well-known/did.json'
+
+export const createSafeFetch = (timeout = Infinity) => {
   const safeFetch = safeFetchWrap({
+    allowCustomPort: true,
     allowImplicitRedirect: true,
     allowIpHost: false,
     responseMaxSize: Infinity,
-    timeout: 30e3,
+    timeout,
   })
 
   return (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) =>
     safeFetch(input, { ...init, redirect: 'error' })
+}
+
+export class SafeDidResolver extends DidResolver {
+  private readonly safeFetch: Fetch
+
+  constructor(opts: DidResolverOpts) {
+    super(opts)
+    this.safeFetch = createSafeFetch(opts.timeout ?? 3000)
+  }
+
+  override async resolveNoCheck(did: string): Promise<unknown> {
+    if (!did.startsWith('did:web:')) {
+      return super.resolveNoCheck(did)
+    }
+
+    const parsedId = did.split(':').slice(2).join(':')
+    const parts = parsedId.split(':').map(decodeURIComponent)
+    if (parts.length < 1) {
+      throw new PoorlyFormattedDidError(did)
+    }
+    if (parts.length !== 1) {
+      throw new UnsupportedDidWebPathError(did)
+    }
+
+    const url = new URL(`https://${parts[0]}${DID_DOC_PATH}`)
+    const res = await this.safeFetch.call(globalThis, url, {
+      headers: { accept: 'application/did+ld+json,application/json' },
+    })
+    if (!res.ok) return null
+    return res.json()
+  }
 }

--- a/packages/ozone/src/safe-fetch.ts
+++ b/packages/ozone/src/safe-fetch.ts
@@ -1,3 +1,4 @@
+import { Transform, type TransformCallback } from 'node:stream'
 import {
   DidResolver,
   type DidResolverOpts,
@@ -7,13 +8,20 @@ import {
 import { type Fetch, safeFetchWrap } from '@atproto-labs/fetch-node'
 
 const DID_DOC_PATH = '/.well-known/did.json'
+const DEFAULT_RESPONSE_MAX_SIZE = 10 * 1024 * 1024
 
-export const createSafeFetch = (timeout = Infinity) => {
+export const createSafeFetch = ({
+  timeout = Infinity,
+  responseMaxSize = DEFAULT_RESPONSE_MAX_SIZE,
+}: {
+  timeout?: number
+  responseMaxSize?: number
+} = {}) => {
   const safeFetch = safeFetchWrap({
     allowCustomPort: true,
     allowImplicitRedirect: true,
     allowIpHost: false,
-    responseMaxSize: Infinity,
+    responseMaxSize,
     timeout,
   })
 
@@ -26,7 +34,7 @@ export class SafeDidResolver extends DidResolver {
 
   constructor(opts: DidResolverOpts) {
     super(opts)
-    this.safeFetch = createSafeFetch(opts.timeout ?? 3000)
+    this.safeFetch = createSafeFetch({ timeout: opts.timeout ?? 3000 })
   }
 
   override async resolveNoCheck(did: string): Promise<unknown> {
@@ -47,7 +55,55 @@ export class SafeDidResolver extends DidResolver {
     const res = await this.safeFetch.call(globalThis, url, {
       headers: { accept: 'application/did+ld+json,application/json' },
     })
-    if (!res.ok) return null
+    if (!res.ok) {
+      await res.body?.cancel()
+      return null
+    }
     return res.json()
+  }
+}
+
+export class BodyTimeoutTransform extends Transform {
+  private timer: NodeJS.Timeout | undefined
+
+  constructor(private readonly timeout: number) {
+    super()
+    this.resetTimer()
+  }
+
+  override _transform(
+    chunk: unknown,
+    encoding: BufferEncoding,
+    callback: TransformCallback,
+  ) {
+    this.resetTimer()
+    callback(null, chunk)
+  }
+
+  override _flush(callback: TransformCallback) {
+    this.clearTimer()
+    callback()
+  }
+
+  override _destroy(
+    error: Error | null,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.clearTimer()
+    callback(error)
+  }
+
+  private resetTimer() {
+    this.clearTimer()
+    this.timer = setTimeout(
+      () => this.destroy(new Error('Blob body timeout')),
+      this.timeout,
+    )
+    this.timer.unref()
+  }
+
+  private clearTimer() {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
   }
 }

--- a/packages/ozone/tests/safe-fetch.test.ts
+++ b/packages/ozone/tests/safe-fetch.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { createSafeFetch } from '../src/safe-fetch.js'
+import { SafeDidResolver, createSafeFetch } from '../src/safe-fetch.js'
 
 describe('safe fetch', () => {
   it.each([
@@ -25,5 +25,22 @@ describe('safe fetch', () => {
     expect(request).toBeInstanceOf(Request)
     expect((request as Request).redirect).toBe('error')
     fetch.mockRestore()
+  })
+
+  it('allows nonstandard HTTPS ports', async () => {
+    const fetch = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+    const safeFetch = createSafeFetch()
+
+    await safeFetch('https://api.bsky.app:8443')
+
+    expect(fetch).toHaveBeenCalled()
+    fetch.mockRestore()
+  })
+
+  it('protects did:web resolution', async () => {
+    const resolver = new SafeDidResolver({ timeout: 100 })
+    await expect(resolver.resolve('did:web:127.0.0.1')).rejects.toThrow()
   })
 })

--- a/packages/ozone/tests/safe-fetch.test.ts
+++ b/packages/ozone/tests/safe-fetch.test.ts
@@ -9,7 +9,7 @@ describe('safe fetch', () => {
     'https://[::1]',
     'https://169.254.169.254',
   ])('rejects unsafe target %s', async (target) => {
-    const safeFetch = createSafeFetch(1024)
+    const safeFetch = createSafeFetch()
     await expect(safeFetch(target)).rejects.toThrow()
   })
 
@@ -17,7 +17,7 @@ describe('safe fetch', () => {
     const fetch = jest
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response(null, { status: 200 }))
-    const safeFetch = createSafeFetch(1024)
+    const safeFetch = createSafeFetch()
 
     await safeFetch('https://api.bsky.app')
 

--- a/packages/ozone/tests/safe-fetch.test.ts
+++ b/packages/ozone/tests/safe-fetch.test.ts
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals'
+import { createSafeFetch } from '../src/safe-fetch.js'
+
+describe('safe fetch', () => {
+  it.each([
+    'http://example.com',
+    'https://localhost',
+    'https://127.0.0.1',
+    'https://[::1]',
+    'https://169.254.169.254',
+  ])('rejects unsafe target %s', async (target) => {
+    const safeFetch = createSafeFetch(1024)
+    await expect(safeFetch(target)).rejects.toThrow()
+  })
+
+  it('disables redirects', async () => {
+    const fetch = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }))
+    const safeFetch = createSafeFetch(1024)
+
+    await safeFetch('https://api.bsky.app')
+
+    const request = fetch.mock.calls[0][0]
+    expect(request).toBeInstanceOf(Request)
+    expect((request as Request).redirect).toBe('error')
+    fetch.mockRestore()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1833,6 +1833,9 @@ importers:
 
   packages/ozone:
     dependencies:
+      '@atproto-labs/fetch-node':
+        specifier: workspace:^
+        version: link:../internal/fetch-node
       '@atproto/api':
         specifier: workspace:^
         version: link:../api


### PR DESCRIPTION
## Summary

- route DID-derived Ozone PDS requests through connection-time SSRF protection
- protect `did:web` resolution in both the API and daemon identity resolvers
- reject private/non-unicast DNS results, IP hosts, non-HTTPS production endpoints, and redirects
- preserve nonstandard HTTPS ports and the blob path’s existing 10-second header and 30-second body-inactivity timeouts
- add regression coverage for loopback, metadata, HTTP, redirects, custom ports, and `did:web` resolution

## Context

Ozone previously validated only the URL scheme, literal IP hostnames, and `localhost` before constructing an `AtpAgent`. DNS names resolving to private addresses and DNS rebinding remained possible. Blob diversion passed the PDS endpoint from a DID document directly to `undici.request()`, and the default `did:web` resolver fetched identity-controlled hosts without private-address filtering.

This change deliberately does not introduce response-size policy or a new global PDS timeout.

## Validation

- Ozone TypeScript build
- focused ESLint checks
- focused SSRF tests: 8 passed
- `git diff --check`
- two adversarial cross-model reviews; final review has no findings

The existing blob-diversion integration test could not run locally because Docker was unavailable and `DB_TEST_POSTGRES_URL` was not configured.