### PR TITLE
ozone: copy lex-password-session into ozone docker container

### DIFF
--- a/services/ozone/Dockerfile
+++ b/services/ozone/Dockerfile
@@ -44,6 +44,7 @@ COPY ./packages/lex/lex-data ./packages/lex/lex-data
 COPY ./packages/lex/lex-document ./packages/lex/lex-document
 COPY ./packages/lex/lex-installer ./packages/lex/lex-installer
 COPY ./packages/lex/lex-json ./packages/lex/lex-json
+COPY ./packages/lex/lex-password-session ./packages/lex/lex-password-session
 COPY ./packages/lex/lex-resolver ./packages/lex/lex-resolver
 COPY ./packages/lex/lex-schema ./packages/lex/lex-schema
 COPY ./packages/lex/lex ./packages/lex/lex


### PR DESCRIPTION
## What & why

Fixes build issue where lex migration dependency needed to be copied into docker container during image build

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? Say so here, and name the tooling. Written with opus5
