### PR TITLE
pds: send DID-resolved XRPC calls through safeFetch

### DIFF
--- a/.changeset/heavy-donuts-shake.md
+++ b/.changeset/heavy-donuts-shake.md
@@ -3,6 +3,4 @@
 ---
 
 `registerPush`, `unregisterPush` and `createReport` now issue their outbound
-call through the PDS's SSRF-protected fetch, so a service endpoint resolved from
-a DID document must be an https origin resolving to a unicast address, and its
-response is size-capped. Unchanged when `disableSsrfProtection` is set.
+call through the PDS's default `safeFetch`

--- a/.changeset/heavy-donuts-shake.md
+++ b/.changeset/heavy-donuts-shake.md
@@ -1,0 +1,8 @@
+---
+'@atproto/pds': patch
+---
+
+`registerPush`, `unregisterPush` and `createReport` now issue their outbound
+call through the PDS's SSRF-protected fetch, so a service endpoint resolved from
+a DID document must be an https origin resolving to a unicast address, and its
+response is size-capped. Unchanged when `disableSsrfProtection` is set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ For working with that SDK, invoke the focused skills under [.agents/skills/](.ag
 
 - **Lexicons are the contract.** The JSON files in [lexicons/](lexicons/) drive both client types and server route validation. Service packages don't hand-write XRPC method signatures — they import the generated definitions from their `src/lexicons/` directory (gitignored / regenerated).
 - ([packages/pds](packages/pds)) — a single-tenant atproto server: account management, repo storage (kysely-over-sqlite), actor storage (kysely-over-postgres), email, OAuth provider, blob storage. Runtime entry point is [services/pds](services/pds); production code is in `packages/pds/src`.
+  - Outbound requests to a URL resolved from a DID document are untrusted. Make them with `ctx.safeClient(url).xrpc(…)`, never a bare `xrpc(url, …)`, which uses the global fetch and bypasses the https-only/unicast-only checks. (`ctx.proxyAgent` is a separate thing — an undici `Dispatcher` used by pipethrough.)
 - ([packages/bsky](packages/bsky)) — read-side service for `app.bsky.*` queries (timelines, profiles, feed generators, hydration pipeline, GraphQL-like view composition). Talks to PDSes via XRPC and to `bsync` via Connect-RPC (protobuf in `packages/bsky/proto`). Runtime entry point in [services/bsky](services/bsky).
 - ([packages/bsync](packages/bsync)) — internal service for cross-AppView synchronization (mutes, notifications). Connect-RPC interface.
 - ([packages/ozone](packages/ozone)) — moderation service for `tools.ozone.*`.

--- a/packages/pds/src/api/app/bsky/notification/registerPush.ts
+++ b/packages/pds/src/api/app/bsky/notification/registerPush.ts
@@ -1,5 +1,4 @@
 import { getNotif } from '@atproto/identity'
-import { xrpc } from '@atproto/lex'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import { AuthScope } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
@@ -48,13 +47,12 @@ export default function (server: Server, ctx: AppContext) {
 
       const notifEndpoint = await getEndpoint(ctx, serviceDid)
 
-      await xrpc(notifEndpoint, app.bsky.notification.registerPush, {
-        validateRequest: ctx.cfg.service.devMode,
-        validateResponse: ctx.cfg.service.devMode,
-        strictResponseProcessing: ctx.cfg.service.devMode,
-        body,
-        headers,
-      })
+      await ctx
+        .safeClient(notifEndpoint)
+        .xrpc(app.bsky.notification.registerPush, {
+          body,
+          headers,
+        })
     },
   })
 }

--- a/packages/pds/src/api/app/bsky/notification/unregisterPush.ts
+++ b/packages/pds/src/api/app/bsky/notification/unregisterPush.ts
@@ -1,5 +1,4 @@
 import { getNotif } from '@atproto/identity'
-import { xrpc } from '@atproto/lex'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
 import { app } from '../../../../lexicons/index.js'
@@ -42,13 +41,12 @@ export default function (server: Server, ctx: AppContext) {
 
       const notifEndpoint = await getEndpoint(ctx, serviceDid)
 
-      await xrpc(notifEndpoint, app.bsky.notification.unregisterPush, {
-        validateRequest: ctx.cfg.service.devMode,
-        validateResponse: ctx.cfg.service.devMode,
-        strictResponseProcessing: ctx.cfg.service.devMode,
-        body,
-        headers,
-      })
+      await ctx
+        .safeClient(notifEndpoint)
+        .xrpc(app.bsky.notification.unregisterPush, {
+          body,
+          headers,
+        })
     },
   })
 }

