### PR TITLE
Update zed cfg to use vtsls

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -17,8 +17,8 @@
   "languages": {
     "JavaScript": {
       "language_servers": [
-        "typescript-ls",
-        "!vtsls",
+        "vtsls",
+        "!typescript-ls",
         "!typescript-language-server",
       ],
       // Formatting (prettier) applied through eslint
@@ -29,8 +29,8 @@
     },
     "TypeScript": {
       "language_servers": [
-        "typescript-ls",
-        "!vtsls",
+        "vtsls",
+        "!typescript-ls",
         "!typescript-language-server",
       ],
       // Formatting (prettier) applied through eslint
@@ -41,8 +41,8 @@
     },
     "TSX": {
       "language_servers": [
-        "typescript-ls",
-        "!vtsls",
+        "vtsls",
+        "!typescript-ls",
         "!typescript-language-server",
       ],
       // Formatting (prettier) applied through eslint


### PR DESCRIPTION
The new tsgo extension has a Zed bug that recursively watches pnpm’s symlinked node_modules, causing millions of indexed files, multi-GB memory spikes, and freezes. Switching to Zed’s built-in vtsls avoids it.

vtsls doesn't yet support Typescript 7. But it at least keeps the editor functioning