### PR TITLE
telemetry: drop @connectrpc/connect from opentelemetry-node

### DIFF
--- a/.changeset/soft-pumas-rescue.md
+++ b/.changeset/soft-pumas-rescue.md
@@ -1,0 +1,5 @@
+---
+'@atproto-labs/opentelemetry-node': patch
+---
+
+Drop the `@connectrpc/connect` dependency: `statusCodeToString()` now takes a plain `number` and resolves the status name through a hand-rolled map of the Connect `Code` enum values. Importing the library here would load it before it gets instrumented, breaking the instrumentation.

--- a/packages/internal/opentelemetry-node/package.json
+++ b/packages/internal/opentelemetry-node/package.json
@@ -43,7 +43,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@connectrpc/connect": "^1.1.4",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.77.0",
     "@opentelemetry/core": "^2.9.0",

--- a/packages/internal/opentelemetry-node/src/util.test.ts
+++ b/packages/internal/opentelemetry-node/src/util.test.ts
@@ -1,23 +1,34 @@
-import { Code } from '@connectrpc/connect'
 import { describe, expect, test } from 'vitest'
 import { extractNormalizedLxm, statusCodeToString } from './util.js'
 
 describe(statusCodeToString, () => {
-  test('success is spelled out, since Code has no member for it', () => {
+  test('success is spelled out, since the Code enum has no member for it', () => {
     expect(statusCodeToString(undefined)).toBe('ok')
   })
 
   test.each([
-    { code: Code.NotFound, expected: 'not_found' },
-    { code: Code.DeadlineExceeded, expected: 'deadline_exceeded' },
-    { code: Code.ResourceExhausted, expected: 'resource_exhausted' },
-    { code: Code.Unavailable, expected: 'unavailable' },
+    { code: 1, expected: 'canceled' },
+    { code: 2, expected: 'unknown' },
+    { code: 3, expected: 'invalid_argument' },
+    { code: 4, expected: 'deadline_exceeded' },
+    { code: 5, expected: 'not_found' },
+    { code: 6, expected: 'already_exists' },
+    { code: 7, expected: 'permission_denied' },
+    { code: 8, expected: 'resource_exhausted' },
+    { code: 9, expected: 'failed_precondition' },
+    { code: 10, expected: 'aborted' },
+    { code: 11, expected: 'out_of_range' },
+    { code: 12, expected: 'unimplemented' },
+    { code: 13, expected: 'internal' },
+    { code: 14, expected: 'unavailable' },
+    { code: 15, expected: 'data_loss' },
+    { code: 16, expected: 'unauthenticated' },
   ])('$expected', ({ code, expected }) => {
     expect(statusCodeToString(code)).toBe(expected)
   })
 
   test('unknown numeric code falls back to its digits', () => {
-    expect(statusCodeToString(9999 as Code)).toBe('9999')
+    expect(statusCodeToString(9999)).toBe('9999')
   })
 })
 

--- a/packages/internal/opentelemetry-node/src/util.ts
+++ b/packages/internal/opentelemetry-node/src/util.ts
@@ -1,16 +1,41 @@
-import { Code } from '@connectrpc/connect'
+/**
+ * Numeric values of the Connect/gRPC `Code` enum, spelled out here so that
+ * this package does not depend on `@connectrpc/connect`. Importing the
+ * library here would load it before it gets instrumented, breaking the
+ * instrumentation.
+ *
+ * @see {@link https://connectrpc.com/docs/protocol#error-codes}
+ */
+const CODE_NAMES: Record<number, string> = {
+  1: 'Canceled',
+  2: 'Unknown',
+  3: 'InvalidArgument',
+  4: 'DeadlineExceeded',
+  5: 'NotFound',
+  6: 'AlreadyExists',
+  7: 'PermissionDenied',
+  8: 'ResourceExhausted',
+  9: 'FailedPrecondition',
+  10: 'Aborted',
+  11: 'OutOfRange',
+  12: 'Unimplemented',
+  13: 'Internal',
+  14: 'Unavailable',
+  15: 'DataLoss',
+  16: 'Unauthenticated',
+}
 
 /**
  * Renders a Connect status as the snake_case string the
  * `rpc.response.status_code` attribute expects. Success is spelled out here
- * because Connect's {@link Code} enum only enumerates errors.
+ * because the `Code` enum only enumerates errors.
  *
  * @note Both the caller and the callee of an RPC label their metrics with this,
  * so that the two halves of a call can be plotted on the same dimensions.
  */
-export const statusCodeToString = (code?: Code): string => {
+export const statusCodeToString = (code?: number): string => {
   if (code === undefined) return 'ok'
-  const name = Code[code]
+  const name = CODE_NAMES[code]
   if (name === undefined) return String(code)
   return name.replace(/(?<=.)[A-Z]/g, (c) => `_${c}`).toLowerCase()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,9 +910,6 @@ importers:
 
   packages/internal/opentelemetry-node:
     dependencies:
-      '@connectrpc/connect':
-        specifier: ^1.1.4
-        version: 1.3.0(@bufbuild/protobuf@1.6.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1


### PR DESCRIPTION
## What

`@atproto-labs/opentelemetry-node` is the bootstrap library that gets loaded before instrumentation is set up, so it must not import `@connectrpc/connect` — doing so would load the library before it gets instrumented, breaking the instrumentation. `statusCodeToString()` now takes a plain `number` and resolves the status name through a hand-rolled map of the Connect `Code` enum values, and the dependency is dropped from the package.

Follow-up to #5470 / #5472 (APP-2987).

## Notes

- The enum values (1-16) are copied from `@connectrpc/connect`'s `Code` enum, which mirrors gRPC status codes. The map is deliberately frozen at these — user-defined codes don't exist in the Connect spec.
- Callers in `@atproto/bsky` and `@atproto/bsync` are unaffected: they still pass `err.code` from `ConnectError`, which is a numeric enum, so the widened `number` parameter accepts it unchanged.
- Tests now cover all 16 codes instead of a 4-code sample.