### PR TITLE
fetch-node: apply safe fetch checks to redirect hops

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,30 @@
+---
+'@atproto-labs/fetch-node': minor
+'@atproto-labs/fetch': patch
+---
+
+`safeFetchWrap()` now applies its url policy — the protocol, custom port,
+hostname, forbidden-domain-name and literal-IP checks — to every request it
+issues, rather than only to the one it was handed. The policy runs again at
+dispatch time, which is the layer that observes each redirect hop, and a hop is
+refused before its connection is made.
+
+The dispatcher is installed even when `ssrfProtection` (or `allowPrivateIps`)
+relaxes the unicast requirement, so relaxing that no longer relaxes the
+remaining checks along with it. As a consequence, a custom `dispatcher` can no
+longer be supplied through the request init in that configuration.
+
+This requires undici's `Dispatcher.compose()`, which is feature-detected rather
+than inferred from a version number: on a NodeJS whose bundled undici predates
+it, constructing a safe fetch now throws instead of issuing requests without the
+per-hop checks.
+
+Redirect handling itself is unchanged: bodies are still replayed across 307/308,
+methods still downgrade on 301/302/303, and the existing timeout still covers
+the whole chain rather than a single hop.
+
+`@atproto-labs/fetch` exposes the policy as three url-level predicates —
+`checkProtocolPolicy()`, `checkHostHeaderPolicy()` and
+`checkForbiddenDomainNamePolicy()` — which return the reason a url is
+unacceptable instead of throwing. The request transforms built on them are
+unchanged, status codes included.

--- a/packages/internal/fetch-node/src/dispatch.ts
+++ b/packages/internal/fetch-node/src/dispatch.ts
@@ -1,0 +1,177 @@
+import type { LookupFunction } from 'node:net'
+import { Agent as Undici6Agent } from 'undici_v6' // NodeJS 22
+import { Agent as Undici7Agent } from 'undici_v7' // NodeJS 24
+import { Agent as Undici8Agent } from 'undici_v8' // NodeJS 26
+import {
+  type Fetch,
+  type FetchContext,
+  FetchRequestError,
+  type UrlPolicyReason,
+  asRequest,
+} from '@atproto-labs/fetch'
+import { compareVersions, parseVersion } from './util.js'
+
+export type UrlCheck = (url: URL) => UrlPolicyReason | undefined
+
+/**
+ * The undici 6/7/8 `Agent` classes are structurally incompatible as a union, so
+ * dispatch composition is expressed against this narrow view of them. Only the
+ * fields the guard actually reads are described.
+ */
+type DispatchOptions = {
+  origin: string | URL
+}
+type Dispatch = (opts: DispatchOptions, handler: unknown) => boolean
+type DispatchInterceptor = (dispatch: Dispatch) => Dispatch
+type ComposableAgent = {
+  compose?: (interceptor: DispatchInterceptor) => unknown
+}
+
+export type SafeDispatchFetchWrapOptions<C = FetchContext> = {
+  fetch?: Fetch<C>
+
+  /**
+   * Invoked for **every** request issued through the returned fetch, including
+   * every redirect hop, before a connection is attempted.
+   *
+   * This is the only place a redirect hop can be vetoed: `fetch()` follows
+   * redirects internally, above the dispatcher, so request-level transforms
+   * only ever observe the initial url.
+   *
+   * @note The {@link URL} it receives carries the dispatched **origin** only —
+   * its path and query are always empty. The dispatcher cannot report them
+   * soundly (see {@link urlCheckInterceptor}), so a policy must not depend on
+   * them.
+   */
+  checkUrl?: UrlCheck
+
+  /**
+   * Connect-time DNS guard. Catches hostnames that *resolve* to a forbidden
+   * address, which {@link checkUrl} cannot see. Note that NodeJS does not
+   * resolve literal-IP hosts, so this is never called for them — those must be
+   * caught by {@link checkUrl}.
+   */
+  lookup?: LookupFunction
+}
+
+/**
+ * Wraps a fetch function so that every request it issues — including every
+ * redirect hop — is dispatched through a guarded undici Agent.
+ */
+export function safeDispatchFetchWrap<C = FetchContext>({
+  fetch = globalThis.fetch,
+  checkUrl,
+  lookup,
+}: SafeDispatchFetchWrapOptions<C> = {}): Fetch<C> {
+  const dispatcher = buildDispatcher({ checkUrl, lookup })
+
+  return async function (this: C, input, init): Promise<Response> {
+    if (init != null && 'dispatcher' in init && init.dispatcher != null) {
+      const request = asRequest(input, init)
+      await request.body?.cancel()
+      const cause = new FetchRequestError(
+        request,
+        500,
+        'SSRF protection cannot be used with a custom request dispatcher',
+      )
+      // @NOTE Use Whatwg style errors so that the error is similar whether
+      // caused by this line of an error caused by the lookup function
+      throw new TypeError('fetch failed', { cause })
+    }
+
+    return fetch.call(this, input, {
+      ...init,
+      // @ts-ignore There is a type mismatch because of undici version
+      // differences, but we know this is safe because we are using the correct
+      // Agent class for the undici version.
+      dispatcher,
+    })
+  }
+}
+
+function buildDispatcher({ checkUrl, lookup }: SafeDispatchFetchWrapOptions) {
+  // @NOTE we parse here instead of top-level to allow version mocking in tests.
+  const nodeUndiciVersion = parseVersion(process.versions.undici)
+
+  if (
+    !nodeUndiciVersion ||
+    // https://github.com/nodejs/undici/pull/2928
+    compareVersions(nodeUndiciVersion, [6, 11, 1]) < 0
+  ) {
+    throw new Error('Unicast SSRF protection requires Node.js 20.6+')
+  }
+
+  const connect = lookup ? { lookup } : undefined
+
+  // @NOTE Since major versions of undici are not guaranteed to be backwards
+  // compatible, we need to check the major version and use the appropriate
+  // Agent class for that version, to ensure that the dispatcher interface is
+  // compatible with the version of undici being used.
+  const agent =
+    nodeUndiciVersion[0] === 6
+      ? new Undici6Agent({ connect })
+      : nodeUndiciVersion[0] === 7
+        ? new Undici7Agent({ connect })
+        : nodeUndiciVersion[0] === 8
+          ? new Undici8Agent({ connect })
+          : null
+
+  // @NOTE Because this is a security feature, we don't want to fallback to
+  // using Agent8 to "future proof" this package. Although future version of
+  // undici may have a backwards compatible dispatcher interface, we don't want
+  // to assume that and risk a security issue.
+  if (!agent) {
+    throw new Error(
+      'This version of @atproto-labs/fetch-node does not support your version of undici. Please upgrade @atproto-labs/fetch-node, and use a version of NodeJS that uses undici 6, 7, or 8 internally.',
+    )
+  }
+
+  if (!checkUrl) return agent
+
+  const composable = agent as unknown as ComposableAgent
+
+  // @NOTE Feature-detected rather than gated on a version number: `compose()`
+  // landed partway through the undici 6.x line, and guessing the exact release
+  // would risk either rejecting a capable runtime or, worse, silently skipping
+  // the redirect hop checks on an incapable one. Fail loudly instead.
+  if (typeof composable.compose !== 'function') {
+    throw new Error(
+      `The undici version bundled with this NodeJS release (${process.versions.undici}) does not support dispatcher interceptors, which are required to validate redirect hops. Please upgrade NodeJS.`,
+    )
+  }
+
+  return composable.compose(urlCheckInterceptor(checkUrl))
+}
+
+/**
+ * Vetoes a dispatch whose url violates the policy, before any connection is
+ * made. Because `fetch()` re-dispatches through the same dispatcher for each
+ * redirect hop, this observes the whole chain.
+ */
+function urlCheckInterceptor(checkUrl: UrlCheck): DispatchInterceptor {
+  return (dispatch) => (opts, handler) => {
+    // @NOTE The origin alone, never resolved against `opts.path`. Every check
+    // in the policy judges origin-level properties, so the path adds nothing
+    // — and letting it participate is unsound: a pathname beginning with `//`
+    // is protocol-relative, so `new URL(path, origin)` discards the origin and
+    // yields a url describing the *path's* host rather than the host that is
+    // about to be dialed.
+    const url = new URL(String(opts.origin))
+
+    const reason = checkUrl(url)
+    if (reason) {
+      // @NOTE The origin, not the full url, in the message: paths and query
+      // strings may carry tokens that should not reach a log.
+      //
+      // @NOTE A plain Error rather than a FetchError: the caller's Request is
+      // not available at this layer, and `fetch()` wraps whatever is thrown
+      // here in `TypeError: fetch failed` regardless. Because the cause
+      // carries no status code, consumers resolve it to a non-exposed 500, so
+      // the reason stays available for logs without reaching a downstream
+      // client.
+      throw new Error(`Blocked by url policy (${url.origin}): ${reason}`)
+    }
+
+    return dispatch(opts, handler)
+  }
+}

