### PR TITLE
Finish notification read fanout rollout

### DIFF
--- a/.changeset/clean-notification-fanout.md
+++ b/.changeset/clean-notification-fanout.md
@@ -1,0 +1,5 @@
+---
+"@atproto/bsky": patch
+---
+
+Route notification read updates exclusively through bsync fanout.

--- a/packages/bsky/src/api/app/bsky/notification/updateSeen.ts
+++ b/packages/bsky/src/api/app/bsky/notification/updateSeen.ts
@@ -4,7 +4,6 @@ const Murmurhash = ((m) => m.default ?? m)(MurmurhashModule)
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
-import { httpLogger } from '../../../../logger.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(app.bsky.notification.updateSeen, {
@@ -13,17 +12,8 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const seenAt = new Date(input.body.seenAt)
       const timestamp = Timestamp.fromDate(seenAt)
-      // @TODO remove the direct dataplane call and bsync error handling after the bsync path is verified in production.
       await Promise.all([
-        ctx.dataplane.updateNotificationSeen({
-          actorDid: viewer,
-          timestamp,
-        }),
-        ctx.bsyncClient
-          .fanoutNotificationSeen({ actorDid: viewer, timestamp })
-          .catch((err) => {
-            httpLogger.error({ err }, 'failed to fan out notification seen')
-          }),
+        ctx.bsyncClient.fanoutNotificationSeen({ actorDid: viewer, timestamp }),
         ctx.courierClient?.pushNotifications({
           notifications: [
             {


### PR DESCRIPTION
## Summary

- route AppView notification read updates exclusively through bsync fanout
- propagate bsync fanout failures instead of swallowing them
- remove the temporary direct dataplane write

## Testing

- `pnpm run build` in `packages/bsky`
- `pnpm test tests/views/notifications.test.ts` in `packages/bsky`

Linear: https://linear.app/blueskyweb/issue/PLA-33/fanout-notification-read-to-both-pops

Follow-up to https://github.com/bluesky-social/atproto/pull/5484