### PR TITLE
Add since and startCursor to getTimeline and getListFeed

### DIFF
--- a/.changeset/bounded-timeline-since.md
+++ b/.changeset/bounded-timeline-since.md
@@ -1,0 +1,8 @@
+---
+'@atproto/api': patch
+'@atproto/bsky': patch
+'@atproto/ozone': patch
+'@atproto/pds': patch
+---
+
+Add `since` and `startCursor` to `getTimeline` and `getListFeed`, for reading everything strictly newer than a previously returned position.

--- a/lexicons/app/bsky/feed/getListFeed.json
+++ b/lexicons/app/bsky/feed/getListFeed.json
@@ -20,7 +20,11 @@
             "maximum": 100,
             "default": 50
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string" },
+          "since": {
+            "type": "string",
+            "description": "Return only items newer than the position identified by this cursor value, newest first. Use the startCursor from a previous response. The item at that position is not returned because the caller already holds it. When the bounded range is exhausted, the returned cursor equals this value so that pagination continues below the boundary."
+          }
         }
       },
       "output": {
@@ -30,6 +34,10 @@
           "required": ["feed"],
           "properties": {
             "cursor": { "type": "string" },
+            "startCursor": {
+              "type": "string",
+              "description": "Cursor identifying the newest item in this page. Pass it as since on a later request to fetch only newer content."
+            },
             "feed": {
               "type": "array",
               "items": {

--- a/lexicons/app/bsky/feed/getTimeline.json
+++ b/lexicons/app/bsky/feed/getTimeline.json
@@ -18,7 +18,11 @@
             "maximum": 100,
             "default": 50
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string" },
+          "since": {
+            "type": "string",
+            "description": "Return only items newer than the position identified by this cursor value, newest first. Use the startCursor from a previous response. The item at that position is not returned because the caller already holds it. When the bounded range is exhausted, the returned cursor equals this value so that pagination continues below the boundary."
+          }
         }
       },
       "output": {
@@ -28,6 +32,10 @@
           "required": ["feed"],
           "properties": {
             "cursor": { "type": "string" },
+            "startCursor": {
+              "type": "string",
+              "description": "Cursor identifying the newest item in this page. Pass it as since on a later request to fetch only newer content."
+            },
             "feed": {
               "type": "array",
               "items": {

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1090,11 +1090,13 @@ message GetTimelineRequest {
   bool exclude_replies = 4;
   bool exclude_reposts = 5;
   bool exclude_quotes = 6;
+  string since = 7;
 }
 
 message GetTimelineResponse {
   repeated TimelineFeedItem items = 1;
   string cursor = 2;
+  string start_cursor = 3;
 }
 
 message TimelineFeedItem {
@@ -1117,11 +1119,13 @@ message GetListFeedRequest {
   bool exclude_replies = 4;
   bool exclude_reposts = 5;
   bool exclude_quotes = 6;
+  string since = 7;
 }
 
 message GetListFeedResponse {
   repeated TimelineFeedItem items = 1;
   string cursor = 2;
+  string start_cursor = 3;
 }
 
 //

--- a/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getListFeed.ts
@@ -2,7 +2,10 @@ import { mapDefined } from '@atproto/common'
 import type { AtUriString, DidString } from '@atproto/syntax'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import type { FeedItem } from '../../../../hydration/feed.js'
 import {
   type HydrateCtx,
@@ -40,6 +43,10 @@ export default function (server: Server, ctx: AppContext) {
       const result = await fillPage({
         cursor: params.cursor,
         limit: params.limit,
+        // @NOTE the dataplane echoes `since` back as the cursor once the
+        // bounded range is exhausted. Refilling past it would read below the
+        // boundary.
+        terminalCursor: params.since,
         fetch: ({ cursor, limit }) =>
           getListFeed({ ...params, cursor, limit, hydrateCtx }, ctx),
         items: (r) => r.feed,
@@ -62,13 +69,16 @@ export const skeleton = async (inputs: {
 }): Promise<Skeleton> => {
   const { ctx, params } = inputs
   if (clearlyBadCursor(params.cursor)) {
-    return { items: [] }
+    return { items: [], cursor: params.since }
   }
-  const res = await ctx.dataplane.getListFeed({
-    listUri: params.list,
-    limit: params.limit,
-    cursor: params.cursor,
-  })
+  const res = await ctx.dataplane
+    .getListFeed({
+      listUri: params.list,
+      limit: params.limit,
+      cursor: params.cursor,
+      since: params.since,
+    })
+    .catch(asInvalidRequest())
   return {
     items: res.items.map((item) => ({
       post: { uri: item.uri as AtUriString, cid: item.cid || undefined },
@@ -77,6 +87,7 @@ export const skeleton = async (inputs: {
         : undefined,
     })),
     cursor: parseString(res.cursor),
+    startCursor: parseString(res.startCursor),
   }
 }
 
@@ -130,7 +141,11 @@ const presentation = (inputs: {
   const feed = mapDefined(skeleton.items, (item) =>
     ctx.views.feedViewPost(item, hydration),
   )
-  return { feed, cursor: skeleton.cursor }
+  return {
+    feed,
+    cursor: skeleton.cursor,
+    startCursor: skeleton.startCursor,
+  }
 }
 
 const getBlocks = async (input: {
@@ -158,4 +173,5 @@ type Params = app.bsky.feed.getListFeed.$Params & { hydrateCtx: HydrateCtx }
 type Skeleton = {
   items: FeedItem[]
   cursor?: string
+  startCursor?: string
 }

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -2,7 +2,10 @@ import { mapDefined } from '@atproto/common'
 import type { AtUriString } from '@atproto/syntax'
 import type { Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { DataPlaneClient } from '../../../../data-plane/index.js'
+import {
+  type DataPlaneClient,
+  asInvalidRequest,
+} from '../../../../data-plane/index.js'
 import type { FeedItem } from '../../../../hydration/feed.js'
 import type {
   HydrateCtxWithViewer,
@@ -43,6 +46,10 @@ export default function (server: Server, ctx: AppContext) {
       const result = await fillPage({
         cursor: params.cursor,
         limit: params.limit,
+        // @NOTE the dataplane echoes `since` back as the cursor once the
+        // bounded range is exhausted. Refilling past it would read below the
+        // boundary.
+        terminalCursor: params.since,
         fetch: ({ cursor, limit }) =>
           getTimeline({ ...params, cursor, limit, hydrateCtx }, ctx),
         items: (r) => r.feed,
@@ -65,13 +72,16 @@ export const skeleton = async (inputs: {
 }): Promise<Skeleton> => {
   const { ctx, params } = inputs
   if (clearlyBadCursor(params.cursor)) {
-    return { items: [] }
+    return { items: [], cursor: params.since }
   }
-  const res = await ctx.dataplane.getTimeline({
-    actorDid: params.hydrateCtx.viewer,
-    limit: params.limit,
-    cursor: params.cursor,
-  })
+  const res = await ctx.dataplane
+    .getTimeline({
+      actorDid: params.hydrateCtx.viewer,
+      limit: params.limit,
+      cursor: params.cursor,
+      since: params.since,
+    })
+    .catch(asInvalidRequest())
   return {
     items: res.items.map((item) => ({
       post: { uri: item.uri as AtUriString, cid: item.cid || undefined },
@@ -80,6 +90,7 @@ export const skeleton = async (inputs: {
         : undefined,
     })),
     cursor: parseString(res.cursor),
+    startCursor: parseString(res.startCursor),
   }
 }
 
@@ -128,7 +139,11 @@ const presentation = (inputs: {
   const feed = mapDefined(skeleton.items, (item) =>
     ctx.views.feedViewPost(item, hydration),
   )
-  return { feed, cursor: skeleton.cursor }
+  return {
+    feed,
+    cursor: skeleton.cursor,
+    startCursor: skeleton.startCursor,
+  }
 }
 
 type Context = {
@@ -144,4 +159,5 @@ type Params = app.bsky.feed.getTimeline.$Params & {
 type Skeleton = {
   items: FeedItem[]
   cursor?: string
+  startCursor?: string
 }

--- a/packages/bsky/src/api/util.test.ts
+++ b/packages/bsky/src/api/util.test.ts
@@ -97,4 +97,69 @@ describe('fillPage', () => {
     ).resolves.toEqual({ items: [], cursor: undefined })
     expect(fetch).toHaveBeenCalledTimes(2)
   })
+
+  it('keeps the start cursor of the first page across refills', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], cursor: 'a', startCursor: 'newest' })
+      .mockResolvedValueOnce({ items: [1, 2], cursor: 'b', startCursor: 'old' })
+
+    await expect(
+      fillPage({ cursor: undefined, limit: 2, fetch, items: (r) => r.items }),
+    ).resolves.toEqual({ items: [1, 2], cursor: 'b', startCursor: 'newest' })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('serves a short page rather than refilling past the terminal cursor', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [1], cursor: 'since', startCursor: 'n' })
+
+    await expect(
+      fillPage({
+        cursor: undefined,
+        limit: 4,
+        terminalCursor: 'since',
+        fetch,
+        items: (r) => r.items,
+      }),
+    ).resolves.toEqual({ items: [1], cursor: 'since', startCursor: 'n' })
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('preserves a terminal cursor reached while refilling', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], cursor: 'a' })
+      .mockResolvedValueOnce({ items: [], cursor: 'since' })
+
+    await expect(
+      fillPage({
+        cursor: undefined,
+        limit: 2,
+        terminalCursor: 'since',
+        fetch,
+        items: (r) => r.items,
+      }),
+    ).resolves.toEqual({ items: [], cursor: 'since' })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('refills normally when no terminal cursor is reached', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], cursor: 'a' })
+      .mockResolvedValueOnce({ items: [1], cursor: 'b' })
+
+    await expect(
+      fillPage({
+        cursor: undefined,
+        limit: 1,
+        terminalCursor: 'since',
+        fetch,
+        items: (r) => r.items,
+      }),
+    ).resolves.toEqual({ items: [1], cursor: 'b' })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/bsky/src/api/util.ts
+++ b/packages/bsky/src/api/util.ts
@@ -43,6 +43,11 @@ export const fillPage = async <
   cursor?: string
   limit: number
   maxRequests?: number
+  /**
+   * Cursor marking the end of a bounded range. Reaching it stops the refill,
+   * and it is returned untouched rather than read as an exhausted page.
+   */
+  terminalCursor?: string
   fetch: F
   items: (result: Awaited<ReturnType<F>>) => T[]
 }): Promise<Awaited<ReturnType<F>>> => {
@@ -58,7 +63,10 @@ export const fillPage = async <
   let cursor = result.cursor
   for (
     let requests = 1;
-    requests < maxRequests && cursor && items.length < enoughItems;
+    requests < maxRequests &&
+    cursor &&
+    cursor !== opts.terminalCursor &&
+    items.length < enoughItems;
     requests++
   ) {
     const previousCursor = cursor

--- a/packages/bsky/src/data-plane/server/db/pagination.ts
+++ b/packages/bsky/src/data-plane/server/db/pagination.ts
@@ -93,19 +93,40 @@ export abstract class GenericKeyset<R, LR extends KeysetLabeledResult> {
       }
     }
   }
+  /**
+   * Exclusive bound at the end of the range the cursor walks towards: for
+   * `desc`, only rows above it, with each cursor decreasing towards it.
+   */
+  getSinceSql(labeled?: LR, direction?: 'asc' | 'desc') {
+    if (labeled === undefined) return
+    if (direction === 'asc') {
+      return sql<SqlBool>`((${this.primary}, ${this.secondary}) < (${labeled.primary}, ${labeled.secondary}))`
+    } else {
+      return sql<SqlBool>`((${this.primary}, ${this.secondary}) > (${labeled.primary}, ${labeled.secondary}))`
+    }
+  }
   paginate<QB extends AnyQb>(
     qb: QB,
     opts: {
       limit?: number
       cursor?: string
+      since?: string
       direction?: 'asc' | 'desc'
       tryIndex?: boolean
       // By default, pg does nullsFirst
       nullsLast?: boolean
     },
   ): QB {
-    const { limit, cursor, direction = 'desc', tryIndex, nullsLast } = opts
+    const {
+      limit,
+      cursor,
+      since,
+      direction = 'desc',
+      tryIndex,
+      nullsLast,
+    } = opts
     const keysetSql = this.getSql(this.unpack(cursor), direction, tryIndex)
+    const sinceSql = this.getSinceSql(this.unpack(since), direction)
     return qb
       .$if(!!limit, (q) => q.limit((limit as number) + 1))
       .$if(!nullsLast, (q) =>
@@ -124,7 +145,8 @@ export abstract class GenericKeyset<R, LR extends KeysetLabeledResult> {
               : sql`${this.secondary} desc nulls last`,
           ),
       )
-      .$if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb)) as QB
+      .$if(!!keysetSql, (qb) => (keysetSql ? qb.where(keysetSql) : qb))
+      .$if(!!sinceSql, (qb) => (sinceSql ? qb.where(sinceSql) : qb)) as QB
   }
 }
 
@@ -185,6 +207,7 @@ export const paginate = <
   opts: {
     limit?: number
     cursor?: string
+    since?: string
     direction?: 'asc' | 'desc'
     keyset: K
     tryIndex?: boolean

--- a/packages/bsky/src/data-plane/server/routes/feeds.ts
+++ b/packages/bsky/src/data-plane/server/routes/feeds.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import type { ServiceImpl } from '@connectrpc/connect'
+import { Code, ConnectError, type ServiceImpl } from '@connectrpc/connect'
 import { app } from '../../../lexicons/index.js'
 import type { Service } from '../../../proto/bsky_connect.js'
 import { FeedType } from '../../../proto/bsky_pb.js'
@@ -90,13 +90,14 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   },
 
   async getTimeline(req) {
-    const { actorDid, limit, cursor } = req
+    const { actorDid, limit, cursor, since } = req
     const { ref } = db.db.dynamic
 
     const keyset = new TimeCidKeyset(
       ref('feed_item.sortAt'),
       ref('feed_item.cid'),
     )
+    assertValidSince(keyset, since)
 
     let followQb = db.db
       .selectFrom('feed_item')
@@ -107,6 +108,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     followQb = paginate(followQb, {
       limit,
       cursor,
+      since,
       keyset,
       tryIndex: true,
     })
@@ -119,6 +121,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     selfQb = paginate(selfQb, {
       limit,
       cursor,
+      since,
       keyset,
       tryIndex: true,
     })
@@ -149,27 +152,28 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
     const page = keyset.page(feedItems, limit)
     if (page.items.length === 0) {
-      return { items: [], cursor: undefined }
+      return { items: [], cursor: exhaustedCursor(since) }
     }
     const items = page.items.map(feedItemFromRow)
+    const startCursor = keyset.packFromResult(page.items[0])
 
     // The combined results exceeded the requested limit.
     if (page.cursor) {
-      return { items, cursor: page.cursor }
+      return { items, cursor: page.cursor, startCursor }
     }
 
     // Own posts exceeded their separate cap, but the combined results did not exceed the requested limit.
     if (selfHasMore) {
       const lastItem = page.items.at(-1)
       assert(lastItem)
-      return { items, cursor: keyset.packFromResult(lastItem) }
+      return { items, cursor: keyset.packFromResult(lastItem), startCursor }
     }
 
-    return { items, cursor: undefined }
+    return { items, cursor: exhaustedCursor(since), startCursor }
   },
 
   async getListFeed(req) {
-    const { listUri, cursor, limit } = req
+    const { listUri, cursor, since, limit } = req
     const { ref } = db.db.dynamic
     const list = await db.db
       .selectFrom('list')
@@ -198,20 +202,43 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     }
 
     const keyset = new TimeCidKeyset(ref('post.sortAt'), ref('post.cid'))
+    assertValidSince(keyset, since)
     builder = paginate(builder, {
       limit,
       cursor,
+      since,
       keyset,
       tryIndex: true,
     })
     const page = keyset.page(await builder.execute(), limit)
+    const firstItem = page.items[0]
 
     return {
       items: page.items.map((item) => ({ uri: item.uri, cid: item.cid })),
-      cursor: page.cursor,
+      cursor: page.cursor ?? exhaustedCursor(since),
+      startCursor: firstItem ? keyset.packFromResult(firstItem) : undefined,
     }
   },
 })
+
+/**
+ * A `since`-bounded request never reports exhaustion with an empty cursor: it
+ * echoes `since`, a position the client can keep paginating below.
+ */
+const exhaustedCursor = (since: string) => since || undefined
+
+/**
+ * Rejects a `since` the keyset cannot unpack. Left to `paginate` it would raise
+ * an xrpc error, which a Connect handler reports as an internal error.
+ */
+const assertValidSince = (keyset: TimeCidKeyset, since: string) => {
+  if (!since) return
+  try {
+    keyset.unpack(since)
+  } catch {
+    throw new ConnectError('Malformed since cursor', Code.InvalidArgument)
+  }
+}
 
 // @NOTE does not support additional fields in the protos specific to author feeds
 // and timelines. at the time of writing, hydration/view implementations do not rely on them.

--- a/packages/bsky/tests/views/list-feed.test.ts
+++ b/packages/bsky/tests/views/list-feed.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { type AppBskyFeedGetListFeed, type AtpAgent, ids } from '@atproto/api'
 import {
@@ -276,5 +277,286 @@ describe('list feed views', () => {
 
     const hasBob = res.data.feed.some((item) => item.post.author.did === bob)
     expect(hasBob).toBe(false)
+  })
+
+  describe('bounded by since', () => {
+    let sinceList: RecordRef
+    /** Posts present when `startCursor` was captured, oldest first. */
+    let initial: RecordRef[]
+    /** Posts made after `startCursor` was captured, oldest first. */
+    let subsequent: RecordRef[]
+    /** Start cursor of the list feed as it stood before `subsequent` existed. */
+    let startCursor: string
+
+    const fetchListFeed = async (
+      params: AppBskyFeedGetListFeed.QueryParams,
+    ) => {
+      const { data } = await agent.api.app.bsky.feed.getListFeed(params, {
+        headers: await network.serviceHeaders(
+          carol,
+          ids.AppBskyFeedGetListFeed,
+        ),
+      })
+      return data
+    }
+
+    /*
+     * sortAt is the lesser of createdAt and indexedAt, so backdating pins it to
+     * createdAt and makes the order these tests bracket deterministic.
+     */
+    const postAt = async (did: DidString, text: string, createdAt: string) => {
+      const post = await sc.post(did, text, undefined, undefined, undefined, {
+        createdAt,
+      })
+      return post.ref
+    }
+
+    beforeAll(async () => {
+      const member = await sc.createAccount('list-since-member', {
+        handle: 'list-since.test',
+        email: 'list-since-member@example.com',
+        password: 'hunter2',
+      })
+      sinceList = await sc.createList(alice, 'since list', 'curate')
+      await sc.addToList(alice, member.did, sinceList)
+
+      initial = [
+        await postAt(
+          member.did,
+          'list since initial 1',
+          '2023-01-01T00:00:00.000Z',
+        ),
+        await postAt(
+          member.did,
+          'list since initial 2',
+          '2023-01-02T00:00:00.000Z',
+        ),
+        await postAt(
+          member.did,
+          'list since initial 3',
+          '2023-01-03T00:00:00.000Z',
+        ),
+      ]
+      await network.processAll()
+
+      const before = await fetchListFeed({ list: sinceList.uriStr })
+      assert(before.startCursor, 'expected a start cursor')
+      startCursor = before.startCursor
+
+      subsequent = [
+        await postAt(
+          member.did,
+          'list since subsequent 1',
+          '2023-02-01T00:00:00.000Z',
+        ),
+        await postAt(
+          member.did,
+          'list since subsequent 2',
+          '2023-02-02T00:00:00.000Z',
+        ),
+      ]
+      await network.processAll()
+    })
+
+    it('returns a start cursor identifying the newest item of the page', async () => {
+      const page = await fetchListFeed({ list: sinceList.uriStr })
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+        initial[2].uriStr,
+        initial[1].uriStr,
+        initial[0].uriStr,
+      ])
+      assert(page.startCursor, 'expected a start cursor')
+
+      /*
+       * The bound is exclusive, so a start cursor is pinned to a position by
+       * what it excludes: bounding by the second page's start cursor returns
+       * exactly the items above that page, and none of the page itself.
+       */
+      const first = await fetchListFeed({ list: sinceList.uriStr, limit: 2 })
+      assert(first.cursor, 'expected a cursor')
+      const second = await fetchListFeed({
+        list: sinceList.uriStr,
+        limit: 2,
+        cursor: first.cursor,
+      })
+      expect(second.feed.map((item) => item.post.uri)).toEqual([
+        initial[2].uriStr,
+        initial[1].uriStr,
+      ])
+      assert(second.startCursor, 'expected a start cursor')
+
+      const above = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: second.startCursor,
+      })
+      expect(above.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+    })
+
+    it('returns everything newer than since, echoing the cursor once exhausted', async () => {
+      const page = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: startCursor,
+      })
+
+      // The item at the boundary is not re-delivered: the bound is exclusive.
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+      expect(page.cursor).toBe(startCursor)
+      assert(page.startCursor, 'expected a start cursor')
+      expect(page.startCursor).not.toBe(startCursor)
+    })
+
+    it('returns nothing when since is the newest position the caller holds', async () => {
+      const page = await fetchListFeed({ list: sinceList.uriStr })
+      assert(page.startCursor, 'expected a start cursor')
+
+      /*
+       * `since` names an item the caller already holds, so bounding by the
+       * newest position it knows about leaves nothing to return. The cursor is
+       * still echoed back rather than emptied, so the caller can keep
+       * paginating below the boundary.
+       */
+      const bounded = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: page.startCursor,
+      })
+      expect(bounded.feed).toEqual([])
+      expect(bounded.cursor).toBe(page.startCursor)
+    })
+
+    it('returns a normal cursor while the bounded range still has more', async () => {
+      const page = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: startCursor,
+        limit: 1,
+      })
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+      ])
+      assert(page.cursor, 'expected a cursor')
+      expect(page.cursor).not.toBe(startCursor)
+
+      const next = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: startCursor,
+        cursor: page.cursor,
+        limit: 1,
+      })
+      expect(next.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[0].uriStr,
+      ])
+      expect(next.cursor).toBe(startCursor)
+    })
+
+    it('rejects a malformed since with a 400', async () => {
+      const promise = fetchListFeed({
+        list: sinceList.uriStr,
+        since: 'garbage',
+      })
+      await expect(promise).rejects.toMatchObject({
+        status: 400,
+        error: 'InvalidRequest',
+      })
+    })
+
+    it('echoes since when a legacy cursor short-circuits the read', async () => {
+      /*
+       * A v1-format cursor is answered with an empty page without consulting
+       * the dataplane, but a `since` request must still not come back with an
+       * empty cursor.
+       */
+      const page = await fetchListFeed({
+        list: sinceList.uriStr,
+        since: startCursor,
+        cursor: '1234567890123::bafyabc',
+      })
+      expect(page.feed).toEqual([])
+      expect(page.cursor).toBe(startCursor)
+    })
+
+    it('keeps the echoed cursor when the bounded page is short after filtering', async () => {
+      const member = await sc.createAccount('list-since-flt-member', {
+        handle: 'list-since-flt.test',
+        email: 'list-since-flt-member@example.com',
+        password: 'hunter2',
+      })
+      const list = await sc.createList(alice, 'since filtered list', 'curate')
+      await sc.addToList(alice, member.did, list)
+      // Anchors the start cursor the bounded read is later bounded by.
+      await postAt(
+        member.did,
+        'list since filtered boundary',
+        '2023-03-01T00:00:00.000Z',
+      )
+      await network.processAll()
+
+      const before = await fetchListFeed({ list: list.uriStr })
+      assert(before.startCursor, 'expected a start cursor')
+
+      const hidden = [
+        await postAt(
+          member.did,
+          'list since filtered 1',
+          '2023-03-02T00:00:00.000Z',
+        ),
+        await postAt(
+          member.did,
+          'list since filtered 2',
+          '2023-03-03T00:00:00.000Z',
+        ),
+      ]
+      const visible = await postAt(
+        member.did,
+        'list since filtered visible',
+        '2023-03-04T00:00:00.000Z',
+      )
+      await network.processAll()
+      await Promise.all(
+        hidden.map((ref) =>
+          network.bsky.ctx.dataplane.takedownRecord({ recordUri: ref.uriStr }),
+        ),
+      )
+
+      // The page comes back under-filled, which would normally trigger a
+      // refill; the echoed cursor has to survive that.
+      const page = await fetchListFeed({
+        list: list.uriStr,
+        since: before.startCursor,
+        limit: 3,
+      })
+      expect(page.feed.map((item) => item.post.uri)).toEqual([visible.uriStr])
+      expect(page.cursor).toBe(before.startCursor)
+    })
+
+    it('bounds the dataplane page exclusively', async () => {
+      const page = await network.bsky.ctx.dataplane.getListFeed({
+        listUri: sinceList.uriStr,
+        limit: 10,
+        since: startCursor,
+      })
+      expect(page.items.map((item) => item.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+      expect(page.cursor).toBe(startCursor)
+      expect(page.startCursor).not.toBe('')
+      expect(page.startCursor).not.toBe(startCursor)
+
+      const partial = await network.bsky.ctx.dataplane.getListFeed({
+        listUri: sinceList.uriStr,
+        limit: 1,
+        since: startCursor,
+      })
+      expect(partial.items).toHaveLength(1)
+      expect(partial.cursor).not.toBe('')
+      expect(partial.cursor).not.toBe(startCursor)
+    })
   })
 })

