### PR TITLE
bsky: make the feedgen skeleton timeout configurable

### DIFF
--- a/.changeset/lucky-bats-hammer.md
+++ b/.changeset/lucky-bats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Add a `BSKY_FEED_GEN_SKELETON_TIMEOUT` option, bounding feed generator skeleton requests. Defaults to 5s, lowered from the previously hardcoded 10s.

--- a/.changeset/lucky-bats-hammer.md
+++ b/.changeset/lucky-bats-hammer.md
@@ -1,5 +1,6 @@
 ---
 '@atproto/bsky': patch
+'@atproto/dev-env': patch
 ---
 
 Add a `BSKY_FEED_GEN_SKELETON_TIMEOUT` option, bounding feed generator skeleton requests. Defaults to 5s, lowered from the previously hardcoded 10s.

--- a/packages/bsky/src/api/app/bsky/feed/getFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getFeed.ts
@@ -287,7 +287,10 @@ const skeletonFromFeedGen = async (
   // @TODO currently passthrough auth headers from pds
   const result = await xrpcSafe(endpoint, app.bsky.feed.getFeedSkeleton, {
     strictResponseProcessing: false,
-    signal: AbortSignal.any([params.signal, AbortSignal.timeout(10_000)]),
+    signal: AbortSignal.any([
+      params.signal,
+      AbortSignal.timeout(ctx.cfg.feedGenSkeletonTimeout),
+    ]),
     headers,
     params: {
       feed: params.feed,

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { noUndefinedVals } from '@atproto/common'
+import { SECOND, noUndefinedVals } from '@atproto/common'
 import { type DidString, isDidString } from '@atproto/lex'
 import { subLogger as log } from './logger.js'
 
@@ -72,7 +72,7 @@ export interface ServerConfigValues {
   irisFeedUris?: Set<string> // `iris:feed:enable` gate to serve via iris instead of seeemore
   irisStagingUrl?: string
   irisStagingFeedUris?: Set<string> // serve via iris staging instead of the registered feed generator
-  feedGenSkeletonTimeout?: number
+  feedGenSkeletonTimeout: number
   cdnUrl?: string
   videoPlaylistUrlPattern?: string
   videoThumbnailUrlPattern?: string
@@ -183,9 +183,9 @@ export class ServerConfig {
     const irisStagingFeedUris = new Set(
       envList(process.env.BSKY_IRIS_STAGING_FEED_URIS),
     )
-    const feedGenSkeletonTimeout =
-      parseInt(process.env.BSKY_FEED_GEN_SKELETON_TIMEOUT || '', 10) ||
-      undefined
+    const feedGenSkeletonTimeout = process.env.BSKY_FEED_GEN_SKELETON_TIMEOUT
+      ? parseInt(process.env.BSKY_FEED_GEN_SKELETON_TIMEOUT || '', 10)
+      : 5 * SECOND
     const dataplaneUrls =
       overrides?.dataplaneUrls ?? envList(process.env.BSKY_DATAPLANE_URLS)
     const dataplaneUrlsEtcdKeyPrefix =
@@ -588,8 +588,8 @@ export class ServerConfig {
     return this.cfg.irisStagingFeedUris
   }
 
-  get feedGenSkeletonTimeout(): number {
-    return this.cfg.feedGenSkeletonTimeout ?? 5e3
+  get feedGenSkeletonTimeout() {
+    return this.cfg.feedGenSkeletonTimeout
   }
 
   get cdnUrl() {

--- a/packages/bsky/src/config.ts
+++ b/packages/bsky/src/config.ts
@@ -72,6 +72,7 @@ export interface ServerConfigValues {
   irisFeedUris?: Set<string> // `iris:feed:enable` gate to serve via iris instead of seeemore
   irisStagingUrl?: string
   irisStagingFeedUris?: Set<string> // serve via iris staging instead of the registered feed generator
+  feedGenSkeletonTimeout?: number
   cdnUrl?: string
   videoPlaylistUrlPattern?: string
   videoThumbnailUrlPattern?: string
@@ -182,6 +183,9 @@ export class ServerConfig {
     const irisStagingFeedUris = new Set(
       envList(process.env.BSKY_IRIS_STAGING_FEED_URIS),
     )
+    const feedGenSkeletonTimeout =
+      parseInt(process.env.BSKY_FEED_GEN_SKELETON_TIMEOUT || '', 10) ||
+      undefined
     const dataplaneUrls =
       overrides?.dataplaneUrls ?? envList(process.env.BSKY_DATAPLANE_URLS)
     const dataplaneUrlsEtcdKeyPrefix =
@@ -380,6 +384,7 @@ export class ServerConfig {
       irisFeedUris,
       irisStagingUrl,
       irisStagingFeedUris,
+      feedGenSkeletonTimeout,
       didPlcUrl,
       labelsFromIssuerDids,
       handleResolveNameservers,
@@ -581,6 +586,10 @@ export class ServerConfig {
 
   get irisStagingFeedUris() {
     return this.cfg.irisStagingFeedUris
+  }
+
+  get feedGenSkeletonTimeout(): number {
+    return this.cfg.feedGenSkeletonTimeout ?? 5e3
   }
 
   get cdnUrl() {

--- a/packages/dev-env/src/bsky.ts
+++ b/packages/dev-env/src/bsky.ts
@@ -2,6 +2,7 @@ import { Client as PlcClient } from '@did-plc/lib'
 import * as ui8 from 'uint8arrays'
 import { AtpAgent } from '@atproto/api'
 import * as bsky from '@atproto/bsky'
+import { SECOND } from '@atproto/common-web'
 import { Secp256k1Keypair } from '@atproto/crypto'
 import { Client } from '@atproto/lex'
 import type { DidString } from '@atproto/syntax'
@@ -90,6 +91,7 @@ export class TestBsky {
       visibilityTagRankPrefix: '',
       debugFieldAllowedDids: new Set(),
       draftsLimit: 500,
+      feedGenSkeletonTimeout: 5 * SECOND,
       ...cfg,
       adminPasswords: [ADMIN_PASSWORD],
       etcdHosts: [],


### PR DESCRIPTION
Feed generator skeleton requests are bounded by a hardcoded 10s timeout, set in #5039. This makes that bound configurable via `BSKY_FEED_GEN_SKELETON_TIMEOUT`, and lowers the default to 5s.

Motivation: 10s is a long time to hold a `getFeed` request open waiting on a third-party feedgen that is likely not going to answer. Making it a config means we can tune it from bsky-infra without cutting a release, and revert quickly if 5s turns out to cut off too many legitimately slow feedgens.

The timeout still composes with the caller's signal (`AbortSignal.any`), so a client disconnect cancels the upstream request as before.

I will set `appview_feed_gen_skeleton_timeout: 5000` in bsky-infra once this merges and I have a tag.
