### PR TITLE
fix(car): decode varints through the CJS default export

### DIFF
--- a/.changeset/lucky-varints-decode.md
+++ b/.changeset/lucky-varints-decode.md
@@ -1,0 +1,5 @@
+---
+'@atproto/car': patch
+---
+
+Fix `decodeVarInt` throwing `varint.decode is not a function` under Node's ESM/CJS interop, which made every CAR read fail in built output.

--- a/packages/car/src/lib/varint.ts
+++ b/packages/car/src/lib/varint.ts
@@ -1,4 +1,15 @@
-import * as varint from 'varint'
+import * as varintModule from 'varint'
+
+// `varint` is CommonJS, and its `module.exports` is an object literal whose
+// values are `require()` calls. Node's cjs-module-lexer only detects the first
+// of them, so under ESM this namespace holds `default` and `encode` and no
+// `decode` — making `decode` `undefined` in built output while `encode` works.
+// The whole module object is always reachable through `default`; bundlers and
+// test transforms, which do synthesize both named exports, fall back to the
+// namespace itself.
+const varint =
+  (varintModule as unknown as { default?: typeof varintModule }).default ??
+  varintModule
 
 // @TODO we might optimize this:
 // - by using a pre-allocated buffer and writing into it, then slicing it to the correct length


### PR DESCRIPTION
## Problem

`packages/car/src/lib/varint.ts` does `import * as varint from 'varint'`. `varint@6.0.0` is CommonJS, and its `module.exports` is an object literal whose values are `require()` calls, of which Node's `cjs-module-lexer` detects only the first. From inside `packages/car` on Node 22:

```
namespace keys : [ 'default', 'encode' ]
typeof decode  : undefined
default.decode : function
```

So in built ESM output `encodeVarInt` works and `decodeVarInt` throws `TypeError: varint.decode is not a function`. `decodeVarInt` reads every block length in `lib/bytes-reader.ts`, so **every CAR read fails in a built package**, `readCarWithRoot` included.

The package's 40 tests pass before and after this change: vitest transforms through esbuild, whose interop does supply `varint.decode`, so no unit test here can observe the difference. Reproduction is the built `dist` under plain Node:

```
$ pnpm --filter @atproto/car build
$ cd packages/car && node --input-type=module \
  -e "import {decodeVarInt} from './dist/lib/varint.js'; console.log(decodeVarInt(new Uint8Array([0xac,0x02])))"
TypeError: varint.decode is not a function    # before
300                                           # after
```

## Where it was found

On `permissioned-data-alpha`, every OAuth authorization request carrying a `space:` scope is rejected with `invalid_scope` / "Unable to retrieve space declarations", and every request carrying `include:<permission-set>` is rejected at PAR. The chain is:

`LexResolver.fetchLexiconUri` fetches the declaration with `com.atproto.sync.getRecord`, which returns a CAR → `verifyRecordProof` → `readCarWithRoot` → `TypeError` → wrapped as `LexResolverError` (`lex-resolver.ts:458`) → `LexiconGetter` swallows it and stores `lexicon: null` → `LexiconManager.getSpace` throws → `oauth-provider.ts:783` raises `AuthorizationError('Unable to retrieve space declarations', 'invalid_scope')`. The permission-set path fails the same way at `request-manager.ts:296`.

This is not specific to one authority. With the fix, against a live server:

```
OK   space.highport.sites.space  -> at://did:plc:ciygg5hma4q7ah2kxaszkyob/…
OK   space.highport.authManage   -> at://did:plc:ciygg5hma4q7ah2kxaszkyob/…
OK   com.atproto.repo.getRecord  -> at://did:plc:6msi3pj7krzih5qxqtryxlzw/…
```

All three fail with `Failed to verify Lexicon record proof at <uri>` / `varint.decode is not a function` before it.

## Fix

Reach the module object through `default`, falling back to the namespace for bundlers and test transforms, which do synthesize both named exports.

A plain `import varint from 'varint'` is the smaller change and is the house style for CJS dependencies elsewhere in the repo, but `@types/varint` declares named exports and no default, so it fails `import-x/default`. The namespace-plus-`default` form is runtime-correct in all three environments and lints clean without a disable comment.

No test is added, because none in this package can fail before the fix — see above. The durable guard would be a lint rule against namespace-importing CJS dependencies, or an ESM smoke check over built output; both are tooling changes, so I have left them out of a one-line fix rather than making that call unilaterally. Happy to add either if you'd like it here.

`pnpm --filter @atproto/car build`, `test` (40/40), `eslint` and `prettier --check` are clean on the change.

## Disclosure

Written with Claude Code (Claude Opus 5), per CONTRIBUTING.md. I read the full diff, verified the interop behaviour and the before/after reproduction myself, and can answer for every line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