--- a/packages/bsky/tests/views/timeline.test.ts
+++ b/packages/bsky/tests/views/timeline.test.ts
@@ -16,10 +16,12 @@ import {
 } from '@atproto/api'
 import {
   EXAMPLE_LABELER,
+  type RecordRef,
   type SeedClient,
   TestNetwork,
   basicSeed,
 } from '@atproto/dev-env'
+import type { DidString } from '@atproto/syntax'
 import { Gate } from '../../src/feature-gates/gates.js'
 import type { Database } from '../../src/index.js'
 import { forSnapshot, getOriginator, paginateAll } from '../_util.js'
@@ -641,6 +643,404 @@ describe('timeline views', () => {
       },
     )
     expect(timeline).toEqual({ feed: [] })
+  })
+
+  describe('bounded by since', () => {
+    let viewer: DidString
+    let author: DidString
+    /** Posts present when `startCursor` was captured, oldest first. */
+    let initial: RecordRef[]
+    /** Posts made after `startCursor` was captured, oldest first. */
+    let subsequent: RecordRef[]
+    /** Start cursor of the timeline as it stood before `subsequent` existed. */
+    let startCursor: string
+
+    const fetchTimeline = async (
+      did: string,
+      params: AppBskyFeedGetTimeline.QueryParams,
+    ) => {
+      const { data } = await agent.api.app.bsky.feed.getTimeline(params, {
+        headers: await network.serviceHeaders(did, ids.AppBskyFeedGetTimeline),
+      })
+      return data
+    }
+
+    /*
+     * sortAt is the lesser of createdAt and indexedAt, so backdating pins it to
+     * createdAt and makes the order these tests bracket deterministic.
+     */
+    const postAt = async (did: DidString, text: string, createdAt: string) => {
+      const post = await sc.post(did, text, undefined, undefined, undefined, {
+        createdAt,
+      })
+      return post.ref
+    }
+
+    beforeAll(async () => {
+      const viewerAccount = await sc.createAccount('tl-since-viewer', {
+        handle: 'tl-since-viewer.test',
+        email: 'tl-since-viewer@example.com',
+        password: 'hunter2',
+      })
+      const authorAccount = await sc.createAccount('tl-since-author', {
+        handle: 'tl-since-author.test',
+        email: 'tl-since-author@example.com',
+        password: 'hunter2',
+      })
+      viewer = viewerAccount.did
+      author = authorAccount.did
+      await sc.follow(viewer, author)
+
+      initial = [
+        await postAt(author, 'since initial 1', '2023-01-01T00:00:00.000Z'),
+        await postAt(author, 'since initial 2', '2023-01-02T00:00:00.000Z'),
+        await postAt(author, 'since initial 3', '2023-01-03T00:00:00.000Z'),
+      ]
+      await network.processAll()
+
+      const before = await fetchTimeline(viewer, {})
+      assert(before.startCursor, 'expected a start cursor')
+      startCursor = before.startCursor
+
+      subsequent = [
+        await postAt(author, 'since subsequent 1', '2023-02-01T00:00:00.000Z'),
+        await postAt(author, 'since subsequent 2', '2023-02-02T00:00:00.000Z'),
+      ]
+      await network.processAll()
+    })
+
+    it('returns a start cursor identifying the newest item of the page', async () => {
+      const page = await fetchTimeline(viewer, {})
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+        initial[2].uriStr,
+        initial[1].uriStr,
+        initial[0].uriStr,
+      ])
+      assert(page.startCursor, 'expected a start cursor')
+
+      /*
+       * The bound is exclusive, so a start cursor is pinned to a position by
+       * what it excludes: bounding by the second page's start cursor returns
+       * exactly the items above that page, and none of the page itself.
+       */
+      const first = await fetchTimeline(viewer, { limit: 2 })
+      assert(first.cursor, 'expected a cursor')
+      const second = await fetchTimeline(viewer, {
+        limit: 2,
+        cursor: first.cursor,
+      })
+      expect(second.feed.map((item) => item.post.uri)).toEqual([
+        initial[2].uriStr,
+        initial[1].uriStr,
+      ])
+      assert(second.startCursor, 'expected a start cursor')
+
+      const above = await fetchTimeline(viewer, { since: second.startCursor })
+      expect(above.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+    })
+
+    it('returns everything newer than since, echoing the cursor once exhausted', async () => {
+      const page = await fetchTimeline(viewer, { since: startCursor })
+
+      // The item at the boundary is not re-delivered: the bound is exclusive.
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+      expect(page.cursor).toBe(startCursor)
+      expect(page.startCursor).not.toBe(startCursor)
+      assert(page.startCursor, 'expected a start cursor')
+    })
+
+    it('returns nothing when since is the newest position the caller holds', async () => {
+      const page = await fetchTimeline(viewer, {})
+      assert(page.startCursor, 'expected a start cursor')
+
+      /*
+       * `since` names an item the caller already holds, so bounding by the
+       * newest position it knows about leaves nothing to return. The cursor is
+       * still echoed back rather than emptied, so the caller can keep
+       * paginating below the boundary.
+       */
+      const bounded = await fetchTimeline(viewer, { since: page.startCursor })
+      expect(bounded.feed).toEqual([])
+      expect(bounded.cursor).toBe(page.startCursor)
+    })
+
+    it('returns a normal cursor while the bounded range still has more', async () => {
+      const page = await fetchTimeline(viewer, { since: startCursor, limit: 1 })
+      expect(page.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[1].uriStr,
+      ])
+      assert(page.cursor, 'expected a cursor')
+      expect(page.cursor).not.toBe(startCursor)
+
+      const next = await fetchTimeline(viewer, {
+        since: startCursor,
+        cursor: page.cursor,
+        limit: 1,
+      })
+      expect(next.feed.map((item) => item.post.uri)).toEqual([
+        subsequent[0].uriStr,
+      ])
+      expect(next.cursor).toBe(startCursor)
+    })
+
+    it('rejects a malformed since with a 400', async () => {
+      const promise = fetchTimeline(viewer, { since: 'garbage' })
+      await expect(promise).rejects.toMatchObject({
+        status: 400,
+        error: 'InvalidRequest',
+      })
+    })
+
+    it('echoes since when a legacy cursor short-circuits the read', async () => {
+      /*
+       * A v1-format cursor is answered with an empty page without consulting
+       * the dataplane, but a `since` request must still not come back with an
+       * empty cursor.
+       */
+      const page = await fetchTimeline(viewer, {
+        since: startCursor,
+        cursor: '1234567890123::bafyabc',
+      })
+      expect(page.feed).toEqual([])
+      expect(page.cursor).toBe(startCursor)
+    })
+
+    it('bounds the viewer own posts as well as followed accounts', async () => {
+      const selfViewer = await sc.createAccount('tl-since-self-viewer', {
+        handle: 'tl-since-self-v.test',
+        email: 'tl-since-self-viewer@example.com',
+        password: 'hunter2',
+      })
+      const selfAuthor = await sc.createAccount('tl-since-self-author', {
+        handle: 'tl-since-self-a.test',
+        email: 'tl-since-self-author@example.com',
+        password: 'hunter2',
+      })
+      await sc.follow(selfViewer.did, selfAuthor.did)
+      const selfBelow = await postAt(
+        selfViewer.did,
+        'since self below',
+        '2023-04-01T00:00:00.000Z',
+      )
+      // Anchors the start cursor above the viewer's own earlier post.
+      await postAt(
+        selfAuthor.did,
+        'since self boundary',
+        '2023-04-02T00:00:00.000Z',
+      )
+      await network.processAll()
+
+      const before = await fetchTimeline(selfViewer.did, {})
+      assert(before.startCursor, 'expected a start cursor')
+
+      const selfAbove = await postAt(
+        selfViewer.did,
+        'since self above',
+        '2023-04-03T00:00:00.000Z',
+      )
+      const authorAbove = await postAt(
+        selfAuthor.did,
+        'since self author above',
+        '2023-04-04T00:00:00.000Z',
+      )
+      await network.processAll()
+
+      // Own posts are merged in from a sub-query of their own, which the bound
+      // has to reach as well.
+      const page = await fetchTimeline(selfViewer.did, {
+        since: before.startCursor,
+      })
+      const uris = page.feed.map((item) => item.post.uri)
+      expect(uris).toEqual([authorAbove.uriStr, selfAbove.uriStr])
+      expect(uris).not.toContain(selfBelow.uriStr)
+      expect(page.cursor).toBe(before.startCursor)
+    })
+
+    it('keeps the echoed cursor when the bounded page is short after filtering', async () => {
+      const boundedViewer = await sc.createAccount('tl-since-flt-viewer', {
+        handle: 'tl-since-flt-v.test',
+        email: 'tl-since-flt-viewer@example.com',
+        password: 'hunter2',
+      })
+      const boundedAuthor = await sc.createAccount('tl-since-flt-author', {
+        handle: 'tl-since-flt-a.test',
+        email: 'tl-since-flt-author@example.com',
+        password: 'hunter2',
+      })
+      await sc.follow(boundedViewer.did, boundedAuthor.did)
+      // Anchors the start cursor the bounded read is later bounded by.
+      await postAt(
+        boundedAuthor.did,
+        'since filtered boundary',
+        '2023-03-01T00:00:00.000Z',
+      )
+      await network.processAll()
+
+      const before = await fetchTimeline(boundedViewer.did, {})
+      assert(before.startCursor, 'expected a start cursor')
+
+      const hidden = [
+        await postAt(
+          boundedAuthor.did,
+          'since filtered 1',
+          '2023-03-02T00:00:00.000Z',
+        ),
+        await postAt(
+          boundedAuthor.did,
+          'since filtered 2',
+          '2023-03-03T00:00:00.000Z',
+        ),
+      ]
+      const visible = await postAt(
+        boundedAuthor.did,
+        'since filtered visible',
+        '2023-03-04T00:00:00.000Z',
+      )
+      await network.processAll()
+      await Promise.all(
+        hidden.map((ref) =>
+          network.bsky.ctx.dataplane.takedownRecord({ recordUri: ref.uriStr }),
+        ),
+      )
+
+      // The page comes back under-filled, which would normally trigger a
+      // refill; the echoed cursor has to survive that.
+      const page = await fetchTimeline(boundedViewer.did, {
+        since: before.startCursor,
+        limit: 3,
+      })
+      expect(page.feed.map((item) => item.post.uri)).toEqual([visible.uriStr])
+      expect(page.cursor).toBe(before.startCursor)
+    })
+
+    it('bounds the dataplane page exclusively', async () => {
+      const page = await network.bsky.ctx.dataplane.getTimeline({
+        actorDid: viewer,
+        limit: 10,
+        since: startCursor,
+      })
+      expect(page.items.map((item) => item.uri)).toEqual([
+        subsequent[1].uriStr,
+        subsequent[0].uriStr,
+      ])
+      expect(page.cursor).toBe(startCursor)
+      expect(page.startCursor).not.toBe('')
+      expect(page.startCursor).not.toBe(startCursor)
+
+      const partial = await network.bsky.ctx.dataplane.getTimeline({
+        actorDid: viewer,
+        limit: 1,
+        since: startCursor,
+      })
+      expect(partial.items).toHaveLength(1)
+      expect(partial.cursor).not.toBe('')
+      expect(partial.cursor).not.toBe(startCursor)
+    })
+
+    describe('with the top of the bounded range taken down', () => {
+      let refillViewer: DidString
+      /** Post at the boundary the bounded reads below are bounded by. */
+      let boundary: RecordRef
+      /** Taken-down posts sitting above `visible`, newest last. */
+      let hidden: RecordRef[]
+      /** The only renderable post above the boundary. */
+      let visible: RecordRef
+      let since: string
+
+      beforeAll(async () => {
+        const viewerAccount = await sc.createAccount('tl-since-refill-viewer', {
+          handle: 'tl-since-rf-v.test',
+          email: 'tl-since-refill-viewer@example.com',
+          password: 'hunter2',
+        })
+        const authorAccount = await sc.createAccount('tl-since-refill-author', {
+          handle: 'tl-since-rf-a.test',
+          email: 'tl-since-refill-author@example.com',
+          password: 'hunter2',
+        })
+        refillViewer = viewerAccount.did
+        await sc.follow(refillViewer, authorAccount.did)
+        boundary = await postAt(
+          authorAccount.did,
+          'since refill boundary',
+          '2023-05-01T00:00:00.000Z',
+        )
+        await network.processAll()
+
+        const before = await fetchTimeline(refillViewer, {})
+        assert(before.startCursor, 'expected a start cursor')
+        since = before.startCursor
+
+        visible = await postAt(
+          authorAccount.did,
+          'since refill visible',
+          '2023-05-02T00:00:00.000Z',
+        )
+        hidden = [
+          await postAt(
+            authorAccount.did,
+            'since refill hidden 1',
+            '2023-05-03T00:00:00.000Z',
+          ),
+          await postAt(
+            authorAccount.did,
+            'since refill hidden 2',
+            '2023-05-04T00:00:00.000Z',
+          ),
+        ]
+        await network.processAll()
+        await Promise.all(
+          hidden.map((ref) =>
+            network.bsky.ctx.dataplane.takedownRecord({
+              recordUri: ref.uriStr,
+            }),
+          ),
+        )
+      })
+
+      it('refills within the bound rather than reading below it', async () => {
+        /*
+         * Both taken-down posts fill the first dataplane page, which therefore
+         * comes back empty of renderable items and with a normal cursor: the
+         * refill has to re-apply `since` to stay above the boundary.
+         */
+        const page = await fetchTimeline(refillViewer, { since, limit: 2 })
+        const uris = page.feed.map((item) => item.post.uri)
+        expect(uris).toEqual([visible.uriStr])
+        expect(uris).not.toContain(boundary.uriStr)
+        expect(page.cursor).toBe(since)
+      })
+
+      it('reports the newest dataplane row as the start cursor', async () => {
+        const page = await fetchTimeline(refillViewer, { since, limit: 2 })
+        assert(page.startCursor, 'expected a start cursor')
+        expect(page.feed.map((item) => item.post.uri)).toEqual([visible.uriStr])
+
+        // The newest row of the page is taken down, so the start cursor sits
+        // above the first rendered item rather than on it.
+        const rows = await network.bsky.ctx.dataplane.getTimeline({
+          actorDid: refillViewer,
+          limit: 2,
+          since,
+        })
+        expect(rows.items[0].uri).toBe(hidden[1].uriStr)
+        expect(page.startCursor).toBe(rows.startCursor)
+
+        const above = await fetchTimeline(refillViewer, {
+          since: page.startCursor,
+        })
+        expect(above.feed).toEqual([])
+        expect(above.cursor).toBe(page.startCursor)
+      })
+    })
   })
 })
 

