### PR TITLE
Add `updatedAt` to interests preference

### DIFF
--- a/.changeset/fresh-owls-update.md
+++ b/.changeset/fresh-owls-update.md
@@ -1,0 +1,5 @@
+---
+'@atproto/api': patch
+---
+
+Set `updatedAt` when updating interests with `setInterestsPref`.

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -480,6 +480,11 @@
       "type": "object",
       "required": ["tags"],
       "properties": {
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The timestamp when the account owner last updated their interests."
+        },
         "tags": {
           "type": "array",
           "maxLength": 100,

--- a/packages/api/src/agent.ts
+++ b/packages/api/src/agent.ts
@@ -1,6 +1,12 @@
 import AwaitLock from 'await-lock'
 import { TID, retry } from '@atproto/common-web'
-import { AtUri, type DidString, ensureValidDidRegex } from '@atproto/syntax'
+import {
+  AtUri,
+  type DidString,
+  currentDatetimeString,
+  ensureValidDidRegex,
+  toDatetimeString,
+} from '@atproto/syntax'
 import {
   type FetchHandler,
   type FetchHandlerOptions,
@@ -648,8 +654,14 @@ export class Agent extends XrpcClient {
         const { $type: _, ...v } = pref
         prefs.threadViewPrefs = { ...prefs.threadViewPrefs, ...v }
       } else if (predicate.isValidInterestsPref(pref)) {
-        const { $type: _, ...v } = pref
-        prefs.interests = { ...prefs.interests, ...v }
+        const { $type: _, updatedAt, ...v } = pref
+        prefs.interests = {
+          ...prefs.interests,
+          ...v,
+          ...(updatedAt !== undefined && {
+            updatedAt: toDatetimeString(updatedAt),
+          }),
+        }
       } else if (predicate.isValidMutedWordsPref(pref)) {
         prefs.moderationPrefs.mutedWords = pref.items
 
@@ -1073,6 +1085,7 @@ export class Agent extends XrpcClient {
           ...existing,
           ...pref,
           $type: 'app.bsky.actor.defs#interestsPref',
+          updatedAt: currentDatetimeString(),
         })
     })
   }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,3 +1,4 @@
+import type { DatetimeString } from '@atproto/syntax'
 import type { AppBskyActorDefs } from './client/index.js'
 import type { ModerationPrefs } from './moderation/types.js'
 
@@ -121,6 +122,7 @@ export interface BskyThreadViewPreference {
  */
 export interface BskyInterestsPreference {
   tags: string[]
+  updatedAt?: DatetimeString
   [key: string]: any
 }
 

--- a/packages/api/tests/atp-agent.test.ts
+++ b/packages/api/tests/atp-agent.test.ts
@@ -1379,6 +1379,7 @@ describe('agent', () => {
         },
         interests: {
           tags: ['foo', 'bar'],
+          updatedAt: expect.any(String),
         },
         bskyAppState: {
           activeProgressGuide: undefined,
@@ -1397,6 +1398,21 @@ describe('agent', () => {
           hideAllFeeds: false,
         },
       })
+
+      const firstUpdatedAt = (await agent.getPreferences()).interests.updatedAt
+      expect(firstUpdatedAt).toBeDefined()
+
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      await agent.setInterestsPref({ tags: ['baz'] })
+
+      const updatedInterests = (await agent.getPreferences()).interests
+      expect(updatedInterests).toEqual({
+        tags: ['baz'],
+        updatedAt: expect.any(String),
+      })
+      expect(Date.parse(updatedInterests.updatedAt!)).toBeGreaterThan(
+        Date.parse(firstUpdatedAt!),
+      )
     })
 
     it('resolves duplicates correctly', async () => {


### PR DESCRIPTION
Ports bluesky-social/bsky#42 to the canonical Lexicon and `@atproto/api`.

## Summary
- add optional `updatedAt` to `app.bsky.actor.defs#interestsPref`
- stamp `updatedAt` whenever `setInterestsPref` creates or updates the preference
- expose the timestamp through `BskyInterestsPreference`

## Testing
- `pnpm codegen`
- `cd packages/api && pnpm run build`
- `cd packages/api && pnpm test tests/atp-agent.test.ts --runInBand`
- `pnpm run build:ts`