### PR TITLE
pds, oauth-provider: bound decompressed body buffering

### DIFF
--- a/.changeset/oauth-provider-body-bound.md
+++ b/.changeset/oauth-provider-body-bound.md
@@ -1,0 +1,8 @@
+---
+'@atproto/oauth-provider': patch
+---
+
+Bound the request bodies accepted by the OAuth and account-management endpoints
+at 100 KiB. The bound is on the decoded body, so a compressed request is
+measured after decompression, and a `content-length` above it is rejected
+without reading the body. Oversized bodies fail with a 413.

--- a/.changeset/proxy-decoded-response-bound.md
+++ b/.changeset/proxy-decoded-response-bound.md
@@ -1,0 +1,8 @@
+---
+'@atproto/pds': patch
+---
+
+Bound the decoded size of the upstream responses that the proxy buffers — error
+bodies, and the read-after-write path — at `proxy.maxResponseSize`, which
+previously bounded only the bytes read off the wire. A response that decodes
+past the bound fails as an upstream error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ For working with that SDK, invoke the focused skills under [.agents/skills/](.ag
 - Node ≥22 runtime floor; build/dev default to Node 24 (`.nvmrc`). Use `node --enable-source-maps` for production-style runs.
 - TypeScript compilation uses the native TS7 `tsc` (the standard `typescript` package). There is no per-package `typescript` devDependency — it is hoisted at the root. Note TS7 has no stable programmatic API yet; tools needing one must pin TS6.
 - **Every package touched by a change needs a changeset entry.** Add a file under [.changeset/](.changeset/) listing each modified package with an appropriate bump level (pre-v1 breaking changes are `minor` and everything else `patch`, post-v1 `major` for breaking changes, `minor` for new public API, `patch` otherwise). Dependency-only bumps are generated automatically — don't list them by hand. Create that file with `pnpm changeset`.
+- **Never buffer an unbounded stream from outside the process.** Decoding or buffering a request/response body that did not originate locally requires an explicit size bound on the _decoded_ bytes — a wire-size cap does not bound a compressed payload. Compose `createDecoders` with `MaxSizeChecker` in a `pipeline` (see `packages/xrpc-server/src/util.ts`), rather than passing a decoded stream straight to `streamToNodeBuffer`.
 
 ## Agent files
 

--- a/packages/oauth/oauth-provider/src/lib/http/stream.test.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/stream.test.ts
@@ -1,0 +1,106 @@
+import type { IncomingMessage } from 'node:http'
+import { Readable } from 'node:stream'
+import { gzipSync } from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+import { parseHttpRequest } from './stream.js'
+
+// Bodies are bounded at two layers: `content-length` bounds the wire size, and
+// a MaxSizeChecker bounds the decoded size. The cases below cross those bounds
+// independently — a small gzip body that decodes past the limit, an oversized
+// identity body, an oversized `content-length` — since neither bound implies
+// the other.
+
+const asRequest = (body: Buffer, headers: Record<string, string>) => {
+  const req = Readable.from([body]) as unknown as IncomingMessage
+  req.headers = headers
+  return req
+}
+
+describe('parseHttpRequest', () => {
+  it('parses a normal json payload.', async () => {
+    const body = Buffer.from(JSON.stringify({ hello: 'world' }))
+    const req = asRequest(body, { 'content-type': 'application/json' })
+    await expect(parseHttpRequest(req, ['json'])).resolves.toEqual({
+      hello: 'world',
+    })
+  })
+
+  it('parses a normal urlencoded payload.', async () => {
+    const body = Buffer.from('hello=world')
+    const req = asRequest(body, {
+      'content-type': 'application/x-www-form-urlencoded',
+    })
+    await expect(parseHttpRequest(req, ['urlencoded'])).resolves.toEqual({
+      hello: 'world',
+    })
+  })
+
+  it('rejects a body whose decoded size exceeds the limit.', async () => {
+    const raw = Buffer.alloc(4096, 'A')
+    const req = asRequest(gzipSync(raw), {
+      'content-type': 'application/json',
+      'content-encoding': 'gzip',
+    })
+    await expect(parseHttpRequest(req, ['json'], 1024)).rejects.toMatchObject({
+      status: 413,
+    })
+  })
+
+  it('rejects an oversized body that is not compressed.', async () => {
+    const req = asRequest(Buffer.alloc(4096, 'A'), {
+      'content-type': 'application/json',
+    })
+    await expect(parseHttpRequest(req, ['json'], 1024)).rejects.toMatchObject({
+      status: 413,
+    })
+  })
+
+  it('rejects an oversized content-length without reading the body.', async () => {
+    let consumed = false
+    const req = Readable.from(
+      (function* () {
+        consumed = true
+        yield Buffer.alloc(2048, 'A')
+      })(),
+    ) as unknown as IncomingMessage
+    req.headers = {
+      'content-type': 'application/json',
+      'content-length': '2048',
+    }
+    await expect(parseHttpRequest(req, ['json'], 1024)).rejects.toMatchObject({
+      status: 413,
+    })
+    expect(consumed).toBe(false)
+  })
+
+  it('accepts a body whose content-length is within the limit.', async () => {
+    const body = Buffer.from(JSON.stringify({ hello: 'world' }))
+    const req = asRequest(body, {
+      'content-type': 'application/json',
+      'content-length': String(body.byteLength),
+    })
+    await expect(parseHttpRequest(req, ['json'], 1024)).resolves.toEqual({
+      hello: 'world',
+    })
+  })
+
+  it('rejects a malformed content-length.', async () => {
+    const req = asRequest(Buffer.from('{}'), {
+      'content-type': 'application/json',
+      'content-length': 'many',
+    })
+    await expect(parseHttpRequest(req, ['json'])).rejects.toMatchObject({
+      status: 400,
+    })
+  })
+
+  it('rejects an unsupported content-encoding.', async () => {
+    const req = asRequest(Buffer.from(JSON.stringify({ hello: 'world' })), {
+      'content-type': 'application/json',
+      'content-encoding': 'bogus',
+    })
+    await expect(parseHttpRequest(req, ['json'])).rejects.toMatchObject({
+      status: 415,
+    })
+  })
+})

--- a/packages/oauth/oauth-provider/src/lib/http/stream.ts
+++ b/packages/oauth/oauth-provider/src/lib/http/stream.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage } from 'node:http'
-import type { Readable } from 'node:stream'
+import { type Duplex, type Readable, pipeline } from 'node:stream'
 import createHttpError from 'http-errors'