--- a/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
+++ b/packages/pds/tests/proxied/__snapshots__/views.test.ts.snap
@@ -1966,6 +1966,7 @@ exports[`proxies view requests feed.getListFeed 1`] = `
       },
     },
   ],
+  "startCursor": "0000000000000::bafycid",
 }
 `;
 
@@ -4186,6 +4187,7 @@ exports[`proxies view requests feed.getTimeline 1`] = `
       },
     },
   ],
+  "startCursor": "0000000000000::bafycid",
 }
 `;
 

--- a/packages/pds/tests/proxied/read-after-write.test.ts
+++ b/packages/pds/tests/proxied/read-after-write.test.ts
@@ -7,6 +7,7 @@ import {
   AppBskyEmbedRecord,
   AppBskyFeedDefs,
   type AtpAgent,
+  ids,
 } from '@atproto/api'
 import { type RecordRef, type SeedClient, TestNetwork } from '@atproto/dev-env'
 import type { DidString } from '@atproto/syntax'
@@ -289,6 +290,91 @@ describe('proxy read after write', () => {
       { headers: { ...sc.getHeaders(alice) } },
     )
     expect(res.data.feed[0].post.uri).toEqual(postRes.uri)
+  })
+
+  it('passes the appview cursors through the timeline munge', async () => {
+    const postRes = await agent.api.app.bsky.feed.post.create(
+      { repo: alice },
+      {
+        text: 'cursor passthrough poast',
+        createdAt: new Date().toISOString(),
+      },
+      sc.getHeaders(alice),
+    )
+    const res = await agent.api.app.bsky.feed.getTimeline(
+      { limit: 2 },
+      { headers: { ...sc.getHeaders(alice) } },
+    )
+    expect(res.data.feed[0].post.uri).toEqual(postRes.uri)
+
+    // The local post is spliced into the feed, but the cursors describe the
+    // appview's page and pass through untouched.
+    const direct = await network.bsky.getAgent().app.bsky.feed.getTimeline(
+      { limit: 2 },
+      {
+        headers: await network.serviceHeaders(
+          alice,
+          ids.AppBskyFeedGetTimeline,
+        ),
+      },
+    )
+    expect(direct.data.startCursor).toBeDefined()
+    expect(res.data.startCursor).toEqual(direct.data.startCursor)
+    expect(res.data.cursor).toEqual(direct.data.cursor)
+  })
+
+  it('forwards since to the appview through the timeline munge', async () => {
+    const postRes = await agent.api.app.bsky.feed.post.create(
+      { repo: alice },
+      {
+        text: 'bounded poast',
+        createdAt: new Date().toISOString(),
+      },
+      sc.getHeaders(alice),
+    )
+    const bskyAgent = network.bsky.getAgent()
+    const headers = await network.serviceHeaders(
+      alice,
+      ids.AppBskyFeedGetTimeline,
+    )
+
+    // A position part-way down the appview's feed, so that a read bounded by
+    // it has something to return without being the whole feed.
+    const firstPage = await bskyAgent.app.bsky.feed.getTimeline(
+      { limit: 2 },
+      { headers },
+    )
+    assert(firstPage.data.cursor, 'expected a cursor')
+    const secondPage = await bskyAgent.app.bsky.feed.getTimeline(
+      { limit: 2, cursor: firstPage.data.cursor },
+      { headers },
+    )
+    assert(secondPage.data.startCursor, 'expected a start cursor')
+    const since = secondPage.data.startCursor
+
+    const direct = await bskyAgent.app.bsky.feed.getTimeline(
+      { since },
+      { headers },
+    )
+    expect(direct.data.feed.map((item) => item.post.uri)).toEqual(
+      firstPage.data.feed.map((item) => item.post.uri),
+    )
+    expect(direct.data.cursor).toEqual(since)
+
+    const proxied = await agent.api.app.bsky.feed.getTimeline(
+      { since },
+      { headers: { ...sc.getHeaders(alice) } },
+    )
+    // The local post is spliced on top of the appview's bounded page; the page
+    // itself, and both cursors, are what the appview returned.
+    const directUris = direct.data.feed.map((item) => item.post.uri)
+    const proxiedUris = proxied.data.feed.map((item) => item.post.uri)
+    expect(proxiedUris).toContain(postRes.uri)
+    expect(proxiedUris.filter((uri) => directUris.includes(uri))).toEqual(
+      directUris,
+    )
+    expect(proxied.data.cursor).toEqual(since)
+    expect(proxied.data.startCursor).toEqual(direct.data.startCursor)
   })
 
   it('returns lag headers', async () => {


### PR DESCRIPTION
## What & why

Adds an optional `since` parameter and an optional `startCursor` output to `app.bsky.feed.getTimeline` and `app.bsky.feed.getListFeed`, and implements them in the appview and the reference dataplane.

- `since` is an exclusive lower bound on sort position, symmetric with `cursor`: both name the position of an item the caller already holds, and the server returns what lies strictly between them, `since < position < cursor`.
- `startCursor` is the position of the newest dataplane row in the page. The client persists it and later passes it back as `since` to fetch only what is strictly newer.
- When a bounded range is exhausted the dataplane echoes `since` back as the cursor instead of returning an empty one. An empty cursor already means "end of feed" to every client, and a bounded read running out must not be confused with that.
- `fillPage` gains an optional `terminalCursor`, which the two handlers set to `params.since`. Without it the refill loop would ask for "older than since and newer than since", get the echo again, trip its infinite-loop guard, and null the cursor. `startCursor` survives refills with no new code because `fillPage` already spreads the first result; a test now pins that.
- A malformed `since` is a 400. The reference dataplane raises Connect `InvalidArgument` and both handlers attach the `asInvalidRequest` catch the search handlers use. The legacy-cursor short-circuit returns `cursor: since` so the never-empty invariant holds on that path too.
- No PDS source change. Read-after-write forwards the raw query string and returns cursors unchanged; two tests and two snapshot lines prove it.

This is the appview half of Following v2 position restoration (APP-3037): the client persists its Following feed cache and, on the next launch, fetches upward from the newest item it holds and prepends. Design doc: https://linear.app/blueskyweb/document/following-v2-position-restoration-and-new-content-indicators-be3ed8459a81

### Merge order and degraded behavior

Field numbers (`since = 7`, `start_cursor = 3`) match the parallel atlantis change, bluesky-social/tango#1540, which is not merged yet. Merge order is atlantis, then the lexicons in bluesky-social/bsky#48, then this. Until atlantis deploys, an appview that sends `since` gets an ordinary unbounded page back with no `startCursor`, because protobuf drops the unknown field. That is the documented degraded behavior and why both fields are optional. The lexicon JSON here is byte-identical to the bsky PR.

### Contract

Both fields optional. `since` returns only items strictly newer than the position, newest first, up to `limit`. If the bounded range is exhausted (including zero rows), `cursor` equals the exact `since` string received. Otherwise `cursor` is the last row's position as today. A request with `since` never returns an empty cursor. `startCursor` is the first dataplane row's position when the page is non-empty, whether or not `since` was sent, so with the top of a page filtered out it points above the first visible item, which is the conservative direction for a later bounded read.

Two caveats for callers: the bound is on sort position, not arrival time, so items that land later with a position below the boundary are not seen by a bounded read and clients should still do an occasional unbounded refresh; and with `since` set to the newest position the caller holds, the normal response is an empty `feed` with a non-empty `cursor`, which is correct and easy to mistake for a bug.

The reference dataplane bounds on the full `(sortAt, cid)` keyset like its cursor does; production bounds on the timestamp alone. Nothing in the appview depends on the difference.

One known gap, accepted: the pre-existing fail-open path for legacy `::` cursors returns before the dataplane call, so a request combining a legacy cursor with a malformed `since` gets an empty page echoing that `since` rather than a 400. The page is empty either way and nothing incorrect is served. Validating `since` in the appview would mean teaching it a cursor format, which differs between the reference and production dataplanes, so it stays where it is. (Found by Roast, LOW.)

### Testing

- `packages/bsky/src/api/util.test.ts`: 5 new `fillPage` cases (terminal cursor served short, reached mid-refill, never reached, first page's `startCursor` survives a refill).
- `packages/bsky/tests/views/timeline.test.ts` and `list-feed.test.ts`, `describe('bounded by since')`, 11 + 8 cases: boundary item excluded and cursor echoed; empty feed with echo when nothing is new; normal cursor while the range has more, echo on the next page; `startCursor` identity proved by bounding on the second page's `startCursor`; short-after-takedown page still ends on the echo; `since: 'garbage'` is a 400; legacy cursor plus `since` returns the echo; the bound reaches the viewer's own posts; a first dataplane page filled with taken-down posts is refilled within the bound; `startCursor` names the taken-down newest row; dataplane-level assertions for the exclusive bound.
- `packages/pds/tests/proxied/read-after-write.test.ts`: cursors pass through the munge unchanged; `since` sent through the proxy and directly yields the same page and cursors.
- Mutation-checked: `getSinceSql` flipped to `>=` fails 15 integration cases; reverting the `terminalCursor` guard fails 12; dropping `since` from refills only fails exactly the two refill cases; removing the `asInvalidRequest` catch turns both 400 cases into 500s.
- Suites: `packages/bsky` 982 passed / 15 skipped, `packages/pds` 405 passed / 1 skipped with 31 snapshots, `packages/api` 444 passed. Root `pnpm build --force && pnpm verify` clean.

Generated code is gitignored; run `pnpm codegen` after checkout.

### Open questions

- `getSinceSql` uses only the row-value form, unlike `getSql` which keeps an OR-based variant behind `tryIndex`. Both call sites pass `tryIndex: true`.
- `paginateAll`-style drain helpers will spin on a bounded request since the cursor never empties. Nothing in-tree does this.
- `getAuthorFeed` has the same shape and is not covered here.

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches (`@atproto/api`, `@atproto/bsky`, `@atproto/ozone`, `@atproto/pds`, all patch, matching prior lexicon-addition PRs)
- [x] Written with the help of an LLM or coding agent? Yes: Claude Code, a Fable 5.1 session orchestrating Opus subagents, working from the design doc. The diff was then read line by line, adversarially reviewed by a separate agent and by Roast with findings applied, and I have read the full diff myself.