--- a/packages/pds/src/api/com/atproto/moderation/createReport.ts
+++ b/packages/pds/src/api/com/atproto/moderation/createReport.ts
@@ -1,4 +1,3 @@
-import { xrpc } from '@atproto/lex'
 import type { Server } from '@atproto/xrpc-server'
 import { AuthScope } from '../../../../auth-scope.js'
 import type { AppContext } from '../../../../context.js'
@@ -28,10 +27,7 @@ export default function (server: Server, ctx: AppContext) {
         com.atproto.moderation.createReport.$lxm,
       )
 
-      return xrpc(url, com.atproto.moderation.createReport, {
-        validateRequest: ctx.cfg.service.devMode,
-        validateResponse: ctx.cfg.service.devMode,
-        strictResponseProcessing: ctx.cfg.service.devMode,
+      return ctx.safeClient(url).xrpc(com.atproto.moderation.createReport, {
         headers,
         params,
         body,

--- a/packages/pds/src/context.ts
+++ b/packages/pds/src/context.ts
@@ -553,6 +553,26 @@ export class AppContext implements AsyncDisposable {
     return forwardedFor(req, authPassthru(req))
   }
 
+  /**
+   * A {@link Client} for a service URL that was resolved from a DID document,
+   * i.e. a URL the PDS does not control. Routes the request through
+   * {@link safeFetch}, which restricts it to https origins that resolve to
+   * unicast addresses, and caps the response size. Lexicon validation follows
+   * the service's dev mode, as it does for the AppView client.
+   *
+   * Any call built from a DID document's service endpoint must use this.
+   */
+  safeClient(service: string | URL): Client {
+    return new Client(
+      { service, fetch: this.safeFetch },
+      {
+        validateRequest: this.cfg.service.devMode,
+        validateResponse: this.cfg.service.devMode,
+        strictResponseProcessing: this.cfg.service.devMode,
+      },
+    )
+  }
+
   async serviceAuthHeaders(did: string, aud: string, lxm: string) {
     const keypair = await this.actorStore.keypair(did)
     return createServiceAuthHeaders({

--- a/packages/pds/tests/ssrf.test.ts
+++ b/packages/pds/tests/ssrf.test.ts
@@ -1,0 +1,195 @@
+import { ComAtprotoModerationDefs } from '@atproto/api'
+import { TestNetworkNoAppView } from '@atproto/dev-env'
+import { startServer } from './_util.js'
+
+// Service endpoints are resolved out of DID documents, which are
+// user-controlled, so every xrpc() call built from one goes through
+// ctx.safeFetch: https-only, unicast-only destinations.
+//
+// These tests point a DID document's service endpoints at a local server and
+// assert that no request leaves the process. The `upstreamRequests` assertion
+// is the load-bearing one: a rejection alone could come from anywhere, but an
+// empty request log proves the fetch never happened.
+
+describe('ssrf protection on did-resolved service endpoints', () => {
+  let upstream: AsyncDisposable & { port: number }
+  let upstreamRequests: string[]
+
+  beforeAll(async () => {
+    upstream = await startServer((req, res) => {
+      upstreamRequests.push(`${req.method} ${req.url}`)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      // createReport relays the upstream response to the caller, and the PDS
+      // validates it against the lexicon in dev mode, so it must be well formed.
+      res.end(
+        req.url?.endsWith('createReport')
+          ? JSON.stringify({
+              id: 1,
+              reasonType: ComAtprotoModerationDefs.REASONSPAM,
+              subject: {
+                $type: 'com.atproto.admin.defs#repoRef',
+                did: 'did:plc:abcdefghijklmnopqrstuvwx',
+              },
+              reportedBy: 'did:plc:abcdefghijklmnopqrstuvwx',
+              createdAt: new Date().toISOString(),
+            })
+          : '{}',
+      )
+    })
+  })
+
+  beforeEach(() => {
+    upstreamRequests = []
+  })
+
+  afterAll(async () => {
+    await upstream?.[Symbol.asyncDispose]()
+  })
+
+  const setup = async (disableSsrfProtection: boolean) => {
+    const network = await TestNetworkNoAppView.create({
+      pds: { disableSsrfProtection },
+    })
+    const sc = network.getSeedClient()
+    await sc.createAccount('reporter', {
+      handle: 'reporter.test',
+      email: 'reporter@test.com',
+      password: 'repo-pass',
+    })
+    await sc.createAccount('notifsvc', {
+      handle: 'notifsvc.test',
+      email: 'notifsvc@test.com',
+      password: 'serv-pass',
+    })
+
+    // Point the service account's DID document at the local upstream.
+    const serviceDid = sc.dids.notifsvc
+    const endpoint = `http://localhost:${upstream.port}`
+    await network.plc
+      .getClient()
+      .updateData(serviceDid, network.pds.ctx.plcRotationKey, (x) => {
+        x.services['bsky_notif'] = {
+          type: 'BskyNotificationService',
+          endpoint,
+        }
+        x.services['atproto_labeler'] = {
+          type: 'AtprotoLabeler',
+          endpoint,
+        }
+        return x
+      })
+    await network.pds.ctx.idResolver.did.resolve(serviceDid, true)
+
+    const agent = network.pds.getAgent()
+    const headers = sc.getHeaders(sc.dids.reporter)
+    const pushInput = {
+      serviceDid,
+      token: 'tok1',
+      platform: 'web' as const,
+      appId: 'app1',
+    }
+    const reportInput = {
+      reasonType: ComAtprotoModerationDefs.REASONSPAM,
+      reason: 'ssrf probe',
+      subject: {
+        $type: 'com.atproto.admin.defs#repoRef',
+        did: sc.dids.reporter,
+      },
+    }
+
+    return {
+      network,
+      registerPush: () =>
+        agent.api.app.bsky.notification.registerPush(pushInput, {
+          headers,
+          encoding: 'application/json',
+        }),
+      unregisterPush: () =>
+        agent.api.app.bsky.notification.unregisterPush(pushInput, {
+          headers,
+          encoding: 'application/json',
+        }),
+      createReport: () =>
+        agent.api.com.atproto.moderation.createReport(reportInput, {
+          headers: {
+            ...headers,
+            'atproto-proxy': `${serviceDid}#atproto_labeler`,
+          },
+          encoding: 'application/json',
+        }),
+    }
+  }
+
+  const settle = (promise: Promise<unknown>) =>
+    promise.then(
+      () => 'resolved' as const,
+      () => 'rejected' as const,
+    )
+
+  describe('with ssrf protection enabled', () => {
+    let ctx: Awaited<ReturnType<typeof setup>>
+
+    beforeAll(async () => {
+      ctx = await setup(false)
+    })
+
+    afterAll(async () => {
+      await ctx?.network.close()
+    })
+
+    it('refuses to send registerPush to a non-unicast endpoint.', async () => {
+      const outcome = await settle(ctx.registerPush())
+      expect(upstreamRequests).toEqual([])
+      expect(outcome).toBe('rejected')
+    })
+
+    it('refuses to send unregisterPush to a non-unicast endpoint.', async () => {
+      const outcome = await settle(ctx.unregisterPush())
+      expect(upstreamRequests).toEqual([])
+      expect(outcome).toBe('rejected')
+    })
+
+    it('refuses to send createReport to a non-unicast endpoint.', async () => {
+      const outcome = await settle(ctx.createReport())
+      expect(upstreamRequests).toEqual([])
+      expect(outcome).toBe('rejected')
+    })
+  })
+
+  // Differential control: the same endpoints, the same calls, with the guard
+  // turned off. Without this, the tests above could pass for the wrong reason
+  // (e.g. a DID document the PDS never managed to resolve) and we would not
+  // notice that they had stopped testing anything.
+  describe('with ssrf protection disabled', () => {
+    let ctx: Awaited<ReturnType<typeof setup>>
+
+    beforeAll(async () => {
+      ctx = await setup(true)
+    })
+
+    afterAll(async () => {
+      await ctx?.network.close()
+    })
+
+    it('sends registerPush to the endpoint.', async () => {
+      await ctx.registerPush()
+      expect(upstreamRequests).toEqual([
+        'POST /xrpc/app.bsky.notification.registerPush',
+      ])
+    })
+
+    it('sends unregisterPush to the endpoint.', async () => {
+      await ctx.unregisterPush()
+      expect(upstreamRequests).toEqual([
+        'POST /xrpc/app.bsky.notification.unregisterPush',
+      ])
+    })
+
+    it('sends createReport to the endpoint.', async () => {
+      await ctx.createReport()
+      expect(upstreamRequests).toEqual([
+        'POST /xrpc/com.atproto.moderation.createReport',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
`registerPush`, `unregisterPush` and `createReport` now issue their outbound call through the PDS's default `safeFetch`.