### PR TITLE
Resolve bsync dataplane hosts over IPv4

### DIFF
--- a/.changeset/fix-bsync-dataplane-dns.md
+++ b/.changeset/fix-bsync-dataplane-dns.md
@@ -1,0 +1,5 @@
+---
+"@atproto/bsync": patch
+---
+
+Resolve private dataplane hosts over IPv4.

--- a/packages/bsync/src/dataplane.ts
+++ b/packages/bsync/src/dataplane.ts
@@ -1,3 +1,4 @@
+import { lookup as dnsLookup } from 'node:dns'
 import {
   type Interceptor,
   type PromiseClient,
@@ -30,6 +31,8 @@ export function createDataplaneClient(opts: {
     ],
     nodeOptions: {
       rejectUnauthorized: opts.rejectUnauthorized,
+      lookup: (hostname, options, callback) =>
+        dnsLookup(hostname, { ...options, family: 4 }, callback),
     },
   })
   return createPromiseClient(Service, transport)


### PR DESCRIPTION
## Summary

- force bsync dataplane DNS lookups to IPv4, matching appview-sandbox
- restore connectivity to the private PoP Atlantis Proxy hostnames from EKS

Production traces currently show `getaddrinfo ENOTFOUND` for both private PoP hostnames without this override.

## Testing

- `pnpm run build` in `packages/bsync`
- `pnpm test tests/fanout-notification-seen.test.ts` in `packages/bsync`

Linear: https://linear.app/blueskyweb/issue/PLA-33/fanout-notification-read-to-both-pops