### PR TITLE
fix(pds): resolve local lexicons without public self-fetch

### DIFF
--- a/.changeset/quiet-clubs-mix.md
+++ b/.changeset/quiet-clubs-mix.md
@@ -1,0 +1,5 @@
+---
+"@atproto/pds": patch
+---
+
+Resolve locally hosted OAuth permission-set Lexicons using local repository proofs instead of fetching the PDS public hostname. This avoids failures when self-fetches are blocked by local networking or SSRF protection, while retaining DID authority, signature and schema validation, and account availability checks.

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -88,6 +88,7 @@
   "devDependencies": {
     "@atproto/api": "workspace:^",
     "@atproto/lex-document": "workspace:^",
+    "@atproto/lex-resolver": "workspace:^",
     "@atproto/oauth-client-browser-example": "workspace:^",
     "@did-plc/server": "^0.0.1",
     "@jest/globals": "^30.0.0",

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -6,6 +6,7 @@ import * as nodemailer from 'nodemailer'
 import * as ui8 from 'uint8arrays'
 import type * as undici from 'undici'
 import { KmsKeypair, S3BlobStore } from '@atproto/aws'
+import { streamToBytes } from '@atproto/common'
 import * as crypto from '@atproto/crypto'
 import { IdResolver } from '@atproto/identity'
 import { Client } from '@atproto/lex'
@@ -16,8 +17,9 @@ import {
   OAuthProvider,
 } from '@atproto/oauth-provider/provider'
 import { OAuthVerifier } from '@atproto/oauth-provider/verifier'
-import type { BlobStore } from '@atproto/repo'
+import { type BlobStore, getRecords } from '@atproto/repo'
 import {
+  InvalidRequestError,
   createServiceAuthHeaders,
   createServiceJwt,
 } from '@atproto/xrpc-server'
@@ -47,6 +49,7 @@ import { DidSqliteCache } from './did-cache/index.js'
 import { DiskBlobStore } from './disk-blobstore.js'
 import { events } from './events.js'
 import { ImageUrlBuilder } from './image/image-url-builder.js'
+import { createLexiconFetch } from './lexicon-fetch.js'
 import { fetchLogger, lexiconResolverLogger, oauthLogger } from './logger.js'
 import { ServerMailer } from './mailer/index.js'
 import { ModerationMailer } from './mailer/moderation.js'
@@ -367,7 +370,31 @@ export class AppContext implements AsyncDisposable {
           branding: cfg.oauth.provider.branding,
           safeFetch,
           lexResolver: new LexResolver({
-            fetch: safeFetch,
+            fetch: createLexiconFetch({
+              publicUrl: cfg.service.publicUrl,
+              fetch: safeFetch,
+              getLocalRecord: async ({ did, collection, rkey }) => {
+                const account = await accountManager.getAccount(did)
+                if (!account) {
+                  throw new InvalidRequestError(
+                    'Repo not available',
+                    'RepoNotFound',
+                  )
+                }
+                return actorStore.read(did, async ({ repo: { storage } }) => {
+                  const commit = await storage.getRoot()
+                  if (!commit) {
+                    throw new InvalidRequestError(
+                      'Repo not found',
+                      'RepoNotFound',
+                    )
+                  }
+                  return streamToBytes(
+                    getRecords(storage, commit, [{ collection, rkey }]),
+                  )
+                })
+              },
+            }),
             plcDirectoryUrl: cfg.identity.plcUrl,
             hooks: {
               onResolveAuthority: ({ nsid }) => {

--- a/packages/pds/src/lexicon-fetch.ts
+++ b/packages/pds/src/lexicon-fetch.ts
@@ -1,0 +1,39 @@
+import * as lexiconSchema from './lexicons/com/atproto/lexicon/schema.js'
+import * as getRecord from './lexicons/com/atproto/sync/getRecord.js'
+
+/** Fetch local Lexicon proofs without connecting back through the public host. */
+export function createLexiconFetch({
+  publicUrl,
+  getLocalRecord,
+  fetch,
+}: {
+  publicUrl: string
+  getLocalRecord: (params: getRecord.$Params) => Promise<Uint8Array>
+  fetch: typeof globalThis.fetch
+}): typeof globalThis.fetch {
+  const origin = new URL(publicUrl).origin
+
+  return async (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input)
+    const method =
+      init?.method ?? (input instanceof Request ? input.method : 'GET')
+    if (
+      method.toUpperCase() !== 'GET' ||
+      url.origin !== origin ||
+      url.pathname !== `/xrpc/${getRecord.$lxm}` ||
+      url.searchParams.get('collection') !== lexiconSchema.$nsid
+    ) {
+      return fetch(input, init)
+    }
+
+    const signal =
+      init?.signal ?? (input instanceof Request ? input.signal : undefined)
+    signal?.throwIfAborted()
+    const params = getRecord.$params.fromURLSearchParams(url.searchParams)
+    const bytes = await getLocalRecord(params)
+    signal?.throwIfAborted()
+    return new Response(new Uint8Array(bytes), {
+      headers: { 'content-type': 'application/vnd.ipld.car' },
+    })
+  }
+}

--- a/packages/pds/tests/lexicon-fetch.test.ts
+++ b/packages/pds/tests/lexicon-fetch.test.ts
@@ -1,0 +1,208 @@
+import { jest } from '@jest/globals'
+import { streamToBytes } from '@atproto/common'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import { LexResolver, type LexResolverHooks } from '@atproto/lex-resolver'
+import {
+  MemoryBlockstore,
+  Repo,
+  WriteOpAction,
+  getRecords,
+} from '@atproto/repo'
+import { safeFetchWrap } from '@atproto-labs/fetch-node'
+import { createLexiconFetch } from '../src/lexicon-fetch.js'
+import * as lexiconSchema from '../src/lexicons/com/atproto/lexicon/schema.js'
+import * as getRecord from '../src/lexicons/com/atproto/sync/getRecord.js'
+
+const publicUrl = 'http://127.0.0.1:2583'
+const did = 'did:plc:abcdefghijklmnopqrstuvwx'
+const nsid = 'com.example.authFull'
+const record = {
+  $type: lexiconSchema.$nsid,
+  lexicon: 1,
+  id: nsid,
+  defs: {
+    main: {
+      type: 'permission-set',
+      title: 'Example',
+      permissions: [
+        {
+          type: 'permission',
+          resource: 'repo',
+          collection: ['com.example.post'],
+          action: ['create'],
+        },
+      ],
+    },
+  },
+}
+const params = { did, collection: lexiconSchema.$nsid, rkey: nsid }
+const recordUrl = `${publicUrl}/xrpc/${getRecord.$lxm}?${new URLSearchParams(params)}`
+
+async function fixture(lexicon = record) {
+  const key = await Secp256k1Keypair.create()
+  const storage = new MemoryBlockstore()
+  const repo = await Repo.create(storage, did, key, [
+    {
+      action: WriteOpAction.Create,
+      collection: lexiconSchema.$nsid,
+      rkey: nsid,
+      record: lexicon,
+    },
+  ])
+  const proof = await streamToBytes(getRecords(storage, repo.cid, [params]))
+  const document = {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: did,
+    verificationMethod: [
+      {
+        id: `${did}#atproto`,
+        type: 'Multikey',
+        controller: did,
+        publicKeyMultibase: key.did().slice('did:key:'.length),
+      },
+    ],
+    service: [
+      {
+        id: '#atproto_pds',
+        type: 'AtprotoPersonalDataServer',
+        serviceEndpoint: publicUrl,
+      },
+    ],
+  }
+  const safeFetch = safeFetchWrap({
+    allowIpHost: false,
+    allowImplicitRedirect: false,
+  })
+  const fetch: typeof globalThis.fetch = (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input)
+    if (url.origin === 'https://plc.directory') {
+      return Promise.resolve(Response.json(document))
+    }
+    return safeFetch(input, init)
+  }
+  const getLocalRecord = jest
+    .fn<Parameters<typeof createLexiconFetch>[0]['getLocalRecord']>()
+    .mockResolvedValue(proof)
+  return { fetch, getLocalRecord, document }
+}
+
+describe(createLexiconFetch, () => {
+  it('resolves a signed local permission set even when self-fetch is blocked', async () => {
+    const { fetch, getLocalRecord } = await fixture()
+    const hooks: LexResolverHooks = { onResolveAuthority: () => did }
+    await expect(new LexResolver({ fetch, hooks }).get(nsid)).rejects.toThrow(
+      'Failed to fetch Record',
+    )
+    const resolver = new LexResolver({
+      hooks,
+      fetch: createLexiconFetch({ publicUrl, fetch, getLocalRecord }),
+    })
+    await expect(resolver.get(nsid)).resolves.toMatchObject({ lexicon: record })
+    expect(getLocalRecord).toHaveBeenCalledWith(params)
+  })
+
+  it('still verifies local proof signatures against the DID document', async () => {
+    const { fetch, getLocalRecord, document } = await fixture()
+    const otherKey = await Secp256k1Keypair.create()
+    document.verificationMethod[0].publicKeyMultibase = otherKey
+      .did()
+      .slice('did:key:'.length)
+    const resolver = new LexResolver({
+      hooks: { onResolveAuthority: () => did },
+      fetch: createLexiconFetch({ publicUrl, fetch, getLocalRecord }),
+    })
+    await expect(resolver.get(nsid)).rejects.toThrow(
+      'Failed to verify Lexicon record proof',
+    )
+  })
+
+  it.each([
+    [{ ...record, lexicon: 2 }, 'Invalid Lexicon document'],
+    [{ ...record, id: 'com.example.other' }, 'Invalid document id'],
+  ] as const)(
+    'validates local Lexicon documents: %s',
+    async (lexicon, message) => {
+      const { fetch, getLocalRecord } = await fixture(lexicon)
+      const resolver = new LexResolver({
+        hooks: { onResolveAuthority: () => did },
+        fetch: createLexiconFetch({ publicUrl, fetch, getLocalRecord }),
+      })
+      await expect(resolver.get(nsid)).rejects.toThrow(message)
+    },
+  )
+
+  it('uses the current DID service endpoint instead of a leftover local repo', async () => {
+    const { fetch, getLocalRecord, document } = await fixture()
+    document.service[0].serviceEndpoint = 'https://moved.example.com'
+    const remoteFetch: typeof globalThis.fetch = (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input)
+      if (url.origin === document.service[0].serviceEndpoint) {
+        return Promise.reject(new Error('remote PDS'))
+      }
+      return fetch(input, init)
+    }
+    const resolver = new LexResolver({
+      hooks: { onResolveAuthority: () => did },
+      fetch: createLexiconFetch({
+        publicUrl,
+        fetch: remoteFetch,
+        getLocalRecord,
+      }),
+    })
+    await expect(resolver.get(nsid)).rejects.toThrow('Failed to fetch Record')
+    expect(getLocalRecord).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    recordUrl.replace('127.0.0.1:2583', '127.0.0.1:2584'),
+    recordUrl.replace('http:', 'https:'),
+    recordUrl.replace(lexiconSchema.$nsid, 'com.example.post'),
+    recordUrl.replace(getRecord.$lxm, 'com.atproto.repo.getRecord'),
+  ])(
+    'delegates requests outside the local Lexicon endpoint: %s',
+    async (url) => {
+      const fetch = jest
+        .fn<typeof globalThis.fetch>()
+        .mockRejectedValue(new Error('protected fetch'))
+      const getLocalRecord =
+        jest.fn<Parameters<typeof createLexiconFetch>[0]['getLocalRecord']>()
+      await expect(
+        createLexiconFetch({ publicUrl, fetch, getLocalRecord })(url),
+      ).rejects.toThrow('protected fetch')
+      expect(fetch).toHaveBeenCalledWith(url, undefined)
+      expect(getLocalRecord).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not fall back to HTTP for unavailable local records', async () => {
+    const fetch = jest.fn<typeof globalThis.fetch>()
+    const getLocalRecord = jest
+      .fn<Parameters<typeof createLexiconFetch>[0]['getLocalRecord']>()
+      .mockRejectedValue(new Error('Repo not available'))
+    await expect(
+      createLexiconFetch({ publicUrl, fetch, getLocalRecord })(recordUrl),
+    ).rejects.toThrow('Repo not available')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('validates local request parameters before reading a repo', async () => {
+    const { fetch, getLocalRecord } = await fixture()
+    const invalidUrl = new URL(recordUrl)
+    invalidUrl.searchParams.set('did', '../other')
+    await expect(
+      createLexiconFetch({ publicUrl, fetch, getLocalRecord })(invalidUrl),
+    ).rejects.toThrow()
+    expect(getLocalRecord).not.toHaveBeenCalled()
+  })
+
+  it('honors cancellation before reading a local proof', async () => {
+    const { fetch, getLocalRecord } = await fixture()
+    const signal = AbortSignal.abort(new Error('cancelled'))
+    await expect(
+      createLexiconFetch({ publicUrl, fetch, getLocalRecord })(
+        new Request(recordUrl, { signal }),
+      ),
+    ).rejects.toThrow('cancelled')
+    expect(getLocalRecord).not.toHaveBeenCalled()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2141,6 +2141,9 @@ importers:
       '@atproto/lex-document':
         specifier: workspace:^
         version: link:../lex/lex-document
+      '@atproto/lex-resolver':
+        specifier: workspace:^
+        version: link:../lex/lex-resolver
       '@atproto/oauth-client-browser-example':
         specifier: workspace:^
         version: link:../oauth/oauth-client-browser-example


### PR DESCRIPTION
<!--
Thanks for contributing! Please read CONTRIBUTING.md if you haven't yet:
https://github.com/bluesky-social/atproto/blob/main/CONTRIBUTING.md
-->

## What & why

The PDS fetched its own Lexicons through its public hostname, which can fail under local networking or SSRF protection. The fix reads local signed proofs directly while preserving validation and remote protections.

The reference PDS not resolving lexicon schema if the repo owner of the schema is on the same PDS has been an issue for [developers before](https://marvins-guide.leaflet.pub/3mbfvey7sok26/l-quote/119_0-119_516#119_0); I just came across it when trying to sign in to a local build of https://witchsky.app from @witchsky.app (using oauth with `app.witchsky.theme.authFull`), which at the time is hosted on a ref pds. 
<!-- What does this change, and what problem does it solve? Link the issue if there is one. -->

## Checklist

- [x] `pnpm build --force && pnpm verify` passes
- [x] Tests pass, and new behavior is covered by tests
- [x] A changeset is included for every package this touches
- [x] Written with the help of an LLM or coding agent? **GPT-6**