-import { decodeStream, streamToNodeBuffer } from '@atproto/common'
+import {
+  MaxSizeChecker,
+  createDecoders,
+  streamToNodeBuffer,
+} from '@atproto/common'
 import {
   type KnownNames,
   type KnownParser,
@@ -10,9 +14,47 @@ import {
   parsers,
 } from './parser.js'
 
-export function decodeHttpRequest(req: IncomingMessage): Readable {
+/**
+ * Bounds the decoded request body, whichever content-encoding it arrived with.
+ * The payloads these routes legitimately carry are single-digit kilobytes, so
+ * this leaves ample headroom.
+ */
+export const DEFAULT_MAX_BODY_SIZE = 100 * 1024 // 100 KiB
+
+export function decodeHttpRequest(
+  req: IncomingMessage,
+  maxSize: number,
+): Readable {
+  // @NOTE Content-Length counts the octets actually transferred, i.e. the
+  // body *after* content-encoding. It therefore bounds the wire size, which
+  // the MaxSizeChecker below does not (that one bounds the decoded size);
+  // these are two distinct bounds that happen to share a constant. It is not
+  // a substitute for the checker: the header is absent under chunked transfer
+  // encoding, and a client may understate it.
+  const contentLength = req.headers['content-length']
+  if (contentLength != null) {
+    const size = Number(contentLength)
+    if (!Number.isInteger(size) || size < 0) {
+      throw createHttpError(400, 'Invalid content-length')
+    }
+    if (size > maxSize) {
+      throw createHttpError(413, 'Payload too large')
+    }
+  }
+
   try {
-    return decodeStream(req, req.headers['content-encoding'])
+    // @NOTE The checker is applied even when the body is not encoded: nothing
+    // else bounds the size of these requests.
+    return pipeline(
+      [
+        req,
+        ...createDecoders(req.headers['content-encoding']),
+        new MaxSizeChecker(maxSize, () =>
+          createHttpError(413, 'Payload too large'),
+        ),
+      ],
+      () => {},
+    ) as Duplex
   } catch (cause) {
     const message =
       cause instanceof TypeError ? cause.message : `Invalid content-encoding`
@@ -30,6 +72,7 @@ export function decodeHttpRequest(req: IncomingMessage): Readable {
 export async function parseHttpRequest<A extends readonly KnownNames[]>(
   req: IncomingMessage,
   allow: A,
+  maxSize: number = DEFAULT_MAX_BODY_SIZE,
 ) {
   const type = parseContentType(
     req.headers['content-type'] ?? 'application/octet-stream',
@@ -43,7 +86,7 @@ export async function parseHttpRequest<A extends readonly KnownNames[]>(
     throw createHttpError(415, `Unsupported content-type: ${type.mime}`)
   }
 
-  const stream = decodeHttpRequest(req)
+  const stream = decodeHttpRequest(req, maxSize)
   const buffer = await streamToNodeBuffer(stream)
   return parser.parse(buffer, type) as ParserResult<
     Extract<KnownParser, { name: A[number] }>

--- a/packages/pds/src/pipethrough.ts
+++ b/packages/pds/src/pipethrough.ts
@@ -1,9 +1,16 @@
 import type { IncomingHttpHeaders, ServerResponse } from 'node:http'
-import { PassThrough, type Readable, finished } from 'node:stream'
+import {
+  type Duplex,
+  PassThrough,
+  type Readable,
+  finished,
+  pipeline,
+} from 'node:stream'
 import type { Request } from 'express'
 import { Agent, type Dispatcher, Pool, interceptors } from 'undici'
 import {
-  decodeStream,
+  MaxSizeChecker,
+  createDecoders,
   getServiceEndpoint,
   omit,
   streamToNodeBuffer,
@@ -378,7 +385,11 @@ async function pipethroughStream(
         if (upstream.statusCode >= 400) {
           const passThrough = new PassThrough()
 
-          void tryParsingError(upstream.headers, passThrough).then((parsed) => {
+          void tryParsingError(
+            upstream.headers,
+            passThrough,
+            ctx.cfg.proxy.maxResponseSize,
+          ).then((parsed) => {
             const xrpcError = new PipethroughUpstreamError(upstream, parsed, {
               cause: dispatchOptions,
             })
@@ -427,7 +438,11 @@ async function pipethroughRequest(
     .catch(handleUpstreamRequestError.bind(req))
 
   if (upstream.statusCode >= 400) {
-    const parsed = await tryParsingError(upstream.headers, upstream.body)
+    const parsed = await tryParsingError(
+      upstream.headers,
+      upstream.body,
+      ctx.cfg.proxy.maxResponseSize,
+    )
 
     throw new PipethroughUpstreamError(upstream, parsed, {
       cause: dispatchOptions,
@@ -466,6 +481,7 @@ export function isJsonContentType(contentType?: string): boolean | undefined {
 async function tryParsingError(
   headers: IncomingHttpHeaders,
   readable: Readable,
+  maxSize: number,
 ): Promise<{ error?: string; message?: string }> {
   if (isJsonContentType(headers['content-type']) === false) {
     // We don't known how to parse non JSON content types so we can discard the
@@ -496,6 +512,7 @@ async function tryParsingError(
     const buffer = await bufferUpstreamResponse(
       readable,
       headers['content-encoding'],
+      maxSize,
     )
 
     const errInfo: unknown = JSON.parse(buffer.toString('utf8'))
@@ -511,10 +528,27 @@ async function tryParsingError(
 
 async function bufferUpstreamResponse(
   readable: Readable,
-  contentEncoding?: string | string[],
+  contentEncoding: string | string[] | undefined,
+  maxSize: number,
 ): Promise<Buffer> {
   try {
-    return await streamToNodeBuffer(decodeStream(readable, contentEncoding))
+    // @NOTE maxResponseSize bounds the wire stream that undici reads, and
+    // decoding it can yield a much larger buffer, so the decoded stream needs
+    // its own bound. The checker is applied even when there is no
+    // content-encoding, so that an identity-encoded body is bounded too.
+    return await streamToNodeBuffer(
+      pipeline(
+        [
+          readable,
+          ...createDecoders(contentEncoding),
+          new MaxSizeChecker(
+            maxSize,
+            () => new TypeError('upstream response too large'),
+          ),
+        ],
+        () => {},
+      ) as Duplex,
+    )
   } catch (err) {
     if (!readable.destroyed) readable.destroy()
 
@@ -529,11 +563,13 @@ async function bufferUpstreamResponse(
 
 export async function asPipeThroughBuffer(
   input: HandlerPipeThroughStream,
+  maxSize: number,
 ): Promise<HandlerPipeThroughBuffer> {
   return {
     buffer: await bufferUpstreamResponse(
       input.stream,
       input.headers?.['content-encoding'],
+      maxSize,
     ),
     headers: omit(input.headers, ['content-encoding', 'content-length']),
     encoding: input.encoding,

--- a/packages/pds/src/read-after-write/util.ts
+++ b/packages/pds/src/read-after-write/util.ts
@@ -61,7 +61,10 @@ export const pipethroughReadAfterWrite = async <
       const local = await store.record.getRecordsSinceRev(rev)
       if (local.count === 0) return streamRes
 
-      const { buffer } = (bufferRes = await asPipeThroughBuffer(streamRes))
+      const { buffer } = (bufferRes = await asPipeThroughBuffer(
+        streamRes,
+        ctx.cfg.proxy.maxResponseSize,
+      ))
 
       const lex = lexParse(buffer.toString('utf8'), { strict: false })
 

--- a/packages/pds/tests/proxied/decompression-bound.test.ts
+++ b/packages/pds/tests/proxied/decompression-bound.test.ts
@@ -1,0 +1,157 @@
+import { gzipSync } from 'node:zlib'
+import type { AtpAgent } from '@atproto/api'
+import { TestNetworkNoAppView } from '@atproto/dev-env'
+import { startServer } from '../_util.js'
+
+// undici's maxResponseSize bounds what the proxy reads off the wire, but the
+// buffering paths decode before they buffer, so they bound the decoded stream
+// separately. These tests exercise that bound: wire size stays under the cap
+// while decoded size exceeds it.
+
+describe('proxied response decompression bounds', () => {
+  const MAX_RESPONSE_SIZE = 64 * 1024 // both the wire cap and the decoded cap
+  const DECODED_SIZE = 1024 * 1024 // ~1 MiB decoded, ~1 KiB gzipped
+
+  let network: TestNetworkNoAppView
+  let upstream: AsyncDisposable & { port: number }
+  let agent: AtpAgent
+  let headers: Record<string, string>
+  let proxyHeader: string
+
+  // A repo rev strictly between two local writes: everything after it counts
+  // as "since rev" for getRecordsSinceRev, while a record at-or-before it
+  // still exists so its sanity check (which bails out to an empty result if
+  // *every* local record postdates the given rev, e.g. after an account
+  // migration) doesn't discard the read-after-write splice.
+  let sinceRev: string
+
+  // Set per test, before issuing the request.
+  let upstreamStatus: number
+  let upstreamEncoding: 'gzip' | 'identity'
+  let upstreamRepoRev: string | undefined
+
+  beforeAll(async () => {
+    upstream = await startServer((req, res) => {
+      const raw = Buffer.from(
+        JSON.stringify({ error: 'Bomb', message: 'A'.repeat(DECODED_SIZE) }),
+      )
+      const body = upstreamEncoding === 'gzip' ? gzipSync(raw) : raw
+      res.writeHead(upstreamStatus, {
+        'content-type': 'application/json',
+        ...(upstreamEncoding === 'gzip'
+          ? { 'content-encoding': 'gzip' }
+          : undefined),
+        ...(upstreamRepoRev
+          ? { 'atproto-repo-rev': upstreamRepoRev }
+          : undefined),
+      })
+      res.end(body)
+    })
+
+    network = await TestNetworkNoAppView.create({
+      pds: { proxyMaxResponseSize: MAX_RESPONSE_SIZE },
+    })
+    const sc = network.getSeedClient()
+    await sc.createAccount('alice', {
+      handle: 'alice.test',
+      email: 'alice@test.com',
+      password: 'alice-pass',
+    })
+
+    const serviceDid = sc.dids.alice
+    await network.plc
+      .getClient()
+      .updateData(serviceDid, network.pds.ctx.plcRotationKey, (x) => {
+        x.services['atproto_test'] = {
+          type: 'AtprotoTestService',
+          endpoint: `http://localhost:${upstream.port}`,
+        }
+        return x
+      })
+    await network.pds.ctx.idResolver.did.resolve(serviceDid, true)
+
+    agent = network.pds.getAgent()
+    headers = sc.getHeaders(sc.dids.alice)
+    proxyHeader = `${serviceDid}#atproto_test`
+
+    // A local write, then a captured rev, then another local write -- so the
+    // read-after-write path has a record strictly since `sinceRev` to splice
+    // in, without `sinceRev` predating every local record (see `sinceRev`).
+    await sc.post(sc.dids.alice, 'hello')
+    const commit = await agent.api.com.atproto.sync.getLatestCommit({
+      did: serviceDid,
+    })
+    sinceRev = commit.data.rev
+    await sc.post(sc.dids.alice, 'world')
+  }, 60_000)
+
+  beforeEach(() => {
+    upstreamStatus = 200
+    upstreamEncoding = 'gzip'
+    upstreamRepoRev = undefined
+  })
+
+  afterAll(async () => {
+    await upstream?.[Symbol.asyncDispose]()
+    await network?.close()
+  })
+
+  const getProfile = () =>
+    agent.api.app.bsky.actor
+      .getProfile(
+        { actor: 'alice.test' },
+        { headers: { ...headers, 'atproto-proxy': proxyHeader } },
+      )
+      .then(
+        (res) => ({
+          status: 200,
+          error: undefined,
+          message: undefined,
+          data: res.data,
+        }),
+        (err) => ({
+          status: err.status,
+          error: err.error,
+          message: err.message,
+          data: undefined,
+        }),
+      )
+
+  it('stops parsing an oversized decoded error body.', async () => {
+    upstreamStatus = 418
+
+    // tryParsingError swallows its own failures, so the upstream status is
+    // still relayed on the wire -- but the client-side XRPC library maps any
+    // HTTP status it doesn't recognize as a ResponseType (418 is not one) down
+    // to 400, which is what we observe here. The load-bearing assertion is
+    // that the oversized body must never be parsed, so the upstream's error
+    // name must not reach the client.
+    const res = await getProfile()
+
+    expect(res.status).toBe(400)
+    expect(res.error).not.toBe('Bomb')
+  })
+
+  it('rejects an oversized decoded read-after-write body.', async () => {
+    upstreamRepoRev = sinceRev
+
+    const res = await getProfile()
+
+    expect(res.status).toBe(502)
+    // Pins the specific size-failure label: a 502 alone does not distinguish
+    // this from the generic "unable to decode request body" failure that the
+    // catch-all branch in bufferUpstreamResponse() would otherwise produce.
+    expect(res.message).toBe('upstream response too large')
+    expect(res.data).toBeUndefined()
+  })
+
+  it('rejects an oversized body that is not compressed.', async () => {
+    upstreamEncoding = 'identity'
+    upstreamRepoRev = sinceRev
+
+    const res = await getProfile()
+
+    expect(res.status).toBe(502)
+    expect(res.data).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Bound the request bodies accepted by the OAuth, account-management, and all PDS proxy endpoints. The bound is on the decoded body, so a compressed request is measured after decompression, and a `content-length` above it is rejected without reading the body. Oversized bodies fail with a 413.