--- a/packages/internal/fetch-node/src/index.ts
+++ b/packages/internal/fetch-node/src/index.ts
@@ -1,5 +1,6 @@
 export * from '@atproto-labs/fetch'
 
+export * from './dispatch.js'
 export * from './safe.js'
 export * from './unicast.js'
 

--- a/packages/internal/fetch-node/src/safe.test.ts
+++ b/packages/internal/fetch-node/src/safe.test.ts
@@ -1,0 +1,229 @@
+import { type RequestListener, createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { safeFetchWrap } from './safe.js'
+
+type TestServer = AsyncDisposable & { origin: (host?: string) => string }
+
+const servers: TestServer[] = []
+
+async function startServer(listener: RequestListener): Promise<TestServer> {
+  const server = createServer(listener)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  const testServer: TestServer = {
+    origin: (host = '127.0.0.1') => `http://${host}:${port}`,
+    [Symbol.asyncDispose]: () =>
+      new Promise<void>((resolve) => server.close(() => resolve())),
+  }
+  servers.push(testServer)
+  return testServer
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => s[Symbol.asyncDispose]()))
+})
+
+/**
+ * A server that records every request it receives, so a test can assert that a
+ * blocked hop never reached the network rather than merely that it errored.
+ */
+async function recordingServer(listener?: RequestListener) {
+  const requests: string[] = []
+  const server = await startServer(async (req, res) => {
+    let body = ''
+    for await (const chunk of req) body += chunk
+    requests.push(`${req.method} ${req.url} ${body}`)
+    if (listener) return listener(req, res)
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('final')
+  })
+  return { ...server, requests }
+}
+
+async function redirectingServer(location: () => string, status = 302) {
+  return startServer((req, res) => {
+    res.writeHead(status, { location: location() })
+    res.end()
+  })
+}
+
+describe(safeFetchWrap, () => {
+  it('follows a redirect to an allowed destination', async () => {
+    const target = await recordingServer()
+    const entry = await redirectingServer(() => `${target.origin()}/final`)
+
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      forbiddenDomainNames: [],
+    })
+
+    const res = await safeFetch(`${entry.origin('localhost')}/start`, {
+      redirect: 'follow',
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.text()).resolves.toBe('final')
+    expect(target.requests).toHaveLength(1)
+  })
+
+  it('applies the url policy to redirect hops, not just the initial url', async () => {
+    const target = await recordingServer()
+    const entry = await redirectingServer(() => `${target.origin()}/final`)
+
+    // The entry point is reached over `localhost`; the redirect hop lands on
+    // `127.0.0.1`, which the deny list forbids. Only a per-hop check can catch
+    // it — the initial url is perfectly acceptable.
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      forbiddenDomainNames: ['127.0.0.1'],
+    })
+
+    // The rejection must name the hop that was refused — the initial url is
+    // all that reaches the fetch logger, so without this the operator has no
+    // way to tell where the request was redirected to.
+    await expect(
+      safeFetch(`${entry.origin('localhost')}/start`, { redirect: 'follow' }),
+    ).rejects.toSatisfy(
+      causedBy(
+        `Blocked by url policy (${target.origin()}): Forbidden hostname`,
+      ),
+    )
+
+    // Load-bearing: an error alone could come from anywhere. An empty request
+    // log proves the connection was never made.
+    expect(target.requests).toEqual([])
+  })
+
+  it('applies the url policy to redirect hops when ssrf protection is disabled', async () => {
+    const target = await recordingServer()
+    const entry = await redirectingServer(() => `${target.origin()}/final`)
+
+    // `ssrfProtection: false` relaxes the unicast requirement. It must not
+    // silently disable the remaining per-hop checks.
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      allowPrivateIps: true,
+      forbiddenDomainNames: ['127.0.0.1'],
+    })
+
+    await expect(
+      safeFetch(`${entry.origin('localhost')}/start`, { redirect: 'follow' }),
+    ).rejects.toThrow()
+
+    expect(target.requests).toEqual([])
+  })
+
+  it('rejects a redirect hop onto a literal ip host', async () => {
+    const target = await recordingServer()
+    const entry = await redirectingServer(() => `${target.origin()}/final`)
+
+    // `allowIpHost: false` rejects literal-IP hosts. The entry point is a
+    // domain name, so only a per-hop check can see the `127.0.0.1` hop. This
+    // stands in for the case the connect-time DNS guard structurally cannot
+    // catch: NodeJS performs no lookup for a literal ip.
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      allowIpHost: false,
+      forbiddenDomainNames: [],
+    })
+
+    await expect(
+      safeFetch(`${entry.origin('localhost')}/start`, { redirect: 'follow' }),
+    ).rejects.toThrow()
+
+    expect(target.requests).toEqual([])
+  })
+
+  it('rejects a redirect hop whose path makes the url protocol-relative', async () => {
+    const target = await recordingServer()
+    // A pathname beginning with `//` is protocol-relative. A per-hop check that
+    // resolves the path against the origin therefore discards the origin and
+    // judges the path as if it were the host: this hop must be attributed to
+    // `127.0.0.1`, not to `evil.example.com`.
+    const entry = await redirectingServer(
+      () => `${target.origin()}//evil.example.com/final`,
+    )
+
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      allowIpHost: false,
+      forbiddenDomainNames: [],
+    })
+
+    await expect(
+      safeFetch(`${entry.origin('localhost')}/start`, { redirect: 'follow' }),
+    ).rejects.toSatisfy(
+      causedBy(`Blocked by url policy (${target.origin()}): Invalid hostname`),
+    )
+
+    expect(target.requests).toEqual([])
+  })
+
+  it('rejects a protocol-relative redirect hop onto a bracketed IPv6 host', async () => {
+    const target = await recordingServer()
+    // Same shape, with an IPv6 literal: the brackets `URL` keeps in `hostname`
+    // are what the ip checks match on, so the hop must stay attributed to
+    // `[::1]`. Nothing needs to listen there — the hop is refused before a
+    // connection is attempted.
+    const entry = await redirectingServer(
+      () => `${target.origin('[::1]')}//evil.example.com/final`,
+    )
+
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      allowIpHost: false,
+      forbiddenDomainNames: [],
+    })
+
+    await expect(
+      safeFetch(`${entry.origin('localhost')}/start`, { redirect: 'follow' }),
+    ).rejects.toSatisfy(
+      causedBy(
+        `Blocked by url policy (${target.origin('[::1]')}): Invalid hostname`,
+      ),
+    )
+
+    expect(target.requests).toEqual([])
+  })
+
+  it('still rejects a forbidden domain on the initial url', async () => {
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      forbiddenDomainNames: ['example.com'],
+    })
+
+    await expect(
+      safeFetch('http://example.com/', { redirect: 'follow' }),
+    ).rejects.toThrow('Forbidden hostname')
+  })
+
+  it('replays the request body across a 307 redirect', async () => {
+    const target = await recordingServer()
+    const entry = await redirectingServer(() => `${target.origin()}/final`, 307)
+
+    const safeFetch = safeFetchWrap({
+      ssrfProtection: false,
+      forbiddenDomainNames: [],
+    })
+
+    const res = await safeFetch(`${entry.origin('localhost')}/start`, {
+      redirect: 'follow',
+      method: 'POST',
+      body: '{"replayed":true}',
+      headers: { 'content-type': 'application/json' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(target.requests).toEqual(['POST /final {"replayed":true}'])
+  })
+})
+
+function causedBy(message: string) {
+  return (err: unknown) => {
+    expect(err).toBeInstanceOf(TypeError)
+    expect((err as TypeError).cause).toBeInstanceOf(Error)
+    expect(((err as TypeError).cause as Error).message).toBe(message)
+    return true
+  }
+}

--- a/packages/internal/fetch-node/src/safe.ts
+++ b/packages/internal/fetch-node/src/safe.ts
@@ -1,7 +1,12 @@
 import {
   DEFAULT_FORBIDDEN_DOMAIN_NAMES,
   type Fetch,
+  type ProtocolConfig,
+  type UrlPolicyReason,
   asRequest,
+  checkForbiddenDomainNamePolicy,
+  checkHostHeaderPolicy,
+  checkProtocolPolicy,
   explicitRedirectCheckRequestTransform,
   fetchMaxSizeProcessor,
   forbiddenDomainNameRequestTransform,
@@ -10,9 +15,11 @@ import {
   timedFetch,
 } from '@atproto-labs/fetch'
 import { pipe } from '@atproto-labs/pipe'
-import { type UnicastFetchWrapOptions, unicastFetchWrap } from './unicast.js'
+import { safeDispatchFetchWrap } from './dispatch.js'
+import { checkUnicastPolicy, unicastLookup } from './unicast.js'
 
-export type SafeFetchWrapOptions<C> = UnicastFetchWrapOptions<C> & {
+export type SafeFetchWrapOptions<C> = {
+  fetch?: Fetch<C>
   responseMaxSize?: number
   ssrfProtection?: boolean
   allowCustomPort?: boolean
@@ -36,6 +43,14 @@ export type SafeFetchWrapOptions<C> = UnicastFetchWrapOptions<C> & {
  * with user provided input (URL).
  *
  * @see {@link https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html}
+ *
+ * @note The url policy is enforced twice, deliberately. The request transforms
+ * below apply it to the initial url, where a rejection can carry the caller's
+ * own {@link Request} and can reject schemes (`data:`, `file:`) that never
+ * reach the network. The dispatcher guard applies the same policy to every
+ * request that is actually issued, which is the only way to cover redirect
+ * hops: `fetch()` follows redirects internally, above the dispatcher, so a
+ * transform only ever observes the url it was handed.
  *
  * @note When {@link SafeFetchWrapOptions.allowImplicitRedirect} is `false`
  * (default), then the returned function **must** be called setting the second
@@ -63,6 +78,33 @@ export function safeFetchWrap<C>({
   forbiddenDomainNames = DEFAULT_FORBIDDEN_DOMAIN_NAMES as Iterable<string>,
   allowImplicitRedirect = false,
 }: SafeFetchWrapOptions<C> = {}) {
+  /**
+   * Prevent using http:, file: or data: protocols.
+   */
+  const protocols: ProtocolConfig = {
+    'about:': false,
+    'data:': allowData,
+    'file:': false,
+    'http:': allowHttp && { allowCustomPort },
+    'https:': { allowCustomPort },
+  }
+
+  const forbiddenDomainNameSet = new Set<string>(forbiddenDomainNames)
+
+  /**
+   * The whole url policy, as a single check over a {@link URL}, so that it can
+   * be applied to every redirect hop and not only to the initial url.
+   *
+   * @note {@link checkUnicastPolicy} is applied here (rather than left to the
+   * connect-time DNS guard) because NodeJS does not resolve literal-IP hosts,
+   * so the lookup is never invoked for them.
+   */
+  const checkUrl = (url: URL): UrlPolicyReason | undefined =>
+    checkProtocolPolicy(url, protocols) ??
+    (allowIpHost ? undefined : checkHostHeaderPolicy(url)) ??
+    checkForbiddenDomainNamePolicy(url, forbiddenDomainNameSet) ??
+    (allowPrivateIps ? undefined : checkUnicastPolicy(url))
+
   return pipe(
     /**
      * Require explicit {@link RequestInit['redirect']} mode
@@ -74,16 +116,7 @@ export function safeFetchWrap<C>({
      */
     allowIpHost ? asRequest : requireHostHeaderTransform(),
 
-    /**
-     * Prevent using http:, file: or data: protocols.
-     */
-    protocolCheckRequestTransform({
-      'about:': false,
-      'data:': allowData,
-      'file:': false,
-      'http:': allowHttp && { allowCustomPort },
-      'https:': { allowCustomPort },
-    }),
+    protocolCheckRequestTransform(protocols),
 
     /**
      * Disallow fetching from domains we know are not atproto/OIDC client
@@ -96,6 +129,9 @@ export function safeFetchWrap<C>({
     /**
      * Since we will be fetching from the network based on user provided
      * input, let's mitigate resource exhaustion attacks by setting a timeout.
+     *
+     * @note This budget covers the entire redirect chain, since `fetch()`
+     * follows redirects within this single call.
      */
     timedFetch(
       timeout,
@@ -104,8 +140,16 @@ export function safeFetchWrap<C>({
        * Since we will be fetching from the network based on user provided
        * input, we need to make sure that the request is not vulnerable to SSRF
        * attacks.
+       *
+       * @note The dispatcher is installed even when private IPs are allowed:
+       * relaxing the unicast requirement must not silently disable the
+       * remaining per-hop checks. Only the DNS guard is conditional.
        */
-      allowPrivateIps ? fetch : unicastFetchWrap({ fetch }),
+      safeDispatchFetchWrap({
+        fetch,
+        checkUrl,
+        lookup: allowPrivateIps ? undefined : unicastLookup,
+      }),
     ),
 
     /**

--- a/packages/internal/fetch-node/src/unicast.test.ts
+++ b/packages/internal/fetch-node/src/unicast.test.ts
@@ -1,5 +1,9 @@
 import { assert, describe, expect, it, vi } from 'vitest'
-import { unicastFetchWrap, unicastLookup } from './unicast.js'
+import {
+  checkUnicastPolicy,
+  unicastFetchWrap,
+  unicastLookup,
+} from './unicast.js'
 
 vi.mock(import('node:dns'), async (importOriginal) => {
   const dns = await importOriginal()
@@ -20,6 +24,29 @@ vi.mock(import('node:dns'), async (importOriginal) => {
       return dns.lookup(hostname, options, callback)
     }) as typeof dns.lookup,
   }
+})
+
+describe(checkUnicastPolicy, () => {
+  // `unicastLookup` cannot cover these: NodeJS performs no DNS resolution for a
+  // literal-IP host, so the connect-time guard is never invoked for one.
+  it.each([
+    'http://127.0.0.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://10.0.0.1/',
+    'http://[::1]/',
+  ])('rejects the non-unicast literal ip in %s', (href) => {
+    expect(checkUnicastPolicy(new URL(href))).toBe(
+      'Hostname is a non-unicast address',
+    )
+  })
+
+  it('allows a public literal ip', () => {
+    expect(checkUnicastPolicy(new URL('http://1.1.1.1/'))).toBeUndefined()
+  })
+
+  it('defers a domain name to the connect-time lookup', () => {
+    expect(checkUnicastPolicy(new URL('http://example.com/'))).toBeUndefined()
+  })
 })
 
 describe(unicastLookup, () => {

--- a/packages/internal/fetch-node/src/unicast.ts
+++ b/packages/internal/fetch-node/src/unicast.ts
@@ -2,17 +2,16 @@ import type { LookupAddress, LookupOptions } from 'node:dns'
 import { lookup } from 'node:dns'
 import type { LookupFunction } from 'node:net'
 import ipaddr from 'ipaddr.js'
-import { Agent as Undici6Agent } from 'undici_v6' // NodeJS 22
-import { Agent as Undici7Agent } from 'undici_v7' // NodeJS 24
-import { Agent as Undici8Agent } from 'undici_v8' // NodeJS 26
 import {
   type Fetch,
   type FetchContext,
   FetchRequestError,
+  type UrlPolicyReason,
   asRequest,
   extractUrl,
 } from '@atproto-labs/fetch'
-import { compareVersions, isUnicastIpHostname, parseVersion } from './util.js'
+import { safeDispatchFetchWrap } from './dispatch.js'
+import { isUnicastIpHostname } from './util.js'
 
 const { IPv4, IPv6 } = ipaddr
 
@@ -21,81 +20,48 @@ export type UnicastFetchWrapOptions<C = FetchContext> = {
 }
 
 /**
+ * Rejects urls whose host is a literal non-unicast IP address.
+ *
+ * @note This is *not* redundant with {@link unicastLookup}: NodeJS does not
+ * perform DNS resolution for literal-IP hosts, so the connect-time lookup is
+ * never invoked for them. Without this check, a request to (or a redirect
+ * towards) `http://127.0.0.1/` would not be checked at all.
+ */
+export function checkUnicastPolicy(url: URL): UrlPolicyReason | undefined {
+  if (url.hostname && isUnicastIpHostname(url.hostname) === false) {
+    return 'Hostname is a non-unicast address'
+  }
+  return undefined
+}
+
+/**
  * @see {@link https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/}
  */
 export function unicastFetchWrap<C = FetchContext>({
   fetch = globalThis.fetch,
 }: UnicastFetchWrapOptions<C> = {}): Fetch<C> {
-  // @NOTE we parse here instead of top-level to allow version mocking in tests.
-  const nodeUndiciVersion = parseVersion(process.versions.undici)
-
-  if (
-    !nodeUndiciVersion ||
-    // https://github.com/nodejs/undici/pull/2928
-    compareVersions(nodeUndiciVersion, [6, 11, 1]) < 0
-  ) {
-    throw new Error('Unicast SSRF protection requires Node.js 20.6+')
-  }
-
-  // @NOTE Since major versions of undici are not guaranteed to be backwards
-  // compatible, we need to check the major version and use the appropriate
-  // Agent class for that version, to ensure that the dispatcher interface is
-  // compatible with the version of undici being used.
-  const dispatcher =
-    nodeUndiciVersion[0] === 6
-      ? new Undici6Agent({ connect: { lookup: unicastLookup } })
-      : nodeUndiciVersion[0] === 7
-        ? new Undici7Agent({ connect: { lookup: unicastLookup } })
-        : nodeUndiciVersion[0] === 8
-          ? new Undici8Agent({ connect: { lookup: unicastLookup } })
-          : null
-
-  // @NOTE Because this is a security feature, we don't want to fallback to
-  // using Agent8 to "future proof" this package. Although future version of
-  // undici may have a backwards compatible dispatcher interface, we don't want
-  // to assume that and risk a security issue.
-  if (!dispatcher) {
-    throw new Error(
-      'This version of @atproto-labs/fetch-node does not support your version of undici. Please upgrade @atproto-labs/fetch-node, and use a version of NodeJS that uses undici 6, 7, or 8 internally.',
-    )
-  }
+  const dispatchFetch = safeDispatchFetchWrap<C>({
+    fetch,
+    checkUrl: checkUnicastPolicy,
+    lookup: unicastLookup,
+  })
 
   return async function (this: C, input, init): Promise<Response> {
-    if (init != null && 'dispatcher' in init && init.dispatcher != null) {
+    // @NOTE The dispatcher guard already applies this check to every request,
+    // including redirect hops. It is repeated here so that a rejection of the
+    // *initial* url happens before any body is consumed, and so that the error
+    // carries the caller's own Request.
+    const reason = checkUnicastPolicy(extractUrl(input))
+    if (reason) {
       const request = asRequest(input, init)
       await request.body?.cancel()
-      const cause = new FetchRequestError(
-        request,
-        500,
-        'SSRF protection cannot be used with a custom request dispatcher',
-      )
+      const cause = new FetchRequestError(request, 400, reason)
       // @NOTE Use Whatwg style errors so that the error is similar whether
       // caused by this line of an error caused by the lookup function
       throw new TypeError('fetch failed', { cause })
     }
 
-    const url = extractUrl(input)
-
-    if (url.hostname && isUnicastIpHostname(url.hostname) === false) {
-      const request = asRequest(input, init)
-      await request.body?.cancel()
-      const cause = new FetchRequestError(
-        request,
-        400,
-        'Hostname is a non-unicast address',
-      )
-      // @NOTE Use Whatwg style errors so that the error is similar whether
-      // caused by this line of an error caused by the lookup function
-      throw new TypeError('fetch failed', { cause })
-    }
-
-    return fetch.call(this, input, {
-      ...init,
-      // @ts-ignore There is a type mismatch because of undici version
-      // differences, but we know this is safe because we are using the correct
-      // Agent class for the undici version.
-      dispatcher,
-    })
+    return dispatchFetch.call(this, input, init)
   }
 }
 

--- a/packages/internal/fetch/package.json
+++ b/packages/internal/fetch/package.json
@@ -31,6 +31,10 @@
     "@atproto-labs/pipe": "workspace:^"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.json"
+    "build": "tsc --build tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/internal/fetch/src/fetch-request.test.ts
+++ b/packages/internal/fetch/src/fetch-request.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FORBIDDEN_DOMAIN_NAMES,
+  FetchRequestError,
+  type ProtocolConfig,
+  checkForbiddenDomainNamePolicy,
+  checkHostHeaderPolicy,
+  checkProtocolPolicy,
+  forbiddenDomainNameRequestTransform,
+  protocolCheckRequestTransform,
+  requireHostHeaderTransform,
+} from './fetch-request.js'
+
+// These predicates are the security policy that `@atproto-labs/fetch-node`'s
+// safeFetchWrap applies to every request it issues, including every redirect
+// hop. The hop cases that cannot be reached from an integration test — a
+// plaintext downgrade, a link-local address — are pinned down here.
+
+const httpsOnly: ProtocolConfig = {
+  'about:': false,
+  'data:': false,
+  'file:': false,
+  'http:': false,
+  'https:': { allowCustomPort: false },
+}
+
+describe(checkProtocolPolicy, () => {
+  it('allows https', () => {
+    expect(
+      checkProtocolPolicy(new URL('https://example.com/'), httpsOnly),
+    ).toBeUndefined()
+  })
+
+  it('rejects a plaintext http downgrade', () => {
+    expect(checkProtocolPolicy(new URL('http://example.com/'), httpsOnly)).toBe(
+      'Forbidden protocol "http:"',
+    )
+  })
+
+  it.each(['data:text/plain,hi', 'file:///etc/passwd', 'about:blank'])(
+    'rejects %s',
+    (href) => {
+      expect(checkProtocolPolicy(new URL(href), httpsOnly)).toMatch(
+        /^Forbidden protocol/,
+      )
+    },
+  )
+
+  it('rejects a custom port when not allowed', () => {
+    expect(
+      checkProtocolPolicy(new URL('https://example.com:8443/'), httpsOnly),
+    ).toBe('Custom https: ports not allowed')
+  })
+
+  it('allows a custom port when allowed', () => {
+    expect(
+      checkProtocolPolicy(new URL('https://example.com:8443/'), {
+        ...httpsOnly,
+        'https:': { allowCustomPort: true },
+      }),
+    ).toBeUndefined()
+  })
+
+  it('treats the default port as no port', () => {
+    expect(
+      checkProtocolPolicy(new URL('https://example.com:443/'), httpsOnly),
+    ).toBeUndefined()
+  })
+
+  it('rejects a protocol absent from the config', () => {
+    expect(checkProtocolPolicy(new URL('ftp://example.com/'), httpsOnly)).toBe(
+      'Forbidden protocol "ftp:"',
+    )
+  })
+})
+
+describe(checkHostHeaderPolicy, () => {
+  it('allows a domain name', () => {
+    expect(
+      checkHostHeaderPolicy(new URL('https://example.com/')),
+    ).toBeUndefined()
+  })
+
+  it.each([
+    'http://127.0.0.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::1]/',
+  ])('rejects the literal ip host in %s', (href) => {
+    expect(checkHostHeaderPolicy(new URL(href))).toBe('Invalid hostname')
+  })
+
+  it('rejects a non-http protocol', () => {
+    expect(checkHostHeaderPolicy(new URL('data:text/plain,hi'))).toBe(
+      '"data:" requests are not allowed',
+    )
+  })
+})
+
+describe(checkForbiddenDomainNamePolicy, () => {
+  const denySet = new Set(['example.com', '*.example.org'])
+
+  it('allows a hostname that is not listed', () => {
+    expect(
+      checkForbiddenDomainNamePolicy(new URL('https://atproto.com/'), denySet),
+    ).toBeUndefined()
+  })
+
+  it('rejects an exact match', () => {
+    expect(
+      checkForbiddenDomainNamePolicy(new URL('https://example.com/'), denySet),
+    ).toBe('Forbidden hostname')
+  })
+
+  it('rejects a subdomain of a wildcard entry', () => {
+    expect(
+      checkForbiddenDomainNamePolicy(
+        new URL('https://a.b.example.org/'),
+        denySet,
+      ),
+    ).toBe('Forbidden hostname')
+  })
+
+  it('does not treat a wildcard entry as an exact match', () => {
+    expect(
+      checkForbiddenDomainNamePolicy(new URL('https://example.org/'), denySet),
+    ).toBeUndefined()
+  })
+})
+
+// The status code lives at the throw site rather than on the policy reason.
+// It is load-bearing: `FetchError.expose` derives from it, and the OAuth
+// provider uses `expose` to decide whether a client developer is told why
+// their client_id was rejected. An inferred status would fall through to 500
+// and silently swallow the reason.
+describe('request transform status codes', () => {
+  const expectThrows = async (
+    fn: () => unknown,
+    statusCode: number,
+    message: string,
+  ) => {
+    try {
+      await fn()
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(FetchRequestError)
+      const fetchErr = err as FetchRequestError
+      expect(fetchErr.statusCode).toBe(statusCode)
+      expect(fetchErr.message).toBe(message)
+      expect(fetchErr.expose).toBe(true)
+    }
+  }
+
+  it('reports a protocol violation as an exposed 400', async () => {
+    const transform = protocolCheckRequestTransform(httpsOnly)
+    await expectThrows(
+      () => transform('http://example.net/'),
+      400,
+      'Forbidden protocol "http:"',
+    )
+  })
+
+  it('reports an ip host as an exposed 400', async () => {
+    const transform = requireHostHeaderTransform()
+    await expectThrows(
+      () => transform('https://127.0.0.1/'),
+      400,
+      'Invalid hostname',
+    )
+  })
+
+  it('reports a forbidden domain as an exposed 403', async () => {
+    const transform = forbiddenDomainNameRequestTransform(
+      DEFAULT_FORBIDDEN_DOMAIN_NAMES,
+    )
+    await expectThrows(
+      () => transform('https://example.com/'),
+      403,
+      'Forbidden hostname',
+    )
+  })
+})

--- a/packages/internal/fetch/src/fetch-request.ts
+++ b/packages/internal/fetch/src/fetch-request.ts
@@ -90,39 +90,98 @@ function extractInfo(err: unknown): [statusCode: number, message: string] {
   return [500, err.message]
 }
 
-export function protocolCheckRequestTransform(protocols: {
+export type ProtocolConfig = {
   'about:'?: boolean
   'blob:'?: boolean
   'data:'?: boolean
   'file:'?: boolean
   'http:'?: boolean | { allowCustomPort: boolean }
   'https:'?: boolean | { allowCustomPort: boolean }
-}) {
+}
+
+/**
+ * The url policy checks below return the reason a url is unacceptable, or
+ * `undefined` when it is fine.
+ *
+ * @note They are expressed over a {@link URL} rather than a {@link Request} so
+ * that the same policy can be applied both to the initial url (by the request
+ * transforms below) and to every redirect hop (by
+ * `@atproto-labs/fetch-node`'s dispatcher guard, which only ever sees an
+ * origin). Keep them free of request state, and of path or query state, for
+ * that reason.
+ *
+ * @note They deliberately carry no status code. The appropriate status depends
+ * on how the caller surfaces the failure, so it belongs at the throw site.
+ */
+export type UrlPolicyReason = string
+
+export function checkProtocolPolicy(
+  url: URL,
+  protocols: ProtocolConfig,
+): UrlPolicyReason | undefined {
+  const { protocol, port } = url
+
+  const config: undefined | boolean | { allowCustomPort?: boolean } =
+    Object.hasOwn(protocols, protocol)
+      ? protocols[protocol as keyof ProtocolConfig]
+      : undefined
+
+  if (!config) {
+    return `Forbidden protocol "${protocol}"`
+  } else if (config === true) {
+    return undefined
+  } else if (!config['allowCustomPort'] && port !== '') {
+    return `Custom ${protocol} ports not allowed`
+  }
+
+  return undefined
+}
+
+export function checkHostHeaderPolicy(url: URL): UrlPolicyReason | undefined {
+  const { protocol, hostname } = url
+
+  // "Host" header only makes sense in the context of an HTTP request
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    return `"${protocol}" requests are not allowed`
+  }
+
+  if (!hostname || isIp(hostname)) {
+    return 'Invalid hostname'
+  }
+
+  return undefined
+}
+
+export function checkForbiddenDomainNamePolicy(
+  url: URL,
+  denySet: ReadonlySet<string>,
+): UrlPolicyReason | undefined {
+  const { hostname } = url
+
+  // Full domain name check
+  if (denySet.has(hostname)) {
+    return 'Forbidden hostname'
+  }
+
+  // Sub domain name check
+  let curDot = hostname.indexOf('.')
+  while (curDot !== -1) {
+    const subdomain = hostname.slice(curDot + 1)
+    if (denySet.has(`*.${subdomain}`)) {
+      return 'Forbidden hostname'
+    }
+    curDot = hostname.indexOf('.', curDot + 1)
+  }
+
+  return undefined
+}
+
+export function protocolCheckRequestTransform(protocols: ProtocolConfig) {
   return (input: Request | string | URL, init?: RequestInit) => {
     const request = asRequest(input, init)
 
-    const { protocol, port } = new URL(request.url)
-
-    const config: undefined | boolean | { allowCustomPort?: boolean } =
-      Object.hasOwn(protocols, protocol)
-        ? protocols[protocol as keyof typeof protocols]
-        : undefined
-
-    if (!config) {
-      throw new FetchRequestError(
-        request,
-        400,
-        `Forbidden protocol "${protocol}"`,
-      )
-    } else if (config === true) {
-      // Safe to proceed
-    } else if (!config['allowCustomPort'] && port !== '') {
-      throw new FetchRequestError(
-        request,
-        400,
-        `Custom ${protocol} ports not allowed`,
-      )
-    }
+    const reason = checkProtocolPolicy(new URL(request.url), protocols)
+    if (reason) throw new FetchRequestError(request, 400, reason)
 
     return request
   }
@@ -159,20 +218,8 @@ export function requireHostHeaderTransform() {
 
     const request = asRequest(input, init)
 
-    const { protocol, hostname } = new URL(request.url)
-
-    // "Host" header only makes sense in the context of an HTTP request
-    if (protocol !== 'http:' && protocol !== 'https:') {
-      throw new FetchRequestError(
-        request,
-        400,
-        `"${protocol}" requests are not allowed`,
-      )
-    }
-
-    if (!hostname || isIp(hostname)) {
-      throw new FetchRequestError(request, 400, 'Invalid hostname')
-    }
+    const reason = checkHostHeaderPolicy(new URL(request.url))
+    if (reason) throw new FetchRequestError(request, 400, reason)
 
     return request
   }
@@ -203,22 +250,8 @@ export function forbiddenDomainNameRequestTransform(
   return async (input: Request | string | URL, init?: RequestInit) => {
     const request = asRequest(input, init)
 
-    const { hostname } = new URL(request.url)
-
-    // Full domain name check
-    if (denySet.has(hostname)) {
-      throw new FetchRequestError(request, 403, 'Forbidden hostname')
-    }
-
-    // Sub domain name check
-    let curDot = hostname.indexOf('.')
-    while (curDot !== -1) {
-      const subdomain = hostname.slice(curDot + 1)
-      if (denySet.has(`*.${subdomain}`)) {
-        throw new FetchRequestError(request, 403, 'Forbidden hostname')
-      }
-      curDot = hostname.indexOf('.', curDot + 1)
-    }
+    const reason = checkForbiddenDomainNamePolicy(new URL(request.url), denySet)
+    if (reason) throw new FetchRequestError(request, 403, reason)
 
     return request
   }

--- a/packages/internal/fetch/tsconfig.build.json
+++ b/packages/internal/fetch/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["../../../tsconfig/isomorphic.tsconfig.json"],
   "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "references": [{ "path": "../pipe/tsconfig.build.json" }],
   "compilerOptions": {
     "outDir": "./dist",

--- a/packages/internal/fetch/tsconfig.json
+++ b/packages/internal/fetch/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "include": [],
-  "references": [{ "path": "./tsconfig.build.json" }],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
 }

--- a/packages/internal/fetch/tsconfig.test.json
+++ b/packages/internal/fetch/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["../../../tsconfig/vitest.tsconfig.json"],
+  "include": ["./tests", "./src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.build.json" }],
+  "compilerOptions": {
+    "rootDir": "./",
+  },
+}

--- a/packages/internal/fetch/vitest.config.ts
+++ b/packages/internal/fetch/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.19.17)(jiti@2.7.0)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.2(@types/node@22.20.1)(jiti@2.7.0)(terser@5.44.0)(yaml@2.9.0))
 
   packages/internal/fetch-node:
     dependencies:
@@ -21146,6 +21146,35 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.2(@types/node@22.20.1)(jiti@2.7.0)(terser@5.44.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.2(@types/node@22.20.1)(jiti@2.7.0)(terser@5.44.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@22.20.1)(jiti@2.7.0)(terser@5.44.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,10 @@ importers:
       '@atproto-labs/pipe':
         specifier: workspace:^
         version: link:../pipe
+    devDependencies:
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@22.19.17)(jiti@2.7.0)(terser@5.44.0)(yaml@2.8.1))
 
   packages/internal/fetch-node:
     dependencies:


### PR DESCRIPTION
`safeFetchWrap()` now applies its url policy to redirect hops, which runs at dispatch time.

This requires undici's `Dispatcher.compose()`, which is feature-detected rather than inferred from a version number: on a NodeJS whose bundled undici predates it, constructing a safe fetch now throws instead of issuing requests without the per-hop checks.

`@atproto-labs/fetch` exposes the policy as three url-level predicates — `checkProtocolPolicy()`, `checkHostHeaderPolicy()` and `checkForbiddenDomainNamePolicy()` — which return the reason a url is unacceptable instead of throwing. The request transforms built on them are unchanged, status codes included.